### PR TITLE
wash-cli: 0.39.0 -> 1.0.0-beta.10

### DIFF
--- a/pkgs/by-name/wa/wash-cli/package.nix
+++ b/pkgs/by-name/wa/wash-cli/package.nix
@@ -1,51 +1,35 @@
 {
   lib,
-  fetchCrate,
+  fetchFromGitHub,
   rustPlatform,
-  pkg-config,
-  openssl,
-  fetchurl,
 }:
 
-let
-  wasiPreviewCommandComponentAdapter = fetchurl {
-    url = "https://github.com/bytecodealliance/wasmtime/releases/download/v22.0.0/wasi_snapshot_preview1.command.wasm";
-    hash = "sha256-UVBFddlI0Yh1ZNs0b2jSnKsHvGGAS5U09yuwm8Q6lxw=";
-  };
-  wasiPreviewReactorComponentAdapter = fetchurl {
-    url = "https://github.com/bytecodealliance/wasmtime/releases/download/v22.0.0/wasi_snapshot_preview1.reactor.wasm";
-    hash = "sha256-oE53IRMZgysSWT7RhrpZJjdaIyzCRf0h4d1yjqj/PSk=";
-  };
-
-in
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "wash-cli";
-  version = "0.39.0";
+  version = "1.0.0-beta.10";
 
-  src = fetchCrate {
-    inherit version pname;
-    hash = "sha256-qOxYBhwkcn4g1cUBHuF0AoecpxN4ukgTjBnzVhWtw7A=";
+  src = fetchFromGitHub {
+    owner = "wasmCloud";
+    repo = "wash";
+    tag = "wash-v${finalAttrs.version}";
+    hash = "sha256-g1OXyxLSKicMz0mnTyHNmihtt5WMx91bNo83NhZpx9s=";
   };
 
-  cargoHash = "sha256-dPHzRZh5jBxbPt+1a9wVbsBclAkfrcAXhpZgTw7e4Qo=";
+  cargoHash = "sha256-/Dah1F3pJBqtrCw7iVRGidQUl8rmD31Eoqva9ejc1iw=";
 
-  nativeBuildInputs = [ pkg-config ];
+  checkFlags = [
+    # Requires internet access
+    "--skip=test_end_to_end_template_to_execution"
+    "--skip=test_plugin_test_inspect_comprehensive"
+    "--skip=test_pull_and_validate_ghcr_component"
+  ];
 
-  buildInputs = [ openssl ];
-
-  preBuild = "
-    export WASI_PREVIEW1_COMMAND_COMPONENT_ADAPTER=${wasiPreviewCommandComponentAdapter}
-    export WASI_PREVIEW1_REACTOR_COMPONENT_ADAPTER=${wasiPreviewReactorComponentAdapter}
-  ";
-
-  # Tests require the internet and don't work when running in nix
-  doCheck = false;
-
-  meta = with lib; {
-    description = "wasmCloud Shell (wash) CLI tool";
-    homepage = "https://wasmcloud.com/";
+  meta = {
+    description = "Command-line tool for developing, building, and managing WebAssembly components";
+    homepage = "https://github.com/wasmCloud/wash";
+    changelog = "https://github.com/wasmCloud/wash/releases/tag/wash-v${finalAttrs.version}";
     mainProgram = "wash";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ bloveless ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ bloveless ];
   };
-}
+})


### PR DESCRIPTION
https://github.com/wasmCloud/wash/releases/tag/wash-v1.0.0-beta.10

wash-cli was renamed to just wash upstream (although the binary name already was `wash` before), but I kept the package name unchanged for now.

I'm not sure to what degree the previous version of wash-cli is affected by CVE-2025-62518 (tracking issue #455265), but it contained the vulnerable tokio-tar dependency in its lockfile while the new version does not. Seeing that wash appears to act as a package manager to some degree, I'm going with "better be safe than sorry" and add the security label to this PR.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
