### PR TITLE
ci/eval: add extraNixpkgsConfig argument

### DIFF
--- a/ci/eval/attrpaths.nix
+++ b/ci/eval/attrpaths.nix
@@ -18,6 +18,7 @@
   lib ? import (path + "/lib"),
   trace ? false,
   path ? ./../..,
+  extraNixpkgsConfigJson ? "{}",
 }:
 let
 
@@ -46,6 +47,7 @@ let
 
   outpaths = import ./outpaths.nix {
     inherit path;
+    extraNixpkgsConfig = builtins.fromJSON extraNixpkgsConfigJson;
     attrNamesOnly = true;
   };
 

--- a/ci/eval/chunk.nix
+++ b/ci/eval/chunk.nix
@@ -8,6 +8,7 @@
   myChunk,
   includeBroken,
   systems,
+  extraNixpkgsConfigJson,
 }:
 
 let
@@ -17,6 +18,7 @@ let
   unfiltered = import ./outpaths.nix {
     inherit path;
     inherit includeBroken systems;
+    extraNixpkgsConfig = builtins.fromJSON extraNixpkgsConfigJson;
   };
 
   # Turns the unfiltered recursive attribute set into one that is limited to myAttrpaths

--- a/ci/eval/default.nix
+++ b/ci/eval/default.nix
@@ -26,6 +26,8 @@
   quickTest ? false,
   # Don't try to eval packages marked as broken.
   includeBroken ? false,
+  # Customize the config used to evaluate nixpkgs
+  extraNixpkgsConfig ? { },
 }:
 
 let
@@ -75,6 +77,7 @@ let
             "$src/ci/eval/attrpaths.nix" \
             -A paths \
             -I "$src" \
+            --argstr extraNixpkgsConfigJson ${lib.escapeShellArg (builtins.toJSON extraNixpkgsConfig)} \
             --option restrict-eval true \
             --option allow-import-from-derivation false \
             --option eval-system "${evalSystem}" > $out/paths.json
@@ -120,6 +123,7 @@ let
           --arg attrpathFile "${attrpathFile}" \
           --arg systems "[ \"$system\" ]" \
           --arg includeBroken ${lib.boolToString includeBroken} \
+          --argstr extraNixpkgsConfigJson ${lib.escapeShellArg (builtins.toJSON extraNixpkgsConfig)} \
           -I ${nixpkgs} \
           -I ${attrpathFile} \
           > "$outputDir/result/$myChunk" \

--- a/ci/eval/outpaths.nix
+++ b/ci/eval/outpaths.nix
@@ -11,6 +11,9 @@
 
   # Set this to `null` to build for builtins.currentSystem only
   systems ? builtins.fromJSON (builtins.readFile ../supportedSystems.json),
+
+  # Customize the config used to evaluate nixpkgs
+  extraNixpkgsConfig ? { },
 }:
 let
   lib = import (path + "/lib");
@@ -55,7 +58,8 @@ let
                 true;
 
             inHydra = true;
-          };
+          }
+          // extraNixpkgsConfig;
 
           __allowFileset = false;
         };


### PR DESCRIPTION
## Things done

### Motivation

As part as the [NixOS CUDA](https://nixos-cuda.org) effort, we would like to generate an hydra jobset that rebuilds all packages affected by `cudaSupport`.
Currently, the [`release-cuda.nix`](https://github.com/NixOS/nixpkgs/blob/cd5bfc082fe97f2aa078b9154e3eb030a44dc7d7/pkgs/top-level/release-cuda.nix) release-file is hard-coding a short-list of some relevant packages.

I would like to leverage the `ci/eval` code to _diff_ the package set with and without `cudaSupport` enabled.

### Implementation

I added a `extraNixpkgsConfig` parameter (attrs type) to `outpaths.nix` that merges into the `nixpkgsArg` attrs used to import `pkgs/top-level/release.nix`.
This parameter is propagated from `baseline`/`full` to `singleSystem` and then to `chunk.nix` which imports `outpaths.nix`.

I thought about simply adding a `cudaSupport` flag, but `extraNixpkgsConfig` seems to be more future proof and general.

### Testing

I was able to test and compute the list of affected packages with `cudaSupport = true;` (125 added packages, 7 removed and 2256 changed).
[`step-summary.md`](https://paste.glepage.com/raw/mole-toad-spider)

```
nix-build ci -A eval.baseline --arg evalSystems '[ "x86_64-linux" ]' --out-link without-cuda
nix-build ci -A eval.full --arg baseline ./without-cuda --arg evalSystems '[ "x86_64-linux" ]' --arg extraNixpkgsConfig '{ cudaSupport = true; allowUnfree = true; }' --out-link with-cuda
```

Please, feel free to suggest changes to this approach. Thanks!

cc @MattSturgeon @wolfgangwalther @SomeoneSerge @ConnorBaker @zimbatm

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
