### PR TITLE
vesktop: 1.6.0 -> 1.6.1; fix use_system_vencord.patch

### DIFF
--- a/pkgs/by-name/ve/vesktop/package.nix
+++ b/pkgs/by-name/ve/vesktop/package.nix
@@ -24,13 +24,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "vesktop";
-  version = "1.6.0";
+  version = "1.6.1";
 
   src = fetchFromGitHub {
     owner = "Vencord";
     repo = "Vesktop";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-kzJsSjaTH6HtBfhEtX4NLJS96zgYr0/Us6H0tDJvb9A=";
+    hash = "sha256-ZFAsyH+5duKerZissOR/lESLetqqEMLk86msLlQO1xU=";
   };
 
   pnpmDeps = pnpm_10.fetchDeps {
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
       patches
       ;
     fetcherVersion = 2;
-    hash = "sha256-Vn+Imarp1OTPfe/PoMgFHU5eWnye5Oa+qoGZaTxOUmU=";
+    hash = "sha256-7fYD4lTSLCMOa+CqGlL45Mjw6qMfIJddPcRF5/dGGrk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ve/vesktop/use_system_vencord.patch
+++ b/pkgs/by-name/ve/vesktop/use_system_vencord.patch
@@ -1,13 +1,10 @@
-diff --git a/src/main/constants.ts b/src/main/constants.ts
-index 40d91a5..7b46bbf 100644
---- a/src/main/constants.ts
-+++ b/src/main/constants.ts
-@@ -49,7 +49,7 @@ export const VENCORD_THEMES_DIR = join(DATA_DIR, "themes");
- // as otherwise "DATA_DIR" (which is used by ./settings) will be uninitialised
- export const VENCORD_FILES_DIR =
-     (require("./settings") as typeof import("./settings")).State.store.vencordDir ||
--    join(SESSION_DATA_DIR, "vencordFiles");
-+    "@vencord@";
+diff --git a/src/main/vencordFilesDir.ts b/src/main/vencordFilesDir.ts
+index 8ef9ab8..ac376e0 100644
+--- a/src/main/vencordFilesDir.ts
++++ b/src/main/vencordFilesDir.ts
+@@ -10,4 +10,4 @@ import { SESSION_DATA_DIR } from "./constants";
+ import { State } from "./settings";
  
- export const USER_AGENT = `Vesktop/${app.getVersion()} (https://github.com/Vencord/Vesktop)`;
- 
+ // this is in a separate file to avoid circular dependencies
+-export const VENCORD_FILES_DIR = State.store.vencordDir || join(SESSION_DATA_DIR, "vencordFiles");
++export const VENCORD_FILES_DIR = State.store.vencordDir || "@vencord@";


### PR DESCRIPTION
Closes #456967
Supersedes #456715
Changelog: https://github.com/Vencord/Vesktop/releases/tag/v1.6.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
