### PR TITLE
odamex: 0.9.5 -> 11.1.1

### DIFF
--- a/pkgs/by-name/od/odamex/package.nix
+++ b/pkgs/by-name/od/odamex/package.nix
@@ -3,21 +3,25 @@
   stdenv,
   fetchurl,
   cmake,
+  alsa-lib,
+  fltk,
   pkg-config,
   makeWrapper,
+  libdwarf,
   SDL,
   SDL_mixer,
   SDL_net,
   wxGTK32,
+  zstd,
 }:
 
 stdenv.mkDerivation rec {
   pname = "odamex";
-  version = "0.9.5";
+  version = "11.1.1";
 
   src = fetchurl {
-    url = "mirror://sourceforge/${pname}/${pname}-src-${version}.tar.bz2";
-    sha256 = "sha256-WBqO5fWzemw1kYlY192v0nnZkbIEVuWmjWYMy+1ODPQ=";
+    url = "mirror://sourceforge/${pname}/${pname}-src-${version}.tar.gz";
+    sha256 = "sha256-DEM0JcA4u4s5OqkPNNcLIf2nLV+M/KHCVI/pSFEfYWA=";
   };
 
   nativeBuildInputs = [
@@ -27,11 +31,24 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
+    alsa-lib
+    fltk
+    libdwarf
     SDL
     SDL_mixer
     SDL_net
     wxGTK32
+    zstd
   ];
+
+  cmakeFlags = [
+    "-DUSE_EXTERNAL_LIBDWARF=ON"
+  ];
+
+  postPatch = ''
+    substituteInPlace libraries/cpptrace-lib.cmake \
+      --replace '"-DCPPTRACE_USE_EXTERNAL_LIBDWARF=''${USE_EXTERNAL_LIBDWARF}"' '"-DCPPTRACE_USE_EXTERNAL_LIBDWARF=''${USE_EXTERNAL_LIBDWARF}" "-DCPPTRACE_FIND_LIBDWARF_WITH_PKGCONFIG=ON"'
+  '';
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
