### PR TITLE
cudaPackages.buildRedist: do not require `config.cudaSupport` to be enabled

### DIFF
--- a/pkgs/development/cuda-modules/buildRedist/default.nix
+++ b/pkgs/development/cuda-modules/buildRedist/default.nix
@@ -376,10 +376,6 @@ extendMkDerivation {
         # because attempts to access attributes on the package will cause evaluation errors.
         brokenAssertions = [
           {
-            message = "CUDA support is enabled by config.cudaSupport";
-            assertion = config.cudaSupport;
-          }
-          {
             message = "lib output precedes static output";
             assertion =
               let


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The rationale behind this change has been comprehensively outlined in https://github.com/NixOS/nixpkgs/issues/457218

Summary: Setting `config.cudaSupport` globally is undesirable in most scenarios, due to the immense amount of rebuilds it causes (even for unrelated packages), therefore we should not require users to do so.

Additionally, this derivation prevents the installation of certain packages in nixpkgs by default (e.g. `nvtopPackages.full`), making these difficult to install on non-NixOS systems (especially for inexperienced users), despite being fully functional when built.

Derivations should instead ensure that their dependencies are built with the required support.

Closes https://github.com/NixOS/nixpkgs/issues/457218
Closes https://github.com/NixOS/nixpkgs/issues/456940
Closes https://github.com/NixOS/nixpkgs/issues/456928

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Packages built: `nvtopPackages.full`

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

cc @ConnorBaker 

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
