### PR TITLE
linuxPackages.morse-driver: init at 1.14.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9613,6 +9613,12 @@
     githubId = 6375438;
     keys = [ { fingerprint = "5214 2D39 A7CE F8FA 872B  CA7F DE62 E1E2 A614 5556"; } ];
   };
+  govindsi = {
+    email = "govind.sk85@gmail.com";
+    github = "govindsi";
+    githubId = 8924200;
+    name = "Govind Singh";
+  };
   gp2112 = {
     email = "me@guip.dev";
     github = "gp2112";

--- a/pkgs/os-specific/linux/morse-driver/0001-fix-fix-conflicting-types-for-morse_firmware_init.patch
+++ b/pkgs/os-specific/linux/morse-driver/0001-fix-fix-conflicting-types-for-morse_firmware_init.patch
@@ -1,0 +1,50 @@
+From 66b5afbfe4a940056b18e8f26f2b515c964a2927 Mon Sep 17 00:00:00 2001
+From: Govind Singh <govind.sk85@gmail.com>
+Date: Fri, 31 Oct 2025 10:52:30 +0400
+Subject: [PATCH] fix: fix conflicting types for 'morse_firmware_init'
+
+fix conflicting types for 'morse_firmware_init' due to
+[-Werror=enum-int-mismatch]
+---
+ debug.h    | 2 +-
+ firmware.h | 4 +++-
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/debug.h b/debug.h
+index 68914da..4a09522 100644
+--- a/debug.h
++++ b/debug.h
+@@ -154,7 +154,7 @@ extern uint debug_mask;
+  *
+  * @returns	True if output would be generated and false otherwise.
+  */
+-bool morse_log_is_enabled(u32 id, u8 level);
++bool morse_log_is_enabled(enum morse_feature_id id, u8 level);
+ 
+ /**
+  * Set the default logging level for all features.
+diff --git a/firmware.h b/firmware.h
+index 0416c29..7ce47ec 100644
+--- a/firmware.h
++++ b/firmware.h
+@@ -31,6 +31,8 @@
+ #error "Capability subset filled by firmware is to big"
+ #endif
+ 
++enum morse_config_test_mode;
++
+ enum morse_fw_info_tlv_type {
+ 	MORSE_FW_INFO_TLV_BCF_ADDR = 1,
+ 	MORSE_FW_INFO_TLV_COREDUMP_MEM_REGION = 2,
+@@ -139,7 +141,7 @@ struct extended_host_table {
+ 	u8 ext_host_table_data_tlvs[];
+ } __packed;
+ 
+-int morse_firmware_init(struct morse *mors, uint test_mode);
++int morse_firmware_init(struct morse *mors, enum morse_config_test_mode test_mode);
+ 
+ /**
+  * @brief Perform non-destructive-reset of the chip,
+-- 
+2.34.1
+

--- a/pkgs/os-specific/linux/morse-driver/default.nix
+++ b/pkgs/os-specific/linux/morse-driver/default.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  kernel,
+}:
+
+stdenv.mkDerivation {
+  pname = "morse-driver";
+  version = "1.14.1-${kernel.version}";
+
+  src = fetchFromGitHub {
+    owner = "MorseMicro";
+    repo = "morse_driver";
+    rev = "33f0092d5c859d8589b99c6e9a77abc58c093648";
+    hash = "sha256-VNw5OdxkP8GltYU2kDYdBUGKWIlPhr3tkzqtW+3MigE=";
+    fetchSubmodules = true;
+  };
+
+  patches = [
+    ./0001-fix-fix-conflicting-types-for-morse_firmware_init.patch
+  ];
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+  hardeningDisable = [ "pic" ];
+
+  makeFlags = [
+    "ARCH=${kernel.arch or stdenv.hostPlatform.linuxArch}"
+    "KERNEL_SRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+
+    # --- Morse-specific Kconfig options ---
+    "CONFIG_WLAN_VENDOR_MORSE=m"
+    "CONFIG_MORSE_SDIO=y"
+    "CONFIG_MORSE_SDIO_ALIGNMENT=4"
+    "CONFIG_MORSE_USER_ACCESS=y"
+    "CONFIG_MORSE_VENDOR_COMMAND=y"
+    "CONFIG_MORSE_COUNTRY=US"
+    "CONFIG_MORSE_DEBUG_MASK=4"
+    "CONFIG_MORSE_SDIO_RESET_TIME=400"
+    "CONFIG_MORSE_POWERSAVE_MODE=0"
+    "CONFIG_MORSE_WATCHDOG_RESET_DEFAULT_DISABLED=y"
+  ]
+  ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+  ];
+
+  installPhase = ''
+    mkdir -p "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
+    find . -name "*.ko" -exec cp {} $out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/ \;
+  '';
+
+  postInstall = ''
+    nuke-refs $out/lib/modules/*/kernel/net/wireless/*.ko
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "Morse Micro Wi-Fi driver";
+    homepage = "https://github.com/MorseMicro/morse_driver";
+    license = licenses.gpl2Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ govindsi ];
+  };
+}

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -570,6 +570,8 @@ in
 
         mxu11x0 = callPackage ../os-specific/linux/mxu11x0 { };
 
+        morse-driver = callPackage ../os-specific/linux/morse-driver { };
+
         # compiles but has to be integrated into the kernel somehow
         # Let's have it uncommented and finish it..
         ndiswrapper = callPackage ../os-specific/linux/ndiswrapper { };


### PR DESCRIPTION
Add the morse Wi-Fi driver package version 1.14.1.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
