### PR TITLE
nixos/vaultwarden: add service dependency based on dbBackend

### DIFF
--- a/nixos/modules/services/security/vaultwarden/default.nix
+++ b/nixos/modules/services/security/vaultwarden/default.nix
@@ -219,8 +219,15 @@ in
     users.groups.vaultwarden = { };
 
     systemd.services.vaultwarden = {
-      after = [ "network-online.target" ];
+      after = [
+        "network-online.target"
+      ]
+      ++ (lib.optionals (cfg.dbBackend == "postgresql") [ "postgresql.service" ])
+      ++ (lib.optionals (cfg.dbBackend == "mysql") [ "mysql.service" ]);
       wants = [ "network-online.target" ];
+      requires =
+        (lib.optionals (cfg.dbBackend == "postgresql") [ "postgresql.service" ])
+        ++ (lib.optionals (cfg.dbBackend == "mysql") [ "mysql.service" ]);
       path = with pkgs; [ openssl ];
       serviceConfig = {
         User = user;

--- a/nixos/modules/services/security/vaultwarden/default.nix
+++ b/nixos/modules/services/security/vaultwarden/default.nix
@@ -228,7 +228,7 @@ in
       requires =
         (lib.optionals (cfg.dbBackend == "postgresql") [ "postgresql.service" ])
         ++ (lib.optionals (cfg.dbBackend == "mysql") [ "mysql.service" ]);
-      path = with pkgs; [ openssl ];
+      path = [ pkgs.openssl ];
       serviceConfig = {
         User = user;
         Group = group;
@@ -284,7 +284,7 @@ in
         DATA_FOLDER = dataDir;
         BACKUP_FOLDER = cfg.backupDir;
       };
-      path = with pkgs; [ sqlite ];
+      path = [ pkgs.sqlite ];
       # if both services are started at the same time, vaultwarden fails with "database is locked"
       before = [ "vaultwarden.service" ];
       serviceConfig = {


### PR DESCRIPTION
When Vaultwarden is configured to use a PostgreSQL or MySQL backend, the corresponding database service must be available before Vaultwarden starts. This change adds conditional `after` and `requires` dependencies to ensure Vaultwarden starts only after the respective database service is ready.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
