### PR TITLE
python3Packages.uv-build: decouple from uv

### DIFF
--- a/pkgs/by-name/uv/uv/package.nix
+++ b/pkgs/by-name/uv/uv/package.nix
@@ -62,7 +62,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   passthru = {
     tests.uv-python = python3Packages.uv;
 
-    # Updating `uv` needs to be done on staging. Disabling r-ryantm update bot:
+    # Updating `uv` needs to be done on staging until the next staging branch-off.
+    # Disabling r-ryantm update bot:
     # nixpkgs-update: no auto update
     updateScript = nix-update-script { };
   };

--- a/pkgs/development/python-modules/uv-build/default.nix
+++ b/pkgs/development/python-modules/uv-build/default.nix
@@ -1,25 +1,33 @@
 {
   lib,
   pkgs,
+  fetchFromGitHub,
   buildPythonPackage,
   rustPlatform,
   callPackage,
 }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "uv-build";
+  version = "0.9.7";
   pyproject = true;
 
-  inherit (pkgs.uv)
-    version
-    src
-    cargoDeps
-    ;
+  src = fetchFromGitHub {
+    owner = "astral-sh";
+    repo = "uv";
+    tag = version;
+    hash = "sha256-I0Oe6vaH7iQh+Ubp5RIk8Ol6Ni7OPu8HKX0fqLdewyk=";
+  };
 
   nativeBuildInputs = [
     rustPlatform.cargoSetupHook
     rustPlatform.maturinBuildHook
   ];
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit pname version src;
+    hash = "sha256-K/RP7EA0VAAI8TGx+VwfKPmyT6+x4p3kekuoMZ0/egc=";
+  };
 
   buildAndTestSubdir = "crates/uv-build";
 

--- a/pkgs/development/python-modules/uv-build/default.nix
+++ b/pkgs/development/python-modules/uv-build/default.nix
@@ -40,7 +40,11 @@ buildPythonPackage rec {
   doCheck = false;
 
   # Run the tests of a package built by `uv_build`.
-  passthru.tests.built-by-uv = callPackage ./built-by-uv.nix { inherit (pkgs) uv; };
+  passthru = {
+    tests.built-by-uv = callPackage ./built-by-uv.nix { inherit (pkgs) uv; };
+
+    # updateScript is not needed here, as updating is done on staging
+  };
 
   meta = {
     description = "Minimal build backend for uv";


### PR DESCRIPTION
Only 1k / 10k rebuilds come solely from `home-assistant`'s dependency on `uv`.

The remainder likely stems from `python3Packages.cryptography`'s transitive dependency on
`python3Packages.uv-build` via `python3Packages.cryptography-vector`'s `build-system`.

The remaining occurrences in the file are in `passthru.tests` and `meta.{changelog,license}`,
so nothing that would influence rebuilds.

CC @mweinelt 


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
