### PR TITLE
servo: 0.0.1-unstable-2025-10-29 -> 0.0.1

### DIFF
--- a/pkgs/by-name/se/servo/package.nix
+++ b/pkgs/by-name/se/servo/package.nix
@@ -144,9 +144,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     udev
     vulkan-loader
   ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    apple-sdk_14
-  ];
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ apple-sdk_14 ];
 
   # Builds with additional features for aarch64, see https://github.com/servo/servo/issues/36819
   buildFeatures = lib.optionals stdenv.hostPlatform.isAarch64 [

--- a/pkgs/by-name/se/servo/package.nix
+++ b/pkgs/by-name/se/servo/package.nix
@@ -64,15 +64,15 @@ let
   );
 in
 
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "servo";
-  version = "0.0.1-unstable-2025-10-29";
+  version = "0.0.1";
 
   src = fetchFromGitHub {
     owner = "servo";
     repo = "servo";
-    rev = "32c0c41d118e55fda1ab9aa778c2a59fa27710e9";
-    hash = "sha256-kQbwqKTsW5gkEeHE7Yp/fbGObjUJnvOG/0U6RSZc7oU=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-xtJg58dQjdyHUfcL5FWyjh5XQJznprXOze9Rz/bW+hc=";
     # Breaks reproducibility depending on whether the picked commit
     # has other ref-names or not, which may change over time, i.e. with
     # "ref-names: HEAD -> main" as long this commit is the branch HEAD
@@ -82,7 +82,7 @@ rustPlatform.buildRustPackage {
     '';
   };
 
-  cargoHash = "sha256-wwS4fhYG8pvmNLCgSO26yf65No7wL1Xrqm+38sP2pxM=";
+  cargoHash = "sha256-JGGV/FtTX80lu/+tC+DK1STeobSBxLBaPnmCloz+CWo=";
 
   # set `HOME` to a temp dir for write access
   # Fix invalid option errors during linking (https://github.com/mozilla/nixpkgs-mozilla/commit/c72ff151a3e25f14182569679ed4cd22ef352328)
@@ -175,7 +175,7 @@ rustPlatform.buildRustPackage {
   '';
 
   passthru = {
-    updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+    updateScript = nix-update-script { };
     tests = { inherit (nixosTests) servo; };
   };
 
@@ -191,4 +191,4 @@ rustPlatform.buildRustPackage {
     mainProgram = "servo";
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
-}
+})


### PR DESCRIPTION
Changelog: https://github.com/servo/servo/releases/tag/v0.0.1

Resolves #457115


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc