### PR TITLE
libxlsxwriter: clean up and improve package

### DIFF
--- a/pkgs/by-name/li/libxlsxwriter/package.nix
+++ b/pkgs/by-name/li/libxlsxwriter/package.nix
@@ -56,7 +56,11 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   passthru = {
-    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    tests.pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+      versionCheck = true;
+    };
+
     updateScript = nix-update-script { };
   };
 

--- a/pkgs/by-name/li/libxlsxwriter/package.nix
+++ b/pkgs/by-name/li/libxlsxwriter/package.nix
@@ -49,9 +49,6 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "BUILD_TESTS" finalAttrs.doCheck)
   ];
 
-  # TEST 428/429 worksheet:worksheet_table15 *** buffer overflow detected ***: terminated
-  hardeningDisable = [ "fortify3" ];
-
   doCheck = true;
 
   nativeCheckInputs = [

--- a/pkgs/by-name/li/libxlsxwriter/package.nix
+++ b/pkgs/by-name/li/libxlsxwriter/package.nix
@@ -7,14 +7,14 @@
   zlib,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libxlsxwriter";
   version = "1.2.4";
 
   src = fetchFromGitHub {
     owner = "jmcnamara";
     repo = "libxlsxwriter";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-mbi2jxxlXVyBTXkmSraZn6vMQAJ61PX2vwG10q2Ixos=";
   };
 
@@ -42,9 +42,9 @@ stdenv.mkDerivation rec {
   meta = {
     description = "C library for creating Excel XLSX files";
     homepage = "https://libxlsxwriter.github.io/";
-    changelog = "https://github.com/jmcnamara/libxlsxwriter/blob/${src.rev}/Changes.txt";
+    changelog = "https://github.com/jmcnamara/libxlsxwriter/blob/${finalAttrs.src.tag}/Changes.txt";
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ dotlambda ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/li/libxlsxwriter/package.nix
+++ b/pkgs/by-name/li/libxlsxwriter/package.nix
@@ -8,6 +8,7 @@
   openssl,
   python3,
   zlib,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -46,6 +47,8 @@ stdenv.mkDerivation (finalAttrs: {
   nativeCheckInputs = [
     python3.pkgs.pytest
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "C library for creating Excel XLSX files";

--- a/pkgs/by-name/li/libxlsxwriter/package.nix
+++ b/pkgs/by-name/li/libxlsxwriter/package.nix
@@ -2,6 +2,8 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  cmake,
+  pkg-config,
   minizip,
   python3,
   zlib,
@@ -18,14 +20,19 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-mbi2jxxlXVyBTXkmSraZn6vMQAJ61PX2vwG10q2Ixos=";
   };
 
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
   buildInputs = [
     minizip
     zlib
   ];
 
-  makeFlags = [
-    "PREFIX=${placeholder "out"}"
-    "USE_SYSTEM_MINIZIP=1"
+  cmakeFlags = [
+    "-DUSE_SYSTEM_MINIZIP=ON"
+    (lib.cmakeBool "BUILD_TESTS" finalAttrs.doCheck)
   ];
 
   # TEST 428/429 worksheet:worksheet_table15 *** buffer overflow detected ***: terminated
@@ -36,8 +43,6 @@ stdenv.mkDerivation (finalAttrs: {
   nativeCheckInputs = [
     python3.pkgs.pytest
   ];
-
-  checkTarget = "test";
 
   meta = {
     description = "C library for creating Excel XLSX files";

--- a/pkgs/by-name/li/libxlsxwriter/package.nix
+++ b/pkgs/by-name/li/libxlsxwriter/package.nix
@@ -36,6 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     "-DUSE_SYSTEM_MINIZIP=ON"
     "-DUSE_OPENSSL_MD5=ON"
+    "-DUSE_DTOA_LIBRARY=ON"
     (lib.cmakeBool "BUILD_TESTS" finalAttrs.doCheck)
   ];
 

--- a/pkgs/by-name/li/libxlsxwriter/package.nix
+++ b/pkgs/by-name/li/libxlsxwriter/package.nix
@@ -5,6 +5,7 @@
   cmake,
   pkg-config,
   minizip,
+  openssl,
   python3,
   zlib,
 }:
@@ -27,11 +28,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     minizip
+    openssl
     zlib
   ];
 
   cmakeFlags = [
     "-DUSE_SYSTEM_MINIZIP=ON"
+    "-DUSE_OPENSSL_MD5=ON"
     (lib.cmakeBool "BUILD_TESTS" finalAttrs.doCheck)
   ];
 

--- a/pkgs/by-name/li/libxlsxwriter/package.nix
+++ b/pkgs/by-name/li/libxlsxwriter/package.nix
@@ -8,6 +8,7 @@
   openssl,
   python3,
   zlib,
+  testers,
   nix-update-script,
 }:
 
@@ -57,7 +58,10 @@ stdenv.mkDerivation (finalAttrs: {
     python3.pkgs.pytest
   ];
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "C library for creating Excel XLSX files";
@@ -66,5 +70,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ dotlambda ];
     platforms = lib.platforms.unix;
+    pkgConfigModules = [ "xlsxwriter" ];
   };
 })

--- a/pkgs/by-name/li/libxlsxwriter/package.nix
+++ b/pkgs/by-name/li/libxlsxwriter/package.nix
@@ -15,6 +15,13 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "libxlsxwriter";
   version = "1.2.4";
 
+  outputs = [
+    "out"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.hasSharedLibraries [
+    "dev"
+  ];
+
   src = fetchFromGitHub {
     owner = "jmcnamara";
     repo = "libxlsxwriter";

--- a/pkgs/by-name/li/libxlsxwriter/package.nix
+++ b/pkgs/by-name/li/libxlsxwriter/package.nix
@@ -37,6 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-DUSE_SYSTEM_MINIZIP=ON"
     "-DUSE_OPENSSL_MD5=ON"
     "-DUSE_DTOA_LIBRARY=ON"
+    (lib.cmakeBool "BUILD_SHARED_LIBS" stdenv.hostPlatform.hasSharedLibraries)
     (lib.cmakeBool "BUILD_TESTS" finalAttrs.doCheck)
   ];
 


### PR DESCRIPTION
- Use `finalAttrs` pattern,
- ~remove use of `with lib;`,~
- build using CMake,
- build shared library,
- split outputs,
- enable DTOA library for floating‐point formatting,
- use MD5 from OpenSSL,
- provide update script,
- add `pkg-config` pass‐through test, and
- remove unneeded `hardeningDisable`.

I am not sure if adding OpenSSL to the closure is worth any potential performance or security benefits, but I doubt that there is any system without it.

Building with CMake instead of plain GNU make makes installation more flexible, especially when splitting outputs.

I was not able to reproduce the test failure with `hardeningEnable = [ "fortify3" ]` and therefore I assume that the underlying issue has been resolved.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] ~[NixOS tests] in [nixos/tests]~.
  - [x] [Package tests] at `passthru.tests`.
  - [ ] ~Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality~.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
