### PR TITLE
lib.strings: Add toPascalCase, toKebabCase and toSnakeCase

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -349,6 +349,9 @@ let
         toLower
         toUpper
         toCamelCase
+        toSnakeCase
+        toPascalCase
+        toKebabCase
         toSentenceCase
         addContextFrom
         splitString

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -1620,6 +1620,169 @@ rec {
     );
 
   /**
+    Converts a string to snake_case. Handles camelCase, PascalCase,
+    kebab-case strings as well as strings delimited by spaces.
+
+    # Inputs
+
+    `string`
+    : The string to convert to snake_case
+
+    # Type
+
+    ```
+    toSnakeCase :: string -> string
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.strings.toSnakeCase` usage example
+
+    ```nix
+    toSnakeCase "hello-world"
+    => "hello_world"
+    toSnakeCase "helloWorld"
+    => "hello_world"
+    toSnakeCase "hello world"
+    => "hello_world"
+    toSnakeCase "HelloWorld"
+    => "hello_world"
+    ```
+
+    :::
+  */
+  toSnakeCase =
+    str:
+    lib.throwIfNot (isString str) "toSnakeCase does only accepts string values, but got ${typeOf str}" (
+      let
+        separators = splitStringBy (
+          prev: curr:
+          elem curr [
+            "-"
+            "_"
+            " "
+          ]
+        ) false str;
+
+        parts = lib.flatten (
+          map (splitStringBy (
+            prev: curr: match "[a-z]" prev != null && match "[A-Z]" curr != null
+          ) true) separators
+        );
+      in
+      join "_" (map (addContextFrom str) (map toLower parts))
+    );
+
+  /**
+    Converts a string to PascalCase. Handles camelCase, snake_case,
+    kebab-case strings as well as strings delimited by spaces.
+
+    # Inputs
+
+    `string`
+    : The string to convert to PascalCase
+
+    # Type
+
+    ```
+    toPascalCase :: string -> string
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.strings.toPascalCase` usage example
+
+    ```nix
+    toPascalCase "hello-world"
+    => "HelloWorld"
+    toPascalCase "helloWorld"
+    => "HelloWorld"
+    toPascalCase "hello world"
+    => "HelloWorld"
+    toPascalCase "hello_world"
+    => "HelloWorld"
+    ```
+
+    :::
+  */
+  toPascalCase =
+    str:
+    lib.throwIfNot (isString str) "toPascalCase does only accepts string values, but got ${typeOf str}"
+      (
+        let
+          separators = splitStringBy (
+            prev: curr:
+            elem curr [
+              "-"
+              "_"
+              " "
+            ]
+          ) false str;
+
+          parts = lib.flatten (
+            map (splitStringBy (
+              prev: curr: match "[a-z]" prev != null && match "[A-Z]" curr != null
+            ) true) separators
+          );
+        in
+        concatStrings (map (addContextFrom str) (map toSentenceCase parts))
+      );
+
+  /**
+    Converts a string to kebab-case. Handles camelCase, snake_case,
+    PascalCase strings as well as strings delimited by spaces.
+
+    # Inputs
+
+    `string`
+    : The string to convert to kebab-case
+
+    # Type
+
+    ```
+    toKebabCase :: string -> string
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.strings.toKebabCase` usage example
+
+    ```nix
+    toKebabCase "HelloWorld"
+    => "hello-world"
+    toKebabCase "helloWorld"
+    => "hello-world"
+    toKebabCase "hello world"
+    => "hello-world"
+    toKebabCase "hello_world"
+    => "hello-world"
+    ```
+
+    :::
+  */
+  toKebabCase =
+    str:
+    lib.throwIfNot (isString str) "toKebabCase does only accepts string values, but got ${typeOf str}" (
+      let
+        separators = splitStringBy (
+          prev: curr:
+          elem curr [
+            "-"
+            "_"
+            " "
+          ]
+        ) false str;
+
+        parts = lib.flatten (
+          map (splitStringBy (
+            prev: curr: match "[a-z]" prev != null && match "[A-Z]" curr != null
+          ) true) separators
+        );
+      in
+      join "-" (map (addContextFrom str) (map toLower parts))
+    );
+
+  /**
     Appends string context from string like object `src` to `target`.
 
     :::{.warning}

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -1016,6 +1016,87 @@ runTests {
 
   testToCamelCasePath = testingThrow (strings.toCamelCase ./.);
 
+  testToSnakeCase = {
+    expr = strings.toSnakeCase "Hello world";
+    expected = "hello_world";
+  };
+
+  testToSnakeCaseFromSnake = {
+    expr = strings.toSnakeCase "hello_world";
+    expected = "hello_world";
+  };
+
+  testToSnakeCaseFromKebab = {
+    expr = strings.toSnakeCase "hello-world";
+    expected = "hello_world";
+  };
+
+  testToSnakeCaseFromCamel = {
+    expr = strings.toSnakeCase "helloWorld";
+    expected = "hello_world";
+  };
+
+  testToSnakeCaseFromPascal = {
+    expr = strings.toSnakeCase "HelloWorld";
+    expected = "hello_world";
+  };
+
+  testToSnakeCasePath = testingThrow (strings.toSnakeCase ./.);
+
+  testToPascalCase = {
+    expr = strings.toPascalCase "Hello world";
+    expected = "HelloWorld";
+  };
+
+  testToPascalCaseFromSnake = {
+    expr = strings.toPascalCase "hello_world";
+    expected = "HelloWorld";
+  };
+
+  testToPascalCaseFromKebab = {
+    expr = strings.toPascalCase "hello-world";
+    expected = "HelloWorld";
+  };
+
+  testToPascalCaseFromCamel = {
+    expr = strings.toPascalCase "helloWorld";
+    expected = "HelloWorld";
+  };
+
+  testToPascalCaseFromPascal = {
+    expr = strings.toPascalCase "HelloWorld";
+    expected = "HelloWorld";
+  };
+
+  testToPascalCasePath = testingThrow (strings.toPascalCase ./.);
+
+  testToKebabCase = {
+    expr = strings.toKebabCase "Hello world";
+    expected = "hello-world";
+  };
+
+  testToKebabCaseFromSnake = {
+    expr = strings.toKebabCase "hello_world";
+    expected = "hello-world";
+  };
+
+  testToKebabCaseFromKebab = {
+    expr = strings.toKebabCase "hello-world";
+    expected = "hello-world";
+  };
+
+  testToKebabCaseFromCamel = {
+    expr = strings.toKebabCase "helloWorld";
+    expected = "hello-world";
+  };
+
+  testToKebabCaseFromPascal = {
+    expr = strings.toKebabCase "HelloWorld";
+    expected = "hello-world";
+  };
+
+  testToKebabCasePath = testingThrow (strings.toKebabCase ./.);
+
   testToInt = testAllTrue [
     # Naive
     (123 == toInt "123")


### PR DESCRIPTION
These round out the string coversions to handle any of the most common formats.

There's a fair amount of duplication, but I wasn't sure where to put a common function as it uses `splitStringBy` but I didn't think exporting something like `stringConversionParts` was a good idea.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
