### PR TITLE
python3Packages.pyportainer: 1.0.10 -> 1.0.12

### DIFF
--- a/pkgs/development/python-modules/pyportainer/default.nix
+++ b/pkgs/development/python-modules/pyportainer/default.nix
@@ -3,6 +3,7 @@
   aresponses,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   lib,
   mashumaro,
   orjson,
@@ -15,15 +16,23 @@
 
 buildPythonPackage rec {
   pname = "pyportainer";
-  version = "1.0.10";
+  version = "1.0.12";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "erwindouna";
     repo = "pyportainer";
     tag = "v${version}";
-    hash = "sha256-8wMh41fmeRhZ5kTrBqeZWy8VxJhnKxAlAp3wk732+M4=";
+    hash = "sha256-goTYZhv/+4o2/SMOqANMnR3u4YxwDJVcvT0pz8MT7M8=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "remove-mkdocs-from-dependencies.patch";
+      url = "https://github.com/erwindouna/pyportainer/commit/8ed65c3870ff368465267e9bf2cda441b7b28994.patch";
+      hash = "sha256-3FE8NngAajIt8lDjG//sDPULq8mZ0f53iVemJ2xJ4MQ=";
+    })
+  ];
 
   build-system = [ poetry-core ];
 


### PR DESCRIPTION
Diff: https://github.com/erwindouna/pyportainer/compare/v1.0.10...v1.0.12

Changelog: 
https://github.com/erwindouna/pyportainer/releases/tag/v1.0.11
https://github.com/erwindouna/pyportainer/releases/tag/v1.0.12

depends on https://github.com/NixOS/nixpkgs/pull/457273
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
