### PR TITLE
tomat: init at 2.3.0

### DIFF
--- a/pkgs/by-name/to/tomat/package.nix
+++ b/pkgs/by-name/to/tomat/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  alsa-lib,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "tomat";
+  version = "2.3.0";
+
+  src = fetchFromGitHub {
+    owner = "jolars";
+    repo = "tomat";
+    tag = "v${version}";
+    hash = "sha256-lkNBcTn7uXWifIVNoXmggPy+UjozL5YqVYorH9XAejo=";
+  };
+
+  cargoHash = "sha256-jBpZyNfsJKchJnKwWJQeVavj0Yog83QrCM8kOJFVugg=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    alsa-lib
+  ];
+
+  checkFlags = [
+    # Skip tests that require access to file system locations not available during Nix builds
+    "--skip=timer::tests::test_icon_path_creation"
+    "--skip=timer::tests::test_notification_icon_config"
+    "--skip=integration::"
+  ];
+
+  meta = {
+    description = "Pomodoro timer for status bars";
+    homepage = "https://github.com/jolars/tomat";
+    changelog = "https://github.com/jolars/tomat/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jolars ];
+    mainProgram = "tomat";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
Init tomat at 2.3.0 (https://github.com/jolars/tomat). This is a pomodoro timer with a server-client architecture that feeds information to status bars like waybar and i3status-rust.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
