### PR TITLE
libxml2: 2.15.0 -> 2.15.1

### DIFF
--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -50,23 +50,14 @@ let
       };
     };
     libxml2 = callPackage ./common.nix {
-      version = "2.15.0";
+      version = "2.15.1";
       src = fetchFromGitLab {
         domain = "gitlab.gnome.org";
         owner = "GNOME";
         repo = "libxml2";
         tag = "v${packages.libxml2.version}";
-        hash = "sha256-jumHSiIMDzqG2hvPUdcBP8LsszcU+loOY+vqEh/0Yqo=";
+        hash = "sha256-FUfYMq5xT2i88JdIw9OtSofraUL3yjsyOVund+mfJKQ=";
       };
-      extraPatches = [
-        # Fixes a regression in attribute normalization.
-        # Also see https://www.postgresql.org/message-id/flat/0756AC61-FBA3-46E2-B3C2-19B58B65EBDC%2540yesql.se
-        # To be removed with 2.15.1.
-        (fetchpatch {
-          url = "https://gitlab.gnome.org/GNOME/libxml2/-/commit/da45a190f718e8e2f0e3d2a6325ffa23abc8b90c.patch";
-          hash = "sha256-wqmFszr7w1Lte12YR6Ug7Ng7fXABzizwUsJU1EhylgU=";
-        })
-      ];
       extraMeta = {
         maintainers = with lib.maintainers; [
           jtojnar


### PR DESCRIPTION
Rel notes: https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.15.1

Still building some important downstream packages, but i don't expect significant breaks with this update.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
