### PR TITLE
maintainers: drop thammers

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25743,12 +25743,6 @@
     githubId = 102452;
     name = "Niclas Thall";
   };
-  thammers = {
-    email = "jawr@gmx.de";
-    github = "tobias-hammerschmidt";
-    githubId = 2543259;
-    name = "Tobias Hammerschmidt";
-  };
   thanegill = {
     email = "me@thanegill.com";
     github = "thanegill";

--- a/pkgs/by-name/fl/flvstreamer/package.nix
+++ b/pkgs/by-name/fl/flvstreamer/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
 
     homepage = "https://savannah.nongnu.org/projects/flvstreamer";
 
-    maintainers = [ lib.maintainers.thammers ];
+    maintainers = [ ];
     platforms = with lib.platforms; linux ++ darwin;
   };
 }

--- a/pkgs/by-name/tm/tmux/package.nix
+++ b/pkgs/by-name/tm/tmux/package.nix
@@ -118,7 +118,6 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.unix;
     mainProgram = "tmux";
     maintainers = with lib.maintainers; [
-      thammers
       fpletz
     ];
   };


### PR DESCRIPTION
Hasn't commited to Nixpkgs for so long, that Github [can't find their commits](https://github.com/NixOS/nixpkgs/commits/master/?author=tobias-hammerschmidt). The only known contributions are additions of [Tmux](https://github.com/NixOS/nixpkgs/commit/1db5a9df76d1fbad40077acc03141782edd900e3) and [Flvstreamer](https://github.com/acid-bong/nixpkgs/commit/57c1632f1158da2f6e60b59b029aa212bd55a8e4) from 15 years (SVN, babyyyyyy), and aren't followed by any kind of maintenance of at least these packages since. Also too sporadically active on Github in general (see their page), with a couple of opened threads in 2024 and 2025 each. So, eligible for removal from maintainers per https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status

Tobias @tobias-hammerschmidt, if you're alive and well, we'll give you a week (until 16:00 UTC on Nov 7) to object this and show us your intent to go on with the maintenance. Even if you don't make it, you're still welcome back.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
