### PR TITLE
haskellPackages.nix-paths: fix after upload of `nix` hackage package

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -652,6 +652,16 @@ with haskellLib;
   # https://github.com/awakesecurity/nix-graph/issues/5
   nix-graph = doJailbreak super.nix-graph;
 
+  # Pass in `pkgs.nix` for the required tools. This means that overriding
+  # them sort of works, but only if you override all instances.
+  nix-paths = super.nix-paths.override {
+    nix-build = pkgs.nix;
+    nix-env = pkgs.nix;
+    nix-hash = pkgs.nix;
+    nix-instantiate = pkgs.nix;
+    nix-store = pkgs.nix;
+  };
+
   # Fix `mv` not working on directories
   turtle = appendPatches [
     (pkgs.fetchpatch {

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -654,13 +654,28 @@ with haskellLib;
 
   # Pass in `pkgs.nix` for the required tools. This means that overriding
   # them sort of works, but only if you override all instances.
-  nix-paths = super.nix-paths.override {
-    nix-build = pkgs.nix;
-    nix-env = pkgs.nix;
-    nix-hash = pkgs.nix;
-    nix-instantiate = pkgs.nix;
-    nix-store = pkgs.nix;
-  };
+  nix-paths =
+    if pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform then
+      super.nix-paths.override {
+        nix-build = pkgs.nix;
+        nix-env = pkgs.nix;
+        nix-hash = pkgs.nix;
+        nix-instantiate = pkgs.nix;
+        nix-store = pkgs.nix;
+      }
+    else
+      # When cross-compiling, nix-paths won't be able to detect
+      # the path to the (host) tools at build time from PATH,
+      # so we instruct it to check at runtime.
+      enableCabalFlag "allow-relative-paths" (
+        super.nix-paths {
+          nix-build = null;
+          nix-env = null;
+          nix-hash = null;
+          nix-instantiate = null;
+          nix-store = null;
+        }
+      );
 
   # Fix `mv` not working on directories
   turtle = appendPatches [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Compare https://github.com/NixOS/cabal2nix/pull/683, https://github.com/NixOS/nixpkgs/pull/452254/commits/b69a73923f69ed5c9333525ed186fda999327cc0

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
