### PR TITLE
prefer-remote-fetch: use override instead of knowledge of build helper internals

### DIFF
--- a/pkgs/build-support/binary-cache/default.nix
+++ b/pkgs/build-support/binary-cache/default.nix
@@ -7,6 +7,9 @@
   nix,
   xz,
   zstd,
+
+  # Used in `pkgs/build-support/prefer-remote-fetch/default.nix`
+  preferLocalBuild ? true,
 }:
 
 # This function is for creating a flat-file binary cache, i.e. the kind created by
@@ -34,7 +37,7 @@ stdenv.mkDerivation {
 
   exportReferencesGraph.closure = rootPaths;
 
-  preferLocalBuild = true;
+  inherit preferLocalBuild;
 
   nativeBuildInputs = [
     coreutils

--- a/pkgs/build-support/buildenv/default.nix
+++ b/pkgs/build-support/buildenv/default.nix
@@ -7,6 +7,9 @@
   lib,
   replaceVars,
   writeClosure,
+
+  # Used in `pkgs/build-support/prefer-remote-fetch/default.nix`
+  preferLocalBuild ? true,
 }:
 
 let
@@ -104,10 +107,10 @@ lib.makeOverridable (
           postBuild
           nativeBuildInputs
           buildInputs
+          preferLocalBuild
           ;
         pkgs = builtins.toJSON chosenOutputs;
         extraPathsFrom = lib.optional includeClosures (writeClosure pathsForClosure);
-        preferLocalBuild = true;
         allowSubstitutes = false;
         # XXX: The size is somewhat arbitrary
         passAsFile = if builtins.stringLength pkgs >= 128 * 1024 then [ "pkgs" ] else [ ];

--- a/pkgs/build-support/dotnet/make-nuget-source/default.nix
+++ b/pkgs/build-support/dotnet/make-nuget-source/default.nix
@@ -2,6 +2,9 @@
   lib,
   python3,
   stdenvNoCC,
+
+  # Used in `pkgs/build-support/prefer-remote-fetch/default.nix`
+  preferLocalBuild ? true,
 }:
 
 {
@@ -14,7 +17,7 @@
 stdenvNoCC.mkDerivation (
   lib.recursiveUpdate
     {
-      inherit name;
+      inherit name preferLocalBuild;
 
       nativeBuildInputs = [ python3 ];
 

--- a/pkgs/build-support/fetchdocker/default.nix
+++ b/pkgs/build-support/fetchdocker/default.nix
@@ -5,6 +5,9 @@
   bash,
   gnutar,
   writeText,
+
+  # Used in `pkgs/build-support/prefer-remote-fetch/default.nix`
+  preferLocalBuild ? true,
 }:
 let
   stripScheme = builtins.replaceStrings [ "https://" "http://" ] [ "" "" ];
@@ -59,13 +62,13 @@ in
 stdenv.mkDerivation {
   builder = ./fetchdocker-builder.sh;
   buildInputs = [ coreutils ];
-  preferLocalBuild = true;
 
   inherit
     name
     imageName
     repository
     tag
+    preferLocalBuild
     ;
   inherit
     bash

--- a/pkgs/build-support/fetchfossil/default.nix
+++ b/pkgs/build-support/fetchfossil/default.nix
@@ -3,6 +3,9 @@
   lib,
   fossil,
   cacert,
+
+  # Used in `pkgs/build-support/prefer-remote-fetch/default.nix`
+  preferLocalBuild ? true,
 }:
 
 lib.fetchers.withNormalizedHash { } (
@@ -29,7 +32,6 @@ lib.fetchers.withNormalizedHash { } (
     inherit outputHash outputHashAlgo;
     outputHashMode = "recursive";
 
-    inherit url rev;
-    preferLocalBuild = true;
+    inherit url rev preferLocalBuild;
   }
 )

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -6,9 +6,13 @@
   git,
   git-lfs,
   cacert,
+
+  # Used in `pkgs/build-support/prefer-remote-fetch/default.nix`
+  preferLocalBuild ? true,
 }:
 
 let
+  preferLocalBuildDefault = preferLocalBuild;
   urlToName =
     {
       url,
@@ -68,7 +72,7 @@ lib.makeOverridable (
           # Shell code executed after the file has been fetched
           # successfully. This can do things like check or transform the file.
           postFetch ? "",
-          preferLocalBuild ? true,
+          preferLocalBuild ? preferLocalBuildDefault,
           fetchLFS ? false,
           # Shell code to build a netrc file for BASIC auth
           netrcPhase ? null,

--- a/pkgs/build-support/fetchgx/default.nix
+++ b/pkgs/build-support/fetchgx/default.nix
@@ -5,6 +5,9 @@
   gx-go,
   go,
   cacert,
+
+  # Used in `pkgs/build-support/prefer-remote-fetch/default.nix`
+  preferLocalBuild ? true,
 }:
 
 lib.fetchers.withNormalizedHash { } (
@@ -17,7 +20,7 @@ lib.fetchers.withNormalizedHash { } (
 
   stdenvNoCC.mkDerivation {
     name = "${name}-gxdeps";
-    inherit src;
+    inherit src preferLocalBuild;
 
     nativeBuildInputs = [
       cacert
@@ -42,7 +45,5 @@ lib.fetchers.withNormalizedHash { } (
     installPhase = ''
       mv vendor $out
     '';
-
-    preferLocalBuild = true;
   }
 )

--- a/pkgs/build-support/fetchhg/default.nix
+++ b/pkgs/build-support/fetchhg/default.nix
@@ -2,7 +2,13 @@
   lib,
   stdenvNoCC,
   mercurial,
+
+  # Used in `pkgs/build-support/prefer-remote-fetch/default.nix`
+  preferLocalBuild ? true,
 }:
+let
+  preferLocalBuildDefault = preferLocalBuild;
+in
 
 lib.extendMkDerivation {
   constructDrv = stdenvNoCC.mkDerivation;
@@ -16,7 +22,7 @@ lib.extendMkDerivation {
       sha256 ? null,
       hash ? null,
       fetchSubrepos ? false,
-      preferLocalBuild ? true,
+      preferLocalBuild ? preferLocalBuildDefault,
     }:
     # TODO: statically check if mercurial has https support if the url starts with https.
     {

--- a/pkgs/build-support/fetchipfs/default.nix
+++ b/pkgs/build-support/fetchipfs/default.nix
@@ -2,7 +2,15 @@
   lib,
   stdenv,
   curl,
+
+  # Used in `pkgs/build-support/prefer-remote-fetch/default.nix`
+  preferLocalBuild ? true,
 }:
+
+let
+  preferLocalBuildDefault = preferLocalBuild;
+in
+
 lib.fetchers.withNormalizedHash
   {
     hashTypes = [
@@ -21,7 +29,7 @@ lib.fetchers.withNormalizedHash
       meta ? { },
       port ? "8080",
       postFetch ? "",
-      preferLocalBuild ? true,
+      preferLocalBuild ? preferLocalBuildDefault,
     }:
     stdenv.mkDerivation {
       name = ipfs;

--- a/pkgs/build-support/fetchrepoproject/default.nix
+++ b/pkgs/build-support/fetchrepoproject/default.nix
@@ -4,6 +4,9 @@
   gitRepo,
   cacert,
   copyPathsToStore,
+
+  # Used in `pkgs/build-support/prefer-remote-fetch/default.nix`
+  preferLocalBuild ? true,
 }:
 lib.fetchers.withNormalizedHash { } (
   {
@@ -58,6 +61,7 @@ lib.fetchers.withNormalizedHash { } (
     inherit
       cacert
       manifest
+      preferLocalBuild
       rev
       repoRepoURL
       repoRepoRev
@@ -67,7 +71,6 @@ lib.fetchers.withNormalizedHash { } (
     inherit outputHash outputHashAlgo;
     outputHashMode = "recursive";
 
-    preferLocalBuild = true;
     enableParallelBuilding = true;
 
     impureEnvVars = fetchers.proxyImpureEnvVars ++ [

--- a/pkgs/build-support/fetchs3/default.nix
+++ b/pkgs/build-support/fetchs3/default.nix
@@ -2,6 +2,9 @@
   lib,
   runCommand,
   awscli,
+
+  # Used in `pkgs/build-support/prefer-remote-fetch/default.nix`
+  preferLocalBuild ? true,
 }:
 lib.fetchers.withNormalizedHash { } (
   {
@@ -35,10 +38,8 @@ lib.fetchers.withNormalizedHash { } (
       {
         nativeBuildInputs = [ awscli ];
 
-        inherit outputHash outputHashAlgo;
+        inherit outputHash outputHashAlgo preferLocalBuild;
         outputHashMode = if recursiveHash then "recursive" else "flat";
-
-        preferLocalBuild = true;
 
         AWS_DEFAULT_REGION = region;
       }

--- a/pkgs/build-support/fetchsvn/default.nix
+++ b/pkgs/build-support/fetchsvn/default.nix
@@ -7,9 +7,13 @@
   glibcLocales,
   sshSupport ? true,
   openssh ? null,
+
+  # Used in `pkgs/build-support/prefer-remote-fetch/default.nix`
+  preferLocalBuild ? true,
 }:
 
 let
+  preferLocalBuildDefault = preferLocalBuild;
   repoToName =
     url: rev:
     let
@@ -48,7 +52,7 @@ in
   hash ? "",
   ignoreExternals ? false,
   ignoreKeywords ? false,
-  preferLocalBuild ? true,
+  preferLocalBuild ? preferLocalBuildDefault,
 }:
 
 assert sshSupport -> openssh != null;

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -8,9 +8,13 @@
   cacert ? null,
   rewriteURL,
   hashedMirrors,
+
+  # Used in `pkgs/build-support/prefer-remote-fetch/default.nix`
+  preferLocalBuild ? true,
 }:
 
 let
+  cpPreferLocalBuild = preferLocalBuild;
 
   mirrors = import ./mirrors.nix // {
     inherit hashedMirrors;
@@ -135,7 +139,7 @@ lib.extendMkDerivation {
       passthru ? { },
       # Doing the download on a remote machine just duplicates network
       # traffic, so don't do that by default
-      preferLocalBuild ? true,
+      preferLocalBuild ? cpPreferLocalBuild,
 
       # Additional packages needed as part of a fetch
       nativeBuildInputs ? [ ],

--- a/pkgs/build-support/prefer-remote-fetch/default.nix
+++ b/pkgs/build-support/prefer-remote-fetch/default.nix
@@ -11,23 +11,17 @@
 # $ echo 'self: super: super.prefer-remote-fetch self super' > ~/.config/nixpkgs/overlays/prefer-remote-fetch.nix
 #
 self: super: {
-  binary-cache = args: super.binary-cache ({ preferLocalBuild = false; } // args);
-  buildenv = args: super.buildenv ({ preferLocalBuild = false; } // args);
-  fetchfossil = args: super.fetchfossil ({ preferLocalBuild = false; } // args);
-  fetchdocker = args: super.fetchdocker ({ preferLocalBuild = false; } // args);
-  fetchgit = args: super.fetchgit ({ preferLocalBuild = false; } // args);
-  fetchgx = args: super.fetchgx ({ preferLocalBuild = false; } // args);
-  fetchhg = args: super.fetchhg ({ preferLocalBuild = false; } // args);
-  fetchipfs = args: super.fetchipfs ({ preferLocalBuild = false; } // args);
-  fetchrepoproject = args: super.fetchrepoproject ({ preferLocalBuild = false; } // args);
-  fetchs3 = args: super.fetchs3 ({ preferLocalBuild = false; } // args);
-  fetchsvn = args: super.fetchsvn ({ preferLocalBuild = false; } // args);
-  fetchurl =
-    fpArgs:
-    super.fetchurl (
-      super.lib.extends (finalAttrs: args: { preferLocalBuild = args.preferLocalBuild or false; }) (
-        super.lib.toFunction fpArgs
-      )
-    );
-  mkNugetSource = args: super.mkNugetSource ({ preferLocalBuild = false; } // args);
+  binary-cache = super.binary-cache.override { preferLocalBuild = false; };
+  buildenv = super.buildenv.override { preferLocalBuild = false; };
+  fetchfossil = super.fetchfossil.override { preferLocalBuild = false; };
+  fetchdocker = super.fetchdocker.override { preferLocalBuild = false; };
+  fetchgit = super.fetchgit.override { preferLocalBuild = false; };
+  fetchgx = super.fetchgx.override { preferLocalBuild = false; };
+  fetchhg = super.fetchhg.override { preferLocalBuild = false; };
+  fetchipfs = super.fetchipfs.override { preferLocalBuild = false; };
+  fetchrepoproject = super.fetchrepoproject.override { preferLocalBuild = false; };
+  fetchs3 = super.fetchs3.override { preferLocalBuild = false; };
+  fetchsvn = super.fetchsvn.override { preferLocalBuild = false; };
+  fetchurl = super.fetchurl.override { preferLocalBuild = false; };
+  mkNugetSource = super.mkNugetSource.override { preferLocalBuild = false; };
 }


### PR DESCRIPTION
What do you all think of this? There's a lot of ways to approach this problem, but making these fetchers customizable this way makes sense to me.

Replaces:
- #457086

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md