### PR TITLE
cyclone-scheme: fix cross compilation

### DIFF
--- a/pkgs/by-name/cy/cyclone-scheme/package.nix
+++ b/pkgs/by-name/cy/cyclone-scheme/package.nix
@@ -25,7 +25,11 @@ let
 
     buildInputs = [ libck ];
 
-    makeFlags = [ "PREFIX=${placeholder "out"}" ];
+    makeFlags = [
+      "PREFIX=${placeholder "out"}"
+      "AR:=$(AR)"
+      "RANLIB:=$(RANLIB)"
+    ];
   };
 in
 stdenv.mkDerivation {
@@ -45,7 +49,11 @@ stdenv.mkDerivation {
 
   buildInputs = [ libck ];
 
-  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+    "AR:=$(AR)"
+    "RANLIB:=$(RANLIB)"
+  ];
 
   meta = {
     homepage = "https://justinethier.github.io/cyclone/";


### PR DESCRIPTION
## Things done
- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
