### PR TITLE
bazel_7: fix bazelDeps build on darwin under sandbox=true

### DIFF
--- a/pkgs/by-name/ba/bazel_7/darwin_hacks/BlazeModule.java
+++ b/pkgs/by-name/ba/bazel_7/darwin_hacks/BlazeModule.java
@@ -1,0 +1,7 @@
+package com.google.devtools.build.lib.runtime;
+
+// We only need to capture enough details from Bazel source code
+// to make our modules compile and be binary-compatible.
+// This BlazeModule won't be injected into Bazel classpath.
+public abstract class BlazeModule {
+}

--- a/pkgs/by-name/ba/bazel_7/darwin_hacks/SleepPreventionModule.java
+++ b/pkgs/by-name/ba/bazel_7/darwin_hacks/SleepPreventionModule.java
@@ -1,0 +1,9 @@
+package com.google.devtools.build.lib.platform;
+
+import com.google.devtools.build.lib.runtime.BlazeModule;
+
+// This class can fail in Nix sandbox on Darwin so we replace
+// it with a stub version
+public final class SleepPreventionModule extends BlazeModule {
+  // do nothing
+}

--- a/pkgs/by-name/ba/bazel_7/darwin_hacks/SystemSuspensionModule.java
+++ b/pkgs/by-name/ba/bazel_7/darwin_hacks/SystemSuspensionModule.java
@@ -1,0 +1,15 @@
+package com.google.devtools.build.lib.platform;
+
+import com.google.devtools.build.lib.runtime.BlazeModule;
+
+// This class can fail in Nix sandbox on Darwin so we replace
+// it with a stub version
+public final class SystemSuspensionModule extends BlazeModule {
+  // do nothing
+
+  // this method is part of module interface
+  synchronized void suspendCallback(int reason) {
+    // do nothing
+  }
+}
+

--- a/pkgs/by-name/ba/bazel_7/darwin_hacks/default.nix
+++ b/pkgs/by-name/ba/bazel_7/darwin_hacks/default.nix
@@ -1,0 +1,75 @@
+{
+  stdenv,
+  buildJdk,
+  runJdk,
+  version,
+  writeScript,
+}:
+let
+  fakeBazelModules = stdenv.mkDerivation {
+    pname = "fakeBazelModules";
+    inherit version;
+    dontUnpack = true;
+    buildPhase = "
+      # Java file name needs to match class name so we need to copy
+      cp ${./BlazeModule.java} ./BlazeModule.java
+      cp ${./SystemSuspensionModule.java} ./SystemSuspensionModule.java
+      cp ${./SleepPreventionModule.java} ./SleepPreventionModule.java
+
+      # compile all sources
+      ${buildJdk}/bin/javac -d . BlazeModule.java SystemSuspensionModule.java SleepPreventionModule.java
+
+      # don't package BlazeModule.class as we want to use real base class, but a stub compatible version was needed to make
+      # fake modules compile
+      ${buildJdk}/bin/jar cf output.jar ./com/google/devtools/build/lib/platform/{SystemSuspension,SleepPrevention}Module.class
+    ";
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/
+      install -Dm755 output.jar $out/output.jar
+
+      runHook postInstall
+    '';
+
+  };
+  # bin/java wrapper that injects fake modules into classpath
+  jvmInterceptSh = writeScript "java" ''
+    #!/usr/bin/env bash
+
+    # replaces
+    # .. -jar foo.jar ..
+    # with
+    # .. -cp ..overrides..:foo.jar MainClass ..
+    # to inject fake modules classes into Bazel
+
+    for (( i=2; i <= "$#"; i++ )); do
+      if [[ "''${!i}" == "-jar" ]]; then
+        prev=$(( i - 1 ))
+        jar=$(( i + 1 ))
+        MAIN_CLASS=$(unzip -qc "''${!jar}" META-INF/MANIFEST.MF | grep "^Main-Class: " | cut -d " " -f 2- | tr -d "\r")
+        next=$(( jar + 1 ))
+        exec "${runJdk}/bin/java" "''${@:1:prev}" -cp "${fakeBazelModules}/output.jar:''${!jar}" "$MAIN_CLASS" "''${@:next}"
+      fi
+    done
+
+    echo "Failed to find -jar argument in: $@" >&2
+    exit 1
+  '';
+in
+{
+  jvmIntercept = stdenv.mkDerivation {
+    pname = "jvmIntercept";
+    inherit version;
+    dontUnpack = true;
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/bin
+      install -Dm755 ${jvmInterceptSh} $out/bin/java
+
+      runHook postInstall
+    '';
+  };
+
+}


### PR DESCRIPTION
Fixes
```
Server crashed during startup. Now printing ..../server/jvm.out
OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
FATAL: CHECK failed: (suspend_state.connect_port) != (0):
```
by overriding sleep&suspend prevention module in darwin bootstrap bazel binary

Initially had this code implemented for `bazel_8`, but in the end recent `bazel_8` versions don't need binary bootstrap bazel and don't hit this issue anymore (https://github.com/NixOS/nixpkgs/pull/362414)

Now hit this again trying to update `bazel_7`, so making PR for `bazel_7`, separately from version bump as it is the same thing for 7.6.0 and 7.7.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
