### PR TITLE
ci/eval: avoid passing args around

### DIFF
--- a/ci/eval/default.nix
+++ b/ci/eval/default.nix
@@ -19,6 +19,15 @@
   nix,
 }:
 
+{
+  # The number of attributes per chunk, see ./README.md for more info.
+  chunkSize ? 5000,
+  # Whether to just evaluate a single chunk for quick testing
+  quickTest ? false,
+  # Don't try to eval packages marked as broken.
+  includeBroken ? false,
+}:
+
 let
   nixpkgs =
     with lib.fileset;
@@ -79,13 +88,6 @@ let
       evalSystem ? builtins.currentSystem,
       # The path to the `paths.json` file from `attrpathsSuperset`
       attrpathFile ? "${attrpathsSuperset { inherit evalSystem; }}/paths.json",
-      # The number of attributes per chunk, see ./README.md for more info.
-      chunkSize ? 5000,
-
-      # Don't try to eval packages marked as broken.
-      includeBroken ? false,
-      # Whether to just evaluate a single chunk for quick testing
-      quickTest ? false,
     }:
     let
       singleChunk = writeShellScript "single-chunk" ''
@@ -259,16 +261,13 @@ let
     {
       # Whether to evaluate on a specific set of systems, by default all are evaluated
       evalSystems ? if quickTest then [ "x86_64-linux" ] else supportedSystems,
-      # The number of attributes per chunk, see ./README.md for more info.
-      chunkSize ? 5000,
-      quickTest ? false,
     }:
     symlinkJoin {
       name = "nixpkgs-eval-baseline";
       paths = map (
         evalSystem:
         singleSystem {
-          inherit quickTest evalSystem chunkSize;
+          inherit evalSystem;
         }
       ) evalSystems;
     };
@@ -277,9 +276,6 @@ let
     {
       # Whether to evaluate on a specific set of systems, by default all are evaluated
       evalSystems ? if quickTest then [ "x86_64-linux" ] else supportedSystems,
-      # The number of attributes per chunk, see ./README.md for more info.
-      chunkSize ? 5000,
-      quickTest ? false,
       baseline,
       # Which maintainer should be considered the author?
       # Defaults to nixpkgs-ci which is not a maintainer and skips the check.
@@ -300,7 +296,7 @@ let
             inherit evalSystem;
             beforeDir = baseline;
             afterDir = singleSystem {
-              inherit quickTest evalSystem chunkSize;
+              inherit evalSystem;
             };
           }
         ) evalSystems;


### PR DESCRIPTION
There is no point in passing these arguments around between all the different parts of the eval chain - these global settings should surely not be modified between different steps.

This also makes it simpler to add new arguments like extra nixpkgs configuration.

Result of staring at #457204 and being annoyed why we need to add this in so many places.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
