### PR TITLE
Revert "config: add and document {allow,block}listedLicenses"

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -64,8 +64,8 @@ let
     in
     if envVar != "" then envVar != "0" else config.allowNonSource or true;
 
-  allowlist = config.allowlistedLicenses;
-  blocklist = config.blocklistedLicenses;
+  allowlist = config.allowlistedLicenses or config.whitelistedLicenses or [ ];
+  blocklist = config.blocklistedLicenses or config.blacklistedLicenses or [ ];
 
   areLicenseListsValid =
     if mutuallyExclusive allowlist blocklist then

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -229,36 +229,6 @@ let
       '';
     };
 
-    allowlistedLicenses = mkOption {
-      description = ''
-        Allow licenses that are specifically acceptable. `allowlistedLicenses` only applies to unfree licenses unless
-        `allowUnfree` is enabled. It is not a generic allowlist for all types of licenses.
-      '';
-      default = [ ];
-      type = types.listOf (types.attrsOf types.anything);
-      example = literalExpression ''
-        with lib.licenses; [
-          amd
-          wtfpl
-        ]
-      '';
-    };
-
-    blocklistedLicenses = mkOption {
-      description = ''
-        Block licenses that are specifically unacceptable. Unlike `allowlistedLicenses`, `blocklistedLicenses`
-        applies to all licenses.
-      '';
-      default = [ ];
-      type = types.listOf (types.attrsOf types.anything);
-      example = literalExpression ''
-        with lib.licenses; [
-          agpl3Only
-          gpl3Only
-        ]
-      '';
-    };
-
     cudaSupport = mkMassRebuild {
       feature = "build packages with CUDA support by default";
     };


### PR DESCRIPTION
This reverts commit f5deefd4631e6062a2b84c62f1eb6d0c1a8e4ccf.

See:

- https://github.com/NixOS/nixpkgs/pull/437723 (introduced commit)
- https://github.com/NixOS/nixpkgs/issues/456994 (reported breakage)
- https://github.com/NixOS/nixpkgs/pull/457038 (attempted fix, closed in favor of this revert)
- https://github.com/NixOS/nixpkgs/pull/457120 (fix which would require more breaking changes)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
