### PR TITLE
Fix swap creation failure

### DIFF
--- a/nixos/modules/config/swap.nix
+++ b/nixos/modules/config/swap.nix
@@ -297,7 +297,7 @@ in
               ${lib.optionalString (sw.size != null) ''
                 currentSize=$(( $(stat -c "%s" "$DEVICE" 2>/dev/null || echo 0) / 1024 / 1024 ))
                 if [[ ! -b "$DEVICE" && "${toString sw.size}" != "$currentSize" ]]; then
-                  if [[ $(stat -f -c %T $(dirname "$DEVICE")) == "btrfs" ]]; then
+                  if [[ $(stat -f -c %T "$(dirname "$DEVICE")") == "btrfs" ]]; then
                     # Use btrfs mkswapfile to speed up the creation of swapfile.
                     rm -f "$DEVICE"
                     btrfs filesystem mkswapfile --size "${toString sw.size}M" --uuid clear "$DEVICE"
@@ -307,9 +307,9 @@ in
                     chattr +C "$DEVICE" 2>/dev/null || true
 
                     echo "Creating swap file using dd and mkswap."
-                    mkdir -p $(dirname $DEVICE)
+                    mkdir -p "$(dirname "$DEVICE")"
                     dd if=/dev/zero of="$DEVICE" bs=1M count=${toString sw.size} status=progress
-                    ${lib.optionalString (!sw.randomEncryption.enable) "mkswap ${sw.realDevice}"}
+                    ${lib.optionalString (!sw.randomEncryption.enable) "mkswap \"${sw.realDevice}\""}
                   fi
                 fi
               ''}

--- a/nixos/modules/config/swap.nix
+++ b/nixos/modules/config/swap.nix
@@ -307,6 +307,7 @@ in
                     chattr +C "$DEVICE" 2>/dev/null || true
 
                     echo "Creating swap file using dd and mkswap."
+                    mkdir -p $(dirname $DEVICE)
                     dd if=/dev/zero of="$DEVICE" bs=1M count=${toString sw.size} status=progress
                     ${lib.optionalString (!sw.randomEncryption.enable) "mkswap ${sw.realDevice}"}
                   fi


### PR DESCRIPTION
To ensure correct swap creation and avoid [the system being stuck on boot](https://discourse.nixos.org/t/swapfile-start-fails-on-reboot/35512), It creates the directory beforehand

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

@arianvp
@elvishjerricco