### PR TITLE
mjpegtools: Fix build on POWER targets with AltiVec-free baseline

### DIFF
--- a/pkgs/by-name/mj/mjpegtools/package.nix
+++ b/pkgs/by-name/mj/mjpegtools/package.nix
@@ -56,6 +56,13 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     sed -i -e '/ARCHFLAGS=/s:=.*:=:' configure
+  ''
+  # Only ppc64le baseline guarantees AltiVec, no configure option to disable it so just make checks never signal success.
+  # AltiVec code also fails without disabling new compiler warnings:
+  # quant_non_intra.c:72:42: error: initialization of '__vector unsigned short *' {aka '__vector(8) short unsigned int *'} from incompatible pointer type 'uint16_t *' {aka 'short unsigned int *'} [-Wincompatible-pointer-types]
+  + lib.optionalString (!(stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian)) ''
+    substituteInPlace configure \
+      --replace-fail 'have_altivec=true' 'have_altivec=false'
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
```
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I../.. -I../.. -I../../utils -g -O2 -DHAVE_ALTIVEC_H=1 -maltivec -mabi=altivec -Wall -Wunused -c quant_non_intra.c  -fPIC -DPIC -o .libs/quant_non_intra.o
quant_non_intra.c: In function 'quant_non_intra_altivec':
quant_non_intra.c:72:42: error: initialization of '__vector unsigned short *' {aka '__vector(8) short unsigned int *'} from incompatible pointer type 'uint16_t *' {aka 'short unsigned int *'} [-Wincompatible-pointer-types]
   72 |     vector unsigned short *inter_q_mat = wsp->inter_q_mat;
      |                                          ^~~
make[3]: *** [Makefile:528: quant_non_intra.lo] Error 1
```

The baselines for most POWER platforms don't include the AltiVec extension anyway, so just don't build this.

I'll leave fixing of the AltiVec code (code patching, adding flags to compiler calls, w/e) to ppc64le users.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] powerpc64-linux (native & cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
