### PR TITLE
whisper: built with `-no-pie` (prebuilt libraries)

### DIFF
--- a/pkgs/by-name/wh/whisper/package.nix
+++ b/pkgs/by-name/wh/whisper/package.nix
@@ -35,6 +35,12 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  # The package comes with prebuilt static
+  # libraries of bzip2, zlib, libdeflate and asmlib.
+  # They are not built with -fPIE and thus linking fails.
+  # As asmlib is not packages in nixpkgs let's disable PIE.
+  env.NIX_LDFLAGS = "-no-pie";
+
   installPhase = ''
     runHook preInstall
     install -Dt $out/bin whisper whisper-index
@@ -48,5 +54,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/refresh-bio/whisper";
     maintainers = with maintainers; [ jbedo ];
     platforms = platforms.x86_64;
+    sourceProvenance = [ sourceTypes.binaryNativeCode ];
   };
 }


### PR DESCRIPTION
Without the change the build fails as https://hydra.nixos.org/build/310775846:

    ld: libs/libz.a(deflate.o): relocation R_X86_64_32S against `.rodata' can not be used when making a PIE object; recompile with -fPIE
    ld: failed to set dynamic section sizes: bad value

It happens because `libs/libz.a` comes from a
"source" tarball. As some libraries are not packaged in `nixpkgs` let's fall back to `-no-pie`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
