### PR TITLE
bison: force tests to run serially on FreeBSD

### DIFF
--- a/pkgs/by-name/bi/bison/package.nix
+++ b/pkgs/by-name/bi/bison/package.nix
@@ -41,6 +41,8 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ m4 ];
 
   enableParallelBuilding = true;
+  # tests are flaky / timing sensitive on FreeBSD
+  enableParallelChecking = !stdenv.hostPlatform.isFreeBSD;
 
   # Normal check and install check largely execute the same test suite
   doCheck = false;


### PR DESCRIPTION
I noticed that the bison tests were a bit flaky when running on FreeBSD. Sometimes, anywhere from 2 to 7 tests would fail. Once I noticed that different tests were failing across runs, I set up the tests to run serially instead.

This seems to help improve the reliability of the run, and doesn't effect Linux or Darwin, so I'm proposing this as a fix for now. I didn't investigate too much *why* the tests might fail, but I'd be happy to look into it :)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
