### PR TITLE
libffi: link tsan tests with pthread library on FreeBSD

### DIFF
--- a/pkgs/development/libraries/libffi/default.nix
+++ b/pkgs/development/libraries/libffi/default.nix
@@ -27,6 +27,9 @@ stdenv.mkDerivation (finalAttrs: {
   # cgit) that are needed here should be included directly in Nixpkgs as
   # files.
   patches = [
+    # Threading tests need to be linked against pthread
+    # See: https://github.com/libffi/libffi/pull/944
+    ./freebsd-tsan-pthread.patch
   ];
 
   strictDeps = true;

--- a/pkgs/development/libraries/libffi/freebsd-tsan-pthread.patch
+++ b/pkgs/development/libraries/libffi/freebsd-tsan-pthread.patch
@@ -1,0 +1,24 @@
+From e52a0790a9b80492cba2907c27d0a9e4248b6608 Mon Sep 17 00:00:00 2001
+From: Jon Hermansen <jon@jh86.org>
+Date: Tue, 28 Oct 2025 18:02:39 -0400
+Subject: [PATCH] fix tsan tests on FreeBSD by linking to pthread
+
+---
+ testsuite/lib/libffi.exp | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/testsuite/lib/libffi.exp b/testsuite/lib/libffi.exp
+index 81eff7752..308db6f8d 100644
+--- a/testsuite/lib/libffi.exp
++++ b/testsuite/lib/libffi.exp
+@@ -407,6 +407,10 @@ proc libffi_target_compile { source dest type options } {
+             lappend options "libs= -lpthread"
+         }
+ 
++        if { [string match "*-*-freebsd*" $target_triplet] } {
++            lappend options "libs= -lpthread"
++        }
++
+         lappend options "libs= -lffi"
+ 
+         if { [string match "aarch64*-*-linux*" $target_triplet] } {


### PR DESCRIPTION
https://github.com/libffi/libffi/pull/944

On FreeBSD, libffi's threading tests "fail" because they are not linked with pthread library.

I submitted a PR to fix this upstream, but in the mean time, it will be nice to have this in nixpkgs for FreeBSD support. The patch should not effect Linux or Darwin, though it is applied unconditionally. (If this creates a lot of build churn, I'd be happy to apply it conditionally)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
