### PR TITLE
firefox: relax disallowedRequisites to disallowedReferences to fix cuda build

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -560,7 +560,7 @@ let
         unwrapped = browser;
       };
 
-      disallowedRequisites = [ stdenv.cc ];
+      disallowedReferences = [ stdenv.cc ];
       meta = browser.meta // {
         inherit (browser.meta) description;
         mainProgram = launcherName;


### PR DESCRIPTION
When `cudaSupport` is enabled, `cudaPackages.cuda_nvcc` becomes a transitive dependency of `firefox`.
`cuda_nvcc` has `backendStdenv.cc` in its `propagatedBuildInputs` which violates `firefox`'s `disallowedRequisites` policy.
This breaks `firefox` when `cudaSupport` is enabled:
```
firefox> building '/nix/store/7s1dyndj7r33wck6dywjf6kqxah7ngm2-firefox-144.0.2.drv'
firefox> structuredAttrs is enabled
error: output '/nix/store/b3cyrj28jf03mrf15jmy9whhfrgy2bxw-firefox-144.0.2' is not allowed to refer to the following paths:
         /nix/store/x8mydcgbry214s802nzvy7fdljx404ym-gcc-wrapper-14.3.0
```

I propose to relax the `disallowedRequisites` assertion and simply migrate to `disallowedReferences` which ensures that `stdenv.cc` is not a direct dependency of `firefox`.

_NOTE:_ this only became an issue recently (since https://github.com/NixOS/nixpkgs/pull/437723/) because before, `cudaPackages.backendStdenv` and `stdenv` were differing.
Now they are the same, which triggers this error.

cc @mweinelt @booxter
cc @ConnorBaker @SomeoneSerge


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
