### PR TITLE
copyparty: init at 1.19.20

### DIFF
--- a/pkgs/by-name/co/copyparty-full-buggy/package.nix
+++ b/pkgs/by-name/co/copyparty-full-buggy/package.nix
@@ -1,0 +1,17 @@
+{ copyparty }:
+copyparty.override {
+  withHashedPasswords = true;
+  withCertgen = true;
+  withThumbnails = true;
+  withFastThumbnails = true;
+  withMediaProcessing = true;
+  withBasicAudioMetadata = true;
+  withZeroMQ = true;
+  withFTP = true;
+  withFTPS = true;
+  withTFTP = true;
+  withMagic = true;
+  withSMB = true;
+  nameSuffix = "-full-buggy";
+  longDescription = "Full variant, all dependencies and features including those marked buggy";
+}

--- a/pkgs/by-name/co/copyparty-min/package.nix
+++ b/pkgs/by-name/co/copyparty-min/package.nix
@@ -1,0 +1,17 @@
+{ copyparty }:
+copyparty.override {
+  withHashedPasswords = false;
+  withCertgen = false;
+  withThumbnails = false;
+  withFastThumbnails = false;
+  withMediaProcessing = false;
+  withBasicAudioMetadata = false;
+  withZeroMQ = false;
+  withFTP = false;
+  withFTPS = false;
+  withTFTP = false;
+  withSMB = false;
+  withMagic = false;
+  nameSuffix = "-min";
+  longDescription = "Minimal variant, minimal dependencies and fewest features";
+}

--- a/pkgs/by-name/co/copyparty-most/package.nix
+++ b/pkgs/by-name/co/copyparty-most/package.nix
@@ -1,0 +1,17 @@
+{ copyparty }:
+copyparty.override {
+  withHashedPasswords = true;
+  withCertgen = true;
+  withThumbnails = true;
+  withFastThumbnails = true;
+  withMediaProcessing = true;
+  withBasicAudioMetadata = true;
+  withZeroMQ = true;
+  withFTP = true;
+  withFTPS = true;
+  withTFTP = true;
+  withSMB = false;
+  withMagic = true;
+  nameSuffix = "-most";
+  longDescription = "Almost-full variant, all dependencies and features except those marked buggy";
+}

--- a/pkgs/by-name/co/copyparty/package.nix
+++ b/pkgs/by-name/co/copyparty/package.nix
@@ -1,0 +1,174 @@
+# partially sourced from https://github.com/9001/copyparty/blob/hovudstraum/contrib/package/nix/copyparty/default.nix
+{
+  lib,
+
+  fetchurl,
+
+  python3Packages,
+
+  # non-python deps
+  cfssl,
+  ffmpeg,
+  util-linux,
+
+  # options
+  # use argon2id-hashed passwords in config files (sha2 is always available)
+  withHashedPasswords ? true,
+
+  # generate TLS certificates on startup (pointless when reverse-proxied)
+  withCertgen ? true,
+
+  # create thumbnails with Pillow; faster than FFmpeg / MediaProcessing
+  withThumbnails ? true,
+
+  # create thumbnails with PyVIPS; even faster, uses more memory
+  # -- can be combined with Pillow to support more filetypes
+  withFastThumbnails ? false,
+
+  # enable FFmpeg; thumbnails for most filetypes (also video and audio), extract audio metadata, transcode audio to opus
+  # -- possibly dangerous if you allow anonymous uploads, since FFmpeg has a huge attack surface
+  # -- can be combined with Thumbnails and/or FastThumbnails, since FFmpeg is slower than both
+  withMediaProcessing ? true,
+
+  # if MediaProcessing is not enabled, you probably want this instead (less accurate, but much safer and faster)
+  withBasicAudioMetadata ? false,
+
+  # send ZeroMQ messages from event-hooks
+  withZeroMQ ? true,
+
+  # enable FTP server
+  withFTP ? true,
+
+  # enable FTPS support in the FTP server
+  withFTPS ? false,
+
+  # enable TFTP server
+  withTFTP ? false,
+
+  # samba/cifs server; dangerous and buggy, enable if you really need it
+  withSMB ? false,
+
+  # enables filetype detection for nameless uploads
+  withMagic ? false,
+
+  # extra packages to add to the PATH
+  extraPackages ? [ ],
+
+  # function that accepts a python packageset and returns a list of packages to
+  # be added to the python venv. useful for scripts and such that require
+  # additional dependencies
+  extraPythonPackages ? (_p: [ ]),
+
+  nameSuffix ? "",
+
+  # this goes directly into meta.longDescription
+  longDescription ? "Default build",
+}:
+
+let
+  runtimeDeps = ([ util-linux ] ++ extraPackages ++ lib.optional withMediaProcessing ffmpeg);
+in
+
+python3Packages.buildPythonApplication rec {
+  pname = "copyparty${nameSuffix}";
+  version = "1.19.20";
+
+  src = fetchurl {
+    url = "https://github.com/9001/copyparty/releases/download/v${version}/copyparty-${version}.tar.gz";
+    hash = "sha256-BQzMNFVOWSEKynpn2HoYbmmz9NvgE9XuLxGiLCWagqY=";
+  };
+
+  pyproject = true;
+
+  build-system = [
+    python3Packages.setuptools
+  ];
+
+  dependencies =
+    with python3Packages;
+    [
+      jinja2
+      fusepy
+    ]
+    ++ lib.optional withSMB impacket
+    ++ lib.optional withFTP pyftpdlib
+    ++ lib.optional withFTPS pyopenssl
+    ++ lib.optional withTFTP partftpy
+    ++ lib.optional withCertgen cfssl
+    ++ (lib.optionals withThumbnails [
+      pillow
+      pillow-jpls
+      pillow-heif
+      rawpy
+    ])
+    ++ lib.optional withFastThumbnails pyvips
+    ++ lib.optional withMediaProcessing ffmpeg
+    ++ lib.optional withBasicAudioMetadata mutagen
+    ++ lib.optional withHashedPasswords argon2-cffi
+    ++ lib.optional withZeroMQ pyzmq
+    ++ lib.optional withMagic magic
+    ++ (extraPythonPackages python3Packages);
+
+  makeWrapperArgs = [ "--prefix PATH : ${lib.makeBinPath runtimeDeps}" ];
+
+  meta = {
+    description = "turn almost any device into a file server over http(s), webdav, ftp(s), and tftp";
+    inherit longDescription;
+    homepage = "https://github.com/9001/copyparty";
+    license =
+      let
+        # list from https://github.com/9001/copyparty/blob/hovudstraum/scripts/deps-docker/Dockerfile
+        includedLibraryLicenses = with lib.licenses; {
+          # https://github.com/openpgpjs/asmcrypto.js
+          asmcrypto = mit;
+          # https://github.com/markedjs/marked
+          marked = [
+            # https://github.com/markedjs/marked/blob/master/LICENSE.md
+            mit
+            bsd3
+          ];
+          # https://github.com/Ionaru/easy-markdown-editor
+          easy-markdown-editor = lib.licenses.mit;
+          # https://github.com/codemirror/codemirror5
+          codemirror = lib.licenses.mit;
+          # https://github.com/cure53/DOMPurify
+          dompurify = [
+            asl20 # or
+            mpl20
+          ];
+          # https://github.com/FortAwesome/Font-Awesome
+          font-awesome = [
+            cc-by-40
+            ofl
+            mit
+          ];
+          # https://github.com/PrismJS/prism/blob/v2/LICENSE
+          prism = mit;
+          # https://files.pythonhosted.org/packages/04/0b/4506cb2e831cea4b0214d3625430e921faaa05a7fb520458c75a2dbd2152/fusepy-3.0.1.tar.gz
+          # https://pypi.org/project/fusepy
+          # https://github.com/fusepy/fusepy
+          fusepy = isc;
+        };
+        copypartyLicense = lib.licenses.mit;
+        res = lib.pipe includedLibraryLicenses [
+          builtins.attrValues
+          (a: a ++ [ copypartyLicense ])
+          lib.flatten
+          lib.unique
+        ];
+      in
+      res;
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      # the javascript deps come pre-built
+      # see https://github.com/9001/copyparty/blob/hovudstraum/scripts/deps-docker/Dockerfile
+      binaryBytecode
+      binaryNativeCode
+    ];
+    maintainers = with lib.maintainers; [
+      shelvacu
+    ];
+    mainProgram = "copyparty";
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/development/python-modules/partftpy/default.nix
+++ b/pkgs/development/python-modules/partftpy/default.nix
@@ -1,0 +1,38 @@
+# mostly copied from https://github.com/9001/copyparty/blob/hovudstraum/contrib/package/nix/partftpy/default.nix
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+}:
+buildPythonPackage rec {
+  pname = "partftpy";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "9001";
+    repo = "partftpy";
+    tag = "v${version}";
+    hash = "sha256-9+zY9OpGQ3LbORwtjEYZF1lRaQCLmSyQ9KQdxaOzMuM=";
+  };
+
+  postPatch = ''
+    # poor setuptools gets confused by this dir
+    rm -r t
+  '';
+
+  pyproject = true;
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "partftpy.TftpServer" ];
+
+  meta = {
+    description = "Pure Python TFTP library (copyparty fork of tftpy)";
+    homepage = "https://github.com/9001/partftpy";
+    changelog = "https://github.com/9001/partftpy/releases/tag/${version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.shelvacu ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11550,6 +11550,8 @@ self: super: with self; {
 
   partd = callPackage ../development/python-modules/partd { };
 
+  partftpy = callPackage ../development/python-modules/partftpy { };
+
   partial-json-parser = callPackage ../development/python-modules/partial-json-parser { };
 
   particle = callPackage ../development/python-modules/particle { };


### PR DESCRIPTION
This makes https://github.com/NixOS/nixpkgs/pull/422127 obselete

Copyparty src + readme describing itself: https://github.com/9001/copyparty

Visit the [public demo](https://a.ocv.me/pub/demo/) running on a nuc in the creator's basement, and don't miss [the video](https://a.ocv.me/pub/demo/showcase-hq.webm) made about it.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

---

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `d381ba0755d4e3a0cfad6bb9ef00c752ed30a473`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 12 packages built:</summary>
  <ul>
    <li>copyparty</li>
    <li>copyparty-full-buggy</li>
    <li>copyparty-full-buggy.dist</li>
    <li>copyparty-min</li>
    <li>copyparty-min.dist</li>
    <li>copyparty-most</li>
    <li>copyparty-most.dist</li>
    <li>copyparty.dist</li>
    <li>python312Packages.partftpy-copyparty</li>
    <li>python312Packages.partftpy-copyparty.dist</li>
    <li>python313Packages.partftpy-copyparty</li>
    <li>python313Packages.partftpy-copyparty.dist</li>
  </ul>
</details>


[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
