### PR TITLE
cudaPackages: fix regression, propagating too much

### DIFF
--- a/pkgs/development/cuda-modules/buildRedist/default.nix
+++ b/pkgs/development/cuda-modules/buildRedist/default.nix
@@ -279,8 +279,6 @@ extendMkDerivation {
       ]
       ++ nativeBuildInputs;
 
-      propagatedBuildInputs = [ setupCudaHook ] ++ propagatedBuildInputs;
-
       buildInputs = [
         # autoPatchelfHook will search for a libstdc++ and we're giving it
         # one that is compatible with the rest of nixpkgs, even when

--- a/pkgs/development/cuda-modules/packages/cuda_cudart.nix
+++ b/pkgs/development/cuda-modules/packages/cuda_cudart.nix
@@ -32,12 +32,15 @@ buildRedist (finalAttrs: {
   # NOTE: `cuda_compat` can be disabled by setting the package to `null`. This is useful in cases where
   # the host OS has a recent enough CUDA driver that the compatibility library isn't needed.
   propagatedBuildInputs =
-    # Add the dependency on NVCC's include directory.
-    # - crt/host_config.h
+    # TODO(@SomeoneSerge): Consider propagating `crt/host_config.h`, but only
+    # once we managed to split out `cuda_nvcc`'s headers into a separate output
+    #
     # TODO(@connorbaker): Check that the dependency offset for this is correct.
-    [ (lib.getOutput "include" cuda_nvcc) ]
+    #
+    # [ (lib.getInclude cuda_nvcc) ]
+
     # TODO(@connorbaker): From CUDA 13.0, crt/host_config.h is in cuda_crt
-    ++ lib.optionals (cudaAtLeast "13.0") [ (lib.getOutput "include" cuda_crt) ]
+    lib.optionals (cudaAtLeast "13.0") [ (lib.getOutput "include" cuda_crt) ]
     # Add the dependency on CCCL's include directory.
     # - nv/target
     # TODO(@connorbaker): Check that the dependency offset for this is correct.
@@ -85,6 +88,9 @@ buildRedist (finalAttrs: {
     fi
     popd >/dev/null
   '';
+
+  # "Never again", cf. https://github.com/NixOS/nixpkgs/pull/457424
+  disallowedRequisites = [ (lib.getBin cuda_nvcc) ];
 
   meta.description = "CUDA Runtime";
 })

--- a/pkgs/development/cuda-modules/packages/cuda_nvcc.nix
+++ b/pkgs/development/cuda-modules/packages/cuda_nvcc.nix
@@ -2,6 +2,7 @@
   _cuda,
   backendStdenv,
   buildRedist,
+  setupCudaHook,
   cudaAtLeast,
   cudaOlder,
   cuda_cccl,
@@ -22,7 +23,7 @@ buildRedist (finalAttrs: {
   allowFHSReferences = true;
 
   # Entries here will be in nativeBuildInputs when cuda_nvcc is in nativeBuildInputs
-  propagatedBuildInputs = [ backendStdenv.cc ];
+  propagatedBuildInputs = [ setupCudaHook ];
 
   # Patch the nvcc.profile.
   # Syntax:


### PR DESCRIPTION
Quite likely fixes https://github.com/NixOS/nixpkgs/pull/457391 https://github.com/NixOS/nixpkgs/issues/457406, but I'm waiting for the tests to make sure. Even if it does fix, I'm still analyzing how this could have lead to the extraneous reference in onnxrutime.

Regardless of the bearing on onnxruntime and firefox, this is the pre-refactoring logic that probably shouldn't have been changed (we've been propagating strictly less, and that seemed to have been sufficient).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
