### PR TITLE
xlights: add .desktop file & icon

### DIFF
--- a/pkgs/by-name/xl/xlights/package.nix
+++ b/pkgs/by-name/xl/xlights/package.nix
@@ -13,6 +13,16 @@ appimageTools.wrapType2 rec {
     hash = "sha256-k5HGk5t/ujPuOU/GlxhA+yKKXy0lq8YkxcQkTUVBYXM=";
   };
 
+  appimageContents = appimageTools.extract { inherit pname version src; };
+
+  extraInstallCommands = ''
+    install -m 444 -D ${appimageContents}/xlights.desktop $out/share/applications/xlights.desktop
+    install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/256x256/apps/xlights.png \
+      $out/share/icons/hicolor/256x256/apps/xlights.png
+    substituteInPlace $out/share/applications/xlights.desktop \
+      --replace-fail 'Exec=xLights' 'Exec=xlights'
+  '';
+
   meta = {
     description = "Sequencer for lights with USB and E1.31 drivers";
     homepage = "https://xlights.org";


### PR DESCRIPTION
Allows launching xLights with graphical app launchers, and displays the app icon when launched

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
