### PR TITLE
shadps4: 0.11.0 -> 0.12.5, fix build

### DIFF
--- a/nixos/tests/shadps4.nix
+++ b/nixos/tests/shadps4.nix
@@ -6,7 +6,7 @@
   };
 
   nodes.machine =
-    { config, pkgs, ... }:
+    { pkgs, ... }:
     {
       imports = [ ./common/x11.nix ];
 
@@ -80,37 +80,17 @@
 
     machine.wait_for_x()
 
-    with subtest("starting shadps4 works"):
-        machine.succeed("shadps4 >&2 &")
-        machine.wait_for_text("Directory to install games")
-        machine.screenshot("0001-shadps4-dir-setup-prompt")
-
-        machine.send_chars("/root\n")
-        machine.wait_for_text("Game List")
-        # Make it fullscreen, so mouse coords are simpler & content isn't cut off
-        machine.send_key("alt-f10")
-        # Should now see the rest too
-        machine.wait_for_text("Play Time")
-        machine.screenshot("0002-shadps4-started")
-
     with subtest("running example works"):
         # Ensure that chosen openorbis logo colour isn't present already
         assert (
             check_for_color(openorbisColor)(True) == False
         ), "openorbisColor {} was present on the screen before we launched anything!".format(openorbisColor)
 
-        machine.succeed("xdotool mousemove 20 30 click 1") # click on "File"
-        machine.wait_for_text("Boot Game")
-        machine.send_key("down")
-        machine.send_key("ret")
-
-        # Pick the PNG sample (hello world runs too, but text-only output is currently broken)
-        machine.wait_for_text("Look in")
-        machine.send_chars("/etc/openorbis-sample-packages/OpenOrbis-PNG-Sample/uroot/eboot.bin\n")
+        machine.succeed("shadps4 /etc/openorbis-sample-packages/OpenOrbis-PNG-Sample/uroot/eboot.bin >&2 &")
 
         # Look for logo
         with machine.nested("Waiting for the screen to have openorbisColor {} on it:".format(openorbisColor)):
             retry(check_for_color(openorbisColor))
-        machine.screenshot("0003-shadps4-sample-running")
+        machine.screenshot("0001-shadps4-sample-running")
   '';
 }

--- a/pkgs/by-name/sh/shadps4/package.nix
+++ b/pkgs/by-name/sh/shadps4/package.nix
@@ -21,7 +21,6 @@
   pipewire,
   pkg-config,
   pugixml,
-  qt6,
   rapidjson,
   renderdoc,
   robin-map,
@@ -29,6 +28,7 @@
   sndio,
   stb,
   toml11,
+  util-linux,
   vulkan-headers,
   vulkan-loader,
   vulkan-memory-allocator,
@@ -42,13 +42,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "shadps4";
-  version = "0.11.0";
+  version = "0.12.5";
 
   src = fetchFromGitHub {
     owner = "shadps4-emu";
     repo = "shadPS4";
     tag = "v.${finalAttrs.version}";
-    hash = "sha256-ZHgwFWSoEaWILTafet5iQvaLwLtXy3HuCxjkQMt4PBA=";
+    hash = "sha256-H/GOnArWxMe/90qgyLb9fXbeJabUOV8CjLtpGokoStQ=";
     fetchSubmodules = true;
   };
 
@@ -71,11 +71,6 @@ stdenv.mkDerivation (finalAttrs: {
     libgbm
     pipewire
     pugixml
-    qt6.qtbase
-    qt6.qtdeclarative
-    qt6.qtmultimedia
-    qt6.qttools
-    qt6.qtwayland
     rapidjson
     renderdoc
     robin-map
@@ -83,6 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
     sndio
     stb
     toml11
+    util-linux
     vulkan-headers
     vulkan-loader
     vulkan-memory-allocator
@@ -95,11 +91,9 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     pkg-config
-    qt6.wrapQtAppsHook
   ];
 
   cmakeFlags = [
-    (lib.cmakeBool "ENABLE_QT_GUI" true)
     (lib.cmakeBool "ENABLE_UPDATER" false)
   ];
 


### PR DESCRIPTION
https://github.com/shadps4-emu/shadPS4/releases/tag/v.0.12.5
Diff: https://github.com/shadps4-emu/shadPS4/compare/v.0.11.0...v.0.12.5

Starting from 0.12.5, shadps4 will become CLI only. However, launchers for it will be introduced.
I do want to get Darwin working as well, preferably for ARM.

ZHF: #457852

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
