### PR TITLE
kraft: fix pname

### DIFF
--- a/pkgs/by-name/kr/kraft/package.nix
+++ b/pkgs/by-name/kr/kraft/package.nix
@@ -14,7 +14,7 @@
 }:
 
 buildGoModule rec {
-  pname = "kraftkit";
+  pname = "kraft";
   version = "0.12.5";
 
   src = fetchFromGitHub {


### PR DESCRIPTION
The proper pname is 'kraft' as the tool does not exist as 'kraftkit':

```sh
building the system configuration...
error:
       … while calling the 'head' builtin
         at /nix/store/1l18ynbd52x2xq8asyqbdhdngwvhvich-source/lib/attrsets.nix:1534:13:
         1533|           if length values == 1 || pred here (elemAt values 1) (head values) then
         1534|             head values
             |             ^
         1535|           else

       … while evaluating the attribute 'value'
         at /nix/store/1l18ynbd52x2xq8asyqbdhdngwvhvich-source/lib/modules.nix:1083:7:
         1082|     // {
         1083|       value = addErrorContext "while evaluating the option `${showOption loc}':" value;
             |       ^
         1084|       inherit (res.defsFinal') highestPrio;

       … while evaluating the option `system.build.toplevel':

       … while evaluating definitions from `/nix/store/1l18ynbd52x2xq8asyqbdhdngwvhvich-source/nixos/modules/system/activation/top-level.nix':

       … while evaluating the option `warnings':

       … while evaluating definitions from `/nix/store/1l18ynbd52x2xq8asyqbdhdngwvhvich-source/nixos/modules/system/boot/systemd.nix':

       … while evaluating the option `systemd.services.home-manager-a.serviceConfig':

       … while evaluating definitions from `/nix/store/d7kmay2nyrz55xyxibb0cpvyfqawfs9q-source/nixos':

       … while evaluating the option `home-manager.users.a.home.file."/home/a/.config/fontconfig/conf.d/10-hm-fonts.conf".source':

       … while evaluating definitions from `/nix/store/d7kmay2nyrz55xyxibb0cpvyfqawfs9q-source/modules/files.nix':

       … while evaluating the option `home-manager.users.a.home.file."/home/a/.config/fontconfig/conf.d/10-hm-fonts.conf".text':

       … while evaluating definitions from `/nix/store/d7kmay2nyrz55xyxibb0cpvyfqawfs9q-source/modules/misc/xdg.nix':

       … while evaluating the option `home-manager.users.a.xdg.configFile."fontconfig/conf.d/10-hm-fonts.conf".text':

       … while evaluating definitions from `/nix/store/d7kmay2nyrz55xyxibb0cpvyfqawfs9q-source/modules/misc/fontconfig.nix':

       … while evaluating the option `home-manager.users.a.home.packages':

       … while evaluating definitions from `/nix/store/1l18ynbd52x2xq8asyqbdhdngwvhvich-source/flake.nix':

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: undefined variable 'kraftkit'
       at /nix/store/wiyhscjmdiiz9byy0hx21ax54012ypfk-source/home/a.nix:66:28:
           65|       cue efibootmgr bun go ngrok apacheHttpd moreutils bc
           66|       sysstat awscli2 ffuf kraftkit
             |                            ^
           67|     ];
a@alexhp:/c/ > ,ns add kraft # change it from kraftkit
[main 40e2a4b] add kraft
 1 file changed, 1 insertion(+), 1 deletion(-)
Enumerating objects: 7, done.
Counting objects: 100% (7/7), done.
Delta compression using up to 20 threads
Compressing objects: 100% (4/4), done.
Writing objects: 100% (4/4), 404 bytes | 404.00 KiB/s, done.
Total 4 (delta 2), reused 0 (delta 0), pack-reused 0 (from 0)
remote: Resolving deltas: 100% (2/2), completed with 2 local objects.
To github.com:leapingturtlefrog/NixOS.git
   ed3873e..40e2a4b  main -> main
building the system configuration...
activating the configuration...
setting up /etc...
reloading user units for a...
restarting sysinit-reactivation.target
the following new units were started: libvirtd.service, NetworkManager-dispatcher.service
Done. The new configuration is /nix/store/lmxxzghn985vfh465fvx54299icjp7by-nixos-system-alexhp-25.05.20250729.1f08a4d
a@alexhp:/c/ > 
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
