### PR TITLE
topiary: 0.6.1 -> 0.7.0

### DIFF
--- a/pkgs/by-name/to/topiary/package.nix
+++ b/pkgs/by-name/to/topiary/package.nix
@@ -10,19 +10,19 @@
 }:
 rustPlatform.buildRustPackage rec {
   pname = "topiary";
-  version = "0.6.1";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "tweag";
     repo = "topiary";
     tag = "v${version}";
-    hash = "sha256-CyqZhkzAOqC3xWhwUzCpkDO0UFsO0S4/3sV7zIILiVg=";
+    hash = "sha256-49LTUtgroD0wCwJYYb/IN1lsWbAtdfKjGNMuUa2+vhI=";
   };
 
   nativeBuildInputs = [ installShellFiles ];
   nativeInstallCheckInputs = [ versionCheckHook ];
+  cargoHash = "sha256-I3hsaA4N2x00J5+U0z2B1gi1N7QVf7Vnab2scjDpWoo=";
 
-  cargoHash = "sha256-akAjn9a7dMwjPSNveDY2KJ62evjHCAWpRR3A7Ghkb5A=";
 
   # https://github.com/NixOS/nixpkgs/pull/359145#issuecomment-2542418786
   depsExtraArgs.postBuild = ''

--- a/pkgs/by-name/to/topiary/package.nix
+++ b/pkgs/by-name/to/topiary/package.nix
@@ -3,41 +3,29 @@
   stdenv,
   rustPlatform,
   fetchFromGitHub,
-  iconv,
   installShellFiles,
   versionCheckHook,
   nix-update-script,
 }:
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "topiary";
   version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "tweag";
     repo = "topiary";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-49LTUtgroD0wCwJYYb/IN1lsWbAtdfKjGNMuUa2+vhI=";
   };
 
-  nativeBuildInputs = [ installShellFiles ];
-  nativeInstallCheckInputs = [ versionCheckHook ];
   cargoHash = "sha256-I3hsaA4N2x00J5+U0z2B1gi1N7QVf7Vnab2scjDpWoo=";
 
-
-  # https://github.com/NixOS/nixpkgs/pull/359145#issuecomment-2542418786
-  depsExtraArgs.postBuild = ''
-    find $out -name '*.ps1' -print | while read -r file; do
-      if [ "$(file --brief --mime-encoding "$file")" == utf-16be ]; then
-        ${iconv}/bin/iconv -f UTF-16BE -t UTF16LE "$file" > tmp && mv tmp "$file"
-      fi
-    done
-  '';
+  nativeBuildInputs = [ installShellFiles ];
 
   cargoBuildFlags = [
     "-p"
     "topiary-cli"
   ];
-  cargoTestFlags = cargoBuildFlags;
 
   # Skip tests that cannot be executed in sandbox (operation not permitted)
   checkFlags = [
@@ -76,6 +64,7 @@ rustPlatform.buildRustPackage rec {
     "--skip=test_vis"
     "--skip=test_vis_invalid"
   ];
+  cargoTestFlags = finalAttrs.cargoBuildFlags;
 
   env.TOPIARY_LANGUAGE_DIR = "${placeholder "out"}/share/queries";
 
@@ -89,6 +78,8 @@ rustPlatform.buildRustPackage rec {
       --zsh <($out/bin/topiary completion zsh)
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
   doInstallCheck = true;
   versionCheckProgramArg = "--version";
 
@@ -96,13 +87,13 @@ rustPlatform.buildRustPackage rec {
 
   meta = {
     description = "Uniform formatter for simple languages, as part of the Tree-sitter ecosystem";
-    mainProgram = "topiary";
     homepage = "https://github.com/tweag/topiary";
-    changelog = "https://github.com/tweag/topiary/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/tweag/topiary/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       figsoda
       nartsiss
     ];
+    mainProgram = "topiary";
   };
-}
+})


### PR DESCRIPTION
- Update to version [0.7.0 ](https://github.com/tweag/topiary/releases/tag/v0.7.0)| [Changelog](https://github.com/tweag/topiary/releases/tag/v0.7.0) | [Diff](https://github.com/tweag/topiary/compare/v0.6.1...v0.7.0)
- Remove redundant fix
- Remove rec, use `finalAttrs`
- Reorder phases
- Map skipped tests

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
