### PR TITLE
gthumb: 3.12.7 → 3.12.8.1

### DIFF
--- a/pkgs/by-name/gt/gthumb/package.nix
+++ b/pkgs/by-name/gt/gthumb/package.nix
@@ -6,7 +6,6 @@
   pkg-config,
   meson,
   ninja,
-  adwaita-icon-theme,
   exiv2,
   libheif,
   libjpeg,
@@ -22,8 +21,10 @@
   libX11,
   lcms2,
   bison,
+  brasero,
   flex,
   clutter-gtk,
+  colord,
   wrapGAppsHook3,
   shared-mime-info,
   python3,
@@ -33,12 +34,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gthumb";
-  version = "3.12.7";
+  version = "3.12.8.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gthumb/${lib.versions.majorMinor finalAttrs.version}/gthumb-${finalAttrs.version}.tar.xz";
-    sha256 = "sha256-7hLSTPIxAQJB91jWyVudU6c4Enj6dralGLPQmzce+uw=";
+    sha256 = "sha256-JzYvwRylxYHzFoIjDJUCDlofzd9M/+vnVVeCjGF021s=";
   };
+
+  strictDeps = true;
 
   nativeBuildInputs = [
     bison
@@ -53,10 +56,11 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
+    brasero
     clutter-gtk
+    colord
     exiv2
     glib
-    adwaita-icon-theme
     gsettings-desktop-schemas
     gst_all_1.gst-plugins-base
     (gst_all_1.gst-plugins-good.override { gtkSupport = true; })
@@ -73,14 +77,6 @@ stdenv.mkDerivation (finalAttrs: {
     libtiff
     libwebp
     libX11
-  ];
-
-  mesonFlags = [
-    "-Dlibjxl=true"
-    # Depends on libsoup2.
-    # https://gitlab.gnome.org/GNOME/gthumb/-/issues/244
-    "-Dlibchamplain=false"
-    "-Dwebservices=false"
   ];
 
   postPatch = ''


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/gthumb/-/compare/3.12.7...3.12.8.1

Also clean up mesonFlags since they are identical to upstream's default.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

