### PR TITLE
libreoffice: skip test `ArrayFunctionsTest::testArrayFormulasFODS`

### DIFF
--- a/pkgs/applications/office/libreoffice/skip-broken-tests.patch
+++ b/pkgs/applications/office/libreoffice/skip-broken-tests.patch
@@ -188,3 +188,15 @@ index e37df27fd817..937c12e8c4c5 100644
      saveAsPDF(u"tdf163105-kashida-spaces.fodt");
  
      auto pPdfDocument = parsePDFExport();
+diff --git a/sc/qa/unit/functions_array.cxx b/sc/qa/unit/functions_array.cxx
+index ef0da39f5..43caa9002 100644
+--- a/sc/qa/unit/functions_array.cxx
++++ b/sc/qa/unit/functions_array.cxx
+@@ -25,6 +25,7 @@ void ArrayFunctionsTest::testArrayFormulasFODS()
+ 
+ void ArrayFunctionsTest::testDubiousArrayFormulasFODS()
+ {
++    return; // flaky https://github.com/NixOS/nixpkgs/issues/398633
+     //TODO: sc/qa/unit/data/functions/array/dubious/fods/linest.fods produces widely different
+     // values when built with -ffp-contract enabled (-ffp-contract=on default on Clang 14,
+     // -ffp-contract=fast default when building with optimizations on GCC) on at least aarch64


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/issues/398633
https://lists.freedesktop.org/archives/libreoffice/2023-September/090877.html


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
