### PR TITLE
ci/github-script/labels: fix unmaintained packages

### DIFF
--- a/ci/github-script/labels.js
+++ b/ci/github-script/labels.js
@@ -299,10 +299,10 @@ module.exports = async ({ github, context, core, dry }) => {
         '11.by: package-maintainer':
           packages.length &&
           packages.every((pkg) =>
-            maintainers[pkg].includes(pull_request.user.id),
+            maintainers[pkg]?.includes(pull_request.user.id),
           ),
         '12.approved-by: package-maintainer': packages.some((pkg) =>
-          maintainers[pkg].some((m) => approvals.has(m)),
+          maintainers[pkg]?.some((m) => approvals.has(m)),
         ),
       })
     }


### PR DESCRIPTION
The labeler currently breaks for unmaintained packages after the [recent change](https://github.com/NixOS/nixpkgs/pull/457243) to use maintainer maps.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
