### PR TITLE
nixos/keepalived: support nftables for openFirewall

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -793,7 +793,7 @@ in
   kbd-setfont-decompress = runTest ./kbd-setfont-decompress.nix;
   kbd-update-search-paths-patch = runTest ./kbd-update-search-paths-patch.nix;
   kea = runTest ./kea.nix;
-  keepalived = runTest ./keepalived.nix;
+  keepalived = discoverTests (import ./keepalived.nix);
   keepassxc = runTest ./keepassxc.nix;
   kerberos = handleTest ./kerberos/default.nix { };
   kernel-generic = handleTest ./kernel-generic { };

--- a/nixos/tests/keepalived.nix
+++ b/nixos/tests/keepalived.nix
@@ -1,48 +1,60 @@
-{ pkgs, lib, ... }:
+let
+  mkTest =
+    { useNftables }:
+    import ./make-test-python.nix (
+      { pkgs, lib, ... }:
+      {
+        name = "keepalived-${if useNftables then "nftables" else "iptables"}";
+        meta.maintainers = [ lib.maintainers.raitobezarius ];
+
+        nodes = {
+          node1 =
+            { pkgs, ... }:
+            {
+              networking.nftables.enable = useNftables;
+              services.keepalived.enable = true;
+              services.keepalived.openFirewall = true;
+              services.keepalived.vrrpInstances.test = {
+                interface = "eth1";
+                state = "MASTER";
+                priority = 50;
+                virtualIps = [ { addr = "192.168.1.200"; } ];
+                virtualRouterId = 1;
+              };
+              environment.systemPackages = [ pkgs.tcpdump ];
+            };
+          node2 =
+            { pkgs, ... }:
+            {
+              networking.nftables.enable = useNftables;
+              services.keepalived.enable = true;
+              services.keepalived.openFirewall = true;
+              services.keepalived.vrrpInstances.test = {
+                interface = "eth1";
+                state = "MASTER";
+                priority = 100;
+                virtualIps = [ { addr = "192.168.1.200"; } ];
+                virtualRouterId = 1;
+              };
+              environment.systemPackages = [ pkgs.tcpdump ];
+            };
+        };
+
+        testScript = ''
+          # wait for boot time delay to pass
+          for node in [node1, node2]:
+              node.wait_until_succeeds(
+                "systemctl show -p LastTriggerUSecMonotonic keepalived-boot-delay.timer | grep -vq 'LastTriggerUSecMonotonic=0'"
+              )
+              node.wait_for_unit("keepalived")
+          node2.wait_until_succeeds("ip addr show dev eth1 | grep -q 192.168.1.200")
+          node1.fail("ip addr show dev eth1 | grep -q 192.168.1.200")
+          node1.succeed("ping -c1 192.168.1.200")
+        '';
+      }
+    );
+in
 {
-  name = "keepalived";
-  meta.maintainers = [ lib.maintainers.raitobezarius ];
-
-  nodes = {
-    node1 =
-      { pkgs, ... }:
-      {
-        services.keepalived.enable = true;
-        services.keepalived.openFirewall = true;
-        services.keepalived.vrrpInstances.test = {
-          interface = "eth1";
-          state = "MASTER";
-          priority = 50;
-          virtualIps = [ { addr = "192.168.1.200"; } ];
-          virtualRouterId = 1;
-        };
-        environment.systemPackages = [ pkgs.tcpdump ];
-      };
-    node2 =
-      { pkgs, ... }:
-      {
-        services.keepalived.enable = true;
-        services.keepalived.openFirewall = true;
-        services.keepalived.vrrpInstances.test = {
-          interface = "eth1";
-          state = "MASTER";
-          priority = 100;
-          virtualIps = [ { addr = "192.168.1.200"; } ];
-          virtualRouterId = 1;
-        };
-        environment.systemPackages = [ pkgs.tcpdump ];
-      };
-  };
-
-  testScript = ''
-    # wait for boot time delay to pass
-    for node in [node1, node2]:
-        node.wait_until_succeeds(
-            "systemctl show -p LastTriggerUSecMonotonic keepalived-boot-delay.timer | grep -vq 'LastTriggerUSecMonotonic=0'"
-        )
-        node.wait_for_unit("keepalived")
-    node2.wait_until_succeeds("ip addr show dev eth1 | grep -q 192.168.1.200")
-    node1.fail("ip addr show dev eth1 | grep -q 192.168.1.200")
-    node1.succeed("ping -c1 192.168.1.200")
-  '';
+  nftables = mkTest { useNftables = true; };
+  iptables = mkTest { useNftables = false; };
 }

--- a/pkgs/by-name/ke/keepalived/package.nix
+++ b/pkgs/by-name/ke/keepalived/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  passthru.tests.keepalived = nixosTests.keepalived;
+  passthru.tests = nixosTests.keepalived;
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
* Adds `extraInputRules` that correspond to `extra[Stop]Commands`, in order to support nftables-based NixOS firewall
* Adds an additional NixOS test variant, in order to test under both nftables and iptables firewalls

I recommend reviewing this using the ["Hide whitespace changes"](https://github.blog/news-insights/product-news/ignore-white-space-in-code-review/) option, as the actual changes are pretty minimal, but they resulted in a lot changes to the formatting.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
