### PR TITLE
python3Packages.{coal,pinocchio,example-robot-data,ndcurves,tsid,crocoddyl,aligator,mim-solvers}: allow to opt-out of standalone setup

### DIFF
--- a/pkgs/development/python-modules/aligator/default.nix
+++ b/pkgs/development/python-modules/aligator/default.nix
@@ -12,6 +12,8 @@
   python,
   matplotlib,
   pytest,
+
+  buildStandalone ? true,
 }:
 toPythonModule (
   aligator.overrideAttrs (super: {
@@ -19,7 +21,7 @@ toPythonModule (
 
     cmakeFlags = super.cmakeFlags ++ [
       (lib.cmakeBool "BUILD_PYTHON_INTERFACE" true)
-      (lib.cmakeBool "BUILD_STANDALONE_PYTHON_INTERFACE" true)
+      (lib.cmakeBool "BUILD_STANDALONE_PYTHON_INTERFACE" buildStandalone)
     ];
 
     # this is used by CMake at configure/build time
@@ -27,11 +29,12 @@ toPythonModule (
       python
     ];
 
-    propagatedBuildInputs = super.propagatedBuildInputs ++ [
-      aligator
+    propagatedBuildInputs = [
       crocoddyl
       pinocchio
-    ];
+    ]
+    ++ super.propagatedBuildInputs
+    ++ lib.optional buildStandalone aligator;
 
     nativeCheckInputs = [
       pythonImportsCheckHook

--- a/pkgs/development/python-modules/coal/default.nix
+++ b/pkgs/development/python-modules/coal/default.nix
@@ -10,6 +10,8 @@
   eigenpy,
   pylatexenc,
   numpy,
+
+  buildStandalone ? true,
 }:
 toPythonModule (
   coal.overrideAttrs (super: {
@@ -17,7 +19,7 @@ toPythonModule (
 
     cmakeFlags = super.cmakeFlags ++ [
       (lib.cmakeBool "BUILD_PYTHON_INTERFACE" true)
-      (lib.cmakeBool "BUILD_STANDALONE_PYTHON_INTERFACE" true)
+      (lib.cmakeBool "BUILD_STANDALONE_PYTHON_INTERFACE" buildStandalone)
     ];
 
     # those are used by CMake at configure/build time
@@ -26,11 +28,12 @@ toPythonModule (
       pylatexenc
     ];
 
-    propagatedBuildInputs = super.propagatedBuildInputs ++ [
+    propagatedBuildInputs = [
       boost
-      coal
       eigenpy
-    ];
+    ]
+    ++ super.propagatedBuildInputs
+    ++ lib.optional buildStandalone coal;
 
     nativeCheckInputs = [
       pythonImportsCheckHook

--- a/pkgs/development/python-modules/crocoddyl/default.nix
+++ b/pkgs/development/python-modules/crocoddyl/default.nix
@@ -14,6 +14,8 @@
   ipykernel,
   python,
   scipy,
+
+  buildStandalone ? true,
 }:
 toPythonModule (
   crocoddyl.overrideAttrs (super: {
@@ -21,7 +23,7 @@ toPythonModule (
 
     cmakeFlags = super.cmakeFlags ++ [
       (lib.cmakeBool "BUILD_PYTHON_INTERFACE" true)
-      (lib.cmakeBool "BUILD_STANDALONE_PYTHON_INTERFACE" true)
+      (lib.cmakeBool "BUILD_STANDALONE_PYTHON_INTERFACE" buildStandalone)
     ];
 
     # those are used by CMake at configure/build time
@@ -29,10 +31,11 @@ toPythonModule (
       python
     ];
 
-    propagatedBuildInputs = super.propagatedBuildInputs ++ [
-      crocoddyl
+    propagatedBuildInputs = [
       example-robot-data
-    ];
+    ]
+    ++ super.propagatedBuildInputs
+    ++ lib.optional buildStandalone crocoddyl;
 
     nativeCheckInputs = [
       ffmpeg

--- a/pkgs/development/python-modules/example-robot-data/default.nix
+++ b/pkgs/development/python-modules/example-robot-data/default.nix
@@ -8,6 +8,8 @@
 
   python,
   pinocchio,
+
+  buildStandalone ? true,
 }:
 toPythonModule (
   example-robot-data.overrideAttrs (super: {
@@ -15,17 +17,18 @@ toPythonModule (
 
     cmakeFlags = super.cmakeFlags ++ [
       (lib.cmakeBool "BUILD_PYTHON_INTERFACE" true)
-      (lib.cmakeBool "BUILD_STANDALONE_PYTHON_INTERFACE" true)
+      (lib.cmakeBool "BUILD_STANDALONE_PYTHON_INTERFACE" buildStandalone)
     ];
 
     nativeBuildInputs = super.nativeBuildInputs ++ [
       python
     ];
 
-    propagatedBuildInputs = super.propagatedBuildInputs ++ [
-      example-robot-data
+    propagatedBuildInputs = [
       pinocchio
-    ];
+    ]
+    ++ super.propagatedBuildInputs
+    ++ lib.optional buildStandalone example-robot-data;
 
     nativeCheckInputs = [
       pythonImportsCheckHook

--- a/pkgs/development/python-modules/mim-solvers/default.nix
+++ b/pkgs/development/python-modules/mim-solvers/default.nix
@@ -19,6 +19,8 @@
 
   # nativeCheckInputs
   pytest,
+
+  buildStandalone ? true,
 }:
 toPythonModule (
   mim-solvers.overrideAttrs (super: {
@@ -26,7 +28,7 @@ toPythonModule (
 
     cmakeFlags = super.cmakeFlags ++ [
       (lib.cmakeBool "BUILD_PYTHON_INTERFACE" true)
-      (lib.cmakeBool "BUILD_STANDALONE_PYTHON_INTERFACE" true)
+      (lib.cmakeBool "BUILD_STANDALONE_PYTHON_INTERFACE" buildStandalone)
     ];
 
     # this is used by CMake at configure/build time
@@ -38,12 +40,12 @@ toPythonModule (
       boost
       crocoddyl
       eigenpy
-      mim-solvers
       osqp
       proxsuite
       scipy
     ]
-    ++ super.propagatedBuildInputs;
+    ++ super.propagatedBuildInputs
+    ++ lib.optional buildStandalone mim-solvers;
 
     nativeCheckInputs = super.nativeCheckInputs ++ [
       pythonImportsCheckHook

--- a/pkgs/development/python-modules/ndcurves/default.nix
+++ b/pkgs/development/python-modules/ndcurves/default.nix
@@ -9,13 +9,15 @@
   boost,
   pinocchio,
   python,
+
+  buildStandalone ? true,
 }:
 toPythonModule (
   ndcurves.overrideAttrs (super: {
     pname = "py-${super.pname}";
     cmakeFlags = super.cmakeFlags ++ [
       (lib.cmakeBool "BUILD_PYTHON_INTERFACE" true)
-      (lib.cmakeBool "BUILD_STANDALONE_PYTHON_INTERFACE" true)
+      (lib.cmakeBool "BUILD_STANDALONE_PYTHON_INTERFACE" buildStandalone)
     ];
     # those are used by CMake at configure/build time
     nativeBuildInputs = super.nativeBuildInputs ++ [
@@ -24,12 +26,14 @@ toPythonModule (
     propagatedBuildInputs = [
       boost
       pinocchio
-      ndcurves
     ]
-    ++ super.propagatedBuildInputs;
+    ++ super.propagatedBuildInputs
+    ++ lib.optional buildStandalone ndcurves;
+
     nativeCheckInputs = [
       pythonImportsCheckHook
     ];
+
     pythonImportsCheck = [
       "ndcurves"
     ];

--- a/pkgs/development/python-modules/pinocchio/default.nix
+++ b/pkgs/development/python-modules/pinocchio/default.nix
@@ -10,6 +10,8 @@
   casadi,
   matplotlib,
   python,
+
+  buildStandalone ? true,
 }:
 toPythonModule (
   pinocchio.overrideAttrs (super: {
@@ -17,18 +19,19 @@ toPythonModule (
 
     cmakeFlags = super.cmakeFlags ++ [
       (lib.cmakeBool "BUILD_PYTHON_INTERFACE" true)
-      (lib.cmakeBool "BUILD_STANDALONE_PYTHON_INTERFACE" true)
+      (lib.cmakeBool "BUILD_STANDALONE_PYTHON_INTERFACE" buildStandalone)
     ];
 
     nativeBuildInputs = super.nativeBuildInputs ++ [
       python
     ];
 
-    propagatedBuildInputs = super.propagatedBuildInputs ++ [
+    propagatedBuildInputs = [
       casadi
       coal
-      pinocchio
-    ];
+    ]
+    ++ super.propagatedBuildInputs
+    ++ lib.optional buildStandalone pinocchio;
 
     checkInputs = super.checkInputs ++ [
       matplotlib

--- a/pkgs/development/python-modules/tsid/default.nix
+++ b/pkgs/development/python-modules/tsid/default.nix
@@ -8,6 +8,8 @@
 
   pinocchio,
   python,
+
+  buildStandalone ? true,
 }:
 toPythonModule (
   tsid.overrideAttrs (super: {
@@ -15,7 +17,7 @@ toPythonModule (
 
     cmakeFlags = super.cmakeFlags ++ [
       (lib.cmakeBool "BUILD_PYTHON_INTERFACE" true)
-      (lib.cmakeBool "BUILD_STANDALONE_PYTHON_INTERFACE" true)
+      (lib.cmakeBool "BUILD_STANDALONE_PYTHON_INTERFACE" buildStandalone)
     ];
 
     # those are used by CMake at configure/build time
@@ -23,10 +25,11 @@ toPythonModule (
       python
     ];
 
-    propagatedBuildInputs = super.propagatedBuildInputs ++ [
+    propagatedBuildInputs = [
       pinocchio
-      tsid
-    ];
+    ]
+    ++ super.propagatedBuildInputs
+    ++ lib.optional buildStandalone tsid;
 
     nativeCheckInputs = [
       pythonImportsCheckHook


### PR DESCRIPTION
Hi,

In https://github.com/NixOS/nixpkgs/pull/427827 I introduced a new feature in those packages to allow building the pkgs.xxx C++ library, then let pkgs.python3Packages.xxx depend on that instead of rebuilding.

This save a lot of resources, and I think this is the right thing for nixpkgs.

But in other cases, it would be useful to allow opt-out of this feature, eg. to:
- provide devShells with every dependency for manually building those packages from source
- build faster the lib+python module in only one package for CI

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
