### PR TITLE
 empty-epsilon: fix serious-proton build by downgrading glm 

### DIFF
--- a/pkgs/by-name/em/empty-epsilon/package.nix
+++ b/pkgs/by-name/em/empty-epsilon/package.nix
@@ -7,7 +7,7 @@
   libX11,
   glew,
   python3,
-  glm,
+  glm_1_0_1,
   meshoptimizer,
   SDL2,
   ninja,
@@ -42,7 +42,7 @@ let
     buildInputs = [
       sfml
       libX11
-      glm
+      glm_1_0_1
       SDL2
     ];
 
@@ -80,7 +80,7 @@ stdenv.mkDerivation {
     glew
     libX11
     python3
-    glm
+    glm_1_0_1
     SDL2
     ninja
   ];

--- a/pkgs/by-name/em/empty-epsilon/package.nix
+++ b/pkgs/by-name/em/empty-epsilon/package.nix
@@ -14,7 +14,7 @@
 }:
 
 let
-  version = {
+  versions = {
     seriousproton = "2024.12.08";
     emptyepsilon = "2024.12.08";
     basis-universal = "1.15_final";
@@ -23,18 +23,18 @@ let
   basis-universal = fetchFromGitHub {
     owner = "BinomialLLC";
     repo = "basis_universal";
-    tag = version.basis-universal;
+    tag = versions.basis-universal;
     hash = "sha256-pKvfVvdbPIdzdSOklicThS7xwt4i3/21bE6wg9f8kHY=";
   };
 
   serious-proton = stdenv.mkDerivation {
     pname = "serious-proton";
-    version = version.seriousproton;
+    version = versions.seriousproton;
 
     src = fetchFromGitHub {
       owner = "daid";
       repo = "SeriousProton";
-      tag = "EE-${version.seriousproton}";
+      tag = "EE-${versions.seriousproton}";
       hash = "sha256-k1YCB7EJIL+kdlHEU4cJjmLZZAZyxIPU0XlSn2t4C90=";
     };
 
@@ -64,12 +64,12 @@ in
 
 stdenv.mkDerivation {
   pname = "empty-epsilon";
-  version = version.emptyepsilon;
+  version = versions.emptyepsilon;
 
   src = fetchFromGitHub {
     owner = "daid";
     repo = "EmptyEpsilon";
-    tag = "EE-${version.emptyepsilon}";
+    tag = "EE-${versions.emptyepsilon}";
     hash = "sha256-JsHFwbt4VGsgaZz9uxEmwzZGfkYTNsIZTKkpvCCmI48=";
   };
 
@@ -87,10 +87,10 @@ stdenv.mkDerivation {
 
   cmakeFlags = [
     (lib.cmakeFeature "SERIOUS_PROTON_DIR" "${serious-proton.src}")
-    (lib.cmakeFeature "CPACK_PACKAGE_VERSION" "${version.emptyepsilon}")
-    (lib.cmakeFeature "CPACK_PACKAGE_VERSION_MAJOR" "${lib.versions.major version.emptyepsilon}")
-    (lib.cmakeFeature "CPACK_PACKAGE_VERSION_MINOR" "${lib.versions.minor version.emptyepsilon}")
-    (lib.cmakeFeature "CPACK_PACKAGE_VERSION_PATCH" "${lib.versions.patch version.emptyepsilon}")
+    (lib.cmakeFeature "CPACK_PACKAGE_VERSION" "${versions.emptyepsilon}")
+    (lib.cmakeFeature "CPACK_PACKAGE_VERSION_MAJOR" "${lib.versions.major versions.emptyepsilon}")
+    (lib.cmakeFeature "CPACK_PACKAGE_VERSION_MINOR" "${lib.versions.minor versions.emptyepsilon}")
+    (lib.cmakeFeature "CPACK_PACKAGE_VERSION_PATCH" "${lib.versions.patch versions.emptyepsilon}")
     (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_BASIS" "${basis-universal}")
     (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_MESHOPTIMIZER" "${meshoptimizer.src}")
     (lib.cmakeFeature "CMAKE_AR" "${stdenv.cc.cc}/bin/gcc-ar")

--- a/pkgs/by-name/gl/glm/1_0_1.nix
+++ b/pkgs/by-name/gl/glm/1_0_1.nix
@@ -4,12 +4,12 @@
 }:
 
 callPackage ./generic.nix rec {
-  version = "1.0.2";
+  version = "1.0.1";
 
   src = fetchFromGitHub {
     owner = "g-truc";
     repo = "glm";
     rev = version;
-    sha256 = "sha256-2xKv1nO+OdwA0r+I9OZ+OCL9dJFg/LJsQfIvIF76vc0=";
+    sha256 = "sha256-GnGyzNRpzuguc3yYbEFtYLvG+KiCtRAktiN+NvbOICE=";
   };
 }

--- a/pkgs/by-name/gl/glm/generic.nix
+++ b/pkgs/by-name/gl/glm/generic.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+
+  version,
+  src,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "glm";
+  inherit version src;
+
+  outputs = [
+    "out"
+    "doc"
+  ];
+
+  patches = lib.optionals stdenv.hostPlatform.isLinux [
+    # Remove when https://github.com/g-truc/glm/pull/1001 merged & in release.
+    # Relies on <endian.h>, Linux-specific
+    ./1001-glm-Fix-packing-on-BE.patch
+  ];
+
+  nativeBuildInputs = [ cmake ];
+
+  env.NIX_CFLAGS_COMPILE =
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=102823
+    if (stdenv.cc.isGNU && lib.versionAtLeast stdenv.cc.version "11") then
+      "-fno-ipa-modref"
+    # Fix compilation errors on darwin
+    else if (stdenv.cc.isClang) then
+      "-Wno-error"
+    else
+      "";
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" false)
+    (lib.cmakeBool "BUILD_STATIC_LIBS" false)
+    (lib.cmakeBool "GLM_TEST_ENABLE" doCheck)
+  ];
+
+  doCheck = true;
+
+  postInstall = ''
+    # Install pkg-config file
+    mkdir -p $out/lib/pkgconfig
+    substituteAll ${./glm.pc.in} $out/lib/pkgconfig/glm.pc
+
+    # Install docs
+    mkdir -p $doc/share/doc/glm
+    cp -rv ../doc/api $doc/share/doc/glm/html
+    cp -v ../doc/manual.pdf $doc/share/doc/glm
+  '';
+
+  meta = with lib; {
+    description = "OpenGL Mathematics library for C++";
+    longDescription = ''
+      OpenGL Mathematics (GLM) is a header only C++ mathematics library for
+      graphics software based on the OpenGL Shading Language (GLSL)
+      specification and released under the MIT license.
+    '';
+    homepage = "https://github.com/g-truc/glm";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    # https://github.com/g-truc/glm/issues/897 indicates that packing isn't implemented properly on non-LE.
+    # Patch from https://github.com/g-truc/glm/pull/1001 currently relies on Linux-only header.
+    broken = !stdenv.hostPlatform.isLittleEndian && !stdenv.hostPlatform.isLinux;
+    maintainers = with maintainers; [ smancill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1659,6 +1659,8 @@ with pkgs;
 
   glances = python3Packages.callPackage ../applications/system/glances { };
 
+  glm_1_0_1 = callPackage ../by-name/gl/glm/1_0_1.nix { };
+
   go2tv-lite = go2tv.override { withGui = false; };
 
   guglielmo = libsForQt5.callPackage ../applications/radio/guglielmo { };


### PR DESCRIPTION
@wuyoli 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
