### PR TITLE
pacman: 7.0.0 -> 7.1.0, paru: 2.1.0 -> 2.1.0-unstable-2026-01-09

### DIFF
--- a/pkgs/by-name/pa/pacman/dont-create-empty-dirs.patch
+++ b/pkgs/by-name/pa/pacman/dont-create-empty-dirs.patch
@@ -1,8 +1,17 @@
 diff --git a/meson.build b/meson.build
-index c8ee42fd..610401ca 100644
+index 1e8bd8f8..86e68a75 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -414,15 +414,6 @@ install_data(
+@@ -433,8 +433,6 @@ configure_file(
+   configuration : substs,
+   install_dir : join_paths(SYSCONFDIR, 'makepkg.conf.d/'))
+ 
+-install_emptydir(join_paths(SYSCONFDIR, 'makepkg.d/'))
+-
+ configure_file(
+   input : 'etc/pacman.conf.in',
+   output : 'pacman.conf',
+@@ -448,15 +446,6 @@ install_data(
    'proto/proto.install',
    install_dir : join_paths(DATAROOTDIR, 'pacman'))
  

--- a/pkgs/by-name/pa/pacman/package.nix
+++ b/pkgs/by-name/pa/pacman/package.nix
@@ -41,7 +41,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pacman";
-  version = "7.0.0";
+  version = "7.1.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.archlinux.org";
@@ -101,10 +101,6 @@ stdenv.mkDerivation (finalAttrs: {
         --replace-fail "/bin/true" "${coreutils}/bin/true"
       substituteInPlace scripts/repo-add.sh.in \
         --replace-fail bsdtar "${libarchive}/bin/bsdtar"
-
-      # Fix https://gitlab.archlinux.org/pacman/pacman/-/issues/171
-      substituteInPlace scripts/libmakepkg/source/git.sh.in \
-        --replace-warn "---mirror" "--mirror"
     '';
 
   mesonFlags = [

--- a/pkgs/by-name/pa/pacman/package.nix
+++ b/pkgs/by-name/pa/pacman/package.nix
@@ -50,8 +50,8 @@ stdenv.mkDerivation (finalAttrs: {
     domain = "gitlab.archlinux.org";
     owner = "pacman";
     repo = "pacman";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-ejOBxN2HjV4dZwFA7zvPz3JUJa0xiJ/jZ+evEQYG1Mc=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-bGg2ZrIsEYJYZCLsIh4FZROhpyLSBO0Lar1mSoz66wI=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/pa/pacman/package.nix
+++ b/pkgs/by-name/pa/pacman/package.nix
@@ -34,6 +34,9 @@
   gnugrep,
   gnupg,
 
+  # makepkg requires compgen to work
+  bashInteractive,
+
   # Tells pacman where to find ALPM hooks provided by packages.
   # This path is very likely to be used in an Arch-like root.
   sysHookDir ? "/usr/share/libalpm/hooks/",
@@ -55,6 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     asciidoc
+    bashInteractive
     gettext
     installShellFiles
     libarchive

--- a/pkgs/by-name/pa/paru/package.nix
+++ b/pkgs/by-name/pa/paru/package.nix
@@ -12,16 +12,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "paru";
-  version = "2.1.0";
+  version = "2.1.0-unstable-2026-01-09";
 
   src = fetchFromGitHub {
     owner = "Morganamilo";
     repo = "paru";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-i99f2ngYhfVCKpImJ8L7u2T2FgOt7Chp8DHDbrNh1kw=";
+    rev = "9ac3578807a87858651e81a02586ceb947686e7c";
+    hash = "sha256-TJbhxVnP5UhlCmwxKjXq/XaqPGtzHoN5S+lizm3Bmvs=";
   };
 
-  cargoHash = "sha256-USIceRh24WGV0TIrpuyHs4thjaghpxqZmk2uVKBxlm4=";
+  cargoHash = "sha256-Shp/2jQtO3pulT2gmsAcsEVPpv76nbEiGol+kYD7kr8=";
 
   nativeBuildInputs = [
     gettext


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://gitlab.archlinux.org/pacman/pacman/-/releases/v7.1.0

Also bumping paru to the latest commit, so that it can build against pacman 7.1.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
