### PR TITLE
nixos/oink: update service options to pass secrets via file

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -225,6 +225,8 @@
 
 - `rocmPackages.triton` has been removed in favor of `python3Packages.triton`.
 
+- `oink` service no longer accepts `settings.apiKey` and `settings.secretApiKey` options as these have been replaced by `apiKeyFile` and `secretApiKeyFile`.
+
 - `linpinyin`, which is used for Chinese character input, has migrated from the unmaintained BDB database format to the newer KyotoCabinet database format. If you want to migrate your user input statistics you can consider using [bdbtokyotodb](https://codeberg.org/raboof/bdbtokyotodb).
 
 - `go-mockery` has been updated to v3. For migration instructions see the [upstream documentation](https://vektra.github.io/mockery/latest/v3/). If v2 is still required `go-mockery_v2` has been added but will be removed on or before 2029-12-31 in-line with its [upstream support lifecycle](https://vektra.github.io/mockery/)

--- a/nixos/modules/services/networking/oink.nix
+++ b/nixos/modules/services/networking/oink.nix
@@ -20,15 +20,17 @@ in
   options.services.oink = {
     enable = lib.mkEnableOption "Oink, a dynamic DNS client for Porkbun";
     package = lib.mkPackageOption pkgs "oink" { };
+    apiKeyFile = lib.mkOption {
+      type = lib.types.path;
+      example = "/run/keys/oink-api-key";
+      description = "Path to a file containing the API key to use when modifying DNS records.";
+    };
+    secretApiKeyFile = lib.mkOption {
+      type = lib.types.path;
+      example = "/run/keys/oink-secret-api-key";
+      description = "Path to a file containing the secret API key to use when modifying DNS records.";
+    };
     settings = {
-      apiKey = lib.mkOption {
-        type = lib.types.str;
-        description = "API key to use when modifying DNS records.";
-      };
-      secretApiKey = lib.mkOption {
-        type = lib.types.str;
-        description = "Secret API key to use when modifying DNS records.";
-      };
       interval = lib.mkOption {
         # https://github.com/rlado/oink/blob/v1.1.1/src/main.go#L364
         type = lib.types.ints.between 60 172800; # 48 hours
@@ -79,12 +81,29 @@ in
     };
   };
 
+  imports = [
+    (lib.mkRemovedOptionModule [ "services" "oink" "settings" "apiKey" ] ''
+      This option has been removed because it would make the API key world-readable.
+      Use {option}`apiKeyFile` instead.
+      If you insist on keeping the API key world-readable, you can use `oink.apiKeyFile = pkgs.writeText "api-key" "secret";`.
+    '')
+    (lib.mkRemovedOptionModule [ "services" "oink" "settings" "secretApiKey" ] ''
+      This option has been removed because it would make the API key world-readable.
+      Use {option}`secretApiKeyFile` instead.
+      If you insist on keeping the API key world-readable, you can use `oink.secretApiKeyFile = pkgs.writeText "secret-api-key" "secret";`.
+    '')
+  ];
   config = lib.mkIf cfg.enable {
     systemd.services.oink = {
       description = "Dynamic DNS client for Porkbun";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      script = "${cfg.package}/bin/oink -c ${oinkConfig}";
+      script =
+        lib.optionalString (cfg.apiKeyFile != null) "OINK_OVERRIDE_APIKEY=\"$(cat ${cfg.apiKeyFile})\" "
+        + lib.optionalString (
+          cfg.secretApiKeyFile != null
+        ) "OINK_OVERRIDE_SECRETAPIKEY=\"$(cat ${cfg.secretApiKeyFile})\" "
+        + "${cfg.package}/bin/oink -c ${oinkConfig}";
       serviceConfig = {
         Restart = "on-failure";
         RestartSec = "10";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

fixes https://github.com/NixOS/nixpkgs/issues/340376

adds api key file options to not have sensible data world readable, by e.g. providing them via sops-nix

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
