### PR TITLE
workflows/bot: fix permission in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,9 @@ jobs:
               '.github/workflows/pull-request-target.yml',
               '.github/workflows/reviewers.yml',
               '.github/workflows/test.yml',
+              'ci/github-script/bot.js',
+              'ci/github-script/merge.js',
+              'ci/github-script/withRateLimit.js',
             ].includes(file))) core.setOutput('pr', true)
 
   merge-group:


### PR DESCRIPTION
When fixing the permissions of the workflow in CI, I forgot to adjust the permissions for the Test workflow. This is only relevant when making changes to these workflows, not for any other PRs.

Forgot to do that in #457566. This one needs *no* adjustments for the app. Should fix the CI failure in the backport #457557.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
