### PR TITLE
nixos/printing: fix printing from cups-browsed (eg, from ipp-usb)

### DIFF
--- a/nixos/modules/services/printing/cupsd.nix
+++ b/nixos/modules/services/printing/cupsd.nix
@@ -54,6 +54,7 @@ let
       cups-filters
       pkgs.ghostscript
     ]
+    ++ lib.optional cfg.browsed.enable cfg.browsed.package
     ++ cfg.drivers;
     pathsToLink = [
       "/lib"


### PR DESCRIPTION
When cups-browsed was separated from cups in f1f9a54031dbc95b6e924772fddd125debb697bb the implicitclass backend ($out/lib/cups/backend/implicitclass) was moved from cups-filters to cups-browsed. When ipp-usb advertises a printer, cups-browsed configures cups to add an implicitclass://... printer and cups fails to find the corresponding backend:

```
cups.service cupsd[788465] DEBUG Canon_TR4500_series_USB device-uri: Unknown scheme in URI
cups.service cupsd[788465] DEBUG CUPS-Add-Modify-Printer client-error-not-possible: Bad device-uri scheme "implicitclass". 
cups.service cupsd[788465] ERROR [Client 6] Returning IPP client-error-not-possible for CUPS-Add-Modify-Printer (ipp://localhost/printers/Canon_TR4500_series_USB) from localhost
```

This commit adds cups-browsed to the packages that compose the ServerBin option of cups-files.conf so that cups can find the implicitclass backend.

cc cups maintainer @matthewbauer 
cc author of the regression @raboof 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] manually with nixos-rebuild build-vm
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
