### PR TITLE
[Backport release-25.05] powershell: 7.5.1 -> 7.5.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24187,6 +24187,14 @@
     githubId = 1552853;
     name = "Vincent Ambo";
   };
+  tbaldwin = {
+    email = "trent.baldwin@proton.me";
+    matrix = "@tbaldwin:matrix.org";
+    github = "tbaldwin-dev";
+    githubId = 220447215;
+    name = "Trent Baldwin";
+    keys = [ { fingerprint = "930C 3A61 F911 1296 7DA5  56D1 665A 9E2A FCDD 68AA"; } ];
+  };
   tbenst = {
     email = "nix@tylerbenster.com";
     github = "tbenst";

--- a/pkgs/by-name/po/powershell-editor-services/package.nix
+++ b/pkgs/by-name/po/powershell-editor-services/package.nix
@@ -7,11 +7,11 @@
 }:
 stdenvNoCC.mkDerivation rec {
   pname = "powershell-editor-services";
-  version = "4.3.0";
+  version = "4.4.0";
 
   src = fetchzip {
     url = "https://github.com/PowerShell/PowerShellEditorServices/releases/download/v${version}/PowerShellEditorServices.zip";
-    hash = "sha256-YiXxztfsYujJK6+56Lwi4QdRIZb7NH+dAUJTOYk8pGI=";
+    hash = "sha256-tmz6xkcF44xnG5VwSeHNWzjRQK6wxQ7Ii6mDNisCMb8=";
     stripRoot = false;
   };
 

--- a/pkgs/by-name/po/powershell/package.nix
+++ b/pkgs/by-name/po/powershell/package.nix
@@ -31,7 +31,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "powershell";
-  version = "7.5.3";
+  version = "7.5.4";
 
   src =
     passthru.sources.${stdenv.hostPlatform.system}
@@ -96,19 +96,19 @@ stdenv.mkDerivation rec {
     sources = {
       aarch64-darwin = fetchurl {
         url = "https://github.com/PowerShell/PowerShell/releases/download/v${version}/powershell-${version}-osx-arm64.tar.gz";
-        hash = "sha256-9PrFxy6MCbo7b7hmfyGx1zVWBHgZhX/OeIMmjQI2nN4=";
+        hash = "sha256-OqrdfKYvHk2+WRRbavJOkm1h+NqKR4K8U15QDBhBNfA=";
       };
       aarch64-linux = fetchurl {
         url = "https://github.com/PowerShell/PowerShell/releases/download/v${version}/powershell-${version}-linux-arm64.tar.gz";
-        hash = "sha256-SmtlbdDnUegsXfm5pCRb0ex9Id5TNK+72ALf0AlZVZk=";
+        hash = "sha256-SzLUy4akPfuD1WAtApQpW/Ivr7+eB4XRqu+Bk4zakvg=";
       };
       x86_64-darwin = fetchurl {
         url = "https://github.com/PowerShell/PowerShell/releases/download/v${version}/powershell-${version}-osx-x64.tar.gz";
-        hash = "sha256-wxAB9bwKTSNkGarwVNjAMWAnozHTPi+0HPjSdko1fgU=";
+        hash = "sha256-zRagTBuZzay9wDN7D9DaUNvxqLToQ3vLTKkRjvcpIRo=";
       };
       x86_64-linux = fetchurl {
         url = "https://github.com/PowerShell/PowerShell/releases/download/v${version}/powershell-${version}-linux-x64.tar.gz";
-        hash = "sha256-XHTgu6/YvlnnImfwVwD9ZhU0TZz00wRg2bbRLNSoiow=";
+        hash = "sha256-H9eYP+VsqeYjPxJpJe2yS/a2sz41a2mZbZJcTblOL+8=";
       };
     };
     tests.version = testers.testVersion {

--- a/pkgs/by-name/po/powershell/package.nix
+++ b/pkgs/by-name/po/powershell/package.nix
@@ -31,7 +31,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "powershell";
-  version = "7.5.2";
+  version = "7.5.3";
 
   src =
     passthru.sources.${stdenv.hostPlatform.system}
@@ -96,19 +96,19 @@ stdenv.mkDerivation rec {
     sources = {
       aarch64-darwin = fetchurl {
         url = "https://github.com/PowerShell/PowerShell/releases/download/v${version}/powershell-${version}-osx-arm64.tar.gz";
-        hash = "sha256-oC0deViccejTXkWNkPCFz8HwpojrvqTauGMhh8BX96E=";
+        hash = "sha256-9PrFxy6MCbo7b7hmfyGx1zVWBHgZhX/OeIMmjQI2nN4=";
       };
       aarch64-linux = fetchurl {
         url = "https://github.com/PowerShell/PowerShell/releases/download/v${version}/powershell-${version}-linux-arm64.tar.gz";
-        hash = "sha256-1NLFVih1X1zYsmCa1xF8Hq2gqgCG8ZXUgTHuSC731xo=";
+        hash = "sha256-SmtlbdDnUegsXfm5pCRb0ex9Id5TNK+72ALf0AlZVZk=";
       };
       x86_64-darwin = fetchurl {
         url = "https://github.com/PowerShell/PowerShell/releases/download/v${version}/powershell-${version}-osx-x64.tar.gz";
-        hash = "sha256-kF3J7Au1iJk6rKn//hXdv/x2QWSwnL32PV6iXoNig5w=";
+        hash = "sha256-wxAB9bwKTSNkGarwVNjAMWAnozHTPi+0HPjSdko1fgU=";
       };
       x86_64-linux = fetchurl {
         url = "https://github.com/PowerShell/PowerShell/releases/download/v${version}/powershell-${version}-linux-x64.tar.gz";
-        hash = "sha256-j6lYT2+V0pyhRmxDl6w5w3E3PWWBwS366evVPAbXdmQ=";
+        hash = "sha256-XHTgu6/YvlnnImfwVwD9ZhU0TZz00wRg2bbRLNSoiow=";
       };
     };
     tests.version = testers.testVersion {

--- a/pkgs/by-name/po/powershell/package.nix
+++ b/pkgs/by-name/po/powershell/package.nix
@@ -31,7 +31,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "powershell";
-  version = "7.5.1";
+  version = "7.5.2";
 
   src =
     passthru.sources.${stdenv.hostPlatform.system}
@@ -96,19 +96,19 @@ stdenv.mkDerivation rec {
     sources = {
       aarch64-darwin = fetchurl {
         url = "https://github.com/PowerShell/PowerShell/releases/download/v${version}/powershell-${version}-osx-arm64.tar.gz";
-        hash = "sha256-0fAWzM5acQbjYJC/E65xtGEV8lZGWu4Hdgsm5gf00DM=";
+        hash = "sha256-oC0deViccejTXkWNkPCFz8HwpojrvqTauGMhh8BX96E=";
       };
       aarch64-linux = fetchurl {
         url = "https://github.com/PowerShell/PowerShell/releases/download/v${version}/powershell-${version}-linux-arm64.tar.gz";
-        hash = "sha256-h5Y93+/2rHJmv/vgIbCK2u0mStSjq5Nqgg5tf0Wp7oo=";
+        hash = "sha256-1NLFVih1X1zYsmCa1xF8Hq2gqgCG8ZXUgTHuSC731xo=";
       };
       x86_64-darwin = fetchurl {
         url = "https://github.com/PowerShell/PowerShell/releases/download/v${version}/powershell-${version}-osx-x64.tar.gz";
-        hash = "sha256-SwXo6jVSZhFKmm8/A0yosaKamLGhbKYL2OVLNf+horM=";
+        hash = "sha256-kF3J7Au1iJk6rKn//hXdv/x2QWSwnL32PV6iXoNig5w=";
       };
       x86_64-linux = fetchurl {
         url = "https://github.com/PowerShell/PowerShell/releases/download/v${version}/powershell-${version}-linux-x64.tar.gz";
-        hash = "sha256-u5tff4BgAHNU112pL8ZDDHe6B0z4G/ohVvG6Nz/0d+U=";
+        hash = "sha256-j6lYT2+V0pyhRmxDl6w5w3E3PWWBwS366evVPAbXdmQ=";
       };
     };
     tests.version = testers.testVersion {

--- a/pkgs/development/tools/ilspycmd/default.nix
+++ b/pkgs/development/tools/ilspycmd/default.nix
@@ -8,15 +8,15 @@
   autoSignDarwinBinariesHook,
   glibcLocales,
 }:
-buildDotnetModule (finalAttrs: rec {
+buildDotnetModule (finalAttrs: {
   pname = "ilspycmd";
-  version = "9.0-preview3";
+  version = "9.1";
 
   src = fetchFromGitHub {
     owner = "icsharpcode";
     repo = "ILSpy";
-    rev = "v${version}";
-    hash = "sha256-7cPXFaEKr76GtqcNsKx7tstRUeTpSTF8ggxbyEnQa9M=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-YkZEStCI6Omu8HgClm5qHnXxm5pKJVILtbydY8vAFic=";
   };
 
   nativeBuildInputs = [
@@ -53,6 +53,9 @@ buildDotnetModule (finalAttrs: rec {
       fromSource
       binaryBytecode
     ];
-    maintainers = with lib.maintainers; [ emilytrau ];
+    maintainers = with lib.maintainers; [
+      emilytrau
+      tbaldwin
+    ];
   };
 })

--- a/pkgs/development/tools/ilspycmd/deps.json
+++ b/pkgs/development/tools/ilspycmd/deps.json
@@ -195,6 +195,11 @@
     "hash": "sha256-FeM40ktcObQJk4nMYShB61H/E8B7tIKfl9ObJ0IOcCM="
   },
   {
+    "pname": "Microsoft.Sbom.Targets",
+    "version": "3.1.0",
+    "hash": "sha256-7q/fcTp7yU/yj7pCmzIyqBO3hOZ2Uko/jfZugIPjyrs="
+  },
+  {
     "pname": "Microsoft.SourceLink.Common",
     "version": "8.0.0",
     "hash": "sha256-AfUqleVEqWuHE7z2hNiwOLnquBJ3tuYtbkdGMppHOXc="
@@ -221,33 +226,33 @@
   },
   {
     "pname": "NuGet.Common",
-    "version": "6.11.1",
-    "hash": "sha256-UyZtDyTuymC+sKSX+ripOI6MmJZn11loVapVs4uzaGo="
+    "version": "6.13.2",
+    "hash": "sha256-ASLa/Jigg5Eop0ZrXPl98RW2rxnJRC7pbbxhuV74hFw="
   },
   {
     "pname": "NuGet.Configuration",
-    "version": "6.11.1",
-    "hash": "sha256-JH2UCpjYg8pkqxQ4j4BrWiTKhGzgfn55NMr32wf6+FQ="
+    "version": "6.13.2",
+    "hash": "sha256-z8VW1YdRDanyyRTDYRvRkSv/XPR3c/hMM1y8cNNjx0Y="
   },
   {
     "pname": "NuGet.Frameworks",
-    "version": "6.11.1",
-    "hash": "sha256-p25Oa7wJjwF+2puIhBkZZkKSuk4jGq7xikYSCdfp9Vc="
+    "version": "6.13.2",
+    "hash": "sha256-caDyc+WgYOo43AUTjtbP0MyvYDb6JweEKDdIul61Cac="
   },
   {
     "pname": "NuGet.Packaging",
-    "version": "6.11.1",
-    "hash": "sha256-1yY3p5hQwbUgYCyHnBcuGWiiIib1ppPYt2ntxwXSJW0="
+    "version": "6.13.2",
+    "hash": "sha256-lhO+SFwIYZ4aPHxIGm5ubkkE2a5Ve2xgtroRbNh7hpw="
   },
   {
     "pname": "NuGet.Protocol",
-    "version": "6.11.1",
-    "hash": "sha256-/zFvBV83Q5oMNu68BjmrHtZMAxf/YkDJV8HSsl5GjsY="
+    "version": "6.13.2",
+    "hash": "sha256-5lnAHHZjy7A4vgv65AeBAs64mSNpuoUjxW3HnrMpuzY="
   },
   {
     "pname": "NuGet.Versioning",
-    "version": "6.11.1",
-    "hash": "sha256-fl8lyChMjV7Sp8keAP7CdXZh7ARN/mU39T3gG74jDWY="
+    "version": "6.13.2",
+    "hash": "sha256-gmpyBpKnt+GHqgx/2uFKp+J2csbxEAy1E7WdVT117sw="
   },
   {
     "pname": "System.Buffers",
@@ -260,14 +265,24 @@
     "hash": "sha256-DKEbpFqXCIEfqp9p3ezqadn5b/S1YTk32/EQK+tEScs="
   },
   {
+    "pname": "System.Collections.Immutable",
+    "version": "8.0.0",
+    "hash": "sha256-F7OVjKNwpqbUh8lTidbqJWYi476nsq9n+6k0+QVRo3w="
+  },
+  {
+    "pname": "System.Collections.Immutable",
+    "version": "9.0.4",
+    "hash": "sha256-0A6gCPjhx0IIAlhskPsWS8cjWpoBJGEYTnW1fkdpFTg="
+  },
+  {
     "pname": "System.ComponentModel.Annotations",
     "version": "5.0.0",
     "hash": "sha256-0pST1UHgpeE6xJrYf5R+U7AwIlH3rVC3SpguilI/MAg="
   },
   {
     "pname": "System.Composition.AttributedModel",
-    "version": "8.0.0",
-    "hash": "sha256-n3aXiBAFIlQicSRLiNtLh++URSUxRBLggsjJ8OMNRpo="
+    "version": "9.0.4",
+    "hash": "sha256-r71EJF5F5ZjAgkuvcI00tAnnIrK+IQ5Wj7wU8MwwRRQ="
   },
   {
     "pname": "System.Diagnostics.EventLog",
@@ -276,8 +291,8 @@
   },
   {
     "pname": "System.Formats.Asn1",
-    "version": "6.0.0",
-    "hash": "sha256-KaMHgIRBF7Nf3VwOo+gJS1DcD+41cJDPWFh+TDQ8ee8="
+    "version": "8.0.1",
+    "hash": "sha256-may/Wg+esmm1N14kQTG4ESMBi+GQKPp0ZrrBo/o6OXM="
   },
   {
     "pname": "System.Memory",
@@ -296,13 +311,18 @@
   },
   {
     "pname": "System.Reflection.Metadata",
-    "version": "8.0.1",
-    "hash": "sha256-Swip1XuTs/r2m4RKuG5BXXxcaNGRh+jbMnjFRNdL87U="
+    "version": "9.0.4",
+    "hash": "sha256-JG4esIQbb7J9u/H0HmwFpHjhUYTGIiRVD5KPt3w5okA="
   },
   {
     "pname": "System.Runtime.CompilerServices.Unsafe",
     "version": "6.0.0",
     "hash": "sha256-bEG1PnDp7uKYz/OgLOWs3RWwQSVYm+AnPwVmAmcgp2I="
+  },
+  {
+    "pname": "System.Runtime.CompilerServices.Unsafe",
+    "version": "6.1.2",
+    "hash": "sha256-X2p/U680Zfkr622oc+vg5JYgbDEzE7mLre5DVaayWTc="
   },
   {
     "pname": "System.Security.Cryptography.Pkcs",
@@ -316,8 +336,8 @@
   },
   {
     "pname": "TomsToolbox.Composition.Analyzer",
-    "version": "2.20.0",
-    "hash": "sha256-xjWXdkXF8X9nDdzLNA2H1WcpPZV4NDiKf//TeQbLUtc="
+    "version": "2.22.0",
+    "hash": "sha256-AXU4yapjJ612DiqezH0lkJA4ktiP3w11gYKVFGAl+A8="
   },
   {
     "pname": "TunnelVisionLabs.ReferenceAssemblyAnnotator",


### PR DESCRIPTION
Manual backport of #419923 #441876 #454274 #440573 #428720 to 25.05.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
