### PR TITLE
zatackax: init at 1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1069,6 +1069,13 @@
       }
     ];
   };
+  alch-emi = {
+    email = "emi@alchemi.dev";
+    github = "Alch-Emi";
+    githubId = 38897201;
+    name = "Emi";
+    matrix = "@emi:the-apothecary.club";
+  };
   aldenparker = {
     github = "aldenparker";
     githubId = 32986873;

--- a/pkgs/by-name/za/zatackax/package.nix
+++ b/pkgs/by-name/za/zatackax/package.nix
@@ -1,0 +1,50 @@
+{
+  autoreconfHook,
+  fetchFromGitHub,
+  SDL,
+  SDL_image,
+  SDL_mixer,
+  SDL_ttf,
+  stdenv,
+  lib,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "zatackax";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "simenheg";
+    repo = "zatackax";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-1m99hi0kjpj5Yl1nAmwSMMdQWcP0rfLLPFJPkU4oVbM=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+
+  buildInputs = [
+    SDL_mixer
+    SDL_ttf
+    SDL_image
+    SDL
+  ];
+
+  configureFlags = [ "CFLAGS=-I${lib.getDev SDL}/include/SDL" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Open-source remake of the early computer game \"Achtung, die Kurve!\"";
+    homepage = "https://github.com/simenheg/zatackax";
+    changelog = "https://github.com/simenheg/zatackax/releases";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ lib.maintainers.alch-emi ];
+    mainProgram = "zatackax";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Zatackax is an open-source remake of the early computer game *Achtung, die Kurve!*  More information can be found on the projects [GitHub](https://github.com/simenheg/zatackax).

Packaging considerations:
- **Is the package ready for general use?**
  Zatackax was originally released in 2010, and is still passively maintained to this day.
- **Does the project have a clear license statement?**
  Zatackax is licensed under GPL3+, as declared in its README.
- **How realistic is it that it will be used by other people?**
  Zatackax is currently packaged by Debian, OpenSUSE, the AUR, and more.  A full list of repositories which include Zatackax is included on their README.
- **Is the software actively maintained upstream?**
  Zatackax currently recieves passive maintenance.  However,  it is not a security-critical package, nor is it integrated into a fast-changing ecosystem.
- **Are you willing to maintain the package?**
  Yes.  While I did choose to contribute this package first as an exercise to help familiarize myself with the process of contributing to nixpkgs, and I forsee only a very small maintance burden from this package, I understand that I am taking on a multi-year commitment, and am willing to provide maintainership for at least a release cycle, and likely much longer.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
