### PR TITLE
workflows/pull-request-target: increase retries for prepare step

### DIFF
--- a/.github/workflows/pull-request-target.yml
+++ b/.github/workflows/pull-request-target.yml
@@ -45,7 +45,7 @@ jobs:
       - id: prepare
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
-          retries: 3
+          retries: 10
           # The default for this includes code 422, which happens regularly for us when comparing commits:
           #   422 - Server Error: Sorry, this diff is taking too long to generate.
           # Listing all other values from here to effectively remove 422:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,12 @@ jobs:
       - id: prepare
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
-          retries: 3
+          retries: 10
+          # The default for this includes code 422, which happens regularly for us when comparing commits:
+          #   422 - Server Error: Sorry, this diff is taking too long to generate.
+          # Listing all other values from here to effectively remove 422:
+          #   https://github.com/octokit/plugin-retry.js/blob/9a2443746c350b3beedec35cf26e197ea318a261/src/index.ts#L14
+          retry-exempt-status-codes: 400,401,403,404
           script: |
             require('./ci/github-script/prepare.js')({
               github,


### PR DESCRIPTION
We still get plenty of errors in the prepare step for the diff requests to take way too long - let's increase the number of retries massively now. These are repeated with exponential backoff, so hopefully they will succeed with some cooldown, when GitHub had time to compute the right diff in the background.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
