### PR TITLE
[25.05] opensmtpd: 7.6.0p1 -> 7.8.0p0

### DIFF
--- a/pkgs/by-name/op/opensmtpd/package.nix
+++ b/pkgs/by-name/op/opensmtpd/package.nix
@@ -18,7 +18,7 @@
 
 stdenv.mkDerivation rec {
   pname = "opensmtpd";
-  version = "7.6.0p1";
+  version = "7.7.0p0";
 
   nativeBuildInputs = [
     autoreconfHook
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://www.opensmtpd.org/archives/${pname}-${version}.tar.gz";
-    hash = "sha256-snyAaYKmZTomN/gQrnpFNyuaf/mTUO4QA3RlA/8OSpc=";
+    hash = "sha256-sJU9oc4sv+S+E5zbGaqTX7+rQs8KmT1CWzejl9xIOWg=";
   };
 
   patches = [

--- a/pkgs/by-name/op/opensmtpd/package.nix
+++ b/pkgs/by-name/op/opensmtpd/package.nix
@@ -18,7 +18,7 @@
 
 stdenv.mkDerivation rec {
   pname = "opensmtpd";
-  version = "7.7.0p0";
+  version = "7.8.0p0";
 
   nativeBuildInputs = [
     autoreconfHook
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://www.opensmtpd.org/archives/${pname}-${version}.tar.gz";
-    hash = "sha256-sJU9oc4sv+S+E5zbGaqTX7+rQs8KmT1CWzejl9xIOWg=";
+    hash = "sha256-QDTeLpLGH6g+7a2x2Ni9/mXlfrUM6WeeAUCVDjTKSrc=";
   };
 
   patches = [


### PR DESCRIPTION
Fixes CVE-2025-62875.

https://www.opensmtpd.org/announces/release-7.7.0p0.txt
https://www.mail-archive.com/misc@opensmtpd.org/msg06634.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
