### PR TITLE
sdl-jstest: disable SDL1 build

### DIFF
--- a/pkgs/by-name/sd/sdl-jstest/package.nix
+++ b/pkgs/by-name/sd/sdl-jstest/package.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   cmake,
   pkg-config,
-  SDL,
   SDL2,
   ncurses,
   docbook_xsl,
@@ -24,10 +23,10 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [
-    SDL
     SDL2
     ncurses
   ];
+
   nativeBuildInputs = [
     cmake
     pkg-config
@@ -35,11 +34,14 @@ stdenv.mkDerivation {
     git
   ];
 
+  cmakeFlags = [ (lib.cmakeBool "BUILD_SDL_JSTEST" false) ];
+
   meta = with lib; {
     homepage = "https://github.com/Grumbel/sdl-jstest";
     description = "Simple SDL joystick test application for the console";
     license = licenses.gpl3;
     platforms = platforms.linux;
     maintainers = [ ];
+    mainProgram = "sdl2-jstest";
   };
 }

--- a/pkgs/by-name/sd/sdl-jstest/package.nix
+++ b/pkgs/by-name/sd/sdl-jstest/package.nix
@@ -36,11 +36,11 @@ stdenv.mkDerivation {
 
   cmakeFlags = [ (lib.cmakeBool "BUILD_SDL_JSTEST" false) ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/Grumbel/sdl-jstest";
     description = "Simple SDL joystick test application for the console";
-    license = licenses.gpl3;
-    platforms = platforms.linux;
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
     maintainers = [ ];
     mainProgram = "sdl2-jstest";
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
As suggested in https://github.com/NixOS/nixpkgs/pull/455307#pullrequestreview-3407526585.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
