### PR TITLE
git-credential-email: init at 5.5.2

### DIFF
--- a/pkgs/by-name/gi/git-credential-email/git-credential-aol/default.nix
+++ b/pkgs/by-name/gi/git-credential-email/git-credential-aol/default.nix
@@ -1,0 +1,14 @@
+{
+  lib,
+  callPackage,
+}:
+
+let
+  script = "git-credential-aol";
+in
+callPackage ../package.nix {
+  pname = script;
+  scripts = [ script ];
+  description = "Git credential helper for AOL accounts";
+  license = lib.licenses.asl20;
+}

--- a/pkgs/by-name/gi/git-credential-email/git-credential-aol/default.nix
+++ b/pkgs/by-name/gi/git-credential-email/git-credential-aol/default.nix
@@ -3,12 +3,9 @@
   callPackage,
 }:
 
-let
-  script = "git-credential-aol";
-in
 callPackage ../package.nix {
-  pname = script;
-  scripts = [ script ];
+  pname = "git-credential-aol";
+  scripts = [ "git-credential-aol" ];
   description = "Git credential helper for AOL accounts";
   license = lib.licenses.asl20;
 }

--- a/pkgs/by-name/gi/git-credential-email/git-credential-gmail/default.nix
+++ b/pkgs/by-name/gi/git-credential-email/git-credential-gmail/default.nix
@@ -1,0 +1,14 @@
+{
+  lib,
+  callPackage,
+}:
+
+let
+  script = "git-credential-gmail";
+in
+callPackage ../package.nix {
+  pname = script;
+  scripts = [ script ];
+  description = "Git credential helper for Gmail accounts";
+  license = lib.licenses.asl20;
+}

--- a/pkgs/by-name/gi/git-credential-email/git-credential-gmail/default.nix
+++ b/pkgs/by-name/gi/git-credential-email/git-credential-gmail/default.nix
@@ -3,12 +3,9 @@
   callPackage,
 }:
 
-let
-  script = "git-credential-gmail";
-in
 callPackage ../package.nix {
-  pname = script;
-  scripts = [ script ];
+  pname = "git-credential-gmail";
+  scripts = [ "git-credential-gmail" ];
   description = "Git credential helper for Gmail accounts";
   license = lib.licenses.asl20;
 }

--- a/pkgs/by-name/gi/git-credential-email/git-credential-outlook/default.nix
+++ b/pkgs/by-name/gi/git-credential-email/git-credential-outlook/default.nix
@@ -1,0 +1,14 @@
+{
+  lib,
+  callPackage,
+}:
+
+let
+  script = "git-credential-outlook";
+in
+callPackage ../package.nix {
+  pname = script;
+  scripts = [ script ];
+  description = "Git credential helper for Microsoft Outlook accounts";
+  license = lib.licenses.asl20;
+}

--- a/pkgs/by-name/gi/git-credential-email/git-credential-outlook/default.nix
+++ b/pkgs/by-name/gi/git-credential-email/git-credential-outlook/default.nix
@@ -3,12 +3,9 @@
   callPackage,
 }:
 
-let
-  script = "git-credential-outlook";
-in
 callPackage ../package.nix {
-  pname = script;
-  scripts = [ script ];
+  pname = "git-credential-outlook";
+  scripts = [ "git-credential-outlook" ];
   description = "Git credential helper for Microsoft Outlook accounts";
   license = lib.licenses.asl20;
 }

--- a/pkgs/by-name/gi/git-credential-email/git-credential-yahoo/default.nix
+++ b/pkgs/by-name/gi/git-credential-email/git-credential-yahoo/default.nix
@@ -1,0 +1,14 @@
+{
+  lib,
+  callPackage,
+}:
+
+let
+  script = "git-credential-yahoo";
+in
+callPackage ../package.nix {
+  pname = script;
+  scripts = [ script ];
+  description = "Git credential helper for Yahoo accounts";
+  license = lib.licenses.asl20;
+}

--- a/pkgs/by-name/gi/git-credential-email/git-credential-yahoo/default.nix
+++ b/pkgs/by-name/gi/git-credential-email/git-credential-yahoo/default.nix
@@ -3,12 +3,9 @@
   callPackage,
 }:
 
-let
-  script = "git-credential-yahoo";
-in
 callPackage ../package.nix {
-  pname = script;
-  scripts = [ script ];
+  pname = "git-credential-yahoo";
+  scripts = [ "git-credential-yahoo" ];
   description = "Git credential helper for Yahoo accounts";
   license = lib.licenses.asl20;
 }

--- a/pkgs/by-name/gi/git-credential-email/git-msgraph/default.nix
+++ b/pkgs/by-name/gi/git-credential-email/git-msgraph/default.nix
@@ -1,0 +1,14 @@
+{
+  lib,
+  callPackage,
+}:
+
+let
+  script = "git-msgraph";
+in
+callPackage ../package.nix {
+  pname = script;
+  scripts = [ script ];
+  description = "Git helper to use Microsoft Graph API instead of SMTP to send emails";
+  license = lib.licenses.asl20;
+}

--- a/pkgs/by-name/gi/git-credential-email/git-msgraph/default.nix
+++ b/pkgs/by-name/gi/git-credential-email/git-msgraph/default.nix
@@ -3,12 +3,9 @@
   callPackage,
 }:
 
-let
-  script = "git-msgraph";
-in
 callPackage ../package.nix {
-  pname = script;
-  scripts = [ script ];
+  pname = "git-msgraph";
+  scripts = [ "git-msgraph" ];
   description = "Git helper to use Microsoft Graph API instead of SMTP to send emails";
   license = lib.licenses.asl20;
 }

--- a/pkgs/by-name/gi/git-credential-email/git-protonmail/default.nix
+++ b/pkgs/by-name/gi/git-credential-email/git-protonmail/default.nix
@@ -1,0 +1,14 @@
+{
+  lib,
+  callPackage,
+}:
+
+let
+  script = "git-protonmail";
+in
+callPackage ../package.nix {
+  pname = script;
+  scripts = [ script ];
+  description = "Git helper to use ProtonMail API to send emails";
+  license = lib.licenses.gpl3Only;
+}

--- a/pkgs/by-name/gi/git-credential-email/git-protonmail/default.nix
+++ b/pkgs/by-name/gi/git-credential-email/git-protonmail/default.nix
@@ -3,12 +3,9 @@
   callPackage,
 }:
 
-let
-  script = "git-protonmail";
-in
 callPackage ../package.nix {
-  pname = script;
-  scripts = [ script ];
+  pname = "git-protonmail";
+  scripts = [ "git-protonmail" ];
   description = "Git helper to use ProtonMail API to send emails";
   license = lib.licenses.gpl3Only;
 }

--- a/pkgs/by-name/gi/git-credential-email/package.nix
+++ b/pkgs/by-name/gi/git-credential-email/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  withOpencv ? false,
+  withPyqt6 ? if builtins.elem "git-protonmail" scripts then true else false,
+  withQrcode ? true,
+  pname ? "git-credential-email",
+  scripts ? [
+    "git-credential-aol"
+    "git-credential-gmail"
+    "git-credential-outlook"
+    "git-credential-yahoo"
+    "git-msgraph"
+    "git-protonmail"
+  ],
+  description ? "Git credential helpers for Microsoft Outlook, Gmail, Yahoo, AOL and Proton Mail accounts",
+  license ? with lib.licenses; [
+    asl20
+    gpl3Only
+  ],
+}:
+
+let
+  withProtonmail = builtins.elem "git-protonmail" scripts;
+in
+python3Packages.buildPythonApplication rec {
+  inherit pname;
+  version = "5.5.2";
+
+  src = fetchFromGitHub {
+    owner = "AdityaGarg8";
+    repo = "git-credential-email";
+    tag = "v${version}";
+    hash = "sha256-N4w339MvIOronA4MKS4ipLpQt+0xo+JVbgKWFYP2zP0=";
+  };
+
+  dependencies =
+    with python3Packages;
+    [
+      keyring
+      requests
+    ]
+    ++ lib.optionals withPyqt6 [ pyqt6 ]
+    ++ lib.optionals withQrcode [ qrcode ]
+    ++ lib.optionals withProtonmail [
+      bcrypt
+      cryptography
+      pgpy
+      requests-toolbelt
+      typing-extensions
+    ]
+    ++ lib.optionals (withProtonmail && withOpencv) [ opencv4 ];
+
+  pyproject = false;
+
+  installPhase = ''
+    install -D -t $out/bin ${lib.concatStringsSep " " scripts}
+  '';
+
+  meta = rec {
+    inherit description license;
+    homepage = "https://github.com/AdityaGarg8/git-credential-email";
+    changelog = "${homepage}/releases/tag/${src.tag}";
+    maintainers = with lib.maintainers; [ sephalon ];
+  };
+}

--- a/pkgs/by-name/gi/git-credential-email/package.nix
+++ b/pkgs/by-name/gi/git-credential-email/package.nix
@@ -3,7 +3,7 @@
   python3Packages,
   fetchFromGitHub,
   withOpencv ? false,
-  withPyqt6 ? if builtins.elem "git-protonmail" scripts then true else false,
+  withPyqt6 ? builtins.elem "git-protonmail" scripts,
   withQrcode ? true,
   pname ? "git-credential-email",
   scripts ? [
@@ -58,10 +58,10 @@ python3Packages.buildPythonApplication rec {
     install -D -t $out/bin ${lib.concatStringsSep " " scripts}
   '';
 
-  meta = rec {
+  meta = {
     inherit description license;
     homepage = "https://github.com/AdityaGarg8/git-credential-email";
-    changelog = "${homepage}/releases/tag/${src.tag}";
+    changelog = "https://github.com/AdityaGarg8/git-credential-email/releases/tag/${src.tag}";
     maintainers = with lib.maintainers; [ sephalon ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1237,6 +1237,18 @@ with pkgs;
 
   git-credential-manager = callPackage ../applications/version-management/git-credential-manager { };
 
+  git-credential-aol = callPackage ../by-name/gi/git-credential-email/git-credential-aol { };
+
+  git-credential-gmail = callPackage ../by-name/gi/git-credential-email/git-credential-gmail { };
+
+  git-credential-outlook = callPackage ../by-name/gi/git-credential-email/git-credential-outlook { };
+
+  git-credential-yahoo = callPackage ../by-name/gi/git-credential-email/git-credential-yahoo { };
+
+  git-msgraph = callPackage ../by-name/gi/git-credential-email/git-msgraph { };
+
+  git-protonmail = callPackage ../by-name/gi/git-credential-email/git-protonmail { };
+
   gitRepo = git-repo;
 
   merge-fmt = callPackage ../applications/version-management/merge-fmt {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Git credential helpers for Microsoft Outlook, Gmail, Yahoo, AOL and Proton Mail accounts.

Each script is packaged separately, following the convention used by [other distributions](https://github.com/AdityaGarg8/git-credential-email/tree/main?tab=readme-ov-file#linux).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
