### PR TITLE
nixos/networkd: explicitly set IPv6AcceptRA=yes on networking.useDHCP = true

### DIFF
--- a/nixos/modules/tasks/network-interfaces-systemd.nix
+++ b/nixos/modules/tasks/network-interfaces-systemd.nix
@@ -65,11 +65,13 @@ let
       };
       DHCP = "yes";
       networkConfig.IPv6PrivacyExtensions = "kernel";
+      networkConfig.IPv6AcceptRA = "yes";
     };
     networks."99-wireless-client-dhcp" = {
       matchConfig.WLANInterfaceType = "station";
       DHCP = "yes";
       networkConfig.IPv6PrivacyExtensions = "kernel";
+      networkConfig.IPv6AcceptRA = "yes";
       # We also set the route metric to one more than the default
       # of 1024, so that Ethernet is preferred if both are
       # available.


### PR DESCRIPTION


On a default NixOS installation, this setting is implied and there's no real need to do it by yourself.

However, IPv6AcceptRA is disabled e.g. with IPv6 forwarding being enabled. It took me a while to figure out why a machine only had an IPv4 address via DHCP, but didn't accept any RA.

It turned out that I had set

    systemd.network.config.networkConfig = {
      IPv6Forwarding = true;
    }

following upstream's recommendation[1] for setting it globally when IPv6 forwarding is desired. The result of silently turning off IPv6AcceptRA was pretty unintuitive for me.

Since it's kinda the point of these definitions to be a fallback that just enables automatic address allocation, I think it's reasonable to set IPv6AcceptRA explicitly as well.

[1] https://github.com/yuwata/systemd/commit/865d314e4d294c6daa29d4ff482ca067df112316#diff-d81a981ca75657b8fc8f6ad6871cb9f8d7705944919b67dad745680ebeec1b4eR851


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
