### PR TITLE
git: 2.51.1 -> 2.51.2

### DIFF
--- a/pkgs/applications/version-management/git/default.nix
+++ b/pkgs/applications/version-management/git/default.nix
@@ -60,7 +60,7 @@ assert sendEmailSupport -> perlSupport;
 assert svnSupport -> perlSupport;
 
 let
-  version = "2.51.1";
+  version = "2.51.2";
   svn = subversionClient.override { perlBindings = perlSupport; };
   gitwebPerlLibs = with perlPackages; [
     CGI
@@ -89,7 +89,7 @@ stdenv.mkDerivation (finalAttrs: {
         }.tar.xz"
       else
         "https://www.kernel.org/pub/software/scm/git/git-${version}.tar.xz";
-    hash = "sha256-qD/Z/67X7uZ57ZLOsG91tGFev2bTrE+9v7yVZ9xTP0o=";
+    hash = "sha256-Iz1xQ6LVjmB1Xu6bdvVZ7HPqKzwpf1tQMWKs6VlmtOM=";
   };
 
   outputs = [ "out" ] ++ lib.optional withManual "doc";


### PR DESCRIPTION
Changelog: https://git.kernel.org/pub/scm/git/git.git/tree/Documentation/RelNotes/2.51.2.adoc?h=v2.51.2

Diff: https://github.com/git/git/compare/v2.51.1...v2.51.2

<hr/>

Git 2.51.2 Release Notes
========================

In addition to fixes for an unfortunate regression introduced in Git 2.51.1 that caused "git diff --quiet -w" to be not so quiet when there are additions, deletions and conflicts, this maintenance release merges more fixes/improvements that have landed on the master front, primarily to make the CI part of the system a bit more robust.

Fixes since Git 2.51.1
----------------------

 * Recently we attempted to improve `git diff -w --quiet` and friends to handle cases where patch output would be suppressed, but it introduced a bug that emits unnecessary output, which has been corrected.

 * The code to squelch output from `git diff -w --name-status` etc. for paths that `git diff -w -p` would have stayed silent leaked output from dry-run patch generation, which has been corrected.

 * Windows "real-time monitoring" interferes with the execution of tests and affects negatively in both correctness and performance, which has been disabled in Gitlab CI.

 * An earlier addition to `git diff --no-index A B` to limit the output with pathspec after the two directories misbehaved when these directories were given with a trailing slash, which has been corrected.

 * The `--short` option of `git status` that meant output for humans and `-z` option to show NUL delimited output format did not mix well, and colored some but not all things. The command has been updated to color all elements consistently in such a case.

 * Unicode width table update.

 * Recent OpenSSH creates the Unix domain socket to communicate with `ssh-agent` under `$HOME` instead of `/tmp`, which causes our test to fail due to an overly long path in our test environment, which has been worked around by using `ssh-agent -T`.

Also contains various documentation updates, code cleanups and minor fixups.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
