### PR TITLE
linux: Partially revert "linux: drop hacky passing around of positions"

### DIFF
--- a/pkgs/os-specific/linux/kernel/build.nix
+++ b/pkgs/os-specific/linux/kernel/build.nix
@@ -51,6 +51,8 @@ lib.makeOverridable (
     version,
     # The kernel pname (should be set for variants)
     pname ? "linux",
+    # Position of the Linux build expression
+    pos ? null,
     # Additional kernel make flags
     extraMakeFlags ? [ ],
     # The name of the kernel module directory
@@ -550,6 +552,8 @@ lib.makeOverridable (
     ];
 
     karch = stdenv.hostPlatform.linuxArch;
+
+    pos = lib.optionalDrvAttr (pos != null) pos;
 
     meta = {
       # https://github.com/NixOS/nixpkgs/pull/345534#issuecomment-2391238381

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -293,6 +293,7 @@ let
           configfile
           modDirVersion
           ;
+        pos = builtins.unsafeGetAttrPos "version" args;
 
         config = {
           CONFIG_MODULES = "y";


### PR DESCRIPTION
This partially reverts commit 845e340ed98ef6d8a5c5d7069663f2cd034e508a.

This re-introduces the `pos` juggling previous done.

The rationale used in the commit was:

> This is long obsolete since the versions are maintained in a JSON
> file now.

That is only accurate for `mainline`. Other in-tree kernels are maintained in different ways. This led to a loss of information.

Before (cf3f5c4def3c):

```
nix-repl> linux_latest.meta.position
".../pkgs/os-specific/linux/kernel/mainline.nix:34"
nix-repl> linux_rpi0.meta.position
".../pkgs/os-specific/linux/kernel/linux-rpi.nix:20"

```

After (2fb006b87f04c):

```
nix-repl> linux_latest.meta.position
".../pkgs/os-specific/linux/kernel/build.nix:558"
nix-repl> linux_rpi0.meta.position
".../pkgs/os-specific/linux/kernel/build.nix:558"
```

This is also observable for out-of-tree kernels:

```
nix-repl> pkgs.linux_jovian.meta.position
".../Jovian-NixOS/pkgs/linux-jovian/default.nix:11"

nix-repl> :r # after updating the Nixpkgs input

nix-repl> pkgs.linux_jovian.meta.position
"/nix/store/xjjq52iwslhz6lbc621a31v0nfdhr5ks-source/pkgs/os-specific/linux/kernel/build.nix:558"
```

This also conveniently works around the root cause of an `stdenv.mkDerivation`-based `pos` infrec regression when using the kernel package version in a NixOS configuration to conditionally apply kernel patches.


See:

 - https://github.com/NixOS/nixpkgs/pull/448835#issuecomment-3476536100
 - https://github.com/NixOS/nixpkgs/pull/448835#issuecomment-3476882817

cc @Ma27, author of both previous changes (introduction of `pos` juggling, and deletion of `pos` juggling).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Note: this is an evaluation-time change. Nothing was built, thus the checkboxes left unchecked.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
