### PR TITLE
ci/github-script/merge: various improvements

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -44,7 +44,9 @@ To ensure security and a focused utility, the bot adheres to specific limitation
 
 - The PR targets `master`, `staging`, or `staging-next`.
 - The PR only touches packages located under `pkgs/by-name/*`.
-- The PR is authored by [@r-ryantm](https://nix-community.github.io/nixpkgs-update/r-ryantm/) or a [committer][@NixOS/nixpkgs-committers].
+- The PR is either:
+  - authored by a [committer][@NixOS/nixpkgs-committers], or
+  - created by [@r-ryantm](https://nix-community.github.io/nixpkgs-update/r-ryantm/).
 - The user attempting to merge is a member of [@NixOS/nixpkgs-maintainers].
 - The user attempting to merge is a maintainer of all packages touched by the PR.
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -43,7 +43,7 @@ These issues effectively list PRs the merge bot has interacted with.
 To ensure security and a focused utility, the bot adheres to specific limitations:
 
 - The PR targets `master`, `staging`, or `staging-next`.
-- The PR only touches files located under `pkgs/by-name/*`.
+- The PR only touches packages located under `pkgs/by-name/*`.
 - The PR is authored by [@r-ryantm](https://nix-community.github.io/nixpkgs-update/r-ryantm/) or a [committer][@NixOS/nixpkgs-committers].
 - The user attempting to merge is a member of [@NixOS/nixpkgs-maintainers].
 - The user attempting to merge is a maintainer of all packages touched by the PR.

--- a/ci/github-script/merge.js
+++ b/ci/github-script/merge.js
@@ -180,6 +180,7 @@ async function handleMerge({
       log('Auto Merge failed', e.response.errors[0].message)
     }
 
+    // TODO: Observe whether the below is true and whether manual enqueue is actually needed.
     // Auto-merge doesn't work if the target branch has already run all CI, in which
     // case the PR must be enqueued explicitly.
     // We now have merge queues enabled on all development branches, thus don't need a

--- a/ci/github-script/merge.js
+++ b/ci/github-script/merge.js
@@ -27,14 +27,16 @@ function runChecklist({
       'staging',
       'staging-next',
     ].includes(pull_request.base.ref),
-    'PR touches only files in `pkgs/by-name/`.': allByName,
+    'PR touches only packages in `pkgs/by-name/`.': allByName,
     'PR authored by r-ryantm or committer.':
       pull_request.user.login === 'r-ryantm' ||
       committers.has(pull_request.user.id),
   }
 
   if (user) {
-    checklist[`${user.login} can use the merge bot.`] = userIsMaintainer
+    checklist[
+      `${user.login} is a member of [@NixOS/nixpkgs-maintainers](https://github.com/orgs/NixOS/teams/nixpkgs-maintainers).`
+    ] = userIsMaintainer
     if (allByName) {
       // We can only determine the below, if all packages are in by-name, since
       // we can't reliably relate changed files to packages outside by-name.
@@ -249,8 +251,9 @@ async function handleMerge({
 
     const body = [
       `<!-- comment: ${comment.node_id} -->`,
+      `@${comment.user.login} wants to merge this PR.`,
       '',
-      'Requirements to merge this PR:',
+      'Requirements to merge this PR with `@NixOS/nixpkgs-merge-bot merge`:',
       ...Object.entries(checklist).map(
         ([msg, res]) => `- :${res ? 'white_check_mark' : 'x'}: ${msg}`,
       ),


### PR DESCRIPTION
Some wording improvements, a TODO and preparation for both #451324 and #451362.

The nested checklists look like https://github.com/NixOS/nixpkgs/pull/451362#discussion_r2482795813.

## Things done

- [x] Tested locally again.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
