### PR TITLE
warnAlias -> lib.warnings.warnAlias

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -131,6 +131,9 @@ tests/sources.sh
 # Run the lib.filesystem tests
 tests/filesystem.sh
 
+# Run the lib.warnings tests
+tests/warnings.sh
+
 # Run the lib.path property tests
 path/tests/prop.sh
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -84,6 +84,7 @@ let
 
       # misc
       asserts = callLibs ./asserts.nix;
+      warnings = callLibs ./warnings.nix;
       debug = callLibs ./debug.nix;
       misc = callLibs ./deprecated/misc.nix;
 
@@ -401,7 +402,7 @@ let
         renameCrossIndexTo
         mapCrossIndex
         ;
-      inherit (self.derivations) lazyDerivation optionalDrvAttr warnOnInstantiate;
+      inherit (self.derivations) lazyDerivation optionalDrvAttr;
       inherit (self.generators) mkLuaInline;
       inherit (self.meta)
         addMetaAttrs
@@ -515,6 +516,10 @@ let
       inherit (self.asserts)
         assertMsg
         assertOneOf
+        ;
+      inherit (self.warnings)
+        warnOnInstantiate
+        warnAlias
         ;
       inherit (self.debug)
         traceIf

--- a/lib/derivations.nix
+++ b/lib/derivations.nix
@@ -212,43 +212,4 @@ in
     :::
   */
   optionalDrvAttr = cond: value: if cond then value else null;
-
-  /**
-    Wrap a derivation such that instantiating it produces a warning.
-
-    All attributes will be wrapped with `lib.warn` except from `.meta`, `.name`,
-    and `.type` which are used by `nix search`, and `.outputName` which avoids
-    double warnings with `nix-instantiate` and `nix-build`.
-
-    # Inputs
-
-    `msg`
-    : The warning message to emit (via `lib.warn`).
-
-    `drv`
-    : The derivation to wrap.
-
-    # Examples
-    :::{.example}
-    ## `lib.derivations.warnOnInstantiate` usage example
-
-    ```nix
-    {
-      myPackage = warnOnInstantiate "myPackage has been renamed to my-package" my-package;
-    }
-    ```
-
-    :::
-  */
-  warnOnInstantiate =
-    msg: drv:
-    let
-      drvToWrap = removeAttrs drv [
-        "meta"
-        "name"
-        "type"
-        "outputName"
-      ];
-    in
-    drv // mapAttrs (_: lib.warn msg) drvToWrap;
 }

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -6,7 +6,7 @@
   which is `throw`'s and `abort`'s, without error messages.
 
   If you need to test error messages or more complex evaluations, see
-  `lib/tests/modules.sh`, `lib/tests/sources.sh` or `lib/tests/filesystem.sh` as examples.
+  `.sh` files in this directory as examples.
 
   To run these tests:
 

--- a/lib/tests/test-with-nix.nix
+++ b/lib/tests/test-with-nix.nix
@@ -63,6 +63,9 @@ pkgs.runCommand "nixpkgs-lib-tests-nix-${nix.version}"
     echo "Running lib/tests/network.sh"
     TEST_LIB=$PWD/lib bash lib/tests/network.sh
 
+    echo "Running lib/tests/warnings.sh"
+    TEST_LIB=$PWD/lib bash lib/tests/warnings.sh
+
     echo "Running lib/fileset/tests.sh"
     TEST_LIB=$PWD/lib bash lib/fileset/tests.sh
 

--- a/lib/tests/warnings.nix
+++ b/lib/tests/warnings.nix
@@ -1,0 +1,32 @@
+# Test cases for `lib.warnings.warnAlias`, see `lib/tests/warnings.sh` for more details
+{
+  pkgs ? import <nixpkgs> { },
+}:
+let
+  lib = pkgs.lib;
+
+  # renames all attr keys to xDest, e.g. drv -> drvDest
+  renameDestinations =
+    destinations: lib.mapAttrs' (name: value: lib.nameValuePair (name + "Dest") value) destinations;
+  mkAliases =
+    destinations:
+    # create a lib.warnAlias for each attribute
+    (lib.mapAttrs (name: value: lib.warnAlias (name + " alias") value) destinations)
+    // (renameDestinations destinations);
+in
+(mkAliases {
+  drv = pkgs.hello;
+  attrs = {
+    a = "b";
+  };
+  list = [
+    1
+    2
+    3
+  ];
+  arbitrary = "abc";
+})
+// rec {
+  func = (lib.warnAlias "func alias" (_: funcDest)) "123";
+  funcDest = "abc";
+}

--- a/lib/tests/warnings.sh
+++ b/lib/tests/warnings.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+
+# Tests lib/warnings.nix
+# Run:
+# [nixpkgs]$ lib/tests/warnings.sh
+# or:
+# [nixpkgs]$ nix-build lib/tests/release.nix
+
+set -euo pipefail
+shopt -s inherit_errexit
+
+die() {
+  printf ' test case failed: %s\n' "$1" >&2
+  printf '%s\n' "${@:2}" >&2
+  exit 1
+}
+
+if test -n "${TEST_LIB:-}"; then
+  NIX_PATH=nixpkgs="$(dirname "$TEST_LIB")"
+else
+  NIX_PATH=nixpkgs="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.."; pwd)"
+fi
+export NIX_PATH
+
+PREFIX_IMPORT="(import $NIX_PATH/lib/tests/warnings.nix { })"
+
+firstLine() {
+  echo "$1" | head -n 1
+}
+
+# Completely tests a type for warnAlias function
+testAliasCase() {
+  local attributeName=$1
+  echo "Testing attribute '$attributeName'..."
+
+  local eval_arg
+  # --eval on derivations tries to evaluate all attributes recursively, which
+  # always results in some kind of error, which is not what we want at all
+  if [ "$attributeName" != "drv" ]; then
+    eval_arg="1"
+  fi
+
+  # Evaluate attribute and checks for warning using regex
+  echo " Evaluating for warning..."
+  if result=$(
+    NIX_ABORT_ON_WARN=1 \
+      nix-instantiate ${eval_arg:+"--eval"} --strict \
+        --expr "$PREFIX_IMPORT.$attributeName" \
+        2>&1
+  ); then
+    die "'$attributeName' did not produce warning, but it was expected to:" "$result"
+  fi
+
+  local expectedWarningRegex="^trace: evaluation warning: $attributeName alias$"
+  if [[ ! $(firstLine "$result") =~ $expectedWarningRegex ]]; then
+    die "Result is '$(firstLine "$result")', but '$expectedWarningRegex' was expected" "$result"
+  fi
+
+  # Evaluate attribute for value, and check it with the value it is aliasing to
+  # but do not error on warning
+  echo " Evaluating for value..."
+  if ! result_attr=$(
+    nix-instantiate ${eval_arg:+"--eval"} --strict \
+      --expr "$PREFIX_IMPORT.$attributeName" \
+      2>/dev/null
+  ); then
+    die "'$attributeName' failed to evaluate for value, but it was expected to succeed" "$result"
+  fi
+  # Evaluating the original value to check it with alias
+  echo " Getting expected value..."
+  if ! expected_attr=$(
+    NIX_ABORT_ON_WARN=1 \
+      nix-instantiate ${eval_arg:+"--eval"} --strict \
+        --expr "$PREFIX_IMPORT.${attributeName}Dest" \
+        2>/dev/null
+  ); then
+    die "'${attributeName}Dest' failed to evaluate with message, but it was expected to succeed" "$result"
+  fi
+
+  if [[ "$result_attr" != "$expected_attr" ]]; then
+    die "'$attributeName' expected to be '$expected_attr', but it is '$result_attr'"
+  fi
+  echo " Done testing $attributeName!"
+}
+
+expectSuccess() {
+  local expr=$1
+  local expectedResultRegex=$2
+  echo "Testing '$expr'..."
+  if ! result=$(
+    NIX_ABORT_ON_WARN=1 \
+      nix-instantiate --eval --strict \
+        --expr "with (import <nixpkgs> { }); $expr" \
+        2>&1
+  ); then
+    die "'$expr' failed to evaluate, but it was expected to succeed:" "$result"
+  fi
+  if [[ ! $(firstLine "$result") =~ $expectedResultRegex ]]; then
+    die "Mismatched regex; expected '$expectedResultRegex' but result is:" "$result"
+  fi
+}
+
+expectFailure() {
+  local expr=$1
+  local expectedErrorRegex=$2
+  echo "Testing '$expr'..."
+  if result=$(
+    NIX_ABORT_ON_WARN=1 \
+      nix-instantiate --eval --strict \
+        --expr "with (import <nixpkgs> { }); $expr" \
+        2>&1
+  ); then
+    die "'$expr' evaluated successfully, but it was expected to fail:" "$result"
+  fi
+  if [[ ! $(firstLine "$result") =~ $expectedErrorRegex ]]; then
+    die "Mismatched regex; expected '$expectedErrorRegex' but result is:" "$result"
+  fi
+}
+
+# tests for warnAlias
+testAliasCase drv
+testAliasCase attrs
+testAliasCase func
+testAliasCase list
+testAliasCase arbitrary
+
+# tests for warnOnInstantiate
+expectFailure 'lib.warnOnInstantiate "error message" hello' '^trace: evaluation warning: error message$'
+expectSuccess '(lib.warnOnInstantiate "error message" hello).meta' 'description = "Program that produces a familiar, friendly greeting";'
+expectSuccess '(lib.warnOnInstantiate "error message" hello).name' '^"hello-2.12.2"$'
+expectSuccess '(lib.warnOnInstantiate "error message" hello).type' '^"derivation"$'
+expectSuccess '(lib.warnOnInstantiate "error message" hello).outputName' '^"out"$'

--- a/lib/warnings.nix
+++ b/lib/warnings.nix
@@ -1,0 +1,97 @@
+{ lib }:
+
+let
+  inherit (lib)
+    isAttrs
+    isDerivation
+    isFunction
+    isList
+    mapAttrs
+    removeAttrs
+    warn
+    ;
+in
+rec {
+  /**
+    Raise warning on an arbitrary value, when it is accessed
+    and alias it to something else.
+
+    # Inputs
+
+    `msg`
+    : The warning message to emit (via `lib.warn`).
+
+    `v`
+    : The value to wrap. Can be derivation/attribute set/function/list.
+
+    # Examples
+    :::{.example}
+    ## `lib.derivations.warnAlias` usage example
+
+    ```nix
+    {
+      myFunc = warnAlias "myFunc has been renamed to my-func" my-func;
+    }
+    ```
+
+    :::
+  */
+  warnAlias =
+    msg: v:
+    if isDerivation v then
+      warnOnInstantiate msg v
+    else if isAttrs v then
+      mapAttrs (_: warn msg) v
+    else if isFunction v then
+      arg: warn msg (v arg)
+    else if isList v then
+      map (warn msg) v
+    else
+      # Can’t do better than this, and a `throw` would be more
+      # disruptive for users…
+      #
+      # `nix search` flags up warnings already, so hopefully this won’t
+      # make things much worse until we have proper CI for aliases,
+      # especially since aliases of paths and numbers are presumably
+      # not common.
+      warn msg v;
+
+  /**
+    Wrap a derivation such that instantiating it produces a warning.
+
+    All attributes will be wrapped with `lib.warn` except from `.meta`, `.name`,
+    and `.type` which are used by `nix search`, and `.outputName` which avoids
+    double warnings with `nix-instantiate` and `nix-build`.
+
+    # Inputs
+
+    `msg`
+    : The warning message to emit (via `lib.warn`).
+
+    `drv`
+    : The derivation to wrap.
+
+    # Examples
+    :::{.example}
+    ## `lib.derivations.warnOnInstantiate` usage example
+
+    ```nix
+    {
+      myPackage = warnOnInstantiate "myPackage has been renamed to my-package" my-package;
+    }
+    ```
+
+    :::
+  */
+  warnOnInstantiate =
+    msg: drv:
+    let
+      drvToWrap = removeAttrs drv [
+        "meta"
+        "name"
+        "type"
+        "outputName"
+      ];
+    in
+    drv // mapAttrs (_: lib.warn msg) drvToWrap;
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -225,7 +225,7 @@ let
     if lib.isDerivation v then
       lib.warnOnInstantiate msg v
     else if lib.isAttrs v then
-      lib.mapAttrs (lib.warn msg) v
+      lib.mapAttrs (_: lib.warn msg) v
     else if lib.isFunction v then
       arg: lib.warn msg (v arg)
     else if lib.isList v then

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -20,6 +20,8 @@ lib: self: super:
 with self;
 
 let
+  inherit (lib) warnAlias;
+
   # Removing recurseForDerivation prevents derivations of aliased attribute set
   # to appear while listing all the packages available.
   removeRecurseForDerivations =
@@ -219,26 +221,6 @@ let
     aliases: lib.mapAttrs (n: alias: removeRecurseForDerivations (checkInPkgs n alias)) aliases;
 
   plasma5Throws = mapAliases (lib.mapAttrs (k: _: makePlasma5Throw k) deprecatedPlasma5Packages);
-
-  warnAlias =
-    msg: v:
-    if lib.isDerivation v then
-      lib.warnOnInstantiate msg v
-    else if lib.isAttrs v then
-      lib.mapAttrs (_: lib.warn msg) v
-    else if lib.isFunction v then
-      arg: lib.warn msg (v arg)
-    else if lib.isList v then
-      map (lib.warn msg) v
-    else
-      # Can’t do better than this, and a `throw` would be more
-      # disruptive for users…
-      #
-      # `nix search` flags up warnings already, so hopefully this won’t
-      # make things much worse until we have proper CI for aliases,
-      # especially since aliases of paths and numbers are presumably
-      # not common.
-      lib.warn msg v;
 in
 
 mapAliases {


### PR DESCRIPTION
`warnAlias` was added in https://github.com/NixOS/nixpkgs/pull/456527 exclusively to `pkgs/top-level/aliases.nix` but I think it will be useful in stdlib.

Also comes with tests!

https://github.com/NixOS/nixpkgs/pull/457349 is included in this PR, because tests fail otherwise.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
