### PR TITLE
rPackages.FLAMES: update patch

### DIFF
--- a/pkgs/development/r-modules/patches/FLAMES.patch
+++ b/pkgs/development/r-modules/patches/FLAMES.patch
@@ -1,17 +1,13 @@
 diff --git a/src/Makevars b/src/Makevars
-index 4f3fa42ce752..e48e45561292 100755
+index ce72c93..b52a2c6 100755
 --- a/src/Makevars
 +++ b/src/Makevars
-@@ -24,12 +24,6 @@ FILES = $(CFILES) $(CPPFILES)
- SOURCES = $(FILES)
- OBJECTS = $(CPPFILES:.cpp=.o) $(CFILES:.c=.o)
+@@ -42,7 +42,7 @@ RUST_OK := $(shell [ "$(RUST_VERSION)" != "" ] && \
+                    [ "$$(printf '%s\n' 1.77.0 $(RUST_VERSION) | sort -V | head -n1)" = "1.77.0" ] && echo "yes" || echo "no")
  
--strippedLib: $(SHLIB)
--	if test -e "/usr/bin/strip" & test -e "/bin/uname" & [[ `uname` == "Linux" ]] ; then /usr/bin/strip --strip-debug $(SHLIB); fi
--clean:
--	rm $(OBJECTS)
--.phony: strippedLib clean
--
- RHTSLIB_LIBS=$(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript" -e \
-     'Rhtslib::pkgconfig("PKG_LIBS")')
- RHTSLIB_CPPFLAGS=$(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript" -e \
+ # Targets
+-all: strippedLib ../inst/bin/minimap2 ../inst/bin/oarfish
++all: ../inst/bin/minimap2 ../inst/bin/oarfish
+ 
+ strippedLib: $(SHLIB)
+ 	if test -e "/usr/bin/strip" & test -e "/bin/uname" & [[ `uname` == "Linux" ]] ; then /usr/bin/strip --strip-debug $(SHLIB); fi


### PR DESCRIPTION
- Original file changed
- Removed the target that includes the /usr/bin/strip
- This is OK, because nix should strip anyway

https://github.com/NixOS/nixpkgs/pull/457385

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
