### PR TITLE
libfprint-2-tod1-broadcom: 5.12.018 -> 5.15.285-5.15.010.0; libfprint-2-tod1-broadcom-cv3plus: init at 6.3.299-6.3.040.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -873,6 +873,12 @@
     github = "AimPizza";
     githubId = 64905268;
   };
+  aionescu = {
+    name = "Alex Ionescu";
+    email = "github@ionescu.sh";
+    github = "aionescu";
+    githubId = 48064242;
+  };
   aiotter = {
     email = "git@aiotter.com";
     github = "aiotter";

--- a/pkgs/by-name/li/libfprint-2-tod1-broadcom-cv3plus/package.nix
+++ b/pkgs/by-name/li/libfprint-2-tod1-broadcom-cv3plus/package.nix
@@ -1,0 +1,91 @@
+{
+  autoPatchelfHook,
+  fetchgit,
+  lib,
+  libfprint-tod,
+  openssl,
+  patchelfUnstable,
+  stdenv,
+}:
+
+let
+  pname = "libfprint-2-tod1-broadcom-cv3plus";
+  version = "6.3.299-6.3.040.0";
+
+  src = fetchgit {
+    url = "git://git.launchpad.net/~oem-solutions-engineers/pc-enablement/+git/libfprint-2-tod1-broadcom-cv3plus/";
+    branchName = "ubuntu/latest";
+    rev = "ac7a8ab2318216e603c8c23b279bbad28a301d3";
+    hash = "sha256-4JwoUuvskj8GqTUQpKBECCL+jkSfxpaukqRTTVTmSLk=";
+  };
+
+  wrapperLibName = "wrapper-lib.so";
+  wrapperLibSource = "wrapper-lib.c";
+
+  # wraps `fopen()` for finding firmware files
+  wrapperLib = stdenv.mkDerivation {
+    pname = "${pname}-wrapper-lib";
+    inherit version;
+
+    src = builtins.path {
+      name = "${pname}-wrapper-lib-source";
+      path = ./.;
+      filter = path: type: baseNameOf path == wrapperLibSource;
+    };
+
+    postPatch = ''
+      substitute ${wrapperLibSource} lib.c \
+        --subst-var-by to "${src}/var/lib/fprint/.broadcomCv3plusFW"
+      cc -fPIC -shared lib.c -o ${wrapperLibName}
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      install -D -t $out/lib ${wrapperLibName}
+      runHook postInstall
+    '';
+  };
+in
+stdenv.mkDerivation {
+  inherit src pname version;
+
+  buildInputs = [
+    libfprint-tod
+    openssl
+    wrapperLib
+  ];
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    patchelfUnstable # have to use patchelfUnstable to support --rename-dynamic-symbols
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -D -t "$out/lib/libfprint-2/tod-1/" -m 644 -v usr/lib/x86_64-linux-gnu/libfprint-2/tod-1/libfprint-2-tod-1-broadcom-cv3plus.so
+    install -D -t "$out/lib/udev/rules.d/"      -m 644 -v lib/udev/rules.d/60-libfprint-2-device-broadcom-cv3plus.rules
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    echo fopen64 fopen_wrapper > fopen_name_map
+    patchelf \
+      --rename-dynamic-symbols fopen_name_map \
+      --add-needed ${wrapperLibName} \
+      "$out/lib/libfprint-2/tod-1/libfprint-2-tod-1-broadcom-cv3plus.so"
+  '';
+
+  passthru.driverPath = "/lib/libfprint-2/tod-1";
+
+  meta = with lib; {
+    description = "Broadcom driver module for libfprint-2-tod Touch OEM Driver for Dell ControlVault v3+";
+    homepage = "https://git.launchpad.net/~oem-solutions-engineers/pc-enablement/+git/libfprint-2-tod1-broadcom-cv3plus/";
+    license = licenses.unfree;
+    maintainers = with maintainers; [
+      aionescu
+      pitkling
+    ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/by-name/li/libfprint-2-tod1-broadcom-cv3plus/wrapper-lib.c
+++ b/pkgs/by-name/li/libfprint-2-tod1-broadcom-cv3plus/wrapper-lib.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const char from[] =  "/var/lib/fprint/.broadcomCv3plusFW";
+static const char to[]   = "@to@";
+
+FILE* fopen_wrapper(const char* fn, const char* mode) {
+    size_t fn_len = strlen(fn);
+    size_t from_len = strlen(from);
+    if (fn_len > from_len && memcmp(fn, from, from_len) == 0) {
+        size_t to_len = strlen(to);
+        char* rewritten = calloc(fn_len + (to_len - from_len) + 1, 1);
+        memcpy(rewritten, to, to_len);
+        memcpy(rewritten + to_len, fn + from_len, fn_len - from_len);
+
+        printf("fopen_wrapper.c: Replacing path '%s' with '%s'\n", fn, rewritten);
+        FILE* result = fopen(rewritten, mode);
+        free(rewritten);
+        return result;
+    }
+    return fopen(fn, mode);
+}

--- a/pkgs/by-name/li/libfprint-2-tod1-broadcom/package.nix
+++ b/pkgs/by-name/li/libfprint-2-tod1-broadcom/package.nix
@@ -1,10 +1,10 @@
 {
   autoPatchelfHook,
-  fetchzip,
+  fetchgit,
   lib,
   libfprint-tod,
   openssl,
-  patchelfUnstable, # have to use patchelfUnstable to support --rename-dynamic-symbols
+  patchelfUnstable,
   stdenv,
 }:
 
@@ -13,13 +13,13 @@
 #   * https://github.com/NixOS/nixpkgs/pull/260715
 let
   pname = "libfprint-2-tod1-broadcom";
-  version = "5.12.018";
+  version = "5.15.285-5.15.010.0";
 
-  src = fetchzip {
-    url = "http://dell.archive.canonical.com/updates/pool/public/libf/${pname}/${pname}_${version}.orig.tar.gz";
-    hash = "sha256-0C2PpYpEJNrU+8NT95w4QV0J5nHQisMY94Czw3jQOzw=";
-    pname = "${pname}-unpacked";
-    inherit version;
+  src = fetchgit {
+    url = "git://git.launchpad.net/~oem-solutions-engineers/libfprint-2-tod1-broadcom/";
+    branchName = "ubuntu/latest";
+    rev = "4372071d7296f40050b67e62ab256db71bd9ea30";
+    hash = "sha256-zJiRos0SrU1FxX8SfEnIv0cVy3snkRuTWaLy+MywF+Q=";
   };
 
   wrapperLibName = "wrapper-lib.so";
@@ -60,7 +60,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [
     autoPatchelfHook
-    patchelfUnstable
+    patchelfUnstable # have to use patchelfUnstable to support --rename-dynamic-symbols
   ];
 
   installPhase = ''
@@ -81,10 +81,13 @@ stdenv.mkDerivation {
   passthru.driverPath = "/lib/libfprint-2/tod-1";
 
   meta = {
-    description = "Broadcom driver module for libfprint-2-tod Touch OEM Driver (from Dell)";
-    homepage = "http://dell.archive.canonical.com/updates/pool/public/libf/libfprint-2-tod1-broadcom/";
+    description = "Broadcom driver module for libfprint-2-tod Touch OEM Driver for Dell ControlVault v3";
+    homepage = "https://git.launchpad.net/~oem-solutions-engineers/libfprint-2-tod1-broadcom/";
     license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [ pitkling ];
+    maintainers = with lib.maintainers; [
+      aionescu
+      pitkling
+    ];
     platforms = [ "x86_64-linux" ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };


### PR DESCRIPTION
This PR does two things:

* Updates the `libfprint-2-tod1-broadcom` fingerprint driver to the latest upstream version, also updating its source URL (since it changed recently).
* Adds the `libfprint-2-tod1-broadcom-cv3plus` fingerprint driver, which is required for newer Dell devices.

Notes for reviewers:

* The new `-cv3plus` package uses the same `patchelf --rename-dynamic-symbols` technique as the existing package, just with a different path. I duplicated the `wrapper-lib` C code because `nixpkgs-vet` didn't let me share it between packages. It would probably be a good idea to abstract out this pattern, given that more packages than just these 2 are using it, but that would likely be a larger-scale endeavor.
* I included both changes in one PR since the packages are related and their definitions are very similar. I'm also happy to split them into separate PRs.
* The `-cv3plus` driver could instead be included as part of the base package, but I thought it's better to keep them separate as they are released & versioned independently.

Closes #343133.

Pinging @pitkling and @sunsetkookaburra for potential reviews (based on the discussion in the linked issue).

Also, @pitkling, this PR is partly based on [your fork](https://github.com/pitkling/nixpkgs/tree/libfprint-2-tod1-broadcom-update). Would you like to be added as co-author (and/or co-maintainer of the new `-cv3plus` package)?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
