### PR TITLE
openapi-generator-cli: 7.16.0 -> 7.17.0; add passthru.updateScript

### DIFF
--- a/pkgs/by-name/op/openapi-generator-cli/package.nix
+++ b/pkgs/by-name/op/openapi-generator-cli/package.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
   maven,
   makeWrapper,
+  nix-update-script,
 }:
 
 let
@@ -47,8 +48,11 @@ let
       runHook postInstall
     '';
 
-    passthru.tests.example = callPackage ./example.nix {
-      openapi-generator-cli = this;
+    passthru = {
+      updateScript = nix-update-script { };
+      tests.example = callPackage ./example.nix {
+        openapi-generator-cli = this;
+      };
     };
 
     meta = {

--- a/pkgs/by-name/op/openapi-generator-cli/package.nix
+++ b/pkgs/by-name/op/openapi-generator-cli/package.nix
@@ -9,7 +9,7 @@
 
 let
   jre = jre_headless;
-  version = "7.16.0";
+  version = "7.17.0";
   mainProgram = "openapi-generator-cli";
   this = maven.buildMavenPackage {
     inherit version;
@@ -20,10 +20,10 @@ let
       owner = "OpenAPITools";
       repo = "openapi-generator";
       tag = "v${version}";
-      hash = "sha256-CoztWf2H2rXcx4d8Av8cBXzMqIZsrSCgx21i3+o2ufo=";
+      hash = "sha256-9jO+u08wrxW0RcXTGDh8mpPp9Eu2PwRifKNsso6s3QM=";
     };
 
-    mvnHash = "sha256-5Kzv9h3X5s/1D0Gd1XQRvNGVAyf44QcriJFvS07wdZo=";
+    mvnHash = "sha256-PiLpJponpJUXakdno+KGxzDvZG6jYRPp3t5q/G5JX+M=";
     mvnParameters = "-Duser.home=$TMPDIR";
     doCheck = false;
 


### PR DESCRIPTION
Updates `openapi-generator-cli` to 7.17.0.
Adds update-script for better maintainability.

Homepage: https://github.com/OpenAPITools/openapi-generator
Changelog: https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.17.0 

Provided by [DigitalBrewStudios](https://digitalbrewstudios.com) (Open-source commitment statement coming soon!).


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
