### PR TITLE
python3Packages.flake8-deprecated: 2.2.1 -> 2.3.0

### DIFF
--- a/pkgs/development/python-modules/flake8-deprecated/default.nix
+++ b/pkgs/development/python-modules/flake8-deprecated/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
-  pythonOlder,
-  fetchPypi,
+  fetchFromGitHub,
   buildPythonPackage,
   hatchling,
   flake8,
@@ -10,15 +9,14 @@
 
 buildPythonPackage rec {
   pname = "flake8-deprecated";
-  version = "2.2.1";
+  version = "2.3.0";
   pyproject = true;
 
-  disabled = pythonOlder "3.8";
-
-  src = fetchPypi {
-    pname = "flake8_deprecated";
-    inherit version;
-    hash = "sha256-7pbKAB0coFYfqORvI+LSRgsYqGaWNzyrZE4QKuD/KqI=";
+  src = fetchFromGitHub {
+    owner = "gforcada";
+    repo = "flake8-deprecated";
+    tag = version;
+    hash = "sha256-KF0hWhMZEWuSPUyfStayNa5Nfss9NpTvMXPeemWbQXU=";
   };
 
   build-system = [ hatchling ];
@@ -31,10 +29,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "flake8_deprecated" ];
 
-  meta = with lib; {
+  meta = {
+    changelog = "https://github.com/gforcada/flake8-deprecated/blob/${src.tag}/CHANGES.rst";
     description = "Flake8 plugin that warns about deprecated method calls";
     homepage = "https://github.com/gforcada/flake8-deprecated";
-    license = licenses.gpl2Only;
-    maintainers = with maintainers; [ lopsided98 ];
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ lopsided98 ];
   };
 }


### PR DESCRIPTION
Diff: https://github.com/gforcada/flake8-deprecated/compare/2.2.1...2.3.0

Changelog: https://github.com/gforcada/flake8-deprecated/blob/2.3.0/CHANGES.rst

closes https://github.com/NixOS/nixpkgs/pull/457669
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
