### PR TITLE
coreutils: fix darwin env regression by disabling singleBinary

### DIFF
--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -25,7 +25,7 @@
   withOpenssl ? !minimal,
   openssl,
   withPrefix ? false,
-  singleBinary ? "symlinks", # you can also pass "shebangs" or false
+  singleBinary ? (if stdenv.hostPlatform.isDarwin then false else "symlinks"), # you can also pass "shebangs" or false
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus cannot use
@@ -34,6 +34,7 @@
 
 assert aclSupport -> acl != null;
 assert selinuxSupport -> libselinux != null && libsepol != null;
+assert stdenv.hostPlatform.isDarwin -> singleBinary == false; # https://debbugs.gnu.org/cgi/bugreport.cgi?bug=79714
 
 let
   inherit (lib)


### PR DESCRIPTION
In v9.8, coreutils began linking against CoreFoundation. Doing so always adds the `__CF_USER_TEXT_ENCODING` to the environment of the running program. This means that `env -i env` is not empty, since the second invocation adds that environment var. Coreutils v9.9 included a change to more narrowly link CoreFoundation, but with singleBinary it is, of course, always linked-in. As such, disable and assert against enabling `singleBinary` on Darwin since it results in incorrect behavior. FWIW, neither Homebrew nor MacPorts enables single-binary.

See https://debbugs.gnu.org/cgi/bugreport.cgi?bug=79714


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Have built atop a recent staging commit (to avoid big rebuild), overriding only for coreutils-full. Verified behavior is incorrect before and correct after (with `env -i env`). Derivation is (as-expected) unchanged on x86_64-linux vs. staging.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
