### PR TITLE
{libbladeRF,uhd}: fix darwin-aarch64 builds

### DIFF
--- a/pkgs/by-name/li/libbladeRF/package.nix
+++ b/pkgs/by-name/li/libbladeRF/package.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
   ];
 
   env = lib.optionalAttrs stdenv.cc.isClang {
-    NIX_CFLAGS_COMPILE = "-Wno-error=unused-but-set-variable";
+    NIX_CFLAGS_COMPILE = "-Wno-error=unused-but-set-variable -Wno-error=tautological-overlap-compare";
   };
 
   hardeningDisable = [ "fortify" ];

--- a/pkgs/by-name/uh/uhd/package.nix
+++ b/pkgs/by-name/uh/uhd/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  llvmPackages_20,
   substitute,
   fetchpatch,
   fetchurl,
@@ -36,9 +37,15 @@
 
 let
   inherit (lib) optionals cmakeBool;
+  stdenv' = (
+    if stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64 then
+      llvmPackages_20.stdenv
+    else
+      stdenv
+  );
 in
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv'.mkDerivation (finalAttrs: {
   pname = "uhd";
   # NOTE: Use the following command to update the package, and the uhdImageSrc attribute:
   #
@@ -148,7 +155,7 @@ stdenv.mkDerivation (finalAttrs: {
     # ABI differences GCC 7.1
     # /nix/store/wd6r25miqbk9ia53pp669gn4wrg9n9cj-gcc-7.3.0/include/c++/7.3.0/bits/vector.tcc:394:7: note: parameter passing for argument of type 'std::vector<uhd::range_t>::iterator {aka __gnu_cxx::__normal_iterator<uhd::range_t*, std::vector<uhd::range_t> >}' changed in GCC 7.1
   ]
-  ++ optionals stdenv.hostPlatform.isAarch32 [
+  ++ optionals stdenv'.hostPlatform.isAarch32 [
     "-DCMAKE_CXX_FLAGS=-Wno-psabi"
   ];
 
@@ -181,7 +188,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # many tests fails on darwin, according to ofborg
-  doCheck = !stdenv.hostPlatform.isDarwin;
+  doCheck = !stdenv'.hostPlatform.isDarwin;
 
   doInstallCheck = true;
 
@@ -192,7 +199,7 @@ stdenv.mkDerivation (finalAttrs: {
     "installFirmware"
     "removeInstalledTests"
   ]
-  ++ optionals (enableUtils && stdenv.hostPlatform.isLinux) [
+  ++ optionals (enableUtils && stdenv'.hostPlatform.isLinux) [
     "moveUdevRules"
   ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fix build of two specific gnuradio dependencies on aarch64-darwin. libbladeRF and uhd both had issues building specifically on aarch64-darwin. 

- libbladeRF had a compiler warning in its unit tests, this was fixed by adding `Wno-error=tautological-overlap-compare` to CFLAGS.
- uhd requires an older clang to build, this was inspired by issues like https://github.com/nixos/nixpkgs/issues/449650. Downgraded to clang_20 for now only on aarch64-darwin



- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

