### PR TITLE
sfizz-ui: new package, to reflect the upstream split of sfizz

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12655,6 +12655,12 @@
     github = "jonocodes";
     githubId = 1310468;
   };
+  joostn = {
+    name = "Joost Nieuwenhuijse";
+    email = "joost@newhouse.nl";
+    github = "joostn";
+    githubId = 1309157;
+  };
   jopejoe1 = {
     email = "nixpkgs@missing.ninja";
     matrix = "@jopejoe1:matrix.org";

--- a/pkgs/by-name/sf/sfizz-ui/package.nix
+++ b/pkgs/by-name/sf/sfizz-ui/package.nix
@@ -1,0 +1,104 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  libjack2,
+  libsndfile,
+  xorg,
+  freetype,
+  libxkbcommon,
+  cairo,
+  glib,
+  zenity,
+  flac,
+  libogg,
+  libvorbis,
+  libopus,
+  cmake,
+  pango,
+  pkg-config,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sfizz-ui";
+  version = "1.2.3";
+
+  src = fetchFromGitHub {
+    owner = "sfztools";
+    repo = "sfizz-ui";
+    rev = finalAttrs.version;
+    # Upstream requires submodules:
+    # VST3_SDK, vstgui4, sfzt_auwrapper and sfizz
+    fetchSubmodules = true;
+    hash = "sha256-Rf1i+tu91bqzO1wWJi7mw2BvbX9K0mDNPqsTUoqPd4U=";
+  };
+
+  buildInputs = [
+    cairo
+    flac
+    freetype
+    glib
+    libjack2
+    libogg
+    libopus
+    libsndfile
+    libvorbis
+    libxkbcommon
+    pango
+    xorg.libX11
+    xorg.libXau
+    xorg.libxcb
+    xorg.libXdmcp
+    xorg.xcbutil
+    xorg.xcbutilcursor
+    xorg.xcbutilimage
+    xorg.xcbutilkeysyms
+    xorg.xcbutilrenderutil
+    zenity
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "SFIZZ_TESTS" true)
+  ];
+
+  doCheck = true;
+
+  postPatch = ''
+    # Hard code zenity path (1/2):
+    substituteInPlace plugins/editor/src/editor/NativeHelpers.cpp \
+      --replace-fail \
+        'auto glibPath = g_find_program_in_path("zenity");' \
+        'auto glibPath = g_strdup("${lib.getExe zenity}");'
+
+    # Hard code zenity path (2/2):
+    substituteInPlace plugins/editor/external/vstgui4/vstgui/lib/platform/linux/x11fileselector.cpp \
+      --replace-fail \
+        'zenitypath = "zenity"' \
+        'zenitypath = "${lib.getExe zenity}"'
+
+    # Fix compilation error in GCC 14:
+    # https://github.com/sfztools/vstgui/pull/5
+    # https://github.com/steinbergmedia/vstgui/issues/324
+    # This has been upstreamed into master, remove when we switch to a newer upstream version.
+    substituteInPlace plugins/editor/external/vstgui4/vstgui/lib/finally.h \
+      --replace-fail \
+        "other.invoke (false);" \
+        "other.invoke = false;"
+  '';
+
+  meta = {
+    description = "SFZ based sampler, providing AU / LV2 / PD / VST3 plugins using the sfizz library";
+    homepage = "https://github.com/sfztools/sfizz-ui/";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [
+      joostn
+      magnetophon
+    ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Upstream sfizz since version 1.2.2 no longer contains VST and LV2 plugins. These were moved to sfztools/sfizz-ui repository.

Also see https://github.com/NixOS/nixpkgs/issues/434654

This pull request creates a new sfizz-ui package. Alternatively we could update the sfizz package (and switch it to sfizz-ui upstream) but I think this is more appropriate.

@magnetophon can I add you as maintainer? I'm happy to co-maintain (also for the original sfizz) but would also be happy to leave the maintenance to you.

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
