### PR TITLE
onnxruntime: add support for openvino execution provider

### DIFF
--- a/pkgs/by-name/im/immich-machine-learning/package.nix
+++ b/pkgs/by-name/im/immich-machine-learning/package.nix
@@ -57,6 +57,14 @@ python.pkgs.buildPythonApplication rec {
   # inside the nix build sandbox.
   doCheck = stdenv.buildPlatform.system != "aarch64-linux";
 
+  disabledTests = [
+    # These tests fail with OpenVINO-enabled onnxruntime
+    # (https://github.com/immich-app/immich/issues/23456)
+    "test_recognition"
+    "test_recognition_adds_batch_axis_for_ort"
+    "test_recognition_does_not_add_batch_axis_if_exists"
+  ];
+
   nativeCheckInputs = with python.pkgs; [
     httpx
     pytest-asyncio

--- a/pkgs/by-name/on/onnxruntime/0001-use-constexpr-for-constexpr-things.patch
+++ b/pkgs/by-name/on/onnxruntime/0001-use-constexpr-for-constexpr-things.patch
@@ -1,0 +1,34 @@
+From 1a24a500a59f0b70d6ee78c90acea21b737cb21f Mon Sep 17 00:00:00 2001
+From: Simonas Kazlauskas <git@kazlauskas.me>
+Date: Sat, 1 Nov 2025 01:21:06 +0200
+Subject: [PATCH] use constexpr for constexpr things
+
+ref https://github.com/microsoft/onnxruntime/issues/26283
+---
+ include/onnxruntime/core/framework/ortdevice.h | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/include/onnxruntime/core/framework/ortdevice.h b/include/onnxruntime/core/framework/ortdevice.h
+index adade482f6..5ba2a3e405 100644
+--- a/include/onnxruntime/core/framework/ortdevice.h
++++ b/include/onnxruntime/core/framework/ortdevice.h
+@@ -13,11 +13,11 @@ struct OrtDevice {
+   using DeviceId = int16_t;
+ 
+   // Pre-defined device types.
+-  static const DeviceType CPU = 0;
+-  static const DeviceType GPU = 1;  // Nvidia or AMD
+-  static const DeviceType FPGA = 2;
+-  static const DeviceType NPU = 3;  // Ascend
+-  static const DeviceType DML = 4;
++  static constexpr DeviceType CPU = 0;
++  static constexpr DeviceType GPU = 1;  // Nvidia or AMD
++  static constexpr DeviceType FPGA = 2;
++  static constexpr DeviceType NPU = 3;  // Ascend
++  static constexpr DeviceType DML = 4;
+ 
+   struct MemType {
+     // Pre-defined memory types.
+-- 
+2.51.0
+

--- a/pkgs/by-name/on/onnxruntime/package.nix
+++ b/pkgs/by-name/on/onnxruntime/package.nix
@@ -106,6 +106,8 @@ effectiveStdenv.mkDerivation rec {
     # https://github.com/microsoft/onnxruntime/pull/15661
     # https://github.com/microsoft/onnxruntime/pull/20509
     ./cpuinfo-logging.patch
+    # Fixes build against OpenVINO. Remove when no longer applies as it'll be fixed upstream
+    ./0001-use-constexpr-for-constexpr-things.patch
   ]
   ++ lib.optionals cudaSupport [
     # We apply the referenced 1064.patch ourselves to our nix dependency.

--- a/pkgs/by-name/on/onnxruntime/package.nix
+++ b/pkgs/by-name/on/onnxruntime/package.nix
@@ -244,14 +244,22 @@ effectiveStdenv.mkDerivation rec {
     (lib.cmakeBool "onnxruntime_USE_NCCL" (cudaSupport && ncclSupport))
     (lib.cmakeBool "onnxruntime_USE_ROCM" rocmSupport)
     (lib.cmakeBool "onnxruntime_ENABLE_LTO" (!cudaSupport || cudaPackages.cudaOlder "12.8"))
-  ] ++ lib.optionals openvinoSupport [
+  ]
+  ++ lib.optionals openvinoSupport [
     (lib.cmakeBool "onnxruntime_USE_OPENVINO" true)
-    (lib.cmakeFeature "onnxruntime_USE_OPENVINO_AUTO" (if effectiveStdenv.hostPlatform.system == "x86_64-linux" then "NPU,GPU,CPU" else "GPU"))
+    (lib.cmakeFeature "onnxruntime_USE_OPENVINO_AUTO" (
+      if effectiveStdenv.hostPlatform.system == "x86_64-linux" then "NPU,GPU,CPU" else "GPU"
+    ))
     (lib.cmakeBool "onnxruntime_USE_OPENVINO_GPU" true)
-    (lib.cmakeBool "onnxruntime_USE_OPENVINO_CPU" (effectiveStdenv.hostPlatform.system == "x86_64-linux"))
-    (lib.cmakeBool "onnxruntime_USE_OPENVINO_NPU" (effectiveStdenv.hostPlatform.system == "x86_64-linux"))
+    (lib.cmakeBool "onnxruntime_USE_OPENVINO_CPU" (
+      effectiveStdenv.hostPlatform.system == "x86_64-linux"
+    ))
+    (lib.cmakeBool "onnxruntime_USE_OPENVINO_NPU" (
+      effectiveStdenv.hostPlatform.system == "x86_64-linux"
+    ))
     (lib.cmakeFeature "OpenVINO_DIR" "${lib.getDev openvino}/runtime/cmake")
-  ] ++ lib.optionals pythonSupport [
+  ]
+  ++ lib.optionals pythonSupport [
     (lib.cmakeBool "onnxruntime_ENABLE_PYTHON" true)
   ]
   ++ lib.optionals cudaSupport [
@@ -274,25 +282,24 @@ effectiveStdenv.mkDerivation rec {
     (lib.cmakeBool "onnxruntime_USE_COMPOSABLE_KERNEL_CK_TILE" false)
   ];
 
-  env =
-    {
-      NIX_CFLAGS_COMPILE = "-Wno-error";
-    }
-    // lib.optionalAttrs rocmSupport {
-      MIOPEN_PATH = rocmPackages.miopen;
-      # HIP steps fail to find ROCm libs when not in HIPFLAGS, causing
-      # fatal error: 'rocrand/rocrand.h' file not found
-      HIPFLAGS = lib.concatMapStringsSep " " (pkg: "-I${lib.getInclude pkg}/include") [
-        rocmPackages.hipblas
-        rocmPackages.hipcub
-        rocmPackages.hiprand
-        rocmPackages.hipsparse
-        rocmPackages.rocblas
-        rocmPackages.rocprim
-        rocmPackages.rocrand
-        rocmPackages.rocthrust
-      ];
-    };
+  env = {
+    NIX_CFLAGS_COMPILE = "-Wno-error";
+  }
+  // lib.optionalAttrs rocmSupport {
+    MIOPEN_PATH = rocmPackages.miopen;
+    # HIP steps fail to find ROCm libs when not in HIPFLAGS, causing
+    # fatal error: 'rocrand/rocrand.h' file not found
+    HIPFLAGS = lib.concatMapStringsSep " " (pkg: "-I${lib.getInclude pkg}/include") [
+      rocmPackages.hipblas
+      rocmPackages.hipcub
+      rocmPackages.hiprand
+      rocmPackages.hipsparse
+      rocmPackages.rocblas
+      rocmPackages.rocprim
+      rocmPackages.rocrand
+      rocmPackages.rocthrust
+    ];
+  };
 
   doCheck =
     !(

--- a/pkgs/by-name/on/onnxruntime/package.nix
+++ b/pkgs/by-name/on/onnxruntime/package.nix
@@ -32,6 +32,7 @@
   cudaPackages ? { },
   rocmPackages,
   openvino,
+  onnxruntime,
 }@inputs:
 
 let

--- a/pkgs/by-name/op/openvino/cmake-install-paths.patch
+++ b/pkgs/by-name/op/openvino/cmake-install-paths.patch
@@ -1,0 +1,145 @@
+--- a/cmake/developer_package/packaging/archive.cmake
++++ b/cmake/developer_package/packaging/archive.cmake
+@@ -25,14 +25,15 @@ endif()
+ macro(ov_archive_cpack_set_dirs)
+     # common "archive" package locations
+     # TODO: move current variables to OpenVINO specific locations
+-    set(OV_CPACK_INCLUDEDIR runtime/include)
+-    set(OV_CPACK_OPENVINO_CMAKEDIR runtime/cmake)
+-    set(OV_CPACK_DOCDIR docs)
+-    set(OV_CPACK_LICENSESDIR licenses)
+-    set(OV_CPACK_SAMPLESDIR samples)
++    set(OV_CPACK_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")
++    set(OV_CPACK_OPENVINO_CMAKEDIR "${CMAKE_INSTALL_FULL_LIBDIR}/cmake/openvino")
++    set(OV_CPACK_DOCDIR "${CMAKE_INSTALL_DATAROOTDIR}/doc/openvino")
++    set(OV_CPACK_LICENSESDIR "${CMAKE_INSTALL_DATAROOTDIR}/licenses/openvino")
++    set(OV_CPACK_SAMPLESDIR "${CMAKE_INSTALL_DATAROOTDIR}/openvino/samples")
+     set(OV_CPACK_WHEELSDIR wheels)
+     set(OV_CPACK_DEVREQDIR tools)
+-    set(OV_CPACK_PYTHONDIR python)
++    find_package(Python QUIET REQUIRED COMPONENTS Interpreter Development)
++    set(OV_CPACK_PYTHONDIR "${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
+ 
+     if(USE_BUILD_TYPE_SUBFOLDER)
+         set(build_type ${CMAKE_BUILD_TYPE})
+@@ -49,11 +50,11 @@ macro(ov_archive_cpack_set_dirs)
+         set(OV_CPACK_RUNTIMEDIR runtime/lib/${ARCH_FOLDER}/${build_type})
+         set(OV_CPACK_ARCHIVEDIR runtime/lib/${ARCH_FOLDER}/${build_type})
+     else()
+-        set(OV_CPACK_LIBRARYDIR runtime/lib/${ARCH_FOLDER})
+-        set(OV_CPACK_RUNTIMEDIR runtime/lib/${ARCH_FOLDER})
+-        set(OV_CPACK_ARCHIVEDIR runtime/lib/${ARCH_FOLDER})
++        set(OV_CPACK_LIBRARYDIR "${CMAKE_INSTALL_LIBDIR}")
++        set(OV_CPACK_RUNTIMEDIR "${CMAKE_INSTALL_LIBDIR}")
++        set(OV_CPACK_ARCHIVEDIR "${CMAKE_INSTALL_LIBDIR}")
+     endif()
+-    set(OV_CPACK_PLUGINSDIR ${OV_CPACK_RUNTIMEDIR})
++    set(OV_CPACK_PLUGINSDIR "${OV_CPACK_RUNTIMEDIR}/openvino")
+ endmacro()
+ 
+ ov_archive_cpack_set_dirs()
+@@ -78,9 +79,9 @@ macro(ov_define_component_include_rules)
+     # licensing
+     unset(OV_CPACK_COMP_LICENSING_EXCLUDE_ALL)
+     # samples
+-    unset(OV_CPACK_COMP_CPP_SAMPLES_EXCLUDE_ALL)
+-    unset(OV_CPACK_COMP_C_SAMPLES_EXCLUDE_ALL)
+-    unset(OV_CPACK_COMP_PYTHON_SAMPLES_EXCLUDE_ALL)
++    set(OV_CPACK_COMP_CPP_SAMPLES_EXCLUDE_ALL EXCLUDE_FROM_ALL)
++    set(OV_CPACK_COMP_C_SAMPLES_EXCLUDE_ALL EXCLUDE_FROM_ALL)
++    set(OV_CPACK_COMP_PYTHON_SAMPLES_EXCLUDE_ALL EXCLUDE_FROM_ALL)
+     # python
+     unset(OV_CPACK_COMP_PYTHON_OPENVINO_EXCLUDE_ALL)
+     unset(OV_CPACK_COMP_BENCHMARK_APP_EXCLUDE_ALL)
+@@ -92,8 +93,8 @@ macro(ov_define_component_include_rules)
+     # nodejs
+     set(OV_CPACK_COMP_NPM_EXCLUDE_ALL EXCLUDE_FROM_ALL)
+     # scripts
+-    unset(OV_CPACK_COMP_INSTALL_DEPENDENCIES_EXCLUDE_ALL)
+-    unset(OV_CPACK_COMP_SETUPVARS_EXCLUDE_ALL)
++    set(OV_CPACK_COMP_INSTALL_DEPENDENCIES_EXCLUDE_ALL EXCLUDE_FROM_ALL)
++    set(OV_CPACK_COMP_SETUPVARS_EXCLUDE_ALL EXCLUDE_FROM_ALL)
+     # pkgconfig
+     set(OV_CPACK_COMP_PKG_CONFIG_EXCLUDE_ALL ${OV_CPACK_COMP_CORE_DEV_EXCLUDE_ALL})
+     # symbolic links
+--- a/src/plugins/intel_npu/tools/compile_tool/CMakeLists.txt
++++ b/src/plugins/intel_npu/tools/compile_tool/CMakeLists.txt
+@@ -28,7 +28,7 @@ ov_add_target(ADD_CPPLINT
+                       npu_tools_utils)
+ 
+ set_target_properties(${TARGET_NAME} PROPERTIES
+-                          FOLDER ${CMAKE_CURRENT_SOURCE_DIR}
++                          FOLDER ${CMAKE_CURRENT_SOURCE_DIR} OUTPUT_NAME ov-${TARGET_NAME}
+                           CXX_STANDARD 17)
+ 
+ # TODO: fix warnings and remove this exception
+@@ -41,13 +41,13 @@ endif()
+ #
+ 
+ install(TARGETS ${TARGET_NAME}
+-        RUNTIME DESTINATION "tools/${TARGET_NAME}"
++        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+         COMPONENT ${NPU_INTERNAL_COMPONENT}
+         ${OV_CPACK_COMP_NPU_INTERNAL_EXCLUDE_ALL})
+ 
+ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
+     install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/README.md"
+-            DESTINATION "tools/${TARGET_NAME}"
++            DESTINATION "${OV_CPACK_DOCDIR}" RENAME README-${TARGET_NAME}.md
+             COMPONENT ${NPU_INTERNAL_COMPONENT}
+             ${OV_CPACK_COMP_NPU_INTERNAL_EXCLUDE_ALL})
+ endif()
+--- a/src/plugins/intel_npu/tools/protopipe/CMakeLists.txt
++++ b/src/plugins/intel_npu/tools/protopipe/CMakeLists.txt
+@@ -52,7 +52,7 @@ ov_add_target(ADD_CPPLINT
+               LINK_LIBRARIES PRIVATE ${DEPENDENCIES})
+ 
+ set_target_properties(${TARGET_NAME} PROPERTIES
+-                          FOLDER ${CMAKE_CURRENT_SOURCE_DIR}
++                          FOLDER ${CMAKE_CURRENT_SOURCE_DIR} OUTPUT_NAME ov-${TARGET_NAME}
+                           CXX_STANDARD 17)
+ 
+ #
+@@ -60,13 +60,13 @@ set_target_properties(${TARGET_NAME} PROPERTIES
+ #
+ 
+ install(TARGETS ${TARGET_NAME}
+-        RUNTIME DESTINATION "tools/${TARGET_NAME}"
++        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+         COMPONENT ${NPU_INTERNAL_COMPONENT}
+         ${OV_CPACK_COMP_NPU_INTERNAL_EXCLUDE_ALL})
+ 
+ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
+     install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/README.md"
+-            DESTINATION "tools/${TARGET_NAME}"
++            DESTINATION "${OV_CPACK_DOCDIR}" RENAME README-${TARGET_NAME}.md
+             COMPONENT ${NPU_INTERNAL_COMPONENT}
+             ${OV_CPACK_COMP_NPU_INTERNAL_EXCLUDE_ALL})
+ endif()
+--- a/src/plugins/intel_npu/tools/single-image-test/CMakeLists.txt
++++ b/src/plugins/intel_npu/tools/single-image-test/CMakeLists.txt
+@@ -50,7 +50,7 @@ ov_add_target(ADD_CPPLINT
+ ov_set_threading_interface_for(${TARGET_NAME})
+ 
+ set_target_properties(${TARGET_NAME} PROPERTIES
+-                          FOLDER ${CMAKE_CURRENT_SOURCE_DIR}
++                          FOLDER ${CMAKE_CURRENT_SOURCE_DIR} OUTPUT_NAME ov-${TARGET_NAME}
+                           CXX_STANDARD 17)
+ 
+ # TODO: fix warnings and remove this exception
+@@ -63,13 +63,13 @@ endif()
+ #
+ 
+ install(TARGETS ${TARGET_NAME}
+-        RUNTIME DESTINATION "tools/${TARGET_NAME}"
++        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+         COMPONENT ${NPU_INTERNAL_COMPONENT}
+         ${OV_CPACK_COMP_NPU_INTERNAL_EXCLUDE_ALL})
+ 
+ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
+     install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/README.md"
+-            DESTINATION "tools/${TARGET_NAME}"
++            DESTINATION "${OV_CPACK_DOCDIR}" RENAME README-${TARGET_NAME}.md
+             COMPONENT ${NPU_INTERNAL_COMPONENT}
+             ${OV_CPACK_COMP_NPU_INTERNAL_EXCLUDE_ALL})
+ endif()

--- a/pkgs/by-name/op/openvino/cmake-install-paths.patch
+++ b/pkgs/by-name/op/openvino/cmake-install-paths.patch
@@ -34,7 +34,7 @@
 +        set(OV_CPACK_ARCHIVEDIR "${CMAKE_INSTALL_LIBDIR}")
      endif()
 -    set(OV_CPACK_PLUGINSDIR ${OV_CPACK_RUNTIMEDIR})
-+    set(OV_CPACK_PLUGINSDIR "${OV_CPACK_RUNTIMEDIR}/openvino")
++    set(OV_CPACK_PLUGINSDIR "${OV_CPACK_RUNTIMEDIR}")
  endmacro()
 
  ov_archive_cpack_set_dirs()

--- a/pkgs/by-name/op/openvino/cmake-install-paths.patch
+++ b/pkgs/by-name/op/openvino/cmake-install-paths.patch
@@ -19,7 +19,7 @@
 -    set(OV_CPACK_PYTHONDIR python)
 +    find_package(Python QUIET REQUIRED COMPONENTS Interpreter Development)
 +    set(OV_CPACK_PYTHONDIR "${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
- 
+
      if(USE_BUILD_TYPE_SUBFOLDER)
          set(build_type ${CMAKE_BUILD_TYPE})
 @@ -49,11 +50,11 @@ macro(ov_archive_cpack_set_dirs)
@@ -36,7 +36,7 @@
 -    set(OV_CPACK_PLUGINSDIR ${OV_CPACK_RUNTIMEDIR})
 +    set(OV_CPACK_PLUGINSDIR "${OV_CPACK_RUNTIMEDIR}/openvino")
  endmacro()
- 
+
  ov_archive_cpack_set_dirs()
 @@ -78,9 +79,9 @@ macro(ov_define_component_include_rules)
      # licensing
@@ -66,22 +66,22 @@
 +++ b/src/plugins/intel_npu/tools/compile_tool/CMakeLists.txt
 @@ -28,7 +28,7 @@ ov_add_target(ADD_CPPLINT
                        npu_tools_utils)
- 
+
  set_target_properties(${TARGET_NAME} PROPERTIES
 -                          FOLDER ${CMAKE_CURRENT_SOURCE_DIR}
 +                          FOLDER ${CMAKE_CURRENT_SOURCE_DIR} OUTPUT_NAME ov-${TARGET_NAME}
                            CXX_STANDARD 17)
- 
+
  # TODO: fix warnings and remove this exception
 @@ -41,13 +41,13 @@ endif()
  #
- 
+
  install(TARGETS ${TARGET_NAME}
 -        RUNTIME DESTINATION "tools/${TARGET_NAME}"
 +        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
          COMPONENT ${NPU_INTERNAL_COMPONENT}
          ${OV_CPACK_COMP_NPU_INTERNAL_EXCLUDE_ALL})
- 
+
  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
      install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/README.md"
 -            DESTINATION "tools/${TARGET_NAME}"
@@ -93,22 +93,22 @@
 +++ b/src/plugins/intel_npu/tools/protopipe/CMakeLists.txt
 @@ -52,7 +52,7 @@ ov_add_target(ADD_CPPLINT
                LINK_LIBRARIES PRIVATE ${DEPENDENCIES})
- 
+
  set_target_properties(${TARGET_NAME} PROPERTIES
 -                          FOLDER ${CMAKE_CURRENT_SOURCE_DIR}
 +                          FOLDER ${CMAKE_CURRENT_SOURCE_DIR} OUTPUT_NAME ov-${TARGET_NAME}
                            CXX_STANDARD 17)
- 
+
  #
 @@ -60,13 +60,13 @@ set_target_properties(${TARGET_NAME} PROPERTIES
  #
- 
+
  install(TARGETS ${TARGET_NAME}
 -        RUNTIME DESTINATION "tools/${TARGET_NAME}"
 +        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
          COMPONENT ${NPU_INTERNAL_COMPONENT}
          ${OV_CPACK_COMP_NPU_INTERNAL_EXCLUDE_ALL})
- 
+
  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
      install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/README.md"
 -            DESTINATION "tools/${TARGET_NAME}"
@@ -120,22 +120,22 @@
 +++ b/src/plugins/intel_npu/tools/single-image-test/CMakeLists.txt
 @@ -50,7 +50,7 @@ ov_add_target(ADD_CPPLINT
  ov_set_threading_interface_for(${TARGET_NAME})
- 
+
  set_target_properties(${TARGET_NAME} PROPERTIES
 -                          FOLDER ${CMAKE_CURRENT_SOURCE_DIR}
 +                          FOLDER ${CMAKE_CURRENT_SOURCE_DIR} OUTPUT_NAME ov-${TARGET_NAME}
                            CXX_STANDARD 17)
- 
+
  # TODO: fix warnings and remove this exception
 @@ -63,13 +63,13 @@ endif()
  #
- 
+
  install(TARGETS ${TARGET_NAME}
 -        RUNTIME DESTINATION "tools/${TARGET_NAME}"
 +        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
          COMPONENT ${NPU_INTERNAL_COMPONENT}
          ${OV_CPACK_COMP_NPU_INTERNAL_EXCLUDE_ALL})
- 
+
  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
      install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/README.md"
 -            DESTINATION "tools/${TARGET_NAME}"

--- a/pkgs/by-name/op/openvino/package.nix
+++ b/pkgs/by-name/op/openvino/package.nix
@@ -190,7 +190,7 @@ stdenv.mkDerivation rec {
 
     substituteInPlace $dev/lib/pkgconfig/openvino.pc \
       --replace-fail "include_prefix=\''${prefix}/" "include_prefix=" \
-      --replace-fail "exec_prefix=\''${prefix}/" "exec_prefix="}
+      --replace-fail "exec_prefix=\''${prefix}/" "exec_prefix="
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/op/openvino/package.nix
+++ b/pkgs/by-name/op/openvino/package.nix
@@ -78,6 +78,8 @@ stdenv.mkDerivation rec {
       url = "https://github.com/openvinotoolkit/openvino/commit/677716c2471cadf1bf1268eca6343498a886a229.patch?full_index=1";
       hash = "sha256-iaifJBdl7+tQZq1d8SiczUaXz+AdfMrLtwzfTmSG+XA=";
     })
+    # https://aur.archlinux.org/cgit/aur.git/tree/010-openvino-change-install-paths.patch?h=openvino
+    ./cmake-install-paths.patch
   ];
 
   outputs = [
@@ -103,10 +105,6 @@ stdenv.mkDerivation rec {
     cudaPackages.cuda_nvcc
   ];
 
-  patches = [
-    # https://aur.archlinux.org/cgit/aur.git/tree/010-openvino-change-install-paths.patch?h=openvino
-    ./cmake-install-paths.patch
-  ];
 
   postPatch = ''
     mkdir -p temp/tbbbind_${tbbbind_version}

--- a/pkgs/by-name/op/openvino/package.nix
+++ b/pkgs/by-name/op/openvino/package.nix
@@ -105,7 +105,6 @@ stdenv.mkDerivation rec {
     cudaPackages.cuda_nvcc
   ];
 
-
   postPatch = ''
     mkdir -p temp/tbbbind_${tbbbind_version}
     pushd temp/tbbbind_${tbbbind_version}

--- a/pkgs/development/python-modules/onnxruntime/default.nix
+++ b/pkgs/development/python-modules/onnxruntime/default.nix
@@ -10,6 +10,7 @@
   re2,
 
   # dependencies
+  openvino,
   coloredlogs,
   numpy,
   packaging,
@@ -72,6 +73,7 @@ buildPythonPackage {
     ++ lib.optionals onnxruntime.passthru.ncclSupport [
       nccl # libnccl.so.XX
     ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ openvino ]
   );
 
   dependencies = [

--- a/pkgs/development/python-modules/openvino/default.nix
+++ b/pkgs/development/python-modules/openvino/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   openvino-native,
   numpy,
-  python,
 }:
 
 buildPythonPackage {
@@ -18,8 +17,8 @@ buildPythonPackage {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/${python.sitePackages}
-    cp -Rv * $out/${python.sitePackages}/
+    mkdir -p $out
+    cp -Rv * $out/
 
     runHook postInstall
   '';

--- a/pkgs/development/python-modules/openvino/default.nix
+++ b/pkgs/development/python-modules/openvino/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   openvino-native,
   numpy,
+  packaging,
 }:
 
 buildPythonPackage {
@@ -12,7 +13,10 @@ buildPythonPackage {
 
   src = openvino-native.python;
 
-  propagatedBuildInputs = [ numpy ];
+  dependencies = [
+    numpy
+    packaging
+  ];
 
   installPhase = ''
     runHook preInstall
@@ -23,10 +27,7 @@ buildPythonPackage {
     runHook postInstall
   '';
 
-  pythonImportsCheck = [
-    "openvino"
-    "openvino.runtime"
-  ];
+  pythonImportsCheck = [ "openvino" ];
 
   meta = with lib; {
     description = "OpenVINO(TM) Runtime";

--- a/pkgs/development/python-modules/openvino/default.nix
+++ b/pkgs/development/python-modules/openvino/default.nix
@@ -3,7 +3,7 @@
   buildPythonPackage,
   openvino-native,
   numpy,
-  packaging,
+  python,
 }:
 
 buildPythonPackage {
@@ -13,21 +13,21 @@ buildPythonPackage {
 
   src = openvino-native.python;
 
-  dependencies = [
-    numpy
-    packaging
-  ];
+  propagatedBuildInputs = [ numpy ];
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out
-    cp -Rv * $out/
+    mkdir -p $out/${python.sitePackages}
+    cp -Rv * $out/${python.sitePackages}/
 
     runHook postInstall
   '';
 
-  pythonImportsCheck = [ "openvino" ];
+  pythonImportsCheck = [
+    "openvino"
+    "openvino.runtime"
+  ];
 
   meta = with lib; {
     description = "OpenVINO(TM) Runtime";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11072,6 +11072,7 @@ self: super: with self; {
       python3Packages = self;
       pythonSupport = true;
     };
+    inherit (pkgs) openvino;
   };
 
   onnxruntime-tools = callPackage ../development/python-modules/onnxruntime-tools { };


### PR DESCRIPTION
This is a rebase/fixup of https://github.com/NixOS/nixpkgs/pull/380543. This enables the openVINO provider to hw-accelerate inference in apps that use onnxruntime for their AI needs (such as immich, possibly frigate, etc.)

Fixes #457288 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
