### PR TITLE
ci/github-script/merge: add trusted maintainers

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -46,7 +46,9 @@ To ensure security and a focused utility, the bot adheres to specific limitation
 - The PR only touches packages located under `pkgs/by-name/*`.
 - The PR is either:
   - approved by a [committer][@NixOS/nixpkgs-committers].
+  - approved by a [trusted maintainer][@NixOS/nixpkgs-trusted-maintainers].
   - authored by a [committer][@NixOS/nixpkgs-committers].
+  - authored by a [trusted maintainer][@NixOS/nixpkgs-trusted-maintainers].
   - backported via label.
   - created by [@r-ryantm](https://nix-community.github.io/nixpkgs-update/r-ryantm/).
 - The user attempting to merge is a member of [@NixOS/nixpkgs-maintainers].
@@ -101,6 +103,7 @@ This script can also be run locally to print basic test cases.
 
 [@NixOS/nixpkgs-maintainers]: https://github.com/orgs/NixOS/teams/nixpkgs-maintainers
 [@NixOS/nixpkgs-committers]: https://github.com/orgs/NixOS/teams/nixpkgs-committers
+[@NixOS/nixpkgs-trusted-maintainers]: https://github.com/orgs/NixOS/teams/nixpkgs-trusted-maintainers
 [@NixOS/nixpkgs-ci]: https://github.com/orgs/NixOS/teams/nixpkgs-ci
 [@NixOS/nixpkgs-core]: https://github.com/orgs/NixOS/teams/nixpkgs-core
 [RFC 172]: https://github.com/NixOS/rfcs/pull/172


### PR DESCRIPTION
*(only the last commit belongs to this PR, everything else is part of #457652)*

This introduces the concept of "trusted maintainers", which are similar to "scoped committers". They can merge changes from any contributor, as long as these are scoped to the packages the TM maintains. Basic criteria like by-name apply as well, of course.

It also allows the reverse flow, where a PR created by a trusted maintainer can be merged by a regular maintainer of that package.

More elaborated checks for rebuild counts were intentionally left out, because it is already the case that regular maintainers can merge potentially breaking updates to load-bearing packages. To help *all* maintainers deal with the fallout of such a merge, the merge-bot should be extended to support merging reverts instead. This is out of scope for here, though.

## Things done

(the intent is to put the concept of "trusted maintainers" through some kind of public feedback cycle first, so this PR is just a reference implementation for that proposal)

- [ ] [Approvals from nixpkgs-core](https://github.com/NixOS/nixpkgs/blob/master/ci/README.md#nixpkgs-merge-bot), because this increases the scope of the merge-bot.
- [ ] Creating the `nixpkgs-trusted-maintainers` team.
- [ ] Tested locally.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
