### PR TITLE
thinkfan: fix missing sleep bin in thinkfan-sleep.service

### DIFF
--- a/pkgs/by-name/th/thinkfan/package.nix
+++ b/pkgs/by-name/th/thinkfan/package.nix
@@ -7,6 +7,7 @@
   yaml-cpp,
   pkg-config,
   procps,
+  coreutils,
   smartSupport ? false,
   libatasmart,
 }:
@@ -31,6 +32,8 @@ stdenv.mkDerivation (finalAttrs: {
   + ''
     substituteInPlace rcscripts/systemd/thinkfan-sleep.service \
       --replace-fail "/usr/bin/pkill" "${lib.getExe' procps "pkill"}"
+    substituteInPlace rcscripts/systemd/thinkfan-sleep.service \
+      --replace-fail "ExecStart=sleep " "ExecStart=${lib.getExe' coreutils "sleep"} "
     substituteInPlace rcscripts/systemd/thinkfan-wakeup.service \
       --replace-fail "/usr/bin/pkill" "${lib.getExe' procps "pkill"}"
     substituteInPlace rcscripts/systemd/thinkfan.service.cmake \


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/457772

Substitue missing sleep bin in the unit file 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
