### PR TITLE
nixos/actual: revert 452544 and allow specifying secrets using genJqSecretsReplacementSnippet

### DIFF
--- a/nixos/modules/services/web-apps/actual.nix
+++ b/nixos/modules/services/web-apps/actual.nix
@@ -2,6 +2,7 @@
   lib,
   pkgs,
   config,
+  utils,
   ...
 }:
 let
@@ -16,7 +17,6 @@ let
     ;
 
   cfg = config.services.actual;
-  configFile = formatType.generate "config.json" cfg.settings;
   dataDir = "/var/lib/actual";
 
   formatType = pkgs.formats.json { };
@@ -34,7 +34,10 @@ in
 
     settings = mkOption {
       default = { };
-      description = "Server settings, refer to [the documentation](https://actualbudget.org/docs/config/) for available options.";
+      description = ''
+        Server settings, refer to [the documentation](https://actualbudget.org/docs/config/) for available options.
+        You can specify secret values in this configuration by setting `somevalue._secret = "/path/to/file"` instead of setting `somevalue` directly.
+      '';
       type = types.submodule {
         freeformType = formatType.type;
 
@@ -68,13 +71,20 @@ in
       description = "Actual server, a local-first personal finance app";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      environment.ACTUAL_CONFIG_PATH = configFile;
+      environment.ACTUAL_CONFIG_PATH = "/run/actual/config.json";
+
+      preStart = ''
+        # Generate config including secret values.
+        ${utils.genJqSecretsReplacementSnippet cfg.settings "/run/actual/config.json"}
+      '';
+
       serviceConfig = {
         ExecStart = getExe cfg.package;
         DynamicUser = true;
         User = "actual";
         Group = "actual";
         StateDirectory = "actual";
+        RuntimeDirectory = "actual";
         WorkingDirectory = dataDir;
         LimitNOFILE = "1048576";
         PrivateTmp = true;

--- a/nixos/modules/services/web-apps/actual.nix
+++ b/nixos/modules/services/web-apps/actual.nix
@@ -32,16 +32,6 @@ in
       description = "Whether to open the firewall for the specified port.";
     };
 
-    environmentFile = mkOption {
-      type = types.nullOr types.path;
-      default = null;
-      description = ''
-        Environment file for specifying additional settings such as secrets.
-
-        See <https://actualbudget.org/docs/config/oauth-auth#environment-variables>.
-      '';
-    };
-
     settings = mkOption {
       default = { };
       description = "Server settings, refer to [the documentation](https://actualbudget.org/docs/config/) for available options.";
@@ -86,7 +76,6 @@ in
         Group = "actual";
         StateDirectory = "actual";
         WorkingDirectory = dataDir;
-        EnvironmentFile = cfg.environmentFile;
         LimitNOFILE = "1048576";
         PrivateTmp = true;
         PrivateDevices = true;


### PR DESCRIPTION
Reverted #452544 as discussed [here](https://github.com/NixOS/nixpkgs/pull/452544#issuecomment-3470031584).
Also provides an alternative way to specify secrets using `utils.genJqSecretsReplacementSnippet`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
