### PR TITLE
[25.05] libwebsockets: apply patches for CVE-2025-11677 and CVE-2025-11678

### DIFF
--- a/pkgs/by-name/li/libwebsockets/package.nix
+++ b/pkgs/by-name/li/libwebsockets/package.nix
@@ -21,6 +21,14 @@ stdenv.mkDerivation rec {
     hash = "sha256-KOAhIVn4G5u0A1TE75Xv7iYO3/i8foqWYecH0kJHdBM=";
   };
 
+  # Updating to 4.4.1 would bring some errors, and the patch doesn't apply cleanly
+  # https://github.com/warmcat/libwebsockets/commit/47efb8c1c2371fa309f85a32984e99b2cc1d614a
+  postPatch = ''
+    for f in $(find . -name CMakeLists.txt); do
+      sed '/^cmake_minimum_required/Is/VERSION [0-9]\.[0-9]/VERSION 3.5/' -i "$f"
+    done
+  '';
+
   outputs = [
     "out"
     "dev"

--- a/pkgs/by-name/li/libwebsockets/package.nix
+++ b/pkgs/by-name/li/libwebsockets/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   openssl,
   zlib,
@@ -20,6 +21,19 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     hash = "sha256-KOAhIVn4G5u0A1TE75Xv7iYO3/i8foqWYecH0kJHdBM=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2025-11677.patch";
+      url = "https://libwebsockets.org/git/libwebsockets/patch?id=2f082ec31261f556969160143ba94875d783971a";
+      hash = "sha256-FeiZAbr1kpt+YNjhi2gfG2A6nXKiSssMFRmlALaneu4=";
+    })
+    (fetchpatch {
+      name = "CVE-2025-11678.patch";
+      url = "https://libwebsockets.org/git/libwebsockets/patch?id=2bb9598562b37c942ba5b04bcde3f7fdf66a9d3a";
+      hash = "sha256-1uQUkoMbK+3E/QYMIBLlBZypwHBIrWBtm+KIW07WRj8=";
+    })
+  ];
 
   # Updating to 4.4.1 would bring some errors, and the patch doesn't apply cleanly
   # https://github.com/warmcat/libwebsockets/commit/47efb8c1c2371fa309f85a32984e99b2cc1d614a


### PR DESCRIPTION
https://libwebsockets.org/git/libwebsockets/commit?id=2f082ec31261f556969160143ba94875d783971a
https://libwebsockets.org/git/libwebsockets/commit?id=2bb9598562b37c942ba5b04bcde3f7fdf66a9d3a

Manual backport of #456575 to pull an additional commit to avoid conflicts.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 457785`
Commit: `e51631083c5104e2ba23f6f68c0faa71a5dcac2b`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 30 packages built:</summary>
  <ul>
    <li>ardour</li>
    <li>ardour_7</li>
    <li>chickenPackages_5.chickenEggs.mosquitto</li>
    <li>clive</li>
    <li>collectd</li>
    <li>domoticz</li>
    <li>driftnet</li>
    <li>ebusd</li>
    <li>guacamole-server</li>
    <li>guile-mqtt</li>
    <li>janus-gateway</li>
    <li>janus-gateway.dev</li>
    <li>janus-gateway.doc</li>
    <li>janus-gateway.man</li>
    <li>kismet</li>
    <li>libwebsockets</li>
    <li>libwebsockets.dev</li>
    <li>mosquitto</li>
    <li>mosquitto.dev</li>
    <li>mosquitto.lib</li>
    <li>owntone</li>
    <li>owntracks-recorder</li>
    <li>seafile-client</li>
    <li>seafile-shared</li>
    <li>shairport-sync</li>
    <li>shairport-sync-airplay2</li>
    <li>ttyd</li>
    <li>ttyd.man</li>
    <li>ustreamer</li>
    <li>vhs</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
