### PR TITLE
backrest: fix build on darwin

### DIFF
--- a/pkgs/by-name/ba/backrest/package.nix
+++ b/pkgs/by-name/ba/backrest/package.nix
@@ -93,6 +93,7 @@ buildGoModule {
       ++ lib.optionals stdenv.hostPlatform.isDarwin [
         "TestBackup" # relies on ionice
         "TestCancelBackup"
+        "TestFirstRun" # e2e test requires networking
       ];
     in
     [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];


### PR DESCRIPTION
Without this patch, the package fails on community builder machine
```
       > ok       github.com/garethgeorge/backrest/internal/oplog/storetests      1.050s
       > ok       github.com/garethgeorge/backrest/internal/orchestrator  3.307s
       > ok       github.com/garethgeorge/backrest/internal/orchestrator/repo     12.910s
       > ok      github.com/garethgeorge/backrest/internal/orchestrator/tasks    0.640s
       > ok       github.com/garethgeorge/backrest/internal/protoutil     0.183s
       > ok       github.com/garethgeorge/backrest/internal/queue 3.138s
       > ok       github.com/garethgeorge/backrest/internal/resticinstaller       0.148s
       > ok       github.com/garethgeorge/backrest/pkg/restic     9.851s
       > --- FAIL: TestFirstRun (2.62s)
       >     first_run_test.go:48: failed to listen: listen tcp :0: bind: operation not permitted
       > FAIL
       > FAIL        github.com/garethgeorge/backrest/test/e2e       2.819s
       > FAIL
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
