### PR TITLE
fluida-lv2: new package (FluidSynth as an LV2 plugin)

### DIFF
--- a/pkgs/by-name/fl/fluida-lv2/package.nix
+++ b/pkgs/by-name/fl/fluida-lv2/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  libX11,
+  cairo,
+  lv2,
+  fluidsynth,
+  writableTmpDirAsHomeHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fluida-lv2";
+  version = "0.9.5";
+
+  src = fetchFromGitHub {
+    owner = "brummer10";
+    repo = "Fluida.lv2";
+    tag = "v${finalAttrs.version}";
+    # submodule: https://github.com/brummer10/libxputty.git
+    fetchSubmodules = true;
+    hash = "sha256-5Oud5s81DIc7p/GAJT3i8FHHBh4y9uJqOxfchmX1nE4=";
+  };
+
+  nativeBuildInputs = [
+    writableTmpDirAsHomeHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    cairo
+    fluidsynth
+    libX11
+    lv2
+  ];
+
+  postInstall = ''
+    # Output files were installed in ~/.lv2
+    # copy to the output directory:
+    mkdir -p $out/lib/lv2
+    cp -r $HOME/.lv2/* $out/lib/lv2/
+  '';
+
+  meta = {
+    changelog = "https://github.com/brummer10/Fluida.lv2/releases/tag/v${finalAttrs.version}";
+    description = "Fluidsynth as LV2 plugin";
+    homepage = "https://github.com/brummer10/Fluida.lv2";
+    license = lib.licenses.gpl2;
+    maintainers = with lib.maintainers; [ joostn ];
+    platforms = [ "x86_64-linux" ];
+  };
+})


### PR DESCRIPTION
This is a new package for https://github.com/brummer10/Fluida.lv2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
