### PR TITLE
nixos/journald-gateway: change default of user and system option to false

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -257,6 +257,8 @@
 
 - The `services.meilisearch` module now always defaults to the latest version of meilisearch, as the previous `meilisearch_1_11` package was removed. This is only an issue if you were using the old version.
 
+- `services.journald.gateway.user` and `services.journald.gateway.system` now defaults to `false`. This new behaviour matches the default behaviour of the [`systemd-journal-gatewayd`](https://www.freedesktop.org/software/systemd/man/latest/systemd-journal-gatewayd.service.html) service itself.
+
 - The `services.postgresql` module now sets up a systemd unit `postgresql.target`. Depending on `postgresql.target` guarantees that postgres is in read-write mode and initial/ensure scripts were executed. Depending on `postgresql.service` only guarantees a read-only connection.
 
 - The `services.mysql` module now restarts the database `on-abnormal`, which means that it now will be restarted in certain situations, it wasn't before. For example an OOM-kill.

--- a/nixos/modules/system/boot/systemd/journald-gateway.nix
+++ b/nixos/modules/system/boot/systemd/journald-gateway.nix
@@ -75,7 +75,7 @@ in
     };
 
     system = lib.mkOption {
-      default = true;
+      default = false;
       type = lib.types.bool;
       description = ''
         Serve entries from system services and the kernel.
@@ -85,7 +85,7 @@ in
     };
 
     user = lib.mkOption {
-      default = true;
+      default = false;
       type = lib.types.bool;
       description = ''
         Serve entries from services for the current user.


### PR DESCRIPTION
Follow up of https://github.com/NixOS/nixpkgs/pull/328645 and https://github.com/NixOS/nixpkgs/pull/453807

Change default of `services.journald.gateway.user` and `services.journald.gateway.system` to `false`. Until now, both options are set to true as default. But the [systemd-journal-gatewayd](https://www.freedesktop.org/software/systemd/man/latest/systemd-journal-gatewayd.service.html) service defaults them to false. To match the origin behaviour, the defaults have been changed.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
