### PR TITLE
jameica: 2.10.5 -> 2.12.0

### DIFF
--- a/pkgs/by-name/ja/jameica/package.nix
+++ b/pkgs/by-name/ja/jameica/package.nix
@@ -15,10 +15,6 @@
 }:
 
 let
-  _version = "2.10.5";
-  _build = "488";
-  version = "${_version}-${_build}";
-
   swtSystem =
     if stdenv.hostPlatform.system == "i686-linux" then
       "linux"
@@ -45,13 +41,14 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "jameica";
-  inherit version;
+  version = "2.12.0";
 
   src = fetchFromGitHub {
     owner = "willuhn";
     repo = "jameica";
-    rev = "V_${builtins.replaceStrings [ "." ] [ "_" ] _version}_BUILD_${_build}";
-    hash = "sha256-xzSyq5Cse/TCzyb/eQNZyQS/I3mcPsvzWk3VjZg95gE=";
+    # Releases currently happen on branches named like the version number. Rev of the "2.12.0" branch.
+    rev = "b74b160643b18171d2d185b80b60e82a02a75898";
+    hash = "sha256-7KpQas8ttL2DP+gFH87uLQyx4PMwVQ+FaqXpZBPWV5U=i";
   };
 
   nativeBuildInputs = [
@@ -88,7 +85,7 @@ stdenv.mkDerivation rec {
     # copy platform-specific SWT
     cp lib/swt/${swtSystem}/swt.jar $out/share/jameica-${version}/
 
-    install -Dm644 releases/${_version}-*/jameica/jameica.jar $out/share/java/
+    install -Dm644 releases/${version}/jameica/jameica.jar $out/share/java/
     install -Dm644 plugin.xml $out/share/java/
     install -Dm644 build/jameica-icon.png $out/share/pixmaps/jameica.png
     cp ${desktopItem}/share/applications/* $out/share/applications/
@@ -97,8 +94,8 @@ stdenv.mkDerivation rec {
 
     # Create .app bundle for macOS
     mkdir -p $out/Applications
-    chmod +x releases/${_version}-${_build}-${_build}/tmp/jameica.app/jameica*.sh
-    cp -r releases/${_version}-${_build}-${_build}/tmp/jameica.app $out/Applications/Jameica.app
+    chmod +x releases/${version}/tmp/jameica.app/jameica*.sh
+    cp -r releases/${version}/tmp/jameica.app $out/Applications/Jameica.app
   ''
   + ''
 


### PR DESCRIPTION
Updated jameica

The releases get their own branch and aren't taged anymore so not using
the tag anymore.
And also the build version is no longer used.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
