### PR TITLE
{cudaPackages.nccl, onnxruntime}: remove reference to nvcc in binary

### DIFF
--- a/pkgs/development/cuda-modules/packages/nccl.nix
+++ b/pkgs/development/cuda-modules/packages/nccl.nix
@@ -10,6 +10,7 @@
   flags,
   lib,
   python3,
+  removeReferencesTo,
   which,
   # passthru.updateScript
   gitUpdater,
@@ -72,6 +73,7 @@ backendStdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cuda_nvcc
     python3
+    removeReferencesTo
     which
   ];
 
@@ -117,7 +119,21 @@ backendStdenv.mkDerivation (finalAttrs: {
   postFixup = ''
     _overrideFirst outputStatic "static" "lib" "out"
     moveToOutput lib/libnccl_static.a "''${!outputStatic:?}"
+  ''
+  # Since CUDA 12.8, the cuda_nvcc path leaks in:
+  # - libnccl.so's .nv_fatbin section
+  # - libnccl_static.a
+  # &devrt -L /nix/store/00000000000000000000000000000000-...nvcc-.../bin/...
+  # This string makes cuda_nvcc a runtime dependency of nccl.
+  # See https://github.com/NixOS/nixpkgs/pull/457803
+  + ''
+    remove-references-to -t "${lib.getBin cuda_nvcc}" \
+      ''${!outputLib}/lib/libnccl.so.* \
+      ''${!outputStatic}/lib/*.a
   '';
+
+  # C.f. remove-references-to above. Ensure *all* references to cuda_nvcc are removed
+  disallowedRequisites = [ (lib.getBin cuda_nvcc) ];
 
   passthru = {
     platformAssertions = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Since CUDA 12.8, the `.nv_fatbin` section of `libnccl.so` contains a reference to the `cuda_nvcc` derivation:
```
❮ strings -td $(nix-build --arg config '{ allowUnfree = true; cudaSupport = true; }' -A cudaPackages.nccl)/lib/libnccl.so | grep -F -- "-L /nix/store"
282100688 &devrt -L /nix/store/ygd3s9zm1pf77n3q3ac63v58www5scbc-9
312945964 &devrt -L /nix/store/ygd3s9zm1pf77n3q3ac63v58www5scbc-9

❮ nix-store --query --requisites "$(nix-build --arg config '{ allowUnfree = true; cudaSupport = true; }' -A cudaPackages.nccl)" | grep nvcc
/nix/store/ygd3s9zm1pf77n3q3ac63v58www5scbc-cuda12.8-cuda_nvcc-12.8.93
```
This makes `cuda_nvcc` (and `cudaPackages.stdenv.cc`, i.e. `gcc-wrapper`) a runtime dependency of `cudaPackages.nccl`.

Although not being desirable in principle, it actually breaks `firefox`, which has `disallowedRequisites = [ stdenv.cc ]`.

This patch simply removes all references to the `cuda_nvcc` out path from `cudaPackages.nccl`'s `libnccl.so` binary.

With this patch:
```
❮ strings -td $(nix-build --arg config '{ allowUnfree = true; cudaSupport = true; }' -A cudaPackages.nccl)/lib/libnccl.so | grep -F -- "-L /nix/store"
282100676 &devrt -L /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-9
312945944 &devrt -L /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-9

❮ nix-store --query --requisites "$(nix-build --arg config '{ allowUnfree = true; cudaSupport = true; }' -A cudaPackages.nccl)" | grep nvcc
```

Fixes #457406
Related: #457424

cc @SomeoneSerge @ConnorBaker 

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
