### PR TITLE
xorg.xorgserver: 21.1.18 -> 21.1.20

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -3352,11 +3352,11 @@ self: with self; {
     }:
     stdenv.mkDerivation (finalAttrs: {
       pname = "xorg-server";
-      version = "21.1.18";
+      version = "21.1.20";
       builder = ./builder.sh;
       src = fetchurl {
-        url = "mirror://xorg/individual/xserver/xorg-server-21.1.18.tar.xz";
-        sha256 = "0lk3268gzpll547zvaa64rdhs4z89d7w567lbd55swl71n9x2y68";
+        url = "mirror://xorg/individual/xserver/xorg-server-21.1.20.tar.xz";
+        sha256 = "sha256-dpW8YYJLOoG2utL3iwVADKAVAD3kAtGzIhFxBbcC6Tc=";
       };
       hardeningDisable = [
         "bindnow"

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -77,4 +77,4 @@ mirror://xorg/individual/font/font-jis-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-meltho-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-misc-1.1.3.tar.xz
 mirror://xorg/individual/lib/libXTrap-1.0.1.tar.bz2
-mirror://xorg/individual/xserver/xorg-server-21.1.18.tar.xz
+mirror://xorg/individual/xserver/xorg-server-21.1.20.tar.xz


### PR DESCRIPTION
Fixes CVE-2025-62229, CVE-2025-62230 and CVE-2025-62231.
https://lists.x.org/archives/xorg-announce/2025-October/003635.html

Changelog:
https://lists.x.org/archives/xorg-announce/2025-October/003636.html
https://lists.x.org/archives/xorg-announce/2025-October/003638.html

Manually handled the upgrade, the other upgrades do not seem needed to get X.Org 21.1.20: 
```
    xdpyinfo: 1.3.4 -> 1.4.0
    xf86-input-mouse: 1.9.5 -> 2.0.0
    xf86-video-amdgpu: 23.0.0 -> 25.0.0
    xf86-video-ast: 1.2.0 -> 1.2.1
    xf86-video-geode: 2.18.1 -> 2.18.2
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
