### PR TITLE
opencode: 1.0.25 -> 1.0.35 (built from source)

### DIFF
--- a/pkgs/by-name/op/opencode/hashes.json
+++ b/pkgs/by-name/op/opencode/hashes.json
@@ -1,0 +1,8 @@
+{
+  "node_modules": {
+    "aarch64-linux": "sha256-nNzDvqsFLJdZYDjvuYAcohnGnqNiGiS1mI9zAeKPr/U=",
+    "x86_64-linux": "sha256-rrW97K4eNtW3gGxu49BdzL6p8/goHBi3IT6z0IcQY0A=",
+    "aarch64-darwin": "sha256-joKBnXYVtDiJeq7sdDZwseXdNIjXM6BO3RqLTvq8kTQ=",
+    "x86_64-darwin": "sha256-6hLqaOP6qxnkUPHsWvlD96SjXRrbqWLeExWwlRgrUdg="
+  }
+}

--- a/pkgs/by-name/op/opencode/local-models-dev.patch
+++ b/pkgs/by-name/op/opencode/local-models-dev.patch
@@ -1,0 +1,20 @@
+diff --git i/packages/opencode/src/provider/models-macro.ts w/packages/opencode/src/provider/models-macro.ts
+index 91a0348..4f60069 100644
+--- i/packages/opencode/src/provider/models-macro.ts
++++ w/packages/opencode/src/provider/models-macro.ts
+@@ -1,4 +1,15 @@
+ export async function data() {
++  const localApiJsonPath = process.env.MODELS_DEV_API_JSON
++  
++  // Try to read from local file if path is provided
++  if (localApiJsonPath) {
++    const localFile = Bun.file(localApiJsonPath)
++    if (await localFile.exists()) {
++      return await localFile.text()
++    }
++  }
++  
++  // Fallback to fetching from remote URL
+   const json = await fetch("https://models.dev/api.json").then((x) => x.text())
+   return json
+ }

--- a/pkgs/by-name/op/opencode/skip-npm-pack.patch
+++ b/pkgs/by-name/op/opencode/skip-npm-pack.patch
@@ -1,0 +1,24 @@
+diff --git i/packages/opencode/script/build.ts w/packages/opencode/script/build.ts
+index 4ce8bfba..5b3da591 100755
+--- i/packages/opencode/script/build.ts
++++ w/packages/opencode/script/build.ts
+@@ -39,17 +39,9 @@ for (const [os, arch] of targets) {
+   const name = `${pkg.name}-${os}-${arch}`
+   await $`mkdir -p dist/${name}/bin`
+ 
+-  const opentui = `@opentui/core-${os === "windows" ? "win32" : os}-${arch.replace("-baseline", "")}`
+-  await $`mkdir -p ../../node_modules/${opentui}`
+-  await $`npm pack ${opentui}@${pkg.dependencies["@opentui/core"]}`.cwd(
+-    path.join(dir, "../../node_modules"),
+-  )
+-  await $`tar -xf ../../node_modules/${opentui.replace("@opentui/", "opentui-")}-*.tgz -C ../../node_modules/${opentui} --strip-components=1`
++  // Skip npm pack - packages already installed in node_modules by Nix
+ 
+-  const watcher = `@parcel/watcher-${os === "windows" ? "win32" : os}-${arch.replace("-baseline", "")}${os === "linux" ? "-glibc" : ""}`
+-  await $`mkdir -p ../../node_modules/${watcher}`
+-  await $`npm pack ${watcher}`.cwd(path.join(dir, "../../node_modules")).quiet()
+-  await $`tar -xf ../../node_modules/${watcher.replace("@parcel/", "parcel-")}-*.tgz -C ../../node_modules/${watcher} --strip-components=1`
++  // Skip npm pack - packages already installed in node_modules by Nix
+ 
+   const parserWorker = fs.realpathSync(
+     path.resolve(dir, "./node_modules/@opentui/core/parser.worker.js"),


### PR DESCRIPTION
A first draft for building `opencode` v1.x from source.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
