### PR TITLE
python3Packages.torch-audiomentations: cleanup, skip failing tests

### DIFF
--- a/pkgs/development/python-modules/lightning/default.nix
+++ b/pkgs/development/python-modules/lightning/default.nix
@@ -1,10 +1,5 @@
 {
-  lib,
   buildPythonPackage,
-  fetchFromGitHub,
-
-  # build-system
-  setuptools,
 
   # dependencies
   pytorch-lightning,
@@ -32,7 +27,7 @@ buildPythonPackage {
     pytestCheckHook
   ];
 
-  # Some packages are not in NixPkgs; other tests try to build distributed
+  # Some packages are not in nixpkgs; other tests try to build distributed
   # models, which doesn't work in the sandbox.
   doCheck = false;
 

--- a/pkgs/development/python-modules/pyannote-audio/default.nix
+++ b/pkgs/development/python-modules/pyannote-audio/default.nix
@@ -1,31 +1,36 @@
 {
   lib,
-  asteroid-filterbanks,
   buildPythonPackage,
-  einops,
   fetchFromGitHub,
+
+  # build-system
+  pyscaffold,
+  setuptools,
+
+  # dependencies
+  asteroid-filterbanks,
+  einops,
   huggingface-hub,
-  hydra-core,
   numpy,
   omegaconf,
   pyannote-core,
   pyannote-database,
   pyannote-metrics,
   pyannote-pipeline,
-  pyscaffold,
-  pythonOlder,
   pytorch-lightning,
   pytorch-metric-learning,
   rich,
   semver,
-  setuptools,
   soundfile,
   speechbrain,
   tensorboardx,
-  torch-audiomentations,
   torch,
+  torch-audiomentations,
   torchaudio,
   torchmetrics,
+
+  # optional-dependencies
+  hydra-core,
   typer,
 }:
 
@@ -34,22 +39,13 @@ buildPythonPackage rec {
   version = "3.4.0";
   pyproject = true;
 
-  disabled = pythonOlder "3.9";
-
   src = fetchFromGitHub {
     owner = "pyannote";
     repo = "pyannote-audio";
     tag = version;
-    hash = "sha256-NnwJJasObePBYWBnuVzOLFz2eqOHoOA6W5CzAEpkDV4=";
     fetchSubmodules = true;
+    hash = "sha256-NnwJJasObePBYWBnuVzOLFz2eqOHoOA6W5CzAEpkDV4=";
   };
-
-  pythonRelaxDeps = [ "torchaudio" ];
-
-  build-system = [
-    pyscaffold
-    setuptools
-  ];
 
   postPatch = ''
     substituteInPlace setup.cfg \
@@ -58,15 +54,25 @@ buildPythonPackage rec {
       --replace-fail "lightning" "pytorch-lightning"
   '';
 
+  build-system = [
+    pyscaffold
+    setuptools
+  ];
+
+  pythonRelaxDeps = [
+    "torchaudio"
+  ];
   dependencies = [
     asteroid-filterbanks
     einops
     huggingface-hub
+    numpy
     omegaconf
     pyannote-core
     pyannote-database
     pyannote-metrics
     pyannote-pipeline
+    pytorch-lightning
     pytorch-metric-learning
     rich
     semver
@@ -77,8 +83,6 @@ buildPythonPackage rec {
     torch-audiomentations
     torchaudio
     torchmetrics
-    numpy
-    pytorch-lightning
   ];
 
   optional-dependencies = {
@@ -90,11 +94,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pyannote.audio" ];
 
-  meta = with lib; {
+  meta = {
     description = "Neural building blocks for speaker diarization: speech activity detection, speaker change detection, overlapped speech detection, speaker embedding";
     homepage = "https://github.com/pyannote/pyannote-audio";
-    changelog = "https://github.com/pyannote/pyannote-audio/blob/${src.rev}/CHANGELOG.md";
-    license = licenses.mit;
+    changelog = "https://github.com/pyannote/pyannote-audio/blob/${src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
     maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pyannote-audio/default.nix
+++ b/pkgs/development/python-modules/pyannote-audio/default.nix
@@ -99,6 +99,8 @@ buildPythonPackage rec {
     homepage = "https://github.com/pyannote/pyannote-audio";
     changelog = "https://github.com/pyannote/pyannote-audio/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [
+      GaetanLepage
+    ];
   };
 }

--- a/pkgs/development/python-modules/pyannote-core/default.nix
+++ b/pkgs/development/python-modules/pyannote-core/default.nix
@@ -2,57 +2,53 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
+  hatch-vcs,
+  hatchling,
+
+  # dependencies
   numpy,
   pandas,
-  pytestCheckHook,
-  scipy,
-  setuptools,
   sortedcontainers,
-  typing-extensions,
-  versioneer,
+
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "pyannote-core";
-  version = "5.0.1";
+  version = "6.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pyannote";
     repo = "pyannote-core";
     tag = version;
-    hash = "sha256-28LVgI5bDFv71co/JsSrPrAcdugXiMRe6T1Jp0CO0XY=";
+    hash = "sha256-r5NkOAzrQGcb6LPi4/DA0uT9R0ELiYuwQkbT1l6R8Mw=";
   };
 
-  postPatch = ''
-    # Remove vendorized versioneer.py
-    rm versioneer.py
-  '';
-
   build-system = [
-    setuptools
-    versioneer
+    hatch-vcs
+    hatchling
   ];
 
   dependencies = [
-    sortedcontainers
     numpy
-    scipy
-    typing-extensions
+    pandas
+    sortedcontainers
   ];
 
   nativeCheckInputs = [
-    pandas
     pytestCheckHook
   ];
 
   pythonImportsCheck = [ "pyannote.core" ];
 
-  meta = with lib; {
+  meta = {
     description = "Advanced data structures for handling temporal segments with attached labels";
     homepage = "https://github.com/pyannote/pyannote-core";
     changelog = "https://github.com/pyannote/pyannote-core/releases/tag/${version}";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pyannote-database/default.nix
+++ b/pkgs/development/python-modules/pyannote-database/default.nix
@@ -2,53 +2,61 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
+  hatch-vcs,
+  hatchling,
+
+  # dependencies
   pandas,
   pyannote-core,
-  pythonOlder,
   pyyaml,
-  setuptools,
   typer,
-  versioneer,
+
+  # tests
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "pyannote-database";
-  version = "5.0.1";
+  version = "6.1.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "pyannote";
     repo = "pyannote-database";
     tag = version;
-    hash = "sha256-A7Xr24O8OvVAlURrR+SDCh8Uv9Yz3AUJSFDyDShVVjA=";
+    hash = "sha256-WDAkxoSI/IW2nIXCDoKa+p2ep1xcWW6WGNHCCZT51tY=";
   };
 
-  postPatch = ''
-    # Remove vendorized versioneer.py
-    rm versioneer.py
-  '';
-
   build-system = [
-    setuptools
-    versioneer
+    hatch-vcs
+    hatchling
   ];
 
   dependencies = [
+    pandas
     pyannote-core
     pyyaml
-    pandas
+    # Imported in pyannote/database/cli.py
     typer
   ];
 
   pythonImportsCheck = [ "pyannote.database" ];
 
-  meta = with lib; {
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    $out/bin/pyannote-database --help
+  '';
+
+  meta = {
     description = "Reproducible experimental protocols for multimedia (audio, video, text) database";
     homepage = "https://github.com/pyannote/pyannote-database";
-    license = licenses.mit;
-    maintainers = with maintainers; [ matthewcroughan ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ matthewcroughan ];
     mainProgram = "pyannote-database";
   };
 }

--- a/pkgs/development/python-modules/pyannote-metrics/default.nix
+++ b/pkgs/development/python-modules/pyannote-metrics/default.nix
@@ -1,66 +1,77 @@
 {
   lib,
   buildPythonPackage,
-  docopt,
   fetchFromGitHub,
-  matplotlib,
+
+  # build-system
+  hatch-vcs,
+  hatchling,
+
+  # dependencies
   numpy,
   pandas,
   pyannote-core,
   pyannote-database,
-  pythonOlder,
   scikit-learn,
   scipy,
-  setuptools,
-  sympy,
+  # undeclared cli dependencies
+  docopt,
   tabulate,
-  versioneer,
+
+  # tests
+  pytestCheckHook,
+  versionCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "pyannote-metrics";
-  version = "3.3.0";
+  version = "4.0.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "pyannote";
     repo = "pyannote-metrics";
     tag = version;
-    hash = "sha256-tinNdFiUISnzUDnzM8wT3+0W8Dlc9gbCiNoIMo9xNKY=";
+    hash = "sha256-Ga5oSRkVdeQkDnjFcFebdZnFljjyn/TrtV8Y6UJxT2c=";
   };
 
   postPatch = ''
-    # Remove vendorized versioneer.py
-    rm versioneer.py
+    substituteInPlace src/pyannote/metrics/cli.py \
+      --replace-fail \
+        'version="Evaluation"' \
+        'version="${version}"'
   '';
 
   build-system = [
-    setuptools
-    versioneer
+    hatch-vcs
+    hatchling
   ];
 
   dependencies = [
+    numpy
+    pandas
     pyannote-core
     pyannote-database
-    pandas
-    scipy
     scikit-learn
+    scipy
+    # Imported in pyannote/metrics/cli.py
     docopt
     tabulate
-    matplotlib
-    sympy
-    numpy
   ];
 
   pythonImportsCheck = [ "pyannote.metrics" ];
 
-  meta = with lib; {
+  nativeCheckInputs = [
+    pytestCheckHook
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--version";
+
+  meta = {
     description = "Toolkit for reproducible evaluation, diagnostic, and error analysis of speaker diarization systems";
     homepage = "https://github.com/pyannote/pyannote-metrics";
     changelog = "http://pyannote.github.io/pyannote-metrics/changelog.html";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     maintainers = [ ];
     mainProgram = "pyannote-metrics";
   };

--- a/pkgs/development/python-modules/pyannote-pipeline/default.nix
+++ b/pkgs/development/python-modules/pyannote-pipeline/default.nix
@@ -1,58 +1,74 @@
 {
   lib,
   buildPythonPackage,
-  docopt,
   fetchFromGitHub,
+
+  # build-system
+  hatch-vcs,
+  hatchling,
+
+  # dependencies
+  docopt,
   filelock,
   optuna,
   pyannote-core,
   pyannote-database,
   pyyaml,
-  scikit-learn,
-  setuptools,
+  scipy,
   tqdm,
-  versioneer,
+
+  # tests
+  pytestCheckHook,
+  versionCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "pyannote-pipeline";
-  version = "3.1.2";
+  version = "4.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pyannote";
     repo = "pyannote-pipeline";
     tag = version;
-    hash = "sha256-MMMwZMxu8viUt2DgCgymbz2vEMM9TT0ySKL2KPzAPLA=";
+    hash = "sha256-H2yIeCKhZFUkZXww+eaRKMzJrbALdARady02fq/pJrU=";
   };
 
   postPatch = ''
-    # Remove vendorized versioeer.py
-    rm versioneer.py
+    substituteInPlace src/pyannote/pipeline/experiment.py \
+      --replace-fail \
+        'version="Tunable pipelines"' \
+        'version="${version}"'
   '';
 
   build-system = [
-    setuptools
-    versioneer
+    hatch-vcs
+    hatchling
   ];
 
   dependencies = [
+    docopt # imported in pyannote/pipeline/experiment.py
+    filelock
+    optuna
     pyannote-core
     pyannote-database
     pyyaml
-    optuna
+    scipy # imported in pyannote/pipeline/optimizer.py
     tqdm
-    docopt
-    filelock
-    scikit-learn
   ];
 
   pythonImportsCheck = [ "pyannote.pipeline" ];
 
-  meta = with lib; {
+  nativeCheckInputs = [
+    pytestCheckHook
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--version";
+
+  meta = {
     description = "Tunable pipelines";
     homepage = "https://github.com/pyannote/pyannote-pipeline";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     maintainers = [ ];
     mainProgram = "pyannote-pipeline";
   };

--- a/pkgs/development/python-modules/pyannoteai-sdk/default.nix
+++ b/pkgs/development/python-modules/pyannoteai-sdk/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  hatch-vcs,
+  hatchling,
+
+  # dependencies
+  requests,
+}:
+
+buildPythonPackage rec {
+  pname = "pyannoteai-sdk";
+  version = "0.3.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "pyannoteai_sdk";
+    inherit version;
+    hash = "sha256-QOA1ABzi3rNR/aDFNXxZhNzBrYL+JEexpi1fTOZYCa0=";
+  };
+
+  build-system = [
+    hatch-vcs
+    hatchling
+  ];
+
+  dependencies = [
+    requests
+  ];
+
+  pythonImportsCheck = [ "pyannoteai.sdk" ];
+
+  # No tests (at least in the Pypi archive)
+  doCheck = false;
+
+  meta = {
+    description = "Official pyannoteAI Python SDK";
+    homepage = "https://pypi.org/project/pyannoteai-sdk";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/development/python-modules/torch-audiomentations/default.nix
+++ b/pkgs/development/python-modules/torch-audiomentations/default.nix
@@ -2,23 +2,26 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
   julius,
   librosa,
+  torch,
+  torch-pitch-shift,
+  torchaudio,
+
+  # tests
   pytest-cov-stub,
   pytestCheckHook,
-  pythonOlder,
-  setuptools,
-  torch-pitch-shift,
-  torch,
-  torchaudio,
 }:
 
 buildPythonPackage rec {
   pname = "torch-audiomentations";
   version = "0.12.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "asteroid-team";
@@ -35,8 +38,8 @@ buildPythonPackage rec {
     julius
     librosa
     torch
-    torchaudio
     torch-pitch-shift
+    torchaudio
   ];
 
   nativeCheckInputs = [
@@ -54,13 +57,25 @@ buildPythonPackage rec {
     "tests/test_background_noise.py"
   ];
 
-  disabledTests = [ "test_transform_is_differentiable" ];
+  disabledTests = [
+    # AttributeError: module 'torchaudio' has no attribute 'info'
+    # Removed in torchaudio v2.9.0
+    # See https://github.com/pytorch/audio/issues/3902 for context
+    # Reported to torch-audiomentations: https://github.com/iver56/torch-audiomentations/issues/184
+    "test_background_noise_no_guarantee_with_empty_tensor"
+    "test_colored_noise_guaranteed_with_batched_tensor"
+    "test_colored_noise_guaranteed_with_single_tensor"
+    "test_colored_noise_guaranteed_with_zero_length_samples"
+    "test_colored_noise_no_guarantee_with_single_tensor"
+    "test_same_min_max_f_decay"
+    "test_transform_is_differentiable"
+  ];
 
-  meta = with lib; {
+  meta = {
     description = "Fast audio data augmentation in PyTorch";
     homepage = "https://github.com/asteroid-team/torch-audiomentations";
     changelog = "https://github.com/asteroid-team/torch-audiomentations/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ matthewcroughan ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ matthewcroughan ];
   };
 }

--- a/pkgs/development/python-modules/whisperx/default.nix
+++ b/pkgs/development/python-modules/whisperx/default.nix
@@ -8,14 +8,17 @@
   setuptools,
 
   # dependencies
+  av,
   ctranslate2,
   faster-whisper,
   nltk,
+  numpy,
   pandas,
   pyannote-audio,
   torch,
   torchaudio,
   transformers,
+  triton,
 
   # native packages
   ffmpeg,
@@ -35,28 +38,15 @@ let
 in
 buildPythonPackage rec {
   pname = "whisperx";
-  version = "3.4.3";
+  version = "3.7.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "m-bain";
     repo = "whisperX";
     tag = "v${version}";
-    hash = "sha256-zx77Fx8KYTWCFcC6Uy6pbe8LJtXP3b6lkwuOSEEYJfU=";
+    hash = "sha256-wmCGHRx1JaOs5+7fp2jeh8PIR5dlmOl8hKrIw2550Bk=";
   };
-
-  build-system = [ setuptools ];
-
-  dependencies = [
-    ctranslate
-    faster-whisper
-    nltk
-    pandas
-    pyannote-audio # Missing from pyproject.toml, but used in `whisperx/vad.py`
-    torch
-    torchaudio
-    transformers
-  ];
 
   # As `makeWrapperArgs` does not apply to the module, and whisperx depends on `ffmpeg`,
   # we replace the `"ffmpeg"` string in `subprocess.run` with the full path to the binary.
@@ -67,13 +57,29 @@ buildPythonPackage rec {
       '"ffmpeg"' '"${lib.getExe ffmpeg}"'
   '';
 
-  pythonRelaxDeps = [
-    # > Checking runtime dependencies for whisperx-3.3.2-py3-none-any.whl
-    # >   - faster-whisper==1.1.0 not satisfied by version 1.1.1
-    # This has been updated on main, so we expect this clause to be removed upon the next update.
-    "faster-whisper"
+  build-system = [ setuptools ];
 
-    "ctranslate2"
+  pythonRelaxDeps = [
+    "numpy"
+    "pandas"
+    "pyannote-audio"
+    "torch"
+    "torchaudio"
+  ];
+  dependencies = [
+    av
+    ctranslate
+    faster-whisper
+    nltk
+    numpy
+    pandas
+    pyannote-audio
+    torch
+    torchaudio
+    transformers
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64) [
+    triton
   ];
 
   # Import check fails due on `aarch64-linux` ONLY in the sandbox due to onnxruntime

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12665,6 +12665,8 @@ self: super: with self; {
 
   pyannote-pipeline = callPackage ../development/python-modules/pyannote-pipeline { };
 
+  pyannoteai-sdk = callPackage ../development/python-modules/pyannoteai-sdk { };
+
   pyaprilaire = callPackage ../development/python-modules/pyaprilaire { };
 
   pyarlo = callPackage ../development/python-modules/pyarlo { };


### PR DESCRIPTION
## Things done

Failures reported upstream: https://github.com/iver56/torch-audiomentations/issues/184

cc @MatthewCroughan

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
