### PR TITLE
ci/request-reviews: fix request-reviewers.sh

### DIFF
--- a/ci/request-reviews/request-reviewers.sh
+++ b/ci/request-reviews/request-reviewers.sh
@@ -59,7 +59,7 @@ while read -r handle && [[ -n "$handle" ]]; do
             "/orgs/$org/teams/$team/members" \
             --jq '.[].login' > "$tmp/team-members"
         readarray -t members < "$tmp/team-members"
-        log "Team $entry has these members: ${members[*]}"
+        log "Team $handle has these members: ${members[*]}"
 
         for user in "${members[@]}"; do
             users[${user,,}]=


### PR DESCRIPTION
We recently moved some code around and forgot to adjust the log line here.

Should help with https://github.com/NixOS/nixpkgs/pull/457503#issuecomment-3478073440.

Can't really test this easily, because I don't have teams in my fork.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
