### PR TITLE
nixos/syncthing-multi: init module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1373,6 +1373,7 @@
   ./services/networking/supybot.nix
   ./services/networking/suricata/default.nix
   ./services/networking/syncplay.nix
+  ./services/networking/syncthing-multi.nix
   ./services/networking/syncthing-relay.nix
   ./services/networking/syncthing.nix
   ./services/networking/tailscale-auth.nix

--- a/nixos/modules/services/networking/syncthing-multi.nix
+++ b/nixos/modules/services/networking/syncthing-multi.nix
@@ -1,0 +1,185 @@
+{
+  config,
+  lib,
+  pkgs,
+  utils,
+  ...
+}:
+let
+  cfg = config.services.syncthing-multi;
+  inherit (lib) types;
+in
+{
+  options.services.syncthing-multi = {
+    enable = lib.mkEnableOption "Syncthing";
+
+    package = lib.mkPackageOption pkgs "syncthing" { };
+
+    instances = lib.mkOption {
+      description = ''
+        Syncthing instances to run.
+      '';
+      default = { };
+      type = types.attrsOf (
+        types.submodule (
+          let
+            globalConfig = config;
+          in
+          { name, config, ... }:
+          {
+            options = {
+              settings = lib.mkOption {
+                type =
+                  let
+                    simples = [
+                      types.bool
+                      types.str
+                      types.int
+                      types.float
+                    ];
+                  in
+                  types.attrsOf (
+                    types.oneOf (
+                      simples
+                      ++ [
+                        (types.listOf (types.oneOf simples))
+                      ]
+                    )
+                  );
+                default = { };
+                example = {
+                  gui-address = "localhost:8000";
+                };
+                description = ''
+                  Settings that should be passed to Syncthing via long options.
+                  See {manpage}`syncthing(1)` for available options.
+                '';
+              };
+
+              user = lib.mkOption {
+                type = types.str;
+                default = name;
+                defaultText = "<name>";
+                description = ''
+                  The name of an existing user account under which the Syncthing process should run.
+                  If the name of the user is "syncthing", then an account will be created automatically.
+                '';
+              };
+
+              group = lib.mkOption {
+                type = types.nullOr types.str;
+                default = null;
+                description = ''
+                  The name of an existing user group under which the Syncthing process should run.
+                  If the name of the group is "syncthing", then a group will be created automatically.
+                '';
+              };
+
+              workDir = lib.mkOption {
+                type = types.str;
+                default = globalConfig.users.users.${config.user}.home;
+                defaultText = ''
+                  The user's home directory.
+                '';
+                description = ''
+                  The working directory of the Syncthing process.
+                '';
+              };
+            };
+          }
+        )
+      );
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services = lib.mkMerge (
+      lib.mapAttrsToList (
+        instanceName: instance:
+        let
+          systemdName = "syncthing-${instanceName}";
+        in
+        {
+          ${systemdName} = {
+            description = "Syncthing instance ${instanceName}";
+
+            after = [ "network.target" ];
+            wantedBy = [ "multi-user.target" ];
+
+            environment = {
+              STNORESTART = "yes";
+              STNOUPGRADE = "yes";
+            };
+
+            serviceConfig = {
+              Type = "simple";
+
+              User = instance.user;
+              Group = lib.mkIf (instance.group != null) instance.group;
+
+              WorkingDirectory = instance.workDir;
+
+              ExecStart =
+                let
+                  settingsToCommandLine = lib.cli.toCommandLineGNU {
+                    isLong = _: true;
+                  };
+                in
+                utils.escapeSystemdExecArgs (
+                  [
+                    (lib.getExe cfg.package)
+                    "serve"
+                    "--no-browser"
+                  ]
+                  ++ settingsToCommandLine instance.settings
+                );
+
+              MemoryDenyWriteExecute = true;
+              NoNewPrivileges = true;
+              PrivateDevices = true;
+              PrivateMounts = true;
+              PrivateTmp = true;
+              PrivateUsers = true;
+              ProtectControlGroups = true;
+              ProtectHostname = true;
+              ProtectKernelModules = true;
+              ProtectKernelTunables = true;
+              RestrictNamespaces = true;
+              RestrictRealtime = true;
+              RestrictSUIDSGID = true;
+              CapabilityBoundingSet = [
+                "~CAP_SYS_PTRACE"
+                "~CAP_SYS_ADMIN"
+                "~CAP_SETGID"
+                "~CAP_SETUID"
+                "~CAP_SETPCAP"
+                "~CAP_SYS_TIME"
+                "~CAP_KILL"
+              ];
+            };
+          };
+        }
+      ) cfg.instances
+    );
+
+    users = lib.mkMerge (
+      lib.mapAttrsToList (instanceName: instance: {
+        users = lib.mkIf (instance.user == "syncthing") {
+          syncthing = {
+            group = "syncthing";
+            home = "/var/lib/syncthing";
+            createHome = true;
+            uid = config.ids.uids.syncthing;
+            description = "Syncthing service user";
+          };
+        };
+
+        groups =
+          lib.mkIf (instance.group == "syncthing" || (instance.group == null && instance.user == "syncthing"))
+            {
+              syncthing.gid = config.ids.gids.syncthing;
+            };
+      }) cfg.instances
+    );
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1436,6 +1436,7 @@ in
   # FIXME: Test has been failing since 2025-07-06:
   # https://github.com/NixOS/nixpkgs/issues/447674
   # syncthing-many-devices = runTest ./syncthing/many-devices.nix;
+  syncthing-multi = runTest ./syncthing-multi.nix;
   syncthing-no-settings = runTest ./syncthing/no-settings.nix;
   syncthing-relay = runTest ./syncthing/relay.nix;
   sysfs = runTest ./sysfs.nix;

--- a/nixos/tests/syncthing-multi.nix
+++ b/nixos/tests/syncthing-multi.nix
@@ -1,0 +1,29 @@
+{
+  name = "syncthing-multi";
+
+  nodes.machine = {
+    users.users.test.isNormalUser = true;
+
+    services.syncthing-multi = {
+      enable = true;
+      instances = {
+        syncthing.settings.gui-address = "localhost:8000";
+        test.settings.gui-address = "localhost:8010";
+      };
+    };
+  };
+
+  testScript = ''
+    machine.start()
+
+    machine.wait_for_unit("syncthing-syncthing.service")
+    machine.wait_for_open_port(8000)
+    machine.succeed("curl --fail http://localhost:8000/")
+
+    machine.wait_for_unit("syncthing-test.service")
+    machine.wait_for_open_port(8010)
+    machine.succeed("curl --fail http://localhost:8010/")
+
+    machine.shutdown()
+  '';
+}

--- a/pkgs/applications/networking/syncthing/default.nix
+++ b/pkgs/applications/networking/syncthing/default.nix
@@ -73,6 +73,7 @@ let
             syncthing-init
             syncthing-no-settings
             syncthing-relay
+            syncthing-multi
             ;
         };
         updateScript = nix-update-script { };


### PR DESCRIPTION
This PR adds a module that supports multiple instances of Syncthing. The current module only supports a single instance, which means that if multiple instances for different users are needed, you have to rely on user services. User services come with a few drawbacks; for example, you need to enable lingering to keep the service running after the user logs out of their interactive session. Lingering, of course, applies to all user services, not just Syncthing, so this is very coarse-grained. Using multiple system services also means that you don't have to use something like home-manager to declaratively manage Syncthing user services.

It would be nice if this could replace the existing Syncthing module because this would effectively make the other one obsolete, but since backwards compatibility is a potential issue, I'm not really sure.

Regarding the declarative configuration of Syncthing itself: I omitted it because I personally prefer to configure it imperatively in the GUI, but it would probably not be difficult to add.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
