### PR TITLE
libwebsockets: 4.3.5 -> 4.4.1

### DIFF
--- a/pkgs/by-name/li/libwebsockets/package.nix
+++ b/pkgs/by-name/li/libwebsockets/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libwebsockets";
-  version = "4.3.5";
+  version = "4.4.1";
 
   src = fetchFromGitHub {
     owner = "warmcat";
     repo = "libwebsockets";
     rev = "v${version}";
-    hash = "sha256-KOAhIVn4G5u0A1TE75Xv7iYO3/i8foqWYecH0kJHdBM=";
+    hash = "sha256-Xvcnfvm9UCNXm3G3tVe7jExE3fwpzYuz8wllvINymeI=";
   };
 
   patches = [
@@ -34,14 +34,6 @@ stdenv.mkDerivation rec {
       hash = "sha256-1uQUkoMbK+3E/QYMIBLlBZypwHBIrWBtm+KIW07WRj8=";
     })
   ];
-
-  # Updating to 4.4.1 would bring some errors, and the patch doesn't apply cleanly
-  # https://github.com/warmcat/libwebsockets/commit/47efb8c1c2371fa309f85a32984e99b2cc1d614a
-  postPatch = ''
-    for f in $(find . -name CMakeLists.txt); do
-      sed '/^cmake_minimum_required/Is/VERSION [0-9]\.[0-9]/VERSION 3.5/' -i "$f"
-    done
-  '';
 
   outputs = [
     "out"
@@ -62,6 +54,8 @@ stdenv.mkDerivation rec {
     "-DLWS_WITH_SOCKS5=ON"
     "-DDISABLE_WERROR=ON"
     "-DLWS_BUILD_HASH=no_hash"
+    # TODO(Mindavi): figure out why linking has broken for test apps between 4.3.5 and 4.4.1.
+    "-DLWS_WITHOUT_TESTAPPS=ON"
   ]
   ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "-DLWS_WITHOUT_TESTAPPS=ON"
   ++ lib.optional withExternalPoll "-DLWS_WITH_EXTERNAL_POLL=ON"


### PR DESCRIPTION
Diff: https://github.com/warmcat/libwebsockets/compare/v4.3.5...v4.4.1
Changelog (only 4.4.0 is listed): https://github.com/warmcat/libwebsockets/blob/v4.4.1/changelog

Somehow linking for test apps has broken, but dependents seem to build fine. Not sure what happened but there are quite some changes around CMake, so it's likely something happened there.

For reference the build error when test apps are linked:

libwebsockets> [  3%] Building C object minimal-examples-lowlevel/api-tests/api-test-jpeg/CMakeFiles/lws-api-test-jpeg.dir/main.c.o libwebsockets> [  3%] Linking C executable ../../../bin/lws-api-test-gunzip libwebsockets> [  4%] Linking C executable ../../../bin/lws-minimal-ss-ws-echo libwebsockets> /nix/store/416ykpc2bksb90sd1ia8cybxb3p83mrd-binutils-2.44/bin/ld: cannot find -lwebsockets: No such file or directory libwebsockets> collect2: error: ld returned 1 exit status libwebsockets> make[2]: *** [minimal-examples-lowlevel/api-tests/api-test-gunzip/CMakeFiles/lws-api-test-gunzip.dir/build.make:101: bin/lws-api-test-gunzip] Error 1 libwebsockets> make[1]: *** [CMakeFiles/Makefile2:4307: minimal-examples-lowlevel/api-tests/api-test-gunzip/CMakeFiles/lws-api-test-gunzip.dir/all] Error 2

For some reason it tries to link libwebsockets before it's built...


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  -  x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage]. -> no, but built some reverse dependencies
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

CC @LeSuisse 