### PR TITLE
python3Packages.fireworks-ai: 0.17.16 -> 0.19.20

### DIFF
--- a/pkgs/development/python-modules/fireworks-ai/default.nix
+++ b/pkgs/development/python-modules/fireworks-ai/default.nix
@@ -115,15 +115,11 @@ buildPythonPackage rec {
     httpx
     httpx
     httpx-sse
-    httpx-sse
-    httpx-ws
     httpx-ws
     mmh3
     openai
     pillow
-    pillow
     protobuf
-    pydantic
     pydantic
     python-dateutil
     rich

--- a/pkgs/development/python-modules/fireworks-ai/default.nix
+++ b/pkgs/development/python-modules/fireworks-ai/default.nix
@@ -9,6 +9,7 @@
   # dependencies
   asyncstdlib-fw,
   betterproto-fw,
+  googleapis-common-protos,
   grpcio,
   grpclib,
   httpx-sse,
@@ -21,6 +22,7 @@
   pydantic,
   python-dateutil,
   rich,
+  toml,
   typing-extensions,
 
   # optional dependencies
@@ -36,14 +38,14 @@
 
 buildPythonPackage rec {
   pname = "fireworks-ai";
-  version = "0.17.16";
+  version = "0.19.20";
   pyproject = true;
 
   # no source available
   src = fetchPypi {
     pname = "fireworks_ai";
     inherit version;
-    hash = "sha256-WblcAaYjnzwPS4n5rixNHbHLNGTE3bTPXvQ9lYZ1f9A=";
+    hash = "sha256-zK8lO+vFnMEPPl79QGfqPdemZT7kQdCqAPiCrcXdqYQ=";
   };
 
   build-system = [
@@ -51,12 +53,14 @@ buildPythonPackage rec {
   ];
 
   pythonRelaxDeps = [
+    "attrs"
     "protobuf"
   ];
 
   dependencies = [
     asyncstdlib-fw
     betterproto-fw
+    googleapis-common-protos
     grpcio
     grpclib
     httpx
@@ -70,6 +74,7 @@ buildPythonPackage rec {
     pydantic
     python-dateutil
     rich
+    toml
     typing-extensions
   ];
 

--- a/pkgs/development/python-modules/fireworks-ai/default.nix
+++ b/pkgs/development/python-modules/fireworks-ai/default.nix
@@ -6,11 +6,9 @@
   # build-system
   pdm-backend,
 
-  # local dependencies
-  black,
-  mypy,
-
   # dependencies
+  asyncstdlib-fw,
+  betterproto-fw,
   grpcio,
   grpclib,
   httpx-sse,
@@ -36,57 +34,6 @@
   tqdm,
 }:
 
-let
-  asyncstdlib-fw = buildPythonPackage rec {
-    pname = "asyncstdlib_fw";
-    version = "3.13.2";
-    pyproject = true;
-
-    src = fetchPypi {
-      inherit pname version;
-      hash = "sha256-Ua0JTCBMWTbDBA84wy/W1UmzkcmA8h8foJW2X7aAah8=";
-    };
-
-    build-system = [
-      pdm-backend
-    ];
-
-    dependencies = [
-      black
-      mypy
-    ];
-
-    pythonImportsCheck = [
-      "asyncstdlib"
-    ];
-  };
-
-  betterproto-fw = buildPythonPackage rec {
-    pname = "betterproto_fw";
-    version = "2.0.3";
-    pyproject = true;
-
-    src = fetchPypi {
-      inherit version pname;
-      hash = "sha256-ut5GchUiTygHhC2hj+gSWKCoVnZrrV8KIKFHTFzba5M=";
-    };
-
-    build-system = [
-      pdm-backend
-    ];
-
-    dependencies = [
-      grpclib
-      python-dateutil
-      typing-extensions
-    ];
-
-    pythonImportsCheck = [
-      "betterproto"
-    ];
-
-  };
-in
 buildPythonPackage rec {
   pname = "fireworks-ai";
   version = "0.17.16";


### PR DESCRIPTION
1. Remove duplicate dependencies
2. Remove `asyncstdlib-fw` and `betterproto-fw` from `let`, use the standalone packages instead
3. Version bump

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
