### PR TITLE
postgresqlPackages.omnigres: fix build

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/omnigres.nix
+++ b/pkgs/servers/sql/postgresql/ext/omnigres.nix
@@ -58,6 +58,7 @@ postgresqlBuildExtension (finalAttrs: {
 
   cmakeFlags = [
     "-DOPENSSL_CONFIGURED=1"
+    "-DCMAKE_POLICY_VERSION_MINIMUM=3.10"
     "-DPG_CONFIG=${pgWithExtensions.pg_config}/bin/pg_config"
     "-DPostgreSQL_TARGET_EXTENSION_DIR=${placeholder "out"}/share/postgresql/extension/"
     "-DPostgreSQL_TARGET_PACKAGE_LIBRARY_DIR=${placeholder "out"}/lib/"


### PR DESCRIPTION
There's a current broken build on the `omnigres` PostgreSQL extension, `libfyaml` seems to be the cause. I've added another `cmake` flag and the build is fine now. 

Tracking: https://github.com/NixOS/nixpkgs/issues/445447

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
