### PR TITLE
btdu: 0.6.0 -> 0.7.2

### DIFF
--- a/pkgs/by-name/bt/btdu/dub-lock.json
+++ b/pkgs/by-name/bt/btdu/dub-lock.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
     "ae": {
-      "version": "0.0.3461",
-      "sha256": "1mk075r3bas8s699y6sc4fxbdyjhc9cm6qxcqqaj0di9ijb71fq1"
+      "version": "0.0.3655",
+      "sha256": "0d7qy66nyxqva66chqcvf0jw9ajyvmkh98gci2cs2qlj2srb2lbn"
     },
     "btrfs": {
       "version": "0.0.21",

--- a/pkgs/by-name/bt/btdu/dub-lock.json
+++ b/pkgs/by-name/bt/btdu/dub-lock.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
     "ae": {
-      "version": "0.0.3655",
-      "sha256": "0d7qy66nyxqva66chqcvf0jw9ajyvmkh98gci2cs2qlj2srb2lbn"
+      "version": "0.0.3701",
+      "sha256": "0vf458cvr8mmvjr87g2i6yhn7yyz1cg4lbixf62b9qnszd88j2q2"
     },
     "btrfs": {
       "version": "0.0.21",

--- a/pkgs/by-name/bt/btdu/package.nix
+++ b/pkgs/by-name/bt/btdu/package.nix
@@ -8,13 +8,13 @@
 
 buildDubPackage rec {
   pname = "btdu";
-  version = "0.7.0";
+  version = "0.7.2";
 
   src = fetchFromGitHub {
     owner = "CyberShadow";
     repo = "btdu";
     rev = "v${version}";
-    hash = "sha256-sPNnM3UAtV39vDWz6MpaGob1ckVkgQPZory0OZW25oQ=";
+    hash = "sha256-ZZaBaDKfW52w2YWj34gXFruWNBNqjLUFsPCHmrCKT7I=";
   };
 
   dubLock = ./dub-lock.json;

--- a/pkgs/by-name/bt/btdu/package.nix
+++ b/pkgs/by-name/bt/btdu/package.nix
@@ -27,6 +27,8 @@ buildDubPackage rec {
   installPhase = ''
     runHook preInstall
     install -Dm755 btdu -t $out/bin
+    ./btdu --man "" > btdu.1
+    install -Dm644 btdu.1 -t $out/share/man/man1
     runHook postInstall
   '';
 

--- a/pkgs/by-name/bt/btdu/package.nix
+++ b/pkgs/by-name/bt/btdu/package.nix
@@ -8,13 +8,13 @@
 
 buildDubPackage rec {
   pname = "btdu";
-  version = "0.6.1";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "CyberShadow";
     repo = "btdu";
     rev = "v${version}";
-    hash = "sha256-LAArbq59ZYbOZAOmsEYXsruC4j8wjAzFTEha6kh6uE0=";
+    hash = "sha256-sPNnM3UAtV39vDWz6MpaGob1ckVkgQPZory0OZW25oQ=";
   };
 
   dubLock = ./dub-lock.json;

--- a/pkgs/by-name/bt/btdu/package.nix
+++ b/pkgs/by-name/bt/btdu/package.nix
@@ -8,13 +8,13 @@
 
 buildDubPackage rec {
   pname = "btdu";
-  version = "0.6.0";
+  version = "0.6.1";
 
   src = fetchFromGitHub {
     owner = "CyberShadow";
     repo = "btdu";
     rev = "v${version}";
-    hash = "sha256-B8ojxdXibeNEZay9S5lzpB6bTKNB2ZI6AQ3XKUHioE0=";
+    hash = "sha256-LAArbq59ZYbOZAOmsEYXsruC4j8wjAzFTEha6kh6uE0=";
   };
 
   dubLock = ./dub-lock.json;


### PR DESCRIPTION
https://github.com/CyberShadow/btdu/releases/tag/v0.6.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
