### PR TITLE
mpich: fix cross compilation

### DIFF
--- a/pkgs/development/libraries/mpich/default.nix
+++ b/pkgs/development/libraries/mpich/default.nix
@@ -117,9 +117,9 @@ stdenv.mkDerivation rec {
       the Message Passing Interface (MPI) standard, both version 1 and
       version 2.
     '';
-    homepage = "http://www.mcs.anl.gov/mpi/mpich2/";
+    homepage = "https://www.mpich.org";
     license = {
-      url = "http://git.mpich.org/mpich.git/blob/a385d6d0d55e83c3709ae851967ce613e892cd21:/COPYRIGHT";
+      url = "https://github.com/pmodels/mpich/blob/15f59ab2b740539472dfd130f7fe01b61c28bba4/COPYRIGHT";
       fullName = "MPICH license (permissive)";
     };
     maintainers = [ lib.maintainers.markuskowa ];

--- a/pkgs/development/libraries/mpich/default.nix
+++ b/pkgs/development/libraries/mpich/default.nix
@@ -118,6 +118,7 @@ stdenv.mkDerivation rec {
       version 2.
     '';
     homepage = "https://www.mpich.org";
+    changelog = "https://github.com/pmodels/mpich/releases/tag/v${version}";
     license = {
       url = "https://github.com/pmodels/mpich/blob/15f59ab2b740539472dfd130f7fe01b61c28bba4/COPYRIGHT";
       fullName = "MPICH license (permissive)";

--- a/pkgs/development/libraries/mpich/default.nix
+++ b/pkgs/development/libraries/mpich/default.nix
@@ -22,6 +22,9 @@
   # PMIX support is likely incompatible with process managers (`--with-pm`)
   # https://github.com/NixOS/nixpkgs/pull/274804#discussion_r1432601476
   pmixSupport ? false,
+  # Enable Fortran support (disabled when cross compiling)
+  fortranSupport ? stdenv.hostPlatform == stdenv.buildPlatform,
+  targetPackages,
 }:
 
 let
@@ -63,18 +66,21 @@ stdenv.mkDerivation rec {
   ]
   ++ lib.optionals pmixSupport [
     "--with-pmix"
+  ]
+  ++ lib.optionals (!fortranSupport) [
+    "--disable-fortran"
   ];
 
   enableParallelBuilding = true;
 
   nativeBuildInputs = [
-    gfortran
     python3
     autoconf
     automake
-  ];
-  buildInputs = [
     perl
+  ]
+  ++ lib.optional fortranSupport gfortran;
+  buildInputs = [
     openssh
     hwloc
   ]
@@ -86,14 +92,23 @@ stdenv.mkDerivation rec {
 
   preFixup = ''
     # Ensure the default compilers are the ones mpich was built with
-    sed -i 's:CC="gcc":CC=${stdenv.cc}/bin/gcc:' $out/bin/mpicc
-    sed -i 's:CXX="g++":CXX=${stdenv.cc}/bin/g++:' $out/bin/mpicxx
-    sed -i 's:FC="gfortran":FC=${gfortran}/bin/gfortran:' $out/bin/mpifort
+    sed -i 's:^CC=.*:CC=${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}cc:' $out/bin/mpicc
+    sed -i 's:^CXX=.*:CXX=${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}c++:' $out/bin/mpicxx
+  ''
+  + lib.optionalString fortranSupport ''
+    sed -i 's:^FC=.*:FC=${targetPackages.gfortran or gfortran}/bin/${
+      targetPackages.gfortran.targetPrefix or gfortran.targetPrefix
+    }gfortran:' $out/bin/mpifort
   '';
 
   meta = {
-    # As far as we know, --with-pmix silently disables all of `--with-pm`
-    broken = pmixSupport && withPm != [ ];
+    broken =
+      # As far as we know, --with-pmix silently disables all of `--with-pm`.
+      (pmixSupport && withPm != [ ])
+      ||
+        # When cross compiling fortan type sizes have to be set manually:
+        # https://github.com/pmodels/mpich/issues/5380#issuecomment-866483882
+        (fortranSupport && stdenv.hostPlatform != stdenv.buildPlatform);
 
     description = "Implementation of the Message Passing Interface (MPI) standard";
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Moved `perl` to `nativeBuildInputs`
- Fixed `preFixup` so default compilers are set properly in the wrappers, matching what is done in openmpi: https://github.com/NixOS/nixpkgs/blob/135013a6c475770c2065a341a0efe7eaa0cf0256/pkgs/by-name/op/openmpi/package.nix#L174-L178
- Added `fortranSupport` flag, disabled by default when cross compiling and marked as broken
- Fixed broken links in metadata and added changelog

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
