### PR TITLE
nextvi: init at 2.1

### DIFF
--- a/pkgs/by-name/ne/nextvi/package.nix
+++ b/pkgs/by-name/ne/nextvi/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  installShellFiles,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nextvi";
+  version = "2.1";
+
+  src = fetchFromGitHub {
+    owner = "kyx0r";
+    repo = "nextvi";
+    tag = finalAttrs.version;
+    hash = "sha256-FBUcmCkGOf7HVLkZqHWxHxS0qhz5t9VwbWb0VOGnb28=";
+  };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    sh ./cbuild.sh
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    PREFIX=$out sh ./cbuild.sh install
+
+    mv $out/bin/{vi,nextvi}
+    installManPage --name nextvi.1 vi.1
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Next version of neatvi (a small vi/ex editor)";
+    homepage = "https://github.com/kyx0r/nextvi";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+    maintainers = [ lib.maintainers.sikmir ];
+    mainProgram = "nextvi";
+  };
+})


### PR DESCRIPTION
Nextvi - A small vi/ex terminal text editor (https://github.com/kyx0r/nextvi)

cc @kyx0r

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
