### PR TITLE
whisper: set knownVulnerabilities due to dated vendored libraries

### DIFF
--- a/pkgs/by-name/wh/whisper/package.nix
+++ b/pkgs/by-name/wh/whisper/package.nix
@@ -51,6 +51,15 @@ stdenv.mkDerivation rec {
     broken = stdenv.hostPlatform.isDarwin;
     description = "Short read sequence mapper";
     license = licenses.gpl3;
+    # vendored libraries acof, aelf, deflate, bzip2, zlib
+    # https://github.com/refresh-bio/Whisper/issues/18
+    knownVulnerabilities = [
+      # src/libs/libz.a from 2017
+      "CVE-2018-25032"
+      "CVE-2022-37434"
+      # src/libs/libbzip2.lib
+      "CVE-2019-12900"
+    ];
     homepage = "https://github.com/refresh-bio/whisper";
     maintainers = with maintainers; [ jbedo ];
     platforms = platforms.x86_64;


### PR DESCRIPTION
whisper vendors libraries that haven't been updated in 6 to 8 years.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Informed upstream https://github.com/refresh-bio/Whisper/issues/18
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
