### PR TITLE
Restore tt-rss

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1727,6 +1727,7 @@
   ./services/web-apps/suwayomi-server.nix
   ./services/web-apps/szurubooru.nix
   ./services/web-apps/trilium.nix
+  ./services/web-apps/tt-rss.nix
   ./services/web-apps/tuliprox.nix
   ./services/web-apps/umami.nix
   ./services/web-apps/vikunja.nix

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -290,9 +290,6 @@ in
     (mkRemovedOptionModule [ "services" "sourcehut" ] ''
       The sourcehut packages and the corresponding module have been removed due to being broken and unmaintained.
     '')
-    (mkRemovedOptionModule [ "services" "tt-rss" ] ''
-      The tt-rss package and module have been removed, since upstream development ceased 2025-11-01 and the source is no longer available officially.
-    '')
     (mkRemovedOptionModule [ "services" "tvheadend" ]
       "The tvheadend package and the corresponding module have been removed as nobody was willing to maintain them and they were stuck on an unmaintained version that required FFmpeg 4; please see https://github.com/NixOS/nixpkgs/pull/332259 if you are interested in maintaining a newer version."
     )

--- a/nixos/modules/services/web-apps/tt-rss.nix
+++ b/nixos/modules/services/web-apps/tt-rss.nix
@@ -1,0 +1,712 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+let
+  cfg = config.services.tt-rss;
+
+  inherit (cfg) phpPackage;
+
+  configVersion = 26;
+
+  dbPort =
+    if cfg.database.port == null then
+      (if cfg.database.type == "pgsql" then 5432 else 3306)
+    else
+      cfg.database.port;
+
+  poolName = "tt-rss";
+
+  mysqlLocal = cfg.database.createLocally && cfg.database.type == "mysql";
+  pgsqlLocal = cfg.database.createLocally && cfg.database.type == "pgsql";
+
+  tt-rss-config =
+    let
+      password =
+        if (cfg.database.password != null) then
+          "'${(escape [ "'" "\\" ] cfg.database.password)}'"
+        else if (cfg.database.passwordFile != null) then
+          "file_get_contents('${cfg.database.passwordFile}')"
+        else
+          null;
+    in
+    pkgs.writeText "config.php" ''
+      <?php
+        putenv('TTRSS_PHP_EXECUTABLE=${phpPackage}/bin/php');
+
+        putenv('TTRSS_LOCK_DIRECTORY=${cfg.root}/lock');
+        putenv('TTRSS_CACHE_DIR=${cfg.root}/cache');
+        putenv('TTRSS_ICONS_DIR=${cfg.root}/feed-icons');
+        putenv('TTRSS_ICONS_URL=feed-icons');
+        putenv('TTRSS_SELF_URL_PATH=${cfg.selfUrlPath}');
+
+        putenv('TTRSS_MYSQL_CHARSET=UTF8');
+
+        putenv('TTRSS_DB_TYPE=${cfg.database.type}');
+        putenv('TTRSS_DB_HOST=${optionalString (cfg.database.host != null) cfg.database.host}');
+        putenv('TTRSS_DB_USER=${cfg.database.user}');
+        putenv('TTRSS_DB_NAME=${cfg.database.name}');
+        putenv('TTRSS_DB_PASS=' ${optionalString (password != null) ". ${password}"});
+        putenv('TTRSS_DB_PORT=${toString dbPort}');
+
+        putenv('TTRSS_AUTH_AUTO_CREATE=${boolToString cfg.auth.autoCreate}');
+        putenv('TTRSS_AUTH_AUTO_LOGIN=${boolToString cfg.auth.autoLogin}');
+
+        putenv('TTRSS_FEED_CRYPT_KEY=${escape [ "'" "\\" ] cfg.feedCryptKey}');
+
+
+        putenv('TTRSS_SINGLE_USER_MODE=${boolToString cfg.singleUserMode}');
+
+        putenv('TTRSS_SIMPLE_UPDATE_MODE=${boolToString cfg.simpleUpdateMode}');
+
+        # Never check for updates - the running version of the code should
+        # be controlled entirely by the version of TT-RSS active in the
+        # current Nix profile. If TT-RSS updates itself to a version
+        # requiring a database schema upgrade, and then the SystemD
+        # tt-rss.service is restarted, the old code copied from the Nix
+        # store will overwrite the updated version, causing the code to
+        # detect the need for a schema "upgrade" (since the schema version
+        # in the database is different than in the code), but the update
+        # schema operation in TT-RSS will do nothing because the schema
+        # version in the database is newer than that in the code.
+        putenv('TTRSS_CHECK_FOR_UPDATES=false');
+
+        putenv('TTRSS_FORCE_ARTICLE_PURGE=${toString cfg.forceArticlePurge}');
+        putenv('TTRSS_SESSION_COOKIE_LIFETIME=${toString cfg.sessionCookieLifetime}');
+        putenv('TTRSS_ENABLE_GZIP_OUTPUT=${boolToString cfg.enableGZipOutput}');
+
+        putenv('TTRSS_PLUGINS=${builtins.concatStringsSep "," cfg.plugins}');
+
+        putenv('TTRSS_LOG_DESTINATION=${cfg.logDestination}');
+        putenv('TTRSS_CONFIG_VERSION=${toString configVersion}');
+
+
+        putenv('TTRSS_PUBSUBHUBBUB_ENABLED=${boolToString cfg.pubSubHubbub.enable}');
+        putenv('TTRSS_PUBSUBHUBBUB_HUB=${cfg.pubSubHubbub.hub}');
+
+        putenv('TTRSS_SPHINX_SERVER=${cfg.sphinx.server}');
+        putenv('TTRSS_SPHINX_INDEX=${builtins.concatStringsSep "," cfg.sphinx.index}');
+
+        putenv('TTRSS_ENABLE_REGISTRATION=${boolToString cfg.registration.enable}');
+        putenv('TTRSS_REG_NOTIFY_ADDRESS=${cfg.registration.notifyAddress}');
+        putenv('TTRSS_REG_MAX_USERS=${toString cfg.registration.maxUsers}');
+
+        putenv('TTRSS_SMTP_SERVER=${cfg.email.server}');
+        putenv('TTRSS_SMTP_LOGIN=${cfg.email.login}');
+        putenv('TTRSS_SMTP_PASSWORD=${escape [ "'" "\\" ] cfg.email.password}');
+        putenv('TTRSS_SMTP_SECURE=${cfg.email.security}');
+
+        putenv('TTRSS_SMTP_FROM_NAME=${escape [ "'" "\\" ] cfg.email.fromName}');
+        putenv('TTRSS_SMTP_FROM_ADDRESS=${escape [ "'" "\\" ] cfg.email.fromAddress}');
+        putenv('TTRSS_DIGEST_SUBJECT=${escape [ "'" "\\" ] cfg.email.digestSubject}');
+
+        ${cfg.extraConfig}
+    '';
+
+  # tt-rss and plugins and themes and config.php
+  servedRoot = pkgs.runCommand "tt-rss-served-root" { } ''
+    cp --no-preserve=mode -r ${pkgs.tt-rss} $out
+    cp ${tt-rss-config} $out/config.php
+    ${optionalString (cfg.pluginPackages != [ ]) ''
+      for plugin in ${concatStringsSep " " cfg.pluginPackages}; do
+      cp -r "$plugin"/* "$out/plugins.local/"
+      done
+    ''}
+    ${optionalString (cfg.themePackages != [ ]) ''
+      for theme in ${concatStringsSep " " cfg.themePackages}; do
+      cp -r "$theme"/* "$out/themes.local/"
+      done
+    ''}
+  '';
+
+in
+{
+
+  ###### interface
+
+  options = {
+
+    services.tt-rss = {
+
+      enable = mkEnableOption "tt-rss";
+
+      root = mkOption {
+        type = types.path;
+        default = "/var/lib/tt-rss";
+        description = ''
+          Root of the application.
+        '';
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "tt_rss";
+        description = ''
+          User account under which both the update daemon and the web-application run.
+        '';
+      };
+
+      pool = mkOption {
+        type = types.str;
+        default = "${poolName}";
+        description = ''
+          Name of existing phpfpm pool that is used to run web-application.
+          If not specified a pool will be created automatically with
+          default values.
+        '';
+      };
+
+      virtualHost = mkOption {
+        type = types.nullOr types.str;
+        default = "tt-rss";
+        description = ''
+          Name of the nginx virtualhost to use and setup. If null, do not setup any virtualhost.
+        '';
+      };
+
+      database = {
+        type = mkOption {
+          type = types.enum [
+            "pgsql"
+            "mysql"
+          ];
+          default = "pgsql";
+          description = ''
+            Database to store feeds. Supported are pgsql and mysql.
+          '';
+        };
+
+        host = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = ''
+            Host of the database. Leave null to use Unix domain socket.
+          '';
+        };
+
+        name = mkOption {
+          type = types.str;
+          default = "tt_rss";
+          description = ''
+            Name of the existing database.
+          '';
+        };
+
+        user = mkOption {
+          type = types.str;
+          default = "tt_rss";
+          description = ''
+            The database user. The user must exist and has access to
+            the specified database.
+          '';
+        };
+
+        password = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = ''
+            The database user's password.
+          '';
+        };
+
+        passwordFile = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = ''
+            The database user's password.
+          '';
+        };
+
+        port = mkOption {
+          type = types.nullOr types.port;
+          default = null;
+          description = ''
+            The database's port. If not set, the default ports will be provided (5432
+            and 3306 for pgsql and mysql respectively).
+          '';
+        };
+
+        createLocally = mkOption {
+          type = types.bool;
+          default = true;
+          description = "Create the database and database user locally.";
+        };
+      };
+
+      auth = {
+        autoCreate = mkOption {
+          type = types.bool;
+          default = true;
+          description = ''
+            Allow authentication modules to auto-create users in tt-rss internal
+            database when authenticated successfully.
+          '';
+        };
+
+        autoLogin = mkOption {
+          type = types.bool;
+          default = true;
+          description = ''
+            Automatically login user on remote or other kind of externally supplied
+            authentication, otherwise redirect to login form as normal.
+            If set to true, users won't be able to set application language
+            and settings profile.
+          '';
+        };
+      };
+
+      pubSubHubbub = {
+        hub = mkOption {
+          type = types.str;
+          default = "";
+          description = ''
+            URL to a PubSubHubbub-compatible hub server. If defined, "Published
+            articles" generated feed would automatically become PUSH-enabled.
+          '';
+        };
+
+        enable = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Enable client PubSubHubbub support in tt-rss. When disabled, tt-rss
+            won't try to subscribe to PUSH feed updates.
+          '';
+        };
+      };
+
+      sphinx = {
+        server = mkOption {
+          type = types.str;
+          default = "localhost:9312";
+          description = ''
+            Hostname:port combination for the Sphinx server.
+          '';
+        };
+
+        index = mkOption {
+          type = types.listOf types.str;
+          default = [
+            "ttrss"
+            "delta"
+          ];
+          description = ''
+            Index names in Sphinx configuration. Example configuration
+            files are available on tt-rss wiki.
+          '';
+        };
+      };
+
+      registration = {
+        enable = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Allow users to register themselves. Please be aware that allowing
+            random people to access your tt-rss installation is a security risk
+            and potentially might lead to data loss or server exploit. Disabled
+            by default.
+          '';
+        };
+
+        notifyAddress = mkOption {
+          type = types.str;
+          default = "";
+          description = ''
+            Email address to send new user notifications to.
+          '';
+        };
+
+        maxUsers = mkOption {
+          type = types.int;
+          default = 0;
+          description = ''
+            Maximum amount of users which will be allowed to register on this
+            system. 0 - no limit.
+          '';
+        };
+      };
+
+      email = {
+        server = mkOption {
+          type = types.str;
+          default = "";
+          example = "localhost:25";
+          description = ''
+            Hostname:port combination to send outgoing mail. Blank - use system
+            MTA.
+          '';
+        };
+
+        login = mkOption {
+          type = types.str;
+          default = "";
+          description = ''
+            SMTP authentication login used when sending outgoing mail.
+          '';
+        };
+
+        password = mkOption {
+          type = types.str;
+          default = "";
+          description = ''
+            SMTP authentication password used when sending outgoing mail.
+          '';
+        };
+
+        security = mkOption {
+          type = types.enum [
+            ""
+            "ssl"
+            "tls"
+          ];
+          default = "";
+          description = ''
+            Used to select a secure SMTP connection. Allowed values: ssl, tls,
+            or empty.
+          '';
+        };
+
+        fromName = mkOption {
+          type = types.str;
+          default = "Tiny Tiny RSS";
+          description = ''
+            Name for sending outgoing mail. This applies to password reset
+            notifications, digest emails and any other mail.
+          '';
+        };
+
+        fromAddress = mkOption {
+          type = types.str;
+          default = "";
+          description = ''
+            Address for sending outgoing mail. This applies to password reset
+            notifications, digest emails and any other mail.
+          '';
+        };
+
+        digestSubject = mkOption {
+          type = types.str;
+          default = "[tt-rss] New headlines for last 24 hours";
+          description = ''
+            Subject line for email digests.
+          '';
+        };
+      };
+
+      sessionCookieLifetime = mkOption {
+        type = types.int;
+        default = 86400;
+        description = ''
+          Default lifetime of a session (e.g. login) cookie. In seconds,
+          0 means cookie will be deleted when browser closes.
+        '';
+      };
+
+      selfUrlPath = mkOption {
+        type = types.str;
+        description = ''
+          Full URL of your tt-rss installation. This should be set to the
+          location of tt-rss directory, e.g. http://example.org/tt-rss/
+          You need to set this option correctly otherwise several features
+          including PUSH, bookmarklets and browser integration will not work properly.
+        '';
+        example = "http://localhost";
+      };
+
+      feedCryptKey = mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+          Key used for encryption of passwords for password-protected feeds
+          in the database. A string of 24 random characters. If left blank, encryption
+          is not used. Requires mcrypt functions.
+          Warning: changing this key will make your stored feed passwords impossible
+          to decrypt.
+        '';
+      };
+
+      singleUserMode = mkOption {
+        type = types.bool;
+        default = false;
+
+        description = ''
+          Operate in single user mode, disables all functionality related to
+          multiple users and authentication. Enabling this assumes you have
+          your tt-rss directory protected by other means (e.g. http auth).
+        '';
+      };
+
+      simpleUpdateMode = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enables fallback update mode where tt-rss tries to update feeds in
+          background while tt-rss is open in your browser.
+          If you don't have a lot of feeds and don't want to or can't run
+          background processes while not running tt-rss, this method is generally
+          viable to keep your feeds up to date.
+          Still, there are more robust (and recommended) updating methods
+          available, you can read about them here: <https://tt-rss.org/wiki/UpdatingFeeds>
+        '';
+      };
+
+      forceArticlePurge = mkOption {
+        type = types.int;
+        default = 0;
+        description = ''
+          When this option is not 0, users ability to control feed purging
+          intervals is disabled and all articles (which are not starred)
+          older than this amount of days are purged.
+        '';
+      };
+
+      enableGZipOutput = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Selectively gzip output to improve wire performance. This requires
+          PHP Zlib extension on the server.
+          Enabling this can break tt-rss in several httpd/php configurations,
+          if you experience weird errors and tt-rss failing to start, blank pages
+          after login, or content encoding errors, disable it.
+        '';
+      };
+
+      phpPackage = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.php;
+        defaultText = "pkgs.php";
+        description = ''
+          php package to use for php fpm and update daemon.
+        '';
+      };
+
+      plugins = mkOption {
+        type = types.listOf types.str;
+        default = [
+          "auth_internal"
+          "note"
+        ];
+        description = ''
+          List of plugins to load automatically for all users.
+          System plugins have to be specified here. Please enable at least one
+          authentication plugin here (auth_*).
+          Users may enable other user plugins from Preferences/Plugins but may not
+          disable plugins specified in this list.
+          Disabling auth_internal in this list would automatically disable
+          reset password link on the login form.
+        '';
+      };
+
+      pluginPackages = mkOption {
+        type = types.listOf types.package;
+        default = [ ];
+        description = ''
+          List of plugins to install. The list elements are expected to
+          be derivations. All elements in this derivation are automatically
+          copied to the `plugins.local` directory.
+        '';
+      };
+
+      themePackages = mkOption {
+        type = types.listOf types.package;
+        default = [ ];
+        description = ''
+          List of themes to install. The list elements are expected to
+          be derivations. All elements in this derivation are automatically
+          copied to the `themes.local` directory.
+        '';
+      };
+
+      logDestination = mkOption {
+        type = types.enum [
+          ""
+          "sql"
+          "syslog"
+        ];
+        default = "sql";
+        description = ''
+          Log destination to use. Possible values: sql (uses internal logging
+          you can read in Preferences -> System), syslog - logs to system log.
+          Setting this to blank uses PHP logging (usually to http server
+          error.log).
+        '';
+      };
+
+      updateDaemon = {
+        commandFlags = mkOption {
+          type = types.str;
+          default = "--quiet";
+          description = ''
+            Command-line flags passed to the update daemon.
+            The default --quiet flag mutes all logging, including errors.
+          '';
+        };
+      };
+
+      extraConfig = mkOption {
+        type = types.lines;
+        default = "";
+        description = ''
+          Additional lines to append to `config.php`.
+        '';
+      };
+    };
+  };
+
+  imports = [
+    (mkRemovedOptionModule [ "services" "tt-rss" "checkForUpdates" ] ''
+      This option was removed because setting this to true will cause TT-RSS
+      to be unable to start if an automatic update of the code in
+      services.tt-rss.root leads to a database schema upgrade that is not
+      supported by the code active in the Nix store.
+    '')
+  ];
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+    assertions = [
+      {
+        assertion = cfg.database.password != null -> cfg.database.passwordFile == null;
+        message = "Cannot set both password and passwordFile";
+      }
+      {
+        assertion =
+          cfg.database.createLocally -> cfg.database.name == cfg.user && cfg.database.user == cfg.user;
+        message = ''
+          When creating a database via NixOS, the db user and db name must be equal!
+          If you already have an existing DB+user and this assertion is new, you can safely set
+          `services.tt-rss.database.createLocally` to `false` because removal of `ensureUsers`
+          and `ensureDatabases` doesn't have any effect.
+        '';
+      }
+    ];
+
+    services.phpfpm.pools = mkIf (cfg.pool == "${poolName}") {
+      ${poolName} = {
+        inherit (cfg) user;
+        inherit phpPackage;
+        settings = mapAttrs (name: mkDefault) {
+          "listen.owner" = "nginx";
+          "listen.group" = "nginx";
+          "listen.mode" = "0600";
+          "pm" = "dynamic";
+          "pm.max_children" = 75;
+          "pm.start_servers" = 10;
+          "pm.min_spare_servers" = 5;
+          "pm.max_spare_servers" = 20;
+          "pm.max_requests" = 500;
+          "catch_workers_output" = 1;
+        };
+      };
+    };
+
+    # NOTE: No configuration is done if not using virtual host
+    services.nginx = mkIf (cfg.virtualHost != null) {
+      enable = true;
+      virtualHosts = {
+        ${cfg.virtualHost} = {
+          root = "${cfg.root}/www";
+
+          locations."/" = {
+            index = "index.php";
+          };
+
+          locations."^~ /feed-icons" = {
+            root = "${cfg.root}";
+          };
+
+          locations."~ \\.php$" = {
+            extraConfig = ''
+              fastcgi_split_path_info ^(.+\.php)(/.+)$;
+              fastcgi_pass unix:${config.services.phpfpm.pools.${cfg.pool}.socket};
+              fastcgi_index index.php;
+            '';
+          };
+        };
+      };
+    };
+
+    systemd.tmpfiles.rules = [
+      "d '${cfg.root}' 0555 ${cfg.user} tt_rss - -"
+      "d '${cfg.root}/lock' 0755 ${cfg.user} tt_rss - -"
+      "d '${cfg.root}/cache' 0755 ${cfg.user} tt_rss - -"
+      "d '${cfg.root}/cache/upload' 0755 ${cfg.user} tt_rss - -"
+      "d '${cfg.root}/cache/images' 0755 ${cfg.user} tt_rss - -"
+      "d '${cfg.root}/cache/export' 0755 ${cfg.user} tt_rss - -"
+      "d '${cfg.root}/feed-icons' 0755 ${cfg.user} tt_rss - -"
+      "L+ '${cfg.root}/www' - - - - ${servedRoot}"
+    ];
+
+    systemd.services = {
+      phpfpm-tt-rss = mkIf (cfg.pool == "${poolName}") {
+        restartTriggers = [ servedRoot ];
+      };
+
+      tt-rss = {
+        description = "Tiny Tiny RSS feeds update daemon";
+
+        preStart = ''
+          ${phpPackage}/bin/php ${cfg.root}/www/update.php --update-schema --force-yes
+        '';
+
+        serviceConfig = {
+          User = "${cfg.user}";
+          Group = "tt_rss";
+          ExecStart = "${phpPackage}/bin/php ${cfg.root}/www/update.php --daemon ${cfg.updateDaemon.commandFlags}";
+          Restart = "on-failure";
+          RestartSec = "60";
+          SyslogIdentifier = "tt-rss";
+        };
+
+        wantedBy = [ "multi-user.target" ];
+        requires = optional mysqlLocal "mysql.service" ++ optional pgsqlLocal "postgresql.target";
+        after = [
+          "network.target"
+        ]
+        ++ optional mysqlLocal "mysql.service"
+        ++ optional pgsqlLocal "postgresql.target";
+      };
+    };
+
+    services.mysql = mkIf mysqlLocal {
+      enable = true;
+      package = mkDefault pkgs.mariadb;
+      ensureDatabases = [ cfg.database.name ];
+      ensureUsers = [
+        {
+          name = cfg.user;
+          ensurePermissions = {
+            "${cfg.database.name}.*" = "ALL PRIVILEGES";
+          };
+        }
+      ];
+    };
+
+    services.postgresql = mkIf pgsqlLocal {
+      enable = mkDefault true;
+      ensureDatabases = [ cfg.database.name ];
+      ensureUsers = [
+        {
+          name = cfg.database.user;
+          ensureDBOwnership = true;
+        }
+      ];
+    };
+
+    users.users.tt_rss = optionalAttrs (cfg.user == "tt_rss") {
+      description = "tt-rss service user";
+      isSystemUser = true;
+      group = "tt_rss";
+    };
+
+    users.groups.tt_rss = { };
+  };
+}

--- a/nixos/modules/services/web-apps/tt-rss.nix
+++ b/nixos/modules/services/web-apps/tt-rss.nix
@@ -619,8 +619,10 @@ in
             index = "index.php";
           };
 
-          locations."^~ /feed-icons" = {
-            root = "${cfg.root}";
+          # some clients might still access this old path directly, forward them to the API instead
+          # e.g. https://apps.apple.com/de/app/tiny-reader-rss/id689519762 at version 2.2.0
+          locations."~* /feed-icons/(\\d+)\\.ico" = {
+            return = "302 /public.php?op=feed_icon&id=$1";
           };
 
           locations."~ \\.php$" = {
@@ -641,7 +643,7 @@ in
       "d '${cfg.root}/cache/upload' 0755 ${cfg.user} tt_rss - -"
       "d '${cfg.root}/cache/images' 0755 ${cfg.user} tt_rss - -"
       "d '${cfg.root}/cache/export' 0755 ${cfg.user} tt_rss - -"
-      "d '${cfg.root}/feed-icons' 0755 ${cfg.user} tt_rss - -"
+      "d '${cfg.root}/cache/feed-icons' 0755 ${cfg.user} tt_rss - -"
       "L+ '${cfg.root}/www' - - - - ${servedRoot}"
     ];
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1581,6 +1581,7 @@ in
   trickster = runTest ./trickster.nix;
   trilium-server = runTestOn [ "x86_64-linux" ] ./trilium-server.nix;
   tsm-client-gui = runTest ./tsm-client-gui.nix;
+  tt-rss = runTest ./web-apps/tt-rss.nix;
   ttyd = runTest ./web-servers/ttyd.nix;
   tuliprox = runTest ./tuliprox.nix;
   tuned = runTest ./tuned.nix;

--- a/nixos/tests/web-apps/tt-rss.nix
+++ b/nixos/tests/web-apps/tt-rss.nix
@@ -1,0 +1,45 @@
+{ ... }:
+{
+  name = "tt-rss-nixos";
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.tt-rss = {
+        enable = true;
+        virtualHost = "localhost";
+        selfUrlPath = "http://localhost/";
+        pluginPackages = with pkgs; [
+          tt-rss-plugin-auth-ldap
+          tt-rss-plugin-feediron
+        ];
+        plugins = [
+          "auth_internal"
+          "feediron"
+          "note"
+        ];
+        singleUserMode = true;
+        themePackages = with pkgs; [ tt-rss-theme-feedly ];
+      };
+    };
+
+  testScript = ''
+    import json
+    import re
+    machine.wait_for_unit("tt-rss.service")
+
+    matches = re.search('__csrf_token = "([^"]*)"', machine.succeed("curl -sSfL --cookie cjar --cookie-jar cjar -sSfL http://localhost/"))
+    if matches is None:
+      assert False, "CSRF token not found"
+    csrf_token = matches.group(1)
+
+    # Ensure themes are loaded. No API found for these, so it's a crude check.
+    preference_page = machine.succeed("curl -sSfL --cookie cjar --cookie-jar cjar http://localhost/backend.php?op=Pref_Prefs")
+    assert "feedly" in preference_page
+
+    plugins = json.loads(machine.succeed(f"curl -sSfL --cookie cjar --cookie-jar cjar 'http://localhost/backend.php' -X POST --data-raw 'op=Pref_Prefs&method=getPluginsList&csrf_token={csrf_token}'"))["plugins"]
+    expected_plugins = ["auth_internal", "auth_ldap", "feediron", "note"];
+    found_plugins = [p["name"] for p in plugins if p["name"] in expected_plugins]
+    assert len(found_plugins) == len(expected_plugins), f"Expected plugins {expected_plugins}, found {found_plugins}"
+  '';
+}

--- a/pkgs/by-name/tt/tt-rss-plugin-auth-ldap/package.nix
+++ b/pkgs/by-name/tt/tt-rss-plugin-auth-ldap/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  nixosTests,
+  stdenv,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation {
+  pname = "tt-rss-plugin-auth-ldap";
+  version = "unstable-2022-11-30";
+
+  src = fetchFromGitHub {
+    owner = "hydrian";
+    repo = "TTRSS-Auth-LDAP";
+    rev = "582ade49fd433a30b403caa1d0689fca5f3c99e1";
+    sha256 = "sha256-favz/2KvWqvv8ehTv3gc7TBbFDjkrOmutChnyKPgces=";
+  };
+
+  installPhase = ''
+    install -D plugins/auth_ldap/init.php $out/auth_ldap/init.php
+  '';
+
+  passthru = {
+    tests = { inherit (nixosTests) tt-rss; };
+  };
+
+  meta = with lib; {
+    description = "Plugin for TT-RSS to authenticate users via ldap";
+    license = licenses.asl20;
+    homepage = "https://github.com/hydrian/TTRSS-Auth-LDAP";
+    maintainers = with maintainers; [ mic92 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/by-name/tt/tt-rss-plugin-data-migration/package.nix
+++ b/pkgs/by-name/tt/tt-rss-plugin-data-migration/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+}:
+
+stdenv.mkDerivation {
+  pname = "tt-rss-plugin-data-migration";
+  version = "0-unstable-2023-11-01";
+
+  src = fetchgit {
+    url = "https://git.tt-rss.org/fox/ttrss-data-migration.git";
+    rev = "e13d5f97b4887ce7b57b3d76228d838dec15963d";
+    hash = "sha256-xnbR5IQ0h7ilxchNj55ROZdq1L7MIAwv3/00k09WTTs=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D init.php $out/data_migration/init.php
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Plugin for TT-RSS to exports and imports *all* articles of a specific user via neutral format (JSON files in a ZIP archive)";
+    # this plugin doesn't have a license file
+    license = lib.licenses.unfree;
+    homepage = "https://git.tt-rss.org/fox/ttrss-data-migration.git/";
+    maintainers = with lib.maintainers; [ wrvsrx ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/by-name/tt/tt-rss-plugin-feediron/package.nix
+++ b/pkgs/by-name/tt/tt-rss-plugin-feediron/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  tt-rss,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tt-rss-plugin-feediron";
+  version = "1.33";
+
+  src = fetchFromGitHub {
+    owner = "feediron";
+    repo = "ttrss_plugin-feediron";
+    rev = "v${version}";
+    sha256 = "sha256-KU4XQJNK7Ua7rZaXA32lv16RlloCysAb54E5kEY847A=";
+  };
+
+  installPhase = ''
+    mkdir -p $out/feediron
+
+    cp -r bin filters init.php preftab recipes $out/feediron/
+  '';
+
+  meta = with lib; {
+    description = "Evolution of ttrss_plugin-af_feedmod";
+    longDescription = ''
+      This is a plugin for Tiny Tiny RSS (tt-rss).
+      It allows you to replace an article's contents by the contents of an element on the linked URL's page
+
+      i.e. create a "full feed".
+    '';
+    license = licenses.mit;
+    homepage = "https://github.com/feediron/ttrss_plugin-feediron";
+    maintainers = with maintainers; [ milogert ];
+    inherit (tt-rss.meta) platforms;
+  };
+}

--- a/pkgs/by-name/tt/tt-rss-plugin-ff-instagram/package.nix
+++ b/pkgs/by-name/tt/tt-rss-plugin-ff-instagram/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
     '';
     license = licenses.agpl3Plus;
     homepage = "https://github.com/wltb/ff_instagram";
-    maintainers = with maintainers; [ das_j ];
+    maintainers = with maintainers; [ gileri ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/by-name/tt/tt-rss-plugin-ff-instagram/package.nix
+++ b/pkgs/by-name/tt/tt-rss-plugin-ff-instagram/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation {
+  pname = "tt-rss-plugin-ff-instagram";
+  version = "0-unstable-2019-01-10"; # No release, see https://github.com/wltb/ff_instagram/issues/6
+
+  src = fetchFromGitHub {
+    owner = "wltb";
+    repo = "ff_instagram";
+    rev = "0366ffb18c4d490c8fbfba2f5f3367a5af23cfe8";
+    sha256 = "0vvzl6wi6jmrqknsfddvckjgsgfizz1d923d1nyrpzjfn6bda1vk";
+  };
+
+  installPhase = ''
+    mkdir -p $out/ff_instagram
+
+    cp *.php $out/ff_instagram
+  '';
+
+  meta = with lib; {
+    broken = true; # Plugin code does not conform to plugin API changes. See https://github.com/wltb/ff_instagram/issues/13
+    description = "Plugin for Tiny Tiny RSS that allows to fetch posts from Instagram user sites";
+    longDescription = ''
+      Plugin for Tiny Tiny RSS that allows to fetch posts from Instagram user sites.
+
+      The name of the plugin in TT-RSS is 'ff_instagram'.
+    '';
+    license = licenses.agpl3Plus;
+    homepage = "https://github.com/wltb/ff_instagram";
+    maintainers = with maintainers; [ das_j ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/by-name/tt/tt-rss-plugin-freshapi/package.nix
+++ b/pkgs/by-name/tt/tt-rss-plugin-freshapi/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation {
+  pname = "tt-rss-plugin-freshapi";
+  version = "0-unstable-2024-11-14";
+
+  src = fetchFromGitHub {
+    owner = "eric-pierce";
+    repo = "freshapi";
+    rev = "44c98f12e8a4423501fc6d8cb7903cca11094dc6";
+    hash = "sha256-1cQ4QMrXOdtelAbmMEuhWJPFi5XrAoR3IGlFzb8122k=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D init.php $out/freshapi/init.php
+    install -D api/greader.php $out/freshapi/api/greader.php
+    install -D api/freshapi.php $out/freshapi/api/freshapi.php
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "FreshRSS / Google Reader API Plugin for Tiny-Tiny RSS";
+    license = lib.licenses.agpl3Only;
+    homepage = "https://github.com/eric-pierce/freshapi";
+    maintainers = with lib.maintainers; [ wrvsrx ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/by-name/tt/tt-rss-theme-feedly/package.nix
+++ b/pkgs/by-name/tt/tt-rss-theme-feedly/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  nixosTests,
+  stdenv,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tt-rss-theme-feedly";
+  version = "4.1.0";
+
+  src = fetchFromGitHub {
+    owner = "levito";
+    repo = "tt-rss-feedly-theme";
+    rev = "v${version}";
+    sha256 = "sha256-3mD1aY7gjdvucRzY7sLmZ1RsHtraAg1RGE/3uDp6/o4=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir $out
+
+    cp -ra feedly *.css $out
+  '';
+
+  passthru = {
+    tests = { inherit (nixosTests) tt-rss; };
+  };
+
+  meta = with lib; {
+    description = "Feedly theme for Tiny Tiny RSS";
+    license = licenses.mit;
+    homepage = "https://github.com/levito/tt-rss-feedly-theme";
+    maintainers = with maintainers; [ das_j ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/by-name/tt/tt-rss/package.nix
+++ b/pkgs/by-name/tt/tt-rss/package.nix
@@ -9,12 +9,12 @@
 
 stdenv.mkDerivation rec {
   pname = "tt-rss";
-  version = "0-unstable-2025-04-17";
+  version = "0-unstable-2025-10-19";
 
   src = fetchgit {
-    url = "https://git.tt-rss.org/fox/tt-rss.git";
-    rev = "be82663ac9b59de8a135178a519efe9f7ebae213";
-    hash = "sha256-bZrmOOFB5HhiWsV6wWfqv3/wW4rf/05AX7qU+v1IBFE=";
+    url = "https://github.com/tt-rss/tt-rss.git";
+    rev = "f12f46bd6e9d186c0854c15ce4edde229143b848";
+    hash = "sha256-lpb7aum7EkpHFT0kcMwiH83qAjL2iSso+jKeKqk63so=";
   };
 
   installPhase = ''

--- a/pkgs/by-name/tt/tt-rss/package.nix
+++ b/pkgs/by-name/tt/tt-rss/package.nix
@@ -1,0 +1,49 @@
+# nixpkgs-update: no auto update
+{
+  lib,
+  stdenv,
+  fetchgit,
+  nixosTests,
+  unstableGitUpdater,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tt-rss";
+  version = "0-unstable-2025-04-17";
+
+  src = fetchgit {
+    url = "https://git.tt-rss.org/fox/tt-rss.git";
+    rev = "be82663ac9b59de8a135178a519efe9f7ebae213";
+    hash = "sha256-bZrmOOFB5HhiWsV6wWfqv3/wW4rf/05AX7qU+v1IBFE=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    cp -ra * $out/
+
+    # see the code of Config::get_version(). you can check that the version in
+    # the footer of the preferences pages is not UNKNOWN
+    echo "${version}" > $out/version_static.txt
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    tests = { inherit (nixosTests) tt-rss; };
+    updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
+  };
+
+  meta = with lib; {
+    description = "Web-based news feed (RSS/Atom) aggregator";
+    license = licenses.gpl3Plus;
+    homepage = "https://tt-rss.org";
+    maintainers = with maintainers; [
+      gileri
+      globin
+      zohl
+    ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/by-name/tt/tt-rss/package.nix
+++ b/pkgs/by-name/tt/tt-rss/package.nix
@@ -9,12 +9,12 @@
 
 stdenv.mkDerivation rec {
   pname = "tt-rss";
-  version = "0-unstable-2025-10-19";
+  version = "0-unstable-2025-11-01";
 
   src = fetchgit {
     url = "https://github.com/tt-rss/tt-rss.git";
-    rev = "f12f46bd6e9d186c0854c15ce4edde229143b848";
-    hash = "sha256-lpb7aum7EkpHFT0kcMwiH83qAjL2iSso+jKeKqk63so=";
+    rev = "912162ad811869af334232d32fe6c79b3cf095ca";
+    hash = "sha256-2U9V4MTWGNZzdVr9AlH/S7KdBGPap+mm5/KieWLcF1A=";
   };
 
   installPhase = ''

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1599,13 +1599,6 @@ mapAliases {
   trilium-next-server = trilium-server; # Added 2025-08-30
   trojita = throw "'trojita' has been dropped as it depends on KDE Gear 5, and is unmaintained"; # Added 2025-08-20
   trust-dns = throw "'trust-dns' has been renamed to/replaced by 'hickory-dns'"; # Converted to throw 2025-10-27
-  tt-rss = throw "'tt-rss' has been removed, as it was discontinued on 2025-11-01"; # Added 2025-10-03
-  tt-rss-plugin-auth-ldap = throw "'tt-rss-plugin-auth-ldap' has been removed, as tt-rss was discontinued and removed"; # Added 2025-10-03
-  tt-rss-plugin-data-migration = throw "'tt-rss-plugin-data-migration' has been removed, as tt-rss was discontinued and removed"; # Added 2025-10-03
-  tt-rss-plugin-feediron = throw "'tt-rss-plugin-feediron' has been removed, as tt-rss was discontinued and removed"; # Added 2025-10-03
-  tt-rss-plugin-feedly = throw "'tt-rss-plugin-feedly' has been removed, as tt-rss was discontinued and removed"; # Added 2025-10-03
-  tt-rss-plugin-ff-instagram = throw "'tt-rss-plugin-ff-instagram' has been removed, as tt-rss was discontinued and removed"; # Added 2025-10-03
-  tt-rss-plugin-freshapi = throw "'tt-rss-plugin-freshapi' has been removed, as tt-rss was discontinued and removed"; # Added 2025-10-03
   tvbrowser-bin = throw "'tvbrowser-bin' has been renamed to/replaced by 'tvbrowser'"; # Converted to throw 2025-10-27
   typst-fmt = throw "'typst-fmt' has been renamed to/replaced by 'typstfmt'"; # Converted to throw 2025-10-27
   typstfmt = throw "'typstfmt' has been removed due to lack of upstream maintenance, consider using 'typstyle' instead"; # Added 2025-10-26


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Restore tt-rss package and module, build from the [new repository](https://github.com/tt-rss/). This repository is acknowledged by fox, the original creator, as [the previous git forge](https://git.tt-rss.org/fox/tt-rss.git/) is redirecting to the [new github org](https://github.com/tt-rss/). The original domain (tt-rss.org) has not been updated, it's still in possession of the previous owner.

I don't know whether it could be put in 25.11, it's late, but technically is not a breaking change ? More like removing a breaking change. What do you think ?

```
❯ whois tt-rss.org
Domain Name: tt-rss.org
[...]
Updated Date: 2025-10-08T20:44:57Z
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
