### PR TITLE
wheelwizard: add update script

### DIFF
--- a/pkgs/by-name/wh/wheelwizard/package.nix
+++ b/pkgs/by-name/wh/wheelwizard/package.nix
@@ -7,8 +7,10 @@
   makeDesktopItem,
   makeWrapper,
   avalonia,
-  #Runtime dependencies
+  # Runtime dependencies
   libglvnd,
+  # passthru
+  nix-update-script,
 }:
 buildDotnetModule rec {
   pname = "wheelwizard";
@@ -69,6 +71,8 @@ buildDotnetModule rec {
     desktopName = "Wheel Wizard";
     categories = [ "Game" ];
   };
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "WheelWizard, Retro Rewind Launcher";


### PR DESCRIPTION
This pull request adds support for automated package updates to the `wheelwizard` package definition. The most notable change is the addition of a passthru attribute for the update script, which enables easier maintenance and updating of the package.

Automation and maintenance:

* Added `nix-update-script` to the list of dependencies and configured `passthru.updateScript` to enable automated updates for the `wheelwizard` package in `package.nix`. [[1]](diffhunk://#diff-ac3894277cf90ac5154f0d6b61ae5db3013619276bf7f35c86930bc37ab74273R12-R13) [[2]](diffhunk://#diff-ac3894277cf90ac5154f0d6b61ae5db3013619276bf7f35c86930bc37ab74273R75-R76)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
