### PR TITLE
python313Packages.ydata-profiling: 4.16.1 -> 4.17.0

### DIFF
--- a/pkgs/development/python-modules/ydata-profiling/default.nix
+++ b/pkgs/development/python-modules/ydata-profiling/default.nix
@@ -2,13 +2,13 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonOlder,
   pytestCheckHook,
   dacite,
-  htmlmin,
+  filetype,
   imagehash,
   jinja2,
   matplotlib,
+  minify-html,
   multimethod,
   numba,
   numpy,
@@ -31,17 +31,21 @@
 
 buildPythonPackage rec {
   pname = "ydata-profiling";
-  version = "4.16.1";
+  version = "4.17.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "ydataai";
     repo = "ydata-profiling";
     tag = "v${version}";
-    hash = "sha256-gmMEW1aAwBar/xR22Wm98hbjP20ty3idvxfqCJ1uRGM=";
+    hash = "sha256-5CGFchkXyhALiWRTNEvWsfU+hMXeL/geNO/5i5ZKcmg=";
   };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "setuptools>=72.0.0,<80.0.0" "setuptools" \
+      --replace-fail "setuptools-scm>=8.0.0,<9.0.0" "setuptools-scm"
+  '';
 
   preBuild = ''
     echo ${version} > VERSION
@@ -56,15 +60,18 @@ buildPythonPackage rec {
     "imagehash"
     "matplotlib"
     "multimethod"
+    "numba"
     "numpy"
+    "scipy"
   ];
 
   dependencies = [
     dacite
-    htmlmin
+    filetype
     imagehash
     jinja2
     matplotlib
+    minify-html
     multimethod
     numba
     numpy
@@ -91,6 +98,7 @@ buildPythonPackage rec {
   disabledTestPaths = [
     # needs Spark:
     "tests/backends/spark_backend"
+
     # try to download data:
     "tests/issues"
     "tests/unit/test_console.py"


### PR DESCRIPTION
ZHF (#457852).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
