### PR TITLE
gradle_7: fix meta eval

### DIFF
--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -3,6 +3,7 @@
   jdk11,
   jdk17,
   jdk21,
+  nix-update-script,
 }:
 
 let
@@ -15,11 +16,6 @@ let
       symlinkJoin,
       concatTextFile,
       makeSetupHook,
-      nix-update-script,
-
-      # This is the "current" version of gradle in nixpkgs.
-      # Used to define the update script.
-      gradle-unwrapped,
 
       runCommand,
     }:
@@ -84,17 +80,6 @@ let
                 '';
           }
           // gradle.tests;
-        }
-        // lib.optionalAttrs (this-gradle-unwrapped == gradle-unwrapped) {
-          updateScript = nix-update-script {
-            extraArgs = [
-              "--url=https://github.com/gradle/gradle"
-              # Gradle’s .0 releases are tagged as `vX.Y.0`, but the actual
-              # release version omits the `.0`, so we’ll wanto to only capture
-              # the version up but not including the the trailing `.0`.
-              "--version-regex=^v(\\d+\\.\\d+(?:\\.[1-9]\\d?)?)(\\.0)?$"
-            ];
-          };
         };
 
         meta = gradle.meta // {
@@ -133,6 +118,10 @@ let
       # Extra attributes to be merged into the resulting derivation's
       # meta attribute.
       meta ? { },
+
+      # Put the update script in passthru. Should only be on a single attrpath
+      # so that nixpkgs-update doesn't create duplicate PRs.
+      enableUpdateScript ? false,
     }@genArgs:
 
     {
@@ -287,6 +276,19 @@ let
       };
       passthru.jdk = defaultJava;
       passthru.wrapped = callPackage wrapGradle { } (gen' genArgs);
+      passthru.updateScript =
+        if enableUpdateScript then
+          nix-update-script {
+            extraArgs = [
+              "--url=https://github.com/gradle/gradle"
+              # Gradle’s .0 releases are tagged as `vX.Y.0`, but the actual
+              # release version omits the `.0`, so we’ll wanto to only capture
+              # the version up but not including the the trailing `.0`.
+              "--version-regex=^v(\\d+\\.\\d+(?:\\.[1-9]\\d?)?)(\\.0)?$"
+            ];
+          }
+        else
+          null;
 
       meta =
         with lib;
@@ -337,6 +339,8 @@ rec {
     version = "8.14.3";
     hash = "sha256-vXEQIhNJMGCVbsIp2Ua+7lcVjb2J0OYrkbyg+ixfNTE=";
     defaultJava = jdk21;
+    # Only enable this on *one* version to avoid duplicate PRs.
+    enableUpdateScript = true;
   };
   gradle_7 = gen' {
     version = "7.6.6";


### PR DESCRIPTION
Currently `gradle_7.meta` does not evaluate, because evaluation is forced in the wrapper adding the updateScript. We can move the update script to `gradle_8-unwrapped`, for which we don't need to do this check.

## Things done

- [x] `gradle_7.meta.maintainers` evaluates.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
