### PR TITLE
clang-uml: fix build on linux and darwin

### DIFF
--- a/pkgs/by-name/cl/clang-uml/darwin-system-libunwind.patch
+++ b/pkgs/by-name/cl/clang-uml/darwin-system-libunwind.patch
@@ -1,0 +1,29 @@
+diff --git a/cmake/LibUnwindSetup.cmake b/cmake/LibUnwindSetup.cmake
+index a7cfca9..9f451f4 100644
+--- a/cmake/LibUnwindSetup.cmake
++++ b/cmake/LibUnwindSetup.cmake
+@@ -1,22 +1,7 @@
+ if(APPLE)
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+         message(STATUS "AppleClang compiler detected: using system libunwind.")
+-    elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+-        if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "arm" OR "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "arm64")
+-            if("${CMAKE_CXX_COMPILER}" MATCHES "/opt/homebrew/")
+-                set(LIBUNWIND_PREFIX "${LLVM_LIBRARY_DIR}/unwind")
+-                message(STATUS "Homebrew Clang compiler detected: using libunwind from ${LIBUNWIND_PREFIX}")
+-            elseif("${CMAKE_CXX_COMPILER}" MATCHES "/opt/local/")
+-                set(LIBUNWIND_PREFIX "${LLVM_LIBRARY_DIR}/libunwind")
+-                message(STATUS "MacPorts Clang compiler detected: using libunwind from ${LIBUNWIND_PREFIX}")
+-            endif()
+-        elseif("${CMAKE_CXX_COMPILER}" MATCHES "/usr/local/opt/" OR "${CMAKE_CXX_COMPILER}" MATCHES "/usr/local/Cellar/")
+-            set(LIBUNWIND_PREFIX "${LLVM_LIBRARY_DIR}")
+-            message(STATUS "Homebrew Clang compiler detected: using libunwind from ${LIBUNWIND_PREFIX}")
+-        elseif("${CMAKE_CXX_COMPILER}" MATCHES "/opt/local/")
+-                set(LIBUNWIND_PREFIX "${LLVM_LIBRARY_DIR}/libunwind")
+-                message(STATUS "MacPorts Clang compiler detected: using libunwind from ${LIBUNWIND_PREFIX}")
+-        endif()
+-        set(LIBUNWIND_LIBRARY ${LIBUNWIND_PREFIX}/libunwind.dylib)
++    else()
++        message(STATUS "Using system libunwind (provided by libSystem).")
+     endif()
+ endif(APPLE)

--- a/pkgs/by-name/cl/clang-uml/package.nix
+++ b/pkgs/by-name/cl/clang-uml/package.nix
@@ -17,13 +17,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "clang-uml";
-  version = "0.6.1";
+  version = "0.6.2";
 
   src = fetchFromGitHub {
     owner = "bkryza";
     repo = "clang-uml";
     rev = finalAttrs.version;
-    hash = "sha256-mY6kJnwWLgCeKXSquNTxsnr4S3bKwedgiRixzyLWTK8=";
+    hash = "sha256-hGjLOyduTc+yOQhO5gDKNfY0fDvbUfvF0FrdjrDheyw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/cl/clang-uml/package.nix
+++ b/pkgs/by-name/cl/clang-uml/package.nix
@@ -26,6 +26,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-hGjLOyduTc+yOQhO5gDKNfY0fDvbUfvF0FrdjrDheyw=";
   };
 
+  patches = [
+    ./darwin-system-libunwind.patch
+  ];
+
   nativeBuildInputs = [
     cmake
     pkg-config


### PR DESCRIPTION
Updated clang-uml to fix the Linux build and patched the CMake file for LibUnwind on Darwin, which caused a build error.

ZHF: #457852

Hydra current build fail logs : 
https://hydra.nixos.org/build/310533575
https://hydra.nixos.org/build/310533570
https://hydra.nixos.org/build/310533573
https://hydra.nixos.org/build/310533574

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
