### PR TITLE
stub-ld: remove 32-bit test as it's no longer provided

### DIFF
--- a/nixos/tests/stub-ld.nix
+++ b/nixos/tests/stub-ld.nix
@@ -24,12 +24,6 @@ import ./make-test-python.nix (
         libDir = pkgs.stdenv.hostPlatform.libDir;
         ldsoBasename = lib.last (lib.splitString "/" pkgs.stdenv.cc.bintools.dynamicLinker);
 
-        check32 = pkgs.stdenv.hostPlatform.isx86_64;
-        pkgs32 = pkgs.pkgsi686Linux;
-
-        libDir32 = pkgs32.stdenv.hostPlatform.libDir;
-        ldsoBasename32 = lib.last (lib.splitString "/" pkgs32.stdenv.cc.bintools.dynamicLinker);
-
         test-exec =
           builtins.mapAttrs
             (
@@ -45,8 +39,6 @@ import ./make-test-python.nix (
               aarch64-linux.hash = "sha256-hnldbd2cctQIAhIKoEZLIWY8H3jiFBClkNy2UlyyvAs=";
             };
         exec-name = "rustic";
-
-        if32 = pythonStatement: if check32 then pythonStatement else "pass";
       in
       ''
         machine.start()
@@ -54,35 +46,26 @@ import ./make-test-python.nix (
 
         with subtest("Check for stub (enabled, initial)"):
             machine.succeed('test -L /${libDir}/${ldsoBasename}')
-            ${if32 "machine.succeed('test -L /${libDir32}/${ldsoBasename32}')"}
 
         with subtest("Try FHS executable"):
             machine.copy_from_host('${test-exec.${pkgs.stdenv.hostPlatform.system}}','test-exec')
             machine.succeed('if test-exec/${exec-name} 2>outfile; then false; else [ $? -eq 127 ];fi')
             machine.succeed('grep -qi nixos outfile')
-            ${if32 "machine.copy_from_host('${
-              test-exec.${pkgs32.stdenv.hostPlatform.system}
-            }','test-exec32')"}
-            ${if32 "machine.succeed('if test-exec32/${exec-name} 2>outfile32; then false; else [ $? -eq 127 ];fi')"}
-            ${if32 "machine.succeed('grep -qi nixos outfile32')"}
 
         with subtest("Disable stub"):
             machine.succeed("/run/booted-system/specialisation/nostub/bin/switch-to-configuration test")
 
         with subtest("Check for stub (disabled)"):
             machine.fail('test -e /${libDir}/${ldsoBasename}')
-            ${if32 "machine.fail('test -e /${libDir32}/${ldsoBasename32}')"}
 
         with subtest("Create file in stub location (to be overwritten)"):
             machine.succeed('mkdir -p /${libDir};touch /${libDir}/${ldsoBasename}')
-            ${if32 "machine.succeed('mkdir -p /${libDir32};touch /${libDir32}/${ldsoBasename32}')"}
 
         with subtest("Re-enable stub"):
             machine.succeed("/run/booted-system/bin/switch-to-configuration test")
 
         with subtest("Check for stub (enabled, final)"):
             machine.succeed('test -L /${libDir}/${ldsoBasename}')
-            ${if32 "machine.succeed('test -L /${libDir32}/${ldsoBasename32}')"}
       '';
   }
 )


### PR DESCRIPTION
Fixes `nixosTests.stub-ld`.

#398449 removed stub-ld 32-bit support but the tests still checked for it, causing them to fail. This simply removes the 32-bit tests as the functionality is no longer present.

ZHF: #457852

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
