### PR TITLE
umka-lang: init at 1.5.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8187,6 +8187,12 @@
       }
     ];
   };
+  f64u = {
+    email = "me@fadyadal.dev";
+    github = "f64u";
+    githubId = 24705058;
+    name = "Fady Adal";
+  };
   fab = {
     email = "mail@fabian-affolter.ch";
     matrix = "@fabaff:matrix.org";

--- a/pkgs/by-name/um/umka-lang/package.nix
+++ b/pkgs/by-name/um/umka-lang/package.nix
@@ -1,0 +1,38 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "umka-lang";
+  version = "1.5.4";
+
+  src = fetchFromGitHub {
+    owner = "vtereshkov";
+    repo = "umka-lang";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-UerEmJdD0/Hx/Pqw3NI3cZwjkX9lRWqI5rL0GGYKFwc=";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail "RANLIB                = libtool -static -o" "RANLIB = ar -cru"
+  ''
+  + lib.optionalString (!stdenv.hostPlatform.isx86) ''
+    substituteInPlace Makefile \
+      --replace-fail "-malign-double" ""
+  '';
+
+  makeFlags = [
+    "PREFIX=$(out)"
+  ];
+
+  meta = {
+    description = "Statically typed embeddable scripting language";
+    homepage = "https://github.com/vtereshkov/umka-lang";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ f64u ];
+    mainProgram = "umka";
+  };
+})


### PR DESCRIPTION
Added umka, a statically typed embeddable scripting language

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
