### PR TITLE
vite: unstable-2022-05-17 -> 1.4, adopt

### DIFF
--- a/pkgs/applications/science/misc/vite/default.nix
+++ b/pkgs/applications/science/misc/vite/default.nix
@@ -1,6 +1,7 @@
 {
   stdenv,
   fetchFromGitLab,
+  fetchpatch,
   lib,
   cmake,
   qtbase,
@@ -13,17 +14,25 @@
   wrapQtAppsHook,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "vite";
-  version = "unstable-2022-05-17";
+  version = "1.4";
 
   src = fetchFromGitLab {
     domain = "gitlab.inria.fr";
     owner = "solverstack";
     repo = "vite";
-    rev = "6d497cc519fac623e595bd174e392939c4de845c";
-    hash = "sha256-Yf2jYALZplIXzVtd/sg6gzEYrZ+oU0zLG1ETd/hiTi0=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-z2M4BazLzO/NCcq/VKb+tgrZ6QUs+AX0BbzJW809Krg=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "cmake4-fix";
+      url = "https://gitlab.inria.fr/solverstack/vite/-/commit/0359f78c8b11ced3a79ac4d73f4ecb9087eba1e8.patch";
+      hash = "sha256-UMg21ZlwyRSVQ4CD1oKNUkT+RNxqOIQi2WNBLbYPkJg=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake
@@ -54,4 +63,4 @@ stdenv.mkDerivation {
     maintainers = [ ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/applications/science/misc/vite/default.nix
+++ b/pkgs/applications/science/misc/vite/default.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     homepage = "http://vite.gforge.inria.fr/";
     license = lib.licenses.cecill20;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ iedame ];
     platforms = lib.platforms.linux;
   };
 })


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/457852
- https://github.com/NixOS/nixpkgs/issues/445447

Changelog: https://gitlab.inria.fr/solverstack/vite/-/releases/v1.4
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
