### PR TITLE
openwebrx: fix build with cmake 4, add version checks

### DIFF
--- a/pkgs/by-name/cs/csdr/package.nix
+++ b/pkgs/by-name/cs/csdr/package.nix
@@ -6,6 +6,7 @@
   pkg-config,
   fftwFloat,
   libsamplerate,
+  versionCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -45,6 +46,10 @@ stdenv.mkDerivation rec {
       --replace '=''${prefix}//' '=/' \
       --replace '=''${exec_prefix}//' '=/'
   '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+  doInstallCheck = true;
 
   meta = with lib; {
     homepage = "https://github.com/jketterl/csdr";

--- a/pkgs/by-name/cs/csdr/package.nix
+++ b/pkgs/by-name/cs/csdr/package.nix
@@ -22,6 +22,10 @@ stdenv.mkDerivation rec {
   postPatch = ''
     # function is not defined in any headers but used in libcsdr.c
     echo "int errhead();" >> src/predefined.h
+
+    substituteInPlace CMakeLists.txt --replace-fail \
+      "cmake_minimum_required (VERSION 3.0)" \
+      "cmake_minimum_required (VERSION 3.10)"
   '';
 
   nativeBuildInputs = [

--- a/pkgs/by-name/di/digiham/package.nix
+++ b/pkgs/by-name/di/digiham/package.nix
@@ -26,6 +26,12 @@ stdenv.mkDerivation (finalAttrs: {
     ./cpp-17.patch
   ];
 
+  postPatch = ''
+    substituteInPlace CMakeLists.txt --replace-fail \
+      "cmake_minimum_required (VERSION 3.0)" \
+      "cmake_minimum_required (VERSION 3.10)"
+  '';
+
   nativeBuildInputs = [
     cmake
   ];

--- a/pkgs/by-name/op/openwebrx/package.nix
+++ b/pkgs/by-name/op/openwebrx/package.nix
@@ -54,6 +54,12 @@ let
       hash = "sha256-1H0TJ8QN3b6Lof5TWvyokhCeN+dN7ITwzRvEo2X8OWc=";
     };
 
+    postPatch = ''
+      substituteInPlace CMakeLists.txt --replace-fail \
+        "cmake_minimum_required (VERSION 3.0)" \
+        "cmake_minimum_required (VERSION 3.10)"
+    '';
+
     nativeBuildInputs = [
       cmake
       pkg-config

--- a/pkgs/by-name/op/openwebrx/package.nix
+++ b/pkgs/by-name/op/openwebrx/package.nix
@@ -14,6 +14,7 @@
   sox,
   wsjtx,
   codecserver,
+  versionCheckHook,
 }:
 
 let
@@ -73,6 +74,10 @@ let
       soapysdr-with-plugins
     ];
 
+    nativeInstallCheckInputs = [ versionCheckHook ];
+    versionCheckProgram = "${placeholder "out"}/bin/rtl_connector";
+    doInstallCheck = true;
+
     meta = {
       homepage = "https://github.com/jketterl/owrx_connector";
       description = "Set of connectors that are used by OpenWebRX to interface with SDR hardware";
@@ -118,6 +123,9 @@ python3Packages.buildPythonApplication rec {
     "owrx"
     "test"
   ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   passthru = {
     inherit js8py owrx_connector;


### PR DESCRIPTION
This fixes `openwebrx` and its dependencies `csdr` and `digiham`, all of which broke with CMake 4, and adds `versionCheckHook` where possible.

Upstream hasn't seen any updates in a while, so I vendored the necessary patches (via `substituteInPlace`).

Hydra: https://hydra.nixos.org/build/310620840/nixlog/3
CMake 4 tracking: https://github.com/NixOS/nixpkgs/issues/445447
ZHF: https://github.com/NixOS/nixpkgs/issues/457852

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
