### PR TITLE
render-cli: init at 2.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12036,6 +12036,12 @@
     name = "Joshua Suskalo";
     githubId = 27734541;
   };
+  jtamagnan = {
+    email = "jtamagnan@gmail.com";
+    github = "jtamagnan";
+    githubId = 5892061;
+    name = "Jules Tamagnan";
+  };
   jtbx = {
     email = "jeremy@baxters.nz";
     name = "Jeremy Baxter";

--- a/pkgs/by-name/re/render-cli/package.nix
+++ b/pkgs/by-name/re/render-cli/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+}:
+
+buildGoModule rec {
+  pname = "render-cli";
+  version = "2.5.0";
+
+  src = fetchFromGitHub {
+    owner = "render-oss";
+    repo = "cli";
+    rev = "v${version}";
+    hash = "sha256-nOcgDTFngeO7xKB7e9oLtAGD/ZpQqw++CGjvJRu+PUI=";
+  };
+
+  vendorHash = "sha256-Kd4qbBwk4U/LIkfwQopMqN5DqKHN5BMCMYWSR+OSKN0=";
+
+  # Tests require network access
+  doCheck = false;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/render-oss/cli/pkg/cfg.Version=${version}"
+  ];
+
+  postInstall = ''
+    mv $out/bin/cli $out/bin/render
+  '';
+
+  meta = {
+    description = "Official command-line interface for Render cloud hosting platform";
+    homepage = "https://github.com/render-oss/cli";
+    changelog = "https://github.com/render-oss/cli/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ jtamagnan ];
+    mainProgram = "render";
+  };
+}


### PR DESCRIPTION
This is simply to add the https://github.com/render-oss/cli cli to nixpkgs

## Things done

Add the package

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
