### PR TITLE
rusty-path-of-building: 0.2.6 -> 0.2.7

### DIFF
--- a/pkgs/by-name/ru/rusty-path-of-building/package.nix
+++ b/pkgs/by-name/ru/rusty-path-of-building/package.nix
@@ -15,24 +15,18 @@
   wayland,
 }:
 
-let
-  icon = fetchurl {
-    url = "https://raw.githubusercontent.com/PathOfBuildingCommunity/PathOfBuilding-Launcher/9ee18657fa6597c42811152604da4e6b73fac342/PathOfBuilding.ico";
-    hash = "sha256-9EW4ld+xg7GLfd4dEY/xUCBMnKb3uu7LBq2Of3Gq1Y8=";
-  };
-in
 rustPlatform.buildRustPackage rec {
   pname = "rusty-path-of-building";
-  version = "0.2.6";
+  version = "0.2.7";
 
   src = fetchFromGitHub {
     owner = "meehl";
     repo = "rusty-path-of-building";
     rev = "v${version}";
-    hash = "sha256-U2OWNV8bUNXo8/Sro+gV/o3O/D1lMWVlbX3tCONmGOk=";
+    hash = "sha256-J/tTifOcbY1mfcNbQFN4Vdyl78O7vTVbfew3fcnVyTA=";
   };
 
-  cargoHash = "sha256-xB7nhCqUalGE0M762Zw7vVFKzz/TgnMU77xbEHorJ2U=";
+  cargoHash = "sha256-Oekl6SDIvgFIzPnve7nuib3fEjPGC46F/TNULmgOpew=";
 
   nativeBuildInputs = [
     pkg-config
@@ -62,13 +56,7 @@ rustPlatform.buildRustPackage rec {
   ];
 
   postInstall = ''
-    icotool -x ${icon}
-
-    for size in 16 32 48 256; do
-      mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
-      install -Dm 644 *PathOfBuilding*"$size"x"$size"*.png \
-        $out/share/icons/hicolor/"$size"x"$size"/apps/pathofbuilding.png
-    done
+    install -Dm444 assets/icon.png $out/share/icons/hicolor/256x256/apps/path-of-building.png
   '';
 
   postFixup = ''
@@ -88,13 +76,13 @@ rustPlatform.buildRustPackage rec {
 
   desktopItems = [
     (makeDesktopItem {
-      name = "rusty-path-of-building";
+      name = "rusty-path-of-building-1";
       desktopName = "Path of Building";
       comment = "Offline build planner for Path of Exile";
       exec = "rusty-path-of-building poe1";
       terminal = false;
       type = "Application";
-      icon = "pathofbuilding";
+      icon = "path-of-building";
       categories = [ "Game" ];
       keywords = [
         "poe"
@@ -111,7 +99,7 @@ rustPlatform.buildRustPackage rec {
       exec = "rusty-path-of-building poe2";
       terminal = false;
       type = "Application";
-      icon = "pathofbuilding";
+      icon = "path-of-building";
       categories = [ "Game" ];
       keywords = [
         "poe"


### PR DESCRIPTION
Also use icon that's now vendored in upstream repo.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
