### PR TITLE
iterm2: 3.5.14 -> 3.6.6, update script and new maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7666,6 +7666,12 @@
     githubId = 1365692;
     name = "Will Fancher";
   };
+  emaiax = {
+    email = "github@emaiax.dev";
+    github = "emaiax";
+    githubId = 1289661;
+    name = "Eduardo Maia";
+  };
   emantor = {
     email = "rouven+nixos@czerwinskis.de";
     github = "Emantor";

--- a/pkgs/by-name/it/iterm2/package.nix
+++ b/pkgs/by-name/it/iterm2/package.nix
@@ -15,13 +15,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "iterm2";
-  version = "3.5.14";
+  version = "3.6.6";
 
   src = fetchzip {
     url = "https://iterm2.com/downloads/stable/iTerm2-${
       lib.replaceStrings [ "." ] [ "_" ] version
     }.zip";
-    hash = "sha256-cF7gg4kT0z/7Qu7d6AyXpnvrSQ937JbFUgpXw5F4AWE=";
+    hash = "sha256-n3VoRxMOBQK/8mbVbORSBz73tsuKAUMG7dFZIbaqdHU=";
   };
 
   dontFixup = true;
@@ -40,6 +40,8 @@ stdenvNoCC.mkDerivation rec {
     runHook postInstall
   '';
 
+  passthru.updateScript = ./update.sh;
+
   meta = with lib; {
     description = "Replacement for Terminal and the successor to iTerm";
     homepage = "https://www.iterm2.com/";
@@ -48,6 +50,7 @@ stdenvNoCC.mkDerivation rec {
     maintainers = with maintainers; [
       steinybot
       tricktron
+      emaiax
     ];
     platforms = [
       "x86_64-darwin"

--- a/pkgs/by-name/it/iterm2/update.sh
+++ b/pkgs/by-name/it/iterm2/update.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl coreutils common-updater-scripts
+set -eu -o pipefail
+
+currentVersion=$(nix-instantiate --eval -E "with import ./. {}; iterm2.version or (lib.getVersion iterm2)" | tr -d '"')
+
+downloadUrl=$(
+  curl -sL "https://iterm2.com/downloads.html" |
+  grep -o -E 'href="[^"]*iTerm2[^"]*\.zip"' |
+  sed 's/href="//;s/"//' |
+  head -1
+)
+
+if [[ -z "$downloadUrl" ]]; then
+  echo >&2 "Failed to extract download url from iTerm2 downloads page"
+  exit 1
+fi
+
+version=$(echo "$downloadUrl" | sed -E '
+  s/.*iTerm2-?//    # Remove iTerm2 link prefix from download url
+  s/[vV]//          # Remove version "v" prefix
+  s/\.zip$//        # Remove .zip extension
+  s/_/./g           # Convert underscores to dots
+')
+
+# iterm2 is already up to date
+if [[ "$version" == "$currentVersion" ]]; then
+  exit 0
+fi
+
+# Update package version
+#
+source=$(nix-prefetch-url "$downloadUrl" --unpack --name "iterm2-$version")
+hash=$(nix-hash --to-sri --type sha256 "$source")
+
+update-source-version iterm2 $version $hash --ignore-same-version --ignore-same-hash


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Updated version based on https://iterm2.com/downloads.html
- Added update.sh to update version automatically
- Added myself as a maintainer

## Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
