### PR TITLE
python3Packages.fickling: 0.1.3 -> 0.1.4

### DIFF
--- a/pkgs/development/python-modules/fickling/default.nix
+++ b/pkgs/development/python-modules/fickling/default.nix
@@ -6,7 +6,6 @@
   fetchFromGitHub,
   flit-core,
   pytestCheckHook,
-  pythonOlder,
   torch,
   torchvision,
 }:
@@ -16,7 +15,6 @@ buildPythonPackage rec {
   version = "0.1.3";
   pyproject = true;
 
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "trailofbits";
@@ -43,11 +41,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "fickling" ];
 
-  meta = with lib; {
+  meta = {
     description = "Python pickling decompiler and static analyzer";
     homepage = "https://github.com/trailofbits/fickling";
     changelog = "https://github.com/trailofbits/fickling/releases/tag/v${version}";
-    license = licenses.lgpl3Plus;
+    license = lib.licenses.lgpl3Plus;
     maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/fickling/default.nix
+++ b/pkgs/development/python-modules/fickling/default.nix
@@ -5,22 +5,23 @@
   distutils,
   fetchFromGitHub,
   flit-core,
+  numpy,
   pytestCheckHook,
   torch,
   torchvision,
+  stdlib-list,
 }:
 
 buildPythonPackage rec {
   pname = "fickling";
-  version = "0.1.3";
+  version = "0.1.4";
   pyproject = true;
-
 
   src = fetchFromGitHub {
     owner = "trailofbits";
     repo = "fickling";
     tag = "v${version}";
-    hash = "sha256-/cV1XhJ8KMFby9nZ/qXEYxf+P6352Q2DZOLuvebyuHQ=";
+    hash = "sha256-EgVtMYPwSVBlw1bmX3qEeUKvEY7Awv6DOB5tgSLG+xQ=";
   };
 
   build-system = [
@@ -28,10 +29,16 @@ buildPythonPackage rec {
     flit-core
   ];
 
-  dependencies = [ astunparse ];
+  dependencies = [
+    astunparse
+    stdlib-list
+  ];
+
+  pythonRelaxDeps = [ "stdlib_list" ];
 
   optional-dependencies = {
     torch = [
+      numpy
       torch
       torchvision
     ];
@@ -39,12 +46,18 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
+  disabledTestPaths = [
+    # https://github.com/trailofbits/fickling/issues/162
+    # AttributeError: module 'numpy.lib.format' has no attribute...
+    "test/test_polyglot.py"
+  ];
+
   pythonImportsCheck = [ "fickling" ];
 
   meta = {
     description = "Python pickling decompiler and static analyzer";
     homepage = "https://github.com/trailofbits/fickling";
-    changelog = "https://github.com/trailofbits/fickling/releases/tag/v${version}";
+    changelog = "https://github.com/trailofbits/fickling/releases/tag/${src.tag}";
     license = lib.licenses.lgpl3Plus;
     maintainers = [ ];
   };


### PR DESCRIPTION
https://hydra.nixos.org/build/311448994

1. Modernized the build
2. Updated to 0.1.4 (this appears to be back under active development)
3. Filed ~~https://github.com/trailofbits/fickling/issues/161~~ (resolved) and https://github.com/trailofbits/fickling/issues/162

ZHF: #457852

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
