### PR TITLE
robodoc: fix build on darwin, adopt

### DIFF
--- a/pkgs/by-name/ro/robodoc/package.nix
+++ b/pkgs/by-name/ro/robodoc/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   autoreconfHook,
 }:
 
@@ -15,6 +16,14 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "v${finalAttrs.version}";
     hash = "sha256-l3prSdaGhOvXmZfCPbsZJNocO7y20zJjLQpajRTJOqE=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "troff_generator-fix";
+      url = "https://github.com/gumpu/ROBODoc/commit/0f8b35c42523810415bec70bb2200d2ecb41c82f.patch?index=full";
+      hash = "sha256-Pbuc1gHrOeHbR4QT/dZ8wP+vqYQlilayjCGKOJP5wvk=";
+    })
+  ];
 
   postConfigure = lib.optionalString stdenv.hostPlatform.isDarwin ''
     substituteInPlace Docs/makefile.am \

--- a/pkgs/by-name/ro/robodoc/package.nix
+++ b/pkgs/by-name/ro/robodoc/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "gumpu";
     repo = "ROBODoc";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-l3prSdaGhOvXmZfCPbsZJNocO7y20zJjLQpajRTJOqE=";
   };
 
@@ -27,14 +27,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   postConfigure = lib.optionalString stdenv.hostPlatform.isDarwin ''
     substituteInPlace Docs/makefile.am \
-      --replace 'man1_MANS = robodoc.1 robohdrs.1' 'man1_MANS ='
+      --replace-fail 'man1_MANS = robodoc.1 robohdrs.1' 'man1_MANS ='
   '';
 
   nativeBuildInputs = [ autoreconfHook ];
 
   hardeningDisable = [ "format" ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/gumpu/ROBODoc";
     description = "Documentation Extraction Tool";
     longDescription = ''
@@ -56,8 +56,9 @@ stdenv.mkDerivation (finalAttrs: {
       Shell Scripts, Assembler, COBOL, Occam, Postscript, Forth, Tcl/Tk, C++,
       Java -- basically any program in which you can use remarks/comments.
     '';
-    license = with licenses; gpl3Plus;
-    maintainers = [ ];
-    platforms = platforms.all;
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ iedame ];
+    platforms = lib.platforms.all;
+    mainProgram = "robodoc";
   };
 })


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/457852

`robodoc` was failing builds on Hydra since 2023.
aarch64-darwin: https://hydra.nixos.org/build/310732804
x86_64-darwin: https://hydra.nixos.org/build/310732806

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
