### PR TITLE
headson: init at 0.6.7

### DIFF
--- a/pkgs/by-name/he/headson/package.nix
+++ b/pkgs/by-name/he/headson/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  rustPlatform,
+  stdenvNoCC,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "headson";
+  version = "0.6.7";
+
+  src = fetchFromGitHub {
+    owner = "kantord";
+    repo = "headson";
+    tag = "v${finalAttrs.version}";
+    hash =
+      if stdenvNoCC.isDarwin then
+        "sha256-Fnba2XlEZo+KTmVSvqrg2OswCOrw7y+LP/4WXxxRiFg="
+      else
+        "sha256-XruOpiurs1SJeVlZObUSSygOt+jX2bqPXhEQFblVVfQ=";
+  };
+
+  cargoHash = "sha256-wlXBNFl2OImcvdSPjjcFSzLomeoTwPBIrLdTJXfX+Hg=";
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "`head`/`tail` for structured data";
+    longDescription = ''
+      Structure‑aware `head`/tail` for JSON and YAML.  Get a compact
+      preview that shows both the shape and representative values of
+      your data, all within a strict byte budget.  (Just like
+      `head`/`tail`, `headson` can also work with unstructured text
+      files.)
+    '';
+    homepage = "https://github.com/kantord/headson";
+    changelog = "https://github.com/kantord/headson/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "headson";
+  };
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
