### PR TITLE
python3Packages.torf: disable broken tests

### DIFF
--- a/pkgs/by-name/up/upsies/package.nix
+++ b/pkgs/by-name/up/upsies/package.nix
@@ -115,11 +115,11 @@ python3Packages.buildPythonApplication rec {
 
   __darwinAllowLocalNetworking = true;
 
-  meta = with lib; {
+  meta = {
     description = "Toolkit for collecting, generating, normalizing and sharing video metadata";
     homepage = "https://upsies.readthedocs.io/";
-    license = licenses.gpl3Plus;
+    license = lib.licenses.gpl3Plus;
     mainProgram = "upsies";
-    maintainers = with maintainers; [ ambroisie ];
+    maintainers = with lib.maintainers; [ ambroisie ];
   };
 }

--- a/pkgs/development/python-modules/aiobtclientapi/default.nix
+++ b/pkgs/development/python-modules/aiobtclientapi/default.nix
@@ -48,6 +48,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "aiobtclientapi" ];
 
+  disabledTests = [
+    # Timing-sensitive, e.g. "AssertionError: assert 9 <= 7"
+    "test_Monitor_block_until_timeout"
+  ];
+
   disabledTestPaths = [
     # AttributeError
     "tests/clients_test/rtorrent_test/rtorrent_api_test.py"

--- a/pkgs/development/python-modules/torf/default.nix
+++ b/pkgs/development/python-modules/torf/default.nix
@@ -2,13 +2,19 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
   flatbencode,
+
+  # test
   pytest-cov-stub,
   pytest-httpserver,
   pytest-mock,
   pytest-xdist,
   pytestCheckHook,
-  setuptools,
 }:
 
 buildPythonPackage rec {
@@ -48,10 +54,10 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "torf" ];
 
-  meta = with lib; {
+  meta = {
     description = "Create, parse and edit torrent files and magnet links";
     homepage = "https://github.com/rndusr/torf";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ ambroisie ];
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ ambroisie ];
   };
 }

--- a/pkgs/development/python-modules/torf/default.nix
+++ b/pkgs/development/python-modules/torf/default.nix
@@ -50,9 +50,16 @@ buildPythonPackage rec {
     "test_getting_info__xs_fails__as_fails"
     "test_getting_info__xs_returns_invalid_bytes"
     "test_getting_info__as_returns_invalid_bytes"
+    "test_file_in_singlefile_torrent_has_wrong_size"
+    "test_file_in_singlefile_torrent_doesnt_exist"
+    # Broken assertion
+    # AssertionError: assert 1000 < 1000
+    "test_callback_raises_exception"
   ];
 
   pythonImportsCheck = [ "torf" ];
+
+  __darwinAllowLocalNetworking = true;
 
   meta = {
     description = "Create, parse and edit torrent files and magnet links";


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/309714853

1. Cleaned up `with lib;` and imports
2. Disabled broken tests (not filing bugs upstream as it's not maintained)

From `nixpkgs-review`:
3. Disable speed-sensitive test in `python3Packages.aiobtclient` 

ZHF: #457852

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
