### PR TITLE
pkgit: init at 0.0.11

### DIFF
--- a/pkgs/by-name/pk/pkgit/lock.json
+++ b/pkgs/by-name/pk/pkgit/lock.json
@@ -1,0 +1,16 @@
+{
+  "depends": [
+    {
+      "method": "fetchzip",
+      "path": "/nix/store/xvqx70fl7697g5rd00ch51baxrymkqxd-source",
+      "rev": "d297f5a81be2472905d367aa675dcbbca6e7a5d2",
+      "sha256": "0dax2bfzwygx4142qywib9n4z3h3cvvr5dy2h3jy35iizg16iqka",
+      "url": "https://github.com/NimParsers/parsetoml/archive/d297f5a81be2472905d367aa675dcbbca6e7a5d2.tar.gz",
+      "ref": "v0.7.2",
+      "packages": [
+        "parsetoml"
+      ],
+      "srcDir": "src"
+    }
+  ]
+}

--- a/pkgs/by-name/pk/pkgit/package.nix
+++ b/pkgs/by-name/pk/pkgit/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  buildNimPackage,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildNimPackage (finalAttrs: {
+  pname = "pkgit";
+  version = "0.0.11";
+
+  src = fetchFromGitHub {
+    owner = "dacctal";
+    repo = "pkgit";
+    tag = finalAttrs.version;
+    hash = "sha256-k9egbZD7V2EdIQRTJ8kVic7pNvAvIln5O+ke1lciCT8=";
+  };
+
+  lockFile = ./lock.json;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Compile & install packages directly from the git repository";
+    homepage = "https://github.com/dacctal/pkgit";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "pkgit";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
