### PR TITLE
requireFile: allow substitutes

### DIFF
--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -958,7 +958,6 @@ rec {
       outputHashAlgo = hashAlgo_;
       outputHash = hash_;
       preferLocalBuild = true;
-      allowSubstitutes = false;
       builder = writeScript "restrict-message" ''
         source ${stdenvNoCC}/setup
         cat <<_EOF_


### PR DESCRIPTION
This was added in f194659ddbac889755737e7e2dc09b0bb821396a with the explanation "The requireFile call was being substituted from the binary cache. We do not want this to happen"

As far as I can tell, no one has thought about this since. Preventing it here makes no sense:

- Anyone can "get around" this by doing `.overrideAttrs { allowSubstitutes = true; }`, and

- I *want* to cache requireFile derivations in my nixcache, and to do so I have to apply the above fix. I doubt I'm the only one.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable: (N/A)
- [x] Ran `nixpkgs-review` on this PR. (although it was maybe pointless)
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

I used [`liquidfun.src`](https://github.com/NixOS/nixpkgs/blob/3de8f8d73e35724bf9abef41f1bdbedda1e14a31/pkgs/by-name/li/liquidfun/package.nix) as a test:

- `nix run .#liquidfun.src`, got the expected error message
- added `liquidfun-1.1.0.tar.gz` to my nix store
- `nix run .#liquidfun.src`, it successfully realized `/nix/store/4v3q7n13vb9w7qsrf5an4kz8q0f76lzl-liquidfun-1.1.0.tar.gz`
- added it to my cache
- `nix store gc`
- verify nix store path is gone
- `nix build --option substituters "https://cache.nixos.org" .#liquidfun.src` fails as expected
- `nix build .#liquidfun.src` succeeds


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `bf2a1cb3ae20494bf4d8735b817fa366edd371e6`

---
### `x86_64-linux`

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
