### PR TITLE
woof-doom: 15.2.0 -> 15.3.0

### DIFF
--- a/pkgs/by-name/wo/woof-doom/package.nix
+++ b/pkgs/by-name/wo/woof-doom/package.nix
@@ -13,18 +13,20 @@
   libebur128,
   python3,
   yyjson,
+  discord-rpc,
   nix-update-script,
+  withDiscordRpc ? true,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "woof-doom";
-  version = "15.2.0";
+  version = "15.3.0";
 
   src = fetchFromGitHub {
     owner = "fabiangreffrath";
     repo = "woof";
-    rev = "woof_${finalAttrs.version}";
-    hash = "sha256-U1JxdWKSIbIbPMipnjY2SJ5lOP9AFMLNjyplK0mFhxE=";
+    tag = "woof_${finalAttrs.version}";
+    hash = "sha256-G9exAJivfZnT2eWQhFYT8ZVRUU1QT0VAZF1CDCXmJ04=";
   };
 
   nativeBuildInputs = [
@@ -35,24 +37,33 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     SDL2
     SDL2_net
-    alsa-lib
     fluidsynth
     libsndfile
     libxmp
     libebur128
     openal
     yyjson
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    alsa-lib
+  ]
+  ++ lib.optional withDiscordRpc discord-rpc;
+
+  strictDeps = true;
+
+  cmakeFlags = [
+    (lib.cmakeBool "WITH_DISCORD_RPC" withDiscordRpc)
   ];
 
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "Woof! is a continuation of the Boom/MBF bloodline of Doom source ports";
+    description = "Doom source port based on Boom/MBF";
     homepage = "https://github.com/fabiangreffrath/woof";
     changelog = "https://github.com/fabiangreffrath/woof/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [ keenanweaver ];
     mainProgram = "woof";
-    platforms = with lib.platforms; darwin ++ linux ++ windows;
+    platforms = lib.platforms.unix;
   };
 })


### PR DESCRIPTION
- Bumps to latest version
- Modernize the package and cleanup
- Change platform to 'unix', add strictDeps, conditional for alsa-lib
- Add discord-rpc

~Note: Does not compile as it relies on SDL3 3.3.0, which is currently not released/in nixpkgs. Leaving as draft until then.~ Now uses SDL2 again.

Changelog: https://github.com/fabiangreffrath/woof/releases/tag/woof_15.3.0
Compare: https://github.com/fabiangreffrath/woof/compare/woof_15.2.0...woof_15.3.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
