### PR TITLE
deltatouch: 1.14.3 -> 2.22.0

### DIFF
--- a/pkgs/by-name/de/deltatouch/package.nix
+++ b/pkgs/by-name/de/deltatouch/package.nix
@@ -2,25 +2,55 @@
   lib,
   stdenv,
   fetchFromGitea,
+  fetchFromGitHub,
+  fetchpatch,
   cmake,
   intltool,
   libdeltachat,
   lomiri,
   qt5,
   quirc,
+  rustPlatform,
 }:
 
+let
+  libdeltachat' = libdeltachat.overrideAttrs rec {
+    version = "2.22.0";
+    src = fetchFromGitHub {
+      owner = "chatmail";
+      repo = "core";
+      tag = "v${version}";
+      hash = "sha256-DKqqdcG3C7/RF/wz2SqaiPUjZ/7vMFJTR5DIGTXjoTY=";
+    };
+    cargoDeps = rustPlatform.fetchCargoVendor {
+      pname = "chatmail-core";
+      inherit version src;
+      hash = "sha256-x71vytk9ytIhHlRR0lDhDcIaDNJGDdPwb6fkB1SI+NQ=";
+    };
+  };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "deltatouch";
-  version = "1.14.3";
+  version = "2.22.0";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "lk108";
     repo = "deltatouch";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-vumMAMm9+dKlmi5a6ehIDePpQKkco/smYSM1K/QiXu4=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-e8kS6kAjOZ2V33XJuJbvDZ9mfRknDh9un0dn5HtD3UY=";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://codeberg.org/lk108/deltatouch/commit/b19c088ce95e8ca6ff1102c36d91b1db937e3a3a.patch";
+      hash = "sha256-58WPUSFaAUqVVU3iq05tae5Gvvr405zDA145V9DbJ54=";
+    })
+    (fetchpatch {
+      url = "https://codeberg.org/lk108/deltatouch/commit/139f3a4abd772b17142a7f61ef9b442200728f4a.patch";
+      hash = "sha256-bEX4g88CCt7AFok8kTeItzCripXFoG2ED7R9lGYoCAw=";
+    })
+  ];
 
   nativeBuildInputs = [
     qt5.wrapQtAppsHook
@@ -32,50 +62,25 @@ stdenv.mkDerivation (finalAttrs: {
     qt5.qtbase
     qt5.qtwebengine
     qt5.qtquickcontrols2
+    libdeltachat'
     lomiri.lomiri-ui-toolkit
     lomiri.lomiri-ui-extras
     lomiri.lomiri-api
     lomiri.qqc2-suru-style
+    quirc
   ];
 
-  postPatch = ''
-    # Fix all sorts of install locations
-    substituteInPlace CMakeLists.txt \
-      --replace-fail 'set(DATA_DIR /)' 'set(DATA_DIR ''${CMAKE_INSTALL_DATAROOTDIR})' \
-      --replace-fail 'RUNTIME DESTINATION ''${CMAKE_INSTALL_PREFIX}' 'RUNTIME DESTINATION ''${CMAKE_INSTALL_BINDIR}' \
-      --replace-fail 'assets/logo.svg DESTINATION assets' 'assets/logo.svg DESTINATION ''${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/apps RENAME deltatouch.svg' \
-      --replace-fail "\''${DESKTOP_FILE_NAME} DESTINATION \''${DATA_DIR}" "\''${DESKTOP_FILE_NAME} DESTINATION \''${CMAKE_INSTALL_DATAROOTDIR}/applications"
-
-    substituteInPlace plugins/{DeltaHandler,HtmlMsgEngineProfile,WebxdcEngineProfile,XdcPickerEngineProfile}/CMakeLists.txt \
-      --replace-fail 'set(QT_IMPORTS_DIR "/lib/''${ARCH_TRIPLET}")' 'set(QT_IMPORTS_DIR "${placeholder "out"}/${qt5.qtbase.qtQmlPrefix}")'
-
-    # Fix import of library dependencies
-    substituteInPlace plugins/{DeltaHandler,HtmlMsgEngineProfile,WebxdcEngineProfile,XdcPickerEngineProfile}/CMakeLists.txt \
-      --replace-fail 'IMPORTED_LOCATION "''${CMAKE_CURRENT_BINARY_DIR}/libdeltachat.so"' 'IMPORTED_LOCATION "${lib.getLib libdeltachat}/lib/libdeltachat.so"'
-    substituteInPlace plugins/DeltaHandler/CMakeLists.txt \
-      --replace-fail 'IMPORTED_LOCATION "''${CMAKE_CURRENT_BINARY_DIR}/libquirc.so.1.2"' 'IMPORTED_LOCATION "${lib.getLib quirc}/lib/libquirc.so"'
-
-    # Fix icon reference in desktop file
-    substituteInPlace deltatouch.desktop.in \
-      --replace-fail 'Icon=assets/logo.svg' 'Icon=deltatouch'
-  '';
-
-  postInstall = ''
-    # Remove clickable metadata & helpers from out
-    rm $out/{manifest.json,share/push*}
-  '';
-
-  meta = with lib; {
-    changelog = "https://codeberg.org/lk108/deltatouch/src/tag/${finalAttrs.src.rev}/CHANGELOG";
+  meta = {
+    changelog = "https://codeberg.org/lk108/deltatouch/src/tag/${finalAttrs.src.tag}/CHANGELOG";
     description = "Messaging app for Ubuntu Touch, powered by Delta Chat core";
     longDescription = ''
       DeltaTouch is a messenger for Ubuntu Touch based on Delta Chat core.
       Delta Chat works over email.
     '';
     homepage = "https://codeberg.org/lk108/deltatouch";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ link2xt ];
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ link2xt ];
     mainProgram = "deltatouch";
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
 })


### PR DESCRIPTION
Currently, only a blank white window is displayed :cry: 

Diff: https://codeberg.org/lk108/deltatouch/compare/v1.14.3...v2.22.0

Changelog: https://codeberg.org/lk108/deltatouch/src/tag/v2.22.0/CHANGELOG


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
