### PR TITLE
home-assistant: support libre_hardware_monitor component

### DIFF
--- a/pkgs/development/python-modules/librehardwaremonitor-api/default.nix
+++ b/pkgs/development/python-modules/librehardwaremonitor-api/default.nix
@@ -1,0 +1,40 @@
+{
+  aiohttp,
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  pytestCheckHook,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "librehardwaremonitor-api";
+  version = "1.4.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Sab44";
+    repo = "librehardwaremonitor-api";
+    tag = "v${version}";
+    hash = "sha256-yYJOizO6blfwRBWD9oFnaein7DK1F8Kl744ErehXU0Q=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    aiohttp
+  ];
+
+  pythonImportsCheck = [ "librehardwaremonitor_api" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Python API client for LibreHardwareMonitor";
+    homepage = "https://github.com/Sab44/librehardwaremonitor-api";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.dotlambda ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -3282,7 +3282,8 @@
       ];
     "libre_hardware_monitor" =
       ps: with ps; [
-      ]; # missing inputs: librehardwaremonitor-api
+        librehardwaremonitor-api
+      ];
     "lidarr" =
       ps: with ps; [
         aiopyarr
@@ -7450,6 +7451,7 @@
     "lg_netcast"
     "lg_soundbar"
     "lg_thinq"
+    "libre_hardware_monitor"
     "lidarr"
     "life360"
     "lifx"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8377,6 +8377,8 @@ self: super: with self; {
     }
   );
 
+  librehardwaremonitor-api = callPackage ../development/python-modules/librehardwaremonitor-api { };
+
   librepo = lib.pipe pkgs.librepo [
     toPythonModule
     (


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
