### PR TITLE
ci/github-script/merge: two minor improvements

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -43,7 +43,7 @@ These issues effectively list PRs the merge bot has interacted with.
 To ensure security and a focused utility, the bot adheres to specific limitations:
 
 - The PR targets one of the [development branches](#branch-classification).
-- The PR only touches packages located under `pkgs/by-name/*`.
+- The PR only touches files of packages located under `pkgs/by-name/*`.
 - The PR is either:
   - approved by a [committer][@NixOS/nixpkgs-committers].
   - authored by a [committer][@NixOS/nixpkgs-committers].

--- a/ci/README.md
+++ b/ci/README.md
@@ -46,9 +46,9 @@ To ensure security and a focused utility, the bot adheres to specific limitation
 - The PR only touches files of packages located under `pkgs/by-name/*`.
 - The PR is either:
   - approved by a [committer][@NixOS/nixpkgs-committers].
-  - authored by a [committer][@NixOS/nixpkgs-committers].
   - backported via label.
-  - created by [@r-ryantm](https://nix-community.github.io/nixpkgs-update/r-ryantm/).
+  - opened by a [committer][@NixOS/nixpkgs-committers].
+  - opened by [@r-ryantm](https://nix-community.github.io/nixpkgs-update/r-ryantm/).
 - The user attempting to merge is a member of [@NixOS/nixpkgs-maintainers].
 - The user attempting to merge is a maintainer of all packages touched by the PR.
 

--- a/ci/github-script/merge.js
+++ b/ci/github-script/merge.js
@@ -45,11 +45,11 @@ function runChecklist({
     'PR touches only files of packages in `pkgs/by-name/`.': allByName,
     'PR is at least one of:': {
       'Approved by a committer.': committers.intersection(approvals).size > 0,
-      'Authored by a committer.': committers.has(pull_request.user.id),
       'Backported via label.':
         pull_request.user.login === 'nixpkgs-ci[bot]' &&
         pull_request.head.ref.startsWith('backport-'),
-      'Created by r-ryantm.': pull_request.user.login === 'r-ryantm',
+      'Opened by a committer.': committers.has(pull_request.user.id),
+      'Opened by r-ryantm.': pull_request.user.login === 'r-ryantm',
     },
   }
 

--- a/ci/github-script/merge.js
+++ b/ci/github-script/merge.js
@@ -10,13 +10,15 @@ function runChecklist({
   user,
   userIsMaintainer,
 }) {
-  const allByName = files.every(({ filename }) =>
-    filename.startsWith('pkgs/by-name/'),
+  const allByName = files.every(
+    ({ filename }) =>
+      filename.startsWith('pkgs/by-name/') && filename.split('/').length > 4,
   )
 
   const packages = files
     .filter(({ filename }) => filename.startsWith('pkgs/by-name/'))
     .map(({ filename }) => filename.split('/')[3])
+    .filter(Boolean)
 
   const eligible = !packages.length
     ? new Set()
@@ -40,7 +42,7 @@ function runChecklist({
   const checklist = {
     'PR targets a [development branch](https://github.com/NixOS/nixpkgs/blob/-/ci/README.md#branch-classification).':
       classify(pull_request.base.ref).type.includes('development'),
-    'PR touches only packages in `pkgs/by-name/`.': allByName,
+    'PR touches only files of packages in `pkgs/by-name/`.': allByName,
     'PR is at least one of:': {
       'Approved by a committer.': committers.intersection(approvals).size > 0,
       'Authored by a committer.': committers.has(pull_request.user.id),


### PR DESCRIPTION
Two very minor improvements to merge-bot wording / feedback.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
