### PR TITLE
haskell.packages.{ghc96,ghc98}.haskell-language-server: fix build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -220,6 +220,7 @@ in
         haskell-language-server = addBuildDepends [
           self.retrie
           self.floskell
+          self.markdown-unlit
         ] super.haskell-language-server;
         hlint = self.hlint_3_8;
         ormolu = self.ormolu_0_7_4_0;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -222,6 +222,7 @@ in
           self.floskell
           self.markdown-unlit
         ] super.haskell-language-server;
+        hls-plugin-api = super.hls-plugin-api;
         hlint = self.hlint_3_8;
         ormolu = self.ormolu_0_7_4_0;
         retrie = doJailbreak (unmarkBroken super.retrie);
@@ -232,6 +233,7 @@ in
     floskell
     fourmolu
     haskell-language-server
+    hls-plugin-api
     hlint
     ormolu
     retrie

--- a/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
@@ -124,6 +124,7 @@ in
         haskell-language-server = addBuildDepends [
           self.retrie
           self.floskell
+          self.markdown-unlit
         ] super.haskell-language-server;
         hlint = self.hlint_3_8;
         ormolu = self.ormolu_0_7_4_0;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
@@ -126,6 +126,7 @@ in
           self.floskell
           self.markdown-unlit
         ] super.haskell-language-server;
+        hls-plugin-api = super.hls-plugin-api;
         hlint = self.hlint_3_8;
         ormolu = self.ormolu_0_7_4_0;
         retrie = doJailbreak (unmarkBroken super.retrie);
@@ -136,6 +137,7 @@ in
     floskell
     fourmolu
     haskell-language-server
+    hls-plugin-api
     hlint
     ormolu
     retrie


### PR DESCRIPTION
Did not find a way to disable the tutorial, so just added the dependency. This makes these build.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
