### PR TITLE
botan3: fix static build

### DIFF
--- a/pkgs/by-name/bo/botan3/package.nix
+++ b/pkgs/by-name/bo/botan3/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  buildPackages,
+  libcxxStdenv,
   fetchurl,
   pkgsStatic,
   python3,
@@ -9,7 +9,6 @@
   bzip2,
   zlib,
   jitterentropy,
-  darwin,
   esdm,
   tpm2-tss,
   static ? stdenv.hostPlatform.isStatic, # generates static libraries *only*
@@ -20,7 +19,7 @@
   # useful, but have to disable tests for now, as /dev/tpmrm0 is not accessible
   withTpm2 ? false,
   policy ? null,
-}:
+}@args:
 
 assert lib.assertOneOf "policy" policy [
   # no explicit policy is given. The defaults by the library are used
@@ -32,11 +31,10 @@ assert lib.assertOneOf "policy" policy [
   # only allow "modern" algorithms
   "modern"
 ];
-
 let
-  stdenv' = if static then buildPackages.libcxxStdenv else stdenv;
+  stdenv = if static then libcxxStdenv else args.stdenv;
 in
-stdenv'.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   version = "3.9.0";
   pname = "botan";
 


### PR DESCRIPTION
Fixes static build of the library, which broke with the move to pkgs/by-name in #446190 (98a16089ef58d31311fdc177fdf07189658b3fb8).
Also fixes the static cli build using the same workaround for the gcc_eh linking issue as in #391424, which did not produce a statically linked binary even before the move to pkgs/by-name.

(Note that both builds previously ran through without errors, but neither was usable as intended, the library archive wasn't usable for static linking and the cli was dynamically linked)

Also see commit messages.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

---
