### PR TITLE
python3Packages.beanie: init at 2.0.1, and related changes

### DIFF
--- a/pkgs/development/python-modules/beanie/default.nix
+++ b/pkgs/development/python-modules/beanie/default.nix
@@ -1,0 +1,95 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+
+  # build system
+  flit-core,
+
+  # dependencies
+  click,
+  lazy-model,
+  pydantic,
+  pymongo,
+  typing-extensions,
+
+  # test dependencies
+  asgi-lifespan,
+  dnspython,
+  fastapi,
+  httpx,
+  pydantic-extra-types,
+  pydantic-settings,
+  pytest-asyncio,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "beanie";
+  version = "2.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "BeanieODM";
+    repo = "beanie";
+    tag = finalAttrs.version;
+    hash = "sha256-SakJvkewlCjMp5PVwletJhvebmdgzIBDlI8GnJLrxl4=";
+  };
+
+  postPatch = ''
+    # `pytest-cov` supports Python 3.13 from v7.0.0 which isn't in nixpkgs yet
+    substituteInPlace pyproject.toml \
+      --replace-fail 'addopts = "--cov"' ""
+  '';
+
+  build-system = [ flit-core ];
+
+  dependencies = [
+    click
+    lazy-model
+    pydantic
+    pymongo
+    typing-extensions
+  ];
+
+  optional-dependencies = {
+    aws = pymongo.optional-dependencies.aws;
+    encryption = pymongo.optional-dependencies.encryption;
+    gssapi = pymongo.optional-dependencies.gssapi;
+    ocsp = pymongo.optional-dependencies.ocsp;
+    snappy = pymongo.optional-dependencies.snappy;
+    zstd = pymongo.optional-dependencies.zstd;
+  };
+
+  pythonRelaxDeps = [
+    "lazy-model"
+  ];
+
+  pythonImportsCheck = [ "beanie" ];
+
+  disabledTestPaths = [
+    # touches network
+    "tests/fastapi"
+    "tests/migrations"
+    "tests/odm"
+  ];
+
+  nativeCheckInputs = [
+    asgi-lifespan
+    dnspython
+    fastapi
+    httpx
+    pydantic-extra-types
+    pydantic-settings
+    pytest-asyncio
+    pytestCheckHook
+  ]
+  ++ pydantic.optional-dependencies.email;
+
+  meta = {
+    changelog = "https://beanie-odm.dev/changelog";
+    description = "Asynchronous Python ODM for MongoDB";
+    homepage = "https://beanie-odm.dev";
+    license = lib.licenses.asl20;
+  };
+})

--- a/pkgs/development/python-modules/lazy-model/default.nix
+++ b/pkgs/development/python-modules/lazy-model/default.nix
@@ -1,0 +1,43 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+
+  # build system
+  poetry-core,
+
+  # dependencies
+  pydantic,
+
+  # test dependencies
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "lazy-model";
+  version = "0.4.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "BeanieODM";
+    repo = "lazy_model";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2DeGBSoElCGWJDqvYHLK2Zy+ep2kHV56rDYU2P4mEco=";
+  };
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    pydantic
+  ];
+
+  pythonImportsCheck = [ "lazy_model" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  meta = {
+    description = "Lazy parsing for Pydantic models";
+    homepage = "https://github.com/BeanieODM/lazy_model";
+    license = lib.licenses.asl20;
+  };
+})

--- a/pkgs/development/python-modules/pymongo-auth-aws/default.nix
+++ b/pkgs/development/python-modules/pymongo-auth-aws/default.nix
@@ -1,0 +1,54 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+
+  # build system
+  hatchling,
+  hatch-requirements-txt,
+
+  # dependencies
+  boto3,
+  botocore,
+
+  # test dependencies
+  pymongo,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pymongo-auth-aws";
+  version = "1.3.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mongodb";
+    repo = "pymongo-auth-aws";
+    tag = finalAttrs.version;
+    hash = "sha256-532Srsaa1wlFoK4BHiTTl8CtdJ3MBnEm7Apqg05vv0w=";
+  };
+
+  build-system = [
+    hatchling
+    hatch-requirements-txt
+  ];
+
+  dependencies = [
+    boto3
+    botocore
+  ];
+
+  pythonImportsCheck = [ "pymongo_auth_aws" ];
+
+  nativeCheckInputs = [
+    pymongo
+    pytestCheckHook
+  ];
+
+  meta = {
+    changelog = "https://github.com/mongodb/pymongo-auth-aws/blob/${finalAttrs.src.tag}/CHANGELOG.rst";
+    description = "MONGODB-AWS authentication mechanism for PyMongo";
+    homepage = "https://github.com/mongodb/pymongo-auth-aws";
+    license = lib.licenses.asl20;
+  };
+})

--- a/pkgs/development/python-modules/pymongo/default.nix
+++ b/pkgs/development/python-modules/pymongo/default.nix
@@ -1,11 +1,27 @@
 {
-  lib,
   buildPythonPackage,
   fetchPypi,
+  lib,
+  stdenv,
+
+  # build system
   hatchling,
   hatch-requirements-txt,
   setuptools,
+
+  # dependencies
   dnspython,
+
+  # optional dependencies
+  certifi,
+  cryptography,
+  pykerberos,
+  pymongo-auth-aws,
+  pyopenssl,
+  python-snappy,
+  requests,
+  service-identity,
+  zstandard,
 
   # for passthru.tests
   celery, # check-input only
@@ -16,13 +32,13 @@
   pymongo-inmemory,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pymongo";
   version = "4.13.2";
   pyproject = true;
 
   src = fetchPypi {
-    inherit version;
+    inherit (finalAttrs) version;
     pname = "pymongo";
     hash = "sha256-D2TGRpwjYpYubOlyWK4Tkau6FWapU6SSVi0pJLRIFcI=";
   };
@@ -34,6 +50,21 @@ buildPythonPackage rec {
   ];
 
   dependencies = [ dnspython ];
+
+  optional-dependencies = {
+    aws = [ pymongo-auth-aws ];
+    encryption = [ pymongo-auth-aws ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ certifi ];
+    gssapi = [ pykerberos ];
+    ocsp = [
+      cryptography
+      pyopenssl
+      requests
+      service-identity
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [ certifi ];
+    snappy = [ python-snappy ];
+    zstd = [ zstandard ];
+  };
 
   # Tests call a running mongodb instance
   doCheck = false;
@@ -57,4 +88,4 @@ buildPythonPackage rec {
     license = lib.licenses.asl20;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13979,6 +13979,8 @@ self: super: with self; {
 
   pymongo = callPackage ../development/python-modules/pymongo { };
 
+  pymongo-auth-aws = callPackage ../development/python-modules/pymongo-auth-aws { };
+
   pymongo-inmemory = callPackage ../development/python-modules/pymongo-inmemory { };
 
   pymongo-search-utils = callPackage ../development/python-modules/pymongo-search-utils { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8378,6 +8378,8 @@ self: super: with self; {
 
   lazy-loader = callPackage ../development/python-modules/lazy-loader { };
 
+  lazy-model = callPackage ../development/python-modules/lazy-model { };
+
   lazy-object-proxy = callPackage ../development/python-modules/lazy-object-proxy { };
 
   lb-matching-tools = callPackage ../development/python-modules/lb-matching-tools { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1892,6 +1892,8 @@ self: super: with self; {
 
   beanhub-inbox = callPackage ../development/python-modules/beanhub-inbox { };
 
+  beanie = callPackage ../development/python-modules/beanie { };
+
   beanquery = callPackage ../development/python-modules/beanquery { };
 
   beanstalkc = callPackage ../development/python-modules/beanstalkc { };


### PR DESCRIPTION
Add [`beanie`](https://github.com/BeanieODM/beanie), its dependency [`lazy-model`](https://github.com/BeanieODM/lazy_model), and one of its optional dependency [`pymongo-auth-aws`](https://github.com/mongodb/pymongo-auth-aws) (propagated through `pymongo`).

Note that the `encryption` optional dependency in `pymongo` requires packaging [`libmongocrypt`](https://github.com/mongodb/libmongocrypt) which is maybe for another day.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
