### PR TITLE
spandsp,spandsp3: fix tests on musl

### DIFF
--- a/pkgs/development/libraries/spandsp/Check-for-feenableexcept-explicitly.patch
+++ b/pkgs/development/libraries/spandsp/Check-for-feenableexcept-explicitly.patch
@@ -1,0 +1,132 @@
+From c0caa79a2aa6ac5b358f30719ff80ee2c6db51f7 Mon Sep 17 00:00:00 2001
+From: Alyssa Ross <hi@alyssa.is>
+Date: Mon, 3 Nov 2025 12:06:15 +0100
+Subject: [PATCH] Check for feenableexcept() explicitly
+
+musl provides <fenv.h>, but not the non-standard feenableexcept()
+function, so using feenableexcept() whenever <fenv.h> was present
+caused build failures on musl.  Instead, explicitly check for the
+non-standard function we want to use.
+---
+ configure.ac         | 2 +-
+ tests/v17_tests.c    | 6 +++---
+ tests/v27ter_tests.c | 6 +++---
+ tests/v29_tests.c    | 6 +++---
+ 4 files changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index fa87245..a8864d8 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -186,6 +186,7 @@ AC_CHECK_FUNCS([strstr])
+ AC_CHECK_FUNCS([strtol])
+ AC_CHECK_FUNCS([gettimeofday])
+ AC_CHECK_FUNCS([drand48])
++AC_CHECK_FUNCS([feenableexcept])
+ 
+ AC_HEADER_SYS_WAIT
+ 
+@@ -209,7 +210,6 @@ AC_CHECK_HEADERS([sys/select.h])
+ AC_CHECK_HEADERS([sys/ioctl.h])
+ AC_CHECK_HEADERS([sys/fcntl.h])
+ AC_CHECK_HEADERS([sndfile.h])
+-AC_CHECK_HEADERS([fenv.h])
+ AC_CHECK_HEADERS([fftw3.h], , [AC_CHECK_HEADERS([fftw.h])])
+ AC_CHECK_HEADERS([pcap.h])
+ AC_CHECK_HEADERS([pthread.h])
+diff --git a/tests/v17_tests.c b/tests/v17_tests.c
+index 17c7fcb..411396c 100644
+--- a/tests/v17_tests.c
++++ b/tests/v17_tests.c
+@@ -59,7 +59,7 @@ display of modem status is maintained.
+ #include <string.h>
+ #include <sndfile.h>
+ #include <signal.h>
+-#if defined(HAVE_FENV_H)
++#if defined(HAVE_FEENABLEEXCEPT)
+ #define __USE_GNU
+ #include <fenv.h>
+ #endif
+@@ -263,7 +263,7 @@ static void qam_report(void *user_data, const complexf_t *constel, const complex
+ }
+ /*- End of function --------------------------------------------------------*/
+ 
+-#if defined(HAVE_FENV_H)
++#if defined(HAVE_FEENABLEEXCEPT)
+ static void sigfpe_handler(int sig_num, siginfo_t *info, void *data)
+ {
+     switch (sig_num)
+@@ -425,7 +425,7 @@ int main(int argc, char *argv[])
+     inhandle = NULL;
+     outhandle = NULL;
+ 
+-#if defined(HAVE_FENV_H)
++#if defined(HAVE_FEENABLEEXCEPT)
+     fpe_trap_setup();
+ #endif
+ 
+diff --git a/tests/v27ter_tests.c b/tests/v27ter_tests.c
+index 14b06f8..f0559a4 100644
+--- a/tests/v27ter_tests.c
++++ b/tests/v27ter_tests.c
+@@ -58,7 +58,7 @@ display of modem status is maintained.
+ #include <string.h>
+ #include <sndfile.h>
+ #include <signal.h>
+-#if defined(HAVE_FENV_H)
++#if defined(HAVE_FEENABLEEXCEPT)
+ #define __USE_GNU
+ #include <fenv.h>
+ #endif
+@@ -286,7 +286,7 @@ static void qam_report(void *user_data, const complexf_t *constel, const complex
+ }
+ /*- End of function --------------------------------------------------------*/
+ 
+-#if defined(HAVE_FENV_H)
++#if defined(HAVE_FEENABLEEXCEPT)
+ static void sigfpe_handler(int sig_num, siginfo_t *info, void *data)
+ {
+     switch (sig_num)
+@@ -440,7 +440,7 @@ int main(int argc, char *argv[])
+     inhandle = NULL;
+     outhandle = NULL;
+ 
+-#if defined(HAVE_FENV_H)
++#if defined(HAVE_FEENABLEEXCEPT)
+     fpe_trap_setup();
+ #endif
+ 
+diff --git a/tests/v29_tests.c b/tests/v29_tests.c
+index 390663f..7a43797 100644
+--- a/tests/v29_tests.c
++++ b/tests/v29_tests.c
+@@ -58,7 +58,7 @@ display of modem status is maintained.
+ #include <string.h>
+ #include <sndfile.h>
+ #include <signal.h>
+-#if defined(HAVE_FENV_H)
++#if defined(HAVE_FEENABLEEXCEPT)
+ #define __USE_GNU
+ #include <fenv.h>
+ #endif
+@@ -257,7 +257,7 @@ static void qam_report(void *user_data, const complexf_t *constel, const complex
+ }
+ /*- End of function --------------------------------------------------------*/
+ 
+-#if defined(HAVE_FENV_H)
++#if defined(HAVE_FEENABLEEXCEPT)
+ static void sigfpe_handler(int sig_num, siginfo_t *info, void *data)
+ {
+     switch (sig_num)
+@@ -410,7 +410,7 @@ int main(int argc, char *argv[])
+     inhandle = NULL;
+     outhandle = NULL;
+ 
+-#if defined(HAVE_FENV_H)
++#if defined(HAVE_FEENABLEEXCEPT)
+     fpe_trap_setup();
+ #endif
+ 
+-- 
+2.51.0
+

--- a/pkgs/development/libraries/spandsp/Fix-tests-pcap_parse-build-on-musl.patch
+++ b/pkgs/development/libraries/spandsp/Fix-tests-pcap_parse-build-on-musl.patch
@@ -1,0 +1,28 @@
+From 5007684cd46fec39d3c8f67a222f2d34d48fd4b4 Mon Sep 17 00:00:00 2001
+From: Alyssa Ross <hi@alyssa.is>
+Date: Mon, 3 Nov 2025 12:07:48 +0100
+Subject: [PATCH] Fix tests/pcap_parse build on musl
+
+musl only defines the Linux-style struct udphdr member names if
+_GNU_SOURCE is defined, so do that, like certain other tests already
+do.
+---
+ tests/pcap_parse.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/tests/pcap_parse.c b/tests/pcap_parse.c
+index 4e79743..a8a69a3 100644
+--- a/tests/pcap_parse.c
++++ b/tests/pcap_parse.c
+@@ -31,6 +31,8 @@
+ #include "config.h"
+ #endif
+ 
++#define _GNU_SOURCE
++
+ #include <inttypes.h>
+ #include <stdlib.h>
+ #include <stdio.h>
+-- 
+2.51.0
+

--- a/pkgs/development/libraries/spandsp/common.nix
+++ b/pkgs/development/libraries/spandsp/common.nix
@@ -21,6 +21,7 @@
 {
   version,
   src,
+  patches ? [ ],
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -33,7 +34,14 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/freeswitch/spandsp/commit/1f810894804d3fa61ab3fc2f3feb0599145a3436.patch";
       hash = "sha256-Cf8aaoriAvchh5cMb75yP2gsZbZaOLha/j5mq3xlkVA=";
     })
-  ];
+
+    # https://github.com/freeswitch/spandsp/pull/110
+    ./Check-for-feenableexcept-explicitly.patch
+
+    # https://github.com/freeswitch/spandsp/pull/111
+    ./Fix-tests-pcap_parse-build-on-musl.patch
+  ]
+  ++ patches;
 
   postPatch = ''
     patchShebangs autogen.sh

--- a/pkgs/development/libraries/spandsp/default.nix
+++ b/pkgs/development/libraries/spandsp/default.nix
@@ -1,5 +1,6 @@
 {
   fetchurl,
+  fetchpatch,
   callPackage,
 }:
 
@@ -9,4 +10,15 @@
     url = "https://www.soft-switch.org/downloads/spandsp/spandsp-${version}.tar.gz";
     sha256 = "0rclrkyspzk575v8fslzjpgp4y2s4x7xk3r55ycvpi4agv33l1fc";
   };
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/freeswitch/spandsp/commit/f7b96b08db148763039cf3459d0e00da9636eb92.patch";
+      includes = [ "spandsp-sim/g1050.c" ];
+      hash = "sha256-TwMhWJXQG/UaWddWgice0klp1uATyHMiE6DcsCebXYQ=";
+    })
+    (fetchpatch {
+      url = "https://github.com/freeswitch/spandsp/commit/f47bcdc301fbddad44e918939eed1b361882f740.patch";
+      hash = "sha256-O+lIC3V92GVFoiHsUQOXkoTN2hJ7v5+LQP7RrAhvwlY=";
+    })
+  ];
 }


### PR DESCRIPTION
**Should only be merged as-is if we restart the cycle (e.g. for https://github.com/NixOS/nixpkgs/pull/457547).**

Includes a couple of test portability fixes, and also, for spandsp 0.0.6, a couple of memory safety backports that fix test failures on musl.

Tested building:

- spandsp
- pkgsMusl.spandsp
- spandsp3
- pkgsMusl.spandsp3

Fixes: 8ab72653f2cb ("{spandsp,spandsp3}: Enable tests")


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
