### PR TITLE
nix-store-veritysetup-generator: 0.1.0 -> 1.0.0

### DIFF
--- a/nixos/tests/nix-store-veritysetup.nix
+++ b/nixos/tests/nix-store-veritysetup.nix
@@ -18,7 +18,7 @@
         partitions = {
           "nix-store" = {
             storePaths = [ config.system.build.toplevel ];
-            stripNixStorePrefix = true;
+            nixStorePrefix = "/";
             repartConfig = {
               Type = "linux-generic";
               Label = "nix-store";
@@ -89,7 +89,7 @@
         "-f",
         "qcow2",
         "-b",
-        "${nodes.machine.system.build.image}/${nodes.machine.image.repart.imageFile}",
+        "${nodes.machine.system.build.image}/${nodes.machine.image.fileName}",
         "-F",
         "raw",
         tmp_disk_image.name,

--- a/pkgs/by-name/ni/nix-store-veritysetup-generator/package.nix
+++ b/pkgs/by-name/ni/nix-store-veritysetup-generator/package.nix
@@ -7,13 +7,13 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "nix-store-veritysetup-generator";
-  version = "0.1.0";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "nikstur";
     repo = "nix-store-veritysetup-generator";
     rev = version;
-    hash = "sha256-kQ+mFBnvxmEH2+z1sDaehGInEsBpfZu8LMAseGjZ3/I=";
+    hash = "sha256-RTGdcLn4zuZAcC1Td4gJcywIerCYyaD0JYz8g5ybmho=";
   };
 
   sourceRoot = "${src.name}/rust";

--- a/pkgs/by-name/ni/nix-store-veritysetup-generator/package.nix
+++ b/pkgs/by-name/ni/nix-store-veritysetup-generator/package.nix
@@ -3,6 +3,7 @@
   rustPlatform,
   fetchFromGitHub,
   systemd,
+  nixosTests,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -33,6 +34,10 @@ rustPlatform.buildRustPackage rec {
   '';
 
   stripAllList = [ "bin" ];
+
+  passthru.tests = {
+    inherit (nixosTests) nix-store-veritysetup;
+  };
 
   meta = with lib; {
     description = "Systemd unit generator for a verity protected Nix Store";


### PR DESCRIPTION
See the commit messages for more details.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
