### PR TITLE
ocamlPackages.directories: 0.6 -> 0.7

### DIFF
--- a/pkgs/development/ocaml-modules/directories/default.nix
+++ b/pkgs/development/ocaml-modules/directories/default.nix
@@ -5,17 +5,17 @@
   fpath,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "directories";
-  version = "0.6";
+  version = "0.7";
 
   minimalOCamlVersion = "4.14";
 
   src = fetchFromGitHub {
     owner = "OCamlPro";
-    repo = pname;
-    tag = version;
-    hash = "sha256-c/9ChiSODD1K7YsMj65tjErAwXeWvEQ8BkAcUvsr19c=";
+    repo = "directories";
+    tag = finalAttrs.version;
+    hash = "sha256-6qPdHqkZ0xREOTFOe5sGfz2ysDX+9JZDrEmJvenBcqw=";
   };
 
   propagatedBuildInputs = [
@@ -35,8 +35,11 @@ buildDunePackage rec {
       xdg-user-dirs on Linux, Known Folders on Windows, Standard Directories on
       macOS.
     '';
-    changelog = "https://raw.githubusercontent.com/OCamlPro/directories/refs/tags/${src.tag}/CHANGES.md";
+    changelog = "https://raw.githubusercontent.com/OCamlPro/directories/${finalAttrs.version}/CHANGES.md";
     license = lib.licenses.isc;
-    maintainers = with lib.maintainers; [ bcc32 ];
+    maintainers = with lib.maintainers; [
+      bcc32
+      redianthus
+    ];
   };
-}
+})


### PR DESCRIPTION
Update the package and add myself as a maintainer (I'm the author of the package).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
