### PR TITLE
rumdl: 0.0.166 -> 0.0.169

### DIFF
--- a/pkgs/by-name/ru/rumdl/package.nix
+++ b/pkgs/by-name/ru/rumdl/package.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rumdl";
-  version = "0.0.166";
+  version = "0.0.169";
 
   src = fetchFromGitHub {
     owner = "rvben";
     repo = "rumdl";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-I63/GJa0bqJY2BHDmjcNDKSiglCygvpN4XBp/kQ6mEg=";
+    hash = "sha256-1ly0bAA8NGGqdF6U/BYGvr+aR6OU0ArbK7A0vAMdtlQ=";
   };
 
-  cargoHash = "sha256-Uh28HFWQhbJtYpKjUI0TuM0NRLpWnu+zQvt3gkGqKyU=";
+  cargoHash = "sha256-qnNm69SM3pt0LAIOvu0xhnTFft+SCD2LmY3hNoturmo=";
 
   cargoBuildFlags = [
     "--bin=rumdl"


### PR DESCRIPTION
The last nixpkgs-update [run](https://nixpkgs-update-logs.nix-community.org/rumdl/2025-11-03.log) failed due to an upstream [change](https://github.com/rvben/rumdl/commit/d04e76a199ae0b746f1ba269ce110557dfb9ee6b#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R5). Rumdl 0.0.170 requires rustc 1.91.0 or later.
Even so, the [PR](https://github.com/NixOS/nixpkgs/pull/457185) to update rustc in nixpkgs is not yet in master or staging.

I created this patch using nix-update with this command:


```bash
nix-update rumdl --version 0.0.169 --commit
```

Diff: https://github.com/rvben/rumdl/compare/v0.0.166...v0.0.169

Changelog: https://github.com/rvben/rumdl/blob/v0.0.169/CHANGELOG.md

I tested 0.0.169 locally with `rumdl check` and `rumdl fmt` on some files.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc: @Hasnep

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
