### PR TITLE
helix: build offline documentation

### DIFF
--- a/pkgs/by-name/he/helix/package.nix
+++ b/pkgs/by-name/he/helix/package.nix
@@ -2,6 +2,7 @@
   fetchzip,
   lib,
   rustPlatform,
+  mdbook,
   git,
   installShellFiles,
   versionCheckHook,
@@ -11,6 +12,10 @@
 rustPlatform.buildRustPackage (final: {
   pname = "helix";
   version = "25.07.1";
+  outputs = [
+    "out"
+    "doc"
+  ];
 
   # This release tarball includes source code for the tree-sitter grammars,
   # which is not ordinarily part of the repository.
@@ -25,20 +30,26 @@ rustPlatform.buildRustPackage (final: {
   nativeBuildInputs = [
     git
     installShellFiles
+    mdbook
   ];
 
   env.HELIX_DEFAULT_RUNTIME = "${placeholder "out"}/lib/runtime";
+
+  postBuild = ''
+    mdbook build book -d ../book-html
+  '';
 
   postInstall = ''
     # not needed at runtime
     rm -r runtime/grammars/sources
 
-    mkdir -p $out/lib
+    mkdir -p $out/lib $doc/share/doc
     cp -r runtime $out/lib
     installShellCompletion contrib/completion/hx.{bash,fish,zsh}
     mkdir -p $out/share/{applications,icons/hicolor/256x256/apps}
     cp contrib/Helix.desktop $out/share/applications
     cp contrib/helix.png $out/share/icons/hicolor/256x256/apps
+    cp -r book-html $doc/share/doc/$name
   '';
 
   nativeInstallCheckInputs = [


### PR DESCRIPTION
# helix: build offline documentation

```
helix: build offline documentation
```

## Build info of packages affected directly
### helix

<details><summary>content of helix.doc</summary>

```
/nix/store/4y3y0mvbs6s3yas1bqi6g6vkagd8b3w8-helix-25.07.1-doc
└── share
    └── doc
        └── helix-25.07.1
            ├── 404.html
            ├── CNAME
            ├── FontAwesome
            │   ├── css
            │   │   └── font-awesome.css
            │   └── fonts
            │       ├── FontAwesome.ttf
            │       ├── fontawesome-webfont.eot
            │       ├── fontawesome-webfont.svg
            │       ├── fontawesome-webfont.ttf
            │       ├── fontawesome-webfont.woff
            │       └── fontawesome-webfont.woff2
            ├── ayu-highlight.css
            ├── book.js
            ├── building-from-source.html
            ├── clipboard.min.js
            ├── command-line.html
            ├── commands.html
            ├── configuration.html
            ├── css
            │   ├── chrome.css
            │   ├── general.css
            │   ├── print.css
            │   └── variables.css
            ├── custom.css
            ├── ecosystem.html
            ├── editor.html
            ├── elasticlunr.min.js
            ├── favicon.png
            ├── favicon.svg
            ├── fonts
            │   ├── OPEN-SANS-LICENSE.txt
            │   ├── SOURCE-CODE-PRO-LICENSE.txt
            │   ├── fonts.css
            │   ├── open-sans-v17-all-charsets-300.woff2
            │   ├── open-sans-v17-all-charsets-300italic.woff2
            │   ├── open-sans-v17-all-charsets-600.woff2
            │   ├── open-sans-v17-all-charsets-600italic.woff2
            │   ├── open-sans-v17-all-charsets-700.woff2
            │   ├── open-sans-v17-all-charsets-700italic.woff2
            │   ├── open-sans-v17-all-charsets-800.woff2
            │   ├── open-sans-v17-all-charsets-800italic.woff2
            │   ├── open-sans-v17-all-charsets-italic.woff2
            │   ├── open-sans-v17-all-charsets-regular.woff2
            │   └── source-code-pro-v11-all-charsets-500.woff2
            ├── from-vim.html
            ├── generated
            ├── guides
            │   ├── adding_languages.html
            │   ├── indent.html
            │   ├── index.html
            │   ├── injection.html
            │   └── textobject.html
            ├── highlight.css
            ├── highlight.js
            ├── index.html
            ├── install.html
            ├── keymap.html
            ├── lang-support.html
            ├── languages.html
            ├── mark.min.js
            ├── other-software.html
            ├── package-managers.html
            ├── pickers.html
            ├── print.html
            ├── registers.html
            ├── remapping.html
            ├── searcher.js
            ├── searchindex.js
            ├── surround.html
            ├── syntax-aware-motions.html
            ├── textobjects.html
            ├── themes.html
            ├── title-page.html
            ├── toc.html
            ├── toc.js
            ├── tomorrow-night.css
            └── usage.html

11 directories, 71 files
```
</details>

<details><summary>content of helix.out</summary>

```
/nix/store/ghhifp75hl647znl4f18p2jhimcn83p5-helix-25.07.1
├── bin
│   └── hx
├── lib
│   └── runtime
│       ├── grammars
│       │   ├── ada.so
│       │   ├── adl.so
│       │   ├── agda.so
│       │   ├── alloy.so
│       │   ├── amber.so
│       │   ├── astro.so
│       │   ├── awk.so
│       │   ├── bash.so
│       │   ├── bass.so
│       │   ├── beancount.so
│       │   ├── bibtex.so
│       │   ├── bicep.so
│       │   ├── bitbake.so
│       │   ├── blade.so
│       │   ├── blueprint.so
│       │   ├── c-sharp.so
│       │   ├── c.so
│       │   ├── caddyfile.so
│       │   ├── cairo.so
│       │   ├── capnp.so
│       │   ├── cel.so
│       │   ├── circom.so
│       │   ├── clarity.so
│       │   ├── clojure.so
│       │   ├── cmake.so
│       │   ├── comment.so
│       │   ├── cpon.so
│       │   ├── cpp.so
│       │   ├── crystal.so
│       │   ├── css.so
│       │   ├── csv.so
│       │   ├── cue.so
│       │   ├── cylc.so
│       │   ├── d.so
│       │   ├── dart.so
│       │   ├── dbml.so
│       │   ├── debian.so
│       │   ├── devicetree.so
│       │   ├── dhall.so
│       │   ├── diff.so
│       │   ├── djot.so
│       │   ├── dockerfile.so
│       │   ├── dot.so
│       │   ├── dtd.so
│       │   ├── dunstrc.so
│       │   ├── earthfile.so
│       │   ├── edoc.so
│       │   ├── eex.so
│       │   ├── elisp.so
│       │   ├── elixir.so
│       │   ├── elm.so
│       │   ├── elvish.so
│       │   ├── embedded-template.so
│       │   ├── erlang.so
│       │   ├── esdl.so
│       │   ├── fennel.so
│       │   ├── fga.so
│       │   ├── fidl.so
│       │   ├── fish.so
│       │   ├── forth.so
│       │   ├── fortran.so
│       │   ├── fsharp.so
│       │   ├── gas.so
│       │   ├── gdscript.so
│       │   ├── gherkin.so
│       │   ├── ghostty.so
│       │   ├── git-config.so
│       │   ├── git-rebase.so
│       │   ├── gitattributes.so
│       │   ├── gitcommit.so
│       │   ├── gitignore.so
│       │   ├── gleam.so
│       │   ├── glimmer.so
│       │   ├── glsl.so
│       │   ├── gn.so
│       │   ├── go.so
│       │   ├── godot-resource.so
│       │   ├── gomod.so
│       │   ├── gotmpl.so
│       │   ├── gowork.so
│       │   ├── gpr.so
│       │   ├── graphql.so
│       │   ├── gren.so
│       │   ├── groovy.so
│       │   ├── hare.so
│       │   ├── haskell-persistent.so
│       │   ├── haskell.so
│       │   ├── hcl.so
│       │   ├── heex.so
│       │   ├── hocon.so
│       │   ├── hoon.so
│       │   ├── hosts.so
│       │   ├── html.so
│       │   ├── htmldjango.so
│       │   ├── hurl.so
│       │   ├── hyprlang.so
│       │   ├── iex.so
│       │   ├── ini.so
│       │   ├── ink.so
│       │   ├── inko.so
│       │   ├── janet-simple.so
│       │   ├── java.so
│       │   ├── javascript.so
│       │   ├── jinja2.so
│       │   ├── jjdescription.so
│       │   ├── jq.so
│       │   ├── jsdoc.so
│       │   ├── json.so
│       │   ├── json5.so
│       │   ├── jsonnet.so
│       │   ├── julia.so
│       │   ├── just.so
│       │   ├── kdl.so
│       │   ├── koka.so
│       │   ├── kotlin.so
│       │   ├── koto.so
│       │   ├── latex.so
│       │   ├── ld.so
│       │   ├── ldif.so
│       │   ├── lean.so
│       │   ├── ledger.so
│       │   ├── llvm-mir.so
│       │   ├── llvm.so
│       │   ├── log.so
│       │   ├── lpf.so
│       │   ├── lua.so
│       │   ├── luau.so
│       │   ├── mail.so
│       │   ├── make.so
│       │   ├── markdoc.so
│       │   ├── markdown.so
│       │   ├── markdown_inline.so
│       │   ├── matlab.so
│       │   ├── mermaid.so
│       │   ├── meson.so
│       │   ├── mojo.so
│       │   ├── move.so
│       │   ├── nasm.so
│       │   ├── nginx.so
│       │   ├── nickel.so
│       │   ├── nim.so
│       │   ├── nix.so
│       │   ├── nu.so
│       │   ├── ocaml-interface.so
│       │   ├── ocaml.so
│       │   ├── odin.so
│       │   ├── ohm.so
│       │   ├── opencl.so
│       │   ├── openscad.so
│       │   ├── org.so
│       │   ├── pascal.so
│       │   ├── passwd.so
│       │   ├── pem.so
│       │   ├── perl.so
│       │   ├── pest.so
│       │   ├── php-only.so
│       │   ├── php.so
│       │   ├── pkl.so
│       │   ├── po.so
│       │   ├── pod.so
│       │   ├── ponylang.so
│       │   ├── powershell.so
│       │   ├── prisma.so
│       │   ├── prolog.so
│       │   ├── properties.so
│       │   ├── proto.so
│       │   ├── prql.so
│       │   ├── pug.so
│       │   ├── purescript.so
│       │   ├── python.so
│       │   ├── ql.so
│       │   ├── qmljs.so
│       │   ├── query.so
│       │   ├── quint.so
│       │   ├── r.so
│       │   ├── regex.so
│       │   ├── rego.so
│       │   ├── rescript.so
│       │   ├── robot.so
│       │   ├── ron.so
│       │   ├── rst.so
│       │   ├── ruby.so
│       │   ├── rust-format-args.so
│       │   ├── rust.so
│       │   ├── scala.so
│       │   ├── scheme.so
│       │   ├── scss.so
│       │   ├── slang.so
│       │   ├── slint.so
│       │   ├── smali.so
│       │   ├── smithy.so
│       │   ├── sml.so
│       │   ├── snakemake.so
│       │   ├── solidity.so
│       │   ├── sourcepawn.so
│       │   ├── spade.so
│       │   ├── spicedb.so
│       │   ├── sql.so
│       │   ├── sshclientconfig.so
│       │   ├── strace.so
│       │   ├── supercollider.so
│       │   ├── svelte.so
│       │   ├── sway.so
│       │   ├── swift.so
│       │   ├── t32.so
│       │   ├── tablegen.so
│       │   ├── tact.so
│       │   ├── task.so
│       │   ├── tcl.so
│       │   ├── teal.so
│       │   ├── templ.so
│       │   ├── tera.so
│       │   ├── textproto.so
│       │   ├── thrift.so
│       │   ├── tlaplus.so
│       │   ├── todotxt.so
│       │   ├── toml.so
│       │   ├── tsx.so
│       │   ├── twig.so
│       │   ├── typescript.so
│       │   ├── typespec.so
│       │   ├── typst.so
│       │   ├── ungrammar.so
│       │   ├── unison.so
│       │   ├── uxntal.so
│       │   ├── v.so
│       │   ├── vala.so
│       │   ├── vento.so
│       │   ├── verilog.so
│       │   ├── vhdl.so
│       │   ├── vhs.so
│       │   ├── vue.so
│       │   ├── wast.so
│       │   ├── wat.so
│       │   ├── werk.so
│       │   ├── wesl.so
│       │   ├── wgsl.so
│       │   ├── wit.so
│       │   ├── xit.so
│       │   ├── xml.so
│       │   ├── xtc.so
│       │   ├── yaml.so
│       │   ├── yara.so
│       │   ├── yuck.so
│       │   └── zig.so
│       ├── queries
│       │   ├── _gjs
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── _javascript
│       │   │   ├── highlights.scm
│       │   │   ├── locals.scm
│       │   │   └── tags.scm
│       │   ├── _jsx
│       │   │   ├── highlights.scm
│       │   │   └── indents.scm
│       │   ├── _typescript
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── locals.scm
│       │   │   ├── tags.scm
│       │   │   └── textobjects.scm
│       │   ├── ada
│       │   │   ├── folds.scm
│       │   │   ├── highlights.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── adl
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   └── textobjects.scm
│       │   ├── agda
│       │   │   └── highlights.scm
│       │   ├── alloy
│       │   │   └── highlights.scm
│       │   ├── amber
│       │   │   └── highlights.scm
│       │   ├── astro
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── awk
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── bash
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── bass
│       │   │   └── highlights.scm
│       │   ├── beancount
│       │   │   ├── folds.scm
│       │   │   └── highlights.scm
│       │   ├── bibtex
│       │   │   ├── highlights.scm
│       │   │   └── tags.scm
│       │   ├── bicep
│       │   │   └── highlights.scm
│       │   ├── bitbake
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── blade
│       │   │   ├── folds.scm
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── blueprint
│       │   │   └── highlights.scm
│       │   ├── c
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── c-sharp
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   ├── tags.scm
│       │   │   └── textobjects.scm
│       │   ├── caddyfile
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── cairo
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── capnp
│       │   │   ├── folds.scm
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── locals.scm
│       │   ├── cel
│       │   │   └── highlights.scm
│       │   ├── circom
│       │   │   ├── highlights.scm
│       │   │   └── locals.scm
│       │   ├── clarity
│       │   │   └── highlights.scm
│       │   ├── clojure
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── cmake
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── codeql
│       │   │   ├── highlights.scm
│       │   │   └── textobjects.scm
│       │   ├── comment
│       │   │   └── highlights.scm
│       │   ├── common-lisp
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   └── injections.scm
│       │   ├── cpon
│       │   │   ├── highlights.scm
│       │   │   └── indents.scm
│       │   ├── cpp
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── crystal
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   ├── tags.scm
│       │   │   └── textobjects.scm
│       │   ├── css
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   └── injections.scm
│       │   ├── csv
│       │   │   └── highlights.scm
│       │   ├── cue
│       │   │   └── highlights.scm
│       │   ├── cylc
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── d
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── dart
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── dbml
│       │   │   └── highlights.scm
│       │   ├── debian
│       │   │   └── highlights.scm
│       │   ├── devicetree
│       │   │   └── highlights.scm
│       │   ├── dhall
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── diff
│       │   │   └── highlights.scm
│       │   ├── djot
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── docker-compose
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── dockerfile
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── dot
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── dtd
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── dune
│       │   │   └── highlights.scm
│       │   ├── dunstrc
│       │   │   └── highlights.scm
│       │   ├── earthfile
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── ecma
│       │   │   ├── README.md
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── edoc
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── eex
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── ejs
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── elisp
│       │   │   ├── highlights.scm
│       │   │   └── tags.scm
│       │   ├── elixir
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── elm
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   ├── tags.scm
│       │   │   └── textobjects.scm
│       │   ├── elvish
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── env
│       │   │   ├── highlights.scm
│       │   │   └── textobjects.scm
│       │   ├── erb
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── erlang
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── esdl
│       │   │   └── highlights.scm
│       │   ├── fennel
│       │   │   └── highlights.scm
│       │   ├── fga
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   └── textobjects.scm
│       │   ├── fidl
│       │   │   ├── folds.scm
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── fish
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── forth
│       │   │   └── highlights.scm
│       │   ├── fortran
│       │   │   ├── folds.scm
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   └── injections.scm
│       │   ├── fsharp
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   └── locals.scm
│       │   ├── gas
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── gdscript
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── tags.scm
│       │   │   └── textobjects.scm
│       │   ├── gemini
│       │   │   └── highlights.scm
│       │   ├── gherkin
│       │   │   └── highlights.scm
│       │   ├── ghostty
│       │   │   └── highlights.scm
│       │   ├── git-attributes
│       │   │   └── highlights.scm
│       │   ├── git-commit
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── git-config
│       │   │   ├── highlights.scm
│       │   │   └── textobjects.scm
│       │   ├── git-ignore
│       │   │   └── highlights.scm
│       │   ├── git-notes
│       │   │   └── highlights.scm
│       │   ├── git-rebase
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── gjs
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   ├── tags.scm
│       │   │   └── textobjects.scm
│       │   ├── gleam
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── glimmer
│       │   │   └── highlights.scm
│       │   ├── glsl
│       │   │   ├── folds.scm
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── gn
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── go
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   ├── tags.scm
│       │   │   └── textobjects.scm
│       │   ├── godot-resource
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── gomod
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── gotmpl
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── gowork
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── gpr
│       │   │   └── highlights.scm
│       │   ├── graphql
│       │   │   ├── highlights.scm
│       │   │   └── textobjects.scm
│       │   ├── gren
│       │   │   ├── highlights.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── groovy
│       │   │   ├── folds.scm
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   └── locals.scm
│       │   ├── gts
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   ├── tags.scm
│       │   │   └── textobjects.scm
│       │   ├── hare
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   └── locals.scm
│       │   ├── haskell
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── haskell-persistent
│       │   │   ├── folds.scm
│       │   │   └── highlights.scm
│       │   ├── hcl
│       │   │   ├── folds.scm
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── heex
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── helm
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── hocon
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   └── textobjects.scm
│       │   ├── hoon
│       │   │   └── highlights.scm
│       │   ├── hosts
│       │   │   └── highlights.scm
│       │   ├── html
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── htmldjango
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── hurl
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── hyprlang
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   └── injections.scm
│       │   ├── iex
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── ini
│       │   │   └── highlights.scm
│       │   ├── ink
│       │   │   └── highlights.scm
│       │   ├── inko
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── janet
│       │   │   └── highlights.scm
│       │   ├── java
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── javascript
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   ├── tags.scm
│       │   │   └── textobjects.scm
│       │   ├── jinja
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── jjdescription
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── jq
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── jsdoc
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── json
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   └── textobjects.scm
│       │   ├── json-ld
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   └── textobjects.scm
│       │   ├── json5
│       │   │   └── highlights.scm
│       │   ├── jsonc
│       │   │   ├── highlights.scm
│       │   │   └── indents.scm
│       │   ├── jsonnet
│       │   │   └── highlights.scm
│       │   ├── jsx
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   ├── tags.scm
│       │   │   └── textobjects.scm
│       │   ├── julia
│       │   │   ├── folds.scm
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── just
│       │   │   ├── folds.scm
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── kdl
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   └── textobjects.scm
│       │   ├── koka
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── locals.scm
│       │   ├── kotlin
│       │   │   ├── folds.scm
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── koto
│       │   │   ├── folds.scm
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── latex
│       │   │   ├── folds.scm
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── ld
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   └── injections.scm
│       │   ├── ldif
│       │   │   └── highlights.scm
│       │   ├── lean
│       │   │   ├── folds.scm
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   └── locals.scm
│       │   ├── ledger
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── llvm
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── llvm-mir
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── llvm-mir-yaml
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   └── injections.scm
│       │   ├── log
│       │   │   └── highlights.scm
│       │   ├── lpf
│       │   │   └── highlights.scm
│       │   ├── lua
│       │   │   ├── folds.scm
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── luau
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── mail
│       │   │   ├── highlights.scm
│       │   │   └── textobjects.scm
│       │   ├── make
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   └── injections.scm
│       │   ├── markdoc
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── markdown
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── markdown-rustdoc
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── markdown.inline
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── matlab
│       │   │   ├── context.scm
│       │   │   ├── folds.scm
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── mermaid
│       │   │   └── highlights.scm
│       │   ├── meson
│       │   │   ├── highlights.scm
│       │   │   └── indents.scm
│       │   ├── mojo
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── move
│       │   │   └── highlights.scm
│       │   ├── msbuild
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   └── injections.scm
│       │   ├── nasm
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── nestedtext
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── nginx
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── nickel
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   └── injections.scm
│       │   ├── nim
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   └── textobjects.scm
│       │   ├── nix
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── nu
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── nunjucks
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── ocaml
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── locals.scm
│       │   ├── ocaml-interface
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── odin
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── ohm
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── opencl
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── openscad
│       │   │   └── highlights.scm
│       │   ├── org
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── pascal
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── passwd
│       │   │   └── highlights.scm
│       │   ├── pem
│       │   │   └── highlights.scm
│       │   ├── perl
│       │   │   ├── fold.scm
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── pest
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── php
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── tags.scm
│       │   │   └── textobjects.scm
│       │   ├── php-only
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   └── tags.scm
│       │   ├── pkgbuild
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── pkl
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   └── injections.scm
│       │   ├── po
│       │   │   ├── highlights.scm
│       │   │   └── textobjects.scm
│       │   ├── pod
│       │   │   └── highlights.scm
│       │   ├── ponylang
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── powershell
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── prisma
│       │   │   ├── highlights.scm
│       │   │   └── textobjects.scm
│       │   ├── prolog
│       │   │   ├── folds.scm
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   └── injections.scm
│       │   ├── properties
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── protobuf
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── prql
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── pug
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── purescript
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── python
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   ├── tags.scm
│       │   │   └── textobjects.scm
│       │   ├── qml
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── quarto
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   └── injections.scm
│       │   ├── quint
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── r
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   └── locals.scm
│       │   ├── racket
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   └── injections.scm
│       │   ├── regex
│       │   │   └── highlights.scm
│       │   ├── rego
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── rescript
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── rmarkdown
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   └── injections.scm
│       │   ├── robot
│       │   │   └── highlights.scm
│       │   ├── ron
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   └── injections.scm
│       │   ├── rst
│       │   │   └── highlights.scm
│       │   ├── ruby
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   ├── tags.scm
│       │   │   └── textobjects.scm
│       │   ├── rust
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── rust-format-args
│       │   │   └── highlights.scm
│       │   ├── rust-format-args-macro
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── sage
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── scala
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── scheme
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   └── injections.scm
│       │   ├── scss
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── slang
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── slint
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── smali
│       │   │   ├── folds.scm
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── locals.scm
│       │   ├── smithy
│       │   │   └── highlights.scm
│       │   ├── sml
│       │   │   └── highlights.scm
│       │   ├── snakemake
│       │   │   ├── LICENSE
│       │   │   ├── folds.scm
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── locals.scm
│       │   ├── solidity
│       │   │   ├── highlights.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── sourcepawn
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── spade
│       │   │   ├── highlights.scm
│       │   │   └── indents.scm
│       │   ├── spicedb
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   └── tags.scm
│       │   ├── sql
│       │   │   ├── highlights.scm
│       │   │   └── textobjects.scm
│       │   ├── sshclientconfig
│       │   │   └── highlights.scm
│       │   ├── starlark
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── strace
│       │   │   └── highlights.scm
│       │   ├── supercollider
│       │   │   ├── folds.scm
│       │   │   └── highlights.scm
│       │   ├── svelte
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   └── injections.scm
│       │   ├── sway
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── swift
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── systemd
│       │   │   └── highlights.scm
│       │   ├── t32
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── tablegen
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── tact
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── task
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── tcl
│       │   │   ├── folds.scm
│       │   │   ├── highlights.scm
│       │   │   └── indents.scm
│       │   ├── teal
│       │   │   ├── folds.scm
│       │   │   ├── highlights.scm
│       │   │   └── locals.scm
│       │   ├── templ
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── tera
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   └── locals.scm
│       │   ├── textproto
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   └── textobjects.scm
│       │   ├── tfvars
│       │   │   ├── folds.scm
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   └── injections.scm
│       │   ├── thrift
│       │   │   ├── folds.scm
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   └── locals.scm
│       │   ├── tlaplus
│       │   │   ├── highlights.scm
│       │   │   └── locals.scm
│       │   ├── todotxt
│       │   │   └── highlights.scm
│       │   ├── toml
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── tsq
│       │   │   ├── folds.scm
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── tsx
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   ├── tags.scm
│       │   │   └── textobjects.scm
│       │   ├── twig
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── typescript
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   ├── tags.scm
│       │   │   └── textobjects.scm
│       │   ├── typespec
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── typst
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── ungrammar
│       │   │   └── highlights.scm
│       │   ├── unison
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── uxntal
│       │   │   └── highlights.scm
│       │   ├── v
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── vala
│       │   │   ├── highlights.scm
│       │   │   └── textobjects.scm
│       │   ├── vento
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── verilog
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── vhdl
│       │   │   └── highlights.scm
│       │   ├── vhs
│       │   │   └── highlights.scm
│       │   ├── vue
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── wast
│       │   │   └── highlights.scm
│       │   ├── wat
│       │   │   └── highlights.scm
│       │   ├── webc
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── werk
│       │   │   └── highlights.scm
│       │   ├── wesl
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── wgsl
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   ├── wit
│       │   │   ├── highlights.scm
│       │   │   └── indents.scm
│       │   ├── wren
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   ├── locals.scm
│       │   │   └── textobjects.scm
│       │   ├── xit
│       │   │   └── highlights.scm
│       │   ├── xml
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   └── injections.scm
│       │   ├── xtc
│       │   │   └── highlights.scm
│       │   ├── yaml
│       │   │   ├── highlights.scm
│       │   │   ├── indents.scm
│       │   │   ├── injections.scm
│       │   │   └── textobjects.scm
│       │   ├── yara
│       │   │   ├── highlights.scm
│       │   │   ├── injections.scm
│       │   │   └── locals.scm
│       │   ├── yuck
│       │   │   ├── highlights.scm
│       │   │   └── injections.scm
│       │   └── zig
│       │       ├── highlights.scm
│       │       ├── indents.scm
│       │       ├── injections.scm
│       │       └── textobjects.scm
│       ├── themes
│       │   ├── README.md
│       │   ├── acme.toml
│       │   ├── adwaita-dark.toml
│       │   ├── adwaita-light.toml
│       │   ├── amberwood.toml
│       │   ├── ao.toml
│       │   ├── ashen.toml
│       │   ├── ataraxia.toml
│       │   ├── autumn.toml
│       │   ├── autumn_night.toml
│       │   ├── ayu_dark.toml
│       │   ├── ayu_evolve.toml
│       │   ├── ayu_light.toml
│       │   ├── ayu_mirage.toml
│       │   ├── base16_default_dark.toml
│       │   ├── base16_default_light.toml
│       │   ├── base16_terminal.toml
│       │   ├── base16_transparent.toml
│       │   ├── beans.toml
│       │   ├── bogster.toml
│       │   ├── bogster_light.toml
│       │   ├── boo_berry.toml
│       │   ├── carbon.toml
│       │   ├── carbonfox.toml
│       │   ├── catppuccin_frappe.toml
│       │   ├── catppuccin_latte.toml
│       │   ├── catppuccin_macchiato.toml
│       │   ├── catppuccin_mocha.toml
│       │   ├── curzon.toml
│       │   ├── cyan_light.toml
│       │   ├── darcula-solid.toml
│       │   ├── darcula.toml
│       │   ├── dark-synthwave.toml
│       │   ├── dark_high_contrast.toml
│       │   ├── dark_plus.toml
│       │   ├── doom-one.toml
│       │   ├── doom_acario_dark.toml
│       │   ├── dracula.toml
│       │   ├── dracula_at_night.toml
│       │   ├── earl_grey.toml
│       │   ├── eiffel.toml
│       │   ├── emacs.toml
│       │   ├── everblush.toml
│       │   ├── everforest_dark.toml
│       │   ├── everforest_light.toml
│       │   ├── ferra.toml
│       │   ├── flatwhite.toml
│       │   ├── fleet_dark.toml
│       │   ├── flexoki_dark.toml
│       │   ├── flexoki_light.toml
│       │   ├── focus_nova.toml
│       │   ├── github_dark.toml
│       │   ├── github_dark_colorblind.toml
│       │   ├── github_dark_dimmed.toml
│       │   ├── github_dark_high_contrast.toml
│       │   ├── github_dark_tritanopia.toml
│       │   ├── github_light.toml
│       │   ├── github_light_colorblind.toml
│       │   ├── github_light_high_contrast.toml
│       │   ├── github_light_tritanopia.toml
│       │   ├── gruber-darker.toml
│       │   ├── gruvbox-material.toml
│       │   ├── gruvbox.toml
│       │   ├── gruvbox_dark_hard.toml
│       │   ├── gruvbox_dark_soft.toml
│       │   ├── gruvbox_light.toml
│       │   ├── gruvbox_light_hard.toml
│       │   ├── gruvbox_light_soft.toml
│       │   ├── heisenberg.toml
│       │   ├── hex_lavender.toml
│       │   ├── hex_poison.toml
│       │   ├── hex_steel.toml
│       │   ├── hex_toxic.toml
│       │   ├── horizon-dark.toml
│       │   ├── iceberg-dark.toml
│       │   ├── iceberg-light.toml
│       │   ├── ingrid.toml
│       │   ├── iroaseta.toml
│       │   ├── jellybeans.toml
│       │   ├── jetbrains_dark.toml
│       │   ├── kanagawa-dragon.toml
│       │   ├── kanagawa.toml
│       │   ├── kaolin-dark.toml
│       │   ├── kaolin-light.toml
│       │   ├── kaolin-valley-dark.toml
│       │   ├── kinda_nvim.toml
│       │   ├── kinda_nvim_light.toml
│       │   ├── lapis_aquamarine.toml
│       │   ├── licenses
│       │   │   ├── ashen.license
│       │   │   ├── carbonfox.license
│       │   │   ├── cyan_light.LICENSE
│       │   │   ├── dark-synthwave.license
│       │   │   ├── doom-one.LICENSE
│       │   │   ├── everforest.LICENSE
│       │   │   ├── kinda_nvim.LICENSE
│       │   │   ├── lapis_aquamarine.LICENSE
│       │   │   ├── modus_vivendi.LICENSE
│       │   │   ├── modus_vivendi_deuteranopia.LICENSE
│       │   │   ├── modus_vivendi_tinted.LICENSE
│       │   │   ├── modus_vivendi_tritanopia.LICENSE
│       │   │   ├── poimandres.LICENSE
│       │   │   ├── serika-syntax.LICENSE
│       │   │   ├── sonokai.LICENSE
│       │   │   ├── starlight.LICENSE
│       │   │   └── vesper.LICENSE
│       │   ├── material_darker.toml
│       │   ├── material_deep_ocean.toml
│       │   ├── material_oceanic.toml
│       │   ├── material_palenight.toml
│       │   ├── meliora.toml
│       │   ├── mellow.toml
│       │   ├── merionette.toml
│       │   ├── modus_operandi.toml
│       │   ├── modus_operandi_deuteranopia.toml
│       │   ├── modus_operandi_tinted.toml
│       │   ├── modus_operandi_tritanopia.toml
│       │   ├── modus_vivendi.toml
│       │   ├── modus_vivendi_deuteranopia.toml
│       │   ├── modus_vivendi_tinted.toml
│       │   ├── modus_vivendi_tritanopia.toml
│       │   ├── molokai.toml
│       │   ├── monokai.toml
│       │   ├── monokai_aqua.toml
│       │   ├── monokai_pro.toml
│       │   ├── monokai_pro_machine.toml
│       │   ├── monokai_pro_octagon.toml
│       │   ├── monokai_pro_ristretto.toml
│       │   ├── monokai_pro_spectrum.toml
│       │   ├── monokai_soda.toml
│       │   ├── naysayer.toml
│       │   ├── new_moon.toml
│       │   ├── night_owl.toml
│       │   ├── nightfox.toml
│       │   ├── noctis.toml
│       │   ├── noctis_bordo.toml
│       │   ├── nord-night.toml
│       │   ├── nord.toml
│       │   ├── nord_light.toml
│       │   ├── nyxvamp-obsidian.toml
│       │   ├── nyxvamp-radiance.toml
│       │   ├── nyxvamp-veil.toml
│       │   ├── onedark.toml
│       │   ├── onedarker.toml
│       │   ├── onelight.toml
│       │   ├── papercolor-dark.toml
│       │   ├── papercolor-light.toml
│       │   ├── peachpuff.toml
│       │   ├── penumbra+.toml
│       │   ├── poimandres.toml
│       │   ├── poimandres_storm.toml
│       │   ├── pop-dark.toml
│       │   ├── rasmus.toml
│       │   ├── rose_pine.toml
│       │   ├── rose_pine_dawn.toml
│       │   ├── rose_pine_moon.toml
│       │   ├── seoul256-dark-hard.toml
│       │   ├── seoul256-dark-soft.toml
│       │   ├── seoul256-dark.toml
│       │   ├── seoul256-light-hard.toml
│       │   ├── seoul256-light-soft.toml
│       │   ├── seoul256-light.toml
│       │   ├── serika-dark.toml
│       │   ├── serika-light.toml
│       │   ├── sidra.toml
│       │   ├── snazzy.toml
│       │   ├── solarized_dark.toml
│       │   ├── solarized_light.toml
│       │   ├── sonokai.toml
│       │   ├── spacebones_light.toml
│       │   ├── starlight.toml
│       │   ├── sunset.toml
│       │   ├── term16_dark.toml
│       │   ├── term16_light.toml
│       │   ├── tokyonight.toml
│       │   ├── tokyonight_day.toml
│       │   ├── tokyonight_moon.toml
│       │   ├── tokyonight_storm.toml
│       │   ├── ttox.toml
│       │   ├── varua.toml
│       │   ├── vesper.toml
│       │   ├── vim_dark_high_contrast.toml
│       │   ├── vintage.toml
│       │   ├── voxed.toml
│       │   ├── yellowed.toml
│       │   ├── yo.toml
│       │   ├── yo_berry.toml
│       │   ├── yo_light.toml
│       │   ├── zed_onedark.toml
│       │   ├── zed_onelight.toml
│       │   └── zenburn.toml
│       └── tutor
└── share
    ├── applications
    │   └── Helix.desktop
    ├── bash-completion
    │   └── completions
    │       └── hx.bash
    ├── fish
    │   └── vendor_completions.d
    │       └── hx.fish
    ├── icons
    │   └── hicolor
    │       └── 256x256
    │           └── apps
    │               └── helix.png
    └── zsh
        └── site-functions
            └── _hx

299 directories, 1234 files
```
</details>
