### PR TITLE
{,python3Packages.}click-man: init at 0.5.2

### DIFF
--- a/pkgs/by-name/cl/click-man/package.nix
+++ b/pkgs/by-name/cl/click-man/package.nix
@@ -1,0 +1,1 @@
+{ python3Packages }: with python3Packages; toPythonApplication click-man

--- a/pkgs/development/python-modules/click-man/default.nix
+++ b/pkgs/development/python-modules/click-man/default.nix
@@ -1,0 +1,62 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  pyprojectVersionPatchHook,
+
+  # build system
+  setuptools,
+
+  # dependencies
+  click,
+
+  # test dependencies
+  pytestCheckHook,
+  versionCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "click-man";
+  version = "0.5.2";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "click-contrib";
+    repo = "click-man";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-y5rWm5+C27P79E2NxaUaMTG96b1gJIor0k+3iTf0AT8=";
+  };
+
+  nativeBuildInputs = [ pyprojectVersionPatchHook ];
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    click
+  ];
+
+  pythonImportsCheck = [
+    "click_man"
+    "click_man.core"
+    "click_man.man"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    versionCheckHook
+  ];
+
+  meta = {
+    changelog = "https://github.com/click-contrib/click-man/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    description = "Automate generation of man pages for python click applications";
+    homepage = "https://github.com/click-contrib/click-man";
+    license = lib.licenses.mit;
+    mainProgram = "click-man";
+    maintainers = with lib.maintainers; [
+      de11n
+      despsyched
+    ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3192,6 +3192,8 @@ self: super: with self; {
 
   click-log = callPackage ../development/python-modules/click-log { };
 
+  click-man = callPackage ../development/python-modules/click-man { };
+
   click-odoo = callPackage ../development/python-modules/click-odoo { };
 
   click-odoo-contrib = callPackage ../development/python-modules/click-odoo-contrib { };


### PR DESCRIPTION
[`click-man`](https://github.com/click-contrib/click-man) allows for automatic generation of man pages for Python CLIs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
