### PR TITLE
uwsgi, nixos/librespeed: Replace lib.elem with lib.any for predicate matching

### DIFF
--- a/nixos/modules/services/web-apps/librespeed.nix
+++ b/nixos/modules/services/web-apps/librespeed.nix
@@ -338,10 +338,10 @@ in
                 proxy_buffering off;
                 proxy_request_buffering off;
               ''
-              + lib.optionalString (lib.elem "brotli" config.services.nginx.additionalModules) ''
+              + lib.optionalString (lib.any (m: m.name == "brotli") config.services.nginx.additionalModules) ''
                 brotli off;
               ''
-              + lib.optionalString (lib.elem "zstd" config.services.nginx.additionalModules) ''
+              + lib.optionalString (lib.any (m: m.name == "zstd") config.services.nginx.additionalModules) ''
                 zstd off;
               '';
             };

--- a/pkgs/by-name/uw/uwsgi/package.nix
+++ b/pkgs/by-name/uw/uwsgi/package.nix
@@ -145,7 +145,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # this is a hack to make the php plugin link with session.so (which on nixos is a separate package)
   # the hack works in coordination with ./additional-php-ldflags.patch
-  UWSGICONFIG_PHP_LDFLAGS = lib.optionalString (lib.elem "php" needed) (
+  UWSGICONFIG_PHP_LDFLAGS = lib.optionalString (lib.any (x: x.name == "php") needed) (
     lib.concatStringsSep "," [
       "-Wl"
       "-rpath=${php-embed.extensions.session}/lib/php/extensions/"
@@ -176,7 +176,7 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  postFixup = lib.optionalString (lib.elem "php" needed) ''
+  postFixup = lib.optionalString (lib.any (x: x.name == "php") needed) ''
     wrapProgram $out/bin/uwsgi --set PHP_INI_SCAN_DIR ${php-embed}/lib
   '';
 


### PR DESCRIPTION
`lib.elem` can only be used for searching for an exact element in a list. In these two cases, we're matching on the `name` property however, so we have to use `lib.any` instead. See https://github.com/NixOS/nixpkgs/commit/4160763d74f6ec3618dccd101ea299161290650d.

Fixes https://hydra.nixos.org/build/311475077
#457852

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. - `nixosTests.uwsgi`
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
