### PR TITLE
nixos/netbird: open up 0.59.0+ DNS forwarder port

### DIFF
--- a/nixos/modules/services/networking/netbird.nix
+++ b/nixos/modules/services/networking/netbird.nix
@@ -231,6 +231,14 @@ in
                 '';
               };
 
+              openInternalFirewall = mkOption {
+                type = bool;
+                default = true;
+                description = ''
+                  Opens up internal firewall ports for the NetBird's network interface.
+                '';
+              };
+
               hardened = mkOption {
                 type = bool;
                 default = true;
@@ -502,8 +510,11 @@ in
         interfaces = listToAttrs (
           toClientList (client: {
             name = client.interface;
-            value.allowedUDPPorts = optionals client.openFirewall [
-              5353 # required for the DNS forwarding/routing to work
+            value.allowedUDPPorts = optionals client.openInternalFirewall [
+              # note: those should be opened up by NetBird itself, but it needs additional
+              #  NixOS -specific debugging and tweaking before it works
+              5353 # <0.59.0 DNS forwarder port, kept for compatibility with those clients
+              22054 # >=0.59.0 DNS forwarder port
             ];
           })
         );


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

NetBird 0.59.0 introduced a new port `22054` for the DNS forwarder (phasing out `5353` clash with mDNS) that needs to be opened up on NixOS.

As a note NetBird should normally open up firewall by itself on most distributions, but for some reason (probably `nftables` naming conventions on NixOS) it's not picked up and I don't have the capacity to dig deeper into it.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
