### PR TITLE
pizauth: 1.0.7 -> 1.0.8; migrate to finalAttrs; add manpage and systemd user services

### DIFF
--- a/pkgs/by-name/pi/pizauth/package.nix
+++ b/pkgs/by-name/pi/pizauth/package.nix
@@ -6,14 +6,14 @@
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "pizauth";
   version = "1.0.7";
 
   src = fetchFromGitHub {
     owner = "ltratt";
     repo = "pizauth";
-    tag = "pizauth-${version}";
+    tag = "pizauth-${finalAttrs.version}";
     hash = "sha256-lvG50Ej0ius4gHEsyMKOXLD20700mc4iWJxHK5DvYJc=";
   };
 
@@ -31,7 +31,7 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Command-line OAuth2 authentication daemon";
     homepage = "https://github.com/ltratt/pizauth";
-    changelog = "https://github.com/ltratt/pizauth/blob/${src.rev}/CHANGES.md";
+    changelog = "https://github.com/ltratt/pizauth/blob/${finalAttrs.src.rev}/CHANGES.md";
     license = with lib.licenses; [
       asl20
       mit
@@ -39,4 +39,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ moraxyc ];
     mainProgram = "pizauth";
   };
-}
+})

--- a/pkgs/by-name/pi/pizauth/package.nix
+++ b/pkgs/by-name/pi/pizauth/package.nix
@@ -25,6 +25,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     installShellCompletion --cmd pizauth \
       --bash share/bash/completion.bash \
       --fish share/fish/pizauth.fish
+
+    installManPage pizauth.1 pizauth.conf.5
   '';
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/pi/pizauth/package.nix
+++ b/pkgs/by-name/pi/pizauth/package.nix
@@ -8,22 +8,23 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "pizauth";
-  version = "1.0.7";
+  version = "1.0.8";
 
   src = fetchFromGitHub {
     owner = "ltratt";
     repo = "pizauth";
     tag = "pizauth-${finalAttrs.version}";
-    hash = "sha256-lvG50Ej0ius4gHEsyMKOXLD20700mc4iWJxHK5DvYJc=";
+    hash = "sha256-KLHccRCJ19CrGKePhUgW4GhQzn+ULE861cW2ykGoaZk=";
   };
 
-  cargoHash = "sha256-WyQIk74AKfsv0noafCGMRS6o+Lq6CeP99AFSdYq+QHg=";
+  cargoHash = "sha256-m1kOV0b/HCSAGfbEh4GdtrlphoELe7ebG+kgKKNYihY=";
 
   nativeBuildInputs = [ installShellFiles ];
 
   postInstall = ''
     installShellCompletion --cmd pizauth \
-      --bash share/bash/completion.bash
+      --bash share/bash/completion.bash \
+      --fish share/fish/pizauth.fish
   '';
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/pi/pizauth/package.nix
+++ b/pkgs/by-name/pi/pizauth/package.nix
@@ -27,6 +27,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --fish share/fish/pizauth.fish
 
     installManPage pizauth.1 pizauth.conf.5
+
+    substituteInPlace lib/systemd/user/pizauth.service \
+      --replace-fail /usr/bin/pizauth "$out/bin/pizauth"
+    install -Dm444 lib/systemd/user/pizauth{,-*}.service -t $out/lib/systemd/user
   '';
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
- **pizauth: migrate to finalAttrs**
- **pizauth: 1.0.7 -> 1.0.8**
- **pizauth: add manpage**
- **pizauth: add systemd user services**

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
