### PR TITLE
curlMinimal: apply paused HTTP/2 transfer fix

### DIFF
--- a/pkgs/by-name/cu/curlMinimal/fix-h2-paused-transfers.patch
+++ b/pkgs/by-name/cu/curlMinimal/fix-h2-paused-transfers.patch
@@ -1,0 +1,27 @@
+From 7e91f24c73256af59ac9061c41b73a184c4690aa Mon Sep 17 00:00:00 2001
+From: Stefan Eissing <stefan@eissing.org>
+Date: Mon, 3 Nov 2025 15:07:57 +0100
+Subject: [PATCH] cw-out: fix EAGAIN handling on pause
+
+The interim CURLE_AGAIN result was not always converted to a
+CURLE_OK and then caused write callers to report a failure.
+
+Fixes #19334
+Reported-by: pennae on github
+Closes #19338
+---
+ lib/cw-out.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/lib/cw-out.c b/lib/cw-out.c
+index 1f4031649267..9c0a36e7e5e2 100644
+--- a/lib/cw-out.c
++++ b/lib/cw-out.c
+@@ -302,6 +302,7 @@ static CURLcode cw_out_buf_flush(struct cw_out_ctx *ctx,
+                               &consumed);
+     if(result && (result != CURLE_AGAIN))
+       return result;
++    result = CURLE_OK;
+ 
+     if(consumed) {
+       if(consumed == curlx_dyn_len(&cwbuf->b)) {

--- a/pkgs/by-name/cu/curlMinimal/package.nix
+++ b/pkgs/by-name/cu/curlMinimal/package.nix
@@ -98,6 +98,14 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-QMjN28tsxiUcA96kI6Ryps6kA3vmVLpc9d7G6y0i/x0=";
   };
 
+  patches = [
+    # Bug introduced in curl@fa915b (8.16.0) https://github.com/curl/curl/issues/19334 Paused
+    # HTTP/2 transfers will return the wrong errors and trash the whole
+    # transfer. Remove this patch once curl is updated to 8.17.0 which will be
+    # released on the 5th November 2025.
+    ./fix-h2-paused-transfers.patch
+  ];
+
   # this could be accomplished by updateAutotoolsGnuConfigScriptsHook, but that causes infinite recursion
   # necessary for FreeBSD code path in configure
   postPatch = ''


### PR DESCRIPTION
This is done before the final release due to how critical this bug is on any application that relies on paused HTTP/2 transfers (e.g. Lix at high concurrency during substitutions).

This can be removed as soon as 8.17.0 is landed.


cc @K900 @LordGrimmauld as discussed in the staging channel.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
