### PR TITLE
build-support/php: fix variable substitution in bash

### DIFF
--- a/pkgs/build-support/php/builders/v2/hooks/composer-vendor-hook.sh
+++ b/pkgs/build-support/php/builders/v2/hooks/composer-vendor-hook.sh
@@ -10,9 +10,9 @@ declare -g composerNoPlugins
 declare -g composerNoScripts
 
 declare -ga composerFlags=()
-[[ -n "$composerNoDev" ]] && composerFlags+=(--no-dev)
-[[ -n "$composerNoPlugins" ]] && composerFlags+=(--no-plugins)
-[[ -n "$composerNoScripts" ]] && composerFlags+=(--no-scripts)
+[[ -n "${composerNoDev-}" ]] && composerFlags+=(--no-dev)
+[[ -n "${composerNoPlugins-}" ]] && composerFlags+=(--no-plugins)
+[[ -n "${composerNoScripts-}" ]] && composerFlags+=(--no-scripts)
 
 preConfigureHooks+=(composerVendorConfigureHook)
 preBuildHooks+=(composerVendorBuildHook)


### PR DESCRIPTION
This PR fixes a build failure due to undefined variables in a bash build script.

The build environment sets the bash option `NOUNSET` which fails the script for any substitution of uninitialized variables.  The `${VAR-}` construct circumvents this.

This was tested by building the following derivations:

- `phpPackages.box{,.composerVendor}`
- `phpPackages.cyclonedx-php-composer`
- `phpPackages.phing{,.composerVendor}`
- `phpPackages.php-parallel-lint{,.composerVendor}`
- `phpPackages.castor{,.composerVendor}`
- `phpPackages.phive{,.composerVendor}`
- `phpPackages.php-cs-fixer{,.composerVendor}`
- `phpPackages.phpspy`
- `phpPackages.composer`
- `phpPackages.grumphp{,.composerVendor}`
- `phpPackages.phpinsights{,.composerVendor}`
- `phpPackages.phpstan{,.composerVendor}`
- `phpPackages.composer-local-repo-plugin`
- `phpPackages.phan`
- `phpPackages.php-codesniffer{,.composerVendor}`
- `phpPackages.phpmd{,.composerVendor}`
- `phpPackages.psalm{,.composerVendor}`
- `psysh{,.composerVendor}`
- `deployer{,.composerVendor}`


cc @drupol because you last modified this code. I think this problem was introduced in #428676 and psysh was marked as broken in 13b803083352825427606958e0b5545cf1303942.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test



## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `6dd9e9ae1ec6f8587b05861de30d3071ec44bb3c`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>psysh</li>
  </ul>
</details>



---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
