### PR TITLE
cocotb-bus: 0.2.1 -> unstable-2025-11-03

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19554,6 +19554,12 @@
     githubId = 52569953;
     name = "Oskar Manhart";
   };
+  oskarwires = {
+    email = "me@usbcable.io";
+    github = "oskarwires";
+    githubId = 115482671;
+    name = "Oskar";
+  };
   osnyx = {
     email = "os@flyingcircus.io";
     github = "osnyx";

--- a/pkgs/development/python-modules/cocotb-bus/default.nix
+++ b/pkgs/development/python-modules/cocotb-bus/default.nix
@@ -1,23 +1,20 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "cocotb-bus";
-  version = "0.2.1";
+  version = "unstable-2025-11-03";
   format = "setuptools";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "a197aa4b0e0ad28469c8877b41b3fb2ec0206da9f491b9276d1578ce6dd8aa8d";
+  src = fetchFromGitHub {
+    owner = "cocotb";
+    repo = "cocotb-bus";
+    rev = "f72b989bde036e677d5e9ebab3a6a21bdfe43d09";
+    hash = "sha256-4j63kOjBd+iLA2EYqLTM0oKzKksOjH2UqNgDNFvWgYw=";
   };
-
-  postPatch = ''
-    # remove circular dependency cocotb from setup.py
-    substituteInPlace setup.py --replace '"cocotb>=1.5.0.dev,<2.0"' ""
-  '';
 
   # tests require cocotb, disable for now to avoid circular dependency
   doCheck = false;

--- a/pkgs/development/python-modules/cocotb-bus/default.nix
+++ b/pkgs/development/python-modules/cocotb-bus/default.nix
@@ -31,6 +31,6 @@ buildPythonPackage rec {
     description = "Pre-packaged testbenching tools and reusable bus interfaces for cocotb";
     homepage = "https://github.com/cocotb/cocotb-bus";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ prusnak ];
+    maintainers = with maintainers; [ oskarwires ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This PR updates `cocotb-bus` from `0.2.1` to the latest GitHub commit. This is to address the fact that `cocotb-bus` `0.2.1` is incompatible with the latest version of `cocotb`. The latest HEAD hasn't got a version number yet, so this is a temporary solution until one becomes available. As a side note, I'd also like to add myself as a maintainer of this package (CC @prusnak , the current maintainer). If that's okay, I can add another commit to this PR. This is my first ever PR (& change!) here so please forgive any silly mistakes.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
