### PR TITLE
nixos/facter: add graphics hardware detection

### DIFF
--- a/nixos/modules/hardware/facter/default.nix
+++ b/nixos/modules/hardware/facter/default.nix
@@ -7,6 +7,7 @@
   imports = [
     ./disk.nix
     ./firmware.nix
+    ./graphics
     ./keyboard.nix
     ./networking
     ./system.nix

--- a/nixos/modules/hardware/facter/disk.nix
+++ b/nixos/modules/hardware/facter/disk.nix
@@ -22,7 +22,7 @@ in
     '';
   };
 
-  config = {
+  config = lib.mkIf (config.hardware.facter.reportPath != null) {
     boot.initrd.availableKernelModules = config.hardware.facter.detected.boot.disk.kernelModules;
   };
 }

--- a/nixos/modules/hardware/facter/firmware.nix
+++ b/nixos/modules/hardware/facter/firmware.nix
@@ -8,7 +8,7 @@ let
   hasIntelCpu = facterLib.hasIntelCpu report;
 in
 {
-  config = lib.mkIf isBaremetal {
+  config = lib.mkIf (config.hardware.facter.reportPath != null && isBaremetal) {
     # none (e.g. bare-metal)
     # provide firmware for devices that might not have been detected by nixos-facter
     hardware.enableRedistributableFirmware = lib.mkDefault true;

--- a/nixos/modules/hardware/facter/graphics/amd.nix
+++ b/nixos/modules/hardware/facter/graphics/amd.nix
@@ -1,0 +1,18 @@
+{ lib, config, ... }:
+let
+  facterLib = import ../lib.nix lib;
+  cfg = config.hardware.facter.detected.graphics.amd;
+in
+{
+  options.hardware.facter.detected.graphics = {
+    amd.enable = lib.mkEnableOption "Enable the AMD Graphics module" // {
+      default = builtins.elem "amdgpu" (
+        facterLib.collectDrivers (config.hardware.facter.report.hardware.graphics_card or [ ])
+      );
+      defaultText = "hardware dependent";
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    services.xserver.videoDrivers = [ "modesetting" ];
+  };
+}

--- a/nixos/modules/hardware/facter/graphics/amd.nix
+++ b/nixos/modules/hardware/facter/graphics/amd.nix
@@ -12,7 +12,7 @@ in
       defaultText = "hardware dependent";
     };
   };
-  config = lib.mkIf cfg.enable {
+  config = lib.mkIf (config.hardware.facter.reportPath != null && cfg.enable) {
     services.xserver.videoDrivers = [ "modesetting" ];
   };
 }

--- a/nixos/modules/hardware/facter/graphics/default.nix
+++ b/nixos/modules/hardware/facter/graphics/default.nix
@@ -1,0 +1,42 @@
+{ lib, config, ... }:
+let
+  facterLib = import ../lib.nix lib;
+  cfg = config.hardware.facter.detected.graphics;
+in
+{
+  imports = [
+    ./amd.nix
+  ];
+  options.hardware.facter.detected = {
+    graphics.enable = lib.mkEnableOption "Enable the Graphics module" // {
+      default = builtins.length (config.hardware.facter.report.hardware.monitor or [ ]) > 0;
+      defaultText = "hardware dependent";
+    };
+    boot.graphics.kernelModules = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      # We currently don't auto import nouveau, in case the user might want to use the proprietary nvidia driver,
+      # We might want to change this in future, if we have a better idea, how to handle this.
+      default = lib.remove "nouveau" (
+        lib.uniqueStrings (
+          facterLib.collectDrivers (config.hardware.facter.report.hardware.graphics_card or [ ])
+        )
+      );
+      defaultText = "hardware dependent";
+      description = ''
+        List of kernel modules to load at boot for the graphics card.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable (
+    {
+      boot.initrd.kernelModules = config.hardware.facter.detected.boot.graphics.kernelModules;
+    }
+    // (
+      if lib.versionOlder lib.version "24.11pre" then
+        { hardware.opengl.enable = lib.mkDefault true; }
+      else
+        { hardware.graphics.enable = lib.mkDefault true; }
+    )
+  );
+}

--- a/nixos/modules/hardware/facter/graphics/default.nix
+++ b/nixos/modules/hardware/facter/graphics/default.nix
@@ -28,7 +28,7 @@ in
     };
   };
 
-  config = lib.mkIf cfg.enable (
+  config = lib.mkIf (config.hardware.facter.reportPath != null && cfg.enable) (
     {
       boot.initrd.kernelModules = config.hardware.facter.detected.boot.graphics.kernelModules;
     }

--- a/nixos/modules/hardware/facter/keyboard.nix
+++ b/nixos/modules/hardware/facter/keyboard.nix
@@ -15,7 +15,7 @@ in
     '';
   };
 
-  config = {
+  config = lib.mkIf (config.hardware.facter.reportPath != null) {
     boot.initrd.availableKernelModules = config.hardware.facter.detected.boot.keyboard.kernelModules;
   };
 }

--- a/nixos/modules/hardware/facter/networking/default.nix
+++ b/nixos/modules/hardware/facter/networking/default.nix
@@ -60,10 +60,12 @@ in
       ];
     };
   };
-  config = lib.mkIf config.hardware.facter.detected.dhcp.enable {
-    networking.useDHCP = lib.mkDefault true;
+  config =
+    lib.mkIf (config.hardware.facter.reportPath != null && config.hardware.facter.detected.dhcp.enable)
+      {
+        networking.useDHCP = lib.mkDefault true;
 
-    # Per-interface DHCP configuration
-    networking.interfaces = perInterfaceConfig;
-  };
+        # Per-interface DHCP configuration
+        networking.interfaces = perInterfaceConfig;
+      };
 }

--- a/nixos/modules/hardware/facter/networking/initrd.nix
+++ b/nixos/modules/hardware/facter/networking/initrd.nix
@@ -14,7 +14,7 @@ in
     '';
   };
 
-  config = lib.mkIf config.boot.initrd.network.enable {
+  config = lib.mkIf (config.hardware.facter.reportPath != null && config.boot.initrd.network.enable) {
     boot.initrd.kernelModules = config.hardware.facter.detected.boot.initrd.networking.kernelModules;
   };
 }

--- a/nixos/modules/hardware/facter/networking/intel.nix
+++ b/nixos/modules/hardware/facter/networking/intel.nix
@@ -49,7 +49,7 @@ in
     };
   };
 
-  config = {
+  config = lib.mkIf (config.hardware.facter.reportPath != null) {
     networking.enableIntel2200BGFirmware = lib.mkIf cfg._2200BG.enable (lib.mkDefault true);
     hardware.enableRedistributableFirmware = lib.mkIf cfg._3945ABG.enable (lib.mkDefault true);
   };

--- a/nixos/modules/hardware/facter/system.nix
+++ b/nixos/modules/hardware/facter/system.nix
@@ -6,7 +6,7 @@
 }:
 {
   # Skip setting hostPlatform if it's read-only
-  nixpkgs =
+  config.nixpkgs =
     lib.optionalAttrs
       (config.hardware.facter.report.system or null != null && !options.nixpkgs.hostPlatform.readOnly)
       {

--- a/nixos/modules/hardware/facter/system.nix
+++ b/nixos/modules/hardware/facter/system.nix
@@ -8,7 +8,10 @@
   # Skip setting hostPlatform if it's read-only
   config.nixpkgs =
     lib.optionalAttrs
-      (config.hardware.facter.report.system or null != null && !options.nixpkgs.hostPlatform.readOnly)
+      (
+        config.hardware.facter.report.system or null != null
+        && !(options.nixpkgs.hostPlatform.readOnly or false)
+      )
       {
         hostPlatform = lib.mkDefault config.hardware.facter.report.system;
       };

--- a/nixos/modules/hardware/facter/virtualisation.nix
+++ b/nixos/modules/hardware/facter/virtualisation.nix
@@ -51,7 +51,7 @@ in
     };
   };
 
-  config = {
+  config = lib.mkIf (config.hardware.facter.reportPath != null) {
 
     # KVM support
     boot.kernelModules =

--- a/nixos/modules/hardware/facter/virtualisation.nix
+++ b/nixos/modules/hardware/facter/virtualisation.nix
@@ -57,7 +57,14 @@ in
     boot.kernelModules =
       let
         hasCPUFeature =
-          feature: lib.any ({ features, ... }: lib.elem feature features) (report.hardware.cpu or [ ]);
+          feature:
+          lib.any (
+            {
+              features ? [ ],
+              ...
+            }:
+            lib.elem feature features
+          ) (report.hardware.cpu or [ ]);
       in
       lib.mkMerge [
         (lib.mkIf (hasCPUFeature "vmx") [ "kvm-intel" ])


### PR DESCRIPTION
This adds automatic graphics card configuration:

Builds on PR #456698 (virtualization & firmware).
Part of incremental upstreaming from nixos-facter-modules.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
