### PR TITLE
ci/github-script/bot: fix infinite labeling cycle

### DIFF
--- a/ci/github-script/bot.js
+++ b/ci/github-script/bot.js
@@ -322,7 +322,7 @@ module.exports = async ({ github, context, core, dry }) => {
 
       Object.assign(prLabels, evalLabels, {
         '11.by: package-maintainer':
-          packages.length &&
+          Boolean(packages.length) &&
           packages.every((pkg) =>
             maintainers[pkg]?.includes(pull_request.user.id),
           ),


### PR DESCRIPTION
When we recently refactored the code to use the maintainer map for related labels, we made a mistake: When a PR has no packages with maintainers returned from eval, the label would internally be set to `0` instead of `false`.

The code would then go on compare the before and after labels with strict equality - and assume a difference, because `0 !== false`. Thus, it seemed like new labels needed to be set, so the PUT request was actually sent. Of course, the labels were actually the same - when filtering the labels to be set, the `0` would also be treated as falsy, so the label would not be set. This would result in no visible change in the PR, but internall GitHub would replace the `updated_at` timestamp for that PR - after all we replaced all labels.

Repeatedly updating *all* PRs we're looking at quickly causes problems, because we are going to look at the same PRs *again* in the next cycle - essentially causing infinite recursion. The bot became slower and slower over time, because it had to process more and more PRs each run.

Simply casting this to a proper Boolean, should get us out of the mess soon.

## Things done

- [x] Tested locally.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
