### PR TITLE
nixos/_1password-gui: apply polkit override to package option

### DIFF
--- a/nixos/modules/programs/_1password-gui.nix
+++ b/nixos/modules/programs/_1password-gui.nix
@@ -6,9 +6,7 @@
 }:
 
 let
-
   cfg = config.programs._1password-gui;
-
 in
 {
   imports = [

--- a/nixos/modules/programs/_1password-gui.nix
+++ b/nixos/modules/programs/_1password-gui.nix
@@ -30,31 +30,32 @@ in
         '';
       };
 
-      package = lib.mkPackageOption pkgs "1Password GUI" {
-        default = [ "_1password-gui" ];
-      };
+      package =
+        lib.mkPackageOption pkgs "1Password GUI" {
+          default = [ "_1password-gui" ];
+        }
+        // {
+          apply =
+            pkg:
+            pkg.override {
+              inherit (cfg) polkitPolicyOwners;
+            };
+        };
     };
   };
 
-  config =
-    let
-      package = cfg.package.override {
-        polkitPolicyOwners = cfg.polkitPolicyOwners;
-      };
-    in
-    lib.mkIf cfg.enable {
-      environment.systemPackages = [ package ];
-      users.groups.onepassword.gid = config.ids.gids.onepassword;
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    users.groups.onepassword.gid = config.ids.gids.onepassword;
 
-      security.wrappers = {
-        "1Password-BrowserSupport" = {
-          source = "${package}/share/1password/1Password-BrowserSupport";
-          owner = "root";
-          group = "onepassword";
-          setuid = false;
-          setgid = true;
-        };
+    security.wrappers = {
+      "1Password-BrowserSupport" = {
+        source = "${cfg.package}/share/1password/1Password-BrowserSupport";
+        owner = "root";
+        group = "onepassword";
+        setuid = false;
+        setgid = true;
       };
-
     };
+  };
 }


### PR DESCRIPTION
This allows downstream modules to access the same package as is installed into `environment.systemPackages`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
