### PR TITLE
doxygen: fix linker errors in darwin build

### DIFF
--- a/pkgs/development/tools/documentation/doxygen/default.nix
+++ b/pkgs/development/tools/documentation/doxygen/default.nix
@@ -30,6 +30,12 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail 'JAVACC_CHAR_TYPE=\"unsigned char\"' \
                      'JAVACC_CHAR_TYPE=\"char8_t\"' \
       --replace-fail "CMAKE_CXX_STANDARD 17" "CMAKE_CXX_STANDARD 20"
+  ''
+  # otherwise getting linker errors for deps
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)' \
+                     'set(CMAKE_INTERPROCEDURAL_OPTIMIZATION FALSE)'
   '';
 
   nativeBuildInputs = [
@@ -45,13 +51,10 @@ stdenv.mkDerivation (finalAttrs: {
     fmt
     sqlite
   ]
-  ++ lib.optionals (qt5 != null) (
-    with qt5;
-    [
-      qtbase
-      wrapQtAppsHook
-    ]
-  );
+  ++ lib.optionals (qt5 != null) [
+    qt5.qtbase
+    qt5.wrapQtAppsHook
+  ];
 
   cmakeFlags = [
     "-Duse_sys_spdlog=ON"


### PR DESCRIPTION
Encountered weird "file or directory does not exist" errors while trying to link, full logs here: https://gist.github.com/nekowinston/8773bfb1b09c3ece22a7cc7354ad4e1a

I noticed that Debug builds worked, eventually narrowed it down to the `INTERPROCEDURAL_OPTIMIZATION` flag.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
