### PR TITLE
nixos/documenso: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -176,6 +176,8 @@
 
 - [nixbit](https://github.com/pbek/nixbit), a GUI application for updating your NixOS system from a Nix Flakes Git repository. Available as [programs.nixbit](#opt-programs.nixbit.enable).
 
+- [documenso](https://github.com/documenso/documenso), a DocuSign alternative. Available as [services.documenso](#opt-services.documenso.enable).
+
 ## Backward Incompatibilities {#sec-release-25.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1580,6 +1580,7 @@
   ./services/web-apps/dependency-track.nix
   ./services/web-apps/dex.nix
   ./services/web-apps/discourse.nix
+  ./services/web-apps/documenso.nix
   ./services/web-apps/documize.nix
   ./services/web-apps/docuseal.nix
   ./services/web-apps/dokuwiki.nix

--- a/nixos/modules/services/web-apps/documenso.md
+++ b/nixos/modules/services/web-apps/documenso.md
@@ -1,0 +1,41 @@
+# Documenso {#module-services-documenso}
+
+Documenso is an open-source digital signature platform, offering a
+cost-effective and customizable alternative to proprietary solutions like
+DocuSign.
+
+## Quickstart {#module-services-documenso-quickstart}
+
+To run documenso in a non-production environment use this configuration.
+
+```
+{
+  services.documenso = {
+    enable = true;
+  };
+}
+```
+
+If you want to create some initial database content including an admin user run
+the following command:
+
+```ShellSession
+systemctl start documenso-seed-database
+```
+
+## Advanced configuration
+
+Checkout all available options in upstream
+[.env.example](https://github.com/documenso/documenso/blob/main/.env.example).
+You can set a custom environment file using the option `environmentFile`. Use
+this method the setup database connection and other settings, without storing
+secrets in Nix Store, e.g. using Age or Sops.
+
+```
+{
+  services.documenso = {
+    enable = true;
+    environmentFile = ./documenso.env;
+  };
+}
+```

--- a/nixos/modules/services/web-apps/documenso.nix
+++ b/nixos/modules/services/web-apps/documenso.nix
@@ -1,0 +1,204 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.services.documenso;
+in
+{
+  options.services.documenso = {
+
+    enable = lib.mkEnableOption "Documenso service";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.documenso;
+      defaultText = lib.literalExpression "pkgs.documenso";
+      description = ''
+        The documenso package to use.
+      '';
+    };
+
+    serverPort = lib.mkOption {
+      type = lib.types.port;
+      default = 3000;
+      description = "Port the documenso server listens on.";
+    };
+
+    database = {
+      name = lib.mkOption {
+        type = lib.types.str;
+        default = "documenso";
+        description = "Database name.";
+      };
+
+      user = lib.mkOption {
+        type = lib.types.str;
+        default = "documenso";
+        description = "Database user.";
+      };
+
+      url = lib.mkOption {
+        type = lib.types.str;
+        default = "postgres://${config.services.documenso.database.user}@localhost/${config.services.documenso.database.name}?host=/run/postgresql";
+        defaultText = lib.literalExpression ''
+          "postgres://documenso@localhost/documenso?host=/run/postgresql";
+        '';
+        description = ''
+          Database url. Note that any secret here would be world-readable. Use
+          `services.documenso.environmentFile` instead to include database
+          secrets.
+        '';
+      };
+
+      createLocally = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Whether to create a local database automatically.";
+      };
+
+      seedDatabase = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Whether to seed the database with initial users and teams and
+          templates. If you set this to 'true' you can login after first
+          install with `admin@documenso.com` and `password` as password.
+        '';
+      };
+
+    };
+
+    authSecret = lib.mkOption {
+      type = lib.types.str;
+      default = "secret";
+      description = ''
+        NextAuth Secret. Used to encrypt the NextAuth.js JWT, and to hash
+        email verification tokens.
+        Change this value for production environments.
+      '';
+    };
+
+    privateEncryptionKey = lib.mkOption {
+      type = lib.types.str;
+      default = "secretsecret";
+      description = ''
+        Application Key for symmetric encryption and decryption
+        This should be a random string of at least 32 characters.
+        Change this value for production environments.
+      '';
+    };
+
+    privateEncryptionSecondairyKey = lib.mkOption {
+      type = lib.types.str;
+      default = "secretsecretsecret";
+      description = ''
+        Application Key for symmetric encryption and decryption
+        This should be a random string of at least 32 characters.
+        Change this value for production environments.
+      '';
+    };
+
+    environmentFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        Environment file to load extra environment variables from.
+        See https://github.com/documenso/documenso/blob/main/.env.example for
+        common options.
+      '';
+    };
+
+  };
+
+  config = lib.mkIf cfg.enable {
+
+    assertions = [
+      {
+        assertion = cfg.database.createLocally -> cfg.database.name == cfg.database.user;
+        message = ''
+          Automatically provisioning the documenso database requires both database name and database user to be equal. '${cfg.database.name}' != '${cfg.database.user}'
+          To fix this problem, assign the same value to both options services.documenso.database.{name,user}.
+        '';
+      }
+    ];
+
+    services.postgresql = lib.optionalAttrs (cfg.database.createLocally) {
+      enable = lib.mkDefault true;
+
+      ensureDatabases = [ cfg.database.name ];
+      ensureUsers = [
+        {
+          name = cfg.database.user;
+          ensureDBOwnership = true;
+          ensureClauses.login = true;
+        }
+      ];
+    };
+
+    systemd.services =
+      let
+
+        environment = {
+          NEXTAUTH_SECRET = cfg.authSecret;
+          NEXT_PRIVATE_DATABASE_URL = cfg.database.url;
+          NEXT_PRIVATE_DIRECT_DATABASE_URL = cfg.database.url;
+          NEXT_PRIVATE_ENCRYPTION_KEY = cfg.privateEncryptionKey;
+          NEXT_PRIVATE_ENCRYPTION_SECONDARY_KEY = cfg.privateEncryptionSecondairyKey;
+          NEXT_PUBLIC_WEBAPP_URL = "http://localhost:${builtins.toString cfg.serverPort}";
+          NEXT_PRIVATE_INTERNAL_WEBAPP_URL = "http://localhost:${builtins.toString cfg.serverPort}";
+          PORT = builtins.toString cfg.serverPort;
+          #NEXT_PRIVATE_JOBS_PROVIDER="local";
+        };
+
+      in
+      {
+        documenso-server = {
+          inherit environment;
+          description = "documenso server";
+          wantedBy = [ "multi-user.target" ];
+          requires = [ "postgresql.target" ];
+          after = [ "postgresql.target" ];
+          serviceConfig = {
+            DynamicUser = true;
+            User = cfg.database.user;
+            ExecStart = "${cfg.package}/bin/documenso";
+            Restart = "always";
+          }
+          // lib.optionalAttrs (cfg.environmentFile != null) { EnvironmentFile = cfg.environmentFile; };
+        };
+      }
+      // lib.optionalAttrs (cfg.database.seedDatabase == true) {
+        documenso-seed-database = {
+
+          inherit environment;
+
+          description = "documenso database setup";
+          requires = [ "documenso-server.service" ];
+          after = [ "documenso-server.service" ];
+
+          script = ''
+            #!${pkgs.bash}/bin/bash
+            export PKG_CONFIG_PATH=${pkgs.openssl.dev}/lib/pkgconfig;
+            export PRISMA_QUERY_ENGINE_LIBRARY=${pkgs.prisma-engines}/lib/libquery_engine.node
+            export PRISMA_QUERY_ENGINE_BINARY=${pkgs.prisma-engines}/bin/query-engine
+            export PRISMA_SCHEMA_ENGINE_BINARY=${pkgs.prisma-engines}
+            export PATH=$PATH:${cfg.package}/node_modules/.bin
+            cd ${cfg.package}/packages/prisma
+            ${pkgs.prisma}/bin/prisma db seed
+          '';
+
+          serviceConfig = {
+            DynamicUser = true;
+            User = cfg.database.user;
+            Type = "oneshot";
+            RemainAfterExit = true;
+          }
+          // lib.optionalAttrs (cfg.environmentFile != null) { EnvironmentFile = cfg.environmentFile; };
+        };
+      };
+  };
+}

--- a/nixos/modules/services/web-apps/documenso.nix
+++ b/nixos/modules/services/web-apps/documenso.nix
@@ -130,7 +130,7 @@ in
     ];
 
     services.postgresql = lib.optionalAttrs (cfg.database.createLocally) {
-      enable = lib.mkDefault true;
+      enable = true;
 
       ensureDatabases = [ cfg.database.name ];
       ensureUsers = [

--- a/nixos/modules/services/web-apps/documenso.nix
+++ b/nixos/modules/services/web-apps/documenso.nix
@@ -181,7 +181,6 @@ in
           after = [ "documenso-server.service" ];
 
           script = ''
-            #!${pkgs.bash}/bin/bash
             export PKG_CONFIG_PATH=${pkgs.openssl.dev}/lib/pkgconfig;
             export PRISMA_QUERY_ENGINE_LIBRARY=${pkgs.prisma-engines}/lib/libquery_engine.node
             export PRISMA_QUERY_ENGINE_BINARY=${pkgs.prisma-engines}/bin/query-engine

--- a/nixos/modules/services/web-apps/documenso.nix
+++ b/nixos/modules/services/web-apps/documenso.nix
@@ -48,9 +48,12 @@ in
           "postgres://documenso@localhost/documenso?host=/run/postgresql";
         '';
         description = ''
-          Database url. Note that any secret here would be world-readable. Use
-          `services.documenso.environmentFile` instead to include database
-          secrets.
+          Database url.
+          
+          :::{.note}
+          Any secret here would be world-readable.
+          Use `services.documenso.environmentFile` instead to include database secrets.
+          :::
         '';
       };
 

--- a/nixos/modules/services/web-apps/documenso.nix
+++ b/nixos/modules/services/web-apps/documenso.nix
@@ -165,7 +165,7 @@ in
           serviceConfig = {
             DynamicUser = true;
             User = cfg.database.user;
-            ExecStart = "${cfg.package}/bin/documenso";
+            ExecStart = lib.getExe cfg.package;
             Restart = "always";
           }
           // lib.optionalAttrs (cfg.environmentFile != null) { EnvironmentFile = cfg.environmentFile; };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
## Description of changes

This PR adds the documenso module. [Documenso](https://documenso.com) is a signing webapp. This  generates systemd services for the package documenso. By default it automatically sets up a postgres database so a single enable results in a working system. A brief quickstart is added to the manual in `documenso.md`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
