### PR TITLE
step-kms-plugin: fix broken status on darwin

### DIFF
--- a/pkgs/by-name/st/step-kms-plugin/package.nix
+++ b/pkgs/by-name/st/step-kms-plugin/package.nix
@@ -42,13 +42,13 @@ buildGoModule rec {
     "-X github.com/smallstep/step-kms-plugin/cmd.Version=${version}"
   ];
 
+  CGO_CFLAGS = "-I${lib.getDev pcsclite}/include/PCSC/";
+
   meta = with lib; {
     description = "Step plugin to manage keys and certificates on cloud KMSs and HSMs";
     homepage = "https://smallstep.com/cli/";
     license = licenses.asl20;
     maintainers = with maintainers; [ qbit ];
     mainProgram = "step-kms-plugin";
-    # can't find pcsclite header files
-    broken = stdenv.hostPlatform.isDarwin;
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This fixes the broken status on Darwin for `step-kms-plugin` by setting the include flags properly such that the package can build. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] aarch64-darwin
  - [x] x86_64-darwin
- Tested, as applicable:
  - [x] [Package tests] at `passthru.tests`.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
