### PR TITLE
python3Packages.curl-cffi: pin python-websockets at 12.0 and disable problematic tests

### DIFF
--- a/pkgs/development/python-modules/curl-cffi/default.nix
+++ b/pkgs/development/python-modules/curl-cffi/default.nix
@@ -1,5 +1,4 @@
 {
-  stdenv,
   lib,
   buildPythonPackage,
   fetchFromGitHub,
@@ -19,10 +18,30 @@
   python-multipart,
   trustme,
   uvicorn,
-  websockets,
   writableTmpDirAsHomeHook,
 }:
+let
+  # This is only used for testing and requires 12.0 specifically
+  # due to incompatible API changes in later versions.
+  websockets = buildPythonPackage rec {
+    pname = "websockets";
+    version = "12.0";
+    pyproject = true;
 
+    src = fetchFromGitHub {
+      owner = "aaugustin";
+      repo = "websockets";
+      tag = version;
+      hash = "sha256-sOL3VI9Ib/PncZs5KN4dAIHOrBc7LfXqT15LO4M6qKg=";
+    };
+
+    build-system = [ setuptools ];
+
+    doCheck = false;
+
+    pythonImportsCheck = [ "websockets" ];
+  };
+in
 buildPythonPackage rec {
   pname = "curl-cffi";
   version = "0.14.0b2";

--- a/pkgs/development/python-modules/curl-cffi/default.nix
+++ b/pkgs/development/python-modules/curl-cffi/default.nix
@@ -55,6 +55,7 @@ buildPythonPackage rec {
   };
 
   patches = [ ./use-system-libs.patch ];
+
   buildInputs = [ curl-impersonate-chrome ];
 
   build-system = [
@@ -98,8 +99,11 @@ buildPythonPackage rec {
   disabledTestPaths = [
     # test accesses network
     "tests/unittest/test_smoke.py::test_async"
+    # Hangs the build (possibly forever) under websockets > 12
+    # https://github.com/lexiforest/curl_cffi/issues/657
+    "tests/unittest/test_websockets.py::test_websocket"
     # Runs out of memory while testing
-    "tests/unittest/test_websockets.py"
+    "tests/unittest/test_websockets.py::test_receive_large_messages_run_forever"
   ];
 
   disabledTests = [
@@ -121,6 +125,9 @@ buildPythonPackage rec {
     description = "Python binding for curl-impersonate via cffi";
     homepage = "https://curl-cffi.readthedocs.io";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ chuangzhu ];
+    maintainers = with lib.maintainers; [
+      chuangzhu
+      sarahec
+    ];
   };
 }


### PR DESCRIPTION
Supersedes #457592

Hydra: https://hydra.nixos.org/build/311365966

1. The `echo` method called from `test_websocket` fails with a race condition in closing a websocket. This happens during the teardown after pytest is done. Disabled.
2. `test_receive_large_messages_run_forever` can hang testing and/or run out of memory. Disabled.
3. **Pinned python3Packages.websocket to 12.0** Upstream requires it due to api changes in 13 and later. (And there aren't up to date requirements upstream *sigh*)
4. Added self as maintainer based on the changes above

ZHF: #457852

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
