### PR TITLE
marisa: 0.3.0 -> 0.3.1

### DIFF
--- a/pkgs/by-name/ma/marisa/package.nix
+++ b/pkgs/by-name/ma/marisa/package.nix
@@ -2,19 +2,29 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
 }:
 
 stdenv.mkDerivation rec {
   pname = "marisa";
-  version = "0.3.0";
+  version = "0.3.1";
 
   src = fetchFromGitHub {
     owner = "s-yata";
     repo = "marisa-trie";
     tag = "v${version}";
-    hash = "sha256-XOXX0NuU+erL/KDAZgBeX+LKO9uSEOyP1/VuMDE5pi0=";
+    hash = "sha256-+rOmbvlcEBBsjUdWRrW9WN0MfhnSe7Gm3DOXfhtcSDc=";
   };
+
+  patches = [
+    # https://github.com/s-yata/marisa-trie/pull/123
+    (fetchpatch {
+      name = "fix-binding-build.patch";
+      url = "https://github.com/s-yata/marisa-trie/commit/cf4602f08df49861d987d122bd85bfdb456fe7a0.patch";
+      hash = "sha256-h6+ixT63cHSpg3fhiLwJlxU296bD5YgfEaGqAHpm6+g=";
+    })
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/ma/marisa/package.nix
+++ b/pkgs/by-name/ma/marisa/package.nix
@@ -2,19 +2,29 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "marisa";
-  version = "0.3.0";
+  version = "0.3.1";
 
   src = fetchFromGitHub {
     owner = "s-yata";
     repo = "marisa-trie";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-XOXX0NuU+erL/KDAZgBeX+LKO9uSEOyP1/VuMDE5pi0=";
+    hash = "sha256-+rOmbvlcEBBsjUdWRrW9WN0MfhnSe7Gm3DOXfhtcSDc=";
   };
+
+  patches = [
+    # https://github.com/s-yata/marisa-trie/pull/123
+    (fetchpatch {
+      name = "fix-binding-build.patch";
+      url = "https://github.com/s-yata/marisa-trie/commit/cf4602f08df49861d987d122bd85bfdb456fe7a0.patch";
+      hash = "sha256-h6+ixT63cHSpg3fhiLwJlxU296bD5YgfEaGqAHpm6+g=";
+    })
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/python-modules/marisa-trie/default.nix
+++ b/pkgs/development/python-modules/marisa-trie/default.nix
@@ -28,6 +28,12 @@ buildPythonPackage rec {
     })
   ];
 
+  postPatch = ''
+    # https://github.com/pytries/marisa-trie/issues/132
+    substituteInPlace tests/test_binary_trie.py tests/test_trie.py \
+      --replace-fail MARISA_FORMAT_ERROR std::runtime_error
+  '';
+
   build-system = [
     cython
     setuptools

--- a/pkgs/development/python-modules/marisa/default.nix
+++ b/pkgs/development/python-modules/marisa/default.nix
@@ -2,13 +2,18 @@
   lib,
   buildPythonPackage,
   marisa,
+  setuptools,
   swig,
 }:
 
 buildPythonPackage {
   pname = "marisa";
-  format = "setuptools";
   inherit (marisa) src version;
+  pyproject = true;
+
+  patches = marisa.patches or [ ];
+
+  build-system = [ setuptools ];
 
   nativeBuildInputs = [ swig ];
 


### PR DESCRIPTION
Diff: https://github.com/s-yata/marisa-trie/compare/v0.3.0...v0.3.1

Changelog: https://github.com/s-yata/marisa-trie/releases/tag/v0.3.1

closes https://github.com/NixOS/nixpkgs/pull/426943
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
