### PR TITLE
libressl: 4.2.0 -> 4.2.1, 4.1.1 -> 4.1.2, remove 4.0

### DIFF
--- a/pkgs/by-name/li/libressl/default.nix
+++ b/pkgs/by-name/li/libressl/default.nix
@@ -117,27 +117,6 @@ let
   };
 in
 {
-  libressl_4_0 = generic {
-    version = "4.0.1";
-    hash = "sha256-IClLh3eMJidIk4Y5Q8hjWJebSZ03tJl31r+Gj3tZfL0=";
-    # Fixes build on loongarch64
-    # https://github.com/libressl/portable/pull/1146
-    patches = [
-      (fetchpatch {
-        name = "0100-ALT-basic-loongarch64-support.patch";
-        url = "https://git.altlinux.org/gears/L/LibreSSL.git?p=LibreSSL.git;a=blob_plain;f=patches/0100-ALT-basic-loongarch64-support.patch;hb=70ddea860b8b62531bd3968bf4d7a5c4b7086776";
-        stripLen = 2;
-        extraPrefix = "";
-        postFetch = ''
-          substituteInPlace "$out" \
-            --replace-fail "a//dev/null" "/dev/null"
-        '';
-        hash = "sha256-dEdtmHHiR7twAqgebXv1Owle/KYCak71NhDCp0PdseU=";
-      })
-      common-cmake-install-full-dirs-patch
-    ];
-  };
-
   libressl_4_1 = generic {
     version = "4.1.2";
     hash = "sha256-+6Ti+ip/UjBt96OJlwoQ6YuX6w7bKZqf252/SZmcYeE=";

--- a/pkgs/by-name/li/libressl/default.nix
+++ b/pkgs/by-name/li/libressl/default.nix
@@ -139,8 +139,8 @@ in
   };
 
   libressl_4_1 = generic {
-    version = "4.1.1";
-    hash = "sha256-x/96fWddX1dzCUDlzP8dvi3NW3QFtTl+D3/9ZqXtVnk=";
+    version = "4.1.2";
+    hash = "sha256-+6Ti+ip/UjBt96OJlwoQ6YuX6w7bKZqf252/SZmcYeE=";
     # Fixes build on loongarch64
     # https://github.com/libressl/portable/pull/1184
     postPatch = ''
@@ -158,8 +158,8 @@ in
   };
 
   libressl_4_2 = generic {
-    version = "4.2.0";
-    hash = "sha256-D326RNfLjfjVPyz78ZVSVLwSjgCJWV8aui+s+u6ECLI=";
+    version = "4.2.1";
+    hash = "sha256-bVwvWFg1iOp5H0yGRQBAcdAN+lVKW/eIoAbKHrWr1ws=";
     patches = [
       common-cmake-install-full-dirs-patch
     ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8227,7 +8227,6 @@ with pkgs;
   zunclient = with python313Packages; toPythonApplication python-zunclient;
 
   inherit (callPackages ../by-name/li/libressl { })
-    libressl_4_0
     libressl_4_1
     libressl_4_2
     ;


### PR DESCRIPTION
## Things done

* Update LibreSSL 4.1 to 4.1.2 ([changelog](https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-4.1.2-relnotes.txt))
* Update LibreSSL 4.2 to 4.2.1 ([changelog](https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-4.2.1-relnotes.txt))
* Remove LibreSSL 4.0; 4.0 branched off more than a year ago and is no longer supported, 4.1 and 4.2 are the currently supported versions.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
