### PR TITLE
frr: localstatedir=/var so frr_libstatedir is properly set

### DIFF
--- a/pkgs/by-name/fr/frr/package.nix
+++ b/pkgs/by-name/fr/frr/package.nix
@@ -158,7 +158,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--enable-multipath=${toString numMultipath}"
     "--enable-user=frr"
     "--enable-vty-group=frrvty"
-    "--localstatedir=/run/frr"
+    "--localstatedir=/var"
     "--sbindir=${placeholder "out"}/libexec/frr"
     "--sysconfdir=/etc/frr"
     "--with-clippy=${finalAttrs.clippy-helper}/bin/clippy"

--- a/pkgs/by-name/fr/frr/package.nix
+++ b/pkgs/by-name/fr/frr/package.nix
@@ -43,9 +43,7 @@
   numMultipath ? 64,
   watchfrrSupport ? true,
   cumulusSupport ? false,
-  rtadvSupport ? true,
   irdpSupport ? true,
-  routeReplacementSupport ? true,
   mgmtdSupport ? true,
   # Experimental as of 10.1, reconsider if upstream changes defaults
   grpcSupport ? false,
@@ -151,7 +149,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   configureFlags = [
     "--disable-silent-rules"
-    "--disable-exampledir"
     "--enable-configfile-mask=0640"
     "--enable-group=frr"
     "--enable-logfile-mask=0640"
@@ -160,15 +157,13 @@ stdenv.mkDerivation (finalAttrs: {
     "--enable-vty-group=frrvty"
     "--localstatedir=/var"
     "--sbindir=${placeholder "out"}/libexec/frr"
-    "--sysconfdir=/etc/frr"
+    "--sysconfdir=/etc"
     "--with-clippy=${finalAttrs.clippy-helper}/bin/clippy"
     # general options
     (lib.strings.enableFeature snmpSupport "snmp")
     (lib.strings.enableFeature rpkiSupport "rpki")
     (lib.strings.enableFeature watchfrrSupport "watchfrr")
-    (lib.strings.enableFeature rtadvSupport "rtadv")
     (lib.strings.enableFeature irdpSupport "irdp")
-    (lib.strings.enableFeature routeReplacementSupport "rr-semantics")
     (lib.strings.enableFeature mgmtdSupport "mgmtd")
     (lib.strings.enableFeature grpcSupport "grpc")
 


### PR DESCRIPTION
The frr daemon is unable to write out its state: `router1 # [   12.255209] mgmtd[826]: libyang: Failed to open file "/lib/frr/commit-20251103210302839690658.json" (No such file or **directory).` If you run `nixosTests.frr` you'll see the following errors emited any of the routers from the `frr.service`:

```
$ nix run .#nixosTests.frr.driver -L
...
router1 # [   12.255209] mgmtd[826]: libyang: Failed to open file "/lib/frr/commit-20251103210302839690658.json" (No such file or directory).
router1 # [   12.257882] mgmtd[826]: [HAWY9-CP261] Failed to open commit history "/lib/frr/commit-index.dat" for writing: No such file or directory
router1 # [   12.262325] ospfd[833]: [M07SE-0PG8N] failed to open directory (null) for saving daemon state: No such file or directory
router1 # [   12.266073] frrinit.sh[849]: [849|mgmtd] done
router1 # [   12.274428] frrinit.sh[864]: [864|watchfrr] sending configuration
router2 # [   12.057220] mgmtd[829]: libyang: Failed to open file "/lib/frr/commit-20251103210303305166578.json" (No such file or directory).
router1 # [   12.276453] ospfd[833]: [VTVCM-Y2NW3] Configuration Read in Took: 00:00:00
router2 # [   12.059105] mgmtd[829]: [HAWY9-CP261] Failed to open commit history "/lib/frr/commit-index.dat" for writing: No such file or directory
router1 # [   12.277909] ospfd[833]: [G6NKK-8C6DV] end_config: VTY:0x56330a358650, pending SET-CFG: 0
server # [   11.529936] frrinit.sh[824]: [824|mgmtd] sending configuration
router1 # [   12.281320] frrinit.sh[866]: [866|staticd] sending configuration
router2 # [   12.063664] ospfd[834]: [M07SE-0PG8N] failed to open directory (null) for saving daemon state: No such file or directory
...
```

This comes from a warning during the building for `frr`:

```
$ nix build .#frr --rebuild -L
...
frr> configure: WARNING: Please remove /run/frr suffix from --localstatedir=/run/frr (it should be /var in 99% of cases)
frr> configure: WARNING: ^
frr> configure: WARNING: ^
frr> configure: WARNING: ^ warnings regarding system path configuration were printed above
frr> configure: WARNING: ^ paths have been adjusted by temporary workarounds
frr> configure: WARNING: ^ please fix your ./configure invocation (remove /frr) so it will work without the workarounds
frr> configure: WARNING: ^
frr> configure: WARNING: ^
...
```

When `localstatedir=/run/frr` it results in `frr_libstatedir=/lib/frr`. This is due to truncating of `localstatedir` given the following case: https://github.com/FRRouting/frr/blob/ce66553bafc1806d745ea0724caca362d7335851/configure.ac#L59

And then `localstatedir=""` is later used to set `frr_libstatedir="\${localstatedir}/lib/frr"`: https://github.com/FRRouting/frr/blob/ce66553bafc1806d745ea0724caca362d7335851/configure.ac#L94

Setting `localstatedir=/var` (the recommended value) from the warning: https://github.com/FRRouting/frr/blob/ce66553bafc1806d745ea0724caca362d7335851/configure.ac#L61

This correctly sets `frr_libstatedir=/var/lib/frr` and fixes the errors during frr startup:

```
$ nix run .#nixosTests.frr.driverInteractive -L
```
<img width="1354" height="770" alt="ss-202511031762205877" src="https://github.com/user-attachments/assets/a51ec02b-a1aa-4437-b5ec-83482c153537" />

> Screenshot was easiest since it was hard highlight the individual services output when there was no error

Additional `/var/run/frr` is still retained for pids, etc. This mimics previous behavior since `/var/run` is symlinked to `/run` in NixOS and `/run/frr` was what it was originally set to https://github.com/FRRouting/frr/blob/ce66553bafc1806d745ea0724caca362d7335851/configure.ac#L81 :
<img width="732" height="319" alt="ss-202511031762206189" src="https://github.com/user-attachments/assets/043bf102-c835-499a-896a-77a0af8ca775" />

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
