### PR TITLE
gnunet: 0.25.1 -> 0.25.2

### DIFF
--- a/pkgs/by-name/gn/gnunet/package.nix
+++ b/pkgs/by-name/gn/gnunet/package.nix
@@ -39,11 +39,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnunet";
-  version = "0.25.1";
+  version = "0.25.2";
 
   src = fetchurl {
     url = "mirror://gnu/gnunet/gnunet-${finalAttrs.version}.tar.gz";
-    hash = "sha256-ITNsFs1X+R+dX9U1lILZFRp83w1jlvi2GCjBfMxmj1w=";
+    hash = "sha256-6rdvw105OrFfrbY0T4Q1JcFlYZQAc1qm3eCWb2omwuY=";
   };
 
   enableParallelBuilding = true;
@@ -94,12 +94,6 @@ stdenv.mkDerivation (finalAttrs: {
     # builds.
     find . \( -iname \*test\*.c -or -name \*.conf \) | \
       xargs sed -i -e "s|/tmp|$TMPDIR|g"
-
-    # fix error: conflicting types for `GNUNET_TESTING_cmd_{exec,finish}`
-    for name in exec finish; do
-      substituteInPlace src/lib/testing/testing_api_cmd_$name.c \
-        --replace-fail 'const struct GNUNET_TESTING_Command' 'struct GNUNET_TESTING_Command'
-    done
   '';
 
   # unfortunately, there's still a few failures with impure tests


### PR DESCRIPTION
https://git.gnunet.org/gnunet.git/tree/NEWS?h=v0.25.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
