### PR TITLE
aranym: mark as broken on darwin and aarch64 linux, adopt

### DIFF
--- a/pkgs/by-name/ar/aranym/package.nix
+++ b/pkgs/by-name/ar/aranym/package.nix
@@ -56,5 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "aranym";
     maintainers = [ ];
     platforms = lib.platforms.unix;
+    # never successfully built on Hydra for darwin or aarch64 linux
+    broken = stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isAarch64;
   };
 })

--- a/pkgs/by-name/ar/aranym/package.nix
+++ b/pkgs/by-name/ar/aranym/package.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = with lib.licenses; [ gpl2Plus ];
     mainProgram = "aranym";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ iedame ];
     platforms = lib.platforms.unix;
     # never successfully built on Hydra for darwin or aarch64 linux
     broken = stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isAarch64;


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/457852

Marking as broken on Darwin and aarch64 Linux since it never built successfully on Hydra. To be fixed later on a separate PR when I have the time.

aarch64 linux: https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.aranym.aarch64-linux/all
x86_64-darwin: https://hydra.nixos.org/job/nixpkgs/trunk/aranym.x86_64-darwin/all
aarch64-darwin: https://hydra.nixos.org/job/nixpkgs/trunk/aranym.aarch64-darwin/all
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
