### PR TITLE
phytool: init at 2-unstable-2024-07-14

### DIFF
--- a/pkgs/by-name/ph/phytool/package.nix
+++ b/pkgs/by-name/ph/phytool/package.nix
@@ -1,0 +1,35 @@
+{
+  fetchFromGitHub,
+  lib,
+  stdenv,
+}:
+stdenv.mkDerivation {
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  pname = "phytool";
+  version = "2-unstable-2024-07-14";
+
+  src = fetchFromGitHub {
+    owner = "wkz";
+    repo = "phytool";
+    rev = "bcf23b0261aa9f352ee4b944e30e3482158640a4";
+    hash = "sha256-8e2DVjG/2CtJ/+FLzMa1VKajJZfFqjD54XQAMY+0q3U=";
+  };
+
+  makeFlags = [
+    "PREFIX=$(out)"
+  ];
+
+  preInstall = ''
+    mkdir -p "$out/bin"
+  '';
+
+  meta = {
+    description = "Linux MDIO register access";
+    homepage = "https://github.com/wkz/phytool";
+    changelog = "https://github.com/wkz/phytool/releases";
+    license = lib.licenses.gpl2;
+    maintainers = [ lib.maintainers.connorbaker ];
+  };
+}


### PR DESCRIPTION
Useful for dumping registers.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
