### PR TITLE
ci/eval: add allowInsecure parameter

### DIFF
--- a/ci/eval/chunk.nix
+++ b/ci/eval/chunk.nix
@@ -7,6 +7,7 @@
   chunkSize,
   myChunk,
   includeBroken,
+  includeInsecure,
   systems,
   extraNixpkgsConfigJson,
 }:
@@ -17,7 +18,7 @@ let
 
   unfiltered = import ./outpaths.nix {
     inherit path;
-    inherit includeBroken systems;
+    inherit includeBroken includeInsecure systems;
     extraNixpkgsConfig = builtins.fromJSON extraNixpkgsConfigJson;
   };
 

--- a/ci/eval/default.nix
+++ b/ci/eval/default.nix
@@ -26,6 +26,8 @@
   quickTest ? false,
   # Don't try to eval packages marked as broken.
   includeBroken ? false,
+  # Don't try to eval packages marked as insecure.
+  includeInsecure ? true,
   # Customize the config used to evaluate nixpkgs
   extraNixpkgsConfig ? { },
 }:
@@ -123,6 +125,7 @@ let
           --arg attrpathFile "${attrpathFile}" \
           --arg systems "[ \"$system\" ]" \
           --arg includeBroken ${lib.boolToString includeBroken} \
+          --arg includeInsecure ${lib.boolToString includeInsecure} \
           --argstr extraNixpkgsConfigJson ${lib.escapeShellArg (builtins.toJSON extraNixpkgsConfig)} \
           -I ${nixpkgs} \
           -I ${attrpathFile} \

--- a/ci/eval/outpaths.nix
+++ b/ci/eval/outpaths.nix
@@ -4,6 +4,7 @@
 
 {
   includeBroken ? true, # set this to false to exclude meta.broken packages from the output
+  includeInsecure ? true, # set this to false to exclude packages marked as insecure from the output
   path ? ./../..,
 
   # used by ./attrpaths.nix
@@ -29,7 +30,7 @@ let
             allowAliases = false;
             allowBroken = includeBroken;
             allowUnfree = true;
-            allowInsecurePredicate = x: true;
+            allowInsecurePredicate = x: includeInsecure;
             allowVariants = !attrNamesOnly;
             checkMeta = true;
 


### PR DESCRIPTION
## Things done

Introduce an `includeInsecure` parameter (default `true`), similar to `includeBroken` that allows to disable the evaluation of packages marked as insecure.

cc @MattSturgeon @wolfgangwalther

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
