### PR TITLE
shadow: Patch comments and tests

### DIFF
--- a/pkgs/by-name/sh/shadow/disable-xaprintf-test.patch
+++ b/pkgs/by-name/sh/shadow/disable-xaprintf-test.patch
@@ -1,0 +1,14 @@
+diff --git a/tests/unit/Makefile.am b/tests/unit/Makefile.am
+index 6e94318..dca18bb 100644
+--- a/tests/unit/Makefile.am
++++ b/tests/unit/Makefile.am
+@@ -10,8 +10,7 @@ check_PROGRAMS = \
+     test_snprintf \
+     test_strncpy \
+     test_strtcpy \
+-    test_typetraits \
+-    test_xaprintf
++    test_typetraits
+ 
+ if ENABLE_LOGIND
+ check_PROGRAMS += \

--- a/pkgs/by-name/sh/shadow/fix-install-with-tcb.patch
+++ b/pkgs/by-name/sh/shadow/fix-install-with-tcb.patch
@@ -1,28 +1,12 @@
 diff --git a/src/Makefile.am b/src/Makefile.am
-index a1a2e4e..fa17f9d 100644
+index 6981815..bcc4568 100644
 --- a/src/Makefile.am
 +++ b/src/Makefile.am
-@@ -74,10 +74,6 @@ suidubins += newgidmap newuidmap
- endif
- endif
- 
--if WITH_TCB
--shadowsgidubins = passwd
--endif
--
- LDADD          = $(INTLLIBS) \
- 		 $(top_builddir)/libmisc/libmisc.la \
- 		 $(top_builddir)/lib/libshadow.la \
-@@ -146,12 +142,6 @@ install-am: all-am
- 	set -e; for i in $(suidusbins); do \
- 		chmod $(suidperms) $(DESTDIR)$(usbindir)/$$i; \
+@@ -152,7 +152,6 @@ install-am: all-am
  	done
--if WITH_TCB
--	set -e; for i in $(shadowsgidubins); do \
+ if WITH_TCB
+ 	set -e; for i in $(shadowsgidubins); do \
 -		chown root:shadow $(DESTDIR)$(ubindir)/$$i; \
--		chmod $(sgidperms) $(DESTDIR)$(ubindir)/$$i; \
--	done
--endif
- if ENABLE_SUBIDS
- if FCAPS
- 	setcap cap_setuid+ep $(DESTDIR)$(ubindir)/newuidmap
+ 		chmod $(sgidperms) $(DESTDIR)$(ubindir)/$$i; \
+ 	done
+ endif

--- a/pkgs/by-name/sh/shadow/package.nix
+++ b/pkgs/by-name/sh/shadow/package.nix
@@ -68,9 +68,13 @@ stdenv.mkDerivation rec {
   ++ lib.optional withTcb tcb;
 
   patches = [
+    # Don't set $PATH to /bin:/usr/bin but inherit the $PATH of the caller.
     ./keep-path.patch
     # Obtain XML resources from XML catalog (patch adapted from gtk-doc)
     ./respect-xml-catalog-files-var.patch
+    # Avoid a chown during install to fix installation with tcb enabled
+    # Would have to be done as part of the NixOS modules,
+    # see https://github.com/NixOS/nixpkgs/issues/109457
     ./fix-install-with-tcb.patch
   ];
 

--- a/pkgs/by-name/sh/shadow/package.nix
+++ b/pkgs/by-name/sh/shadow/package.nix
@@ -19,6 +19,7 @@
   libbsd,
   withTcb ? lib.meta.availableOn stdenv.hostPlatform tcb,
   tcb,
+  cmocka,
 }:
 let
   glibc' =
@@ -108,6 +109,11 @@ stdenv.mkDerivation rec {
     substituteInPlace lib/nscd.c --replace /usr/sbin/nscd ${glibc'.bin}/bin/nscd
   '';
 
+  doCheck = true;
+  nativeCheckInputs = [
+    cmocka
+  ];
+
   postInstall = ''
     # Move the su binary into the su package
     mkdir -p $su/bin
@@ -129,6 +135,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     shellPath = "/bin/nologin";
+    # TODO: Run system tests: https://github.com/shadow-maint/shadow/blob/master/doc/contributions/tests.md#system-tests
     tests = { inherit (nixosTests) shadow; };
   };
 }

--- a/pkgs/by-name/sh/shadow/package.nix
+++ b/pkgs/by-name/sh/shadow/package.nix
@@ -77,6 +77,9 @@ stdenv.mkDerivation rec {
     # Would have to be done as part of the NixOS modules,
     # see https://github.com/NixOS/nixpkgs/issues/109457
     ./fix-install-with-tcb.patch
+    # This unit test fails: https://github.com/shadow-maint/shadow/issues/1382
+    # Can be removed after the next release
+    ./disable-xaprintf-test.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
- Adds missing comments to shadow patches
- Enables unit tests and adds a note for system tests
  - Disable a failing test, see https://github.com/shadow-maint/shadow/issues/1382

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
