### PR TITLE
filera: init at 0.4.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12629,6 +12629,12 @@
     githubId = 31407988;
     name = "Jon Bosque";
   };
+  joncorv = {
+    email = "joncorv@gmail.com";
+    github = "joncorv";
+    githubId = 151096562;
+    name = "Jonathan Corriveau";
+  };
   jonhermansen = {
     name = "Jon Hermansen";
     email = "jon@jh86.org";

--- a/pkgs/by-name/fi/filera/package.nix
+++ b/pkgs/by-name/fi/filera/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenvNoCC,
+  rustPlatform,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  cargo-tauri,
+  glib-networking,
+  nodejs,
+  npmHooks,
+  openssl,
+  pkg-config,
+  webkitgtk_4_1,
+  wrapGAppsHook4,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "filera";
+  version = "0.4.6";
+
+  src = fetchFromGitHub {
+    owner = "joncorv";
+    repo = "filera";
+    tag = "filera-v${finalAttrs.version}";
+    hash = "sha256-T55F8R+WH38Q4lMPTakR4m7A9ELiJaIPTT4BR3p62cA=";
+  };
+
+  cargoHash = "sha256-7dQt1VEJC9Ia9FnL9wFsIqnqoUeaq8E3DayF9lG9kd8=";
+
+  npmDeps = fetchNpmDeps {
+    name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
+    inherit (finalAttrs) src;
+    hash = "sha256-p+AI4hsHjjG8kXDk4fOqKclMCWx7NA8Tyv5xhfHxExs=";
+  };
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    nodejs
+    npmHooks.npmConfigHook
+    pkg-config
+  ]
+  ++ lib.optionals stdenvNoCC.hostPlatform.isLinux [ wrapGAppsHook4 ];
+
+  buildInputs = lib.optionals stdenvNoCC.hostPlatform.isLinux [
+    glib-networking
+    openssl
+    webkitgtk_4_1
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Modern file management application built with Tauri";
+    homepage = "https://github.com/joncorv/filera";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ joncorv ];
+    mainProgram = "filera";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--

This is the first release for Filera. It is a powerful, cross-platform batch file renaming tool written in Rust. Transform messy, disorganized filenames into clean, organized ones with ease.

I built this app with Tauri, so the backend is in Rust, and the frontend i used Vue. It's really fast, and light because it only uses the built-in system webkit. 

Initial support is only x86 Linux for NixOS, but I plan to also support all the nix platforms, because nix is my favorite OS.

-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
