### PR TITLE
caneda: fix build on cmake 4, adopt, modernise and migrate to pkgs/by-name

### DIFF
--- a/pkgs/applications/science/electronics/caneda/default.nix
+++ b/pkgs/applications/science/electronics/caneda/default.nix
@@ -41,7 +41,7 @@ mkDerivation rec {
     mainProgram = "caneda";
     homepage = "http://caneda.org";
     license = lib.licenses.gpl2Plus;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ magicquark ];
     platforms = with lib.platforms; linux;
   };
 }

--- a/pkgs/applications/science/electronics/caneda/default.nix
+++ b/pkgs/applications/science/electronics/caneda/default.nix
@@ -2,6 +2,7 @@
   mkDerivation,
   lib,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   qtbase,
   qttools,
@@ -19,6 +20,13 @@ mkDerivation rec {
     rev = version;
     sha256 = "sha256-oE0cdOwufc7CHEFr3YU8stjg1hBGs4bemhXpNTCTpDQ=";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/c/caneda/0.4.0-2/debian/patches/fix_cmake_minimum_version.patch";
+      hash = "sha256-MRkCA0GWcI6yEo4Ej+F67k0iNG1JHeLNhH0Rbz1QWoA=";
+    })
+  ];
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [

--- a/pkgs/by-name/ca/caneda/package.nix
+++ b/pkgs/by-name/ca/caneda/package.nix
@@ -1,16 +1,13 @@
 {
-  mkDerivation,
+  stdenv,
   lib,
   fetchFromGitHub,
   fetchpatch,
   cmake,
-  qtbase,
-  qttools,
-  qtsvg,
-  qwt6_1,
+  libsForQt5,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "caneda";
   version = "0.4.0";
 
@@ -28,12 +25,16 @@ mkDerivation rec {
     })
   ];
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    cmake
+    libsForQt5.qt5.wrapQtAppsHook
+  ];
+
   buildInputs = [
-    qtbase
-    qttools
-    qtsvg
-    qwt6_1
+    libsForQt5.qtbase
+    libsForQt5.qttools
+    libsForQt5.qtsvg
+    libsForQt5.qwt6_1
   ];
 
   meta = {

--- a/pkgs/by-name/ca/caneda/package.nix
+++ b/pkgs/by-name/ca/caneda/package.nix
@@ -7,14 +7,14 @@
   libsForQt5,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "caneda";
   version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "Caneda";
     repo = "Caneda";
-    rev = version;
+    rev = finalAttrs.version;
     sha256 = "sha256-oE0cdOwufc7CHEFr3YU8stjg1hBGs4bemhXpNTCTpDQ=";
   };
 
@@ -39,10 +39,11 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Open source EDA software focused on easy of use and portability";
+    changelog = "https://github.com/Caneda/Caneda/releases/tag/${finalAttrs.version}";
     mainProgram = "caneda";
     homepage = "http://caneda.org";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ magicquark ];
     platforms = with lib.platforms; linux;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13800,8 +13800,6 @@ with pkgs;
 
   eagle = libsForQt5.callPackage ../applications/science/electronics/eagle/eagle.nix { };
 
-  caneda = libsForQt5.callPackage ../applications/science/electronics/caneda { };
-
   degate = libsForQt5.callPackage ../applications/science/electronics/degate { };
 
   geda = callPackage ../applications/science/electronics/geda {


### PR DESCRIPTION
### `caneda`: Fix Build, Adopt Package, Modernise and Migrate to pkgs/by-name
- The `caneda` package is broken on [`hydra`](https://hydra.nixos.org/build/310529128) due to the `cmake` version being too low. Debian has fixed this by [patching the package](https://sources.debian.org/patches/caneda/0.4.0-2/fix_cmake_minimum_version.patch/), so I have applied their patch.
- As this package has no maintainers, I have adopted it.
- I have migrated this package to `pkgs/by-name`.
- I have modernised the package by using `finalAttrs` and adding the `changelog` to the `meta`. 

### Tracking
https://github.com/NixOS/nixpkgs/issues/445447
https://github.com/NixOS/nixpkgs/issues/457852

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
