### PR TITLE
getdp: 3.6.0 -> 3.6.0-unstable-2025-10-25, gmsh: 4.14.0 -> 4.15.0, adopt

### DIFF
--- a/pkgs/by-name/ge/getdp/package.nix
+++ b/pkgs/by-name/ge/getdp/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitLab,
   cmake,
   gfortran,
   blas,
@@ -14,12 +14,16 @@
 let
   mpiSupport = petsc.passthru.mpiSupport;
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "getdp";
-  version = "3.6.0";
-  src = fetchurl {
-    url = "http://getdp.info/src/getdp-${version}-source.tgz";
-    hash = "sha256-nzefwCV+Z9BHDofuTfhR+vhqm3cCSiUT+7cbtn601N8=";
+  version = "3.6.0-unstable-2025-10-25";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.onelab.info";
+    owner = "getdp";
+    repo = "getdp";
+    rev = "cac7f393ac34be1618b588083d2e391efd4976f7";
+    hash = "sha256-yiqi9Fb3UM81iJtpU+Mg71BB73injdkWCzbJGgor4ww=";
   };
 
   nativeBuildInputs = [
@@ -35,7 +39,7 @@ stdenv.mkDerivation rec {
   ++ lib.optional mpiSupport mpi;
   cmakeFlags = lib.optional mpiSupport "-DENABLE_MPI=1";
 
-  meta = with lib; {
+  meta = {
     description = "General Environment for the Treatment of Discrete Problems";
     mainProgram = "getdp";
     longDescription = ''
@@ -46,8 +50,8 @@ stdenv.mkDerivation rec {
       symbolic mathematical expressions of these problems.
     '';
     homepage = "http://getdp.info/";
-    license = licenses.gpl2Plus;
+    license = lib.licenses.gpl2Plus;
     maintainers = [ ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/ge/getdp/package.nix
+++ b/pkgs/by-name/ge/getdp/package.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation {
     '';
     homepage = "http://getdp.info/";
     license = lib.licenses.gpl2Plus;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ iedame ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/gm/gmsh/package.nix
+++ b/pkgs/by-name/gm/gmsh/package.nix
@@ -25,11 +25,11 @@ assert (!blas.isILP64) && (!lapack.isILP64);
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gmsh";
-  version = "4.14.0";
+  version = "4.15.0";
 
   src = fetchurl {
     url = "https://gmsh.info/src/gmsh-${finalAttrs.version}-source.tgz";
-    hash = "sha256-2019ogYumkNWqCCDITirmfl69jiL/rIVmaLq37C3aig=";
+    hash = "sha256-q7JjJxW9fQEw3tcUT9YmNjXNfeqIO432G6TaWM5qHf4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gm/gmsh/package.nix
+++ b/pkgs/by-name/gm/gmsh/package.nix
@@ -113,5 +113,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://gmsh.info/";
     changelog = "https://gitlab.onelab.info/gmsh/gmsh/-/releases/gmsh_${lib.concatStringsSep "_" (lib.versions.splitVersion finalAttrs.version)}#changelog";
     license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ iedame ];
   };
 })


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/457852
- https://github.com/NixOS/nixpkgs/issues/445447

updated `getdp` to latest unstable version, fixing cmake4 build error.
switched to official gitlab source since the website tgz files no longer exist for 3.6.0.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
