### PR TITLE
vpp: 25.06 -> 25.10, cleanup

### DIFF
--- a/pkgs/by-name/vp/vpp/use-dynamic-libs.patch
+++ b/pkgs/by-name/vp/vpp/use-dynamic-libs.patch
@@ -11,3 +11,17 @@
  vpp_plugin_find_library(af_xdp ELF_LIB elf)
  vpp_plugin_find_library(af_xdp Z_LIB z)
  if (NOT XDP_LIB OR NOT BPF_LIB OR NOT ELF_LIB OR NOT Z_LIB)
+
+--- a/plugins/rdma/CMakeLists.txt
++++ b/plugins/rdma/CMakeLists.txt
+@@ -18,8 +18,8 @@ if (NOT IBVERBS_INCLUDE_DIR)
+   return()
+ endif()
+ 
+-vpp_plugin_find_library(rdma IBVERBS_LIB libibverbs.a)
+-vpp_plugin_find_library(rdma MLX5_LIB libmlx5.a)
++vpp_plugin_find_library(rdma IBVERBS_LIB ibverbs)
++vpp_plugin_find_library(rdma MLX5_LIB mlx5)
+ 
+ if (NOT IBVERBS_LIB OR NOT MLX5_LIB)
+   message(WARNING "rdma plugin - ibverbs not found - rdma plugin disabled")

--- a/pkgs/by-name/vp/vpp/xdp-skb-mode.patch
+++ b/pkgs/by-name/vp/vpp/xdp-skb-mode.patch
@@ -1,0 +1,10 @@
+--- a/plugins/af_xdp/device.c
++++ b/plugins/af_xdp/device.c
+@@ -330,6 +330,7 @@
+   sock_config.rx_size = args->rxq_size;
+   sock_config.tx_size = args->txq_size;
+   sock_config.bind_flags = XDP_USE_NEED_WAKEUP;
++  sock_config.xdp_flags = XDP_FLAGS_SKB_MODE;
+   switch (args->mode)
+     {
+     case AF_XDP_MODE_AUTO:


### PR DESCRIPTION
Supersedes #446546, is currently soft-blocking #461159.

Added `strictDeps`, replaced `rec` with `finalAttrs`, and generally significantly improved how the optional dependencies are handled. Tested with the tests from #347797.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
