### PR TITLE
reddix: init at 0.2.8

### DIFF
--- a/pkgs/by-name/re/reddix/package.nix
+++ b/pkgs/by-name/re/reddix/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  sqlite,
+  stdenv,
+  darwin,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "reddix";
+  version = "0.2.8";
+
+  src = fetchFromGitHub {
+    owner = "ck-zhang";
+    repo = "reddix";
+    rev = "v${version}";
+    hash = "sha256-ZjsM2Q3vKKw47iOZQDBYTkG/CixErMmfniqZITZdhFY=";
+  };
+
+  cargoHash = "sha256-YRaV3UjgoW9Ursb1Nmh2z7WI7obc9Ow7z9Le6Gmwx9s=";
+
+  passthru.update-script = nix-update-script { };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    sqlite
+  ]
+  ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.AppKit
+    darwin.apple_sdk.frameworks.CoreServices
+    darwin.apple_sdk.frameworks.Security
+  ];
+
+  meta = {
+    description = "Reddix – Reddit, refined for the terminal";
+    homepage = "https://github.com/ck-zhang/reddix";
+    changelog = "https://github.com/ck-zhang/reddix/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nebunebu ];
+    mainProgram = "reddix";
+  };
+}


### PR DESCRIPTION
Initialize reddix, a tui client for reddit. 

https://github.com/ck-zhang/reddix

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
