### PR TITLE
nixos/clickhouse: allow configuring with Nix attribute set

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -279,6 +279,7 @@
 
 - `cloudflare-ddns`: Added package cloudflare-ddns.
 
+- `clickhouse`: Added `serverConfig`, `usersConfig` configuration options accepting Nix attribute sets. Also added `extraServerConfig` and `extraUsersConfig` options accepting plain text (expecting XML configuration).
 
 - [`homebox` 0.20.0](https://github.com/sysadminsmedia/homebox/releases/tag/v0.20.0) changed how assets are stored and hashed. It is recommended to back up your database before this update. In particular, `--storage-data` was replaced with `--storage-conn-string` and `--storage-prefix-path`. If your configuration set `HBOX_STORAGE_DATA` manually, you must migrate it to `HBOX_STORAGE_CONN_STRING` and `HBOX_STORAGE_PREFIX_PATH`.
 

--- a/nixos/modules/services/databases/clickhouse.nix
+++ b/nixos/modules/services/databases/clickhouse.nix
@@ -6,8 +6,14 @@
 }:
 let
   cfg = config.services.clickhouse;
+  format = pkgs.formats.yaml { };
+
+  serverConfigFile = format.generate "config.yaml" cfg.serverConfig;
+  usersConfigFile = format.generate "users.yaml" cfg.usersConfig;
 in
 {
+
+  meta.maintainers = [ "thevar1able" ];
 
   ###### interface
 
@@ -17,7 +23,86 @@ in
 
       enable = lib.mkEnableOption "ClickHouse database server";
 
-      package = lib.mkPackageOption pkgs "clickhouse" { };
+      package = lib.mkPackageOption pkgs "clickhouse" {
+        example = "pkgs.clickhouse-lts";
+      };
+
+      serverConfig = lib.mkOption {
+        type = format.type;
+        default = { };
+        example = lib.literalExpression ''
+          {
+            http_port = 8123;
+            tcp_port = 9000;
+
+            remote_servers = {
+              default = {
+                shard = {
+                  replica = [
+                    { host = "::"; port = "9000"; }
+                    { host = "::"; port = "9001"; }
+                    { host = "::"; port = "9002"; }
+                  ];
+                };
+              };
+            };
+          }
+        '';
+        description = ''
+          Your {file}`config.yaml` as a Nix attribute set.
+          Check the [documentation](https://clickhouse.com/docs/operations/configuration-files)
+          for possible options.
+        '';
+      };
+
+      usersConfig = lib.mkOption {
+        type = format.type;
+        default = { };
+        example = lib.literalExpression ''
+          {
+            profiles = {};
+
+            users = {
+              default = {
+                profile = "default";
+                password_sha256_hex = "36dd292533174299fb0c34665df468bb881756ca9eaf9757d0cfde38f9ededa1";  # `echo -n verysecret | sha256sum`
+              };
+            };
+          }
+        '';
+        description = ''
+          Your {file}`users.yaml` as a Nix attribute set.
+          Check the [documentation](https://clickhouse.com/docs/operations/configuration-files#user-settings)
+          for possible options.
+        '';
+      };
+
+      extraServerConfig = lib.mkOption {
+        type = lib.types.lines;
+        default = "";
+        example = ''
+          <clickhouse>
+            <max_connections>500</max_connections>
+            <keep_alive_timeout>3</keep_alive_timeout>
+          </clickhouse>
+        '';
+        description = "Additional raw XML configuration for ClickHouse server.";
+      };
+
+      extraUsersConfig = lib.mkOption {
+        type = lib.types.lines;
+        default = "";
+        example = ''
+          <clickhouse>
+            <users>
+              <readonly>
+                <profile>readonly</profile>
+              </readonly>
+            </users>
+          </clickhouse>
+        '';
+        description = "Additional raw XML configuration for ClickHouse server.";
+      };
 
     };
 
@@ -40,18 +125,15 @@ in
       description = "ClickHouse server";
 
       wantedBy = [ "multi-user.target" ];
-
       after = [ "network.target" ];
 
       serviceConfig = {
         Type = "notify";
         User = "clickhouse";
         Group = "clickhouse";
-        ConfigurationDirectory = "clickhouse-server";
         AmbientCapabilities = "CAP_SYS_NICE";
         StateDirectory = "clickhouse";
-        LogsDirectory = "clickhouse";
-        ExecStart = "${cfg.package}/bin/clickhouse-server --config-file=/etc/clickhouse-server/config.xml";
+        ExecStart = "${cfg.package}/bin/clickhouse-server --config=/etc/clickhouse-server/config.xml";
         TimeoutStartSec = "infinity";
       };
 
@@ -69,6 +151,26 @@ in
       "clickhouse-server/users.xml" = {
         source = "${cfg.package}/etc/clickhouse-server/users.xml";
       };
+
+      "clickhouse-server/config.d/100-nixos-module-config.yaml" = lib.mkIf (cfg.serverConfig != { }) {
+        source = serverConfigFile;
+      };
+
+      "clickhouse-server/users.d/100-nixos-module-config.yaml" = lib.mkIf (cfg.usersConfig != { }) {
+        source = usersConfigFile;
+      };
+
+      "clickhouse-server/config.d/200-nixos-module-extra-config.xml" =
+        lib.mkIf (cfg.extraServerConfig != "")
+          {
+            text = cfg.extraServerConfig;
+          };
+
+      "clickhouse-server/users.d/200-nixos-module-extra-config.xml" =
+        lib.mkIf (cfg.extraUsersConfig != "")
+          {
+            text = cfg.extraUsersConfig;
+          };
     };
 
     environment.systemPackages = [ cfg.package ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Allow configuring `clickhouse` package with `serverConfig`, `usersConfig` parameters accepting Nix attribute sets.
```
services.clickhouse = {
  enable = true;

   serverConfig = {
     display_name = "hello-from-nixos-module";

     http_port = 8124;
     tcp_port = 9000;
   };
}
```

- If something goes wrong with Nix-to-YAML converter, `extraServerConfig` and `extraUsersConfig` parameters accepting plain text (XML expected) are also provided.
```
services.clickhouse = {
  enable = true;

  extraServerConfig = ''
    <clickhouse>
      <mysql_port>11234</mysql_port>
    </clickhouse>
  '';

  extraUsersConfig = ''
    <clickhouse>
      <users>
        <analyst>
          <profile>default</profile>
          <password>analyst_password</password>
          <quota>default</quota>
          <allow_databases>
            <database>analytics</database>
            <database>logs</database>
          </allow_databases>
        </analyst>
        <readonly_user>
          <profile>readonly</profile>
          <password>readonly_pass</password>
          <quota>default</quota>
          <allow_databases>
            <database>public_data</database>
          </allow_databases>
        </readonly_user>
      </users>
    </clickhouse>
  '';
}
```

Backward compatibility is preserved, embedded config is still placed at `config.xml` and `users.xml` at the root folder. New configuration is picked automatically from `config.d/` and `users.d/`. Notice that configuration files are numbered; before processing, included configuration are sorted to determine overlay priority.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
