### PR TITLE
various: modernize, add self as maintainer

### DIFF
--- a/pkgs/by-name/li/libmnl/package.nix
+++ b/pkgs/by-name/li/libmnl/package.nix
@@ -4,13 +4,13 @@
   fetchurl,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libmnl";
   version = "1.0.5";
 
   src = fetchurl {
-    url = "https://netfilter.org/projects/libmnl/files/${pname}-${version}.tar.bz2";
-    sha256 = "09851ns07399rbz0y8slrlmnw3fn1nakr8d37pxjn5gkks8rnjr7";
+    url = "https://netfilter.org/projects/libmnl/files/libmnl-${finalAttrs.version}.tar.bz2";
+    hash = "sha256-J0ubkZ7zFSv7PaOhPJUN1g1uK81UIw/+yimNA7QNBSU=";
   };
 
   meta = {
@@ -19,12 +19,12 @@ stdenv.mkDerivation rec {
       libmnl is a minimalistic user-space library oriented to Netlink developers.
       There are a lot of common tasks in parsing, validating, constructing of both the Netlink
       header and TLVs that are repetitive and easy to get wrong.
-      This library aims to provide simple helpers that allows you to re-use code and to avoid
+      This library aims to provide simple helpers that allow you to re-use code and avoid
       re-inventing the wheel.
     '';
     homepage = "https://netfilter.org/projects/libmnl/index.html";
     license = lib.licenses.lgpl21Plus;
-
     platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ azey7f ];
   };
-}
+})

--- a/pkgs/by-name/su/subunit/package.nix
+++ b/pkgs/by-name/su/subunit/package.nix
@@ -9,23 +9,26 @@
   python3Packages,
 }:
 
-# NOTE: for subunit python library see pkgs/top-level/python-packages.nix
+# NOTE: for the subunit python library see pkgs/top-level/python-packages.nix
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "subunit";
   version = "1.4.2";
 
   src = fetchurl {
-    url = "https://launchpad.net/subunit/trunk/${version}/+download/${pname}-${version}.tar.gz";
+    url = "https://launchpad.net/subunit/trunk/${finalAttrs.version}/+download/subunit-${finalAttrs.version}.tar.gz";
     hash = "sha256-hlOOv6kIC97w7ICVsuXeWrsUbVu3tCSzEVKUHXYG2dI=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    perl
+    python3Packages.wrapPython
+    python3Packages.testscenarios
+  ];
   buildInputs = [
     check
     cppunit
-    perl
-    python3Packages.wrapPython
   ];
 
   propagatedBuildInputs = with python3Packages; [
@@ -33,13 +36,16 @@ stdenv.mkDerivation rec {
     testscenarios
   ];
 
+  strictDeps = true;
+
   postFixup = "wrapPythonPrograms";
 
-  meta = with lib; {
+  meta = {
     description = "Streaming protocol for test results";
     mainProgram = "subunit-diff";
     homepage = "https://launchpad.net/subunit";
-    license = licenses.asl20;
-    platforms = platforms.all;
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ azey7f ];
   };
-}
+})

--- a/pkgs/by-name/te/terminus_font/package.nix
+++ b/pkgs/by-name/te/terminus_font/package.nix
@@ -7,13 +7,13 @@
   xorg,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "terminus-font";
   version = "4.49.1";
 
   src = fetchurl {
-    url = "mirror://sourceforge/project/${pname}/${pname}-${lib.versions.majorMinor version}/${pname}-${version}.tar.gz";
-    sha256 = "0yggffiplk22lgqklfmd2c0rw8gwchynjh5kz4bz8yv2h6vw2qfr";
+    url = "mirror://sourceforge/project/terminus-font/terminus-font-${lib.versions.majorMinor finalAttrs.version}/terminus-font-${finalAttrs.version}.tar.gz";
+    hash = "sha256-2WHBt4Fie/QX+bNAaT1k/CGeAROtOjrxo0JMeqNz73k=";
   };
 
   patches = [ ./SOURCE_DATE_EPOCH-for-otb.patch ];
@@ -23,6 +23,8 @@ stdenv.mkDerivation rec {
     bdftopcf
     xorg.mkfontscale
   ];
+
+  strictDeps = true;
 
   enableParallelBuilding = true;
 
@@ -40,7 +42,7 @@ stdenv.mkDerivation rec {
   # to make, so we need to disable parallelism:
   enableParallelInstalling = false;
 
-  meta = with lib; {
+  meta = {
     description = "Clean fixed width font";
     longDescription = ''
       Terminus Font is designed for long (8 and more hours per day) work
@@ -55,6 +57,7 @@ stdenv.mkDerivation rec {
       EGA/VGA-bold for 8x14 and 8x16.
     '';
     homepage = "https://terminus-font.sourceforge.net/";
-    license = licenses.ofl;
+    license = lib.licenses.ofl;
+    maintainers = with lib.maintainers; [ azey7f ];
   };
-}
+})

--- a/pkgs/by-name/te/terminus_font_ttf/package.nix
+++ b/pkgs/by-name/te/terminus_font_ttf/package.nix
@@ -4,12 +4,12 @@
   fetchzip,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "terminus-font-ttf";
   version = "4.49.3";
 
   src = fetchzip {
-    url = "https://files.ax86.net/terminus-ttf/files/${version}/terminus-ttf-${version}.zip";
+    url = "https://files.ax86.net/terminus-ttf/files/${finalAttrs.version}/terminus-ttf-${finalAttrs.version}.zip";
     hash = "sha256-dK7MH4I1RhsIGzcnRA+7f3P5oi9B63RA+uASVDNtxNI=";
   };
 
@@ -26,14 +26,14 @@ stdenvNoCC.mkDerivation rec {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Clean fixed width TTF font";
     longDescription = ''
       Monospaced bitmap font designed for long work with computers
       (TTF version, mainly for Java applications)
     '';
     homepage = "https://files.ax86.net/terminus-ttf";
-    license = licenses.ofl;
-    maintainers = [ ];
+    license = lib.licenses.ofl;
+    maintainers = with lib.maintainers; [ azey7f ];
   };
-}
+})


### PR DESCRIPTION
Affected: `terminus-font{,-ttf}`, `libmnl`, `subunit`

None of these packages currently have a maintainer, and since I'm actively using them (both terminus packages on my desktops, and `libmnl`+`subunit` as part of `vpp`, which I'm maintaining) I figured I might as well add myself as a maintainer.

`libmnl` and `terminus-font` were still using the deprecated `sha256` attr instead of `hash`, which I fixed, but will probably cause some rebuilds. I also added `strictDeps` where applicable, made the packages use `finalAttrs` instead of `rec`, and removed instances of `with lib;` and `pname` in `src`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
