### PR TITLE
python3Packages.taxi: disable failing tests

### DIFF
--- a/pkgs/development/python-modules/taxi/default.nix
+++ b/pkgs/development/python-modules/taxi/default.nix
@@ -35,6 +35,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "taxi" ];
 
+  # Broken by the update of `click` from version 8.1.8 -> 8.2.1 in
+  # https://github.com/NixOS/nixpkgs/pull/448189.
+  disabledTests = [
+    "test_ignore_date_error_week_day"
+    "test_ignore_date_error_previous_day"
+  ];
+
   meta = with lib; {
     homepage = "https://github.com/sephii/taxi/";
     description = "Timesheeting made easy";


### PR DESCRIPTION
### python3Packages.taxi: disable failing tests
- This package fails to build in [Hydra](https://hydra.nixos.org/build/310724049).
- This is because the `nixpkgs` update of `python3Packages.click` from 8.1.8 to 8.2.1 in [PR 448189](https://github.com/NixOS/nixpkgs/pull/448189) has made these tests fail. The failures are occurring because of the way that interactive inputs are handled.

### Tracking
https://github.com/NixOS/nixpkgs/issues/457852

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
