### PR TITLE
ankiAddons.fsrs4anki-helper: init at 24.06.3-unstable-2025-01-28

### DIFF
--- a/pkgs/by-name/an/anki/addons/default.nix
+++ b/pkgs/by-name/an/anki/addons/default.nix
@@ -10,6 +10,8 @@
 
   anki-quizlet-importer-extended = callPackage ./anki-quizlet-importer-extended { };
 
+  fsrs4anki-helper = callPackage ./fsrs4anki-helper { };
+
   image-occlusion-enhanced = callPackage ./image-occlusion-enhanced { };
 
   local-audio-yomichan = callPackage ./local-audio-yomichan { };

--- a/pkgs/by-name/an/anki/addons/fsrs4anki-helper/default.nix
+++ b/pkgs/by-name/an/anki/addons/fsrs4anki-helper/default.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  anki-utils,
+  fetchFromGitHub,
+  unstableGitUpdater,
+  python3,
+}:
+
+anki-utils.buildAnkiAddon (finalAttrs: {
+  pname = "fsrs4anki-helper";
+  version = "24.06.3-unstable-2025-01-28";
+
+  src = fetchFromGitHub {
+    owner = "open-spaced-repetition";
+    repo = "fsrs4anki-helper";
+    rev = "8934a5d53caa68bf688e6b0964c36fb5a87970c0";
+    hash = "sha256-2vDPEXfFeR7z8WMC96bSaDJ2nLN16dZicAVu1Nnq558=";
+  };
+
+  postFixup = ''
+    rmdir $out/share/anki/addons/fsrs4anki-helper/python_i18n
+    ln -s \
+      ${python3.pkgs.python-i18n}/${python3.sitePackages} \
+      $out/share/anki/addons/fsrs4anki-helper/python_i18n
+  '';
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "Anki add-on that supports the FSRS algorithm";
+    longDescription = ''
+      FSRS Helper is an Anki add-on that supports the FSRS algorithm. It has eight main features:
+
+      - Reschedule cards based on their entire review histories.
+      - Postpone a selected number of due cards.
+      - Advance a selected number of undue cards.
+      - Balance the load during rescheduling (based on fuzz).
+      - Less Anki on Easy Days (such as weekends) during rescheduling (based on load balance).
+      - Disperse Siblings (cards with the same note) to avoid interference & reminder.
+      - Flatten future due cards to a selected number of reviews per day.
+      - Steps Stats quantify your short-term memory performance and recommend learning steps.
+
+      It can also be configured declaratively, as follows:
+
+      ```nix
+      pkgs.ankiAddons.fsrs4anki-helper.withConfig {
+        config = {
+          days_to_reschedule = 10;
+          auto_reschedule_after_sync = true;
+          display_memory_state = true;
+        };
+      }
+      ```
+
+      For a list of all configuration options, please refer to [config.md](https://github.com/open-spaced-repetition/fsrs4anki-helper/blob/${finalAttrs.src.rev}/config.md).
+    '';
+    homepage = "https://github.com/open-spaced-repetition/fsrs4anki-helper";
+    downloadPage = "https://ankiweb.net/shared/info/759844606";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ eljamm ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
