### PR TITLE
doxygen_gui: build against qt6

### DIFF
--- a/pkgs/development/tools/documentation/doxygen/default.nix
+++ b/pkgs/development/tools/documentation/doxygen/default.nix
@@ -6,7 +6,7 @@
   python3,
   flex,
   bison,
-  qt5,
+  qt6,
   libiconv,
   spdlog,
   fmt,
@@ -45,20 +45,18 @@ stdenv.mkDerivation (finalAttrs: {
     fmt
     sqlite
   ]
-  ++ lib.optionals (qt5 != null) (
-    with qt5;
-    [
-      qtbase
-      wrapQtAppsHook
-    ]
-  );
+  ++ lib.optionals (qt6 != null) [
+    qt6.qtbase
+    qt6.wrapQtAppsHook
+    qt6.qtsvg
+  ];
 
   cmakeFlags = [
     "-Duse_sys_spdlog=ON"
     "-Duse_sys_fmt=ON"
     "-Duse_sys_sqlite3=ON"
   ]
-  ++ lib.optional (qt5 != null) "-Dbuild_wizard=YES";
+  ++ lib.optional (qt6 != null) "-Dbuild_wizard=YES";
 
   # put examples in an output so people/tools can test against them
   outputs = [
@@ -85,6 +83,6 @@ stdenv.mkDerivation (finalAttrs: {
       off-line reference manual (in LaTeX) from a set of documented source
       files.
     '';
-    platforms = if qt5 != null then lib.platforms.linux else lib.platforms.unix;
+    platforms = if qt6 != null then lib.platforms.linux else lib.platforms.unix;
   };
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6495,10 +6495,10 @@ with pkgs;
   dot2tex = with python3.pkgs; toPythonApplication dot2tex;
 
   doxygen = callPackage ../development/tools/documentation/doxygen {
-    qt5 = null;
+    qt6 = null;
   };
 
-  doxygen_gui = lowPrio (doxygen.override { inherit qt5; });
+  doxygen_gui = lowPrio (doxygen.override { inherit qt6; });
 
   drake = callPackage ../development/tools/build-managers/drake { };
 


### PR DESCRIPTION
qt5 is on the way out. Upstream doxygen defaults to qt6 since 1.15.0 [1]. We should adjust our nix packaging accordingly.
This does break the override interface stability.
However, we never really guaranteed override stability, so this should be fine even during freeze month.

[1] https://www.doxygen.nl/manual/changelog.html


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
