### PR TITLE
pkgs/top-level/impure*: use XDG_CONFIG_HOME instead of ~/.config

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -66,6 +66,8 @@
 
 - `super-productivity` has been updated. The binary has been renamed from `super-productivity` to `superproductivity`. A symlink from the old name is provided for backward compatibility.
 
+- Impure config (`config.nix`) and overlays (`overlays.nix` and `overlays/*.nix`) are now detectable under `$XDG_CONFIG_HOME/nixpkgs`, respecting user's choice of `$XDG_CONFIG_HOME` (falls back to `~/.config` if unset).
+
 - Package-URL (PURL, https://github.com/package-url/purl-spec) metadata identifier has been added for `fetchgit`, `fetchpypi` and `fetchFromGithub` fetchers.
   `mkDerivation` has been adjusted to reuse this information.
   Package-URLs allow reliably identifying and locating software packages.

--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -196,6 +196,8 @@
 
 - All databases of the MySQL family – `mysql`, `mariadb` and `percona` – now provide a client-only package `client` sub-attribute. Use the `<dbname>.client` package if the server components are not needed. The main package continues to ship the client binaries as well.
 
+- Impure config (`config.nix`) and overlays (`overlays.nix` and `overlays/*.nix`) are now detectable under `$XDG_CONFIG_HOME/nixpkgs`, respecting user's choice of `$XDG_CONFIG_HOME` (falls back to `~/.config` if unset).
+
 - Package-URL (PURL, https://github.com/package-url/purl-spec) metadata identifier has been added for `fetchgit`, `fetchpypi` and `fetchFromGithub` fetchers.
   `mkDerivation` has been adjusted to reuse this information.
   Package-URLs allow reliably identifying and locating software packages.

--- a/doc/using/configuration.chapter.md
+++ b/doc/using/configuration.chapter.md
@@ -20,7 +20,7 @@ All this is checked during evaluation already, and the check includes any packag
 In particular, all build-time dependencies are checked.
 :::
 
-A user's Nixpkgs configuration is stored in a user-specific configuration file located at `~/.config/nixpkgs/config.nix`. For example:
+A user's Nixpkgs configuration is stored in a user-specific configuration file located at `$XDG_CONFIG_HOME/nixpkgs/config.nix` (if `$XDG_CONFIG_HOME` is unset or empty, the search will fall back to `~/.config/nixpkgs/config.nix`). For example:
 
 ```nix
 { allowUnfree = true; }

--- a/doc/using/overlays.chapter.md
+++ b/doc/using/overlays.chapter.md
@@ -26,7 +26,7 @@ The list of overlays is determined as follows.
 
     See the [section on `NIX_PATH`](https://nixos.org/manual/nix/stable/command-ref/env-common.html#env-NIX_PATH) in the Nix manual for more details on how to set a value for `<nixpkgs-overlays>.`
 
-3.  If one of `~/.config/nixpkgs/overlays.nix` and `~/.config/nixpkgs/overlays/` exists, then we look for overlays at that path, as described below. It is an error if both exist.
+3.  If one of `$XDG_CONFIG_HOME/nixpkgs/overlays.nix` and `$XDG_CONFIG_HOME/nixpkgs/overlays/` exists (if `$XDG_CONFIG_HOME` is unset or empty, the search falls back to `~/.config/nixpkgs/overlays.nix` or `~/.config/nixpkgs/overlays/` respectively), then we look for overlays at that path, as described below. It is an error if both exist.
 
 If we are looking for overlays at a path, then there are two cases:
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -18,6 +18,7 @@ let
   inherit (pkgs.lib)
     isAttrs
     isFunction
+    genAttrs
     mapAttrs
     elem
     recurseIntoAttrs
@@ -1175,6 +1176,13 @@ in
   nixpkgs-config-allow-unfree-packages-and-predicate =
     pkgs.callPackage ../../pkgs/stdenv/generic/check-meta-test.nix
       { };
+  nixpkgs-xdg = genAttrs [ "config" "overlays" ] (
+    feature:
+    runTest {
+      imports = [ ./nixpkgs-xdg.nix ];
+      _module.args = { inherit feature; };
+    }
+  );
   nixseparatedebuginfod2 = runTest ./nixseparatedebuginfod2.nix;
   nmtrust = runTest ./nmtrust.nix;
   node-red = runTest ./node-red.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -18,6 +18,7 @@ let
   inherit (pkgs.lib)
     isAttrs
     isFunction
+    genAttrs
     mapAttrs
     elem
     meta
@@ -1257,6 +1258,13 @@ in
   nixpkgs-config-allow-unfree-packages-and-predicate =
     pkgs.callPackage ../../pkgs/stdenv/generic/check-meta-test.nix
       { };
+  nixpkgs-xdg = genAttrs [ "config" "overlays" ] (
+    feature:
+    runTest {
+      imports = [ ./nixpkgs-xdg.nix ];
+      _module.args = { inherit feature; };
+    }
+  );
   nixseparatedebuginfod2 = runTest ./nixseparatedebuginfod2.nix;
   nmtrust = runTest ./nmtrust.nix;
   node-red = runTest ./node-red.nix;

--- a/nixos/tests/nixpkgs-xdg.nix
+++ b/nixos/tests/nixpkgs-xdg.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  feature,
+  ...
+}:
+{
+  name = "xdg-impure-${feature}";
+  meta.maintainers = with lib.maintainers; [
+    acidbong
+  ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      nix.nixPath = lib.mkOrder 0 [
+        "nixpkgs=${lib.cleanSource pkgs.path}"
+      ];
+    };
+
+  testScript =
+    let
+      key = "xdgConfigHome";
+      finalKey = if (feature == "overlays") then key else "config.${key}";
+      settings = ''{{ ${key} = \"{path}\"; }}'';
+      finalSettings = if (feature == "config") then settings else "[(final: prev: ${settings})]";
+    in
+    /* py */ ''
+      xdg_configs = dict(unset="", default="~/.config", custom="~/.cfg")
+      yellow = "\033[0;33m"
+      bold = "\033[1m"
+      reset = "\033[0m"
+
+      machine.wait_for_unit("nix-daemon.socket")
+      for status, path in xdg_configs.items():
+          print(
+              f"{yellow}XDG_CONFIG_HOME is {bold}{status}{yellow} ({path or f"should default to {xdg_configs["default"]}"}){reset}"
+          )
+          machine.execute(f"mkdir -pv {path or xdg_configs["default"]}/nixpkgs")
+          machine.execute(
+              f"echo '${finalSettings}' > {path or xdg_configs["default"]}/nixpkgs/${feature}.nix"
+          )
+          pathFromNix = machine.succeed(
+              f"env XDG_CONFIG_HOME={path} nix-instantiate --eval -E '(import <nixpkgs> {{}}).${finalKey}'"
+          ).strip('"\n')
+          print(f"{bold}expected:{reset} '{path}'")
+          print(f"{bold}got:{reset} '{pathFromNix}'")
+          assert path == pathFromNix
+    '';
+}

--- a/pkgs/top-level/impure-overlays.nix
+++ b/pkgs/top-level/impure-overlays.nix
@@ -11,11 +11,13 @@ let
     in
     if res.success then res.value else def;
   homeDir = builtins.getEnv "HOME";
+  xdgConfigHomeVar = builtins.getEnv "XDG_CONFIG_HOME";
+  xdgConfigHome = if xdgConfigHomeVar != "" then xdgConfigHomeVar else homeDir + "/.config";
 
   isDir = path: builtins.pathExists (path + "/.");
   pathOverlays = try (toString <nixpkgs-overlays>) "";
-  homeOverlaysFile = homeDir + "/.config/nixpkgs/overlays.nix";
-  homeOverlaysDir = homeDir + "/.config/nixpkgs/overlays";
+  homeOverlaysFile = xdgConfigHome + "/nixpkgs/overlays.nix";
+  homeOverlaysDir = xdgConfigHome + "/nixpkgs/overlays";
   overlays =
     path:
     # check if the path is a directory or a file

--- a/pkgs/top-level/impure.nix
+++ b/pkgs/top-level/impure.nix
@@ -3,12 +3,6 @@
   for the meaning of each argument.
 */
 
-let
-
-  homeDir = builtins.getEnv "HOME";
-
-in
-
 {
   # We put legacy `system` into `localSystem`, if `localSystem` was not passed.
   # If neither is passed, assume we are building packages on the current
@@ -26,8 +20,11 @@ in
   # $HOME/.config/nixpkgs/config.nix.
   config ?
     let
+      homeDir = builtins.getEnv "HOME";
+      xdgConfigHomeVar = builtins.getEnv "XDG_CONFIG_HOME";
+      xdgConfigHome = if xdgConfigHomeVar != "" then xdgConfigHomeVar else homeDir + "/.config";
       configFile = builtins.getEnv "NIXPKGS_CONFIG";
-      configFile2 = homeDir + "/.config/nixpkgs/config.nix";
+      configFile2 = xdgConfigHome + "/nixpkgs/config.nix";
       configFile3 = homeDir + "/.nixpkgs/config.nix"; # obsolete
     in
     if configFile != "" && builtins.pathExists configFile then


### PR DESCRIPTION
If someone wants to change their XDG_CONFIG_HOME from `~/.config`, Nixpkgs impure config and overlays should respect that.

~~Can't test due to typing from Nix-less phone, hope I didn't break anything~~ Got to my PC.

Demo:
```console
$ XDG_CONFIG_HOME=~/.cfg nix-build -A emacs
error:
       … while calling the 'throw' builtin
         at /home/acid/.cfg/nixpkgs/overlays.nix:3:13:
            2|   (final: prev: {
            3|     emacs = throw "hell nah";
             |             ^
            4|   })

       error: hell nah

$ nix-build -A emacs
error:
       … while calling the 'throw' builtin
         at /home/acid/.config/nixpkgs/overlays.nix:3:13:
            2|   (final: prev: {
            3|     emacs = throw "fr?";
             |             ^
            4|   })

       error: fr?
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
  - [x] Misc: when the change is significant.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
