### PR TITLE
maintainers: drop robberer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22251,12 +22251,6 @@
     githubId = 580474;
     name = "Carsten Rohrbach";
   };
-  robberer = {
-    email = "robberer@freakmail.de";
-    github = "robberer";
-    githubId = 6204883;
-    name = "Longrin Wischnewski";
-  };
   robbiebuxton = {
     email = "robbiesbuxton@gmail.com";
     github = "robbiebuxton";

--- a/pkgs/applications/science/electronics/fritzing/default.nix
+++ b/pkgs/applications/science/electronics/fritzing/default.nix
@@ -137,7 +137,6 @@ stdenv.mkDerivation {
       cc-by-sa-30
     ];
     maintainers = with lib.maintainers; [
-      robberer
       muscaln
       iedame
     ];

--- a/pkgs/by-name/cl/clamav/package.nix
+++ b/pkgs/by-name/cl/clamav/package.nix
@@ -82,7 +82,6 @@ stdenv.mkDerivation rec {
     description = "Antivirus engine designed for detecting Trojans, viruses, malware and other malicious threats";
     license = licenses.gpl2Only;
     maintainers = with maintainers; [
-      robberer
       qknight
       globin
     ];

--- a/pkgs/by-name/mr/mrtg/package.nix
+++ b/pkgs/by-name/mr/mrtg/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     description = "Multi Router Traffic Grapher";
     homepage = "https://oss.oetiker.ch/mrtg/";
     license = licenses.gpl2Only;
-    maintainers = with maintainers; [ robberer ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/xs/xsnow/package.nix
+++ b/pkgs/by-name/xs/xsnow/package.nix
@@ -47,10 +47,7 @@ stdenv.mkDerivation rec {
     changelog = "https://ratrabbit.nl/ratrabbit/xsnow/changelog/index.html";
     downloadPage = "https://ratrabbit.nl/ratrabbit/xsnow/downloads/index.html";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [
-      robberer
-      griffi-gh
-    ];
+    maintainers = with maintainers; [ griffi-gh ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/embedded/arduino/arduino-core/default.nix
+++ b/pkgs/development/embedded/arduino/arduino-core/default.nix
@@ -288,7 +288,6 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [
       antono
       auntie
-      robberer
       bjornfor
       bergey
     ];


### PR DESCRIPTION
Doesn't seem to be in the GitHub org anymore and therefore  is unable to receive pings from CI.
Hasn't commented since [Oct 3, 2016](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Arobberer), hasn't opened any tickets themselves since [Oct 3, 2016](https://github.com/NixOS/nixpkgs/issues?q=author%3Arobberer), both of which are longer than the 3 months, specified in the [maintainer README](https://github.com/NixOS/nixpkgs/tree/6d40c7d426c102023aae52888215699bc024cfd3/maintainers#losing-maintainer-status), which makes them eligible for removal from Nixpkgs.

@robberer, you have a week (**_until Nov 11, 2025_**) to object this. Even if you don't make it, you're still welcome back.
```
rg "robberer"
maintainers/maintainer-list.nix
22254:  robberer = {
22255:    email = "robberer@freakmail.de";
22256:    github = "robberer";

pkgs/applications/science/electronics/fritzing/default.nix
140:      robberer

pkgs/by-name/cl/clamav/package.nix
85:      robberer

pkgs/by-name/mr/mrtg/package.nix
39:    maintainers = with maintainers; [ robberer ];

pkgs/by-name/xs/xsnow/package.nix
51:      robberer

pkgs/development/embedded/arduino/arduino-core/default.nix
291:      robberer
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
