### PR TITLE
archi: 5.6.0 -> 5.7.0

### DIFF
--- a/pkgs/by-name/ar/archi/package.nix
+++ b/pkgs/by-name/ar/archi/package.nix
@@ -15,23 +15,23 @@
   makeDesktopItem,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "Archi";
-  version = "5.6.0";
+  version = "5.7.0";
 
   src =
     {
       "x86_64-linux" = fetchurl {
-        url = "https://www.archimatetool.com/downloads/archi/${version}/Archi-Linux64-${version}.tgz";
-        hash = "sha256-zPgsRfbhN22Sph/5AvP7y2uHdgy1cZRcsm+O1dVLNHc=";
+        url = "https://github.com/archimatetool/archi.io/releases/download/57/Archi-Linux64-${finalAttrs.version}.tgz";
+        hash = "sha256-MIUlWt3GP/1oQAeq4W2xnhG63a2zhGldgyoyZ9lNOiI=";
       };
       "x86_64-darwin" = fetchurl {
-        url = "https://www.archimatetool.com/downloads/archi/${version}/Archi-Mac-${version}.dmg";
-        hash = "sha256-NZWMQzLsPcJ7cZoYFUxXxLIu7yCIHE5pw9+UqjtG7Cc=";
+        url = "https://github.com/archimatetool/archi.io/releases/download/57/Archi-Mac-${finalAttrs.version}.dmg";
+        hash = "sha256-wIlhJ6XmhL5rMb5zwHJYwamCwV13PK53wi9uEXIga5I=";
       };
       "aarch64-darwin" = fetchurl {
-        url = "https://www.archimatetool.com/downloads/archi/${version}/Archi-Mac-Silicon-${version}.dmg";
-        hash = "sha256-a80QyJT+mizT4bxhJ/1rXnQGbq0Zxwmqb74n2QH4H3I=";
+        url = "https://github.com/archimatetool/archi.io/releases/download/57/Archi-Mac-Silicon-${finalAttrs.version}.dmg";
+        hash = "sha256-2/w4+aKfjfTGLjjl/nOouFtnv7/kjmfezkrmSa4ablc=";
       };
     }
     .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
@@ -95,7 +95,7 @@ stdenv.mkDerivation rec {
       desktopName = "Archi";
       exec = "Archi";
       type = "Application";
-      comment = meta.description;
+      comment = finalAttrs.meta.description;
       icon = "archi";
       categories = [
         "Development"
@@ -107,20 +107,20 @@ stdenv.mkDerivation rec {
 
   passthru.tests = { inherit (nixosTests) archi; };
 
-  meta = with lib; {
+  meta = {
     description = "ArchiMate modelling toolkit";
     longDescription = ''
       Archi is an open source modelling toolkit to create ArchiMate
       models and sketches.
     '';
     homepage = "https://www.archimatetool.com/";
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    license = licenses.mit;
-    platforms = platforms.linux ++ platforms.darwin;
-    maintainers = with maintainers; [
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    maintainers = with lib.maintainers; [
       earldouglas
       paumr
     ];
     mainProgram = "Archi";
   };
-}
+})


### PR DESCRIPTION
Fix : https://github.com/NixOS/nixpkgs/issues/458385
Changelog : https://www.archimatetool.com/version-history/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
