### PR TITLE
ci/github-script/bot: improve parallelism

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -7,7 +7,9 @@ name: Bot
 
 on:
   schedule:
-    - cron: '05,15,25,35,45,55 * * * *'
+    # Run every 5m
+    # i.e., at each of the listed minutes, every hour
+    - cron: '02,07,12,17,22,27,32,37,42,47,52,57 * * * *'
   workflow_call:
     inputs:
       headBranch:

--- a/ci/github-script/bot.js
+++ b/ci/github-script/bot.js
@@ -587,7 +587,7 @@ module.exports = async ({ github, context, core, dry }) => {
         state: 'open',
         sort: 'created',
         direction: 'asc',
-        per_page: 100,
+        per_page: 50,
         after: cursor,
       })
 

--- a/ci/github-script/withRateLimit.js
+++ b/ci/github-script/withRateLimit.js
@@ -1,4 +1,4 @@
-module.exports = async ({ github, core }, callback) => {
+module.exports = async ({ github, core, maxConcurrent = 1 }, callback) => {
   const Bottleneck = require('bottleneck')
 
   const stats = {
@@ -13,7 +13,7 @@ module.exports = async ({ github, core }, callback) => {
   //   https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api
   const allLimits = new Bottleneck({
     // Avoid concurrent requests
-    maxConcurrent: 1,
+    maxConcurrent,
     // Will be updated with first `updateReservoir()` call below.
     reservoir: 0,
   })


### PR DESCRIPTION
We used to employ the worst strategy for parallelism possibly: The rate limiter capped us at one concurrent request per second, while 100+ items were handled in parallel. This lead to every item taking the full duration of the job to proceed, making the data fetched at the beginning of the job stale at the end. This leads to smaller hiccups when labeling, or to the merge-bot posting comments after the PR has already been closed.

GitHub allows 100 concurrent requests, but considers it a best practice to serialize them. Since serializing all of them causes problems for us, we should try to go higher.

Since other jobs are running in parallel, we use a conservative value of 20 concurrent requests here. We also introduce the same number of workers going through the list of items, to make sure that each item is handled in the shortest time possible from start to finish, before proceeding to the next. This gives us roughly 2.5 seconds per individual item - but speeds up the overall execution of the scheduled job to 20-30 seconds from 3-4 minutes before.

---

Once that's done, we can easily increase the frequency of labeling to every 5 minutes for better UX.

## Things done

- [x] Tested locally - I have exhausted all my API limits now.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
