### PR TITLE
ci/github-script/merge: improve merge operation and error messages

### DIFF
--- a/ci/github-script/merge.js
+++ b/ci/github-script/merge.js
@@ -80,6 +80,7 @@ function runChecklist({
 
   return {
     checklist,
+    eligible,
     result,
   }
 }
@@ -119,6 +120,7 @@ async function handleMerge({
   events,
   maintainers,
   getTeamMembers,
+  getUser,
 }) {
   const pull_number = pull_request.number
 
@@ -240,7 +242,7 @@ async function handleMerge({
       }
     }
 
-    const { result, checklist } = runChecklist({
+    const { result, eligible, checklist } = runChecklist({
       committers,
       events,
       files,
@@ -269,6 +271,18 @@ async function handleMerge({
       ),
       '',
     ]
+
+    if (eligible.size > 0 && !eligible.has(comment.user.id)) {
+      const users = await Promise.all(
+        Array.from(eligible, async (id) => (await getUser(id)).login),
+      )
+      body.push(
+        '> [!TIP]',
+        '> Maintainers eligible to merge are:',
+        ...users.map((login) => `> - ${login}`),
+        '',
+      )
+    }
 
     if (result) {
       await react('ROCKET')

--- a/ci/github-script/merge.js
+++ b/ci/github-script/merge.js
@@ -168,14 +168,15 @@ async function handleMerge({
       // Ignore comments where the user has been deleted already.
       user &&
       // Ignore comments which had already been responded to by the bot.
-      !events.some(
-        ({ event, body }) =>
-          ['commented'].includes(event) &&
-          // We're only testing this hidden reference, but not the author of the comment.
-          // We'll just assume that nobody creates comments with this marker on purpose.
-          // Additionally checking the author is quite annoying for local debugging.
-          body.match(new RegExp(`^<!-- comment: ${node_id} -->$`, 'm')),
-      ),
+      (dry ||
+        !events.some(
+          ({ event, body }) =>
+            ['commented'].includes(event) &&
+            // We're only testing this hidden reference, but not the author of the comment.
+            // We'll just assume that nobody creates comments with this marker on purpose.
+            // Additionally checking the author is quite annoying for local debugging.
+            body.match(new RegExp(`^<!-- comment: ${node_id} -->$`, 'm')),
+        )),
   )
 
   async function merge() {


### PR DESCRIPTION
We previously used auto-merge first and then enqueued explicitly on the assumption that auto-merge would fail if the PR was actually in mergeable state already. This turned out to be false.

Instead, we currently face the problem of auto-merge sometimes getting stuck. This seems to happen when, at the time of enabling auto-merge, the required status checks already passed and the PR would be ready to go - but sometimes GitHub doesn't do it. This *can* be unblocked by approving the PR again, which seems to run the internal "let's check whether we can merge this" procedures on the GitHub side again.

However, we can probably also solve this by just explicitly trying to enqueue the PR first - and only if that fails, fall back to auto-merge. I previously argued against that, based on a potential race condition, in which a PR could become ready to merge between these two requests - at which point the auto-merge operation would fail, if the original assumption was true. But since we don't observe this, we might as well switch.

---

When a user tries to merge a PR, but is not allowed to, it is helpful to explicitly list the users who *are* allowed. This helps explaining *why* the merge-eligible label was set.

I objected to this proposal before, because it would incur too many API requests. But after we have restructured the checklist, this is not actually true anymore - we can now sensibly run this only when a comment is posted and not whenever we check a PR for eligibility.

## Things done

- [x] Tested locally.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
