### PR TITLE
rare-regex: add liberodark to maintainers

### DIFF
--- a/pkgs/by-name/ra/rare-regex/package.nix
+++ b/pkgs/by-name/ra/rare-regex/package.nix
@@ -9,14 +9,14 @@
   rare-regex,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "rare";
   version = "0.5.2";
 
   src = fetchFromGitHub {
     owner = "zix99";
     repo = "rare";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-tzAbt9THSTYDvooU7yNQJhJaFM1bcKCabDNtiMpux3Q=";
   };
 
@@ -28,9 +28,13 @@ buildGoModule rec {
 
   ldflags = [
     "-s"
-    "-w"
-    "-X=main.version=${version}"
-    "-X=main.buildSha=${src.rev}"
+    "-X=main.version=${finalAttrs.version}"
+    "-X=main.buildSha=${finalAttrs.src.tag}"
+  ];
+
+  # Skip tests try /dev.
+  checkFlags = [
+    "-skip=TestNoMountTraverseWithSymlink"
   ];
 
   tags = lib.optionals withPcre2 [
@@ -43,11 +47,12 @@ buildGoModule rec {
     };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Fast text scanner/regex extractor and realtime summarizer";
     homepage = "https://rare.zdyn.net";
-    changelog = "https://github.com/zix99/rare/releases/tag/${src.rev}";
-    license = licenses.gpl3Plus;
     maintainers = [ ];
+    changelog = "https://github.com/zix99/rare/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "rare";
   };
-}
+})

--- a/pkgs/by-name/ra/rare-regex/package.nix
+++ b/pkgs/by-name/ra/rare-regex/package.nix
@@ -50,7 +50,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Fast text scanner/regex extractor and realtime summarizer";
     homepage = "https://rare.zdyn.net";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ liberodark ];
     changelog = "https://github.com/zix99/rare/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl3Plus;
     mainProgram = "rare";


### PR DESCRIPTION
Related to : https://github.com/NixOS/nixpkgs/issues/458096

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
