### PR TITLE
ligolo-ng: refactor

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14442,6 +14442,12 @@
     githubId = 737767;
     name = "Thomas Gerbet";
   };
+  letgamer = {
+    github = "Letgamer";
+    githubId = 62446107;
+    matrix = "@letgamer:tchncs.de";
+    name = "Alex Stephan";
+  };
   lethalman = {
     email = "lucabru@src.gnome.org";
     github = "lucabrunox";

--- a/pkgs/by-name/li/ligolo-ng/package.nix
+++ b/pkgs/by-name/li/ligolo-ng/package.nix
@@ -2,38 +2,67 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  nix-update-script,
+  pkgsCross ? { },
+  versionCheckHook,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "ligolo-ng";
   version = "0.8.2";
 
   src = fetchFromGitHub {
-    owner = "tnpitsecurity";
+    owner = "nicocha30";
     repo = "ligolo-ng";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-ND0SFB0xj4WK6okNzChZWfK5bhNc4PTWuZoq/PodTW0=";
   };
 
   vendorHash = "sha256-oc85xNPMFeaPC7TMcSh3i3Msd8sCJ5QGFmi2fKjcyvk=";
 
-  postConfigure = ''
-    export CGO_ENABLED=0
-  '';
+  env.CGO_ENABLED = 0;
+
+  subPackages = [
+    "cmd/agent"
+    "cmd/proxy"
+  ];
 
   ldflags = [
     "-s"
     "-w"
     "-extldflags '-static'"
+    "-X main.version=${finalAttrs.version}"
   ];
+
+  # This will prefix all the binaries with ligolo-
+  postInstall = ''
+    for f in $out/bin/*; do
+      mv "$f" "$(dirname "$f")/ligolo-$(basename "$f")"
+    done
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/ligolo-agent";
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  passthru = {
+    tests = {
+      win = pkgsCross.mingwW64.ligolo-ng or null;
+      linux64 = pkgsCross.gnu64.ligolo-ng or null;
+    };
+    updateScript = nix-update-script { };
+  };
 
   # Tests require network access
   doCheck = false;
 
   meta = {
-    description = "Tunneling/pivoting tool that uses a TUN interface";
-    homepage = "https://github.com/tnpitsecurity/ligolo-ng";
-    changelog = "https://github.com/nicocha30/ligolo-ng/releases/tag/v${version}";
+    description = "Advanced TUN-based tunneling/pivoting tool";
+    homepage = "https://github.com/nicocha30/ligolo-ng";
+    changelog = "https://github.com/nicocha30/ligolo-ng/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ letgamer ];
+    platforms = lib.platforms.linux ++ lib.platforms.windows;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^ -->

**ligolo-ng**: refactor package and enable cross-compilation

- Refactored the ligolo-ng package to use `finalAttrs`.
- Enabled cross-compilation for Windows.
- Prefixed all binaries with `ligolo-`.
- Added myself as a maintainer.
- Updated the GitHub repository link.

Example usage for Linux and Windows binaries together:

```nix
ligoloJoined = pkgs.symlinkJoin {
  name = "ligolo-joined";
  paths = [
    pkgs.pkgsCross.gnu64.ligolo-ng
    pkgs.pkgsCross.mingwW64.ligolo-ng
  ];
};
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] x86_64-windows
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
