### PR TITLE
{topfew, topfew-rs}: add liberodark to maintainers

### DIFF
--- a/pkgs/by-name/to/topfew-rs/package.nix
+++ b/pkgs/by-name/to/topfew-rs/package.nix
@@ -4,24 +4,24 @@
   fetchFromGitHub,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "topfew-rs";
   version = "0.2.3";
 
   src = fetchFromGitHub {
     owner = "djc";
     repo = "topfew-rs";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-VlSLPcKw3LYGnmKk5YOkcGIizw1tqtKF2BykY+1MtvY=";
   };
 
   cargoHash = "sha256-NAM/s3m+ZqgHoX6GESgJOxr88sy4+JieWB8u8aKbW7Y=";
 
-  meta = with lib; {
+  meta = {
     description = "Rust implementation of Tim Bray's topfew tool";
     homepage = "https://github.com/djc/topfew-rs";
-    license = licenses.gpl3Only;
     maintainers = [ ];
+    license = lib.licenses.gpl3Only;
     mainProgram = "tf";
   };
-}
+})

--- a/pkgs/by-name/to/topfew-rs/package.nix
+++ b/pkgs/by-name/to/topfew-rs/package.nix
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Rust implementation of Tim Bray's topfew tool";
     homepage = "https://github.com/djc/topfew-rs";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ liberodark ];
     license = lib.licenses.gpl3Only;
     mainProgram = "tf";
   };

--- a/pkgs/by-name/to/topfew/package.nix
+++ b/pkgs/by-name/to/topfew/package.nix
@@ -5,14 +5,14 @@
   installShellFiles,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "topfew";
   version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "timbray";
     repo = "topfew";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-P3K3IhgYkrxmEG2l7EQDVWQ+P7fOjUMUFrlAnY+8NmI=";
   };
 
@@ -24,18 +24,17 @@ buildGoModule rec {
 
   ldflags = [
     "-s"
-    "-w"
   ];
 
   postInstall = ''
     installManPage doc/tf.1
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Finds the fields (or combinations of fields) which appear most often in a stream of records";
     homepage = "https://github.com/timbray/topfew";
-    license = licenses.gpl3Only;
     maintainers = [ ];
+    license = lib.licenses.gpl3Only;
     mainProgram = "tf";
   };
-}
+})

--- a/pkgs/by-name/to/topfew/package.nix
+++ b/pkgs/by-name/to/topfew/package.nix
@@ -33,7 +33,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Finds the fields (or combinations of fields) which appear most often in a stream of records";
     homepage = "https://github.com/timbray/topfew";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ liberodark ];
     license = lib.licenses.gpl3Only;
     mainProgram = "tf";
   };


### PR DESCRIPTION
Related to : https://github.com/NixOS/nixpkgs/issues/458096

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
