### PR TITLE
wazero: add liberodark to maintainers

### DIFF
--- a/pkgs/by-name/wa/wazero/package.nix
+++ b/pkgs/by-name/wa/wazero/package.nix
@@ -43,7 +43,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Zero dependency WebAssembly runtime for Go developers";
     homepage = "https://github.com/tetratelabs/wazero";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ liberodark ];
     changelog = "https://github.com/tetratelabs/wazero/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     mainProgram = "wazero";

--- a/pkgs/by-name/wa/wazero/package.nix
+++ b/pkgs/by-name/wa/wazero/package.nix
@@ -6,14 +6,14 @@
   wazero,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "wazero";
   version = "1.9.0";
 
   src = fetchFromGitHub {
     owner = "tetratelabs";
     repo = "wazero";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-yxnHLc0PFxh8NRBgK2hvhKaxRM1w3IZ9TnfJM0+uadg=";
   };
 
@@ -25,8 +25,7 @@ buildGoModule rec {
 
   ldflags = [
     "-s"
-    "-w"
-    "-X=github.com/tetratelabs/wazero/internal/version.version=${version}"
+    "-X=github.com/tetratelabs/wazero/internal/version.version=${finalAttrs.version}"
   ];
 
   checkFlags = [
@@ -41,12 +40,12 @@ buildGoModule rec {
     };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Zero dependency WebAssembly runtime for Go developers";
     homepage = "https://github.com/tetratelabs/wazero";
-    changelog = "https://github.com/tetratelabs/wazero/releases/tag/${src.rev}";
-    license = licenses.asl20;
     maintainers = [ ];
+    changelog = "https://github.com/tetratelabs/wazero/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
     mainProgram = "wazero";
   };
-}
+})


### PR DESCRIPTION
Related to : https://github.com/NixOS/nixpkgs/issues/458096

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
