### PR TITLE
taizen: 0-unstable-2023-06-05 -> 0-unstable-2024-11-16

### DIFF
--- a/pkgs/by-name/ta/taizen/package.nix
+++ b/pkgs/by-name/ta/taizen/package.nix
@@ -8,25 +8,16 @@
   openssl,
 }:
 
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "taizen";
-  version = "0-unstable-2023-06-05";
+  version = "0-unstable-2024-11-16";
 
   src = fetchFromGitHub {
     owner = "oppiliappan";
     repo = "taizen";
-    rev = "5486cd4f4c5aa4e0abbcee180ad2ec22839abd31";
-    hash = "sha256-pGcD3+3Ds3U8NuNySaDnz0zzAvZlSDte1jRPdM5qrZA=";
+    rev = "e57f10845d32d51e78c5bbadf9c40780a0fa2481";
+    hash = "sha256-5XLRANBRtT8LyyS4EhKgZS+Hc3xFg/+N3rZJTVvVrpo=";
   };
-
-  cargoPatches = [
-    # update cargo dependencies upstreamed: https://github.com/oppiliappan/taizen/pull/27
-    (fetchpatch2 {
-      name = "update-cargo-lock.patch";
-      url = "https://github.com/oppiliappan/taizen/commit/104a1663268623e9ded45afaf2fe98c9c42b7b21.patch";
-      hash = "sha256-ujsr7MjZWEu+2mijVH1aqtTJXKZC4m5vl73Jre9XHbU=";
-    })
-  ];
 
   cargoHash = "sha256-kK9na2Pk3Hl4TYYVVUfeBv6DDDkrD7mIv7eVHXkS5QY=";
 
@@ -37,11 +28,11 @@ rustPlatform.buildRustPackage {
     openssl
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Curses-based mediawiki browser";
     homepage = "https://github.com/oppiliappan/taizen";
-    license = licenses.mit;
     maintainers = [ ];
+    license = lib.licenses.mit;
     mainProgram = "taizen";
   };
-}
+})

--- a/pkgs/by-name/ta/taizen/package.nix
+++ b/pkgs/by-name/ta/taizen/package.nix
@@ -31,7 +31,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Curses-based mediawiki browser";
     homepage = "https://github.com/oppiliappan/taizen";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ liberodark ];
     license = lib.licenses.mit;
     mainProgram = "taizen";
   };


### PR DESCRIPTION
Related to : https://github.com/NixOS/nixpkgs/issues/458096

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
