### PR TITLE
system76-wallpapers: 0-unstable-2024-04-26 -> 0-unstable-2025-10-27

### DIFF
--- a/pkgs/by-name/sy/system76-wallpapers/package.nix
+++ b/pkgs/by-name/sy/system76-wallpapers/package.nix
@@ -8,15 +8,15 @@
 
 stdenvNoCC.mkDerivation {
   pname = "system76-wallpapers";
-  version = "0-unstable-2024-04-26";
+  version = "0-unstable-2025-10-27";
 
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "system76-wallpapers";
-    rev = "ff1e25c79d10c699dfb695374d5ae7b3f8031b2b";
+    rev = "c9a5b3943e7fdab96e1cbbdbca1a7ebca371fc3c";
     forceFetchGit = true;
     fetchLFS = true;
-    hash = "sha256-5rddxbi/hRPy93DqswG54HzWK33Y5TteGB8SKjLXJZk=";
+    hash = "sha256-2M6cFuQMjG0edhZIuxw0LLLoau6Np9igVG22bhBUE3Y=";
   };
 
   prePatch = ''
@@ -33,7 +33,7 @@ stdenvNoCC.mkDerivation {
     description = "Wallpapers for System76 products";
     homepage = "https://system76.com/";
     license = with lib.licenses; [
-      unfree # No license specified
+      cc-by-sa-40
     ];
     maintainers = with lib.maintainers; [ pandapip1 ];
     platforms = lib.platforms.all;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Added the licence change here, since I can't push to: #456707.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
