### PR TITLE
python3Packages.rapidocr-onnxruntime: fix aarch64-linux build

### DIFF
--- a/pkgs/development/python-modules/rapidocr-onnxruntime/default.nix
+++ b/pkgs/development/python-modules/rapidocr-onnxruntime/default.nix
@@ -120,9 +120,6 @@ buildPythonPackage {
   passthru.skipBulkUpdate = true;
 
   meta = {
-    # This seems to be related to https://github.com/microsoft/onnxruntime/issues/10038
-    # Also some related issue: https://github.com/NixOS/nixpkgs/pull/319053#issuecomment-2167713362
-    badPlatforms = [ "aarch64-linux" ];
     changelog = "https://github.com/RapidAI/RapidOCR/releases/tag/${src.tag}";
     description = "Cross platform OCR Library based on OnnxRuntime";
     homepage = "https://github.com/RapidAI/RapidOCR";

--- a/pkgs/development/python-modules/rapidocr/default.nix
+++ b/pkgs/development/python-modules/rapidocr/default.nix
@@ -110,9 +110,6 @@ buildPythonPackage {
   doCheck = false;
 
   meta = {
-    # This seems to be related to https://github.com/microsoft/onnxruntime/issues/10038
-    # Also some related issue: https://github.com/NixOS/nixpkgs/pull/319053#issuecomment-2167713362
-    badPlatforms = [ "aarch64-linux" ];
     changelog = "https://github.com/RapidAI/RapidOCR/releases/tag/${src.tag}";
     description = "Cross platform OCR Library based on OnnxRuntime";
     homepage = "https://github.com/RapidAI/RapidOCR";


### PR DESCRIPTION
Reason for change: immich recently added OCR support (via https://github.com/NixOS/nixpkgs/pull/457059), depending on rapidocr, which has been [marked as "bad" on aarch64-linux](https://github.com/pluiedev/nixpkgs/blob/0951d8faa324c89ff2e206c21d44d6218472b38c/pkgs/development/python-modules/rapidocr-onnxruntime/default.nix#L123-L125) since it was added to nixpkgs. Currently throws:

```
       > Error in cpuinfo: failed to parse the list of possible processors in /sys/devices/system/cpu/possible
       > Error in cpuinfo: failed to parse the list of present processors in /sys/devices/system/cpu/present
       > Error in cpuinfo: failed to parse both lists of possible and present processors
       > terminate called after throwing an instance of 'onnxruntime::OnnxRuntimeException'
       >   what():  /build/source/include/onnxruntime/core/common/logging/logging.h:371 static const onnxruntime::logging::Logger& onnxruntime::logging::LoggingManager::DefaultLogger() Attempt to use DefaultLogger but none has been registered.
       >
       > /nix/store/j31jxdli48d90d96iwq40fb1bbwfq9z5-python-imports-check-hook.sh/nix-support/setup-hook: line 6:   272 Aborted                    (core dumped) ( cd "$pythonImportsCheckOutput" && /nix/store/m0b67b3lmjcxa8aplpl75qpb26gr5vsf-python3-3.13.8/bin/python3.13 -c 'import sys; import importlib; list(map(lambda mod: importlib.import_module(mod), sys.argv[1:]))' ${pythonImportsCheck[*]} )
       For full logs, run:
         nix log /nix/store/a3ma9547bqkk895qqm1r5aj8m6pabcgq-python3.13-rapidocr-onnxruntime-1.4.4.drv
```

 (Unsure why [hydra immich aarch64-linux builds](https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.immich.aarch64-linux) are passing though. @dotlambda?).

This implements the suggestion in https://github.com/NixOS/nixpkgs/pull/319053#issuecomment-2167713362

Pinging @wrvsrx @pluiedev.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
