### PR TITLE
nixosTests.lomiri-music-app: Fix OCR

### DIFF
--- a/nixos/tests/lomiri-music-app.nix
+++ b/nixos/tests/lomiri-music-app.nix
@@ -148,10 +148,9 @@ in
         machine.wait_for_text("Albums")
         machine.succeed("xdotool mousemove 25 45 click 1") # Open categories
         machine.sleep(2)
-        machine.wait_for_text("Tracks")
         machine.succeed("xdotool mousemove 25 240 click 1") # Switch to Tracks category
         machine.sleep(2)
-        machine.wait_for_text("${musicFileName}") # the test file
+        machine.wait_for_text("Tracks") # Written in larger text now, easier for OCR
         machine.screenshot("lomiri-music_listing")
 
         # Ensure pause colours isn't present already
@@ -180,8 +179,9 @@ in
 
         machine.screenshot("lomiri-music_paused")
 
-        # Lastly, check if generated cover image got extracted properly
+        # Lastly, check if song details like title & generated cover image got extracted properly
         # if not, indicates an issue with mediascanner / lomiri-thumbnailer
+        machine.wait_for_text("${musicFileName}")
         machine.wait_for_text("${ocrContent}")
 
     machine.succeed("pkill -f lomiri-music-app")


### PR DESCRIPTION
- Stopped finding the Tracks option in the pop-up menu. Just click where it should be, look for the new menu title afterwards.
- Stopped finding the small listing of the song title. Move the check to the very end, when the song is already opened in the player interface.

Haven't checked if OCR issues also exists on stable, backporting just in case (also less diff from master)

https://github.com/NixOS/nixpkgs/pull/453236#issuecomment-3483292757

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
