### PR TITLE
cargo-shear: 1.5.1 -> 1.6.2

### DIFF
--- a/pkgs/by-name/ca/cargo-shear/package.nix
+++ b/pkgs/by-name/ca/cargo-shear/package.nix
@@ -1,38 +1,48 @@
 {
-  fetchFromGitHub,
   lib,
+  fetchCrate,
   rustPlatform,
+  nix-update-script,
   testers,
-  cargo-shear,
 }:
-let
-  version = "1.5.1";
-in
-rustPlatform.buildRustPackage {
-  pname = "cargo-shear";
-  inherit version;
 
-  src = fetchFromGitHub {
-    owner = "Boshen";
-    repo = "cargo-shear";
-    rev = "v${version}";
-    hash = "sha256-4qj+hSoByE5sfT9LTm7hsYsYpOJc5Yxak1V980L/F3c=";
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cargo-shear";
+  version = "1.6.2";
+
+  src = fetchCrate {
+    pname = "cargo-shear";
+    version = finalAttrs.version;
+    hash = "sha256-5N8sAKStdQnrgzXECxu/oRuGVLwLx/KfW2vcPClVZGM=";
   };
 
-  cargoHash = "sha256-btXeytQRZ74S55cbANRGHmLPSXssNPpE/yjA1cJTy7g=";
+  cargoHash = "sha256-WdB4oJtQAh90Fe+Km+SddpmyvHdyemo3KsuRyBtZ5FY=";
 
-  # https://github.com/Boshen/cargo-shear/blob/a0535415a3ea94c86642f39f343f91af5cdc3829/src/lib.rs#L20-L23
-  SHEAR_VERSION = version;
-  passthru.tests.version = testers.testVersion {
-    package = cargo-shear;
+  env = {
+    # https://github.com/Boshen/cargo-shear/blob/v1.6.2/src/lib.rs#L51-L54
+    SHEAR_VERSION = finalAttrs.version;
+  };
+
+  # Integration tests require network access
+  cargoTestFlags = [
+    "--lib"
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = {
+      version = testers.testVersion {
+        package = finalAttrs.finalPackage;
+      };
+    };
   };
 
   meta = {
     description = "Detect and remove unused dependencies from Cargo.toml";
     mainProgram = "cargo-shear";
     homepage = "https://github.com/Boshen/cargo-shear";
-    changelog = "https://github.com/Boshen/cargo-shear/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/Boshen/cargo-shear/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = [ lib.licenses.mit ];
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.cathalmullan ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- updated cargo-shear to v1.6.2
- adopted package
- modernized package

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
