### PR TITLE
music-assistant: 2.6.0 -> 2.6.2, librespot-ma: 0.6.0-unstable-2025-08-10 -> 0.7.1-unstable-2025-11-06

### DIFF
--- a/pkgs/by-name/li/librespot-ma/package.nix
+++ b/pkgs/by-name/li/librespot-ma/package.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage {
   pname = "librespot-ma";
-  version = "0.6.0-unstable-2025-08-10";
+  version = "0.7.1-unstable-2025-11-06";
 
   src = fetchFromGitHub {
     owner = "music-assistant";
     repo = "librespot";
-    rev = "accecb60a16334013c0c99a5ded553794ee871b7";
-    hash = "sha256-vPiI8llXB6+ahX+iad/Ut81D3iZcTSVmYGDXXwApk/w=";
+    rev = "2af61256649d6c1ed149791a53a20a595b617704";
+    hash = "sha256-sarxS6YArK5luX4TRXJUKhreMqhZbsS/3fCVWHxPNpY=";
   };
 
-  cargoHash = "sha256-Lujz2revTAok9B0hzdl8NVQ5XMRY9ACJzoQHIkIgKMg=";
+  cargoHash = "sha256-CI2BFmQNK1+J2qaKg6u6WM83jwBuWjeh9dROnrF3Kv0=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/mu/music-assistant/package.nix
+++ b/pkgs/by-name/mu/music-assistant/package.nix
@@ -47,14 +47,14 @@ assert
 
 python.pkgs.buildPythonApplication rec {
   pname = "music-assistant";
-  version = "2.6.0";
+  version = "2.6.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "music-assistant";
     repo = "server";
     tag = version;
-    hash = "sha256-e596gvj+ZZDQzyBVfI50nO0a0eZifrkQVhUNNP2Jj8A=";
+    hash = "sha256-mNSTXMQDG5LiP3Bv9GGy2AO1bQfpFLH8tSCOB/wAzOU=";
   };
 
   patches = [

--- a/pkgs/by-name/mu/music-assistant/package.nix
+++ b/pkgs/by-name/mu/music-assistant/package.nix
@@ -193,7 +193,10 @@ python.pkgs.buildPythonApplication rec {
     '';
     homepage = "https://github.com/music-assistant/server";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ hexa ];
+    maintainers = with lib.maintainers; [
+      hexa
+      emilylange
+    ];
     mainProgram = "mass";
   };
 }

--- a/pkgs/by-name/mu/music-assistant/providers.nix
+++ b/pkgs/by-name/mu/music-assistant/providers.nix
@@ -1,7 +1,7 @@
 # Do not edit manually, run ./update-providers.py
 
 {
-  version = "2.6.0";
+  version = "2.6.2";
   providers = {
     airplay = ps: [
     ];


### PR DESCRIPTION
https://github.com/music-assistant/server/releases/tag/2.6.2

https://github.com/music-assistant/server/releases/tag/2.6.1

diff: https://github.com/music-assistant/server/compare/2.6.0...2.6.2

diff: https://github.com/music-assistant/librespot/compare/accecb60a16334013c0c99a5ded553794ee871b7...2af61256649d6c1ed149791a53a20a595b617704

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
