### PR TITLE
libnest2d, python3Packages.libsavitar: fix build with cmake4; python3Packages.libarcus, python3Packages.pynest2d: fix build

### DIFF
--- a/pkgs/by-name/li/libnest2d/package.nix
+++ b/pkgs/by-name/li/libnest2d/package.nix
@@ -25,6 +25,9 @@ stdenv.mkDerivation {
   postPatch = ''
     substituteInPlace {,examples/}CMakeLists.txt \
       --replace "set(CMAKE_CXX_STANDARD 11)" "set(CMAKE_CXX_STANDARD 14)"
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "cmake_minimum_required(VERSION 3.1)" "cmake_minimum_required(VERSION 3.10)"
+
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/libarcus/default.nix
+++ b/pkgs/development/python-modules/libarcus/default.nix
@@ -7,6 +7,7 @@
   cmake,
   sip4,
   protobuf,
+  distutils,
 }:
 
 buildPythonPackage rec {
@@ -30,16 +31,25 @@ buildPythonPackage rec {
     })
   ];
 
-  propagatedBuildInputs = [ sip4 ];
-  nativeBuildInputs = [ cmake ];
+  propagatedBuildInputs = [
+    sip4
+    distutils
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    sip4
+  ];
+
   buildInputs = [ protobuf ];
+
+  strictDeps = true;
 
   postPatch = ''
     sed -i 's#''${Python3_SITEARCH}#${placeholder "out"}/${python.sitePackages}#' cmake/SIPMacros.cmake
   '';
 
   meta = with lib; {
-    broken = true;
     description = "Communication library between internal components for Ultimaker software";
     homepage = "https://github.com/Ultimaker/libArcus";
     license = licenses.lgpl3Plus;

--- a/pkgs/development/python-modules/libsavitar/default.nix
+++ b/pkgs/development/python-modules/libsavitar/default.nix
@@ -6,6 +6,7 @@
   fetchFromGitHub,
   cmake,
   sip4,
+  distutils,
 }:
 
 buildPythonPackage rec {
@@ -22,11 +23,22 @@ buildPythonPackage rec {
 
   postPatch = ''
     sed -i 's#''${Python3_SITEARCH}#${placeholder "out"}/${python.sitePackages}#' cmake/SIPMacros.cmake
+
+    substituteInPlace pugixml/CMakeLists.txt \
+      --replace-fail "cmake_minimum_required(VERSION 2.6)" "cmake_minimum_required(VERSION 3.10)"
   '';
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    cmake
+    sip4
+  ];
 
-  propagatedBuildInputs = [ sip4 ];
+  propagatedBuildInputs = [
+    sip4
+    distutils
+  ];
+
+  strictDeps = true;
 
   disabled = pythonOlder "3.4.0";
 

--- a/pkgs/development/python-modules/libsavitar/default.nix
+++ b/pkgs/development/python-modules/libsavitar/default.nix
@@ -40,15 +40,11 @@ buildPythonPackage rec {
 
   strictDeps = true;
 
-  disabled = pythonOlder "3.4.0";
-
-  meta = with lib; {
+  meta = {
     description = "C++ implementation of 3mf loading with SIP python bindings";
     homepage = "https://github.com/Ultimaker/libSavitar";
-    license = licenses.lgpl3Plus;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [
-      orivej
-    ];
+    license = lib.licenses.lgpl3Plus;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ orivej ];
   };
 }

--- a/pkgs/development/python-modules/pynest2d/default.nix
+++ b/pkgs/development/python-modules/pynest2d/default.nix
@@ -7,6 +7,7 @@
   libnest2d,
   sip4,
   clipper,
+  distutils,
 }:
 
 buildPythonPackage rec {
@@ -25,8 +26,14 @@ buildPythonPackage rec {
     libnest2d
     sip4
     clipper
+    distutils
   ];
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    cmake
+    sip4
+  ];
+
+  strictDeps = true;
 
   CLIPPER_PATH = "${clipper.out}";
 


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/457852
- https://github.com/NixOS/nixpkgs/issues/445447

Using `substituteInPlace` since other packages depends on this one and may break with newer version, and my motivation is to fix failures before release, not to create others by updating this without the other 4 packages.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
