### PR TITLE
rPackages.XLConnect: fix build

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -388,6 +388,7 @@ let
     svaRetro = [ jbedo ];
     StructuralVariantAnnotation = [ jbedo ];
     RQuantLib = [ kupac ];
+    XLConnect = [ b-rodrigues ];
   };
 
   packagesWithRDepends = {
@@ -923,7 +924,6 @@ let
       zlib
       libxml2.dev
     ];
-    XLConnect = [ pkgs.jdk ];
     xml2 = [ pkgs.libxml2.dev ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ pkgs.perl ];
     XML = with pkgs; [
       libtool
@@ -2500,6 +2500,83 @@ let
           cp ${redatam-core}/lib/libredengine-1.0.0-rc2.so ./inst/redengine/libredengine-1.0.0-rc2.so
         '';
     });
+
+    XLConnect =
+      let
+        poi-ooxml-full = fetchurl {
+          url = "https://repo1.maven.org/maven2/org/apache/poi/poi-ooxml-full/5.4.1/poi-ooxml-full-5.4.1.jar";
+          hash = "sha256-xRsFFlXVjXTV64nn03NscFLCV09Dx52wyKg60hb23Tc=";
+        };
+        poi-ooxml = fetchurl {
+          url = "https://repo1.maven.org/maven2/org/apache/poi/poi-ooxml/5.4.1/poi-ooxml-5.4.1.jar";
+          hash = "sha256-/SAMnm901wQWCpfp1SBBmV7YdDlFRTAAHt2SBojxn1M=";
+        };
+        poi = fetchurl {
+          url = "https://repo1.maven.org/maven2/org/apache/poi/poi/5.4.1/poi-5.4.1.jar";
+          hash = "sha256-2lq/QtpGBMWnvKOJVq9unW8ZbZttTLfqvuT0gLWA1QU=";
+        };
+        commons-compress = fetchurl {
+          url = "https://repo1.maven.org/maven2/org/apache/commons/commons-compress/1.27.1/commons-compress-1.27.1.jar";
+          hash = "sha256-KT2A9UtTa3QJXc1+o88KKbv8NAJRkoEzJJX0Qg03DRY=";
+        };
+        commons-lang3 = fetchurl {
+          url = "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.16.0/commons-lang3-3.16.0.jar";
+          hash = "sha256-CHCd101gK3Bc5AF9JlRCEAVqS6WD1bIMCTc0Bv56APg=";
+        };
+        xmlbeans = fetchurl {
+          url = "https://repo1.maven.org/maven2/org/apache/xmlbeans/xmlbeans/5.3.0/xmlbeans-5.3.0.jar";
+          hash = "sha256-bMado7TTW4PF5HfNTauiBORBCYM+NK8rmoosh4gomRc=";
+        };
+        commons-collections4 = fetchurl {
+          url = "https://repo1.maven.org/maven2/org/apache/commons/commons-collections4/4.4/commons-collections4-4.4.jar";
+          hash = "sha256-Hfi5QwtcjtFD14FeQD4z71NxskAKrb6b2giDdi4IRtE=";
+        };
+        commons-math3 = fetchurl {
+          url = "https://repo1.maven.org/maven2/org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar";
+          hash = "sha256-HlbXsFjSi2Wr0la4RY44hbZ0wdWI+kPNfRy7nH7yswg=";
+        };
+        log4j-api = fetchurl {
+          url = "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/2.24.3/log4j-api-2.24.3.jar";
+          hash = "sha256-W0oKDNDnUd7UMcFiRCvb3VMyjR+Lsrrl/Bu+7g9m2A8=";
+        };
+        commons-codec = fetchurl {
+          url = "https://repo1.maven.org/maven2/commons-codec/commons-codec/1.18.0/commons-codec-1.18.0.jar";
+          hash = "sha256-ugBfMEzvkqPe3iSjitWsm4r8zw2PdYOdbBM4Y0z39uQ=";
+        };
+        commons-io = fetchurl {
+          url = "https://repo1.maven.org/maven2/commons-io/commons-io/2.18.0/commons-io-2.18.0.jar";
+          hash = "sha256-88oPjWPEDiOlbVQQHGDV7e4Ta0LYS/uFvHljCTEJz4s=";
+        };
+        SparseBitSet = fetchurl {
+          url = "https://repo1.maven.org/maven2/com/zaxxer/SparseBitSet/1.3/SparseBitSet-1.3.jar";
+          hash = "sha256-92uFrbDAByGuJnt8/eTaf3HTEhzCFgyfwAwMifjFPIo=";
+        };
+      in
+      old.XLConnect.overrideAttrs (attrs: {
+        preConfigure = ''
+          cp ${poi-ooxml-full} inst/java/poi-ooxml-full-5.4.1.jar
+          cp ${poi-ooxml} inst/java/poi-ooxml-5.4.1.jar
+          cp ${poi} inst/java/poi-5.4.1.jar
+          cp ${commons-compress} inst/java/commons-compress-1.27.1.jar
+          cp ${commons-lang3} inst/java/commons-lang3-3.16.0.jar
+          cp ${xmlbeans} inst/java/xmlbeans-5.3.0.jar
+          cp ${commons-collections4} inst/java/commons-collections4-4.4.jar
+          cp ${commons-math3} inst/java/commons-math3-3.6.1.jar
+          cp ${log4j-api} inst/java/log4j-api-2.24.3.jar
+          cp ${commons-codec} inst/java/commons-codec-1.18.0.jar
+          cp ${commons-io} inst/java/commons-io-2.18.0.jar
+          cp ${SparseBitSet} inst/java/SparseBitSet-1.3.jar
+        '';
+
+        postPatch = ''
+          substituteInPlace R/onLoad.R \
+            --replace-fail 'system2("java",' 'system2("${lib.getExe pkgs.jre_headless}",'
+
+          # Misleading startup message, JARs are downloaded at build-time
+          substituteInPlace R/onAttach.R \
+            --replace-fail 'if(file.exists(file.path(libname, pkgname, ".fail"))){' 'if(FALSE){'
+        '';
+      });
 
     immunotation =
       let


### PR DESCRIPTION
Fixed build by prefetching all necessary jars and fixing the path to the Java binary. When loading XLConnect, it complains that fetching the JARs may have failed, but that's not the case, the package is functional. 

Edit: I've further patched the package to remove this misleading message, this is the message that appeared before 

```
XLConnect: It seems downloading the JAR dependencies may have failed. If you would like to use a different maven repository, please set the environment variable XLCONNECT_JAVA_REPO_URL to a valid URL, e.g. Sys.setenv(XLCONNECT_JAVA_REPO_URL='https://jcenter.bintray.com'), and reinstall the package. 
```


Here's some code to test it:

```
> library(XLConnect)

XLConnect 1.2.2 by Mirai Solutions GmbH [aut],
  Martin Studer [cre] (ORCID: <https://orcid.org/0009-0004-8250-7303>),
  The Apache Software Foundation [ctb, cph] (Apache POI),
  Graph Builder [ctb, cph] (Curvesapi Java library),
  Brett Woolridge [ctb, cph] (SparseBitSet Java library)
https://mirai-solutions.ch
https://github.com/miraisolutions/xlconnect

> demoExcelFile <- system.file("demoFiles/mtcars.xlsx", package = "XLConnect") 
> wb <- loadWorkbook(demoExcelFile)
> appendWorksheet(wb, mtcars, sheet = "mtcars")
> wb$saveWorkbook()
Error: FileNotFoundException (Java): /nix/store/m1vcwxi1k0rfw6wahflyml3n16qbbma7-r-XLConnect-1.2.2/library/XLConnect/demoFiles/mtcars.xlsx (Read-only file system)
# That's expected!
# So let's save it in ~/ 
> wb$saveWorkbook(file = "~/Downloads/mtcars_yo.xlsx")
```

Context: https://github.com/NixOS/nixpkgs/pull/457385

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
