### PR TITLE
opencl-cts: init

### DIFF
--- a/pkgs/by-name/op/opencl-cts/package.nix
+++ b/pkgs/by-name/op/opencl-cts/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  opencl-headers,
+  spirv-headers,
+  spirv-tools,
+  ocl-icd,
+  python3,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "opencl-cts";
+  version = "2025-08-21-00";
+
+  src = fetchFromGitHub {
+    owner = "KhronosGroup";
+    repo = "OpenCL-CTS";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-/VVT7Q45OvVivbZvULInXf78//Tb3EeV8zqbcDR2Pf4=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    python3
+  ];
+
+  buildInputs = [
+    opencl-headers
+    spirv-headers
+    spirv-tools
+    ocl-icd
+  ];
+
+  # Build errors when format hardening is enabled:
+  #   cc1: error: '-Wformat-security' ignored without '-Wformat' [-Werror=format-security]
+  hardeningDisable = [ "format" ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "CL_INCLUDE_DIR" "${lib.getInclude opencl-headers}/include")
+    # Intentionally no suffix, CMakeLists adds for SPIRV and not for CL ¯\_(ツ)_/¯
+    (lib.cmakeFeature "SPIRV_INCLUDE_DIR" "${lib.getInclude spirv-headers}")
+    (lib.cmakeFeature "CL_LIB_DIR" "${lib.getLib ocl-icd}/lib")
+    (lib.cmakeFeature "SPIRV_TOOLS_DIR" "${lib.getBin spirv-tools}/bin")
+    (lib.cmakeFeature "OPENCL_LIBRARIES" "OpenCL")
+  ];
+
+  meta = {
+    description = "OpenCL Conformance Test Suite";
+    homepage = "https://github.com/KhronosGroup/OpenCL-CTS";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.unix;
+    teams = [ lib.teams.rocm ];
+  };
+})


### PR DESCRIPTION
Packaging https://github.com/KhronosGroup/OpenCL-CTS with intent to use this for `rocmPackages.clr`'s impureTests.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
