### PR TITLE
nixos/automx2: multi-domain support, service improvements, configurability - Rebased

### DIFF
--- a/nixos/modules/services/mail/automx2.nix
+++ b/nixos/modules/services/mail/automx2.nix
@@ -93,6 +93,7 @@ in
         }/bin/flask run --host=127.0.0.1 --port=${toString cfg.port}";
         Restart = "always";
         StateDirectory = "automx2";
+        DynamicUser = true;
         User = "automx2";
         WorkingDirectory = "/var/lib/automx2";
       };
@@ -101,14 +102,6 @@ in
         Documentation = "https://rseichter.github.io/automx2/";
       };
       wantedBy = [ "multi-user.target" ];
-    };
-
-    users = {
-      groups.automx2 = { };
-      users.automx2 = {
-        group = "automx2";
-        isSystemUser = true;
-      };
     };
   };
 

--- a/nixos/modules/services/mail/automx2.nix
+++ b/nixos/modules/services/mail/automx2.nix
@@ -185,10 +185,8 @@ in
           pkgs.python3.buildEnv.override { extraLibs = [ cfg.package ]; }
         }/bin/flask run --host=127.0.0.1 --port=${toString cfg.port}";
         Restart = "always";
-        StateDirectory = "automx2";
         DynamicUser = true;
         User = "automx2";
-        WorkingDirectory = "/var/lib/automx2";
       };
       unitConfig = {
         Description = "Service to automatically configure mail clients";

--- a/nixos/modules/services/mail/automx2.nix
+++ b/nixos/modules/services/mail/automx2.nix
@@ -98,7 +98,7 @@ in
         WorkingDirectory = "/var/lib/automx2";
       };
       unitConfig = {
-        Description = "MUA configuration service";
+        Description = "Service to automatically configure mail clients";
         Documentation = "https://rseichter.github.io/automx2/";
       };
       wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/services/mail/automx2.nix
+++ b/nixos/modules/services/mail/automx2.nix
@@ -166,10 +166,7 @@ in
 
     systemd.services.automx2 = {
       after = [ "network.target" ];
-      postStart = ''
-        sleep 3
-        ${lib.getExe pkgs.curl} -X POST --json @${format.generate "automx2.json" cfg.settings} http://127.0.0.1:${toString cfg.port}/initdb/
-      '';
+      postStart = "${lib.getExe pkgs.curl} -X POST --json @${format.generate "automx2.json" cfg.settings} http://127.0.0.1:${toString cfg.port}/initdb/";
       serviceConfig = {
         Environment = [
           "AUTOMX2_CONF=${pkgs.writeText "automx2-conf" ''
@@ -187,6 +184,7 @@ in
         Restart = "always";
         DynamicUser = true;
         User = "automx2";
+        Type = "notify";
       };
       unitConfig = {
         Description = "Service to automatically configure mail clients";

--- a/nixos/modules/services/mail/automx2.nix
+++ b/nixos/modules/services/mail/automx2.nix
@@ -138,6 +138,20 @@ in
           };
         };
       };
+
+      logLevel = lib.mkOption {
+        type = lib.types.enum [
+          "INFO"
+          "WARNING"
+          "DEBUG"
+          "ERROR"
+          "CRITICAL"
+        ];
+        default = "WARNING";
+        description = "Log level used for automx2 service.";
+        example = "DEBUG";
+      };
+
     };
   };
 
@@ -171,7 +185,7 @@ in
         Environment = [
           "AUTOMX2_CONF=${pkgs.writeText "automx2-conf" ''
             [automx2]
-            loglevel = WARNING
+            loglevel = ${cfg.logLevel}
             db_uri = sqlite:///:memory:
             proxy_count = 1
           ''}"

--- a/nixos/modules/services/mail/automx2.nix
+++ b/nixos/modules/services/mail/automx2.nix
@@ -17,7 +17,7 @@ let
         false
       else if !lib.types.str.check x.type then
         false
-      else if x.type != "imap" && x.type != "smtp" then
+      else if x.type != "imap" && x.type != "smtp" && x.type != "pop" then
         false
       else if !lib.types.str.check x.name then
         false


### PR DESCRIPTION
Rebase of #370074.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
