### PR TITLE
millisecond: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2753,6 +2753,12 @@
     githubId = 333807;
     name = "Pascal Bach";
   };
+  backtail = {
+    name = "Max Genson";
+    email = "mail@maxgenson.de";
+    github = "backtail";
+    githubId = 95583524;
+  };
   backuitist = {
     email = "biethb@gmail.com";
     github = "backuitist";

--- a/pkgs/by-name/mi/millisecond/package.nix
+++ b/pkgs/by-name/mi/millisecond/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  python313,
+  gobject-introspection,
+  gtk4,
+  desktop-file-utils,
+  appstream,
+  glib,
+  wrapGAppsHook4,
+  libadwaita,
+}:
+
+let
+  pythonEnv = python313.withPackages (p: [
+    p.pygobject3
+  ]);
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "millisecond";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "gaheldev";
+    repo = "Millisecond";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-SMGcSlbOfBX5gAwB7CaHRthf9EN5QWAN9ZzrcbQXtm8=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    appstream
+    desktop-file-utils
+    glib
+    gobject-introspection
+    gtk4
+    meson
+    ninja
+    pkg-config
+    pythonEnv
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    libadwaita
+  ];
+
+  meta = {
+    homepage = "https://github.com/gaheldev/Millisecond";
+    description = "Optimize your Linux system for low latency audio";
+    mainProgram = "millisecond";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      backtail
+    ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
A GUI tool that analyses the state of your Linux machine and determines how well it meets real-time audio requirements, in other words: one `millisecond` order of magnitude latency. It will suggest applicable changes that you can be executed by the user. 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
