### PR TITLE
wlock: 0-unstable-2024-09-13 -> 1.0

### DIFF
--- a/pkgs/by-name/wl/wlock/package.nix
+++ b/pkgs/by-name/wl/wlock/package.nix
@@ -2,13 +2,15 @@
   lib,
   stdenv,
   fetchFromGitea,
-  libxcrypt,
   pkg-config,
+  wayland-scanner,
   wayland,
   wayland-protocols,
   libxkbcommon,
-  wayland-scanner,
+  libxcrypt,
+  nix-update-script,
 }:
+
 stdenv.mkDerivation (finalAttrs: {
   pname = "wlock";
   version = "1.0";
@@ -25,28 +27,30 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace Makefile --replace-fail 'chmod 4755' 'chmod 755'
   '';
 
-  buildInputs = [
-    libxcrypt
-    wayland
-    wayland-protocols
-    libxkbcommon
-  ];
-
   strictDeps = true;
-
-  makeFlags = [
-    "PREFIX=$(out)"
-    ("WAYLAND_SCANNER=" + lib.getExe wayland-scanner)
-  ];
 
   nativeBuildInputs = [
     pkg-config
     wayland-scanner
   ];
 
+  buildInputs = [
+    wayland
+    wayland-protocols
+    libxkbcommon
+    libxcrypt
+  ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    ("WAYLAND_SCANNER=" + lib.getExe wayland-scanner)
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Sessionlocker for Wayland compositors that support the ext-session-lock-v1 protocol";
-    license = lib.licenses.gpl3;
+    license = lib.licenses.gpl3Only;
     homepage = "https://codeberg.org/sewn/wlock";
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ fliegendewurst ];

--- a/pkgs/by-name/wl/wlock/package.nix
+++ b/pkgs/by-name/wl/wlock/package.nix
@@ -53,7 +53,10 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Only;
     homepage = "https://codeberg.org/sewn/wlock";
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ fliegendewurst ];
+    maintainers = with lib.maintainers; [
+      fliegendewurst
+      yiyu
+    ];
     mainProgram = "wlock";
   };
 })

--- a/pkgs/by-name/wl/wlock/package.nix
+++ b/pkgs/by-name/wl/wlock/package.nix
@@ -9,16 +9,16 @@
   libxkbcommon,
   wayland-scanner,
 }:
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "wlock";
-  version = "0-unstable-2024-09-13";
+  version = "1.0";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "sewn";
     repo = "wlock";
-    rev = "be975445fa0da7252f8e13b610c518dd472652d0";
-    hash = "sha256-Xt7Q51RhFG+UXYukxfORIhc4Df86nxtpDhAhaSmI38A=";
+    tag = finalAttrs.version;
+    hash = "sha256-vbGrePrZN+IWwzwoNUzMHmb6k9nQbRLVZmbWIAsYneY=";
   };
 
   postPatch = ''
@@ -52,4 +52,4 @@ stdenv.mkDerivation {
     maintainers = with lib.maintainers; [ fliegendewurst ];
     mainProgram = "wlock";
   };
-}
+})


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
