### PR TITLE
fastddsgen: unpin gradle and openjdk

### DIFF
--- a/pkgs/by-name/fa/fastddsgen/493-addendum.patch
+++ b/pkgs/by-name/fa/fastddsgen/493-addendum.patch
@@ -1,0 +1,17 @@
+    Fix gradle error
+    
+    https://docs.gradle.org/9.1.0/userguide/validation_problems.html#private_method_must_not_be_annotated
+
+diff --git a/build.gradle b/build.gradle
+index c6d537e..9029aae 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -69,7 +69,7 @@ public abstract class InstallPath extends DefaultTask {
+      * Install Task Action that copies the script and jar files
+      */
+     @TaskAction
+-    private void install() {
++    public void install() {
+         if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+             final String install_path = (path != null && !path.isEmpty()) ? path : "C:\\Program Files\\fastddsgen\\";
+ 


### PR DESCRIPTION
fastddsgen currently requires `NIXPKGS_ALLOW_INSECURE=1` due to its use of gradle_7. Unbreak fastddsgen using some unmerged upstream PRs.

* gradle_7 is marked insecure (#452022) and up for removal (#358845)
* switch to openjdk21, the current LTS
* add a basic version package test
* update Java dependencies

~Set to draft since upstream PRs are not yet merged and may still get updated.~

FYI maintainer: @wentasah

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
