### PR TITLE
python{2,3}Packages.pythonImportChecksHook: use a "clean" $PYTHONPATH

### DIFF
--- a/pkgs/development/interpreters/python/hooks/python-imports-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-imports-check-hook.sh
@@ -14,11 +14,10 @@ pythonImportsCheckPhase() {
             echo "Using python specific output \$python for imports check"
             pythonImportsCheckOutput=$python
         fi
-        export PYTHONPATH="$pythonImportsCheckOutput/@pythonSitePackages@:$PYTHONPATH"
         # Python modules and namespaces names are Python identifiers, which must not contain spaces.
         # See https://docs.python.org/3/reference/lexical_analysis.html
         # shellcheck disable=SC2048,SC2086
-        (cd "$pythonImportsCheckOutput" && @pythonCheckInterpreter@ -c 'import sys; import importlib; list(map(lambda mod: importlib.import_module(mod), sys.argv[1:]))' ${pythonImportsCheck[*]})
+        (export PYTHONPATH="$pythonImportsCheckOutput/@pythonSitePackages@:$cleanPythonPath" && cd "$pythonImportsCheckOutput" && @pythonCheckInterpreter@ -c 'import sys; import importlib; list(map(lambda mod: importlib.import_module(mod), sys.argv[1:]))' ${pythonImportsCheck[*]})
     fi
 }
 

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -396,6 +396,10 @@ let
 
       inherit dontWrapPythonPrograms;
 
+      preInstall = lib.optionalString (stdenv.buildPlatform == stdenv.hostPlatform) ''
+        export cleanPythonPath=${lib.escapeShellArg (lib.concatMapStringsSep ":" (p: "${p}/${python.sitePackages}") (python.pkgs.requiredPythonModules (finalAttrs.propagatedBuildInputs ++ finalAttrs.buildInputs)))}
+      '';
+
       postFixup =
         optionalString (!finalAttrs.dontWrapPythonPrograms) ''
           wrapPythonPrograms

--- a/pkgs/development/interpreters/python/python2/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/python2/mk-python-derivation.nix
@@ -256,6 +256,10 @@ let
         nativeInstallCheckInputs = nativeCheckInputs;
         installCheckInputs = checkInputs;
 
+        preInstall = lib.optionalString (stdenv.buildPlatform == stdenv.hostPlatform) ''
+          export cleanPythonPath=${lib.escapeShellArg (lib.concatMapStringsSep ":" (p: "${p}/${python.sitePackages}") (python.pkgs.requiredPythonModules (self.propagatedBuildInputs ++ self.buildInputs)))}
+        '';
+
         postFixup =
           lib.optionalString (!dontWrapPythonPrograms) ''
             wrapPythonPrograms

--- a/pkgs/development/python-modules/aioresponses/default.nix
+++ b/pkgs/development/python-modules/aioresponses/default.nix
@@ -10,6 +10,7 @@
 
   # dependencies
   aiohttp,
+  packaging,
 
   # tests
   ddt,
@@ -33,7 +34,7 @@ buildPythonPackage rec {
     setuptools
   ];
 
-  propagatedBuildInputs = [ aiohttp ];
+  propagatedBuildInputs = [ aiohttp packaging ];
 
   pythonImportsCheck = [ "aioresponses" ];
 

--- a/pkgs/development/python-modules/cppy/default.nix
+++ b/pkgs/development/python-modules/cppy/default.nix
@@ -5,6 +5,7 @@
   pythonOlder,
   pytestCheckHook,
   setuptools-scm,
+  setuptools,
 }:
 
 buildPythonPackage rec {
@@ -23,6 +24,7 @@ buildPythonPackage rec {
 
   build-system = [ setuptools-scm ];
 
+  buildInputs = [ setuptools ];
   nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "cppy" ];

--- a/pkgs/development/python-modules/google-cloud-bigquery/default.nix
+++ b/pkgs/development/python-modules/google-cloud-bigquery/default.nix
@@ -12,6 +12,7 @@
   google-cloud-core,
   google-resumable-media,
   grpcio,
+  packaging,
   proto-plus,
   protobuf,
   python-dateutil,
@@ -54,6 +55,7 @@ buildPythonPackage rec {
     google-cloud-core
     google-resumable-media
     grpcio
+    packaging
     proto-plus
     protobuf
     python-dateutil

--- a/pkgs/development/python-modules/pytest-lazy-fixture/default.nix
+++ b/pkgs/development/python-modules/pytest-lazy-fixture/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchPypi,
   setuptools,
+  pytest,
   pytestCheckHook,
 }:
 
@@ -26,6 +27,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pytest_lazyfixture" ];
 
+  buildInputs = [ pytest ];
   nativeCheckInputs = [ pytestCheckHook ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pytest-subtests/default.nix
+++ b/pkgs/development/python-modules/pytest-subtests/default.nix
@@ -13,6 +13,7 @@
 
   # tests
   pytestCheckHook,
+  pytest,
 }:
 
 buildPythonPackage rec {
@@ -35,6 +36,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ attrs ];
 
+  buildInputs = [ pytest ];
   nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "pytest_subtests" ];


### PR DESCRIPTION
Currently, non-propagated build inputs can leak into the import check's environment, leading to packages not having all the dependencies they need specified (with a false sense of security due to the import check succeeding).

To fix this, we construct a clean $PYTHONPATH consisting of only `propagatedBuildInputs` (and, for rare cases like pytest plugins where you might not want to propagate pytest itself, `buildInputs`).

Fixes https://github.com/NixOS/nixpkgs/issues/457347.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
