### PR TITLE
ocamlPackages.qcheck: 0.25 → 0.27

### DIFF
--- a/pkgs/development/ocaml-modules/containers/default.nix
+++ b/pkgs/development/ocaml-modules/containers/default.nix
@@ -1,8 +1,8 @@
 {
   lib,
   fetchFromGitHub,
+  fetchpatch,
   buildDunePackage,
-  ocaml,
   dune-configurator,
   either,
   seq,
@@ -13,18 +13,24 @@
   yojson,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   version = "3.16";
   pname = "containers";
-
-  minimalOCamlVersion = "4.08";
 
   src = fetchFromGitHub {
     owner = "c-cube";
     repo = "ocaml-containers";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-WaHAZRLjaEJUba/I2r3Yof/iUqA3PFUuVbzm88izG1k=";
   };
+
+  patches = [
+    # Compatibility with qcheck ≥ 0.26
+    (fetchpatch {
+      url = "https://github.com/c-cube/ocaml-containers/commit/3b49ad2a4e8cfe366d0588e1940d626f0e1b8a2d.patch";
+      hash = "sha256-LFe+LtpBBrf82SX57b4iQSvfd9tSXmnfhffjvjcfLpg=";
+    })
+  ];
 
   buildInputs = [ dune-configurator ];
   propagatedBuildInputs = [
@@ -40,7 +46,7 @@ buildDunePackage rec {
     yojson
   ];
 
-  doCheck = lib.versionAtLeast ocaml.version "4.08";
+  doCheck = true;
 
   meta = {
     homepage = "https://github.com/c-cube/ocaml-containers";
@@ -57,4 +63,4 @@ buildDunePackage rec {
     '';
     license = lib.licenses.bsd2;
   };
-}
+})

--- a/pkgs/development/ocaml-modules/qcheck/alcotest.nix
+++ b/pkgs/development/ocaml-modules/qcheck/alcotest.nix
@@ -7,7 +7,7 @@
 buildDunePackage {
   pname = "qcheck-alcotest";
 
-  inherit (qcheck-core) version src patches;
+  inherit (qcheck-core) version src;
 
   propagatedBuildInputs = [
     qcheck-core

--- a/pkgs/development/ocaml-modules/qcheck/core.nix
+++ b/pkgs/development/ocaml-modules/qcheck/core.nix
@@ -2,20 +2,22 @@
   lib,
   buildDunePackage,
   fetchFromGitHub,
+  alcotest,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "qcheck-core";
-  version = "0.25";
-
-  minimalOCamlVersion = "4.08";
+  version = "0.27";
 
   src = fetchFromGitHub {
     owner = "c-cube";
     repo = "qcheck";
-    tag = "v${version}";
-    hash = "sha256-Z89jJ21zm89wb9m5HthnbHdnE9iXLyaH9k8S+FAWkKQ=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-UfBfFVSvDeVPUakj2GQCRy5G5IZBxrgdceYtj+VAYbg=";
   };
+
+  doCheck = true;
+  checkInputs = [ alcotest ];
 
   meta = {
     description = "Core qcheck library";
@@ -24,4 +26,4 @@ buildDunePackage rec {
     maintainers = [ lib.maintainers.vbgl ];
   };
 
-}
+})

--- a/pkgs/development/ocaml-modules/qcheck/ounit.nix
+++ b/pkgs/development/ocaml-modules/qcheck/ounit.nix
@@ -7,7 +7,7 @@
 buildDunePackage {
   pname = "qcheck-ounit";
 
-  inherit (qcheck-core) version src patches;
+  inherit (qcheck-core) version src;
 
   propagatedBuildInputs = [
     qcheck-core


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
