### PR TITLE
catch2_3: fix pkgsLLVM checkPhase

### DIFF
--- a/pkgs/by-name/ca/catch2_3/package.nix
+++ b/pkgs/by-name/ca/catch2_3/package.nix
@@ -40,9 +40,9 @@ stdenv.mkDerivation rec {
     "-DCATCH_BUILD_TESTING=${if doCheck then "ON" else "OFF"}"
     "-DCATCH_ENABLE_WERROR=OFF"
   ]
-  ++ lib.optionals (stdenv.hostPlatform.isDarwin && doCheck) [
+  ++ lib.optionals (stdenv.cc.isClang && doCheck) [
     # test has a faulty path normalization technique that won't work in
-    # our darwin build environment https://github.com/catchorg/Catch2/issues/1691
+    # our darwin/LLVM build environment https://github.com/catchorg/Catch2/issues/1691
     "-DCMAKE_CTEST_ARGUMENTS=-E;ApprovalTests"
   ];
 


### PR DESCRIPTION
Think this should fix the checkPhase error encountered by @LordGrimmauld in https://github.com/NixOS/nixpkgs/pull/458211#pullrequestreview-3413145937

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
