### PR TITLE
Revert "wprkflows/bot: increase frequency to every 5 minutes"

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -7,9 +7,9 @@ name: Bot
 
 on:
   schedule:
-    # Run every 5m
+    # Run every 10m
     # i.e., at each of the listed minutes, every hour
-    - cron: '02,07,12,17,22,27,32,37,42,47,52,57 * * * *'
+    - cron: '05,15,25,35,45,55 * * * *'
   workflow_call:
     inputs:
       headBranch:

--- a/ci/github-script/bot.js
+++ b/ci/github-script/bot.js
@@ -587,7 +587,7 @@ module.exports = async ({ github, context, core, dry }) => {
         state: 'open',
         sort: 'created',
         direction: 'asc',
-        per_page: 50,
+        per_page: 100,
         after: cursor,
       })
 


### PR DESCRIPTION
This partially reverts commit 1197fe48da1d45506a3e95702ce5fb6437368598.

GitHub just doesn't schedule these narrow intervals. 10 minutes is alright in practice.

(also, this commit really needs to be reverted given the misspelling in the commit message, phew...)

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
