### PR TITLE
linuxPackages.shufflecake: use wrapped gcc compiler

### DIFF
--- a/pkgs/os-specific/linux/shufflecake/default.nix
+++ b/pkgs/os-specific/linux/shufflecake/default.nix
@@ -9,13 +9,14 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   name = "shufflecake";
-  version = "0.5.2";
+  version = "0.5.5";
+
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "shufflecake";
     repo = "shufflecake-c";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-EF9VKaqcNJt3hd/CUT+QeW17tc5ByStDanGGwi4uL4s=";
+    hash = "sha256-xVuI7tRARPFuETCCKYt507WpvZVZLaj9dhBkhJ03zc8=";
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
@@ -44,13 +45,13 @@ stdenv.mkDerivation (finalAttrs: {
     install -Dm555 shufflecake $bin/shufflecake
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Plausible deniability (hidden storage) layer for Linux";
     homepage = "https://shufflecake.net";
-    license = licenses.gpl2Only;
-    maintainers = with maintainers; [ oluceps ];
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ oluceps ];
     outputsToInstall = [ "bin" ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     broken = kernel.kernelOlder "6.1" || kernel.meta.name == "linux-lqx-6.12.1";
   };
 })

--- a/pkgs/os-specific/linux/shufflecake/default.nix
+++ b/pkgs/os-specific/linux/shufflecake/default.nix
@@ -23,12 +23,16 @@ stdenv.mkDerivation (finalAttrs: {
     libgcrypt
     lvm2
   ];
-  makeFlags = kernelModuleMakeFlags ++ [
-    "KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
-  ];
-
-  # GCC 14 makes this an error by default, remove when fixed upstream
-  env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types";
+  makeFlags =
+    kernelModuleMakeFlags
+    ++ [
+      "KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    ]
+    # Use wrapped gcc compiler since the unwrapped one fails to find the
+    # headers.
+    ++ lib.optionals stdenv.cc.isGNU [
+      "CC=${stdenv.cc.targetPrefix}cc"
+    ];
 
   outputs = [
     "out"


### PR DESCRIPTION
The [build failure](https://hydra.nixos.org/eval/1819915?filter=shufflecake&compare=1819881&full=) is related to https://github.com/NixOS/nixpkgs/pull/402198. Specifically, the [`CC` flag](https://github.com/NixOS/nixpkgs/pull/402198/files#diff-89cc016eeab47b854e5e2574ba0c38c3ed1510e1ac659f784c57933bb6a432eaR11) uses unwrapped compilers, which fail to find the headers. For shufflecake, I've explicitly set it to use the wrapped gcc, which seems to work fine. Not sure what to do about clang or if this is the best approach, but I'm open to suggestions.

ZHF: https://github.com/NixOS/nixpkgs/issues/457852

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
