### PR TITLE
akkuPackages: do not define meta.{description,homepage} to empty strings

### DIFF
--- a/pkgs/tools/package-management/akku/default.nix
+++ b/pkgs/tools/package-management/akku/default.nix
@@ -20,8 +20,8 @@ lib.makeScope newScope (self: rec {
           url,
           sha256,
           source,
-          synopsis ? "",
-          homepage ? "",
+          synopsis ? null,
+          homepage ? null,
           ...
         }:
         (akkuDerivation {
@@ -35,50 +35,56 @@ lib.makeScope newScope (self: rec {
           nativeBuildInputs = map (x: akkuself.${x}) dev-dependencies;
           unpackPhase = "tar xf $src";
 
-          meta.homepage = homepage;
-          meta.description = synopsis;
-          meta.license =
-            let
-              stringToLicense =
-                s:
-                (
-                  lib.licenses
-                  // (with lib.licenses; {
-                    "0bsd" = bsd0;
-                    "agpl" = agpl3Only;
-                    "apache-2.0" = asl20;
-                    "artistic" = artistic2;
-                    "bsd" = bsd3;
-                    "bsd-1-clause" = bsd1;
-                    "bsd-2-clause" = bsd2;
-                    "bsd-3-clause" = bsd3;
-                    "cc0-1.0" = cc0;
-                    "gpl" = gpl3Only;
-                    "gpl-2" = gpl2Only;
-                    "gpl-2.0-or-later" = gpl2Plus;
-                    "gplv2" = gpl2Only;
-                    "gpl-3" = gpl3Only;
-                    "gpl-3.0" = gpl3Only;
-                    "gpl-3.0-or-later" = gpl3Plus;
-                    "gplv3" = gpl3Only;
-                    "lgpl" = lgpl3Only;
-                    "lgpl-2" = lgpl2Only;
-                    "lgpl-2.0+" = lgpl2Plus;
-                    "lgpl-2.1" = lgpl21Only;
-                    "lgpl-2.1-or-later" = lgpl21Plus;
-                    "lgpl-3.0-or-later" = lgpl3Plus;
-                    "lgpl-3" = lgpl3Only;
-                    "lgplv3" = lgpl3Only;
-                    "public-domain" = publicDomain;
-                    "srfi" = bsd3;
-                    "unicode" = ucd;
-                    "xerox" = xerox;
-                    "zlib-acknowledgement" = zlib;
-                    "noassertion" = free;
-                  })
-                ).${s} or s;
-            in
-            if builtins.isList license then map stringToLicense license else stringToLicense license;
+          meta = {
+            license =
+              let
+                stringToLicense =
+                  s:
+                  (
+                    lib.licenses
+                    // (with lib.licenses; {
+                      "0bsd" = bsd0;
+                      "agpl" = agpl3Only;
+                      "apache-2.0" = asl20;
+                      "artistic" = artistic2;
+                      "bsd" = bsd3;
+                      "bsd-1-clause" = bsd1;
+                      "bsd-2-clause" = bsd2;
+                      "bsd-3-clause" = bsd3;
+                      "cc0-1.0" = cc0;
+                      "gpl" = gpl3Only;
+                      "gpl-2" = gpl2Only;
+                      "gpl-2.0-or-later" = gpl2Plus;
+                      "gplv2" = gpl2Only;
+                      "gpl-3" = gpl3Only;
+                      "gpl-3.0" = gpl3Only;
+                      "gpl-3.0-or-later" = gpl3Plus;
+                      "gplv3" = gpl3Only;
+                      "lgpl" = lgpl3Only;
+                      "lgpl-2" = lgpl2Only;
+                      "lgpl-2.0+" = lgpl2Plus;
+                      "lgpl-2.1" = lgpl21Only;
+                      "lgpl-2.1-or-later" = lgpl21Plus;
+                      "lgpl-3.0-or-later" = lgpl3Plus;
+                      "lgpl-3" = lgpl3Only;
+                      "lgplv3" = lgpl3Only;
+                      "public-domain" = publicDomain;
+                      "srfi" = bsd3;
+                      "unicode" = ucd;
+                      "xerox" = xerox;
+                      "zlib-acknowledgement" = zlib;
+                      "noassertion" = free;
+                    })
+                  ).${s} or s;
+              in
+              if builtins.isList license then map stringToLicense license else stringToLicense license;
+          }
+          // lib.optionalAttrs (homepage != null) {
+            inherit homepage;
+          }
+          // lib.optionalAttrs (synopsis != null) {
+            description = synopsis;
+          };
         }).overrideAttrs
           ({ "${pname}" = lib.id; } // overrides)."${pname}";
       deps = lib.importTOML ./deps.toml;


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
