### PR TITLE
microhs: init at 0.14.21.0

### DIFF
--- a/pkgs/by-name/mi/microhs/package.nix
+++ b/pkgs/by-name/mi/microhs/package.nix
@@ -1,0 +1,43 @@
+{
+  callPackage,
+  stdenv,
+  fetchFromGitHub,
+  lib,
+  writableTmpDirAsHomeHook,
+  writeTextDir,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "microhs";
+  version = "0.14.21.0";
+
+  src = fetchFromGitHub {
+    owner = "augustss";
+    repo = "MicroHs";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Tq8fjI3LCP4NWrmbMP0xyhY2fjRmsMCEvgfDQ/SB5Bo=";
+  };
+
+  # mcabal doesn't seem to respect the make flag and fails with /homeless-shelter
+  # This works around the issue
+  nativeBuildInputs = [ writableTmpDirAsHomeHook ];
+
+  makeFlags = [ "MCABAL=$(out)" ];
+  buildFlags = [ "bootstrap" ];
+
+  # MicroCabal is a separate repository, which should be packaged separately
+  # The MicroCabal that is installed by `make install` is pregenerated, does not respect MCABAL above, and so is not useable
+  postInstall = "rm $out/bin/mcabal";
+
+  passthru.tests = {
+    hello-world = callPackage ./test-hello-world.nix { microhs = finalAttrs.finalPackage; };
+  };
+
+  meta = {
+    description = "Haskell implemented with combinators";
+    homepage = "https://github.com/augustss/MicroHs";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.steeleduncan ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/mi/microhs/test-hello-world.nix
+++ b/pkgs/by-name/mi/microhs/test-hello-world.nix
@@ -1,0 +1,34 @@
+{
+  stdenv,
+  microhs,
+  writeTextDir,
+}:
+
+stdenv.mkDerivation {
+  name = "microhs-hello-world";
+  buildInputs = [ microhs ];
+
+  src = writeTextDir "helloworld.hs" ''
+    main :: IO ()
+    main = putStrLn "Hello World"
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    mhs helloworld.hs -oExe
+    runHook postBuild
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    ./Exe | grep "Hello World"
+    runHook postCheck
+  '';
+  doCheck = true;
+
+  installPhase = ''
+    runHook preInstall
+    touch $out
+    runHook postInstall
+  '';
+}


### PR DESCRIPTION
MicroHS is a Haskell compiler and interpreter

This exists as an autogenerated haskell package `haskellPackages.MicroHs`, but this package builds it independently of GHC, using the bootstrap functionality to build it from just a C compiler. This gives an alternate, easily auditable, lightweight haskell compiler and interpreter, that does not rely on the GHC toolchain at all

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
