### PR TITLE
linuxPackages.linux-gpib: 4.3.6 -> 4.3.7

### DIFF
--- a/pkgs/applications/science/electronics/linux-gpib/common.nix
+++ b/pkgs/applications/science/electronics/linux-gpib/common.nix
@@ -4,12 +4,12 @@
   lib,
 }:
 rec {
-  version = "4.3.6";
+  version = "4.3.7";
   inherit pname;
 
   src = fetchurl {
     url = "mirror://sourceforge/project/linux-gpib/linux-gpib%20for%203.x.x%20and%202.6.x%20kernels/${version}/linux-gpib-${version}.tar.gz";
-    hash = "sha256-Gze4xrvkhEgn+J5Jhrycezjp2uhlD1v6aX0WGv4J2Jg=";
+    hash = "sha256-s/+BJgaGXIW1iwEqQhim/juC0XfIwKvHlcsi20HzrWg=";
   };
 
   unpackPhase = ''

--- a/pkgs/applications/science/electronics/linux-gpib/kernel.nix
+++ b/pkgs/applications/science/electronics/linux-gpib/kernel.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation (
 
     makeFlags = [
       "LINUX_SRCDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+      "LINUX_SSRCDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/source"
     ];
 
     installFlags = [


### PR DESCRIPTION
https://hydra.nixos.org/eval/1819915?filter=linux-gpib&compare=1819881&full=

ZHF: https://github.com/NixOS/nixpkgs/issues/457852

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
