### PR TITLE
nixos/datadog-agent: fix runtime directory and upload retrying

### DIFF
--- a/nixos/modules/services/monitoring/datadog-agent.nix
+++ b/nixos/modules/services/monitoring/datadog-agent.nix
@@ -315,7 +315,13 @@ in
             export DD_API_KEY=$(head -n 1 ${cfg.apiKeyFile})
             exec ${datadogPkg}/bin/agent run -c /etc/datadog-agent/datadog.yaml
           '';
-          serviceConfig.PermissionsStartOnly = true;
+          serviceConfig = {
+            PermissionsStartOnly = true;
+            StateDirectory = "datadog-agent";
+          };
+          environment = {
+            DD_RUN_PATH = "%S/datadog-agent";
+          };
         };
 
         dd-jmxfetch = lib.mkIf (lib.hasAttr "jmx" cfg.checks) (makeService {


### PR DESCRIPTION
Fixes datadog-agent being unable to retry sending events, due to missing `/opt/datadog-agent/` on nixos:
```
datadog - (comp/forwarder/defaultforwarder@v0.56.2/default_forwarder.go:525 in sendHTTPTransactions) | Cannot compute the capacity of the retry queues: no such file or directory
```

(I'm realizing now that I have 25.05 as target rather than main, can fix)

It's a little bit hard to see why this fixes the issue, but basically:
 * Datadog uses the configuration's `run_path` to determine where to put the retry database, via `forwarder_storage_path`, which defaults to a path inside `run_path` - see https://github.com/DataDog/datadog-agent/pull/8208
 * datadog will read values for all configuration items by transforming `foo_bar` to `DD_FOO_BAR`
 * So...use systemd to make a nice directory for state and point datadog at it.
This is my first contribution to nix, will need to go through the proper steps to try it outside the configuration tree I already have.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
