### PR TITLE
ryuldn: init at 0-unstable-2025-11-10

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1351,6 +1351,7 @@
   ./services/networking/routinator.nix
   ./services/networking/rpcbind.nix
   ./services/networking/rxe.nix
+  ./services/networking/ryuldn.nix
   ./services/networking/sabnzbd
   ./services/networking/scion/scion-control.nix
   ./services/networking/scion/scion-daemon.nix

--- a/nixos/modules/services/networking/ryuldn.nix
+++ b/nixos/modules/services/networking/ryuldn.nix
@@ -1,0 +1,139 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.ryuldn;
+  user = "ryuldn";
+  dataDir = "/var/lib/${user}";
+in
+{
+  config = lib.mkIf cfg.enable {
+    networking.firewall.allowedTCPPorts = [ cfg.settings.port ];
+
+    services.redis.servers.ryuldn = {
+      enable = cfg.redis.enable;
+      port = 0;
+      save = [ ];
+      settings.loadmodule = [ "${pkgs.redisjson}/lib/librejson.so" ];
+      inherit user;
+    };
+
+    systemd.services = {
+      ryuldn = {
+        after = [ "network.target" ];
+        environment =
+          lib.concatMapAttrs (n: v: {
+            ${"LDN_" + lib.toUpper n} = if lib.isBool v then lib.boolToString v else toString v;
+          }) cfg.settings
+          // {
+            LDN_REDIS_SOCKET = lib.optionalString cfg.redis.enable config.services.redis.servers.ryuldn.unixSocket;
+          };
+        script = lib.getExe cfg.package;
+        serviceConfig = {
+          User = user;
+          WorkingDirectory = dataDir;
+        };
+        wantedBy = [ "multi-user.target" ];
+      };
+      ryuldn-web = {
+        enable = cfg.web.enable;
+        after = [
+          "network.target"
+          "ryuldn.service"
+        ];
+        environment =
+          lib.concatMapAttrs (n: v: {
+            ${lib.toUpper n} = if lib.isBool v then lib.boolToString v else toString v;
+          }) cfg.web.settings
+          // {
+            DATA_PATH = dataDir;
+            REDIS_SOCKET = lib.optionalString cfg.redis.enable config.services.redis.servers.ryuldn.unixSocket;
+          };
+        script = lib.getExe cfg.web.package;
+        serviceConfig = {
+          User = user;
+          WorkingDirectory = dataDir;
+        };
+        wantedBy = [ "multi-user.target" ];
+      };
+    };
+
+    users = {
+      groups.${user} = { };
+      users.${user} = {
+        createHome = true;
+        group = user;
+        home = dataDir;
+        isSystemUser = true;
+      };
+    };
+  };
+
+  options.services.ryuldn = {
+    enable = lib.mkEnableOption "RyuLDN Multiplayer Server";
+    package = lib.mkPackageOption pkgs "ryuldn" { };
+    redis.enable = lib.mkEnableOption "Analytics via Redis" // {
+      default = true;
+    };
+    settings = lib.mkOption {
+      description = "Configuration options for the RyuLDN Multiplayer Server";
+      type = lib.types.submodule {
+        options = {
+          gamelist_path = lib.mkOption {
+            default = "${cfg.package}/gamelist.json";
+            defaultText = lib.literalExpression "\${config.services.ryuldn.package}/gamelist.json";
+            description = "The path to the file containing a mapping of application ids and names";
+            type = lib.types.path;
+          };
+          host = lib.mkOption {
+            default = "0.0.0.0";
+            description = "The address the server should be listening on";
+            type = lib.types.str;
+          };
+          port = lib.mkOption {
+            default = 30456;
+            description = "The port the server should be using";
+            type = lib.types.int;
+          };
+        };
+      };
+    };
+    web = lib.mkOption {
+      description = "RyuLDN Website for the RyuLDN Multiplayer Server";
+      type = lib.types.submodule {
+        options = {
+          enable = lib.mkEnableOption "RyuLDN Website";
+          package = lib.mkPackageOption pkgs "ryuldn-web" { };
+          settings = lib.mkOption {
+            description = "Configuration options for the RyuLDN Website";
+            type = lib.types.submodule {
+              options = {
+                node_env = lib.mkOption {
+                  default = "production";
+                  description = "This should be set to production or development depending on the current environment";
+                  example = "development";
+                  type = lib.types.str;
+                };
+                host = lib.mkOption {
+                  default = "127.0.0.1";
+                  description = "The address this server should be listening on";
+                  type = lib.types.str;
+                };
+                port = lib.mkOption {
+                  default = 3000;
+                  description = "The port this server should be using";
+                  type = lib.types.int;
+                };
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+
+  meta.maintainers = [ lib.maintainers.SchweGELBin ];
+}

--- a/pkgs/by-name/re/redisjson/package.nix
+++ b/pkgs/by-name/re/redisjson/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  rustPlatform,
+  fetchgit,
+  fetchpatch2,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "redisjson";
+  version = "2.8.16";
+
+  src = fetchgit {
+    url = "https://github.com/RedisJSON/RedisJSON";
+    fetchSubmodules = true;
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-LDP4MztuhJvRJ6jm2ciGb5MRZy0IKXVFfyouDMoyQmo=";
+  };
+
+  cargoHash = "sha256-qmEi3MHW2uxENN41+cnho9rX6A2CSewQiceuLfGDk3c=";
+
+  cargoPatches = [
+    (fetchpatch2 {
+      name = "Make rustflags an array";
+      url = "https://github.com/RedisJSON/RedisJSON/commit/48d0d9d490d3272d376a0a5690e3ab7e17db70b1.patch?full_index=1";
+      hash = "sha256-aw5ynoabJk5RZrQoXtkpUU0x5OOHIoTZ5otzyUYoE2k=";
+    })
+  ];
+
+  nativeBuildInputs = [ rustPlatform.bindgenHook ];
+
+  meta = {
+    homepage = finalAttrs.src.url;
+    description = "JSON data type for Redis ";
+    license = lib.licenses.agpl3Only;
+    platforms = lib.platforms.unix;
+    changelog = "${finalAttrs.src.url}/releases/tag/v${finalAttrs.version}";
+    maintainers = [ lib.maintainers.SchweGELBin ];
+  };
+})

--- a/pkgs/by-name/ry/ryuldn-web/package.nix
+++ b/pkgs/by-name/ry/ryuldn-web/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitLab,
+  nodejs,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "ryuldn-web";
+  version = "0-unstable-2025-11-05";
+
+  src = fetchFromGitLab {
+    domain = "git.ryujinx.app";
+    owner = "Ryubing";
+    repo = "ldnweb";
+    rev = "af8fd6a09b7a4edc34a6bab803e980b7c28093a5";
+    hash = "sha256-KNAeNoj0R6D7kWYvzyRs5vOfDrIAJPlYWjLJEJXwTEE=";
+  };
+
+  npmDepsHash = "sha256-fqvUE5/M2VyIL5CyDEuUGye27e9fJJImMYL1wwZNFPg=";
+
+  postPatch = ''
+    substituteInPlace src/titleIdManager.ts \
+      --replace-fail "this.filePath = \`\''${dataDirectory}/ryuldn/otherTitleIds.txt\`;" \
+                     "this.filePath = \`\''${dataDirectory}/otherTitleIds.txt\`;"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    cp -r dist $out
+    cp -r package.json package-lock.json node_modules public $out
+
+    makeWrapper '${nodejs}/bin/node' "$out/bin/ryujinx-ldn-website" --add-flags "$out/index.js"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://ldn.ryujinx.app";
+    description = "Website which connects to a RyuLDN server";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.SchweGELBin ];
+    platforms = lib.platforms.unix;
+    mainProgram = "ryujinx-ldn-website";
+  };
+})

--- a/pkgs/by-name/ry/ryuldn/deps.json
+++ b/pkgs/by-name/ry/ryuldn/deps.json
@@ -1,0 +1,37 @@
+[
+  {
+    "pname": "NetCoreServer",
+    "version": "8.0.7",
+    "hash": "sha256-RUYic8uAgJGdhUCrMJQULKlHB6xvw9H1lnNGU1axNZw="
+  },
+  {
+    "pname": "NetTopologySuite",
+    "version": "2.5.0",
+    "hash": "sha256-nIjkrfQwb8BDbtyLFoKLn5+KklbfW60Dxb1Op9t58lM="
+  },
+  {
+    "pname": "NRedisStack",
+    "version": "0.11.0",
+    "hash": "sha256-UxMIB8q5QQHtrLG9rOUIm3YlDXHtRKXVA589S8U5pko="
+  },
+  {
+    "pname": "Pipelines.Sockets.Unofficial",
+    "version": "2.2.8",
+    "hash": "sha256-4wKlgwM14Ik6WyB/MBDPKhfx9GHeZD2R20OLyRz2sF0="
+  },
+  {
+    "pname": "StackExchange.Redis",
+    "version": "2.6.122",
+    "hash": "sha256-MIIM8KZSLsGvYnBKFto4RnXV4h5GFQp5Y7UmNopiDIo="
+  },
+  {
+    "pname": "System.IO.Pipelines",
+    "version": "5.0.1",
+    "hash": "sha256-2zT5uBiyYm+jLIoJppIKJttTtpcMNKxd7Li0QEVjbv8="
+  },
+  {
+    "pname": "System.Memory",
+    "version": "4.5.4",
+    "hash": "sha256-3sCEfzO4gj5CYGctl9ZXQRRhwAraMQfse7yzKoRe65E="
+  }
+]

--- a/pkgs/by-name/ry/ryuldn/package.nix
+++ b/pkgs/by-name/ry/ryuldn/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildDotnetModule,
+  fetchFromGitLab,
+}:
+
+buildDotnetModule (finalAttrs: {
+  pname = "ryuldn";
+  version = "0-unstable-2025-11-10";
+
+  src = fetchFromGitLab {
+    domain = "git.ryujinx.app";
+    owner = "Ryubing";
+    repo = "ldn";
+    rev = "a0c24aab984cfeb93428cae29e35296a880ff6fa";
+    hash = "sha256-l4twKew1+nMQIslFUiZzX2La1uptGx3Fqmh30pZlyuk=";
+  };
+
+  projectFile = "LanPlayServer.csproj";
+  nugetDeps = ./deps.json;
+
+  dotnetFlags = [ "-p:PublishAOT=false" ];
+
+  postInstall = "cp ${finalAttrs.src}/Utils/gamelist.json $out";
+
+  meta = {
+    homepage = "https://ldn.ryujinx.app";
+    description = "Backend server for using LDN functionality for playing with those who aren't local.";
+    longDescription = ''
+      This server drives multiplayer "matchmaking" in Ryujinx's local wireless implementation.
+      Players can create "networks" on the server, which can then be scanned and found by other players
+      as if they were within that network's range. The server entirely manages the network information
+      and player join/leave lifecycle for all games created.
+    '';
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.SchweGELBin ];
+    platforms = lib.platforms.unix;
+    mainProgram = "LanPlayServer";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

> Ryujinx LDN Multiplayer Server
This server drives multiplayer "matchmaking" in Ryujinx's local wireless implementation. Players can create "networks" on the server, which can then be scanned and found by other players as if they were within that network's range. The server entirely manages the network information and player join/leave lifecycle for all games created.

It's maintained by the Ryubing project and is [pretty actice](https://ldn.ryujinx.app/).
It allows Ryubing users to play online via the Local Wireless mode.

I've included all the dependencies, the server and the website as packages.
The module that I created handles the hosting for you, with or without the website.

You can find more information in the [Ryubing wiki](https://git.ryujinx.app/ryubing/ryujinx/-/wikis/Multiplayer-(LDN-Local-Wireless)-Guide) and the [README](https://git.ryujinx.app/ryubing/ldn/-/blob/master/README.md).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
