### PR TITLE
ci: unbreak

### DIFF
--- a/ci/default.nix
+++ b/ci/default.nix
@@ -30,7 +30,14 @@ let
         inherit (pinned.treefmt-nix) url;
         sha256 = pinned.treefmt-nix.hash;
       };
-      treefmtEval = (import treefmtNixSrc).evalModule pkgs {
+      # Will be upstreamed shortly
+      # error: hash mismatch in file downloaded from 'https://biomejs.dev/schemas/2.1.2/schema.json':
+      patchedTreefmtNixSrc = pkgs.applyPatches {
+        src = treefmtNixSrc;
+        name = "unbreak-ci-20251104";
+        patches = [ ./treefmt-nix-biome-fix.patch ];
+      };
+      treefmtEval = (import patchedTreefmtNixSrc).evalModule pkgs {
         # Important: The auto-rebase script uses `git filter-branch --tree-filter`,
         # which creates trees within the Git repository under `.git-rewrite/t`,
         # notably without having a `.git` themselves.

--- a/ci/treefmt-nix-biome-fix.patch
+++ b/ci/treefmt-nix-biome-fix.patch
@@ -1,0 +1,15 @@
+diff --git a/programs/biome.nix b/programs/biome.nix
+index 287aabd..e261ef9 100644
+--- a/programs/biome.nix
++++ b/programs/biome.nix
+@@ -14,8 +14,8 @@ let
+   biomeVersion = if builtins.match "^1\\." pkgs.biome.version != null then "1.9.4" else "2.1.2";
+   schemaUrl = "https://biomejs.dev/schemas/${biomeVersion}/schema.json";
+   schemaSha256s = {
+-    "1.9.4" = "sha256:0yzw4vymwpa7akyq45v7kkb9gp0szs6zfm525zx2vh1d80568dlz";
+-    "2.1.2" = "sha256:07qlk53lja9rsa46b8nv3hqgdzc9mif5r1nwh7i8mrxcqmfp99s2";
++    "1.9.4" = "sha256:0xia00hbazxnddinwx5bcfy3mrm8q31qgx78jcrj9q34nhn18jaa";
++    "2.1.2" = "sha256:1d909q6abxc3kcaqx4b9ibkfgzpwds5l8cylans8gpz0kvl3b1lz";
+   };
+   schemaSha256 = schemaSha256s.${biomeVersion};
+ 


### PR DESCRIPTION
Tested by running `nix fmt` locally.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
