### PR TITLE
jcmdshell: init at 0.1.0

### DIFF
--- a/pkgs/by-name/jc/jcmdshell/package.nix
+++ b/pkgs/by-name/jc/jcmdshell/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  maven,
+  makeWrapper,
+  fetchFromGitHub,
+  jdk25,
+  runCommand,
+}:
+
+let
+  version = "0.1.0";
+in
+maven.buildMavenPackage {
+  pname = "jcmdshell";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "StackPancakes";
+    repo = "Jcmdshell";
+    rev = version;
+    hash = "sha256-nbLyi7w0frfAxy0sOrUz0pvl9ADh7bYogWi/dvJhlZ0=";
+  };
+
+  mvnHash = "sha256-J7Nkc4MMQm6h32h9/8ik0Tzv7EQkYJorCa23I0Z8xsY=";
+  mvnJdk = jdk25;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/jcmdshell
+    install -Dm644 target/Jcmdshell-fat.jar $out/share/jcmdshell/jcmdshell.jar
+
+    makeWrapper ${jdk25}/bin/java $out/bin/jcmdshell \
+      --add-flags "--enable-native-access=ALL-UNNAMED" \
+      --add-flags "-jar $out/share/jcmdshell/jcmdshell.jar"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Cross-platform command-line shell built in pure Java, designed around the WORE principle (Write Once, Run Everywhere)";
+    homepage = "https://github.com/StackPancakes/Jcmdshell";
+    changelog = "https://github.com/StackPancakes/Jcmdshell/releases/tag/${version}";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ xdhampus ];
+    mainProgram = "jcmdshell";
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
