### PR TITLE
ci/treefmt: disable biome for now

### DIFF
--- a/ci/default.nix
+++ b/ci/default.nix
@@ -48,7 +48,8 @@ let
         programs.actionlint.enable = true;
 
         programs.biome = {
-          enable = true;
+          # FIXME: Disabled temporarily due to https://github.com/numtide/treefmt-nix/pull/430
+          enable = false;
           settings.formatter = {
             useEditorconfig = true;
           };
@@ -58,10 +59,10 @@ let
           };
           settings.json.formatter.enabled = false;
         };
-        settings.formatter.biome.excludes = [
-          "*.min.js"
-          "pkgs/*"
-        ];
+        # settings.formatter.biome.excludes = [
+        #   "*.min.js"
+        #   "pkgs/*"
+        # ];
 
         programs.keep-sorted.enable = true;
 


### PR DESCRIPTION
Temporarily disable biome due to a hash mismatch with validation for the `settings.formatter.biome.options` option.

See https://github.com/numtide/treefmt-nix/pull/430
Closes https://github.com/NixOS/nixpkgs/pull/458647


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
