### PR TITLE
firefox-gnome-theme: init at 143

### DIFF
--- a/pkgs/by-name/fi/firefox-gnome-theme/package.nix
+++ b/pkgs/by-name/fi/firefox-gnome-theme/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "firefox-gnome-theme";
+  version = "143";
+
+  src = fetchFromGitHub {
+    owner = "rafaelmardojai";
+    repo = "firefox-gnome-theme";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-0E3TqvXAy81qeM/jZXWWOTZ14Hs1RT7o78UyZM+Jbr4=";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  # patching the install script for nix:
+  # - point to the nix store
+  # - don't preserve mode so successive installations work without elevation
+  # - don't try to move files out of the nix store
+  postPatch = ''
+    patchShebangs ./scripts
+    substituteInPlace ./scripts/auto-install.sh \
+      --replace-fail \
+        'installScript="./scripts/install.sh"' \
+        'installScript="${placeholder "out"}/bin/install.sh"' \
+      --replace-fail \
+        'eval "chmod +x ''${installScript}"' \
+        ""
+    substituteInPlace ./scripts/install.sh \
+      --replace-fail \
+        'THEMEDIRECTORY=$(cd "$(dirname $0)" && cd .. && pwd)' \
+        'THEMEDIRECTORY="${placeholder "out"}/share/firefox-gnome-theme"' \
+      --replace-fail \
+        'cp -fR "$THEMEDIRECTORY/."' \
+        'cp -fR --no-preserve=mode "$THEMEDIRECTORY/."' \
+      --replace-fail \
+        'mv chrome/firefox-gnome-theme/configuration/user.js' \
+        'cp chrome/firefox-gnome-theme/configuration/user.js'
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm555 ./scripts/{auto-,}install.sh -t $out/bin
+    install -Dm644 ./icon.svg ./user{Chrome,Content}.css -t $out/share/firefox-gnome-theme
+    install -Dm644 ./configuration/user.js -t $out/share/firefox-gnome-theme/configuration
+    cp -r ./theme $out/share/firefox-gnome-theme
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "GNOME theme for Firefox";
+    longDescription = ''
+      A GNOME theme for Firefox.
+      This theme follows latest GNOME Adwaita style.
+    '';
+    homepage = "https://github.com/rafaelmardojai/firefox-gnome-theme";
+    downloadPage = "https://github.com/rafaelmardojai/firefox-gnome-theme/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.unlicense;
+    maintainers = [ lib.maintainers.nekowinston ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Picking up #347611 because I didn't get a response to my review, @ASHGOLDOFFICIAL please let me know if you'd still like to maintain this.

I bothered to patch the install script to an extent where it works on NixOS now. I assume most users will manage it with Home Manager, but it's there if people want it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
