### PR TITLE
parlance: init at 0-unstable-2025-11-03

### DIFF
--- a/pkgs/by-name/pa/parlance/package.nix
+++ b/pkgs/by-name/pa/parlance/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "parlance";
+  version = "0-unstable-2025-11-03";
+
+  src = fetchFromGitHub {
+    owner = "buyukakyuz";
+    repo = "parlance";
+    rev = "8ed03f66780db63b04657e4a09b632c2b0ed8467";
+    hash = "sha256-n6gvHXXG2R2bqiHNmJN+YOkE57PlOFq2mKN+xHdOpbE=";
+  };
+
+  cargoHash = "sha256-fxB0PF04Pikyl2/XTPdLGTGJqfy4brjXA9KSq9eiQ6k=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Peer-to-peer messaging for LANs with UDP multicast discovery and TCP messaging";
+    homepage = "https://github.com/buyukakyuz/parlance";
+    license = lib.licenses.unfree; # https://github.com/buyukakyuz/parlance/issues/1
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "parlance";
+  };
+}


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
