### PR TITLE
lsp-plugins: add build options

### DIFF
--- a/pkgs/by-name/ls/lsp-plugins/package.nix
+++ b/pkgs/by-name/ls/lsp-plugins/package.nix
@@ -13,10 +13,28 @@
   lv2,
   php84,
   pkg-config,
+
+  buildVST3 ? true,
+  buildVST2 ? true,
+  buildCLAP ? true,
+  buildLV2 ? true,
+  buildLADSPA ? true,
+  buildJACK ? true,
+  buildGStreamer ? true,
 }:
 
 let
   php = php84;
+
+  subFeatures = [
+    (lib.optionalString (!buildVST3) "vst3")
+    (lib.optionalString (!buildVST2) "vst2")
+    (lib.optionalString (!buildCLAP) "clap")
+    (lib.optionalString (!buildLV2) "lv2")
+    (lib.optionalString (!buildLADSPA) "ladspa")
+    (lib.optionalString (!buildJACK) "jack")
+    (lib.optionalString (!buildGStreamer) "gst")
+  ];
 in
 
 stdenv.mkDerivation (finalAttrs: {
@@ -63,6 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
     "ETCDIR=${placeholder "out"}/etc"
     "PREFIX=${placeholder "out"}"
     "SHAREDDIR=${placeholder "out"}/share"
+    "SUB_FEATURES=${lib.concatStringsSep " " subFeatures}"
   ];
 
   env.NIX_CFLAGS_COMPILE = "-DLSP_NO_EXPERIMENTAL";


### PR DESCRIPTION
Exposes `SUB_FEATURES`make flag in a set of boolean options.

Does this seem excessive? Maybe it would be better just add a meta option (`subFeatures`)?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
