### PR TITLE
stegsnow: init at 20130616-8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18523,6 +18523,12 @@
     githubId = 6391776;
     name = "Nikita Voloboev";
   };
+  nikitawootten = {
+    email = "nixpkgs@nikita.computer";
+    github = "nikitawootten";
+    githubId = 8916363;
+    name = "Nikita Wootten";
+  };
   niklashh = {
     email = "niklas.2.halonen@aalto.fi";
     github = "xhalo32";

--- a/pkgs/by-name/st/stegsnow/package.nix
+++ b/pkgs/by-name/st/stegsnow/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "stegsnow";
+  version = "20130616-8";
+
+  src = fetchFromGitLab {
+    domain = "salsa.debian.org";
+    owner = "pkg-security-team";
+    repo = "stegsnow";
+    rev = "debian/${finalAttrs.version}";
+    hash = "sha256-5GmU2HfWSLJ8DwjZZmWW277rJhA73is6606YZAKo4r8=";
+  };
+
+  postPatch = ''
+    for i in $(cat debian/patches/series); do
+      patch -p1 < "debian/patches/$i"
+    done
+
+    substituteInPlace Makefile \
+      --replace-fail 'snow:' 'stegsnow:' \
+
+    mv snow.1 stegsnow.1
+  '';
+
+  makeFlags = [
+    "CC=${stdenv.cc.targetPrefix}cc"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 stegsnow $out/bin/stegsnow
+    install -Dm644 stegsnow.1 $out/share/man/man1/stegsnow.1
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Conceal messages in ASCII text by appending whitespace to the end of lines";
+    # Long description via homepage
+    longDescription = ''
+      The program SNOW is used to conceal messages in ASCII text by appending whitespace to the end of lines.
+      Because spaces and tabs are generally not visible in text viewers, the message is effectively hidden from casual observers.
+      And if the built-in encryption is used, the message cannot be read even if it is detected.
+    '';
+    homepage = "https://darkside.com.au/snow/";
+    license = licenses.asl20;
+    platforms = lib.platforms.all;
+    maintainers = with maintainers; [ nikitawootten ];
+    mainProgram = "stegsnow";
+  };
+})


### PR DESCRIPTION
This PR packages [stegsnow](https://darkside.com.au/snow/), a utility for hiding messages in whitespace at the end of lines of a file.

Related to https://github.com/NixOS/nixpkgs/issues/81418

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
