### PR TITLE
buildMozillaMach: workaround llvm 21 bug on aarch64-darwin

### DIFF
--- a/pkgs/build-support/build-mozilla-mach/default.nix
+++ b/pkgs/build-support/build-mozilla-mach/default.nix
@@ -58,7 +58,9 @@ in
   pkgsCross, # wasm32 rlbox
   python3,
   runCommand,
+  rustc,
   rust-cbindgen,
+  rustPlatform,
   unzip,
   which,
   wrapGAppsHook3,
@@ -199,25 +201,9 @@ assert elfhackSupport -> isElfhackPlatform stdenv;
 let
   inherit (lib) enableFeature;
 
-  rustPackages =
-    pkgs:
-    (pkgs.rust.override (
-      # aarch64-darwin firefox crashes on loading favicons due to a llvm 21 bug:
-      # https://github.com/NixOS/nixpkgs/issues/453372
-      # https://bugzilla.mozilla.org/show_bug.cgi?id=1995582#c16
-      lib.optionalAttrs (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) {
-        llvmPackages = pkgs.llvmPackages_20;
-      }
-    )).packages.stable;
-
-  toRustC = pkgs: (rustPackages pkgs).rustc;
-
-  rustc = toRustC pkgs;
-  inherit (rustPackages pkgs) rustPlatform;
-
   # Target the LLVM version that rustc is built with for LTO.
   llvmPackages0 = rustc.llvmPackages;
-  llvmPackagesBuildBuild0 = (toRustC pkgsBuildBuild).llvmPackages;
+  llvmPackagesBuildBuild0 = pkgsBuildBuild.rustc.llvmPackages;
 
   # Force the use of lld and other llvm tools for LTO
   llvmPackages = llvmPackages0.override {
@@ -232,7 +218,7 @@ let
   # LTO requires LLVM bintools including ld.lld and llvm-ar.
   buildStdenv = overrideCC llvmPackages.stdenv (
     llvmPackages.stdenv.cc.override {
-      bintools = if ltoSupport then (toRustC buildPackages).llvmPackages.bintools else stdenv.cc.bintools;
+      bintools = if ltoSupport then buildPackages.rustc.llvmPackages.bintools else stdenv.cc.bintools;
     }
   );
 

--- a/pkgs/build-support/build-mozilla-mach/default.nix
+++ b/pkgs/build-support/build-mozilla-mach/default.nix
@@ -390,6 +390,14 @@ buildStdenv.mkDerivation {
 
   setOutputFlags = false; # `./mach configure` doesn't understand `--*dir=` flags.
 
+  # Workaround for a bug in llvm21 aarch implementation. See:
+  # https://github.com/llvm/llvm-project/pull/129889#issuecomment-3486541843
+  # https://github.com/NixOS/nixpkgs/issues/453372#issuecomment-3494078544
+  # https://bugzilla.mozilla.org/show_bug.cgi?id=1995582#c16
+  CPPFLAGS = lib.optionalString (
+    stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64
+  ) "-mllvm -aarch64-enable-copy-propagation=false";
+
   preConfigure = ''
     # Runs autoconf through ./mach configure in configurePhase
     configureScript="$(realpath ./mach) configure"


### PR DESCRIPTION
- **buildMozillaMach: disable -aarch64-enable-copy-propagation for darwin**
- **Revert "buildMozillaMach: use llvmPackages_20 on aarch64-darwin"**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
