### PR TITLE
yubioath-flutter: 7.3.0 -> 7.3.1

### DIFF
--- a/pkgs/by-name/yu/yubioath-flutter/package.nix
+++ b/pkgs/by-name/yu/yubioath-flutter/package.nix
@@ -1,31 +1,28 @@
 {
   lib,
   flutter335,
-  python3,
+  python3Packages,
   fetchFromGitHub,
   pcre2,
   libnotify,
   libappindicator,
-  pkg-config,
   gnome-screenshot,
-  makeWrapper,
   removeReferencesTo,
   runCommand,
-  yq,
-  yubioath-flutter,
+  yq-go,
   _experimental-update-script-combinators,
-  gitUpdater,
+  nix-update-script,
 }:
 
 flutter335.buildFlutterApplication rec {
   pname = "yubioath-flutter";
-  version = "7.3.0";
+  version = "7.3.1";
 
   src = fetchFromGitHub {
     owner = "Yubico";
     repo = "yubioath-flutter";
     tag = version;
-    hash = "sha256-1Hr8ZDHXiLiYfQg4PEpmIuIJR/USbsGCgI4YZSex2Eg=";
+    hash = "sha256-jfWLj5pN1NGfnmYQ0lYeKwlc0v7pCdvAjmmWX5GP7aM=";
   };
 
   pubspecLock = lib.importJSON ./pubspec.lock.json;
@@ -39,11 +36,7 @@ flutter335.buildFlutterApplication rec {
       --replace-fail "../build/linux/helper" "${passthru.helper}/libexec/helper"
   '';
 
-  nativeBuildInputs = [
-    makeWrapper
-    removeReferencesTo
-    pkg-config
-  ];
+  nativeBuildInputs = [ removeReferencesTo ];
 
   buildInputs = [
     pcre2
@@ -86,19 +79,24 @@ flutter335.buildFlutterApplication rec {
   '';
 
   passthru = {
-    helper = python3.pkgs.callPackage ./helper.nix { inherit src version meta; };
+    helper = python3Packages.callPackage ./helper.nix { inherit src version meta; };
     pubspecSource =
       runCommand "pubspec.lock.json"
         {
-          nativeBuildInputs = [ yq ];
-          inherit (yubioath-flutter) src;
+          inherit src;
+          nativeBuildInputs = [ yq-go ];
         }
         ''
-          cat $src/pubspec.lock | yq > $out
+          yq eval --output-format=json --prettyPrint $src/pubspec.lock > "$out"
         '';
     updateScript = _experimental-update-script-combinators.sequence [
-      (gitUpdater { })
-      (_experimental-update-script-combinators.copyAttrOutputToFile "yubioath-flutter.pubspecSource" ./pubspec.lock.json)
+      (nix-update-script { extraArgs = [ "--use-github-releases" ]; })
+      (
+        (_experimental-update-script-combinators.copyAttrOutputToFile "yubioath-flutter.pubspecSource" ./pubspec.lock.json)
+        // {
+          supportedFeatures = [ ];
+        }
+      )
     ];
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/Yubico/yubioath-flutter/blob/71873fd66ae374994f7f4f0c71427365b38a611b/NEWS#L1
https://github.com/Yubico/yubioath-flutter/releases/tag/7.3.1
https://github.com/Yubico/yubioath-flutter/compare/7.3.0...7.3.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
