### PR TITLE
rocmPackages.rocblas: remove reference to tensile in librocblas, split outputs

### DIFF
--- a/pkgs/development/rocm-modules/6/default.nix
+++ b/pkgs/development/rocm-modules/6/default.nix
@@ -26,8 +26,6 @@ let
     {
       inherit rocmClangStdenv;
       stdenv = rocmClangStdenv;
-      buildTests = false;
-      buildBenchmarks = false;
 
       rocmUpdateScript = self.callPackage ./update.nix { };
 

--- a/pkgs/development/rocm-modules/6/rocblas/default.nix
+++ b/pkgs/development/rocm-modules/6/rocblas/default.nix
@@ -7,6 +7,7 @@
   cmake,
   rocm-cmake,
   clr,
+  diffutils,
   python3,
   tensile,
   boost,
@@ -148,6 +149,12 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace CMakeLists.txt \
       --replace-fail "4.43.0" "4.44.0" \
       --replace-fail '0.10' '1.0'
+  ''
+  # Fixes sh: line 1: /usr/bin/diff: No such file or directory
+  # /build/source/clients/gtest/../include/testing_logging.hpp:1117: Failure
+  + lib.optionals buildTests ''
+    substituteInPlace clients/include/testing_logging.hpp \
+      --replace-fail "/usr/bin/diff" "${lib.getExe' diffutils "diff"}"
   '';
 
   postInstall =

--- a/pkgs/development/rocm-modules/6/rocblas/default.nix
+++ b/pkgs/development/rocm-modules/6/rocblas/default.nix
@@ -24,6 +24,7 @@
   python3Packages,
   rocm-smi,
   pkg-config,
+  removeReferencesTo,
   buildTensile ? true,
   buildTests ? false,
   buildBenchmarks ? false,
@@ -54,6 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
     clr
     gitMinimal
     pkg-config
+    removeReferencesTo
   ]
   ++ lib.optionals buildTensile [
     tensile
@@ -147,6 +149,13 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail "4.43.0" "4.44.0" \
       --replace-fail '0.10' '1.0'
   '';
+
+  postInstall =
+    # tensile isn't needed at runtime and pulls in ~400MB of python deps
+    ''
+      remove-references-to -t ${tensile} \
+        "$out/lib/librocblas.so."*
+    '';
 
   passthru = {
     amdgpu_targets = gpuTargets';


### PR DESCRIPTION
Fixes #458707, resolves follow up requested in #454088 by @JohnRTitor.

rocblas's closure-size was bloated by around 400MB by a ref to tensile in an error message string. tensile is used at build time to build and link kernels, but is not needed at runtime.

Before/after:

```console
$ nix path-info --closure-size -h github:nixos/nixpkgs/master#rocmPackages.gfx1030.rocblas.out
/nix/store/zggwlwji0jca2cvhgl4ick7l3fwlwsfb-rocblas-gfx1030-6.4.3          1.3G
$ nix path-info --closure-size -h .#rocmPackages.gfx1030.rocblas.out
/nix/store/is2l1f3xfwfzffg2npzwsji76w641wns-rocblas-gfx1030-6.4.3        904.5M
```

Per-commit eval diffs:

```console
00207e62b289 (+0    -0    ~17  ) rocmPackages.rocblas: remove reference to tensile in librocblas
f9864971a4c6 (+0    -0    ~0   ) rocmPackages: don't set build{Tests,Benchmarks}=false in scope
5015e4b4468e (+0    -0    ~17  ) rocmPackages.rocblas: split benchmark and test outputs
9a22a291a158 (+0    -0    ~17  ) rocmPackages.rocblas: fix FHS diff path in rocblas test
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
