### PR TITLE
home-assistant: support compit component

### DIFF
--- a/pkgs/development/python-modules/compit-inext-api/default.nix
+++ b/pkgs/development/python-modules/compit-inext-api/default.nix
@@ -1,0 +1,40 @@
+{
+  aiofiles,
+  aiohttp,
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "compit-inext-api";
+  version = "0.3.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Przemko92";
+    repo = "compit-inext-api";
+    tag = version;
+    hash = "sha256-Wx3V0AdxNGLdCIl4G7FlfzeDSirRPnxgQ9Fbp5cRjFw=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    aiofiles
+    aiohttp
+  ];
+
+  pythonImportsCheck = [ "compit_inext_api" ];
+
+  # upstream has no tests
+  doCheck = false;
+
+  meta = {
+    description = "Python client for the Compit iNext API";
+    homepage = "https://github.com/Przemko92/compit-inext-api";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.dotlambda ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -986,7 +986,8 @@
       ];
     "compit" =
       ps: with ps; [
-      ]; # missing inputs: compit-inext-api
+        compit-inext-api
+      ];
     "concord232" =
       ps: with ps; [
         concord232
@@ -7131,6 +7132,7 @@
     "comfoconnect"
     "command_line"
     "compensation"
+    "compit"
     "config"
     "configurator"
     "control4"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2929,6 +2929,8 @@ self: super: with self; {
 
   commonregex = callPackage ../development/python-modules/commonregex { };
 
+  compit-inext-api = callPackage ../development/python-modules/compit-inext-api { };
+
   compliance-trestle = callPackage ../development/python-modules/compliance-trestle { };
 
   complycube = callPackage ../development/python-modules/complycube { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
