### PR TITLE
komika-fonts: correct meta/version, split package

### DIFF
--- a/pkgs/by-name/ko/komika-fonts/package.nix
+++ b/pkgs/by-name/ko/komika-fonts/package.nix
@@ -8,11 +8,6 @@
     "poster"
     "text"
     "title"
-    "komikahuna"
-    "komikandy"
-    "komikazba"
-    "komikaze"
-    "komikazoom"
   ],
 }:
 
@@ -57,26 +52,6 @@ let
         "Referer: https://www.1001freefonts.com/komika-title.font"
       ];
     };
-    "komikahuna" = {
-      url = "https://www.1001fonts.com/download/komikahuna.zip";
-      hash = "sha256-TjGxQA3ZyIOyJUNP+MVkYiSDk9WDIDPy3d2ttWC1aoc=";
-    };
-    "komikandy" = {
-      url = "https://www.1001fonts.com/download/komikandy.zip";
-      hash = "sha256-NqpR+gM2giTHGUBYoJlO8vkzOD0ep7LzAry3nIagjLY=";
-    };
-    "komikazba" = {
-      url = "https://www.1001fonts.com/download/komikazba.zip";
-      hash = "sha256-SGJMP0OdZ/AEImN5S3QshCbWSLXO4qTjHnSQYqoy3Pc=";
-    };
-    "komikaze" = {
-      url = "https://www.1001fonts.com/download/komikaze.zip";
-      hash = "sha256-daJRwgkzL5v224KwkaGMK2FqVnfin8+8WvMTvXTkCGE=";
-    };
-    "komikazoom" = {
-      url = "https://www.1001fonts.com/download/komikazoom.zip";
-      hash = "sha256-/o2QPPPiQBkNU0XRxJyI0+5CKFEv4FKU3A5ku1zyVX4=";
-    };
 
   };
   knownFonts = lib.attrNames fontMap;
@@ -95,20 +70,18 @@ let
 in
 stdenvNoCC.mkDerivation {
   pname = "komika-fonts";
-  version = "0-unstable-2024-08-12";
+  version = "0-unstable-2001-06-16";
   sourceRoot = ".";
 
   srcs = map (variant: fetchFont fontMap.${variant}) selectedFonts;
   installPhase = ''
     runHook preInstall
-    mkdir -p $out/share/fonts/ttf
-    mv **/*.ttf $out/share/fonts/ttf
+    install -Dm444 **/*.ttf -t $out/share/fonts/ttf
     runHook postInstall
   '';
 
   meta = {
-    homepage = "https://moorstation.org/typoasis/designers/lab/index.htm";
-    # description from archive here: http://web.archive.org/web/20030422173903fw_/http://www.hardcovermedia.com/lab/Pages/Fontpages/komikahands.html
+    homepage = "https://pedroreina.net/apostrophiclab/";
     description = "First ever comic lettering super family";
     longDescription = ''
       50 fonts, covering everything the comic artist needs when it comes to lettering. 10 text faces, 10 display faces, 10 tiling faces, 10 hand variations, 9 poster faces, and 20 balloons in a font.

--- a/pkgs/by-name/ko/komikahuna/package.nix
+++ b/pkgs/by-name/ko/komikahuna/package.nix
@@ -1,0 +1,29 @@
+{
+  stdenvNoCC,
+  lib,
+  fetchzip,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "komikahuna";
+  version = "0-unstable-2000-10-14";
+
+  src = fetchzip {
+    url = "https://www.1001fonts.com/download/komikahuna.zip";
+    hash = "sha256-TjGxQA3ZyIOyJUNP+MVkYiSDk9WDIDPy3d2ttWC1aoc=";
+    stripRoot = false;
+  };
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm444 *.ttf -t $out/share/fonts/ttf
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://pedroreina.net/apostrophiclab/0049-Komikahuna/komikahuna.html";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ pancaek ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/by-name/ko/komikandy/package.nix
+++ b/pkgs/by-name/ko/komikandy/package.nix
@@ -1,0 +1,29 @@
+{
+  stdenvNoCC,
+  lib,
+  fetchzip,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "komikandy";
+  version = "0-unstable-2001-05-12";
+
+  src = fetchzip {
+    url = "https://www.1001fonts.com/download/komikandy.zip";
+    hash = "sha256-NqpR+gM2giTHGUBYoJlO8vkzOD0ep7LzAry3nIagjLY=";
+    stripRoot = false;
+  };
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm444 *.ttf -t $out/share/fonts/ttf
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://pedroreina.net/apostrophiclab/0122-Komikandy/komikandy.html";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ pancaek ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/by-name/ko/komikazba/package.nix
+++ b/pkgs/by-name/ko/komikazba/package.nix
@@ -1,0 +1,29 @@
+{
+  stdenvNoCC,
+  lib,
+  fetchzip,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "komikazba";
+  version = "0-unstable-2000-10-30";
+
+  src = fetchzip {
+    url = "https://www.1001fonts.com/download/komikazba.zip";
+    hash = "sha256-SGJMP0OdZ/AEImN5S3QshCbWSLXO4qTjHnSQYqoy3Pc=";
+    stripRoot = false;
+  };
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm444 *.ttf -t $out/share/fonts/ttf
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://pedroreina.net/apostrophiclab/0052-Komikazba/komikazba.html";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ pancaek ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/by-name/ko/komikaze/package.nix
+++ b/pkgs/by-name/ko/komikaze/package.nix
@@ -1,0 +1,29 @@
+{
+  stdenvNoCC,
+  lib,
+  fetchzip,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "komikaze";
+  version = "0-unstable-2000-09-23";
+
+  src = fetchzip {
+    url = "https://www.1001fonts.com/download/komikaze.zip";
+    hash = "sha256-daJRwgkzL5v224KwkaGMK2FqVnfin8+8WvMTvXTkCGE=";
+    stripRoot = false;
+  };
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm444 *.ttf -t $out/share/fonts/ttf
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://pedroreina.net/apostrophiclab/0045-Komikaze/komikaze.html";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ pancaek ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/by-name/ko/komikazoom/package.nix
+++ b/pkgs/by-name/ko/komikazoom/package.nix
@@ -1,0 +1,29 @@
+{
+  stdenvNoCC,
+  lib,
+  fetchzip,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "komikazoom";
+  version = "0-unstable-2000-09-29";
+
+  src = fetchzip {
+    url = "https://www.1001fonts.com/download/komikazoom.zip";
+    hash = "sha256-/o2QPPPiQBkNU0XRxJyI0+5CKFEv4FKU3A5ku1zyVX4=";
+    stripRoot = false;
+  };
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm444 *.ttf -t $out/share/fonts/ttf
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://pedroreina.net/apostrophiclab/0046-Komikazoom/komikazoom.html";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ pancaek ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This is a long one, sorry about that. This maybe needs release notes, but I wanted to wait until getting feedback on the best way to handle some things before I write them up.

The Apostrophic Labs archive www.moorstation.org/typoasis/designers/lab seems to have been taken over by ads, but I found a different live alternative to act as the homepage. In doing so, I also found that some of the fonts originally packaged as part of Komika weren't ACTUALLY part of the family, but created by the same guy and named similarly, hence my original error. (Potentially somewhat related still(?) but not part of the main Komika set, at very least, the history is so murky here)

These have been split into their own packages, so this is technically a breaking change, even though the same stuff remains packaged overall.

----------
I also did some digging with regards to the license, as the whole situation has always felt rather odd to me. It seems as though the fonts were originally freeware (but not free as in `lib.licenses.free`). Then, when the Lab project was completed, the original domain died out and was moved to www.hardcovermedia.com (this modern link seems to have also been taken over), which underwent maintenance until ~August 2004 with some subset of the Lab fonts slated to be made public domain, or at very least some type of copyleft. However, this domain only has functional archives up to the point of this notice, even years after its supposed return. (see [here for the notice](https://web.archive.org/web/20051130030354/http://www.hardcovermedia.com/lab/)) 

https://moorstation.org/typoasis/designers/lab/index.htm was operational until a couple of months ago, which was, to my knowledge, the newest archive that was actually online, and contained a notice that the project was completed, [dated 2005](https://web.archive.org/web/20250126165419/https://moorstation.org/typoasis/designers/lab/).

The archive of the homepage I'm using now does also contain all of the Komika font files, and presumably has functioning copies of the other lab fonts.  It also corroborates the fonts were intended to be at least somewhat more free use (in spanish)

>  El equipo de diseño de Apostrophic Laboratories ha creado a lo largo de varios años numerosos tipos de letra gratuitos de gran calidad. En agosto de 2004, decidieron cambiar la licencia de gran parte de sus tipos para hacerla más libre. Aquí se mantiene el estado de las páginas de los tipos de Apostrophic Laboratories antes de tomar esa decisión. 

Google Translate to English 
> The design team at Apostrophic Laboratories created numerous high-quality, free fonts over several years. In August 2004, they decided to change the license of many of their fonts to make them more open. This page shows the state of the Apostrophic Laboratories fonts before they made that decision.

As well as https://lists.debian.org/debian-legal/2002/10/msg00157.html which at least alludes to possible changes. It is even weirder though that https://vedo.embl.es/fonts/LICENSE.txt lists the license of Komika Title as public domain.

Because of the confusing history of the foundry's site, I even tried to find contact info for Fredrick Nader to clarify the situation, who created Komika, but the closest I can find is Larry E. Yerkes, who was one of his coworkers. (Nader himself seems to have basically disappeared off of the internet by any account I can find)

-----
TL;DR there may be an argument to be made to relicense these Lab fonts to something at least redistributable (as they are unmodified, and so *I think* don't fall under the archived license's restriction of not distributing modifications). I'm not sure what the process would be for figuring out some if some further change (i.e. some license with `free = true;`) would be allowed considering the disappearance of 95% of info. I'm also very much NOT a lawyer, just a nerd who really cares about preserving these particular fonts for some reason.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
