### PR TITLE
octavePackages.video: Fix build & install

### DIFF
--- a/pkgs/development/octave-modules/video/default.nix
+++ b/pkgs/development/octave-modules/video/default.nix
@@ -4,7 +4,9 @@
   lib,
   fetchFromGitHub,
   pkg-config,
-  ffmpeg,
+  autoconf,
+  automake,
+  ffmpeg_7,
 }:
 
 buildOctavePackage rec {
@@ -14,16 +16,28 @@ buildOctavePackage rec {
   src = fetchFromGitHub {
     owner = "Andy1978";
     repo = "octave-video";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-fn9LNfuS9dSStBfzBjRRkvP50JJ5K+Em02J9+cHqt6w=";
   };
 
+  preBuild = ''
+    pushd src
+    patchShebangs bootstrap configure
+    ./bootstrap
+    ./configure
+    popd
+
+    tar --transform 's,^,video-${version}/,' -cz * -f video-${version}.tar.gz
+  '';
+
   nativeBuildInputs = [
     pkg-config
+    autoconf
+    automake
   ];
 
   propagatedBuildInputs = [
-    ffmpeg
+    ffmpeg_7
   ];
 
   meta = {


### PR DESCRIPTION
video uses a slightly different build system from other packages. It uses an autotools bootstrap script to generate a configure script that detects the ffmpeg necessities.

HOWEVER, we notably do not actually run the Makefile that the configure script generates! This pre-build step only creates a "release tarball" for `pkg build` to use. Octave compiles this "release tarball" using the generated `Makefile` in buildOctavePackage's normal buildPhase with `octave-cli --eval 'pkg build ...'`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes #457177.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
