### PR TITLE
nixos/zoom-us: fix compatibility issue with pipewire

### DIFF
--- a/nixos/modules/programs/zoom-us.nix
+++ b/nixos/modules/programs/zoom-us.nix
@@ -17,7 +17,11 @@
       # configuration elsewhere.
       config.programs.zoom-us.package.override (prev: {
         # Support pulseaudio if it's enabled on the system.
-        pulseaudioSupport = prev.pulseaudioSupport or config.services.pulseaudio.enable;
+        pulseaudioSupport =
+          prev.pulseaudioSupport or (
+            config.services.pulseaudio.enable
+            || (config.services.pipewire.enable && config.services.pipewire.pulse.enable)
+          );
 
         # Support Plasma 6 desktop environment if it's enabled on the system.
         plasma6XdgDesktopPortalSupport =


### PR DESCRIPTION
Currently, when `services.pipewire.enable` is set, Zoom cannot find PipeWire audio devices. This issue can be potentially fixed by enabling both PipeWire's PulseAudio server emulation and Zoom's `pulseaudioSupport`.

This PR enables Zoom's `pulseaudioSupport` as long as `services.pipewire.pulse.enable` is set, so that Zoom would work out-of-box when PipeWire's PulseAudio server emulation is enabled.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
