### PR TITLE
flann: fix build with cmake4, modernize; dartsim: fix build on darwin

### DIFF
--- a/pkgs/by-name/da/dartsim/package.nix
+++ b/pkgs/by-name/da/dartsim/package.nix
@@ -142,6 +142,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   pythonImportsCheck = [ "dartpy" ];
 
+  # fix build error on darwin identifier 'xxx' preceded by whitespace in a literal operator declaration is deprecated
+  CXXFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin [ "-Wno-deprecated-literal-operator" ];
+
   cmakeFlags = [
     (lib.cmakeBool "DART_VERBOSE" true)
     (lib.cmakeBool "DART_BUILD_DARTPY" pythonSupport)

--- a/pkgs/by-name/fl/flann/package.nix
+++ b/pkgs/by-name/fl/flann/package.nix
@@ -11,33 +11,33 @@
   enablePython ? false,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "flann";
   version = "1.9.1";
 
   src = fetchFromGitHub {
     owner = "flann-lib";
     repo = "flann";
-    rev = version;
-    sha256 = "13lg9nazj5s9a41j61vbijy04v6839i67lqd925xmxsbybf36gjc";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-TD4z3PJL99qLSA3TY2IayGwCvIxrByMDUUkX+ZVNj44=";
   };
 
   patches = [
     # Patch HDF5_INCLUDE_DIR -> HDF_INCLUDE_DIRS.
     (fetchpatch {
       url = "https://salsa.debian.org/science-team/flann/-/raw/debian/1.9.1+dfsg-9/debian/patches/0001-Updated-fix-cmake-hdf5.patch";
-      sha256 = "yM1ONU4mu6lctttM5YcSTg8F344TNUJXwjxXLqzr5Pk=";
+      hash = "sha256-yM1ONU4mu6lctttM5YcSTg8F344TNUJXwjxXLqzr5Pk=";
     })
     # Patch no-source library workaround that breaks on CMake > 3.11.
     (fetchpatch {
       url = "https://salsa.debian.org/science-team/flann/-/raw/debian/1.9.1+dfsg-9/debian/patches/0001-src-cpp-fix-cmake-3.11-build.patch";
-      sha256 = "REsBnbe6vlrZ+iCcw43kR5wy2o6q10RM73xjW5kBsr4=";
+      hash = "sha256-REsBnbe6vlrZ+iCcw43kR5wy2o6q10RM73xjW5kBsr4=";
     })
     # Fix cmake4 build: https://github.com/flann-lib/flann/pull/480
     (fetchpatch {
       name = "fix-cmake4-build.patch";
-      url = "https://github.com/flann-lib/flann/commit/25eb56ec78472bd419a121c6905095a793cf8992.patch";
-      sha256 = "sha256-wj1z3Z1eTvvKEeWiqPHbNZkF1hsruh4AZ22ALbRWi8M=";
+      url = "https://github.com/flann-lib/flann/commit/25eb56ec78472bd419a121c6905095a793cf8992.patch?full_index=1";
+      hash = "sha256-wj1z3Z1eTvvKEeWiqPHbNZkF1hsruh4AZ22ALbRWi8M=";
       includes = [ "CMakeLists.txt" ];
       hunks = [ "1" ];
     })
@@ -46,20 +46,20 @@ stdenv.mkDerivation rec {
     # Avoid the bundled version of LZ4 and instead use the system one.
     (fetchpatch {
       url = "https://salsa.debian.org/science-team/flann/-/raw/debian/1.9.1+dfsg-9/debian/patches/0003-Use-system-version-of-liblz4.patch";
-      sha256 = "xi+GyFn9PEjLgbJeAIEmsbp7ut9G9KIBkVulyT3nfsg=";
+      hash = "sha256-xi+GyFn9PEjLgbJeAIEmsbp7ut9G9KIBkVulyT3nfsg=";
     })
     # Fix LZ4 string separator issue, see: https://github.com/flann-lib/flann/pull/480
     (fetchpatch {
       name = "fix-lz4-string-separator.patch";
-      url = "https://github.com/flann-lib/flann/commit/25eb56ec78472bd419a121c6905095a793cf8992.patch";
-      sha256 = "sha256-iIztL1LtAO427SD12q2TV2HgMiFysQ4di2AEpUoMKfY=";
+      url = "https://github.com/flann-lib/flann/commit/25eb56ec78472bd419a121c6905095a793cf8992.patch?full_index=1";
+      hash = "sha256-iIztL1LtAO427SD12q2TV2HgMiFysQ4di2AEpUoMKfY=";
       hunks = [ "2-" ];
     })
   ]
   ++ lib.optionals stdenv.cc.isClang [
     # Fix build with Clang 16.
     (fetchpatch {
-      url = "https://github.com/flann-lib/flann/commit/be80cefa69b314a3d9e1ab971715e84145863ebb.patch";
+      url = "https://github.com/flann-lib/flann/commit/be80cefa69b314a3d9e1ab971715e84145863ebb.patch?full_index=1";
       hash = "sha256-4SUKzQCm0Sx8N43Z6ShuMbgbbe7q8b2Ibk3WgkB0qa4=";
     })
   ];
@@ -87,6 +87,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.bsd3;
     description = "Fast approximate nearest neighbor searches in high dimensional spaces";
     maintainers = [ ];
-    platforms = with lib.platforms; linux ++ darwin;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
-}
+})

--- a/pkgs/by-name/fl/flann/package.nix
+++ b/pkgs/by-name/fl/flann/package.nix
@@ -33,6 +33,14 @@ stdenv.mkDerivation rec {
       url = "https://salsa.debian.org/science-team/flann/-/raw/debian/1.9.1+dfsg-9/debian/patches/0001-src-cpp-fix-cmake-3.11-build.patch";
       sha256 = "REsBnbe6vlrZ+iCcw43kR5wy2o6q10RM73xjW5kBsr4=";
     })
+    # Fix cmake4 build: https://github.com/flann-lib/flann/pull/480
+    (fetchpatch {
+      name = "fix-cmake4-build.patch";
+      url = "https://github.com/flann-lib/flann/commit/25eb56ec78472bd419a121c6905095a793cf8992.patch";
+      sha256 = "sha256-wj1z3Z1eTvvKEeWiqPHbNZkF1hsruh4AZ22ALbRWi8M=";
+      includes = [ "CMakeLists.txt" ];
+      hunks = [ "1" ];
+    })
   ]
   ++ lib.optionals (!stdenv.cc.isClang) [
     # Avoid the bundled version of LZ4 and instead use the system one.
@@ -42,8 +50,10 @@ stdenv.mkDerivation rec {
     })
     # Fix LZ4 string separator issue, see: https://github.com/flann-lib/flann/pull/480
     (fetchpatch {
+      name = "fix-lz4-string-separator.patch";
       url = "https://github.com/flann-lib/flann/commit/25eb56ec78472bd419a121c6905095a793cf8992.patch";
-      sha256 = "qt8h576Gn8uR7+T9u9bEBIRz6e6AoTKpa1JfdZVvW9s=";
+      sha256 = "sha256-iIztL1LtAO427SD12q2TV2HgMiFysQ4di2AEpUoMKfY=";
+      hunks = [ "2-" ];
     })
   ]
   ++ lib.optionals stdenv.cc.isClang [


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/457852
- https://github.com/NixOS/nixpkgs/issues/445447

This PR fixes the build with cmake4 on darwin for flann by using unconditionally the LZ4 patch hunk that already addresses the cmake minimum version bump for linux.

It also fixes the build on darwin for dartsim, which failed build with this error:
`error: identifier '_deg' preceded by whitespace in a literal operator declaration is deprecated [-Werror,-Wdeprecated-literal-operator`

There is already an open PR (https://github.com/NixOS/nixpkgs/pull/224817) to update flann to 1.9.2 but that one is stale since March 2024, so I hope to fix build now and get traction to the update PR later. The 1.9.2 version will also need the same cmake4 patch since upstream didn't fix it yet.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
