### PR TITLE
ci/pinned: update

### DIFF
--- a/ci/default.nix
+++ b/ci/default.nix
@@ -49,6 +49,8 @@ let
 
         programs.biome = {
           enable = true;
+          # Disable settings validation because its inputs are liable to hash mismatch
+          validate.enable = false;
           settings.formatter = {
             useEditorconfig = true;
           };

--- a/ci/default.nix
+++ b/ci/default.nix
@@ -48,8 +48,7 @@ let
         programs.actionlint.enable = true;
 
         programs.biome = {
-          # FIXME: Disabled temporarily due to https://github.com/numtide/treefmt-nix/pull/430
-          enable = false;
+          enable = true;
           settings.formatter = {
             useEditorconfig = true;
           };
@@ -59,10 +58,10 @@ let
           };
           settings.json.formatter.enabled = false;
         };
-        # settings.formatter.biome.excludes = [
-        #   "*.min.js"
-        #   "pkgs/*"
-        # ];
+        settings.formatter.biome.excludes = [
+          "*.min.js"
+          "pkgs/*"
+        ];
 
         programs.keep-sorted.enable = true;
 

--- a/ci/pinned.json
+++ b/ci/pinned.json
@@ -9,9 +9,9 @@
       },
       "branch": "nixpkgs-unstable",
       "submodules": false,
-      "revision": "d5faa84122bc0a1fd5d378492efce4e289f8eac1",
-      "url": "https://github.com/NixOS/nixpkgs/archive/d5faa84122bc0a1fd5d378492efce4e289f8eac1.tar.gz",
-      "hash": "0r2pkx7m1pb0fzfhb74jkr8y5qhs2b93sak5bd5rabvbm2zn36zs"
+      "revision": "12c1f0253aa9a54fdf8ec8aecaafada64a111e24",
+      "url": "https://github.com/NixOS/nixpkgs/archive/12c1f0253aa9a54fdf8ec8aecaafada64a111e24.tar.gz",
+      "hash": "0zr033ybqjc5spwh7xnzkhbqgc6gh8waw6z76rpvadxckyqlfgiq"
     },
     "treefmt-nix": {
       "type": "Git",
@@ -22,9 +22,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "f56b1934f5f8fcab8deb5d38d42fd692632b47c2",
-      "url": "https://github.com/numtide/treefmt-nix/archive/f56b1934f5f8fcab8deb5d38d42fd692632b47c2.tar.gz",
-      "hash": "1klcfmqb4q4vvy9kdm5i9ddl26rhlyhf1mrd5aw1d4529bqnq5b5"
+      "revision": "4ef3dfdbb5ddfb9e39999a2f2b0c2637277859d4",
+      "url": "https://github.com/numtide/treefmt-nix/archive/4ef3dfdbb5ddfb9e39999a2f2b0c2637277859d4.tar.gz",
+      "hash": "0dhvpzcknsr2ybi3zz9mjggs93aqkfr24radvlw74y9620dziqw4"
     }
   },
   "version": 5

--- a/doc/tests/manpage-urls.nix
+++ b/doc/tests/manpage-urls.nix
@@ -2,12 +2,12 @@
 {
   lib,
   runCommand,
-  invalidateFetcherByDrvHash,
+  testers,
   cacert,
   python3,
 }:
 
-invalidateFetcherByDrvHash (
+testers.invalidateFetcherByDrvHash (
   {
     name ? "manual_check-manpage-urls",
     script ? ./manpage-urls.py,


### PR DESCRIPTION
This gives us a [bugfix in treefmt-nix for biome](https://github.com/numtide/treefmt-nix/commit/fb030205684fc4b6dee6c7c6bbcd2bc2523270c5).

From the nixpkgs-unstable channel:
https://hydra.nixos.org/build/312625570#tabs-buildinputs

Changes for treefmt-nix:
https://github.com/numtide/treefmt-nix/compare/f56b1934f5f8fcab8deb5d38d42fd692632b47c2...4ef3dfdbb5ddfb9e39999a2f2b0c2637277859d4

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
