### PR TITLE
linuxPackages.nvidiaPackages.production: 580.95.05 -> 580.105.08 (x86_64 only)

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -72,12 +72,32 @@ rec {
   stable = if stdenv.hostPlatform.system == "i686-linux" then legacy_390 else production;
 
   production = generic {
-    version = "580.95.05";
-    sha256_64bit = "sha256-hJ7w746EK5gGss3p8RwTA9VPGpp2lGfk5dlhsv4Rgqc=";
-    sha256_aarch64 = "sha256-zLRCbpiik2fGDa+d80wqV3ZV1U1b4lRjzNQJsLLlICk=";
-    openSha256 = "sha256-RFwDGQOi9jVngVONCOB5m/IYKZIeGEle7h0+0yGnBEI=";
-    settingsSha256 = "sha256-F2wmUEaRrpR1Vz0TQSwVK4Fv13f3J9NJLtBe4UP2f14=";
-    persistencedSha256 = "sha256-QCwxXQfG/Pa7jSTBB0xD3lsIofcerAWWAHKvWjWGQtg=";
+    version = if stdenv.hostPlatform.system == "aarch64-linux" then "580.95.05" else "580.105.08";
+    sha256_64bit =
+      if stdenv.hostPlatform.system == "aarch64-linux" then
+        "sha256-hJ7w746EK5gGss3p8RwTA9VPGpp2lGfk5dlhsv4Rgqc="
+      else
+        "sha256-2cboGIZy8+t03QTPpp3VhHn6HQFiyMKMjRdiV2MpNHU=";
+    sha256_aarch64 =
+      if stdenv.hostPlatform.system == "aarch64-linux" then
+        "sha256-zLRCbpiik2fGDa+d80wqV3ZV1U1b4lRjzNQJsLLlICk="
+      else
+        null;
+    openSha256 =
+      if stdenv.hostPlatform.system == "aarch64-linux" then
+        "sha256-RFwDGQOi9jVngVONCOB5m/IYKZIeGEle7h0+0yGnBEI="
+      else
+        "sha256-FGmMt3ShQrw4q6wsk8DSvm96ie5yELoDFYinSlGZcwQ=";
+    settingsSha256 =
+      if stdenv.hostPlatform.system == "aarch64-linux" then
+        "sha256-F2wmUEaRrpR1Vz0TQSwVK4Fv13f3J9NJLtBe4UP2f14="
+      else
+        "sha256-YvzWO1U3am4Nt5cQ+b5IJ23yeWx5ud1HCu1U0KoojLY=";
+    persistencedSha256 =
+      if stdenv.hostPlatform.system == "aarch64-linux" then
+        "sha256-QCwxXQfG/Pa7jSTBB0xD3lsIofcerAWWAHKvWjWGQtg="
+      else
+        "sha256-qh8pKGxUjEimCgwH7q91IV7wdPyV5v5dc5/K/IcbruI=";
   };
 
   latest = selectHighestVersion production (generic {


### PR DESCRIPTION
There's no production driver for aarch64 , so aarch64 remains at previous version.

I had to pull 66260cc8c48f38529c559ce9529d9398bc8d4837 to be able to nix fmt this- seems we've an issue on nixos-unstable branch with formatter.

Last PR for package:
- https://github.com/NixOS/nixpkgs/pull/447538#issue-3470315329

Release details:
- https://www.nvidia.com/en-us/drivers/details/257493/

```
- Added a new environment variable, CUDA_DISABLE_PERF_BOOST, to allow for disabling the default behavior of boosting the GPU to a higher power state when running CUDA applications. Setting this environment variable to '1' will disable the boost.
- Fixed an issue that caused the vfio-pci module to soft lockup after powering off a VM with passed-through NVIDIA GPUs.
- Fixed a recent regression which prevented HDMI FRL from working after hot unplugging and replugging a display.
- Fixed a bug that caused Rage2 to crash when loading the game menu:
https://forums.developer.nvidia.com/t/rage-2-crashes-when-entering-the-map-seems-nvidia-specific-problem/169063
- Fixed a bug that caused Metro Exodus EE to crash:
https://forums.developer.nvidia.com/t/580-release-feedback-discussion/341205/53
- Fixed a bug that allowed VRR to be enabled on some modes where it isn't actually possible, leading to a black screen.
- Fixed a bug that could cause some HDMI displays to remain blank after unplugging and re-plugging the display.
- Fixed an issue that would prevent large resolution or high refresh rate modes like 7680x2160p@240hz from being available when using HDMI FRL or DisplayPort.
```

<img width="1287" height="429" alt="image" src="https://github.com/user-attachments/assets/e0556c2b-7402-4855-a342-5cbb74d6b5d6" />

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
