### PR TITLE
ispc: unbreak on darwin

### DIFF
--- a/pkgs/by-name/is/ispc/package.nix
+++ b/pkgs/by-name/is/ispc/package.nix
@@ -19,15 +19,15 @@
       [ "sse2-i32x4" ],
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ispc";
   version = "1.28.2";
 
   src = fetchFromGitHub {
     owner = "ispc";
     repo = "ispc";
-    rev = "v${version}";
-    sha256 = "sha256-dmpOvJ5dVhjGKpJ9xw/lXbvk2FgLv2vjzmUExUfLRmo=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-dmpOvJ5dVhjGKpJ9xw/lXbvk2FgLv2vjzmUExUfLRmo=";
   };
 
   nativeBuildInputs = [
@@ -47,13 +47,6 @@ stdenv.mkDerivation rec {
     openmp
     ncurses
   ];
-
-  postPatch = ''
-    substituteInPlace CMakeLists.txt \
-      --replace CURSES_CURSES_LIBRARY CURSES_NCURSES_LIBRARY
-    substituteInPlace cmake/GenerateBuiltins.cmake \
-      --replace 'bit 32 64' 'bit 64'
-  '';
 
   inherit testedTargets;
 
@@ -79,39 +72,33 @@ stdenv.mkDerivation rec {
   '';
 
   cmakeFlags = [
-    "-DFILE_CHECK_EXECUTABLE=${llvmPackages.llvm}/bin/FileCheck"
-    "-DLLVM_AS_EXECUTABLE=${llvmPackages.llvm}/bin/llvm-as"
-    "-DLLVM_CONFIG_EXECUTABLE=${llvmPackages.llvm.dev}/bin/llvm-config"
-    "-DCLANG_EXECUTABLE=${llvmPackages.clang}/bin/clang"
-    "-DCLANGPP_EXECUTABLE=${llvmPackages.clang}/bin/clang++"
-    "-DISPC_INCLUDE_EXAMPLES=OFF"
-    "-DISPC_INCLUDE_UTILS=OFF"
-    (
-      "-DARM_ENABLED="
-      + (if stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isAarch32 then "TRUE" else "FALSE")
-    )
-    (
-      "-DX86_ENABLED="
-      + (if stdenv.hostPlatform.isx86_64 || stdenv.hostPlatform.isx86_32 then "TRUE" else "FALSE")
-    )
+    (lib.cmakeFeature "FILE_CHECK_EXECUTABLE" "${llvmPackages.llvm}/bin/FileCheck")
+    (lib.cmakeFeature "LLVM_AS_EXECUTABLE" "${llvmPackages.llvm}/bin/llvm-as")
+    (lib.cmakeFeature "LLVM_CONFIG_EXECUTABLE" "${llvmPackages.llvm.dev}/bin/llvm-config")
+    (lib.cmakeFeature "CLANG_EXECUTABLE" "${llvmPackages.clang}/bin/clang")
+    (lib.cmakeFeature "CLANGPP_EXECUTABLE" "${llvmPackages.clang}/bin/clang++")
+    (lib.cmakeBool "ISPC_INCLUDE_EXAMPLES" false)
+    (lib.cmakeBool "ISPC_INCLUDE_UTILS" false)
+    (lib.cmakeFeature "ARM_ENABLED=" (
+      if stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isAarch32 then "TRUE" else "FALSE"
+    ))
+    (lib.cmakeFeature "X86_ENABLED=" (
+      if stdenv.hostPlatform.isx86_64 || stdenv.hostPlatform.isx86_32 then "TRUE" else "FALSE"
+    ))
   ];
 
-  meta = with lib; {
-    homepage = "https://ispc.github.io/";
+  meta = {
     description = "Intel 'Single Program, Multiple Data' Compiler, a vectorised language";
-    mainProgram = "ispc";
-    license = licenses.bsd3;
-    platforms = [
-      "x86_64-linux"
-      "x86_64-darwin"
-      "aarch64-linux"
-      "aarch64-darwin"
-    ]; # TODO: buildable on more platforms?
-    maintainers = with maintainers; [
+    homepage = "https://ispc.github.io/";
+    changelog = "https://github.com/ispc/ispc/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [
       aristid
       thoughtpolice
       athas
       alexfmpe
     ];
+    mainProgram = "ispc";
+    platforms = with lib.platforms; linux ++ darwin; # TODO: buildable on more platforms?
   };
-}
+})


### PR DESCRIPTION
ispc was broken on darwin for a month:
- aarch64-darwin: https://hydra.nixos.org/build/310588348
- x86_64-darwin: https://hydra.nixos.org/build/310588351

error:

```
/private/tmp/nix-build-ispc-1.28.2.drv-0/source/src/util.cpp:50:11: error: exception specification in declaration does not match previous declaration
   50 | void std::__libcpp_verbose_abort(char const *format, ...)
      |           ^
/nix/store/1h3bqrd2kvj4afq9xkaxvx4skdnfbql2-libcxx-19.1.2+apple-sdk-15.5/include/c++/v1/__verbose_abort:24:49: note: previous declaration is here
   24 | _LIBCPP_ATTRIBUTE_FORMAT(__printf__, 1, 2) void __libcpp_verbose_abort(const char* __format, ...);
      |                                                 ^
1 error generated.
```

ZHF: #457852

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
