### PR TITLE
treewide: mark as broken on darwin (last successful Hydra build in 2023)

### DIFF
--- a/pkgs/by-name/cc/cccc/package.nix
+++ b/pkgs/by-name/cc/cccc/package.nix
@@ -38,5 +38,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2;
     platforms = lib.platforms.unix;
     maintainers = [ ];
+    # The last successful Darwin Hydra build was in 2023
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/by-name/cp/cpp-ipfs-http-client/package.nix
+++ b/pkgs/by-name/cp/cpp-ipfs-http-client/package.nix
@@ -43,5 +43,7 @@ stdenv.mkDerivation {
       "x86_64-linux"
       "x86_64-darwin"
     ];
+    # The last successful Darwin Hydra build was in 2023
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/by-name/do/doomseeker/package.nix
+++ b/pkgs/by-name/do/doomseeker/package.nix
@@ -56,5 +56,7 @@ stdenv.mkDerivation {
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.unix;
     maintainers = [ ];
+    # The last successful Darwin Hydra build was in 2023
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/by-name/gf/gforth/package.nix
+++ b/pkgs/by-name/gf/gforth/package.nix
@@ -60,7 +60,9 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.gnu.org/software/gforth";
     downloadPage = "https://github.com/forthy42/gforth";
     license = lib.licenses.gpl3Plus;
-    broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64; # segfault when running ./gforthmi
+    # segfault when running ./gforthmi on aarch64 darwin
+    # The last successful Darwin Hydra build was in 2023
+    broken = stdenv.hostPlatform.isDarwin;
     platforms = lib.platforms.all;
     mainProgram = "gforth";
   };

--- a/pkgs/by-name/gl/glicol-cli/package.nix
+++ b/pkgs/by-name/gl/glicol-cli/package.nix
@@ -36,5 +36,7 @@ rustPlatform.buildRustPackage rec {
     license = licenses.mit;
     maintainers = [ ];
     mainProgram = "glicol-cli";
+    # The last successful Darwin Hydra build was in 2023
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/by-name/gl/gloox/package.nix
+++ b/pkgs/by-name/gl/gloox/package.nix
@@ -39,5 +39,7 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3;
     maintainers = [ ];
     platforms = platforms.unix;
+    # The last successful Darwin Hydra build was in 2023
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/by-name/gt/gtkgnutella/package.nix
+++ b/pkgs/by-name/gt/gtkgnutella/package.nix
@@ -67,5 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = [ maintainers.doronbehar ];
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
+    # The last successful Darwin Hydra build was in 2023
+    broken = stdenv.hostPlatform.isDarwin;
   };
 })

--- a/pkgs/by-name/pm/pmenu/package.nix
+++ b/pkgs/by-name/pm/pmenu/package.nix
@@ -59,5 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = [ ];
     platforms = lib.platforms.unix;
     mainProgram = "pmenu";
+    # The last successful Darwin Hydra build was in 2023
+    broken = stdenv.hostPlatform.isDarwin;
   };
 })

--- a/pkgs/by-name/xc/xchainkeys/package.nix
+++ b/pkgs/by-name/xc/xchainkeys/package.nix
@@ -22,5 +22,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3;
     platforms = lib.platforms.unix;
     mainProgram = "xchainkeys";
+    # The last successful Darwin Hydra build was in 2023
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/by-name/ya/yaegi/package.nix
+++ b/pkgs/by-name/ya/yaegi/package.nix
@@ -1,4 +1,5 @@
 {
+  stdenv,
   lib,
   buildGoModule,
   fetchFromGitHub,
@@ -43,5 +44,7 @@ buildGoModule rec {
     changelog = "https://github.com/traefik/yaegi/releases/tag/${src.rev}";
     license = licenses.asl20;
     maintainers = [ ];
+    # The last successful Darwin Hydra build was in 2023
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/development/libraries/glew/1.10.nix
+++ b/pkgs/development/libraries/glew/1.10.nix
@@ -67,5 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
     #["BSD" "GLX" "SGI-B" "GPL2"]
     pkgConfigModules = [ "glew" ];
     inherit (mesa.meta) platforms;
+    # The last successful Darwin Hydra build was in 2023
+    broken = stdenv.hostPlatform.isDarwin;
   };
 })

--- a/pkgs/development/libraries/irrlicht/default.nix
+++ b/pkgs/development/libraries/irrlicht/default.nix
@@ -57,5 +57,7 @@ stdenv.mkDerivation {
     license = lib.licenses.zlib;
     description = "Open source high performance realtime 3D engine written in C++";
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    # The last successful Darwin Hydra build was in 2023
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/development/libraries/l-smash/default.nix
+++ b/pkgs/development/libraries/l-smash/default.nix
@@ -29,5 +29,7 @@ stdenv.mkDerivation rec {
     license = licenses.isc;
     maintainers = [ ];
     platforms = platforms.all;
+    # The last successful Darwin Hydra build was in 2023
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/457852

Actions Taken:
- Identified Darwin builds on Hydra that were last successful in 2023.
- Checked each identified build to see if it currently has any open Pull Requests.
- Verified whether the failures for these builds are due to being outdated.

```
cccc
cpp-ipfs-http-client
doomseeker
gforth
glew110
glicol-cli
gloox
gtkgnutella
irrlicht
l-smash
pmenu
xchainkeys
yaegi
```
Given how cryptic and niche the troubleshooting for Darwin failures can be, and considering the extended period these builds have been failing, this PR marks them as broken.

This action is necessary to conserve compute resources and avoid further waste on inevitable build failures.

Hydra logs:
https://hydra.nixos.org/job/nixpkgs/trunk/gtkgnutella.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/gtkgnutella.aarch64-darwin

https://hydra.nixos.org/job/nixpkgs/trunk/cccc.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/cccc.aarch64-darwin

https://hydra.nixos.org/job/nixpkgs/trunk/cpp-ipfs-http-client.x86_64-darwin

https://hydra.nixos.org/job/nixpkgs/trunk/doomseeker.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/doomseeker.aarch64-darwin

https://hydra.nixos.org/job/nixpkgs/trunk/gforth.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/gforth.aarch64-darwin (already marked as broken)

https://hydra.nixos.org/job/nixpkgs/trunk/glew110.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/glew110.aarch64-darwin

https://hydra.nixos.org/job/nixpkgs/trunk/glicol-cli.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/glicol-cli.aarch64-darwin

https://hydra.nixos.org/job/nixpkgs/trunk/gloox.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/gloox.aarch64-darwin

https://hydra.nixos.org/job/nixpkgs/trunk/irrlicht.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/irrlicht.aarch64-darwin

https://hydra.nixos.org/job/nixpkgs/trunk/l-smash.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/l-smash.aarch64-darwin

https://hydra.nixos.org/job/nixpkgs/trunk/pmenu.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/pmenu.aarch64-darwin

https://hydra.nixos.org/job/nixpkgs/trunk/yaegi.x86_64-darwin

https://hydra.nixos.org/job/nixpkgs/trunk/xchainkeys.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/xchainkeys.aarch64-darwin
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
