### PR TITLE
vimPlugins.nvim-treesitter.tests: fix

### DIFF
--- a/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
@@ -113,11 +113,11 @@ in
           pluginsToCheck =
             map (grammar: grammarToPlugin grammar)
               # true is here because there is `recurseForDerivations = true`
-              (lib.remove true (lib.attrValues tree-sitter-grammars));
+              (lib.filter lib.isDerivation (lib.attrValues tree-sitter-grammars));
         in
         runCommand "nvim-treesitter-test-queries-are-present-for-custom-grammars" { CI = true; } ''
           function check_grammar {
-            EXPECTED_FILES="$2/parser/$1.so `ls $2/queries/$1/*.scm`"
+            EXPECTED_FILES="$2/parser/$1.so `find -L "$2/queries/$1" -name '*.scm'`"
 
             echo
             echo expected files for $1:
@@ -125,7 +125,7 @@ in
 
             # the derivation has only symlinks, and `find` doesn't count them as files
             # so we cannot use `-type f`
-            for file in `find $2 -not -type d`; do
+            for file in `find -L $2 -not -type d`; do
               echo checking $file
               # see https://stackoverflow.com/a/8063284
               if ! echo "$EXPECTED_FILES" | grep -wqF "$file"; then
@@ -141,9 +141,7 @@ in
 
       no-queries-for-official-grammars =
         let
-          pluginsToCheck =
-            # true is here because there is `recurseForDerivations = true`
-            (lib.remove true (lib.attrValues vimPlugins.nvim-treesitter-parsers));
+          pluginsToCheck = lib.filter lib.isDerivation (lib.attrValues vimPlugins.nvim-treesitter-parsers);
         in
         runCommand "nvim-treesitter-test-no-queries-for-official-grammars" { CI = true; } ''
           touch $out

--- a/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
@@ -112,31 +112,36 @@ in
         let
           pluginsToCheck =
             map (grammar: grammarToPlugin grammar)
-              # true is here because there is `recurseForDerivations = true`
+              # non-derivations are here because there is a `recurseForDerivations = true`
               (lib.filter lib.isDerivation (lib.attrValues tree-sitter-grammars));
         in
         runCommand "nvim-treesitter-test-queries-are-present-for-custom-grammars" { CI = true; } ''
-          function check_grammar {
-            EXPECTED_FILES="$2/parser/$1.so `find -L "$2/queries/$1" -name '*.scm'`"
+          touch "$out"
 
-            echo
-            echo expected files for $1:
-            echo $EXPECTED_FILES
+          function check_grammar {
+            local grammar_name="$1"
+            local grammar_path="$2"
+
+            local grammar_queries=$(find -L "$grammar_path/queries/$grammar_name" -name '*.scm')
+            local EXPECTED_FILES="$grammar_path/parser/$grammar_name.so $grammar_queries"
+
+            echo ""
+            echo "expected files for $grammar_name:"
+            echo "$EXPECTED_FILES"
 
             # the derivation has only symlinks, and `find` doesn't count them as files
-            # so we cannot use `-type f`
-            for file in `find -L $2 -not -type d`; do
-              echo checking $file
+            # so we cannot use `-type f`, thus we use `-not -type d`
+            for file in $(find -L $2 -not -type d); do
+              echo "checking $file"
               # see https://stackoverflow.com/a/8063284
               if ! echo "$EXPECTED_FILES" | grep -wqF "$file"; then
-                echo $file is unexpected, exiting
+                echo "$file is unexpected, exiting"
                 exit 1
               fi
             done
           }
 
           ${lib.concatLines (lib.forEach pluginsToCheck (g: "check_grammar \"${g.grammarName}\" \"${g}\""))}
-          touch $out
         '';
 
       no-queries-for-official-grammars =
@@ -144,13 +149,16 @@ in
           pluginsToCheck = lib.filter lib.isDerivation (lib.attrValues vimPlugins.nvim-treesitter-parsers);
         in
         runCommand "nvim-treesitter-test-no-queries-for-official-grammars" { CI = true; } ''
-          touch $out
+          touch "$out"
 
           function check_grammar {
-            echo checking $1...
-            if [ -d $2/queries ]; then
-              echo Queries dir exists in $1
-              echo This is unexpected, see https://github.com/NixOS/nixpkgs/pull/344849#issuecomment-2381447839
+            local grammar_name="$1"
+            local grammar_path="$2"
+
+            echo "checking $1..."
+            if [ -d "$grammar_path/queries" ]; then
+              echo "Queries directory exists in $grammar_name"
+              echo "This is unexpected, see https://github.com/NixOS/nixpkgs/pull/344849#issuecomment-2381447839"
               exit 1
             fi
           }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes tests for our nvim-treesitter, closes https://github.com/NixOS/nixpkgs/issues/333372

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
