### PR TITLE
calls: 48.2 -> 49.1.1

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -27,6 +27,7 @@
   - Removes X11 session support. Though you can still run X11 apps using XWayland.
   - gnome-session’s custom service manager was removed in favour of using systemd.
   - GDM now allows multiple seats, which is useful for e.g. remote logins. Though we currently [limit this to five greeter instances](https://github.com/NixOS/nixpkgs/issues/458058).
+  - `papers` document viewer is now installed by default, replacing `evince`. Though we still include `evince` transitively by `sushi` (quick previewer used by Files/Nautilus) You can disable either using [](#opt-environment.gnome.excludePackages) and restore `evince` with [](#opt-programs.evince.enable).
 
   Refer to the [GNOME release notes](https://release.gnome.org/49/) for more details.
 

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -28,6 +28,7 @@
   - gnome-session’s custom service manager was removed in favour of using systemd.
   - GDM now allows multiple seats, which is useful for e.g. remote logins. Though we currently [limit this to five greeter instances](https://github.com/NixOS/nixpkgs/issues/458058).
   - `papers` document viewer is now installed by default, replacing `evince`. Though we still include `evince` transitively by `sushi` (quick previewer used by Files/Nautilus) You can disable either using [](#opt-environment.gnome.excludePackages) and restore `evince` with [](#opt-programs.evince.enable).
+  - `showtime` video player is now installed by default, replacing `totem`. You can disable it using [](#opt-environment.gnome.excludePackages) and restore `totem` with [](#opt-environment.systemPackages).
 
   Refer to the [GNOME release notes](https://release.gnome.org/49/) for more details.
 

--- a/nixos/modules/services/desktop-managers/gnome.nix
+++ b/nixos/modules/services/desktop-managers/gnome.nix
@@ -232,7 +232,7 @@ in
 
     environment.gnome.excludePackages = mkOption {
       default = [ ];
-      example = literalExpression "[ pkgs.totem ]";
+      example = literalExpression "[ pkgs.showtime ]";
       type = types.listOf types.package;
       description = "Which packages gnome should exclude from the default environment";
     };
@@ -467,9 +467,9 @@ in
         pkgs.nautilus
         pkgs.papers
         pkgs.gnome-connections
+        pkgs.showtime
         pkgs.simple-scan
         pkgs.snapshot
-        pkgs.totem
         pkgs.yelp
       ] config.environment.gnome.excludePackages;
 

--- a/nixos/modules/services/desktop-managers/gnome.nix
+++ b/nixos/modules/services/desktop-managers/gnome.nix
@@ -465,6 +465,7 @@ in
         pkgs.gnome-weather
         pkgs.loupe
         pkgs.nautilus
+        pkgs.papers
         pkgs.gnome-connections
         pkgs.simple-scan
         pkgs.snapshot
@@ -476,7 +477,6 @@ in
       # Since some of these have a corresponding package, we only
       # enable that program module if the package hasn't been excluded
       # through `environment.gnome.excludePackages`
-      programs.evince.enable = notExcluded pkgs.evince;
       programs.file-roller.enable = notExcluded pkgs.file-roller;
       programs.geary.enable = notExcluded pkgs.geary;
       programs.gnome-disks.enable = notExcluded pkgs.gnome-disk-utility;

--- a/pkgs/applications/networking/mailreaders/evolution/evolution/default.nix
+++ b/pkgs/applications/networking/mailreaders/evolution/evolution/default.nix
@@ -46,11 +46,11 @@
 
 stdenv.mkDerivation rec {
   pname = "evolution";
-  version = "3.58.0";
+  version = "3.58.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/evolution/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    hash = "sha256-Nz/hdFow9x8RN1XvKvwwp6F2imA2GVpk2wUplacaGr8=";
+    hash = "sha256-A9jQzM0QKqGnPDHZ4vN0yz24Os3fwRJskYavY9psvsw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ac/accerciser/package.nix
+++ b/pkgs/by-name/ac/accerciser/package.nix
@@ -19,13 +19,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "accerciser";
-  version = "3.46.2";
+  version = "3.48.0";
 
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/accerciser/${lib.versions.majorMinor version}/accerciser-${version}.tar.xz";
-    hash = "sha256-r/RpRR8k5YdpPE9/en+GpQU8ZrIDOndDrZ2DhHSWdw4=";
+    hash = "sha256-kCiOiQCidKOu4gUw6zkWRZlK6YZyIJFroPXEZ3v+n00=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/at/at-spi2-core/package.nix
+++ b/pkgs/by-name/at/at-spi2-core/package.nix
@@ -28,7 +28,7 @@
 
 stdenv.mkDerivation rec {
   pname = "at-spi2-core";
-  version = "2.58.0";
+  version = "2.58.1";
 
   outputs = [
     "out"
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/at-spi2-core/${lib.versions.majorMinor version}/at-spi2-core-${version}.tar.xz";
-    hash = "sha256-390zANong6IZaf+t4oiYF/t8GQak75JJfrpllps9q1o=";
+    hash = "sha256-fzdKajjNcP9LMsnToDEL+oBNlG/tTJ5pp9SfrNy5Xpw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ca/calls/package.nix
+++ b/pkgs/by-name/ca/calls/package.nix
@@ -36,7 +36,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "calls";
-  version = "48.2";
+  version = "49.1.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     repo = "calls";
     rev = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-S1YWFkwK1tcIUOfyOxlEFtKcLlRDiSKf4iUGnb+VlG8=";
+    hash = "sha256-fqvfzdk1szNFm4aRRGNDaA/AmjJdQjBsMhvEolEetE0=";
   };
 
   outputs = [

--- a/pkgs/by-name/ca/cambalache/package.nix
+++ b/pkgs/by-name/ca/cambalache/package.nix
@@ -23,7 +23,7 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "cambalache";
-  version = "0.94.1";
+  version = "0.99.1";
   pyproject = false;
 
   # Did not fetch submodule since it is only for tests we don't run.
@@ -32,7 +32,7 @@ python3.pkgs.buildPythonApplication rec {
     owner = "jpu";
     repo = "cambalache";
     tag = version;
-    hash = "sha256-dX9YiBCBG/ALWX0W1CjvdUlOCQ6UulnQCiYUscRMKWk=";
+    hash = "sha256-0r7VfOnsXnWBtfYI3ki8rzlBOXujpr6PN4A971OWxc8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ca/cambalache/package.nix
+++ b/pkgs/by-name/ca/cambalache/package.nix
@@ -23,7 +23,7 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "cambalache";
-  version = "0.99.1";
+  version = "0.94.1";
   pyproject = false;
 
   # Did not fetch submodule since it is only for tests we don't run.
@@ -32,7 +32,7 @@ python3.pkgs.buildPythonApplication rec {
     owner = "jpu";
     repo = "cambalache";
     tag = version;
-    hash = "sha256-0r7VfOnsXnWBtfYI3ki8rzlBOXujpr6PN4A971OWxc8=";
+    hash = "sha256-dX9YiBCBG/ALWX0W1CjvdUlOCQ6UulnQCiYUscRMKWk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/d-/d-spy/package.nix
+++ b/pkgs/by-name/d-/d-spy/package.nix
@@ -17,7 +17,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "d-spy";
-  version = "49.1";
+  version = "49.2";
 
   outputs = [
     "out"
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/d-spy/${lib.versions.major finalAttrs.version}/d-spy-${finalAttrs.version}.tar.xz";
-    hash = "sha256-4m4YEg5k1FG2HyAs+qORNienAxwqlUrs85HIPYPQnYo=";
+    hash = "sha256-uBT/J9goqrzacvLGLxtB1iA190PQb9mn48XJhsSHmmk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/dc/dconf/package.nix
+++ b/pkgs/by-name/dc/dconf/package.nix
@@ -25,7 +25,7 @@
   withDocs ? withIntrospection,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "dconf";
   version = "0.49.0";
 
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   ++ lib.optional withDocs "devdoc";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/dconf/${lib.versions.majorMinor finalAttrs.version}/dconf-${finalAttrs.version}.tar.xz";
     sha256 = "FqR+SaWBVtu5ZXjhcIMlKZ5MGe6pvhKNW9Ev0JY9bDY=";
   };
 
@@ -79,15 +79,13 @@ stdenv.mkDerivation rec {
     !stdenv.hostPlatform.isAarch32 && !stdenv.hostPlatform.isAarch64 && !stdenv.hostPlatform.isDarwin;
 
   postPatch = ''
-    chmod +x meson_post_install.py tests/test-dconf.py
-    patchShebangs meson_post_install.py
-    patchShebangs tests/test-dconf.py
+    chmod +x tests/test-dconf.py tests/shellcheck.sh
+    patchShebangs tests/test-dconf.py tests/shellcheck.sh
   '';
 
   passthru = {
     updateScript = gnome.updateScript {
-      packageName = pname;
-      versionPolicy = "odd-unstable";
+      packageName = "dconf";
     };
     tests = { inherit (nixosTests) dconf; };
   };
@@ -103,4 +101,4 @@ stdenv.mkDerivation rec {
     teams = [ teams.gnome ];
     mainProgram = "dconf";
   };
-}
+})

--- a/pkgs/by-name/dc/dconf/package.nix
+++ b/pkgs/by-name/dc/dconf/package.nix
@@ -27,7 +27,7 @@
 
 stdenv.mkDerivation rec {
   pname = "dconf";
-  version = "0.40.0";
+  version = "0.49.0";
 
   outputs = [
     "out"
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0cs5nayg080y8pb9b7qccm1ni8wkicdmqp1jsgc22110r6j24zyg";
+    sha256 = "FqR+SaWBVtu5ZXjhcIMlKZ5MGe6pvhKNW9Ev0JY9bDY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ep/epiphany/package.nix
+++ b/pkgs/by-name/ep/epiphany/package.nix
@@ -39,11 +39,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "epiphany";
-  version = "49.0";
+  version = "49.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/epiphany/${lib.versions.major finalAttrs.version}/epiphany-${finalAttrs.version}.tar.xz";
-    hash = "sha256-Jx7HNbmDa5dEnjJ5PTVKivtrn40tPXWCGIXV4VVweSk=";
+    hash = "sha256-12fFy7niVmvJkD1BG2iWFh40P3EqozMFNlc52N7axSE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ev/evolution-data-server/package.nix
+++ b/pkgs/by-name/ev/evolution-data-server/package.nix
@@ -50,7 +50,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "evolution-data-server";
-  version = "3.58.0";
+  version = "3.58.1";
 
   outputs = [
     "out"
@@ -59,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/evolution-data-server/${lib.versions.majorMinor finalAttrs.version}/evolution-data-server-${finalAttrs.version}.tar.xz";
-    hash = "sha256-orWguNsRtyjtwdbxwincJxGWK3qHwDhCIdrI2WAAzvc=";
+    hash = "sha256-qRSSiBTviH8Jebp46o17zJj5bPB8u3CwBRmAvZDsNfA=";
   };
 
   patches = [

--- a/pkgs/by-name/fi/file-roller/package.nix
+++ b/pkgs/by-name/fi/file-roller/package.nix
@@ -24,11 +24,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "file-roller";
-  version = "44.5";
+  version = "44.6";
 
   src = fetchurl {
     url = "mirror://gnome/sources/file-roller/${lib.versions.major finalAttrs.version}/file-roller-${finalAttrs.version}.tar.xz";
-    hash = "sha256-369LuYnAuJhr6L2un//quNDzBmmuOmJ+jD35TyOIgzk=";
+    hash = "sha256-noc7UAW8QleZqM1LI34f/0MOyNazSpksYDPx38bjdk4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gd/gdm/fix-paths.patch
+++ b/pkgs/by-name/gd/gdm/fix-paths.patch
@@ -1,13 +1,9 @@
 diff --git a/daemon/gdm-local-display-factory.c b/daemon/gdm-local-display-factory.c
-index 513b9733d..0c1c8007f 100644
+index ad2e65cf7..61fb78db8 100644
 --- a/daemon/gdm-local-display-factory.c
 +++ b/daemon/gdm-local-display-factory.c
-@@ -269,10 +269,10 @@ struct GdmDisplayServerConfiguration {
-         const char *session_type;
- } display_server_configuration[] = {
- #ifdef ENABLE_WAYLAND_SUPPORT
--        { "wayland", GDM_KEY_WAYLAND_ENABLE, "/usr/bin/Xwayland", "wayland" },
-+        { "wayland", GDM_KEY_WAYLAND_ENABLE, "@xwayland@/bin/Xwayland", "wayland" },
+@@ -272,7 +272,7 @@ struct GdmDisplayServerConfiguration {
+         { "wayland", GDM_KEY_WAYLAND_ENABLE, NULL, "wayland" },
  #endif
  #ifdef ENABLE_X11_SUPPORT
 -        { "xorg", GDM_KEY_XORG_ENABLE, "/usr/bin/Xorg", "x11" },
@@ -16,7 +12,7 @@ index 513b9733d..0c1c8007f 100644
          { NULL, NULL, NULL },
  };
 diff --git a/daemon/gdm-manager.c b/daemon/gdm-manager.c
-index 9568e963f..b1bc8800a 100644
+index 457dcf88d..a71b89ba8 100644
 --- a/daemon/gdm-manager.c
 +++ b/daemon/gdm-manager.c
 @@ -154,7 +154,7 @@ plymouth_is_running (void)

--- a/pkgs/by-name/gd/gdm/package.nix
+++ b/pkgs/by-name/gd/gdm/package.nix
@@ -27,7 +27,6 @@
   plymouth,
   coreutils,
   xorgserver,
-  xwayland,
   dbus,
   nixos-icons,
   runCommand,
@@ -112,7 +111,6 @@ stdenv.mkDerivation (finalAttrs: {
         coreutils
         plymouth
         xorgserver
-        xwayland
         dbus
         ;
     })

--- a/pkgs/by-name/gd/gdm/package.nix
+++ b/pkgs/by-name/gd/gdm/package.nix
@@ -44,7 +44,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gdm";
-  version = "49.0.1";
+  version = "49.1";
 
   outputs = [
     "out"
@@ -53,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gdm/${lib.versions.major finalAttrs.version}/gdm-${finalAttrs.version}.tar.xz";
-    hash = "sha256-GbpC+GkqC/OlK9WX4amrKMnGpRiWpQgjBOX6GlGE2Bo=";
+    hash = "sha256-adpdExncLGit9c05StWb7Jm7LiTyhARaG7Ss13QAROU=";
   };
 
   mesonFlags = [

--- a/pkgs/by-name/gi/gi-docgen/package.nix
+++ b/pkgs/by-name/gi/gi-docgen/package.nix
@@ -9,13 +9,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "gi-docgen";
-  version = "2025.4";
+  version = "2025.5";
 
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gi-docgen/${lib.versions.major version}/gi-docgen-${version}.tar.xz";
-    hash = "sha256-Zshl1Fn+vfteQHiojfBhg2IMPpH3JtHcYI2I7jYFUm4=";
+    hash = "sha256-JXmjP/h7Yi0Q0QLJG30OzlBjQLcONNu2UiFj4WyQrKM=";
   };
 
   depsBuildBuild = [

--- a/pkgs/by-name/gl/glycin-loaders/package.nix
+++ b/pkgs/by-name/gl/glycin-loaders/package.nix
@@ -25,17 +25,17 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "glycin-loaders";
-  version = "2.0.2";
+  version = "2.0.4";
 
   src = fetchurl {
     url = "mirror://gnome/sources/glycin/${lib.versions.majorMinor finalAttrs.version}/glycin-${finalAttrs.version}.tar.xz";
-    hash = "sha256-ZYAOhWs37byNXDM1rVNBUFgc4/LwhFTdAwKiZHC9nRM=";
+    hash = "sha256-w4FHIA9YBKJXNBZ46LzjFLz/eadvmGqMMnnZ2Ej4v/c=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
     name = "glycin-loaders-deps-${finalAttrs.version}";
-    hash = "sha256-9cpvRNqymxkOi6L5oZDGyvB68rzEt97qB8uqzhUYsao=";
+    hash = "sha256-r0TmBggpLG3wwZSWJr1bwyG5RHP/nvDGEJ/JFVAzEFA=";
     dontConfigure = true;
   };
 

--- a/pkgs/by-name/gn/gnome-builder/package.nix
+++ b/pkgs/by-name/gn/gnome-builder/package.nix
@@ -43,7 +43,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-builder";
-  version = "49.0";
+  version = "49.1";
 
   outputs = [
     "out"
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-builder/${lib.versions.major finalAttrs.version}/gnome-builder-${finalAttrs.version}.tar.xz";
-    hash = "sha256-1FmQ22gfle4id75PqfKWSYJwfb3zATCgvecCNLN59WI=";
+    hash = "sha256-O55HmDiPlZ4QMsas5KX7e05Yi2M5/OTCLsJqvoafiis=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-calculator/package.nix
+++ b/pkgs/by-name/gn/gnome-calculator/package.nix
@@ -27,11 +27,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-calculator";
-  version = "49.0.1";
+  version = "49.1.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-calculator/${lib.versions.major version}/gnome-calculator-${version}.tar.xz";
-    hash = "sha256-7L4g5jBXX7i8I3kNNfOGrBd5ADxA3FyHfTzS2g/HRT8=";
+    hash = "sha256-hA00We1p8nh6lmn5b2s/nv8Wy0hpAMcZrCUsQkVjRj0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-characters/package.nix
+++ b/pkgs/by-name/gn/gnome-characters/package.nix
@@ -22,11 +22,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-characters";
-  version = "49.0";
+  version = "49.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-characters/${lib.versions.major version}/gnome-characters-${version}.tar.xz";
-    hash = "sha256-G25UioLiaqTsmv5AnWmiVwk2LAN/pcUzGG1qHbKa9uM=";
+    hash = "sha256-eVwP5DTmAtx4M5H7WDDbx9jh6gXKdyEPsUDi9vQKFFw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-console/package.nix
+++ b/pkgs/by-name/gn/gnome-console/package.nix
@@ -21,11 +21,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-console";
-  version = "49.0";
+  version = "49.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-console/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    hash = "sha256-no6WRvRz0B9LSnvOLEetImtK6D+r8ky7tKyU9qxdXMI=";
+    hash = "sha256-/KOf0EHgXufKbSpcggAZN9Aq4VE/PzZRvTeuDi72bj4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-control-center/package.nix
+++ b/pkgs/by-name/gn/gnome-control-center/package.nix
@@ -76,11 +76,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-control-center";
-  version = "49.0";
+  version = "49.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-control-center/${lib.versions.major finalAttrs.version}/gnome-control-center-${finalAttrs.version}.tar.xz";
-    hash = "sha256-pdjc4qAooAR+hnQ8J3J33os1oGPUSDNgSuo+ieqFn5c=";
+    hash = "sha256-VALv+PIxY6dV3sJJNmwbOmXoDw2mDwd0p0DR5YdG+Gk=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-maps/package.nix
+++ b/pkgs/by-name/gn/gnome-maps/package.nix
@@ -30,11 +30,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-maps";
-  version = "49.1";
+  version = "49.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-maps/${lib.versions.major finalAttrs.version}/gnome-maps-${finalAttrs.version}.tar.xz";
-    hash = "sha256-QG+qUc5zo/iWpKFTBX+gLqp4y4LUjxHbRECDCUl1a+w=";
+    hash = "sha256-dd4/kCjDInLTbgnbqhG/3myFz3USCGVdO6RIJo08PzA=";
   };
 
   doCheck = !stdenv.hostPlatform.isDarwin;

--- a/pkgs/by-name/gn/gnome-music/package.nix
+++ b/pkgs/by-name/gn/gnome-music/package.nix
@@ -31,13 +31,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "gnome-music";
-  version = "49.0.2";
+  version = "49.1";
 
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-music/${lib.versions.major version}/gnome-music-${version}.tar.xz";
-    hash = "sha256-m5dJQgC7qoew7YhJJVQw1WwVjVG03qe+aIn3dWGpVKc=";
+    hash = "sha256-uoga4LVeNOYmn9LT342L+jxex+N7rIlFrseLf/IHvGc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-nibbles/package.nix
+++ b/pkgs/by-name/gn/gnome-nibbles/package.nix
@@ -21,11 +21,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-nibbles";
-  version = "4.4.1";
+  version = "4.4.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-nibbles/${lib.versions.majorMinor finalAttrs.version}/gnome-nibbles-${finalAttrs.version}.tar.xz";
-    hash = "sha256-uIK4n2v9bRX96yr5edkYui8cHMjto5yviCe1Z9N/r5U=";
+    hash = "sha256-FuBgKHBkamZTh2y8Ye4j92NAwmsSyeicfDASCEUEQVU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-notes/package.nix
+++ b/pkgs/by-name/gn/gnome-notes/package.nix
@@ -5,7 +5,6 @@
   ninja,
   gettext,
   fetchurl,
-  fetchpatch,
   pkg-config,
   wrapGAppsHook3,
   itstool,
@@ -35,22 +34,6 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/bijiben/${lib.versions.major version}/bijiben-${version}.tar.xz";
     hash = "sha256-siERvAaVa+81mqzx1u3h5So1sADIgROTZjL4rGztzmc=";
   };
-
-  patches = [
-    # Fix build with meson 0.61
-    # data/appdata/meson.build:3:5: ERROR: Function does not take positional arguments.
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gnome-notes/-/commit/994af76ce5144062d55d141129bf6bf5fab002ee.patch";
-      hash = "sha256-z7dPOLZzaqvdqUIDy6+V3dKossRbG0EDjBu2oJCF6b4=";
-    })
-
-    # build: Depend on webkit2gtk-4.1
-    # https://gitlab.gnome.org/GNOME/gnome-notes/-/merge_requests/200
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gnome-notes/-/commit/0791507873c96d0463cd0c83108415541f854edd.patch";
-      hash = "sha256-TwCi9sDudeiOjrH2VevAynxvy/WTmwB2HrWqhviPg8o=";
-    })
-  ];
 
   doCheck = true;
 

--- a/pkgs/by-name/gn/gnome-notes/package.nix
+++ b/pkgs/by-name/gn/gnome-notes/package.nix
@@ -29,11 +29,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-notes";
-  version = "40.1";
+  version = "40.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/bijiben/${lib.versions.major version}/bijiben-${version}.tar.xz";
-    hash = "sha256-BaBvsGbpgC9fJKtnsNL3FFGGY2O6Pjn593X9SadYe78=";
+    hash = "sha256-siERvAaVa+81mqzx1u3h5So1sADIgROTZjL4rGztzmc=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-online-accounts/package.nix
+++ b/pkgs/by-name/gn/gnome-online-accounts/package.nix
@@ -32,7 +32,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-online-accounts";
-  version = "3.56.0";
+  version = "3.56.1";
 
   outputs = [
     "out"
@@ -45,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-online-accounts/${lib.versions.majorMinor finalAttrs.version}/gnome-online-accounts-${finalAttrs.version}.tar.xz";
-    hash = "sha256-MdagF9Fxsn/5NkeP2weSogDIFC6vwYslUHPOnftBdXI=";
+    hash = "sha256-ZEWTYKNTHrft7i4DvVq3fslfEFG1aeEaR5tPlPQFxT8=";
   };
 
   mesonFlags = [

--- a/pkgs/by-name/gn/gnome-podcasts/package.nix
+++ b/pkgs/by-name/gn/gnome-podcasts/package.nix
@@ -25,19 +25,19 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-podcasts";
-  version = "25.2";
+  version = "25.3";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = "podcasts";
     tag = finalAttrs.version;
-    hash = "sha256-pVGut7kmwybPrR7ZaXPoDx03FOYeZSvchXl++2cdPck=";
+    hash = "sha256-SblEHmKB/WZwT3T3vnlB4yJjY9JhftDkO21/yY//BRM=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-HKU4rd5OzxhYcN6QKiTVj+NnkdyG8T+D6X1txznZ/xM=";
+    hash = "sha256-Ii5M6W5v5t+qppQNZI1ypHGMM5urUMv7e3Fef3FjfAA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-remote-desktop/package.nix
+++ b/pkgs/by-name/gn/gnome-remote-desktop/package.nix
@@ -34,11 +34,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-remote-desktop";
-  version = "49.0";
+  version = "49.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-remote-desktop/${lib.versions.major version}/gnome-remote-desktop-${version}.tar.xz";
-    hash = "sha256-1HrdnZcPIkrMd+/lohZIbUBFHivCG4W/7FOX1CD9oYo=";
+    hash = "sha256-eADziDAe64FHsL5V6Pp8vXUhBmpIoGEVzA6tnwzqGIo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-session/package.nix
+++ b/pkgs/by-name/gn/gnome-session/package.nix
@@ -34,7 +34,7 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-session";
   # Also bump ./ctl.nix when bumping major version.
-  version = "49.0";
+  version = "49.1";
 
   outputs = [
     "out"
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-session/${lib.versions.major finalAttrs.version}/gnome-session-${finalAttrs.version}.tar.xz";
-    hash = "sha256-WnViLmPRt1FFyevmfoKDZ6dfWs5LYjf2TlRmHmpUXvM=";
+    hash = "sha256-F5UQvjc2KNeb56xYk+nTpeqUnAhhfX0uId45DjIN8fY=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-settings-daemon/package.nix
+++ b/pkgs/by-name/gn/gnome-settings-daemon/package.nix
@@ -42,11 +42,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-settings-daemon";
-  version = "49.0";
+  version = "49.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-settings-daemon/${lib.versions.major finalAttrs.version}/gnome-settings-daemon-${finalAttrs.version}.tar.xz";
-    hash = "sha256-IBvUrAxHFHkYLvN15ZneYApRo8CwSehXFaIkRx5bMiY=";
+    hash = "sha256-KplX/E+Rw7kSe0lIQXm+9IUSDZwcII5E1E5qdG5swcE=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-shell/package.nix
+++ b/pkgs/by-name/gn/gnome-shell/package.nix
@@ -73,7 +73,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-shell";
-  version = "49.0";
+  version = "49.1";
 
   outputs = [
     "out"
@@ -82,7 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-shell/${lib.versions.major finalAttrs.version}/gnome-shell-${finalAttrs.version}.tar.xz";
-    hash = "sha256-/whrnDIYCZQw2RhSQ7Z3ajaiy3vLcFqYxhLyz0dCcIo=";
+    hash = "sha256-tC0HMYnkAK+U/Dna66vlo2e7D2z3hOxc6VFodZXvvOs=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-software/package.nix
+++ b/pkgs/by-name/gn/gnome-software/package.nix
@@ -48,11 +48,11 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-software";
-  version = "49.0";
+  version = "49.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-software/${lib.versions.major finalAttrs.version}/gnome-software-${finalAttrs.version}.tar.xz";
-    hash = "sha256-NpzXVD8KS+mjNzPeCvFWNIJmw7XKyqTkc3lZ59FOBB8=";
+    hash = "sha256-Sd/sp3kogBdW0MU4bB0gRUygd2AKXR7WbsRu4zoyxm0=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-sudoku/package.nix
+++ b/pkgs/by-name/gn/gnome-sudoku/package.nix
@@ -23,11 +23,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-sudoku";
-  version = "49.0";
+  version = "49.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-sudoku/${lib.versions.major version}/gnome-sudoku-${version}.tar.xz";
-    hash = "sha256-CzfN4geSLJpKiiIV4s3+nzL0AWHSi2An+aaRMCW1CrU=";
+    hash = "sha256-ymcPrHPZ5cPngz/aNVZxC0Ig22Qz577FCnEFYNp9uEA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-system-monitor/package.nix
+++ b/pkgs/by-name/gn/gnome-system-monitor/package.nix
@@ -25,11 +25,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-system-monitor";
-  version = "49.0";
+  version = "49.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-system-monitor/${lib.versions.major finalAttrs.version}/gnome-system-monitor-${finalAttrs.version}.tar.xz";
-    hash = "sha256-3MhE3XDkoHfwZlJNvRT5z+BLCYMdcLfWmlGBZyPNSqA=";
+    hash = "sha256-kVtqMhraEuunv1eMIMn+XkH1XVMoR8vRJLvdquwR1w8=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-usage/package.nix
+++ b/pkgs/by-name/gn/gnome-usage/package.nix
@@ -23,11 +23,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-usage";
-  version = "48.rc";
+  version = "48.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-usage/${lib.versions.major finalAttrs.version}/gnome-usage-${finalAttrs.version}.tar.xz";
-    hash = "sha256-LUbc2QcKkY/sMUdxaaQDI2CdCFa5XHo3wBusqULTk+w=";
+    hash = "sha256-UB3jxtTWU9Wc4NcHdY3M+D3D6oGi7RSS0vMzFi/uChc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-user-docs/package.nix
+++ b/pkgs/by-name/gn/gnome-user-docs/package.nix
@@ -11,11 +11,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-user-docs";
-  version = "49.0";
+  version = "49.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-user-docs/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    hash = "sha256-7BGNRNoYZuQXONoZz128PZpCklovO/SO5sN+bj5G3fM=";
+    hash = "sha256-DlC4u0/OqpEoNnzTRY5e24YclieMGqmnOm7AQCt7xhc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/go/gom/package.nix
+++ b/pkgs/by-name/go/gom/package.nix
@@ -15,7 +15,7 @@
 
 stdenv.mkDerivation rec {
   pname = "gom";
-  version = "0.5.4";
+  version = "0.5.5";
 
   outputs = [
     "out"
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gom/${lib.versions.majorMinor version}/gom-${version}.tar.xz";
-    sha256 = "V7qAb+CAqTfVZkF40hutdlOyxWHqEoGHp7ELwXYrf2U=";
+    sha256 = "rWHwWvIxenqxdx/PqBaYn7ujsYlX0uC13t6e9F8JtTQ=";
   };
 
   patches = [

--- a/pkgs/by-name/gs/gsettings-desktop-schemas/package.nix
+++ b/pkgs/by-name/gs/gsettings-desktop-schemas/package.nix
@@ -17,11 +17,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gsettings-desktop-schemas";
-  version = "49.0";
+  version = "49.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    hash = "sha256-kSkFzEU4KIikdwLtEQHGsI69ASKjKmfZQKuBFqlsUg0=";
+    hash = "sha256-d3p/g9XlqAdrm/gJyyQQGxsbqcIwI148PejhOWjtDmM=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/li/libadwaita/package.nix
+++ b/pkgs/by-name/li/libadwaita/package.nix
@@ -23,7 +23,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libadwaita";
-  version = "1.8.0";
+  version = "1.8.1";
 
   outputs = [
     "out"
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "GNOME";
     repo = "libadwaita";
     tag = finalAttrs.version;
-    hash = "sha256-neF7nt7x3QhSsWuWGouqniFlDHw1Soco7Dpzhy15gWE=";
+    hash = "sha256-9CcmzwQYZZc6dZAv6x90Od4lrRcYZIejzPgm6S1vz/U=";
   };
 
   depsBuildBuild = [

--- a/pkgs/by-name/li/libglycin/package.nix
+++ b/pkgs/by-name/li/libglycin/package.nix
@@ -27,14 +27,14 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "libglycin";
-  version = "2.0.2";
+  version = "2.0.4";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "GNOME";
     repo = "glycin";
     tag = finalAttrs.version;
-    hash = "sha256-HLvdDQ1rXm2JTUwot07qOIzNaK/sK6zLswips8oIp9c=";
+    hash = "sha256-KPhyL7uP621pxxDGlzbF9WG7A0AcyaS95VstfN/FoQ8=";
   };
 
   nativeBuildInputs = [
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-IaiQ1OdmlBcIYyruG6p/rrOxq7x8csF/W3ONerh2lAA=";
+    hash = "sha256-bYUA8WrCWGTs5P1zT7zMSESkHhsyfBBRUvM2D63OBbA=";
   };
 
   buildInputs = [

--- a/pkgs/by-name/li/libpanel/package.nix
+++ b/pkgs/by-name/li/libpanel/package.nix
@@ -16,7 +16,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libpanel";
-  version = "1.10.2";
+  version = "1.10.3";
 
   outputs = [
     "out"
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/libpanel/${lib.versions.majorMinor finalAttrs.version}/libpanel-${finalAttrs.version}.tar.xz";
-    hash = "sha256-zBLo4Q8eSXe9Eq0/+u3NUqwXY0i0r2/l2mhrljJb/gE=";
+    hash = "sha256-QqAbr4uURA8ZTqg0KyRL1pkt+wJMoxYMlHf/SY7DorY=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/li/librsvg/package.nix
+++ b/pkgs/by-name/li/librsvg/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchurl,
-  fetchpatch,
   pkg-config,
   meson,
   ninja,
@@ -64,16 +63,6 @@ stdenv.mkDerivation (finalAttrs: {
     url = "mirror://gnome/sources/librsvg/${lib.versions.majorMinor finalAttrs.version}/librsvg-${finalAttrs.version}.tar.xz";
     hash = "sha256-pW0sgNdErS8nGPhd9Gb+cdJP8fm8Pl71iL3k1+h4FfI=";
   };
-
-  patches = [
-    (fetchpatch {
-      # https://gitlab.gnome.org/GNOME/librsvg/-/merge_requests/1149
-      # libxml 2.15+ requires adjustments to error handling
-      # remove next librsvg release
-      url = "https://gitlab.gnome.org/GNOME/librsvg/-/commit/6663df8e9aec323f0c124e97a7c7447a90c67c4a.patch";
-      hash = "sha256-+iyRvxVMxSCW0IIizXXheBFytwhBtU4cyJNTBebCOSg=";
-    })
-  ];
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;

--- a/pkgs/by-name/li/librsvg/package.nix
+++ b/pkgs/by-name/li/librsvg/package.nix
@@ -50,7 +50,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "librsvg";
-  version = "2.61.2";
+  version = "2.61.3";
 
   outputs = [
     "out"
@@ -62,7 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/librsvg/${lib.versions.majorMinor finalAttrs.version}/librsvg-${finalAttrs.version}.tar.xz";
-    hash = "sha256-RkTYNiPdYcxEecKzw3Lh2isoFVLryQA1yNGsUC6x3AA=";
+    hash = "sha256-pW0sgNdErS8nGPhd9Gb+cdJP8fm8Pl71iL3k1+h4FfI=";
   };
 
   patches = [
@@ -78,7 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
     name = "librsvg-deps-${finalAttrs.version}";
-    hash = "sha256-OZspQg9ryDNILUZMiB77vIF0uGCMyVe7blX5BJk102k=";
+    hash = "sha256-5uNkjfZhETuG8Sjw66zapYXOj4dgz9Ziry2kAV+pvZQ=";
     dontConfigure = true;
   };
 

--- a/pkgs/by-name/li/libshumate/package.nix
+++ b/pkgs/by-name/li/libshumate/package.nix
@@ -23,7 +23,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libshumate";
-  version = "1.5.0.1";
+  version = "1.5.1";
 
   outputs = [
     "out"
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/libshumate/${lib.versions.majorMinor finalAttrs.version}/libshumate-${finalAttrs.version}.tar.xz";
-    hash = "sha256-qW/nqWN86BnaEh6D4m61M83HjBRvpRqWC73K1VdAnlg=";
+    hash = "sha256-2q34twATQ4jH6TPgtiNYaqp/L76LOmJZOHUTMDuYduY=";
   };
 
   depsBuildBuild = [

--- a/pkgs/by-name/lo/localsearch/package.nix
+++ b/pkgs/by-name/lo/localsearch/package.nix
@@ -50,11 +50,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "localsearch";
-  version = "3.10.0";
+  version = "3.10.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/localsearch/${lib.versions.majorMinor finalAttrs.version}/localsearch-${finalAttrs.version}.tar.xz";
-    hash = "sha256-WNZupEruFknI2YH5NDc7g+GrSkoahLoDBPWvOR5+AIA=";
+    hash = "sha256-XK7zgWDgSV2tj9FVWmmZ9NTVNtnX66GP1J7BdzOMXcI=";
   };
 
   patches = [

--- a/pkgs/by-name/lo/loupe/package.nix
+++ b/pkgs/by-name/lo/loupe/package.nix
@@ -25,17 +25,17 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "loupe";
-  version = "49.0";
+  version = "49.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/loupe/${lib.versions.major finalAttrs.version}/loupe-${finalAttrs.version}.tar.xz";
-    hash = "sha256-os5VTo5eHRa4NuRvFlJ2fbK7O9T33KqH8laa8QuGOTg=";
+    hash = "sha256-MAmLyXmhyHouyye0patyWr+QC9cQu5wrzAyULVFcUcU=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
     name = "loupe-deps-${finalAttrs.version}";
-    hash = "sha256-56yU5h+ZMSX6PH2jkboBwV0IMlcJI9i1sJZx4nNYJe4=";
+    hash = "sha256-GqPHvUBA5aRUnRSP+PpdOCC9sL8axnEdfqtHFp2KYJc=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/mu/mutter/package.nix
+++ b/pkgs/by-name/mu/mutter/package.nix
@@ -71,7 +71,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mutter";
-  version = "49.0";
+  version = "49.1.1";
 
   outputs = [
     "out"
@@ -82,7 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/mutter/${lib.versions.major finalAttrs.version}/mutter-${finalAttrs.version}.tar.xz";
-    hash = "sha256-8Q727SA2ZzcwRhQz4R4L46vHRg0yOz6HCTtsOXLBYzU=";
+    hash = "sha256-EykM/0l0EA4r/XsPrlwG+X+nXSH9xA8fXn5ILzPL0Cc=";
   };
 
   mesonFlags = [

--- a/pkgs/by-name/na/nautilus/package.nix
+++ b/pkgs/by-name/na/nautilus/package.nix
@@ -41,7 +41,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nautilus";
-  version = "49.0";
+  version = "49.1";
 
   outputs = [
     "out"
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/nautilus/${lib.versions.major finalAttrs.version}/nautilus-${finalAttrs.version}.tar.xz";
-    hash = "sha256-sxKScENPx8Uz+X7X+MRCcE8AoC0nopCALY0Wq0Kha/g=";
+    hash = "sha256-rdKg5BD9ItooUd3QxbPSLJ6djDMRFRHzNpYeO0YbU14=";
   };
 
   patches = [

--- a/pkgs/by-name/or/orca/package.nix
+++ b/pkgs/by-name/or/orca/package.nix
@@ -29,13 +29,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "orca";
-  version = "49.1";
+  version = "49.4";
 
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/orca/${lib.versions.major version}/orca-${version}.tar.xz";
-    hash = "sha256-ZTKWhs0V9iq05MDQDOuYTUmbKOwsURdQjDuCiQ1i5+M=";
+    hash = "sha256-trpMxYeEEcNKfVt+6bLFybHQSt0Qv9IPbiMx1ZQWUgc=";
   };
 
   patches = [

--- a/pkgs/by-name/pa/papers/package.nix
+++ b/pkgs/by-name/pa/papers/package.nix
@@ -6,6 +6,7 @@
   ninja,
   pkg-config,
   appstream,
+  blueprint-compiler,
   desktop-file-utils,
   gtk4,
   glib,
@@ -40,7 +41,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "papers";
-  version = "48.5";
+  version = "49.1";
 
   outputs = [
     "out"
@@ -50,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/papers/${lib.versions.major finalAttrs.version}/papers-${finalAttrs.version}.tar.xz";
-    hash = "sha256-DMjXLHHT2KqxvhCuGUGkzZLNHip+gwq3aA4sgt+xnAs=";
+    hash = "sha256-SrI6Z4l73da+LWKYIQ//YCz+wPNWiLxb/ycDYLB4TCk=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
@@ -59,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
       pname
       version
       ;
-    hash = "sha256-1HFecOTn84m9lT166HlmYjqP+KN/ZOTWW4ztigrpqNQ=";
+    hash = "sha256-Pjhpo44Zau2z6aWEQEcIPy3aUYplwdF/XIkO/1Zl+kg=";
   };
 
   nativeBuildInputs = [
@@ -74,6 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
     wrapGAppsHook4
     yelp-tools
     cargo
+    blueprint-compiler
     rustPlatform.cargoSetupHook
   ];
 
@@ -112,7 +114,7 @@ stdenv.mkDerivation (finalAttrs: {
   env.CARGO_BUILD_TARGET = stdenv.hostPlatform.rust.rustcTargetSpec;
 
   postPatch = ''
-    substituteInPlace shell/src/meson.build --replace-fail \
+    substituteInPlace shell/src/meson.build thumbnailer/meson.build --replace-fail \
       "meson.current_build_dir() / rust_target / meson.project_name()" \
       "meson.current_build_dir() / '${stdenv.hostPlatform.rust.cargoShortTarget}' / rust_target / meson.project_name()"
   '';

--- a/pkgs/by-name/qu/quadrapassel/package.nix
+++ b/pkgs/by-name/qu/quadrapassel/package.nix
@@ -23,11 +23,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "quadrapassel";
-  version = "49.0";
+  version = "49.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/quadrapassel/${lib.versions.major finalAttrs.version}/quadrapassel-${finalAttrs.version}.tar.xz";
-    hash = "sha256-VFMe3w+apmk2qjQHmvzCpcAAJfQBaMr7frsduPJC7uE=";
+    hash = "sha256-ttejtndabcTxmAvZN4MkZmF6iX7KoQmPOixZvhdhZQk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/sh/showtime/package.nix
+++ b/pkgs/by-name/sh/showtime/package.nix
@@ -3,15 +3,16 @@
   appstream,
   blueprint-compiler,
   desktop-file-utils,
-  fetchFromGitLab,
+  fetchurl,
+  fetchpatch,
   glib,
+  gnome,
   gobject-introspection,
   gst_all_1,
   gtk4,
   libadwaita,
   meson,
   ninja,
-  nix-update-script,
   pkg-config,
   python3Packages,
   wrapGAppsHook4,
@@ -19,19 +20,28 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "showtime";
-  version = "48.1";
+  version = "49.0";
   pyproject = false;
 
-  src = fetchFromGitLab {
-    domain = "gitlab.gnome.org";
-    group = "GNOME";
-    owner = "Incubator";
-    repo = "showtime";
-    rev = "refs/tags/${version}";
-    hash = "sha256-uk3KgiLsYjqBhlKssnkWO6D4ufwJb/o+rQYSA7pa1lU=";
+  src = fetchurl {
+    url = "mirror://gnome/sources/showtime/${lib.versions.major version}/showtime-${version}.tar.xz";
+    hash = "sha256-Wryvl6telTADgoKEhYjozmwmFztzA+9nVr69sLIO05g=";
   };
 
+  patches = [
+    # Fix startup crash when missing state directory.
+    # https://gitlab.gnome.org/GNOME/showtime/-/merge_requests/80
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/showtime/-/commit/a5d57a6b023664c9dc5aeb55a3467a8b56e1b7bc.patch";
+      hash = "sha256-IUkopJ3J381+9MnvaItx7dn9NAVrqO9y4LjgPh8MU/M=";
+    })
+  ];
+
   strictDeps = true;
+
+  depsBuildBuild = [
+    pkg-config
+  ];
 
   nativeBuildInputs = [
     appstream
@@ -64,8 +74,15 @@ python3Packages.buildPythonApplication rec {
 
   pythonImportsCheck = [ "showtime" ];
 
+  preInstallCheck = ''
+    export XDG_DATA_DIRS="${glib.makeSchemaDataDirPath "$out" "$name"}:$XDG_DATA_DIRS"
+    export HOME="$TEMPDIR"
+  '';
+
   passthru = {
-    updateScript = nix-update-script { };
+    updateScript = gnome.updateScript {
+      packageName = "showtime";
+    };
   };
 
   meta = {

--- a/pkgs/by-name/sh/showtime/package.nix
+++ b/pkgs/by-name/sh/showtime/package.nix
@@ -73,6 +73,7 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://apps.gnome.org/Showtime";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ getchoo ];
+    teams = [ lib.teams.gnome ];
     mainProgram = "showtime";
   };
 }

--- a/pkgs/by-name/si/simple-scan/package.nix
+++ b/pkgs/by-name/si/simple-scan/package.nix
@@ -26,11 +26,11 @@
 
 stdenv.mkDerivation rec {
   pname = "simple-scan";
-  version = "49.0.1";
+  version = "49.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/simple-scan/${lib.versions.major version}/simple-scan-${version}.tar.xz";
-    hash = "sha256-4ZdiQiZj70v1059udfTWGo3hgTcpqW5X4E6Bdk4B6uI=";
+    hash = "sha256-mujUFR7K+VhF65+ZtDbVecg48s8Cdj+6O8A3gCUb4zQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/vt/vte/package.nix
+++ b/pkgs/by-name/vt/vte/package.nix
@@ -38,7 +38,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "vte";
-  version = "0.82.0";
+  version = "0.82.1";
 
   outputs = [
     "out"
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/vte/${lib.versions.majorMinor finalAttrs.version}/vte-${finalAttrs.version}.tar.xz";
-    hash = "sha256-sHGNsyVHMHAbQ79eETy/jNssFHFdMu4einB9xutwU18=";
+    hash = "sha256-eTdtcEAtJx4tOEJEGOGupyNXk00nLjIeOQa3Fwanjjo=";
   };
 
   patches = [

--- a/pkgs/development/libraries/gdk-pixbuf/default.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/default.nix
@@ -28,7 +28,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gdk-pixbuf";
-  version = "2.44.3";
+  version = "2.44.4";
 
   outputs = [
     "out"
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     in
     fetchurl {
       url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-      hash = "sha256-QKktzCN/+UtjqAwVmj9vIs1Z9vtJYfIBx4eZ+iyKwKY=";
+      hash = "sha256-k6Gqw/FCeuc0Vzl1gqLDjQSWOKgBeIzL1fSMpge9vRc=";
     };
 
   patches = [

--- a/pkgs/development/python-modules/pyatspi/default.nix
+++ b/pkgs/development/python-modules/pyatspi/default.nix
@@ -12,12 +12,12 @@
 
 buildPythonPackage rec {
   pname = "pyatspi";
-  version = "2.46.1";
+  version = "2.58.0";
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "+R9qV0NOnAfRPVxL+BndeOjuYFqsKuRdjGTCgRT7BBs=";
+    sha256 = "6dKQ1TzH4wZtly/RilDuiF77i+CqJSYvGe9/iE/qDv8=";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/development/python-modules/pygobject/3.nix
+++ b/pkgs/development/python-modules/pygobject/3.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "pygobject";
-  version = "3.54.3";
+  version = "3.54.5";
 
   outputs = [
     "out"
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.gz";
-    hash = "sha256-qNoJE0oPfVZJHPJBIUXjWqdOkddg6PM3CWoc2guSuuc=";
+    hash = "sha256-tmVvY0j1JFYGzxXqSMOEx/BRVsderSBsGyRsgKIvtYU=";
   };
 
   depsBuildBuild = [ pkg-config ];


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/calls/-/compare/v48.2...v49.1.1

Built without errors on Linux 6.17.5, NixOS, 25.11 (Xantusia), 25.11.20251102.b3d51a0 (x86_64-linux).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
