### PR TITLE
udpipe1: init at version 1.4.0

### DIFF
--- a/pkgs/by-name/ud/udpipe1/package.nix
+++ b/pkgs/by-name/ud/udpipe1/package.nix
@@ -1,0 +1,67 @@
+# https://github.com/apertium/packaging/blob/main/tools/udpipe/debian
+{
+  callPackage,
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  testers,
+  versionCheckHook,
+  udpipe1,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "udpipe1";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "ufal";
+    repo = "udpipe";
+    rev = "a0e72fcb1ba0d36998dc671db4350bbd159861b5";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ekRuaQlNGv+7eFtwqbs6d6hy/b8uZpHq2ffcKPcre7U=";
+  };
+
+  doCheck = true;
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  sourceRoot = "${finalAttrs.src.name}/src";
+
+  makeFlags = [
+    "VERBOSE=1"
+    "MODE=release"
+  ];
+  buildFlags = [
+    "exe"
+    "server"
+    "lib"
+  ];
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/{bin,lib}
+    cp -v udpipe $out/bin
+    cp -v rest_server/udpipe_server $out/bin
+    cp -v libudpipe.a $out/lib/
+    runHook postInstall
+  '';
+
+  passthru.tests = {
+    version = testers.testVersion { package = udpipe1; };
+    run = callPackage ./test.nix { udpipe1 = finalAttrs.finalPackage; };
+  };
+
+  meta = {
+    description = "Trainable pipeline for tokenizing, tagging, lemmatizing and parsing Universal Treebanks and other CoNLL-U files";
+    homepage = "https://github.com/ufal/udpipe";
+    changelog = "https://github.com/ufal/udpipe/blob/${finalAttrs.version}/CHANGES.md";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ unhammer ];
+    mainProgram = "udpipe";
+    platforms = lib.platforms.all;
+    badPlatforms = [ "aarch64-linux" ]; # until https://github.com/ufal/cpp_builtem/pull/2 is merged
+  };
+})

--- a/pkgs/by-name/ud/udpipe1/package.nix
+++ b/pkgs/by-name/ud/udpipe1/package.nix
@@ -1,0 +1,69 @@
+# https://github.com/apertium/packaging/blob/main/tools/udpipe/debian
+{
+  callPackage,
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  testers,
+  versionCheckHook,
+  udpipe1,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "udpipe1";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "ufal";
+    repo = "udpipe";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ekRuaQlNGv+7eFtwqbs6d6hy/b8uZpHq2ffcKPcre7U=";
+  };
+
+  doCheck = true;
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  sourceRoot = "${finalAttrs.src.name}/src";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  makeFlags = [
+    "VERBOSE=1"
+    "MODE=release"
+  ];
+  buildFlags = [
+    "exe"
+    "server"
+    "lib"
+  ];
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/{bin,lib}
+    cp -v udpipe $out/bin
+    cp -v rest_server/udpipe_server $out/bin
+    cp -v libudpipe.a $out/lib/
+    runHook postInstall
+  '';
+
+  passthru.tests = {
+    version = testers.testVersion { package = udpipe1; };
+    run = callPackage ./test.nix { udpipe1 = finalAttrs.finalPackage; };
+  };
+
+  meta = {
+    description = "Trainable pipeline for tokenizing, tagging, lemmatizing and parsing Universal Treebanks and other CoNLL-U files";
+    homepage = "https://github.com/ufal/udpipe";
+    changelog = "https://github.com/ufal/udpipe/blob/${finalAttrs.version}/CHANGES.md";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ unhammer ];
+    mainProgram = "udpipe";
+    platforms = lib.platforms.all;
+    badPlatforms = [ "aarch64-linux" ]; # until https://github.com/ufal/cpp_builtem/pull/2 is merged
+  };
+})

--- a/pkgs/by-name/ud/udpipe1/test.nix
+++ b/pkgs/by-name/ud/udpipe1/test.nix
@@ -1,0 +1,10 @@
+{ runCommand, udpipe1 }:
+
+runCommand "udpipe1-test-run"
+  {
+    nativeBuildInputs = [ udpipe1 ];
+  }
+  ''
+    diff -U3 --color=auto <(udpipe --version|head -n1) <(echo 'UDPipe version 1.3.1 (using UniLib 3.3.1,')
+    touch $out
+  ''


### PR DESCRIPTION
UDPipe is a trainable pipeline for natural language tokenizing, tagging, lemmatizing and parsing Universal Treebanks and other CoNLL-U files.

Upstream: https://github.com/ufal/udpipe?tab=readme-ov-file

Homepage: https://ufal.mff.cuni.cz/udpipe

(This package is named `udpipe1` because UDPipe 2 is a more or less complete rewrite; UDPipe 1 is written in C++ and runs fast on CPU, while UDPipe 2 is mostly written in Python and requires a GPU to run reasonably quick, along with model incompatibilities.)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
        - The only tests provided by udpipe itself are a build with `treat_warnings_as_errors` – which fails. Added some simple version checks. I am able to use the program from `result/bin/udpipe` and `result/bin/udpipe_server`
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
       - This command just ate all my 16G of RAM :-( – it appears [I'm not the only one](https://github.com/Mic92/nixpkgs-review/issues/103)
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
 

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
