### PR TITLE
oatpp: fix standard install directory

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14325,6 +14325,12 @@
     githubId = 182024;
     name = "Lars Rasmusson";
   };
+  larszauberer = {
+    email = "wasser.ian@gmail.com";
+    github = "LarsZauberer";
+    githubId = 22129620;
+    name = "LarsZauberer";
+  };
   lasandell = {
     email = "lasandell@gmail.com";
     github = "lasandell";

--- a/pkgs/by-name/oa/oatpp/package.nix
+++ b/pkgs/by-name/oa/oatpp/package.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   cmake,
 }:
-
 stdenv.mkDerivation rec {
   pname = "oatpp";
   version = "1.3.1";
@@ -26,11 +25,29 @@ stdenv.mkDerivation rec {
       --replace-fail "cmake_minimum_required(VERSION 3.1 FATAL_ERROR)" "cmake_minimum_required(VERSION 3.10)"
   '';
 
+  postInstall = ''
+    # Copy libraries and headers to standard locations
+    cp -r $out/lib/oatpp-1.3.0/* $out/lib/
+    cp -r $out/include/oatpp-1.3.0/oatpp/* $out/include/
+
+    # Fix the broken /nix/store/ paths in the cmake output
+    for file in $out/lib/cmake/oatpp-1.3.0/*.cmake; do
+      sed -i 's|//nix/store/[^/]*/lib/oatpp-1\.3\.0/|"/lib/"|g' "$file"
+      sed -i 's|$out/lib/oatpp-1\.3\.0|$out/lib|g' "$file"
+      sed -i 's|$out/include/oatpp-1\.3\.0/oatpp|$out/include|g' "$file"
+      sed -i 's|lib/oatpp-1\.3\.0|lib|g' "$file"
+      sed -i 's|include/oatpp-1\.3\.0/oatpp|include|g' "$file"
+      sed -i 's|include/oatpp-1\.3\.0/|include/|g' "$file"
+      sed -i 's|$out$out|$out|g' "$file"
+      sed -i 's|//|/|g' "$file"
+    done
+  '';
+
   meta = with lib; {
     homepage = "https://oatpp.io/";
     description = "Light and powerful C++ web framework for highly scalable and resource-efficient web applications";
     license = licenses.asl20;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.larszauberer ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
Fixed the output of the oatpp library to follow the nix standards. Moved all the include files their parent directories so they can be easily found by the linker. Same for the libraries.
Furthermore, this should fix the issues with the cmake output files having faulty nix store paths.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
