### PR TITLE
treewide: mark as broken on darwin (last successful Hydra build in 2024)

### DIFF
--- a/pkgs/applications/science/misc/tulip/default.nix
+++ b/pkgs/applications/science/misc/tulip/default.nix
@@ -77,5 +77,7 @@ stdenv.mkDerivation rec {
 
     maintainers = [ ];
     platforms = lib.platforms.all;
+    # The last successful Darwin Hydra build was in 2024
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/by-name/av/avfs/package.nix
+++ b/pkgs/by-name/av/avfs/package.nix
@@ -32,5 +32,7 @@ stdenv.mkDerivation rec {
     description = "Virtual filesystem that allows browsing of compressed files";
     platforms = lib.platforms.unix;
     license = lib.licenses.gpl2Only;
+    # The last successful Darwin Hydra build was in 2024
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/by-name/co/coan/package.nix
+++ b/pkgs/by-name/co/coan/package.nix
@@ -46,5 +46,7 @@ stdenv.mkDerivation rec {
     homepage = "https://coan2.sourceforge.net/";
     license = licenses.bsd3;
     platforms = platforms.all;
+    # The last successful Darwin Hydra build was in 2024
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/by-name/em/emboss/package.nix
+++ b/pkgs/by-name/em/emboss/package.nix
@@ -50,5 +50,7 @@ stdenv.mkDerivation rec {
     '';
     license = lib.licenses.gpl2;
     homepage = "https://emboss.sourceforge.net/";
+    # The last successful Darwin Hydra build was in 2024
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/by-name/eu/eureka-ideas/package.nix
+++ b/pkgs/by-name/eu/eureka-ideas/package.nix
@@ -1,4 +1,5 @@
 {
+  stdenv,
   lib,
   rustPlatform,
   fetchFromGitHub,
@@ -36,5 +37,7 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.mit;
     maintainers = [ ];
     mainProgram = "eureka";
+    # The last successful Darwin Hydra build was in 2024
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/by-name/fi/finalfrontier/package.nix
+++ b/pkgs/by-name/fi/finalfrontier/package.nix
@@ -50,5 +50,7 @@ rustPlatform.buildRustPackage {
     homepage = "https://github.com/finalfusion/finalfrontier/";
     license = licenses.asl20;
     maintainers = [ ];
+    # The last successful Darwin Hydra build was in 2024
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/by-name/ga/garmintools/package.nix
+++ b/pkgs/by-name/ga/garmintools/package.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
     maintainers = [ ];
     platforms = lib.platforms.unix;
     # never built on aarch64-darwin since first introduction in nixpkgs
-    broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64;
+    # The last successful Darwin Hydra build was in 2024
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/by-name/jo/jose/package.nix
+++ b/pkgs/by-name/jo/jose/package.nix
@@ -48,5 +48,7 @@ stdenv.mkDerivation rec {
     maintainers = [ ];
     license = lib.licenses.asl20;
     platforms = lib.platforms.all;
+    # The last successful Darwin Hydra build was in 2024
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/by-name/li/libinfinity/package.nix
+++ b/pkgs/by-name/li/libinfinity/package.nix
@@ -83,6 +83,8 @@ let
       license = lib.licenses.lgpl2Plus;
       maintainers = [ ];
       platforms = with lib.platforms; linux ++ darwin;
+      # The last successful Darwin Hydra build was in 2024
+      broken = stdenv.hostPlatform.isDarwin;
     };
   };
 in

--- a/pkgs/by-name/pa/packet-sd/package.nix
+++ b/pkgs/by-name/pa/packet-sd/package.nix
@@ -1,4 +1,5 @@
 {
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   fetchpatch2,
@@ -45,5 +46,7 @@ buildGoModule rec {
     license = licenses.asl20;
     maintainers = [ ];
     mainProgram = "prometheus-packet-sd";
+    # The last successful Darwin Hydra build was in 2024
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/by-name/si/sic-image-cli/package.nix
+++ b/pkgs/by-name/si/sic-image-cli/package.nix
@@ -1,4 +1,5 @@
 {
+  stdenv,
   lib,
   rustPlatform,
   fetchFromGitHub,
@@ -43,5 +44,7 @@ rustPlatform.buildRustPackage rec {
     ];
     maintainers = [ ];
     mainProgram = "sic";
+    # The last successful Darwin Hydra build was in 2024
+    broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64;
   };
 }

--- a/pkgs/by-name/te/telepathy-mission-control/package.nix
+++ b/pkgs/by-name/te/telepathy-mission-control/package.nix
@@ -61,5 +61,7 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl21Only;
     maintainers = [ ];
     platforms = platforms.unix;
+    # The last successful Darwin Hydra build was in 2024
+    broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64;
   };
 }

--- a/pkgs/development/compilers/chicken/5/overrides.nix
+++ b/pkgs/development/compilers/chicken/5/overrides.nix
@@ -98,7 +98,6 @@ in
       ] old
     )
     // (addToBuildInputs pkgs.libglut old);
-  iconv = addToBuildInputs (lib.optional stdenv.hostPlatform.isDarwin pkgs.libiconv);
   icu = addToBuildInputsWithPkgConfig pkgs.icu;
   imlib2 = addToBuildInputsWithPkgConfig pkgs.imlib2;
   inotify =
@@ -306,6 +305,8 @@ in
 
   # mark broken darwin
 
+  # The last successful Darwin Hydra build was in 2024
+  iconv = brokenOnDarwin;
   # fatal error: 'mqueue.h' file not found
   posix-mq = brokenOnDarwin;
   # Undefined symbols for architecture arm64: "_pthread_setschedprio"

--- a/pkgs/development/compilers/polyml/5.7.nix
+++ b/pkgs/development/compilers/polyml/5.7.nix
@@ -62,6 +62,7 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl21;
     platforms = with platforms; (linux ++ darwin);
     # never built on aarch64-darwin since first introduction in nixpkgs
-    broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64;
+    # The last successful Darwin Hydra build was in 2024
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/os-specific/linux/firmware/ath9k/default.nix
+++ b/pkgs/os-specific/linux/firmware/ath9k/default.nix
@@ -186,5 +186,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "http://lists.infradead.org/mailman/listinfo/ath9k_htc_fw";
     downloadPage = "https://github.com/qca/open-ath9k-htc-firmware";
     changelog = "https://github.com/qca/open-ath9k-htc-firmware/tags";
+    # The last successful Darwin Hydra build was in 2024
+    broken = stdenv.hostPlatform.isDarwin;
   };
 })

--- a/pkgs/tools/filesystems/encfs/default.nix
+++ b/pkgs/tools/filesystems/encfs/default.nix
@@ -67,5 +67,7 @@ stdenv.mkDerivation rec {
       lgpl3Plus
     ];
     platforms = platforms.unix;
+    # The last successful Darwin Hydra build was in 2024
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/457852

Actions Taken:
- Identified unmaintained Darwin builds on Hydra that were last successful in 2024.
- Checked each identified build to see if it currently has any open Pull Requests.
- Verified whether the failures for these builds are due to being outdated.
```
ath9k-htc-blobless-firmware
ath9k-htc-blobless-firmware-unstable
avfs
chickenPackages_5.chickenEggs.iconv
coan
emboss
encfs
eureka-ideas
finalfrontier
garmintools
jose
libinfinity
packet-sd
polyml57
sic-image-cli
telepathy-mission-control
tulip
```
Given how cryptic and niche the troubleshooting for Darwin failures can be, and considering the extended period these builds have been failing, this PR marks them as broken.

This action is necessary to conserve compute resources and avoid further waste on inevitable build failures.

Hydra logs:
https://hydra.nixos.org/job/nixpkgs/trunk/ath9k-htc-blobless-firmware-unstable.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/ath9k-htc-blobless-firmware-unstable.aarch64-darwin (no last successful build)

https://hydra.nixos.org/job/nixpkgs/trunk/ath9k-htc-blobless-firmware.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/ath9k-htc-blobless-firmware.aarch64-darwin (no last successful build)

https://hydra.nixos.org/job/nixpkgs/trunk/avfs.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/avfs.aarch64-darwin

https://hydra.nixos.org/job/nixpkgs/trunk/chickenPackages_5.chickenEggs.iconv.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/chickenPackages_5.chickenEggs.iconv.aarch64-darwin

https://hydra.nixos.org/job/nixpkgs/trunk/coan.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/coan.aarch64-darwin

https://hydra.nixos.org/job/nixpkgs/trunk/emboss.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/emboss.aarch64-darwin (no last successful build)

https://hydra.nixos.org/job/nixpkgs/trunk/encfs.x86_64-darwin 
https://hydra.nixos.org/job/nixpkgs/trunk/encfs.aarch64-darwin

https://hydra.nixos.org/job/nixpkgs/trunk/eureka-ideas.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/eureka-ideas.aarch64-darwin

https://hydra.nixos.org/job/nixpkgs/trunk/finalfrontier.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/finalfrontier.aarch64-darwin

https://hydra.nixos.org/job/nixpkgs/trunk/garmintools.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/garmintools.aarch64-darwin (already marked as broken)

https://hydra.nixos.org/job/nixpkgs/trunk/tulip.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/tulip.aarch64-darwin

https://hydra.nixos.org/job/nixpkgs/trunk/telepathy-mission-control.x86_64-darwin (aarch64 seems fine)

https://hydra.nixos.org/job/nixpkgs/trunk/jose.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/jose.aarch64-darwin

https://hydra.nixos.org/job/nixpkgs/trunk/libinfinity.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/libinfinity.aarch64-darwin

https://hydra.nixos.org/job/nixpkgs/trunk/packet-sd.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/packet-sd.aarch64-darwin

https://hydra.nixos.org/job/nixpkgs/trunk/sic-image-cli.x86_64-darwin (aarch64 seems fine)

https://hydra.nixos.org/job/nixpkgs/trunk/polyml57.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/polyml57.aarch64-darwin (already marked as broken)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
