### PR TITLE
nixos-rebuild-ng: also consider `--no-build-output` with flake rebuilds

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/nixos-rebuild.8.scd
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/nixos-rebuild.8.scd
@@ -18,13 +18,11 @@ nixos-rebuild - reconfigure a NixOS machine
 # SYNOPSIS
 
 ; document here only non-deprecated flags
-_nixos-rebuild_ \[--verbose] [--max-jobs MAX_JOBS] [--cores CORES] [--log-format LOG_FORMAT] [--keep-going] [--keep-failed] [--fallback] [--repair] [--option OPTION OPTION] [--builders BUILDERS]++
-	\[--include INCLUDE] [--quiet] [--print-build-logs] [--show-trace] [--accept-flake-config] [--refresh] [--impure] [--offline] [--no-net] [--recreate-lock-file]++
-	\[--no-update-lock-file] [--no-write-lock-file] [--no-registries] [--commit-lock-file] [--update-input UPDATE_INPUT] [--override-input OVERRIDE_INPUT OVERRIDE_INPUT]++
-	\[--no-build-output] [--use-substitutes] [--help] [--file FILE] [--attr ATTR] [--flake [FLAKE]] [--no-flake] [--install-bootloader] [--profile-name PROFILE_NAME]++
-	\[--specialisation SPECIALISATION] [--rollback] [--upgrade] [--upgrade-all] [--json] [--ask-sudo-password] [--sudo] [--no-reexec]++
-	\[--image-variant VARIANT]++
-	\[--build-host BUILD_HOST] [--target-host TARGET_HOST]++
+_nixos-rebuild_ \[--verbose] [--quiet] [--max-jobs MAX_JOBS] [--cores CORES] [--log-format LOG_FORMAT] [--keep-going] [--keep-failed] [--fallback] [--repair] [--option OPTION OPTION] [--builders BUILDERS] [--include INCLUDE]++
+	\[--print-build-logs] [--show-trace] [--accept-flake-config] [--refresh] [--impure] [--offline] [--no-net] [--recreate-lock-file] [--no-update-lock-file] [--no-write-lock-file] [--no-registries] [--commit-lock-file]++
+	\[--update-input UPDATE_INPUT] [--override-input OVERRIDE_INPUT OVERRIDE_INPUT] [--no-build-output] [--use-substitutes] [--help] [--debug] [--file FILE] [--attr ATTR] [--flake [FLAKE]] [--no-flake] [--install-bootloader]++
+	\[--profile-name PROFILE_NAME] [--specialisation SPECIALISATION] [--rollback] [--upgrade] [--upgrade-all] [--json] [--ask-sudo-password] [--sudo] [--no-reexec]++
+	\[--build-host BUILD_HOST] [--target-host TARGET_HOST] [--no-build-nix] [--image-variant IMAGE_VARIANT]++
 	\[{switch,boot,test,build,edit,repl,dry-build,dry-run,dry-activate,build-image,build-vm,build-vm-with-bootloader,list-generations}]
 
 # DESCRIPTION
@@ -260,9 +258,10 @@ It must be one of the following:
 	When set, *nixos-rebuild* prefixes activation commands with sudo.
 	Setting this option allows deploying as a non-root user.
 
-*--ask-sudo-password*
+*--ask-sudo-password*, *-S*
 	When set, *nixos-rebuild* will ask for sudo password for remote
 	activation (i.e.: on *--target-host*) at the start of the build process.
+	Implies *--sudo*.
 
 *--file* _path_, *-f* _path_
 	Enable and build the NixOS system from the specified file. The file must
@@ -305,9 +304,9 @@ Flake-related options:
 Builder options:
 
 *--verbose,*  *-v*,  *--quiet*,  *--log-format*,  *--no-build-output*, *-Q*,
-*--max-jobs*, *-j*, *--cores*, *--keep-going*, *-k*, *--keep-failed*, *-K*,
-*--fallback*, *--include*, *-I*, *--option*, *--repair*, *--builders*,
-*--print-build-logs*, *-L*, *--show-trace*
+*--no-link*, *--max-jobs*, *-j*, *--cores*, *--keep-going*, *-k*,
+*--keep-failed*, *-K*, *--fallback*, *--include*, *-I*, *--option*, *--repair*,
+*--builders*, *--print-build-logs*, *-L*, *--show-trace*
 
 See the Nix manual, *nix flake lock --help* or *nix-build --help* for details.
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -153,6 +153,7 @@ def get_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.ArgumentPa
     )
     main_parser.add_argument(
         "--ask-sudo-password",
+        "-S",
         action="store_true",
         help="Asks for sudo password for remote activation, implies --sudo",
     )

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -275,6 +275,8 @@ def execute(argv: list[str]) -> None:
     flake_common_flags = common_flags | vars(args_groups["flake_common_flags"])
     flake_build_flags = common_build_flags | flake_common_flags
     copy_flags = common_flags | vars(args_groups["copy_flags"])
+    if build_flags.get("no_build_output"):
+        flake_build_flags = flake_build_flags | {"no_link": True}
 
     if args.upgrade or args.upgrade_all:
         nix.upgrade_channels(args.upgrade_all, args.sudo)

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -55,7 +55,9 @@ def get_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.ArgumentPa
     flake_common_flags.add_argument("--override-input", nargs=2, action="append")
 
     classic_build_flags = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
-    classic_build_flags.add_argument("--no-build-output", "-Q", action="store_true")
+    classic_build_flags.add_argument(
+        "--no-build-output", "--no-link", "-Q", action="store_true"
+    )
 
     copy_flags = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
     copy_flags.add_argument(

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
@@ -8,9 +8,17 @@ from typing import Final
 
 from . import nix, tmpdir
 from .constants import EXECUTABLE
-from .models import Action, BuildAttr, Flake, ImageVariants, NixOSRebuildError, Profile
+from .models import (
+    Action,
+    BuildAttr,
+    Flake,
+    GroupedNixArgs,
+    ImageVariants,
+    NixOSRebuildError,
+    Profile,
+)
 from .process import Remote, cleanup_ssh
-from .utils import Args, tabulate
+from .utils import tabulate
 
 NIXOS_REBUILD_ATTR: Final = "config.system.build.nixos-rebuild"
 NIXOS_REBUILD_REEXEC_ENV: Final = "_NIXOS_REBUILD_REEXEC"
@@ -21,8 +29,7 @@ logger: Final = logging.getLogger(__name__)
 def reexec(
     argv: list[str],
     args: argparse.Namespace,
-    build_flags: Args,
-    flake_build_flags: Args,
+    grouped_nix_args: GroupedNixArgs,
 ) -> None:
     if os.environ.get(NIXOS_REBUILD_REEXEC_ENV):
         return
@@ -36,14 +43,14 @@ def reexec(
         drv = nix.build_flake(
             NIXOS_REBUILD_ATTR,
             flake,
-            flake_build_flags | {"no_link": True},
+            grouped_nix_args.flake_build_flags | {"no_link": True},
         )
     else:
         build_attr = BuildAttr.from_arg(args.attr, args.file)
         drv = nix.build(
             NIXOS_REBUILD_ATTR,
             build_attr,
-            build_flags | {"no_out_link": True},
+            grouped_nix_args.build_flags | {"no_out_link": True},
         )
 
     if drv:
@@ -88,21 +95,20 @@ def _get_system_attr(
     args: argparse.Namespace,
     flake: Flake | None,
     build_attr: BuildAttr,
-    common_flags: Args,
-    flake_common_flags: Args,
+    grouped_nix_args: GroupedNixArgs,
 ) -> str:
     match action:
         case Action.BUILD_IMAGE if flake:
             variants = nix.get_build_image_variants_flake(
                 flake,
-                eval_flags=flake_common_flags,
+                eval_flags=grouped_nix_args.flake_common_flags,
             )
             _validate_image_variant(args.image_variant, variants)
             attr = f"config.system.build.images.{args.image_variant}"
         case Action.BUILD_IMAGE:
             variants = nix.get_build_image_variants(
                 build_attr,
-                instantiate_flags=common_flags,
+                instantiate_flags=grouped_nix_args.common_flags,
             )
             _validate_image_variant(args.image_variant, variants)
             attr = f"config.system.build.images.{args.image_variant}"
@@ -146,11 +152,7 @@ def _build_system(
     target_host: Remote | None,
     flake: Flake | None,
     build_attr: BuildAttr,
-    build_flags: Args,
-    common_flags: Args,
-    copy_flags: Args,
-    flake_build_flags: Args,
-    flake_common_flags: Args,
+    grouped_nix_args: GroupedNixArgs,
 ) -> Path:
     dry_run = action == Action.DRY_BUILD
     # actions that we will not add a /result symlink in CWD
@@ -162,32 +164,33 @@ def _build_system(
                 attr,
                 flake,
                 build_host,
-                eval_flags=flake_common_flags,
+                eval_flags=grouped_nix_args.flake_common_flags,
                 flake_build_flags={"no_link": no_link, "dry_run": dry_run}
-                | flake_build_flags,
-                copy_flags=copy_flags,
+                | grouped_nix_args.flake_build_flags,
+                copy_flags=grouped_nix_args.copy_flags,
             )
         case (None, Flake(_)):
             path_to_config = nix.build_flake(
                 attr,
                 flake,
                 flake_build_flags={"no_link": no_link, "dry_run": dry_run}
-                | flake_build_flags,
+                | grouped_nix_args.flake_build_flags,
             )
         case (Remote(_), None):
             path_to_config = nix.build_remote(
                 attr,
                 build_attr,
                 build_host,
-                realise_flags=common_flags,
-                instantiate_flags=build_flags,
-                copy_flags=copy_flags,
+                realise_flags=grouped_nix_args.common_flags,
+                instantiate_flags=grouped_nix_args.build_flags,
+                copy_flags=grouped_nix_args.copy_flags,
             )
         case (None, None):
             path_to_config = nix.build(
                 attr,
                 build_attr,
-                build_flags={"no_out_link": no_link, "dry_run": dry_run} | build_flags,
+                build_flags={"no_out_link": no_link, "dry_run": dry_run}
+                | grouped_nix_args.build_flags,
             )
 
     # In dry_run mode there is nothing to copy
@@ -197,7 +200,7 @@ def _build_system(
             path_to_config,
             to_host=target_host,
             from_host=build_host,
-            copy_flags=copy_flags,
+            copy_flags=grouped_nix_args.copy_flags,
         )
 
     return path_to_config
@@ -211,8 +214,7 @@ def _activate_system(
     profile: Profile,
     flake: Flake | None,
     build_attr: BuildAttr,
-    flake_common_flags: Args,
-    common_flags: Args,
+    grouped_nix_args: GroupedNixArgs,
 ) -> None:
     # Print only the result to stdout to make it easier to script
     def print_result(msg: str, result: str | Path) -> None:
@@ -257,13 +259,13 @@ def _activate_system(
                 image_name = nix.get_build_image_name_flake(
                     flake,
                     args.image_variant,
-                    eval_flags=flake_common_flags,
+                    eval_flags=grouped_nix_args.flake_common_flags,
                 )
             else:
                 image_name = nix.get_build_image_name(
                     build_attr,
                     args.image_variant,
-                    instantiate_flags=common_flags,
+                    instantiate_flags=grouped_nix_args.common_flags,
                 )
             disk_path = path_to_config / image_name
             print_result("Done. The disk image can be found in", disk_path)
@@ -277,11 +279,7 @@ def build_and_activate_system(
     profile: Profile,
     flake: Flake | None,
     build_attr: BuildAttr,
-    build_flags: Args,
-    common_flags: Args,
-    copy_flags: Args,
-    flake_build_flags: Args,
-    flake_common_flags: Args,
+    grouped_nix_args: GroupedNixArgs,
 ) -> None:
     logger.info("building the system configuration...")
     attr = _get_system_attr(
@@ -289,8 +287,7 @@ def build_and_activate_system(
         args=args,
         flake=flake,
         build_attr=build_attr,
-        common_flags=common_flags,
-        flake_common_flags=flake_common_flags,
+        grouped_nix_args=grouped_nix_args,
     )
 
     if args.rollback:
@@ -308,11 +305,7 @@ def build_and_activate_system(
             target_host=target_host,
             flake=flake,
             build_attr=build_attr,
-            build_flags=build_flags,
-            common_flags=common_flags,
-            copy_flags=copy_flags,
-            flake_build_flags=flake_build_flags,
-            flake_common_flags=flake_common_flags,
+            grouped_nix_args=grouped_nix_args,
         )
 
     _activate_system(
@@ -323,14 +316,13 @@ def build_and_activate_system(
         profile=profile,
         flake=flake,
         build_attr=build_attr,
-        common_flags=common_flags,
-        flake_common_flags=flake_common_flags,
+        grouped_nix_args=grouped_nix_args,
     )
 
 
-def edit(flake: Flake | None, flake_build_flags: Args | None = None) -> None:
+def edit(flake: Flake | None, grouped_nix_args: GroupedNixArgs) -> None:
     if flake:
-        nix.edit_flake(flake, flake_build_flags)
+        nix.edit_flake(flake, grouped_nix_args.flake_build_flags)
     else:
         nix.edit()
 
@@ -358,17 +350,16 @@ def list_generations(
 def repl(
     flake: Flake | None,
     build_attr: BuildAttr,
-    flake_build_flags: Args,
-    build_flags: Args,
+    grouped_nix_args: GroupedNixArgs,
 ) -> None:
     if flake:
-        nix.repl_flake(flake, flake_build_flags)
+        nix.repl_flake(flake, grouped_nix_args.flake_build_flags)
     else:
-        nix.repl(build_attr, build_flags)
+        nix.repl(build_attr, grouped_nix_args.build_flags)
 
 
-def write_version_suffix(build_flags: Args) -> None:
-    nixpkgs_path = nix.find_file("nixpkgs", build_flags)
+def write_version_suffix(grouped_nix_args: GroupedNixArgs) -> None:
+    nixpkgs_path = nix.find_file("nixpkgs", grouped_nix_args.build_flags)
     rev = nix.get_nixpkgs_rev(nixpkgs_path)
     if nixpkgs_path and rev:
         try:

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
@@ -163,16 +163,16 @@ def _build_system(
                 flake,
                 build_host,
                 eval_flags=flake_common_flags,
-                flake_build_flags=flake_build_flags
-                | {"no_link": no_link, "dry_run": dry_run},
+                flake_build_flags={"no_link": no_link, "dry_run": dry_run}
+                | flake_build_flags,
                 copy_flags=copy_flags,
             )
         case (None, Flake(_)):
             path_to_config = nix.build_flake(
                 attr,
                 flake,
-                flake_build_flags=flake_build_flags
-                | {"no_link": no_link, "dry_run": dry_run},
+                flake_build_flags={"no_link": no_link, "dry_run": dry_run}
+                | flake_build_flags,
             )
         case (Remote(_), None):
             path_to_config = nix.build_remote(
@@ -187,7 +187,7 @@ def _build_system(
             path_to_config = nix.build(
                 attr,
                 build_attr,
-                build_flags=build_flags | {"no_out_link": no_link, "dry_run": dry_run},
+                build_flags={"no_out_link": no_link, "dry_run": dry_run} | build_flags,
             )
 
     # In dry_run mode there is nothing to copy

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -65,8 +65,7 @@ def test_parse_args() -> None:
     assert r1.install_grub is True
     assert r1.profile_name == "system"
     assert r1.action == "switch"
-    # round-trip test (ensure that we have the same flags as parsed)
-    assert nr.utils.dict_to_flags(vars(g1["common_flags"])) == [
+    assert nr.utils.dict_to_flags(g1.common_flags) == [
         "--option",
         "foo1",
         "bar1",
@@ -74,7 +73,13 @@ def test_parse_args() -> None:
         "foo2",
         "bar2",
     ]
-    assert nr.utils.dict_to_flags(vars(g1["flake_common_flags"])) == [
+    assert nr.utils.dict_to_flags(g1.flake_common_flags) == [
+        "--option",
+        "foo1",
+        "bar1",
+        "--option",
+        "foo2",
+        "bar2",
         "--update-input",
         "input1",
         "--update-input",
@@ -112,13 +117,15 @@ def test_parse_args() -> None:
     assert r2.action == "dry-build"
     assert r2.file == "foo"
     assert r2.attr == "bar"
-    # round-trip test (ensure that we have the same flags as parsed)
-    assert nr.utils.dict_to_flags(vars(g2["common_flags"])) == [
+    assert nr.utils.dict_to_flags(g2.common_flags) == [
         "-vvv",
         "--quiet",
         "--quiet",
     ]
-    assert nr.utils.dict_to_flags(vars(g2["common_build_flags"])) == [
+    assert nr.utils.dict_to_flags(g2.build_flags) == [
+        "-vvv",
+        "--quiet",
+        "--quiet",
         "--include",
         "include1",
         "--include",

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_services.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_services.py
@@ -19,7 +19,14 @@ def test_reexec(mock_build: Mock, mock_execve: Mock, monkeypatch: MonkeyPatch) -
     args, _ = n.parse_args(argv)
     mock_build.return_value = Path("/path")
 
-    s.reexec(argv, args, {"build": True}, {"flake": True})
+    grouped_nix_args = n.models.GroupedNixArgs(
+        build_flags={"build": True},
+        common_flags={"common": True},
+        copy_flags={"copy": True},
+        flake_build_flags={"flake_build": True},
+        flake_common_flags={"flake_common": True},
+    )
+    s.reexec(argv, args, grouped_nix_args)
     mock_build.assert_has_calls(
         [
             call(
@@ -34,7 +41,7 @@ def test_reexec(mock_build: Mock, mock_execve: Mock, monkeypatch: MonkeyPatch) -
 
     mock_build.return_value = Path("/path/new")
 
-    s.reexec(argv, args, {}, {})
+    s.reexec(argv, args, grouped_nix_args)
     # exec in the new version successfully
     mock_execve.assert_called_once_with(
         Path("/path/new/bin/nixos-rebuild-ng"),
@@ -45,7 +52,7 @@ def test_reexec(mock_build: Mock, mock_execve: Mock, monkeypatch: MonkeyPatch) -
     mock_execve.reset_mock()
     mock_execve.side_effect = [OSError("BOOM"), None]
 
-    s.reexec(argv, args, {}, {})
+    s.reexec(argv, args, grouped_nix_args)
     # exec in the previous version if the new version fails
     mock_execve.assert_any_call(
         Path("/path/bin/nixos-rebuild-ng"),
@@ -65,18 +72,25 @@ def test_reexec_flake(
     args, _ = n.parse_args(argv)
     mock_build.return_value = Path("/path")
 
-    s.reexec(argv, args, {"build": True}, {"flake": True})
+    grouped_nix_args = n.models.GroupedNixArgs(
+        build_flags={"build": True},
+        common_flags={"common": True},
+        copy_flags={"copy": True},
+        flake_build_flags={"flake_build": True},
+        flake_common_flags={"flake_common": True},
+    )
+    s.reexec(argv, args, grouped_nix_args)
     mock_build.assert_called_once_with(
         s.NIXOS_REBUILD_ATTR,
         n.models.Flake(ANY, ANY),
-        {"flake": True, "no_link": True},
+        {"flake_build": True, "no_link": True},
     )
     # do not exec if there is no new version
     mock_execve.assert_not_called()
 
     mock_build.return_value = Path("/path/new")
 
-    s.reexec(argv, args, {}, {})
+    s.reexec(argv, args, grouped_nix_args)
     # exec in the new version successfully
     mock_execve.assert_called_once_with(
         Path("/path/new/bin/nixos-rebuild-ng"),
@@ -87,7 +101,7 @@ def test_reexec_flake(
     mock_execve.reset_mock()
     mock_execve.side_effect = [OSError("BOOM"), None]
 
-    s.reexec(argv, args, {}, {})
+    s.reexec(argv, args, grouped_nix_args)
     # exec in the previous version if the new version fails
     mock_execve.assert_any_call(
         Path("/path/bin/nixos-rebuild-ng"),
@@ -104,6 +118,13 @@ def test_reexec_skip_if_already_reexec(mock_build: Mock, mock_execve: Mock) -> N
     args, _ = n.parse_args(argv)
     mock_build.return_value = Path("/path")
 
-    s.reexec(argv, args, {"build": True}, {"flake": True})
+    grouped_nix_args = n.models.GroupedNixArgs(
+        build_flags={"build": True},
+        common_flags={"common": True},
+        copy_flags={"copy": True},
+        flake_build_flags={"flake_build": True},
+        flake_common_flags={"flake_common": True},
+    )
+    s.reexec(argv, args, grouped_nix_args)
     mock_build.assert_not_called()
     mock_execve.assert_not_called()


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`--no-build-output` only worked for non-Flakes systems since we are only considering this flag in classic Nix. This should now be fixed.

Also introduces a new model, `GroupedNixArgs`, to make it easier to pass the parsed args between the subsystems before processing.

Fix #437872.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
