### PR TITLE
python3Packages.orbax-checkpoint: 0.11.26 -> 0.11.27

### DIFF
--- a/pkgs/development/python-modules/orbax-checkpoint/default.nix
+++ b/pkgs/development/python-modules/orbax-checkpoint/default.nix
@@ -37,14 +37,14 @@
 
 buildPythonPackage rec {
   pname = "orbax-checkpoint";
-  version = "0.11.26";
+  version = "0.11.27";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "orbax";
     tag = "v${version}";
-    hash = "sha256-CY5Bs/o8fU57QJETYnyJVkP7Y+cahpqZftyIJNU+GvU=";
+    hash = "sha256-KXEwUHJAFxeJTs3qKUXMCYO3t5hoPTjGay9GIOQIuCY=";
   };
 
   sourceRoot = "${src.name}/checkpoint";
@@ -94,6 +94,18 @@ buildPythonPackage rec {
     # AssertionError: 2 not greater than 2.0046136379241943
     "test_async_mkdir_parallel"
     "test_async_mkdir_sequential"
+
+    # AssertionError:
+    # "Handler type string "(?:__main__|orbax.checkpoint._src.handlers.handler_type_registry_test)\.TestHandler" not found in the registry."
+    # does not match
+    # "'Handler type string "handler_type_registry_test.TestHandler" not found in the registry.'"
+    "test_get_handler_type_not_found"
+    "test_no_typestr"
+    "test_register_duplicate_handler_type"
+
+    # AssertionError: False is not true
+    "test_register_and_get"
+    "test_register_different_modules"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # Probably failing because of a filesystem impurity
@@ -107,7 +119,19 @@ buildPythonPackage rec {
     # First from multiprocess_test, Second from orbax.checkpoint._src.testing.multiprocess_test.
     # Description from first occurrence: Number of processes to use.
     # https://github.com/google/orbax/issues/1580
+    "orbax/checkpoint/_src/testing/multiprocess_test.py"
     "orbax/checkpoint/experimental/emergency/"
+
+    # ValueError: Distributed system is not available; please initialize it via `jax.distributed.initialize()` at the start of your program.
+    "orbax/checkpoint/_src/handlers/array_checkpoint_handler_test.py"
+
+    # import file mismatch:
+    # imported module 'registry_test' has this __file__ attribute:
+    #   /build/source/checkpoint/orbax/checkpoint/experimental/v1/_src/layout/registry_test.py
+    # which is not the same as the test file we want to collect:
+    #   /build/source/checkpoint/orbax/checkpoint/experimental/v1/_src/serialization/registry_test.py
+    # HINT: remove __pycache__ / .pyc files and/or use a unique basename for your test file module
+    "orbax/checkpoint/experimental/v1/_src/serialization/registry_test.py"
 
     # E   FileNotFoundError: [Errno 2] No such file or directory:
     # '/build/absl_testing/DefaultSnapshotTest/runTest/root/path/to/source/data.txt'
@@ -121,6 +145,7 @@ buildPythonPackage rec {
     "orbax/checkpoint/_src/tree/parts_of_test.py"
     "orbax/checkpoint/_src/tree/structure_utils_test.py"
     "orbax/checkpoint/_src/tree/utils_test.py"
+    "orbax/checkpoint/checkpoint_manager_test.py"
     "orbax/checkpoint/single_host_test.py"
     "orbax/checkpoint/transform_utils_test.py"
   ];


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/google/orbax/compare/v0.11.26...v0.11.27
Changelog: https://github.com/google/orbax/blob/v0.11.27/checkpoint/CHANGELOG.md

cc @fabaff

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc