### PR TITLE
go: only apply PIE by default when CGO is enabled

### DIFF
--- a/pkgs/build-support/go/module.nix
+++ b/pkgs/build-support/go/module.nix
@@ -253,6 +253,9 @@ lib.extendMkDerivation {
             if [ -f "$NIX_CC_FOR_TARGET/nix-support/dynamic-linker" ]; then
               export GO_LDSO=$(cat $NIX_CC_FOR_TARGET/nix-support/dynamic-linker)
             fi
+            if [ "$CGO_ENABLED" = "0" ]; then
+              export GOFLAGS="-buildmode=exe $GOFLAGS"
+            fi
             cd "$modRoot"
           ''
           + lib.optionalString (finalAttrs.vendorHash != null) ''

--- a/pkgs/development/compilers/go/1.24.nix
+++ b/pkgs/development/compilers/go/1.24.nix
@@ -9,15 +9,12 @@
   buildPackages,
   pkgsBuildTarget,
   targetPackages,
-  testers,
-  skopeo,
   buildGo124Module,
+  callPackage,
 }:
 
 let
   goBootstrap = buildPackages.callPackage ./bootstrap122.nix { };
-
-  skopeoTest = skopeo.override { buildGoModule = buildGo124Module; };
 
   # We need a target compiler which is still runnable at build time,
   # to handle the cross-building case where build != host == target
@@ -195,14 +192,10 @@ stdenv.mkDerivation (finalAttrs: {
   disallowedReferences = [ goBootstrap ];
 
   passthru = {
-    inherit goBootstrap skopeoTest;
-    tests = {
-      skopeo = testers.testVersion { package = skopeoTest; };
-      version = testers.testVersion {
-        package = finalAttrs.finalPackage;
-        command = "go version";
-        version = "go${finalAttrs.version}";
-      };
+    inherit goBootstrap;
+    tests = callPackage ./tests.nix {
+      go = finalAttrs.finalPackage;
+      buildGoModule = buildGo124Module;
     };
   };
 

--- a/pkgs/development/compilers/go/1.25.nix
+++ b/pkgs/development/compilers/go/1.25.nix
@@ -10,19 +10,12 @@
   pkgsBuildTarget,
   targetPackages,
   # for testing
-  testers,
-  runCommand,
-  bintools,
-  skopeo,
-  clickhouse-backup,
   buildGo125Module,
+  callPackage,
 }:
 
 let
   goBootstrap = buildPackages.callPackage ./bootstrap122.nix { };
-
-  skopeoTest = skopeo.override { buildGoModule = buildGo125Module; };
-  clickhouse-backupTest = clickhouse-backup.override { buildGoModule = buildGo125Module; };
 
   # We need a target compiler which is still runnable at build time,
   # to handle the cross-building case where build != host == target
@@ -200,31 +193,10 @@ stdenv.mkDerivation (finalAttrs: {
   disallowedReferences = [ goBootstrap ];
 
   passthru = {
-    inherit goBootstrap skopeoTest;
-    tests = {
-      skopeo = testers.testVersion { package = skopeoTest; };
-      version = testers.testVersion {
-        package = finalAttrs.finalPackage;
-        command = "go version";
-        version = "go${finalAttrs.version}";
-      };
-      # Picked clickhouse-backup as a package that sets CGO_ENABLED=0
-      # Running and outputting the right version proves a working ELF interpreter was picked
-      clickhouse-backup = testers.testVersion { package = clickhouse-backupTest; };
-      clickhouse-backup-is-pie = runCommand "has-pie" { meta.broken = stdenv.hostPlatform.isStatic; } ''
-        ${lib.optionalString (!isCross) ''
-          if ${lib.getExe' bintools "readelf"} -p .comment ${lib.getExe clickhouse-backup} | grep -Fq "GCC: (GNU)"; then
-            echo "${lib.getExe clickhouse-backup} has a GCC .comment, but it should have used the internal go linker"
-            exit 1
-          fi
-        ''}
-        if ${lib.getExe' bintools "readelf"} -h ${lib.getExe clickhouse-backup} | grep -q "Type:.*DYN"; then
-          touch $out
-        else
-          echo "ERROR: clickhouse-backup is NOT PIE"
-          exit 1
-        fi
-      '';
+    inherit goBootstrap;
+    tests = callPackage ./tests.nix {
+      go = finalAttrs.finalPackage;
+      buildGoModule = buildGo125Module;
     };
   };
 

--- a/pkgs/development/compilers/go/tests.nix
+++ b/pkgs/development/compilers/go/tests.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenv,
+  go,
+  buildGoModule,
+  skopeo,
+  testers,
+  runCommand,
+  bintools,
+  clickhouse-backup,
+}:
+let
+  skopeo' = skopeo.override { buildGoModule = buildGoModule; };
+  clickhouse-backup' = clickhouse-backup.override { buildGoModule = buildGoModule; };
+in
+{
+  skopeo = testers.testVersion { package = skopeo'; };
+  version = testers.testVersion {
+    package = go;
+    command = "go version";
+    version = "go${go.version}";
+  };
+  # Picked clickhouse-backup as a package that sets CGO_ENABLED=0
+  # Running and outputting the right version proves a working ELF interpreter was picked
+  clickhouse-backup = testers.testVersion { package = clickhouse-backup'; };
+  clickhouse-backup-is-pie = runCommand "has-pie" { meta.broken = stdenv.hostPlatform.isStatic; } ''
+    ${lib.optionalString (stdenv.buildPlatform == stdenv.targetPlatform) ''
+      if ${lib.getExe' bintools "readelf"} -p .comment ${lib.getExe clickhouse-backup'} | grep -Fq "GCC: (GNU)"; then
+        echo "${lib.getExe clickhouse-backup'} has a GCC .comment, but it should have used the internal go linker"
+        exit 1
+      fi
+    ''}
+    if ${lib.getExe' bintools "readelf"} -h ${lib.getExe clickhouse-backup'} | grep -q "Type:.*DYN"; then
+      touch $out
+    else
+      echo "ERROR: clickhouse-backup is NOT PIE"
+      exit 1
+    fi
+  '';
+}

--- a/pkgs/development/compilers/go/tests.nix
+++ b/pkgs/development/compilers/go/tests.nix
@@ -15,7 +15,7 @@ let
   skopeo' = skopeo.override { buildGoModule = buildGoModule; };
   athens' = athens.override { buildGoModule = buildGoModule; };
   expectedCgoEnabledType = "DYN";
-  expectedCgoDisabledType = "DYN";
+  expectedCgoDisabledType = "EXE";
 in
 {
   skopeo = testers.testVersion { package = skopeo'; };


### PR DESCRIPTION
go: set buildmode=exe when CGO_ENABLED=0

To avoid breaking previous documented[^1] behavior of CGO_ENABLED=0
producing fully static binaries we set buildmode=exe. Sadly go
does not support static-pie binaries so this means these packages
lose ASLR.

This is likely to be revisited after branch-off, as
go packages in the main package set with CGO_ENABLED=0 not having
ASLR is not good security posture in the long term and makes
go packages inconsistent with other languages.

[1]: See [#var-go-CGO_ENABLED](https://nixos.org/manual/nixpkgs/stable/#var-go-CGO_ENABLED)

Fixes: #456953
Fixes: 08aadbf8d4dbdab061b455e3181b16046445b48b

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 458867 --checkout commit --package pkgsCross.aarch64-multiplatform.athens --package pkgsStatic.athens --package pkgsStatic.clickhouse-backup --package go --package nixosTests.traefik --package pkgsStatic.syncthing --package pkgsMusl.tailscale --package go.tests --package pkgsMusl.clickhouse-backup --package athens --package pkgsCross.aarch64-multiplatform.tailscale --package pkgsCross.ppc64-elfv1.clickhouse-backup --package pkgsi686Linux.clickhouse-backup --package pkgsMusl.athens --package pkgsStatic.tailscale --package syncthing --package pkgsCross.aarch64-multiplatform.clickhouse-backup --package pkgsCross.aarch64-multiplatform.syncthing --package pkgsMusl.go --package clickhouse-backup --package pkgsCross.aarch64-multiplatform.go --package pkgsMusl.syncthing --package pkgsCross.ppc64-elfv1.buildPackages.go --package tailscale --package pkgsStatic.go`
Commit: `533ab22ff06ccc348eb395404e9c19fed53d91c2`

---
### `x86_64-linux`
<details>
  <summary>:x: 4 packages failed to build:</summary>
  <ul>
    <li>pkgsCross.aarch64-multiplatform.tailscale</li>
    <li>pkgsCross.aarch64-multiplatform.tailscale.derper - libcap fails to build due to unrecognized -m64 flag </li>
    <li>pkgsStatic.tailscale</li>
    <li>pkgsStatic.tailscale.derper - linking fails, already broken in master which didn't have go PIE changes so seems unrelated</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 1 test built:</summary>
  <ul>
    <li>nixosTests.traefik</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 28 packages built:</summary>
  <ul>
    <li>athens</li>
    <li>clickhouse-backup</li>
    <li>go</li>
    <li>go.tests.athens</li>
    <li>go.tests.athens-bin-type</li>
    <li>go.tests.skopeo</li>
    <li>go.tests.skopeo-bin-type</li>
    <li>go.tests.version</li>
    <li>pkgsCross.aarch64-multiplatform.athens</li>
    <li>pkgsCross.aarch64-multiplatform.clickhouse-backup</li>
    <li>pkgsCross.aarch64-multiplatform.go</li>
    <li>pkgsCross.aarch64-multiplatform.syncthing</li>
    <li>pkgsCross.ppc64-elfv1.buildPackages.go</li>
    <li>pkgsCross.ppc64-elfv1.clickhouse-backup</li>
    <li>pkgsMusl.athens</li>
    <li>pkgsMusl.clickhouse-backup</li>
    <li>pkgsMusl.go</li>
    <li>pkgsMusl.syncthing</li>
    <li>pkgsMusl.tailscale</li>
    <li>pkgsMusl.tailscale.derper (pkgsMusl.tailscale.derper.derper)</li>
    <li>pkgsStatic.athens</li>
    <li>pkgsStatic.clickhouse-backup</li>
    <li>pkgsStatic.go</li>
    <li>pkgsStatic.syncthing</li>
    <li>pkgsi686Linux.clickhouse-backup</li>
    <li>syncthing</li>
    <li>tailscale</li>
    <li>tailscale.derper (tailscale.derper.derper)</li>
  </ul>
</details>

---
<details>
<summary>Error logs: `x86_64-linux`</summary>
<details>
<summary>pkgsStatic.tailscale</summary>
<pre>            FAIL	tailscale.com/tstest/archtest [build failed]
            FAIL
        qemu_test.go:68: output didn&#x27;t contain &quot;I am linux/386&quot;: # tailscale.com/tstest/archtest.test
            loadinternal: cannot find runtime/cgo
            /nix/store/4l1s1zn1sxadywrljsvn6rszvhndc4kf-go-1.25.3/share/go/pkg/tool/linux_amd64/link: running x86_64-unknown-linux-musl-gcc failed: exit status 1
            /nix/store/3cbr8yngzb6ws1c9h91ki328jrkkilci-x86_64-unknown-linux-musl-gcc-wrapper-14.3.0/bin/x86_64-unknown-linux-musl-gcc -m32 -s -o $WORK/b001/archtest.test -rdynamic /build/go-link-3042358262/go.o
            /nix/store/839vnmmfa4j5sn2mkz6vld7mj7f84nq1-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: skipping incompatible /nix/store/956m2qlyyjx5nm696rnywmasqy7472zw-x86_64-unknown-linux-musl-gcc-14.3.0/lib/gcc/x86_64-unknown-linux-musl/14.3.0/libgcc.a when searching for -lgcc
            /nix/store/839vnmmfa4j5sn2mkz6vld7mj7f84nq1-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: cannot find -lgcc: No such file or directory
            /nix/store/839vnmmfa4j5sn2mkz6vld7mj7f84nq1-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: have you installed the static version of the gcc library ?
            /nix/store/839vnmmfa4j5sn2mkz6vld7mj7f84nq1-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: skipping incompatible /nix/store/fzgh85fq2wnkw716xig70c6crjikcq30-musl-static-x86_64-unknown-linux-musl-1.2.5/lib/libc.a when searching for -lc
            /nix/store/839vnmmfa4j5sn2mkz6vld7mj7f84nq1-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: skipping incompatible /nix/store/fzgh85fq2wnkw716xig70c6crjikcq30-musl-static-x86_64-unknown-linux-musl-1.2.5/lib/libc.a when searching for -lc
            /nix/store/839vnmmfa4j5sn2mkz6vld7mj7f84nq1-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: cannot find -lc: No such file or directory
            /nix/store/839vnmmfa4j5sn2mkz6vld7mj7f84nq1-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: have you installed the static version of the c library ?
            collect2: error: ld returned 1 exit status
            
            FAIL	tailscale.com/tstest/archtest [build failed]
            FAIL
FAIL
FAIL	tailscale.com/tstest/archtest	2.256s
FAIL</pre>
</details>
</details>


---


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
