### PR TITLE
feat: add module option `extraFsOptions` to `.amazonImage` for use with `make-disk-image`

### DIFF
--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -150,6 +150,9 @@
   # The root file system type.
   fsType ? "ext4",
 
+  # i.e. [ "-i 256" ] for ext4
+  extraFsOptions ? [ ],
+
   # Filesystem label
   label ? if onlyNixStore then "nix-store" else "nixos",
 
@@ -616,11 +619,11 @@ let
           # Get start & length of the root partition in sectors to $START and $SECTORS.
           eval $(partx $diskImage -o START,SECTORS --nr ${rootPartition} --pairs)
 
-          mkfs.${fsType} -b ${blockSize} -F -L ${label} $diskImage -E offset=$(sectorsToBytes $START) $(sectorsToKilobytes $SECTORS)K
+          mkfs.${fsType} -b ${blockSize} -F -L ${label} ${lib.escapeShellArgs extraFsOptions} $diskImage -E offset=$(sectorsToBytes $START) $(sectorsToKilobytes $SECTORS)K
         ''
       else
         ''
-          mkfs.${fsType} -b ${blockSize} -F -L ${label} $diskImage
+          mkfs.${fsType} -b ${blockSize} -F -L ${label} ${lib.escapeShellArgs extraFsOptions} $diskImage
         ''
     }
 

--- a/nixos/maintainers/scripts/ec2/amazon-image.nix
+++ b/nixos/maintainers/scripts/ec2/amazon-image.nix
@@ -56,6 +56,14 @@ in
     [ "nvme_core.io_timeout=${timeout}" ];
 
   options.amazonImage = {
+    extraFsOptions = mkOption {
+      default = [ ];
+      type = types.listOf types.str;
+      description = ''
+        Extra command-line options to pass to mkfs when creating the rootfs.
+      '';
+    };
+
     contents = mkOption {
       example = literalExpression ''
         [ { source = pkgs.memtest86 + "/memtest.bin";
@@ -171,7 +179,10 @@ in
         inherit (config.image) baseName;
         name = config.image.baseName;
 
+        extraFsOptions = cfg.extraFsOptions;
+
         fsType = "ext4";
+
         partitionTableType = if config.ec2.efi then "efi" else "legacy+gpt";
 
         inherit (config.virtualisation) diskSize;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I was running into a situation where I wanted to test/roll out an AMI whose root (`ext4`-based) filesystem changed the inode/block size ratio (`-i`). So, I've added an `.amazonImage.extraFsOptions` configuration option that gets passed to the AMI logic's call to `make-disk-image`. Concretely, I was using this like
```nix
amazonImage.extraFsOptions = "-i 1024";
```

I'm guessing this sort of VM fs configuration would be useful in the general case, though, so I'm proposing this PR for review. Thanks!

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
