### PR TITLE
wl-crosshair: add license

### DIFF
--- a/pkgs/by-name/wl/wl-crosshair/package.nix
+++ b/pkgs/by-name/wl/wl-crosshair/package.nix
@@ -6,13 +6,13 @@
 }:
 rustPlatform.buildRustPackage {
   pname = "wl-crosshair";
-  version = "0.1.0-unstable-2024-05-09";
+  version = "0.1.0-unstable-2025-11-04";
 
   src = fetchFromGitHub {
     owner = "lelgenio";
     repo = "wl-crosshair";
-    rev = "39b716cf410a1b45006f50f32f8d63de5c43aedb";
-    hash = "sha256-q5key9BWJjJQqECrhflso9ZTzULBeScvromo0S4fjqE=";
+    rev = "233b6db7b39c80a92ac116c4ef4d88de4b49cbce";
+    hash = "sha256-KfieW/NePLvh/5sEpoPW2jkaETSAeEFZsz8580YwbBE=";
   };
 
   cargoHash = "sha256-34K8Vjb7MrB8WGGLase+GnN2bUDuAnvU6VWRV1k+ZYM=";
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage {
   meta = {
     description = "Crosshair overlay for wlroots compositor";
     homepage = "https://github.com/lelgenio/wl-crosshair";
-    license = lib.licenses.unfree; # didn't found a license
+    license = lib.licenses.mit;
     mainProgram = "wl-crosshair";
     maintainers = with lib.maintainers; [ Guanran928 ];
     platforms = lib.platforms.linux;


### PR DESCRIPTION
This project has added an MIT license: https://github.com/lelgenio/wl-crosshair/pull/4

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
