### PR TITLE
Remove most usages of `allowSubstitutes = false` and `preferLocalBuild = true` from the tree

### DIFF
--- a/doc/build-helpers/trivial-build-helpers.chapter.md
+++ b/doc/build-helpers/trivial-build-helpers.chapter.md
@@ -346,10 +346,7 @@ Write a text file to the Nix store.
 
   Passed through to [`preferLocalBuild`](https://nixos.org/manual/nix/stable/language/advanced-attributes#adv-attr-preferLocalBuild) of the underlying call to `derivation`.
 
-  It defaults to `true`, as running the derivation's simple `builder` executable locally is assumed to be faster than network operations.
-  Set it to false if the `checkPhase` step is expensive.
-
-  Default: `true`
+  Default: `false`
 
 `derivationArgs` (Attribute set, _optional_)
 
@@ -381,7 +378,7 @@ writeTextFile {
     license = pkgs.lib.licenses.cc0;
   };
   allowSubstitutes = false;
-  preferLocalBuild = false;
+  preferLocalBuild = true;
 }
 ```
 :::

--- a/doc/build-helpers/trivial-build-helpers.chapter.md
+++ b/doc/build-helpers/trivial-build-helpers.chapter.md
@@ -33,16 +33,9 @@ runCommandWith :: {
 :   The derivation's name, which Nix will append to the store path; see [`mkDerivation`](#sec-using-stdenv).
 
 `runLocal` (Boolean)
-:   If set to `true` this forces the derivation to be built locally, not using [substitutes] nor remote builds.
+:   If set to `true` this forces the derivation to be built locally in the presence of remote builders.
     This is intended for very cheap commands (<1s execution time) which can be sped up by avoiding the network round-trip(s).
-    Its effect is to set [`preferLocalBuild = true`][preferLocalBuild] and [`allowSubstitutes = false`][allowSubstitutes].
-
-   ::: {.note}
-   This prevents the use of [substituters][substituter], so only set `runLocal` (or use `runCommandLocal`) when certain the user will
-   always have a builder for the `system` of the derivation. This should be true for most trivial use cases
-   (e.g., just copying some files to a different location or adding symlinks) because there the `system`
-   is usually the same as `builtins.currentSystem`.
-   :::
+    Its effect is to set [`preferLocalBuild = true`][preferLocalBuild].
 
 `stdenv` (Derivation)
 :   The [standard environment](#chap-stdenv) to use, defaulting to `pkgs.stdenv`
@@ -57,7 +50,6 @@ runCommandWith :: {
     You have to create a file or directory `$out` for Nix to be able to run the builder successfully.
     :::
 
-[allowSubstitutes]: https://nix.dev/manual/nix/latest/language/advanced-attributes.html#adv-attr-allowSubstitutes
 [preferLocalBuild]: https://nix.dev/manual/nix/latest/language/advanced-attributes.html#adv-attr-preferLocalBuild
 [substituter]: https://nix.dev/manual/nix/latest/glossary#gloss-substituter
 [substitutes]: https://nix.dev/manual/nix/latest/glossary#gloss-substitute
@@ -346,10 +338,7 @@ Write a text file to the Nix store.
 : Whether to allow substituting from a binary cache.
   Passed through to [`allowSubstitutes`](https://nixos.org/manual/nix/stable/language/advanced-attributes#adv-attr-allowSubstitutes) of the underlying call to `derivation`.
 
-  It defaults to `false`, as running the derivation's simple `builder` executable locally is assumed to be faster than network operations.
-  Set it to true if the `checkPhase` step is expensive.
-
-  Default: `false`
+  Default: `true`
 
 `preferLocalBuild` (Bool, _optional_)
 
@@ -357,7 +346,8 @@ Write a text file to the Nix store.
 
   Passed through to [`preferLocalBuild`](https://nixos.org/manual/nix/stable/language/advanced-attributes#adv-attr-preferLocalBuild) of the underlying call to `derivation`.
 
-  It defaults to `true` for the same reason `allowSubstitutes` defaults to `false`.
+  It defaults to `true`, as running the derivation's simple `builder` executable locally is assumed to be faster than network operations.
+  Set it to false if the `checkPhase` step is expensive.
 
   Default: `true`
 
@@ -390,7 +380,7 @@ writeTextFile {
   meta = {
     license = pkgs.lib.licenses.cc0;
   };
-  allowSubstitutes = true;
+  allowSubstitutes = false;
   preferLocalBuild = false;
 }
 ```

--- a/nixos/lib/systemd-lib.nix
+++ b/nixos/lib/systemd-lib.nix
@@ -75,7 +75,6 @@ rec {
       pkgs.runCommand "unit-${mkPathSafeName name}"
         {
           preferLocalBuild = true;
-          allowSubstitutes = false;
           # unit.text can be null. But variables that are null listed in
           # passAsFile are ignored by nix, resulting in no file being created,
           # making the mv operation fail.
@@ -91,7 +90,6 @@ rec {
       pkgs.runCommand "unit-${mkPathSafeName name}-disabled"
         {
           preferLocalBuild = true;
-          allowSubstitutes = false;
         }
         ''
           name=${shellEscape name}
@@ -381,7 +379,6 @@ rec {
     pkgs.runCommand "${type}-units"
       {
         preferLocalBuild = true;
-        allowSubstitutes = false;
       }
       ''
         mkdir -p $out

--- a/nixos/lib/testing/driver.nix
+++ b/nixos/lib/testing/driver.nix
@@ -53,7 +53,7 @@ let
         ++ lib.optionals (!config.skipTypeCheck) [ hostPkgs.mypy ];
         buildInputs = [ testDriver ];
         testScript = config.testScriptString;
-        preferLocalBuild = true;
+
         passthru = config.passthru;
         meta = config.meta // {
           mainProgram = "nixos-test-driver";

--- a/nixos/modules/config/console.nix
+++ b/nixos/modules/config/console.nix
@@ -16,7 +16,7 @@ let
       {
         nativeBuildInputs = [ pkgs.buildPackages.kbd ];
         LOADKEYS_KEYMAP_PATH = "${consoleEnv pkgs.kbd}/share/keymaps/**";
-        preferLocalBuild = true;
+
       }
       ''
         loadkeys -b ${lib.optionalString isUnicode "-u"} "${cfg.keyMap}" > $out
@@ -141,7 +141,7 @@ in
       console.keyMap =
         with config.services.xserver;
         lib.mkIf cfg.useXkbConfig (
-          pkgs.runCommand "xkb-console-keymap" { preferLocalBuild = true; } ''
+          pkgs.runCommand "xkb-console-keymap" { } ''
             '${pkgs.buildPackages.ckbcomp}/bin/ckbcomp' \
               ${
                 lib.optionalString (

--- a/nixos/modules/config/fonts/fontconfig.nix
+++ b/nixos/modules/config/fonts/fontconfig.nix
@@ -182,74 +182,69 @@ let
   '';
 
   # fontconfig configuration package
-  confPkg =
-    pkgs.runCommand "fontconfig-conf"
-      {
-        preferLocalBuild = true;
-      }
-      ''
-        dst=$out/etc/fonts/conf.d
-        mkdir -p $dst
+  confPkg = pkgs.runCommand "fontconfig-conf" { } ''
+    dst=$out/etc/fonts/conf.d
+    mkdir -p $dst
 
-        # fonts.conf
-        ln -s ${pkg.out}/etc/fonts/fonts.conf \
-              $dst/../fonts.conf
-        # TODO: remove this legacy symlink once people stop using packages built before #95358 was merged
-        mkdir -p $out/etc/fonts/2.11
-        ln -s /etc/fonts/fonts.conf \
-              $out/etc/fonts/2.11/fonts.conf
+    # fonts.conf
+    ln -s ${pkg.out}/etc/fonts/fonts.conf \
+          $dst/../fonts.conf
+    # TODO: remove this legacy symlink once people stop using packages built before #95358 was merged
+    mkdir -p $out/etc/fonts/2.11
+    ln -s /etc/fonts/fonts.conf \
+          $out/etc/fonts/2.11/fonts.conf
 
-        # fontconfig default config files
-        ln -s ${pkg.out}/etc/fonts/conf.d/*.conf \
-              $dst/
+    # fontconfig default config files
+    ln -s ${pkg.out}/etc/fonts/conf.d/*.conf \
+          $dst/
 
-        ${lib.optionalString (!cfg.antialias) (
-          replaceDefaultConfig "10-yes-antialias.conf" "10-no-antialias.conf"
-        )}
+    ${lib.optionalString (!cfg.antialias) (
+      replaceDefaultConfig "10-yes-antialias.conf" "10-no-antialias.conf"
+    )}
 
-        ${lib.optionalString (cfg.hinting.style != "slight") (
-          replaceDefaultConfig "10-hinting-slight.conf" "10-hinting-${cfg.hinting.style}.conf"
-        )}
+    ${lib.optionalString (cfg.hinting.style != "slight") (
+      replaceDefaultConfig "10-hinting-slight.conf" "10-hinting-${cfg.hinting.style}.conf"
+    )}
 
-        ${lib.optionalString (cfg.subpixel.rgba != "none") (
-          replaceDefaultConfig "10-sub-pixel-none.conf" "10-sub-pixel-${cfg.subpixel.rgba}.conf"
-        )}
+    ${lib.optionalString (cfg.subpixel.rgba != "none") (
+      replaceDefaultConfig "10-sub-pixel-none.conf" "10-sub-pixel-${cfg.subpixel.rgba}.conf"
+    )}
 
-        ${lib.optionalString (cfg.subpixel.lcdfilter != "default") (
-          replaceDefaultConfig "11-lcdfilter-default.conf" "11-lcdfilter-${cfg.subpixel.lcdfilter}.conf"
-        )}
+    ${lib.optionalString (cfg.subpixel.lcdfilter != "default") (
+      replaceDefaultConfig "11-lcdfilter-default.conf" "11-lcdfilter-${cfg.subpixel.lcdfilter}.conf"
+    )}
 
-        ${lib.optionalString cfg.allowBitmaps ''
-          rm -f $dst/70-no-bitmaps-except-emoji.conf
-        ''}
+    ${lib.optionalString cfg.allowBitmaps ''
+      rm -f $dst/70-no-bitmaps-except-emoji.conf
+    ''}
 
-        # 00-nixos-cache.conf
-        ln -s ${cacheConf}  $dst/00-nixos-cache.conf
+    # 00-nixos-cache.conf
+    ln -s ${cacheConf}  $dst/00-nixos-cache.conf
 
-        # 10-nixos-rendering.conf
-        ln -s ${renderConf}       $dst/10-nixos-rendering.conf
+    # 10-nixos-rendering.conf
+    ln -s ${renderConf}       $dst/10-nixos-rendering.conf
 
-        # 50-user.conf
-        ${lib.optionalString (!cfg.includeUserConf) ''
-          rm $dst/50-user.conf
-        ''}
+    # 50-user.conf
+    ${lib.optionalString (!cfg.includeUserConf) ''
+      rm $dst/50-user.conf
+    ''}
 
-        # local.conf (indirect priority 51)
-        ${lib.optionalString (cfg.localConf != "") ''
-          ln -s ${localConf}        $dst/../local.conf
-        ''}
+    # local.conf (indirect priority 51)
+    ${lib.optionalString (cfg.localConf != "") ''
+      ln -s ${localConf}        $dst/../local.conf
+    ''}
 
-        # 52-nixos-default-fonts.conf
-        ln -s ${defaultFontsConf} $dst/52-nixos-default-fonts.conf
+    # 52-nixos-default-fonts.conf
+    ln -s ${defaultFontsConf} $dst/52-nixos-default-fonts.conf
 
-        # 53-no-bitmaps.conf
-        ln -s ${rejectBitmaps} $dst/53-no-bitmaps.conf
+    # 53-no-bitmaps.conf
+    ln -s ${rejectBitmaps} $dst/53-no-bitmaps.conf
 
-        ${lib.optionalString (!cfg.allowType1) ''
-          # 53-nixos-reject-type1.conf
-          ln -s ${rejectType1} $dst/53-nixos-reject-type1.conf
-        ''}
-      '';
+    ${lib.optionalString (!cfg.allowType1) ''
+      # 53-nixos-reject-type1.conf
+      ln -s ${rejectType1} $dst/53-nixos-reject-type1.conf
+    ''}
+  '';
 
   # Package with configuration files
   # this merge all the packages in the fonts.fontconfig.confPackages list

--- a/nixos/modules/config/fonts/fontdir.nix
+++ b/nixos/modules/config/fonts/fontdir.nix
@@ -16,7 +16,7 @@ let
     }:
     runCommand "X11-fonts"
       {
-        preferLocalBuild = true;
+
         nativeBuildInputs = [
           gzip
           xorg.mkfontscale

--- a/nixos/modules/config/malloc.nix
+++ b/nixos/modules/config/malloc.nix
@@ -77,7 +77,7 @@ let
   mallocLib =
     pkgs.runCommand "malloc-provider-${cfg.provider}"
       rec {
-        preferLocalBuild = true;
+
         origLibPath = providerConf.libPath;
         libName = baseNameOf origLibPath;
       }

--- a/nixos/modules/config/malloc.nix
+++ b/nixos/modules/config/malloc.nix
@@ -78,7 +78,6 @@ let
     pkgs.runCommand "malloc-provider-${cfg.provider}"
       rec {
         preferLocalBuild = true;
-        allowSubstitutes = false;
         origLibPath = providerConf.libPath;
         libName = baseNameOf origLibPath;
       }

--- a/nixos/modules/hardware/video/uvcvideo/uvcdynctrl-udev-rules.nix
+++ b/nixos/modules/hardware/video/uvcvideo/uvcdynctrl-udev-rules.nix
@@ -32,7 +32,7 @@ runCommand "uvcdynctrl-udev-rules-${version}"
     ];
     dontPatchELF = true;
     dontStrip = true;
-    preferLocalBuild = true;
+
   }
   ''
     mkdir -p "$out/lib/udev"

--- a/nixos/modules/i18n/input-method/default.nix
+++ b/nixos/modules/i18n/input-method/default.nix
@@ -19,7 +19,7 @@ let
   gtk2_cache =
     pkgs.runCommand "gtk2-immodule.cache"
       {
-        preferLocalBuild = true;
+
         buildInputs = [
           cfg.package
         ];
@@ -32,7 +32,7 @@ let
   gtk3_cache =
     pkgs.runCommand "gtk3-immodule.cache"
       {
-        preferLocalBuild = true;
+
         buildInputs = [
           cfg.package
         ];

--- a/nixos/modules/i18n/input-method/default.nix
+++ b/nixos/modules/i18n/input-method/default.nix
@@ -20,7 +20,6 @@ let
     pkgs.runCommand "gtk2-immodule.cache"
       {
         preferLocalBuild = true;
-        allowSubstitutes = false;
         buildInputs = [
           cfg.package
         ];
@@ -34,7 +33,6 @@ let
     pkgs.runCommand "gtk3-immodule.cache"
       {
         preferLocalBuild = true;
-        allowSubstitutes = false;
         buildInputs = [
           cfg.package
         ];

--- a/nixos/modules/installer/cd-dvd/channel.nix
+++ b/nixos/modules/installer/cd-dvd/channel.nix
@@ -21,21 +21,19 @@ let
   # CD.  These are installed into the "nixos" channel of the root
   # user, as expected by nixos-rebuild/nixos-install. FIXME: merge
   # with make-channel.nix.
-  channelSources =
-    pkgs.runCommand "nixos-${config.system.nixos.version}" { preferLocalBuild = true; }
-      ''
-        mkdir -p $out
-        cp -prd ${nixpkgs.outPath} $out/nixos
-        chmod -R u+w $out/nixos
-        if [ ! -e $out/nixos/nixpkgs ]; then
-          ln -s . $out/nixos/nixpkgs
-        fi
-        ${lib.optionalString (config.system.nixos.revision != null) ''
-          echo -n ${config.system.nixos.revision} > $out/nixos/.git-revision
-        ''}
-        echo -n ${config.system.nixos.versionSuffix} > $out/nixos/.version-suffix
-        echo ${config.system.nixos.versionSuffix} | sed -e s/pre// > $out/nixos/svn-revision
-      '';
+  channelSources = pkgs.runCommand "nixos-${config.system.nixos.version}" { } ''
+    mkdir -p $out
+    cp -prd ${nixpkgs.outPath} $out/nixos
+    chmod -R u+w $out/nixos
+    if [ ! -e $out/nixos/nixpkgs ]; then
+      ln -s . $out/nixos/nixpkgs
+    fi
+    ${lib.optionalString (config.system.nixos.revision != null) ''
+      echo -n ${config.system.nixos.revision} > $out/nixos/.git-revision
+    ''}
+    echo -n ${config.system.nixos.versionSuffix} > $out/nixos/.version-suffix
+    echo ${config.system.nixos.versionSuffix} | sed -e s/pre// > $out/nixos/svn-revision
+  '';
 in
 
 {

--- a/nixos/modules/misc/man-db.nix
+++ b/nixos/modules/misc/man-db.nix
@@ -82,7 +82,7 @@ in
           pkgs.runCommand "man-cache"
             {
               nativeBuildInputs = [ buildPackage ];
-              preferLocalBuild = true;
+
             }
             ''
               echo "MANDB_MAP ${cfg.manualPages}/share/man $out" > man.conf

--- a/nixos/modules/programs/firejail.nix
+++ b/nixos/modules/programs/firejail.nix
@@ -11,7 +11,7 @@ let
   wrappedBins =
     pkgs.runCommand "firejail-wrapped-binaries"
       {
-        preferLocalBuild = true;
+
         # take precedence over non-firejailed versions
         meta.priority = -1;
       }

--- a/nixos/modules/programs/firejail.nix
+++ b/nixos/modules/programs/firejail.nix
@@ -12,7 +12,6 @@ let
     pkgs.runCommand "firejail-wrapped-binaries"
       {
         preferLocalBuild = true;
-        allowSubstitutes = false;
         # take precedence over non-firejailed versions
         meta.priority = -1;
       }

--- a/nixos/modules/programs/fish.nix
+++ b/nixos/modules/programs/fish.nix
@@ -265,7 +265,7 @@ in
                 mkdir -p $out
                 cp * $out/
               '';
-              preferLocalBuild = true;
+
             };
             generateCompletions =
               package:

--- a/nixos/modules/programs/fish.nix
+++ b/nixos/modules/programs/fish.nix
@@ -266,7 +266,6 @@ in
                 cp * $out/
               '';
               preferLocalBuild = true;
-              allowSubstitutes = false;
             };
             generateCompletions =
               package:

--- a/nixos/modules/security/doas.nix
+++ b/nixos/modules/security/doas.nix
@@ -287,7 +287,7 @@ in
               # "root" is allowed to do anything.
               permit nopass keepenv root
             '';
-            preferLocalBuild = true;
+
           }
           # Make sure that the doas.conf file is syntactically valid.
           "${pkgs.buildPackages.doas}/bin/doas -C $src && cp $src $out";

--- a/nixos/modules/security/sudo-rs.nix
+++ b/nixos/modules/security/sudo-rs.nix
@@ -326,7 +326,7 @@ in
     environment.etc.sudoers = {
       source = pkgs.runCommand "sudoers" {
         src = pkgs.writeText "sudoers-in" cfg.configFile;
-        preferLocalBuild = true;
+
       } "${pkgs.buildPackages.sudo-rs}/bin/visudo -f $src -c && cp $src $out";
       mode = "0440";
     };

--- a/nixos/modules/security/sudo.nix
+++ b/nixos/modules/security/sudo.nix
@@ -328,7 +328,7 @@ in
         pkgs.runCommand "sudoers"
           {
             src = pkgs.writeText "sudoers-in" cfg.configFile;
-            preferLocalBuild = true;
+
           }
           # Make sure that the sudoers file is syntactically valid.
           # (currently disabled - NIXOS-66)

--- a/nixos/modules/security/wrappers/default.nix
+++ b/nixos/modules/security/wrappers/default.nix
@@ -346,33 +346,29 @@ in
 
     ###### wrappers consistency checks
     system.checks = lib.singleton (
-      pkgs.runCommand "ensure-all-wrappers-paths-exist"
-        {
-          preferLocalBuild = true;
-        }
-        ''
-          # make sure we produce output
-          mkdir -p $out
+      pkgs.runCommand "ensure-all-wrappers-paths-exist" { } ''
+        # make sure we produce output
+        mkdir -p $out
 
-          echo -n "Checking that Nix store paths of all wrapped programs exist... "
+        echo -n "Checking that Nix store paths of all wrapped programs exist... "
 
-          declare -A wrappers
-          ${lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v: "wrappers['${n}']='${v.source}'") wrappers)}
+        declare -A wrappers
+        ${lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v: "wrappers['${n}']='${v.source}'") wrappers)}
 
-          for name in "''${!wrappers[@]}"; do
-            path="''${wrappers[$name]}"
-            if [[ "$path" =~ /nix/store ]] && [ ! -e "$path" ]; then
-              test -t 1 && echo -ne '\033[1;31m'
-              echo "FAIL"
-              echo "The path $path does not exist!"
-              echo 'Please, check the value of `security.wrappers."'$name'".source`.'
-              test -t 1 && echo -ne '\033[0m'
-              exit 1
-            fi
-          done
+        for name in "''${!wrappers[@]}"; do
+          path="''${wrappers[$name]}"
+          if [[ "$path" =~ /nix/store ]] && [ ! -e "$path" ]; then
+            test -t 1 && echo -ne '\033[1;31m'
+            echo "FAIL"
+            echo "The path $path does not exist!"
+            echo 'Please, check the value of `security.wrappers."'$name'".source`.'
+            test -t 1 && echo -ne '\033[0m'
+            exit 1
+          fi
+        done
 
-          echo "OK"
-        ''
+        echo "OK"
+      ''
     );
   };
 }

--- a/nixos/modules/services/continuous-integration/buildkite-agents.nix
+++ b/nixos/modules/services/continuous-integration/buildkite-agents.nix
@@ -15,14 +15,10 @@ let
         ln --symbolic ${pkgs.writeShellApplication { inherit name text; }}/bin/${name} $out/${name}
       '';
     in
-    pkgs.runCommand "buildkite-agent-hooks"
-      {
-        preferLocalBuild = true;
-      }
-      ''
-        mkdir $out
-        ${lib.concatStringsSep "\n" (lib.mapAttrsToList mkHookEntry hooks)}
-      '';
+    pkgs.runCommand "buildkite-agent-hooks" { } ''
+      mkdir $out
+      ${lib.concatStringsSep "\n" (lib.mapAttrsToList mkHookEntry hooks)}
+    '';
 
   buildkiteOptions =
     {

--- a/nixos/modules/services/databases/hbase-standalone.nix
+++ b/nixos/modules/services/databases/hbase-standalone.nix
@@ -26,7 +26,7 @@ let
           </configuration>
   '';
 
-  configDir = pkgs.runCommand "hbase-config-dir" { preferLocalBuild = true; } ''
+  configDir = pkgs.runCommand "hbase-config-dir" { } ''
     mkdir -p $out
     cp ${cfg.package}/conf/* $out/
     rm $out/hbase-site.xml

--- a/nixos/modules/services/display-managers/default.nix
+++ b/nixos/modules/services/display-managers/default.nix
@@ -8,33 +8,27 @@
 let
   cfg = config.services.displayManager;
 
-  installedSessions =
-    pkgs.runCommand "desktops"
-      {
-        # trivial derivation
-        preferLocalBuild = true;
-      }
-      ''
-        mkdir -p "$out/share/"{xsessions,wayland-sessions}
+  installedSessions = pkgs.runCommand "desktops" { } ''
+    mkdir -p "$out/share/"{xsessions,wayland-sessions}
 
-        ${lib.concatMapStrings (pkg: ''
-          for n in ${lib.concatStringsSep " " pkg.providedSessions}; do
-            if ! test -f ${pkg}/share/wayland-sessions/$n.desktop -o \
-                      -f ${pkg}/share/xsessions/$n.desktop; then
-              echo "Couldn't find provided session name, $n.desktop, in session package ${pkg.name}:"
-              echo "  ${pkg}"
-              return 1
-            fi
-          done
+    ${lib.concatMapStrings (pkg: ''
+      for n in ${lib.concatStringsSep " " pkg.providedSessions}; do
+        if ! test -f ${pkg}/share/wayland-sessions/$n.desktop -o \
+                  -f ${pkg}/share/xsessions/$n.desktop; then
+          echo "Couldn't find provided session name, $n.desktop, in session package ${pkg.name}:"
+          echo "  ${pkg}"
+          return 1
+        fi
+      done
 
-          if test -d ${pkg}/share/xsessions; then
-            ${pkgs.buildPackages.xorg.lndir}/bin/lndir ${pkg}/share/xsessions $out/share/xsessions
-          fi
-          if test -d ${pkg}/share/wayland-sessions; then
-            ${pkgs.buildPackages.xorg.lndir}/bin/lndir ${pkg}/share/wayland-sessions $out/share/wayland-sessions
-          fi
-        '') cfg.sessionPackages}
-      '';
+      if test -d ${pkg}/share/xsessions; then
+        ${pkgs.buildPackages.xorg.lndir}/bin/lndir ${pkg}/share/xsessions $out/share/xsessions
+      fi
+      if test -d ${pkg}/share/wayland-sessions; then
+        ${pkgs.buildPackages.xorg.lndir}/bin/lndir ${pkg}/share/wayland-sessions $out/share/wayland-sessions
+      fi
+    '') cfg.sessionPackages}
+  '';
 in
 {
   options = {

--- a/nixos/modules/services/display-managers/default.nix
+++ b/nixos/modules/services/display-managers/default.nix
@@ -13,7 +13,6 @@ let
       {
         # trivial derivation
         preferLocalBuild = true;
-        allowSubstitutes = false;
       }
       ''
         mkdir -p "$out/share/"{xsessions,wayland-sessions}

--- a/nixos/modules/services/games/archisteamfarm.nix
+++ b/nixos/modules/services/games/archisteamfarm.nix
@@ -250,22 +250,17 @@ in
 
         preStart =
           let
-            createBotsScript =
-              pkgs.runCommand "ASF-bots"
-                {
-                  preferLocalBuild = true;
-                }
-                ''
-                  mkdir -p $out
-                  # clean potential removed bots
-                  rm -rf $out/*.json
-                  for i in ${
-                    lib.concatStringsSep " " (map (x: "${lib.getName x},${x}") (lib.mapAttrsToList mkBot cfg.bots))
-                  }; do IFS=",";
-                    set -- $i
-                    ln -fs $2 $out/$1
-                  done
-                '';
+            createBotsScript = pkgs.runCommand "ASF-bots" { } ''
+              mkdir -p $out
+              # clean potential removed bots
+              rm -rf $out/*.json
+              for i in ${
+                lib.concatStringsSep " " (map (x: "${lib.getName x},${x}") (lib.mapAttrsToList mkBot cfg.bots))
+              }; do IFS=",";
+                set -- $i
+                ln -fs $2 $out/$1
+              done
+            '';
             replaceSecretBin = "${pkgs.replace-secret}/bin/replace-secret";
           in
           ''

--- a/nixos/modules/services/hardware/acpid.nix
+++ b/nixos/modules/services/hardware/acpid.nix
@@ -24,7 +24,7 @@ let
     };
   };
 
-  acpiConfDir = pkgs.runCommand "acpi-events" { preferLocalBuild = true; } ''
+  acpiConfDir = pkgs.runCommand "acpi-events" { } ''
     mkdir -p $out
     ${
       # Generate a configuration file for each event. (You can't have

--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -52,7 +52,7 @@ let
     }:
     pkgs.runCommand name
       {
-        preferLocalBuild = true;
+
         packages = lib.unique (map toString udevPackages);
 
         nativeBuildInputs = [
@@ -169,7 +169,7 @@ let
   hwdbBin =
     pkgs.runCommand "hwdb.bin"
       {
-        preferLocalBuild = true;
+
         packages = lib.unique (map toString ([ udev ] ++ cfg.packages));
       }
       ''

--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -53,7 +53,6 @@ let
     pkgs.runCommand name
       {
         preferLocalBuild = true;
-        allowSubstitutes = false;
         packages = lib.unique (map toString udevPackages);
 
         nativeBuildInputs = [
@@ -171,7 +170,6 @@ let
     pkgs.runCommand "hwdb.bin"
       {
         preferLocalBuild = true;
-        allowSubstitutes = false;
         packages = lib.unique (map toString ([ udev ] ++ cfg.packages));
       }
       ''

--- a/nixos/modules/services/logging/awstats.nix
+++ b/nixos/modules/services/logging/awstats.nix
@@ -151,7 +151,7 @@ in
     environment.etc = lib.mapAttrs' (
       name: opts:
       lib.nameValuePair "awstats/awstats.${name}.conf" {
-        source = pkgs.runCommand "awstats.${name}.conf" { preferLocalBuild = true; } (
+        source = pkgs.runCommand "awstats.${name}.conf" { } (
           ''
             sed \
           ''

--- a/nixos/modules/services/logging/journalwatch.nix
+++ b/nixos/modules/services/logging/journalwatch.nix
@@ -45,16 +45,11 @@ let
   # can't use joinSymlinks directly, because when we point $XDG_CONFIG_HOME
   # to the /nix/store path, we still need the subdirectory "journalwatch" inside that
   # to match journalwatch's expectations
-  journalwatchConfigDir =
-    pkgs.runCommand "journalwatch-config"
-      {
-        preferLocalBuild = true;
-      }
-      ''
-        mkdir -p $out/journalwatch
-        ln -sf ${journalwatchConfig} $out/journalwatch/config
-        ln -sf ${journalwatchPatterns} $out/journalwatch/patterns
-      '';
+  journalwatchConfigDir = pkgs.runCommand "journalwatch-config" { } ''
+    mkdir -p $out/journalwatch
+    ln -sf ${journalwatchConfig} $out/journalwatch/config
+    ln -sf ${journalwatchPatterns} $out/journalwatch/patterns
+  '';
 
 in
 {

--- a/nixos/modules/services/logging/journalwatch.nix
+++ b/nixos/modules/services/logging/journalwatch.nix
@@ -49,7 +49,6 @@ let
     pkgs.runCommand "journalwatch-config"
       {
         preferLocalBuild = true;
-        allowSubstitutes = false;
       }
       ''
         mkdir -p $out/journalwatch

--- a/nixos/modules/services/logging/logcheck.nix
+++ b/nixos/modules/services/logging/logcheck.nix
@@ -7,7 +7,7 @@
 let
   cfg = config.services.logcheck;
 
-  defaultRules = pkgs.runCommand "logcheck-default-rules" { preferLocalBuild = true; } ''
+  defaultRules = pkgs.runCommand "logcheck-default-rules" { } ''
     cp -prd ${pkgs.logcheck}/etc/logcheck $out
     chmod u+w $out
     rm -r $out/logcheck.*

--- a/nixos/modules/services/logging/logstash.nix
+++ b/nixos/modules/services/logging/logstash.nix
@@ -32,7 +32,7 @@ let
       {
         inherit logstashJvmOptionsFile;
         inherit logstashSettingsYml;
-        preferLocalBuild = true;
+
       }
       ''
         mkdir -p $out

--- a/nixos/modules/services/mail/opensmtpd.nix
+++ b/nixos/modules/services/mail/opensmtpd.nix
@@ -10,7 +10,7 @@ let
   conf = pkgs.writeText "smtpd.conf" cfg.serverConfiguration;
   args = lib.concatStringsSep " " cfg.extraServerArgs;
 
-  sendmail = pkgs.runCommand "opensmtpd-sendmail" { preferLocalBuild = true; } ''
+  sendmail = pkgs.runCommand "opensmtpd-sendmail" { } ''
     mkdir -p $out/bin
     ln -s ${cfg.package}/sbin/smtpctl $out/bin/sendmail
   '';

--- a/nixos/modules/services/matrix/appservice-irc.nix
+++ b/nixos/modules/services/matrix/appservice-irc.nix
@@ -20,7 +20,6 @@ let
           (pkgs.python3.withPackages (ps: [ ps.jsonschema ]))
           pkgs.remarshal
         ];
-        preferLocalBuild = true;
 
         config = builtins.toJSON cfg.settings;
         passAsFile = [ "config" ];

--- a/nixos/modules/services/misc/ananicy.nix
+++ b/nixos/modules/services/misc/ananicy.nix
@@ -108,27 +108,22 @@ in
   config = lib.mkIf cfg.enable {
     environment = {
       systemPackages = [ cfg.package ];
-      etc."ananicy.d".source =
-        pkgs.runCommand "ananicyfiles"
-          {
-            preferLocalBuild = true;
-          }
-          ''
-            mkdir -p $out
-            # ananicy-cpp does not include rules or settings on purpose
-            if [[ -d "${cfg.rulesProvider}/etc/ananicy.d/00-default" ]]; then
-              cp -r ${cfg.rulesProvider}/etc/ananicy.d/* $out
-            else
-              cp -r ${cfg.rulesProvider}/* $out
-            fi
+      etc."ananicy.d".source = pkgs.runCommand "ananicyfiles" { } ''
+        mkdir -p $out
+        # ananicy-cpp does not include rules or settings on purpose
+        if [[ -d "${cfg.rulesProvider}/etc/ananicy.d/00-default" ]]; then
+          cp -r ${cfg.rulesProvider}/etc/ananicy.d/* $out
+        else
+          cp -r ${cfg.rulesProvider}/* $out
+        fi
 
-            # configured through .setings
-            rm -f $out/ananicy.conf
-            cp ${configFile} $out/ananicy.conf
-            ${lib.optionalString (cfg.extraRules != [ ]) "cp ${extraRules} $out/nixRules.rules"}
-            ${lib.optionalString (cfg.extraTypes != [ ]) "cp ${extraTypes} $out/nixTypes.types"}
-            ${lib.optionalString (cfg.extraCgroups != [ ]) "cp ${extraCgroups} $out/nixCgroups.cgroups"}
-          '';
+        # configured through .setings
+        rm -f $out/ananicy.conf
+        cp ${configFile} $out/ananicy.conf
+        ${lib.optionalString (cfg.extraRules != [ ]) "cp ${extraRules} $out/nixRules.rules"}
+        ${lib.optionalString (cfg.extraTypes != [ ]) "cp ${extraTypes} $out/nixTypes.types"}
+        ${lib.optionalString (cfg.extraCgroups != [ ]) "cp ${extraCgroups} $out/nixCgroups.cgroups"}
+      '';
     };
 
     # ananicy and ananicy-cpp have different default settings

--- a/nixos/modules/services/misc/gitolite.nix
+++ b/nixos/modules/services/misc/gitolite.nix
@@ -124,7 +124,7 @@ in
   config = lib.mkIf cfg.enable (
     let
       manageGitoliteRc = cfg.extraGitoliteRc != "";
-      rcDir = pkgs.runCommand "gitolite-rc" { preferLocalBuild = true; } rcDirScript;
+      rcDir = pkgs.runCommand "gitolite-rc" { } rcDirScript;
       rcDirScript = ''
         mkdir "$out"
         export HOME=temp-home

--- a/nixos/modules/services/misc/radicle.nix
+++ b/nixos/modules/services/misc/radicle.nix
@@ -173,7 +173,7 @@ in
         type = lib.types.package;
         internal = true;
         default = (json.generate "config.json" cfg.settings).overrideAttrs (previousAttrs: {
-          preferLocalBuild = true;
+
           # None of the usual phases are run here because runCommandWith uses buildCommand,
           # so just append to buildCommand what would usually be a checkPhase.
           buildCommand =

--- a/nixos/modules/services/misc/renovate.nix
+++ b/nixos/modules/services/misc/renovate.nix
@@ -26,7 +26,7 @@ let
           ];
           value = builtins.toJSON value;
           passAsFile = [ "value" ];
-          preferLocalBuild = true;
+
         }
         ''
           jq . "$valuePath"> $out

--- a/nixos/modules/services/misc/taskserver/default.nix
+++ b/nixos/modules/services/misc/taskserver/default.nix
@@ -140,7 +140,7 @@ let
       format = "setuptools";
       name = "nixos-taskserver";
 
-      src = pkgs.runCommand "nixos-taskserver-src" { preferLocalBuild = true; } ''
+      src = pkgs.runCommand "nixos-taskserver-src" { } ''
         mkdir -p "$out"
         cat "${
           pkgs.replaceVars ./helper-tool.py {

--- a/nixos/modules/services/monitoring/apcupsd.nix
+++ b/nixos/modules/services/monitoring/apcupsd.nix
@@ -52,7 +52,7 @@ let
     else
       "";
 
-  scriptDir = pkgs.runCommand "apcupsd-scriptdir" { preferLocalBuild = true; } (
+  scriptDir = pkgs.runCommand "apcupsd-scriptdir" { } (
     ''
       mkdir "$out"
       # Copy SCRIPTDIR from apcupsd package
@@ -75,7 +75,7 @@ let
   wrappedBinaries =
     pkgs.runCommand "apcupsd-wrapped-binaries"
       {
-        preferLocalBuild = true;
+
         nativeBuildInputs = [ pkgs.makeWrapper ];
       }
       ''

--- a/nixos/modules/services/monitoring/graphite.nix
+++ b/nixos/modules/services/monitoring/graphite.nix
@@ -17,7 +17,7 @@ let
     pkgs.runCommand "graphite_local_settings"
       {
         inherit graphiteLocalSettings;
-        preferLocalBuild = true;
+
       }
       ''
         mkdir -p $out

--- a/nixos/modules/services/monitoring/librenms.nix
+++ b/nixos/modules/services/monitoring/librenms.nix
@@ -31,7 +31,7 @@ let
       {
         inherit (package) phpPackage;
         phpOptions = toKeyValue cfg.phpOptions;
-        preferLocalBuild = true;
+
         passAsFile = [ "phpOptions" ];
       }
       ''

--- a/nixos/modules/services/monitoring/nagios.nix
+++ b/nixos/modules/services/monitoring/nagios.nix
@@ -16,7 +16,7 @@ let
 
   nagiosObjectDefsDir = pkgs.runCommand "nagios-objects" {
     inherit nagiosObjectDefs;
-    preferLocalBuild = true;
+
   } "mkdir -p $out; ln -s $nagiosObjectDefs $out/";
 
   nagiosCfgFile =
@@ -41,7 +41,7 @@ let
       lines = lib.mapAttrsToList (key: value: "${key}=${value}") (default // cfg.extraConfig);
       content = lib.concatStringsSep "\n" lines;
       file = pkgs.writeText "nagios.cfg" content;
-      validated = pkgs.runCommand "nagios-checked.cfg" { preferLocalBuild = true; } ''
+      validated = pkgs.runCommand "nagios-checked.cfg" { } ''
         cp ${file} nagios.cfg
         # nagios checks the existence of /var/lib/nagios, but
         # it does not exist in the build sandbox, so we fake it

--- a/nixos/modules/services/monitoring/netdata.nix
+++ b/nixos/modules/services/monitoring/netdata.nix
@@ -7,7 +7,7 @@
 let
   cfg = config.services.netdata;
 
-  wrappedPlugins = pkgs.runCommand "wrapped-plugins" { preferLocalBuild = true; } ''
+  wrappedPlugins = pkgs.runCommand "wrapped-plugins" { } ''
     mkdir -p $out/libexec/netdata/plugins.d
     ln -s /run/wrappers/bin/apps.plugin $out/libexec/netdata/plugins.d/apps.plugin
     ln -s /run/wrappers/bin/cgroup-network $out/libexec/netdata/plugins.d/cgroup-network

--- a/nixos/modules/services/monitoring/prometheus/default.nix
+++ b/nixos/modules/services/monitoring/prometheus/default.nix
@@ -45,7 +45,7 @@ let
     if checkConfigEnabled then
       pkgs.runCommand "${name}-${replaceStrings [ " " ] [ "" ] what}-checked"
         {
-          preferLocalBuild = true;
+
           nativeBuildInputs = [ cfg.package.cli ];
         }
         ''

--- a/nixos/modules/services/monitoring/prometheus/exporters/blackbox.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/blackbox.nix
@@ -40,7 +40,7 @@ let
     file:
     pkgs.runCommand "checked-blackbox-exporter.conf"
       {
-        preferLocalBuild = true;
+
         nativeBuildInputs = [ pkgs.buildPackages.prometheus-blackbox-exporter ];
       }
       ''

--- a/nixos/modules/services/monitoring/prometheus/exporters/snmp.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/snmp.nix
@@ -36,7 +36,7 @@ let
     file:
     pkgs.runCommand "checked-snmp-exporter-config.yml"
       {
-        preferLocalBuild = true;
+
         nativeBuildInputs = [ pkgs.buildPackages.prometheus-snmp-exporter ];
       }
       ''

--- a/nixos/modules/services/monitoring/scollector.nix
+++ b/nixos/modules/services/monitoring/scollector.nix
@@ -7,7 +7,7 @@
 let
   cfg = config.services.scollector;
 
-  collectors = pkgs.runCommand "collectors" { preferLocalBuild = true; } ''
+  collectors = pkgs.runCommand "collectors" { } ''
     mkdir -p $out
     ${lib.concatStringsSep "\n" (
       lib.mapAttrsToList (

--- a/nixos/modules/services/monitoring/uptime.nix
+++ b/nixos/modules/services/monitoring/uptime.nix
@@ -19,7 +19,7 @@ let
   cfg = config.services.uptime;
   opt = options.services.uptime;
 
-  configDir = pkgs.runCommand "config" { preferLocalBuild = true; } (
+  configDir = pkgs.runCommand "config" { } (
     if cfg.configFile != null then
       ''
         mkdir $out

--- a/nixos/modules/services/network-filesystems/openafs/client.nix
+++ b/nixos/modules/services/network-filesystems/openafs/client.nix
@@ -30,7 +30,7 @@ let
     mkCellServDB cfg.cellName cfg.cellServDB
   );
 
-  afsConfig = pkgs.runCommand "afsconfig" { preferLocalBuild = true; } ''
+  afsConfig = pkgs.runCommand "afsconfig" { } ''
     mkdir -p $out
     echo ${cfg.cellName} > $out/ThisCell
     cat ${cellServDB} ${clientServDB} > $out/CellServDB
@@ -223,7 +223,7 @@ in
 
     environment.etc = {
       clientCellServDB = {
-        source = pkgs.runCommand "CellServDB" { preferLocalBuild = true; } ''
+        source = pkgs.runCommand "CellServDB" { } ''
           cat ${cellServDB} ${clientServDB} > $out
         '';
         target = "openafs/CellServDB";

--- a/nixos/modules/services/networking/dnscache.nix
+++ b/nixos/modules/services/networking/dnscache.nix
@@ -7,7 +7,7 @@
 let
   cfg = config.services.dnscache;
 
-  dnscache-root = pkgs.runCommand "dnscache-root" { preferLocalBuild = true; } ''
+  dnscache-root = pkgs.runCommand "dnscache-root" { } ''
     mkdir -p $out/{servers,ip}
 
     ${lib.concatMapStrings (ip: ''

--- a/nixos/modules/services/networking/ferm.nix
+++ b/nixos/modules/services/networking/ferm.nix
@@ -10,7 +10,7 @@ let
   configFile = pkgs.stdenv.mkDerivation {
     name = "ferm.conf";
     text = cfg.config;
-    preferLocalBuild = true;
+
     buildCommand = ''
       echo -n "$text" > $out
       ${cfg.package}/bin/ferm --noexec $out

--- a/nixos/modules/services/networking/hylafax/systemd.nix
+++ b/nixos/modules/services/networking/hylafax/systemd.nix
@@ -66,9 +66,8 @@ let
             "$out/config.${name}"
         '';
     in
-    pkgs.runCommand "hylafax-config-modems" {
-      preferLocalBuild = true;
-    } ''mkdir --parents "$out/" ${concatLines (mapModems mkLine)}'';
+    pkgs.runCommand "hylafax-config-modems" { }
+      ''mkdir --parents "$out/" ${concatLines (mapModems mkLine)}'';
 
   setupSpoolScript = pkgs.replaceVarsWith {
     name = "hylafax-setup-spool.sh";

--- a/nixos/modules/services/networking/jool.nix
+++ b/nixos/modules/services/networking/jool.nix
@@ -290,7 +290,7 @@ in
       pkgs.runCommand "jool-validated"
         {
           nativeBuildInputs = [ jool-cli ];
-          preferLocalBuild = true;
+
         }
         (
           lib.concatStrings (lib.mapAttrsToList checkNat64 cfg.nat64 ++ lib.mapAttrsToList checkSiit cfg.siit)

--- a/nixos/modules/services/networking/ngircd.nix
+++ b/nixos/modules/services/networking/ngircd.nix
@@ -15,8 +15,6 @@ let
 
     text = cfg.config;
 
-    preferLocalBuild = true;
-
     buildCommand = ''
       echo -n "$text" > $out
       ${cfg.package}/sbin/ngircd --config $out --configtest

--- a/nixos/modules/services/networking/thelounge.nix
+++ b/nixos/modules/services/networking/thelounge.nix
@@ -20,18 +20,13 @@ let
       }) cfg.plugins
     );
   };
-  plugins =
-    pkgs.runCommand "thelounge-plugins"
-      {
-        preferLocalBuild = true;
-      }
-      ''
-        mkdir -p $out/node_modules
-        echo ${escapeShellArg (builtins.toJSON pluginManifest)} >> $out/package.json
-        ${concatMapStringsSep "\n" (pkg: ''
-          ln -s ${pkg}/lib/node_modules/${getName pkg} $out/node_modules/${getName pkg}
-        '') cfg.plugins}
-      '';
+  plugins = pkgs.runCommand "thelounge-plugins" { } ''
+    mkdir -p $out/node_modules
+    echo ${escapeShellArg (builtins.toJSON pluginManifest)} >> $out/package.json
+    ${concatMapStringsSep "\n" (pkg: ''
+      ln -s ${pkg}/lib/node_modules/${getName pkg} $out/node_modules/${getName pkg}
+    '') cfg.plugins}
+  '';
 in
 {
   imports = [

--- a/nixos/modules/services/networking/unbound.nix
+++ b/nixos/modules/services/networking/unbound.nix
@@ -47,22 +47,18 @@ let
   '';
   confFile =
     if cfg.checkconf then
-      pkgs.runCommand "unbound-checkconf"
-        {
-          preferLocalBuild = true;
-        }
-        ''
-          cp ${confFileUnchecked} unbound.conf
+      pkgs.runCommand "unbound-checkconf" { } ''
+        cp ${confFileUnchecked} unbound.conf
 
-          # fake stateDir which is not accessible in the sandbox
-          mkdir -p $PWD/state
-          sed -i unbound.conf \
-            -e '/auto-trust-anchor-file/d' \
-            -e "s|${cfg.stateDir}|$PWD/state|"
-          ${cfg.package}/bin/unbound-checkconf unbound.conf
+        # fake stateDir which is not accessible in the sandbox
+        mkdir -p $PWD/state
+        sed -i unbound.conf \
+          -e '/auto-trust-anchor-file/d' \
+          -e "s|${cfg.stateDir}|$PWD/state|"
+        ${cfg.package}/bin/unbound-checkconf unbound.conf
 
-          cp ${confFileUnchecked} $out
-        ''
+        cp ${confFileUnchecked} $out
+      ''
     else
       confFileUnchecked;
 

--- a/nixos/modules/services/networking/xrdp.nix
+++ b/nixos/modules/services/networking/xrdp.nix
@@ -10,7 +10,7 @@ with lib;
 let
   cfg = config.services.xrdp;
 
-  confDir = pkgs.runCommand "xrdp.conf" { preferLocalBuild = true; } ''
+  confDir = pkgs.runCommand "xrdp.conf" { } ''
     mkdir -p $out
 
     cp -r ${cfg.package}/etc/xrdp/* $out

--- a/nixos/modules/services/printing/cupsd.nix
+++ b/nixos/modules/services/printing/cupsd.nix
@@ -21,24 +21,19 @@ let
 
   polkitEnabled = config.security.polkit.enable;
 
-  additionalBackends =
-    pkgs.runCommand "additional-cups-backends"
-      {
-        preferLocalBuild = true;
-      }
-      ''
-        mkdir -p $out
-        if [ ! -e ${cups.out}/lib/cups/backend/smb ]; then
-          mkdir -p $out/lib/cups/backend
-          ln -sv ${pkgs.samba}/bin/smbspool $out/lib/cups/backend/smb
-        fi
+  additionalBackends = pkgs.runCommand "additional-cups-backends" { } ''
+    mkdir -p $out
+    if [ ! -e ${cups.out}/lib/cups/backend/smb ]; then
+      mkdir -p $out/lib/cups/backend
+      ln -sv ${pkgs.samba}/bin/smbspool $out/lib/cups/backend/smb
+    fi
 
-        # Provide support for printing via HTTPS.
-        if [ ! -e ${cups.out}/lib/cups/backend/https ]; then
-          mkdir -p $out/lib/cups/backend
-          ln -sv ${cups.out}/lib/cups/backend/ipp $out/lib/cups/backend/https
-        fi
-      '';
+    # Provide support for printing via HTTPS.
+    if [ ! -e ${cups.out}/lib/cups/backend/https ]; then
+      mkdir -p $out/lib/cups/backend
+      ln -sv ${cups.out}/lib/cups/backend/ipp $out/lib/cups/backend/https
+    fi
+  '';
 
   # Here we can enable additional backends, filters, etc. that are not
   # part of CUPS itself, e.g. the SMB backend is part of Samba.  Since

--- a/nixos/modules/services/scheduling/cron.nix
+++ b/nixos/modules/services/scheduling/cron.nix
@@ -108,7 +108,7 @@ in
           pkgs.runCommand "crontabs"
             {
               inherit allFiles;
-              preferLocalBuild = true;
+
             }
             ''
               touch $out

--- a/nixos/modules/services/web-apps/akkoma.nix
+++ b/nixos/modules/services/web-apps/akkoma.nix
@@ -445,16 +445,12 @@ let
         '';
       };
     in
-    pkgs.runCommand "akkoma-env"
-      {
-        preferLocalBuild = true;
-      }
-      ''
-        mkdir -p "$out/bin"
+    pkgs.runCommand "akkoma-env" { } ''
+      mkdir -p "$out/bin"
 
-        ln -r -s ${escapeShellArg script} "$out/bin/pleroma"
-        ln -r -s ${escapeShellArg script} "$out/bin/pleroma_ctl"
-      '';
+      ln -r -s ${escapeShellArg script} "$out/bin/pleroma"
+      ln -r -s ${escapeShellArg script} "$out/bin/pleroma_ctl"
+    '';
 
   userWrapper = pkgs.writeShellApplication {
     name = "pleroma_ctl";
@@ -497,28 +493,23 @@ let
   staticDir = ex.":pleroma".":instance".static_dir;
   uploadDir = ex.":pleroma".":instance".upload_dir;
 
-  staticFiles =
-    pkgs.runCommand "akkoma-static"
-      {
-        preferLocalBuild = true;
-      }
-      ''
-        ${concatStringsSep "\n" (
-          mapAttrsToList (key: val: ''
-            mkdir -p $out/frontends/${escapeShellArg val.name}/
-            ln -s ${escapeShellArg val.package} $out/frontends/${escapeShellArg val.name}/${escapeShellArg val.ref}
-          '') cfg.frontends
-        )}
+  staticFiles = pkgs.runCommand "akkoma-static" { } ''
+    ${concatStringsSep "\n" (
+      mapAttrsToList (key: val: ''
+        mkdir -p $out/frontends/${escapeShellArg val.name}/
+        ln -s ${escapeShellArg val.package} $out/frontends/${escapeShellArg val.name}/${escapeShellArg val.ref}
+      '') cfg.frontends
+    )}
 
-        ${optionalString (cfg.extraStatic != null) (
-          concatStringsSep "\n" (
-            mapAttrsToList (key: val: ''
-              mkdir -p "$out/$(dirname ${escapeShellArg key})"
-              ln -s ${escapeShellArg val} $out/${escapeShellArg key}
-            '') cfg.extraStatic
-          )
-        )}
-      '';
+    ${optionalString (cfg.extraStatic != null) (
+      concatStringsSep "\n" (
+        mapAttrsToList (key: val: ''
+          mkdir -p "$out/$(dirname ${escapeShellArg key})"
+          ln -s ${escapeShellArg val} $out/${escapeShellArg key}
+        '') cfg.extraStatic
+      )
+    )}
+  '';
 in
 {
   options = {

--- a/nixos/modules/services/web-apps/mattermost.nix
+++ b/nixos/modules/services/web-apps/mattermost.nix
@@ -168,7 +168,7 @@ let
       dontPatch = true;
       dontConfigure = true;
       dontBuild = true;
-      preferLocalBuild = true;
+
     }
   ) cfg.plugins;
 
@@ -201,7 +201,7 @@ let
         dontPatch = true;
         dontConfigure = true;
         dontBuild = true;
-        preferLocalBuild = true;
+
       };
 
   mattermostConfWithoutPlugins = recursiveUpdate {

--- a/nixos/modules/services/web-apps/mediawiki.nix
+++ b/nixos/modules/services/web-apps/mediawiki.nix
@@ -75,7 +75,7 @@ let
     pkgs.runCommand "mediawiki-scripts"
       {
         nativeBuildInputs = [ pkgs.makeWrapper ];
-        preferLocalBuild = true;
+
       }
       ''
         mkdir -p $out/bin

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -52,27 +52,22 @@ let
     };
   };
 
-  webroot =
-    pkgs.runCommand "${overridePackage.name or "nextcloud"}-with-apps"
-      {
-        preferLocalBuild = true;
-      }
-      ''
-        mkdir $out
-        ln -sfv "${overridePackage}"/* "$out"
-        ${lib.concatStrings (
-          lib.mapAttrsToList (
-            name: store:
-            lib.optionalString (store.enabled && store ? linkTarget) ''
-              if [ -e "$out"/${name} ]; then
-                echo "Didn't expect ${name} already in $out!"
-                exit 1
-              fi
-              ln -sfTv ${store.linkTarget} "$out"/${name}
-            ''
-          ) appStores
-        )}
-      '';
+  webroot = pkgs.runCommand "${overridePackage.name or "nextcloud"}-with-apps" { } ''
+    mkdir $out
+    ln -sfv "${overridePackage}"/* "$out"
+    ${lib.concatStrings (
+      lib.mapAttrsToList (
+        name: store:
+        lib.optionalString (store.enabled && store ? linkTarget) ''
+          if [ -e "$out"/${name} ]; then
+            echo "Didn't expect ${name} already in $out!"
+            exit 1
+          fi
+          ln -sfTv ${store.linkTarget} "$out"/${name}
+        ''
+      ) appStores
+    )}
+  '';
 
   inherit (cfg) datadir;
 

--- a/nixos/modules/services/web-apps/stash.nix
+++ b/nixos/modules/services/web-apps/stash.nix
@@ -328,7 +328,7 @@ let
           {
             inherit srcs;
             nativeBuildInputs = [ pkgs.yq-go ];
-            preferLocalBuild = true;
+
           }
           ''
             mkdir -p $out

--- a/nixos/modules/services/web-servers/apache-httpd/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/default.nix
@@ -433,7 +433,7 @@ let
     pkgs.runCommand "php.ini"
       {
         options = cfg.phpOptions;
-        preferLocalBuild = true;
+
       }
       ''
         cat ${php}/etc/php.ini > $out

--- a/nixos/modules/services/web-servers/phpfpm/default.nix
+++ b/nixos/modules/services/web-servers/phpfpm/default.nix
@@ -39,7 +39,7 @@ let
     pkgs.runCommand "php.ini"
       {
         inherit (poolOpts) phpPackage phpOptions;
-        preferLocalBuild = true;
+
         passAsFile = [ "phpOptions" ];
       }
       ''

--- a/nixos/modules/services/x11/window-managers/xmonad.nix
+++ b/nixos/modules/services/x11/window-managers/xmonad.nix
@@ -41,7 +41,7 @@ let
     in
     pkgs.runCommand "xmonad"
       {
-        preferLocalBuild = true;
+
         nativeBuildInputs = [ pkgs.makeWrapper ];
       }
       (

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -130,7 +130,7 @@ let
       {
         fontpath = optionalString (cfg.fontPath != null) ''FontPath "${cfg.fontPath}"'';
         inherit (cfg) config;
-        preferLocalBuild = true;
+
       }
       ''
         echo 'Section "Files"' >> $out
@@ -909,7 +909,7 @@ in
             options
             ;
           nativeBuildInputs = with pkgs.buildPackages; [ xkbvalidate ];
-          preferLocalBuild = true;
+
         }
         ''
           ${optionalString (

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -63,7 +63,7 @@ let
   baseSystem = pkgs.stdenvNoCC.mkDerivation (
     {
       name = "nixos-system-${config.system.name}-${config.system.nixos.label}";
-      preferLocalBuild = true;
+
       passAsFile = [ "extraDependencies" ];
       buildCommand = systemBuilder;
 

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -64,7 +64,6 @@ let
     {
       name = "nixos-system-${config.system.name}-${config.system.nixos.label}";
       preferLocalBuild = true;
-      allowSubstitutes = false;
       passAsFile = [ "extraDependencies" ];
       buildCommand = systemBuilder;
 

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -15,19 +15,14 @@ let
   # We check the source code in a derivation that does not depend on the
   # system configuration so that most users don't have to redo the check and require
   # the necessary dependencies.
-  checkedSource =
-    pkgs.runCommand "systemd-boot"
-      {
-        preferLocalBuild = true;
-      }
-      ''
-        install -m755 -D ${./systemd-boot-builder.py} $out
-        ${lib.getExe pkgs.buildPackages.mypy} \
-          --no-implicit-optional \
-          --disallow-untyped-calls \
-          --disallow-untyped-defs \
-          $out
-      '';
+  checkedSource = pkgs.runCommand "systemd-boot" { } ''
+    install -m755 -D ${./systemd-boot-builder.py} $out
+    ${lib.getExe pkgs.buildPackages.mypy} \
+      --no-implicit-optional \
+      --disallow-untyped-calls \
+      --disallow-untyped-defs \
+      $out
+  '';
 
   edk2ShellEspPath = "efi/edk2-uefi-shell/shell.efi";
 

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -228,7 +228,7 @@ let
     pkgs.runCommand "link-units"
       {
         allowedReferences = [ extraUtils ];
-        preferLocalBuild = true;
+
       }
       (
         ''
@@ -248,7 +248,7 @@ let
     pkgs.runCommand "udev-rules"
       {
         allowedReferences = [ extraUtils ];
-        preferLocalBuild = true;
+
       }
       ''
         mkdir -p $out
@@ -396,7 +396,7 @@ let
           pkgs.runCommand "multipath.conf"
             {
               src = config.environment.etc."multipath.conf".text;
-              preferLocalBuild = true;
+
             }
             ''
               target=$out

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -575,7 +575,7 @@ in
           dir: links:
           pkgs.runCommand "${dir}"
             {
-              preferLocalBuild = true;
+
               packages = cfg.packages;
             }
             ''

--- a/nixos/modules/tasks/filesystems/vboxsf.nix
+++ b/nixos/modules/tasks/filesystems/vboxsf.nix
@@ -11,7 +11,7 @@ let
 
   inInitrd = config.boot.initrd.supportedFilesystems.vboxsf or false;
 
-  package = pkgs.runCommand "mount.vboxsf" { preferLocalBuild = true; } ''
+  package = pkgs.runCommand "mount.vboxsf" { } ''
     mkdir -p $out/bin
     cp ${pkgs.linuxPackages.virtualboxGuestAdditions}/bin/mount.vboxsf $out/bin
   '';

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -534,7 +534,7 @@ let
     mapAttrsToList (name: { description, ... }: ''- `"${name}"` to ${description};'') tempaddrValues
   );
 
-  hostidFile = pkgs.runCommand "gen-hostid" { preferLocalBuild = true; } ''
+  hostidFile = pkgs.runCommand "gen-hostid" { } ''
     hi="${cfg.hostId}"
     ${
       if pkgs.stdenv.hostPlatform.isBigEndian then

--- a/nixos/modules/virtualisation/podman/default.nix
+++ b/nixos/modules/virtualisation/podman/default.nix
@@ -22,7 +22,7 @@ let
           "man"
         ];
         inherit (cfg.package) meta;
-        preferLocalBuild = true;
+
       }
       ''
         mkdir -p $out/bin
@@ -313,7 +313,7 @@ in
         (pkgs.runCommand "podman-tmpfiles-nixos"
           {
             package = cfg.package;
-            preferLocalBuild = true;
+
           }
           ''
             mkdir -p $out/lib/tmpfiles.d/

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -1464,7 +1464,7 @@ in
     system.build.vm =
       hostPkgs.runCommand "nixos-vm"
         {
-          preferLocalBuild = true;
+
           meta.mainProgram = "run-${config.system.name}-vm";
         }
         ''

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -192,7 +192,7 @@ let
         echo "file initrd ${build.netbootRamdisk}/initrd" >> $out/nix-support/hydra-build-products
         echo "file ipxe ${build.netbootIpxeScript}/netboot.ipxe" >> $out/nix-support/hydra-build-products
       '';
-      preferLocalBuild = true;
+
     };
 
 in
@@ -472,7 +472,7 @@ rec {
             }
           );
         }).config.system.build.toplevel;
-      preferLocalBuild = true;
+
     } "mkdir $out; ln -s $toplevel $out/dummy"
   );
 

--- a/nixos/tests/activation/bashless-closure.nix
+++ b/nixos/tests/activation/bashless-closure.nix
@@ -32,8 +32,6 @@ in
 
     exportReferencesGraph.closure = [ machine.toplevel ];
 
-    preferLocalBuild = true;
-
     nativeBuildInputs = [
       jq
     ];
@@ -54,8 +52,6 @@ in
 
   initrd = stdenvNoCC.mkDerivation {
     name = "bashless-closure-initrd";
-
-    preferLocalBuild = true;
 
     nativeBuildInputs = [
       zstd

--- a/nixos/tests/apparmor/default.nix
+++ b/nixos/tests/apparmor/default.nix
@@ -82,7 +82,7 @@ in
               "${getExe' pkgs.diffutils "diff"} -u ${
                 pkgs.writeText "expected.rules" (import ./makeExpectedPolicies.nix { inherit pkgs; })
               } ${
-                pkgs.runCommand "actual.rules" { preferLocalBuild = true; } ''
+                pkgs.runCommand "actual.rules" { } ''
                   ${getExe pkgs.gnused} -e 's:^[^ ]* ${builtins.storeDir}/[^,/-]*-\([^/,]*\):\1 \0:' ${
                     pkgs.apparmorRulesFromClosure {
                       name = "ping";

--- a/nixos/tests/hydra/common.nix
+++ b/nixos/tests/hydra/common.nix
@@ -8,7 +8,6 @@
             system = "${pkgs.stdenv.hostPlatform.system}";
             builder = "/bin/sh";
             allowSubstitutes = false;
-            preferLocalBuild = true;
             args = ["-c" "echo success > $out; exit 0"];
           };
         }

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -222,7 +222,6 @@ let
                   builder = "/bin/sh";
                   args = ["-c" "echo nixos-enter build > $out"];
                   system = builtins.currentSystem;
-                  preferLocalBuild = true;
               }'
               """
           )

--- a/nixos/tests/qemu-vm-store.nix
+++ b/nixos/tests/qemu-vm-store.nix
@@ -36,7 +36,6 @@
         builder = "/bin/sh";
         args = ["-c" "echo something > $out"];
         system = builtins.currentSystem;
-        preferLocalBuild = true;
       }'
     """
 

--- a/pkgs/applications/editors/android-studio-for-platform/common.nix
+++ b/pkgs/applications/editors/android-studio-for-platform/common.nix
@@ -164,7 +164,7 @@ runCommand drvName
       #!${bash}/bin/bash
       ${fhsEnv}/bin/${drvName}-fhs-env ${androidStudioForPlatform}/bin/studio.sh "$@"
     '';
-    preferLocalBuild = true;
+
     passthru = {
       unwrapped = androidStudioForPlatform;
     };

--- a/pkgs/applications/editors/android-studio-for-platform/common.nix
+++ b/pkgs/applications/editors/android-studio-for-platform/common.nix
@@ -165,7 +165,6 @@ runCommand drvName
       ${fhsEnv}/bin/${drvName}-fhs-env ${androidStudioForPlatform}/bin/studio.sh "$@"
     '';
     preferLocalBuild = true;
-    allowSubstitutes = false;
     passthru = {
       unwrapped = androidStudioForPlatform;
     };

--- a/pkgs/applications/editors/android-studio/common.nix
+++ b/pkgs/applications/editors/android-studio/common.nix
@@ -285,7 +285,7 @@ let
             ''}
             exec ${fhsEnv}/bin/${drvName}-fhs-env ${lib.getExe androidStudio} "$@"
           '';
-        preferLocalBuild = true;
+
         passthru =
           let
             withSdk = androidSdk: mkAndroidStudioWrapper { inherit androidStudio androidSdk; };

--- a/pkgs/applications/editors/android-studio/common.nix
+++ b/pkgs/applications/editors/android-studio/common.nix
@@ -286,7 +286,6 @@ let
             exec ${fhsEnv}/bin/${drvName}-fhs-env ${lib.getExe androidStudio} "$@"
           '';
         preferLocalBuild = true;
-        allowSubstitutes = false;
         passthru =
           let
             withSdk = androidSdk: mkAndroidStudioWrapper { inherit androidStudio androidSdk; };

--- a/pkgs/applications/editors/emacs/build-support/wrapper.nix
+++ b/pkgs/applications/editors/emacs/build-support/wrapper.nix
@@ -56,7 +56,6 @@ runCommand (lib.appendToName "with-packages" emacs).name
     ];
 
     preferLocalBuild = true;
-    allowSubstitutes = false;
 
     # Store all paths we want to add to emacs here, so that we only need to add
     # one path to the load lists

--- a/pkgs/applications/editors/emacs/build-support/wrapper.nix
+++ b/pkgs/applications/editors/emacs/build-support/wrapper.nix
@@ -55,8 +55,6 @@ runCommand (lib.appendToName "with-packages" emacs).name
       makeBinaryWrapper
     ];
 
-    preferLocalBuild = true;
-
     # Store all paths we want to add to emacs here, so that we only need to add
     # one path to the load lists
     deps =

--- a/pkgs/applications/editors/jetbrains/bin/linux.nix
+++ b/pkgs/applications/editors/jetbrains/bin/linux.nix
@@ -45,129 +45,124 @@ let
 in
 
 with stdenv;
-lib.makeOverridable mkDerivation (
-  rec {
-    inherit pname version src;
-    passthru.buildNumber = buildNumber;
-    passthru.tests = args.passthru.tests;
-    meta = args.meta // {
-      mainProgram = pname;
-    };
+lib.makeOverridable mkDerivation rec {
+  inherit pname version src;
+  passthru.buildNumber = buildNumber;
+  passthru.tests = args.passthru.tests;
+  meta = args.meta // {
+    mainProgram = pname;
+  };
 
-    desktopItem = makeDesktopItem {
-      name = pname;
-      exec = pname;
-      comment = lib.replaceStrings [ "\n" ] [ " " ] meta.longDescription;
-      desktopName = product;
-      genericName = meta.description;
-      categories = [ "Development" ];
-      icon = pname;
-      startupWMClass = wmClass;
-    };
+  desktopItem = makeDesktopItem {
+    name = pname;
+    exec = pname;
+    comment = lib.replaceStrings [ "\n" ] [ " " ] meta.longDescription;
+    desktopName = product;
+    genericName = meta.description;
+    categories = [ "Development" ];
+    icon = pname;
+    startupWMClass = wmClass;
+  };
 
-    vmoptsIDE = if hiName == "WEBSTORM" then "WEBIDE" else hiName;
-    vmoptsFile = lib.optionalString (vmopts != null) (writeText vmoptsName vmopts);
+  vmoptsIDE = if hiName == "WEBSTORM" then "WEBIDE" else hiName;
+  vmoptsFile = lib.optionalString (vmopts != null) (writeText vmoptsName vmopts);
 
-    nativeBuildInputs = [
-      makeWrapper
-      patchelf
-      unzip
-      autoPatchelfHook
-    ];
-    buildInputs = extraBuildInputs;
+  nativeBuildInputs = [
+    makeWrapper
+    patchelf
+    unzip
+    autoPatchelfHook
+  ];
+  buildInputs = extraBuildInputs;
 
-    postPatch = ''
-      rm -rf jbr
-      # When using the IDE as a remote backend using gateway, it expects the jbr directory to contain the jdk
-      ln -s ${jdk.home} jbr
+  postPatch = ''
+    rm -rf jbr
+    # When using the IDE as a remote backend using gateway, it expects the jbr directory to contain the jdk
+    ln -s ${jdk.home} jbr
 
-      if [ -d "plugins/remote-dev-server" ]; then
-        patch -F3 -p1 < ${../patches/jetbrains-remote-dev.patch}
-      fi
+    if [ -d "plugins/remote-dev-server" ]; then
+      patch -F3 -p1 < ${../patches/jetbrains-remote-dev.patch}
+    fi
 
-      vmopts_file=bin/linux/${vmoptsName}
+    vmopts_file=bin/linux/${vmoptsName}
+    if [[ ! -f $vmopts_file ]]; then
+      vmopts_file=bin/${vmoptsName}
       if [[ ! -f $vmopts_file ]]; then
-        vmopts_file=bin/${vmoptsName}
-        if [[ ! -f $vmopts_file ]]; then
-          echo "ERROR: $vmopts_file not found"
-          exit 1
-        fi
+        echo "ERROR: $vmopts_file not found"
+        exit 1
       fi
-      echo -Djna.library.path=${
-        lib.makeLibraryPath [
-          libsecret
-          e2fsprogs
-          libnotify
-          # Required for Help -> Collect Logs
-          # in at least rider and goland
-          udev
-        ]
-      } >> $vmopts_file
-    '';
+    fi
+    echo -Djna.library.path=${
+      lib.makeLibraryPath [
+        libsecret
+        e2fsprogs
+        libnotify
+        # Required for Help -> Collect Logs
+        # in at least rider and goland
+        udev
+      ]
+    } >> $vmopts_file
+  '';
 
-    installPhase = ''
-      runHook preInstall
+  installPhase = ''
+    runHook preInstall
 
-      mkdir -p $out/{bin,$pname,share/pixmaps,share/icons/hicolor/scalable/apps}
-      cp -a . $out/$pname
-      [[ -f $out/$pname/bin/${loName}.png ]] && ln -s $out/$pname/bin/${loName}.png $out/share/pixmaps/${pname}.png
-      [[ -f $out/$pname/bin/${loName}.svg ]] && ln -s $out/$pname/bin/${loName}.svg $out/share/pixmaps/${pname}.svg \
-        && ln -s $out/$pname/bin/${loName}.svg $out/share/icons/hicolor/scalable/apps/${pname}.svg
-      cp ${libdbm}/lib/libdbm.so $out/$pname/bin/libdbm.so
-      cp ${fsnotifier}/bin/fsnotifier $out/$pname/bin/fsnotifier
+    mkdir -p $out/{bin,$pname,share/pixmaps,share/icons/hicolor/scalable/apps}
+    cp -a . $out/$pname
+    [[ -f $out/$pname/bin/${loName}.png ]] && ln -s $out/$pname/bin/${loName}.png $out/share/pixmaps/${pname}.png
+    [[ -f $out/$pname/bin/${loName}.svg ]] && ln -s $out/$pname/bin/${loName}.svg $out/share/pixmaps/${pname}.svg \
+      && ln -s $out/$pname/bin/${loName}.svg $out/share/icons/hicolor/scalable/apps/${pname}.svg
+    cp ${libdbm}/lib/libdbm.so $out/$pname/bin/libdbm.so
+    cp ${fsnotifier}/bin/fsnotifier $out/$pname/bin/fsnotifier
 
-      jdk=${jdk.home}
-      item=${desktopItem}
+    jdk=${jdk.home}
+    item=${desktopItem}
 
-      needsWrapping=()
+    needsWrapping=()
 
-      if [ -f "$out/$pname/bin/${loName}" ]; then
-        needsWrapping+=("$out/$pname/bin/${loName}")
-      fi
-      if [ -f "$out/$pname/bin/${loName}.sh" ]; then
-        needsWrapping+=("$out/$pname/bin/${loName}.sh")
-      fi
+    if [ -f "$out/$pname/bin/${loName}" ]; then
+      needsWrapping+=("$out/$pname/bin/${loName}")
+    fi
+    if [ -f "$out/$pname/bin/${loName}.sh" ]; then
+      needsWrapping+=("$out/$pname/bin/${loName}.sh")
+    fi
 
-      for launcher in "''${needsWrapping[@]}"
-      do
-        wrapProgram  "$launcher" \
-          --prefix PATH : "${
-            lib.makeBinPath [
-              jdk
-              coreutils
-              gnugrep
-              which
-              git
-            ]
-          }" \
-          --suffix PATH : "${lib.makeBinPath [ python3 ]}" \
-          --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath extraLdPath}" \
-          ${lib.concatStringsSep " " extraWrapperArgs} \
-          --set-default JDK_HOME "$jdk" \
-          --set-default ANDROID_JAVA_HOME "$jdk" \
-          --set-default JAVA_HOME "$jdk" \
-          --set-default JETBRAINS_CLIENT_JDK "$jdk" \
-          --set-default ${hiName}_JDK "$jdk" \
-          --set-default LOCALE_ARCHIVE "${glibcLocales}/lib/locale/locale-archive" \
-          --set-default ${vmoptsIDE}_VM_OPTIONS ${vmoptsFile}
-      done
+    for launcher in "''${needsWrapping[@]}"
+    do
+      wrapProgram  "$launcher" \
+        --prefix PATH : "${
+          lib.makeBinPath [
+            jdk
+            coreutils
+            gnugrep
+            which
+            git
+          ]
+        }" \
+        --suffix PATH : "${lib.makeBinPath [ python3 ]}" \
+        --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath extraLdPath}" \
+        ${lib.concatStringsSep " " extraWrapperArgs} \
+        --set-default JDK_HOME "$jdk" \
+        --set-default ANDROID_JAVA_HOME "$jdk" \
+        --set-default JAVA_HOME "$jdk" \
+        --set-default JETBRAINS_CLIENT_JDK "$jdk" \
+        --set-default ${hiName}_JDK "$jdk" \
+        --set-default LOCALE_ARCHIVE "${glibcLocales}/lib/locale/locale-archive" \
+        --set-default ${vmoptsIDE}_VM_OPTIONS ${vmoptsFile}
+    done
 
-      launcher="$out/$pname/bin/${loName}"
-      if [ ! -e "$launcher" ]; then
-        launcher+=.sh
-      fi
+    launcher="$out/$pname/bin/${loName}"
+    if [ ! -e "$launcher" ]; then
+      launcher+=.sh
+    fi
 
-      ln -s "$launcher" $out/bin/$pname
-      rm -rf $out/$pname/plugins/remote-dev-server/selfcontained/
-      echo -e '#!/usr/bin/env bash\n'"$out/$pname/bin/remote-dev-server.sh"' "$@"' > $out/$pname/bin/remote-dev-server-wrapped.sh
-      chmod +x $out/$pname/bin/remote-dev-server-wrapped.sh
-      ln -s "$out/$pname/bin/remote-dev-server-wrapped.sh" $out/bin/$pname-remote-dev-server
-      ln -s "$item/share/applications" $out/share
+    ln -s "$launcher" $out/bin/$pname
+    rm -rf $out/$pname/plugins/remote-dev-server/selfcontained/
+    echo -e '#!/usr/bin/env bash\n'"$out/$pname/bin/remote-dev-server.sh"' "$@"' > $out/$pname/bin/remote-dev-server-wrapped.sh
+    chmod +x $out/$pname/bin/remote-dev-server-wrapped.sh
+    ln -s "$out/$pname/bin/remote-dev-server-wrapped.sh" $out/bin/$pname-remote-dev-server
+    ln -s "$item/share/applications" $out/share
 
-      runHook postInstall
-    '';
-  }
-  // lib.optionalAttrs (!(meta.license.free or true)) {
-    preferLocalBuild = true;
-  }
-)
+    runHook postInstall
+  '';
+}

--- a/pkgs/applications/editors/neovim/gnvim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/gnvim/wrapper.nix
@@ -25,8 +25,6 @@ stdenv.mkDerivation {
     sed -e "s|Exec=.\\+gnvim\\>|Exec=gnvim|" -i $out/share/applications/*.desktop
   '';
 
-  preferLocalBuild = true;
-
   nativeBuildInputs = [
     makeWrapper
   ];

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -335,8 +335,6 @@ let
           runHook postBuild
         '';
 
-        preferLocalBuild = true;
-
         nativeBuildInputs = [
           makeWrapper
           lndir

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -3321,7 +3321,7 @@ assertNoAdditions {
             ]
           ))
         ];
-        preferLocalBuild = true;
+
         installPhase = ''
           install -Dt $out/bin ftplugin/evinceSync.py
         '';
@@ -3337,7 +3337,7 @@ assertNoAdditions {
           '';
     in
     super.sved.overrideAttrs (old: {
-      preferLocalBuild = true;
+
       postPatch = ''
         rm ftplugin/evinceSync.py
         install -m 544 ${pythonWrapper} ftplugin/evinceSync.py

--- a/pkgs/applications/graphics/inkscape/extensions.nix
+++ b/pkgs/applications/graphics/inkscape/extensions.nix
@@ -22,8 +22,6 @@
       hash = "sha256-pSPAupp3xLlbODE2BGu1Xiiiu1Y6D4gG4HhZwccAZ2E=";
     };
 
-    preferLocalBuild = true;
-
     installPhase = ''
       runHook preInstall
 

--- a/pkgs/applications/misc/blucontrol/wrapper.nix
+++ b/pkgs/applications/misc/blucontrol/wrapper.nix
@@ -20,7 +20,6 @@ stdenv.mkDerivation {
   '';
 
   # trivial derivation
-  preferLocalBuild = true;
 
   meta = with lib; {
     description = "Configurable blue light filter";

--- a/pkgs/applications/misc/blucontrol/wrapper.nix
+++ b/pkgs/applications/misc/blucontrol/wrapper.nix
@@ -21,7 +21,6 @@ stdenv.mkDerivation {
 
   # trivial derivation
   preferLocalBuild = true;
-  allowSubstitutes = false;
 
   meta = with lib; {
     description = "Configurable blue light filter";

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -561,8 +561,6 @@ let
           #############################
         '';
 
-      preferLocalBuild = true;
-
       libs = lib.makeLibraryPath libs + ":" + lib.makeSearchPathOutput "lib" "lib64" libs;
       gtk_modules = map (x: x + x.gtkModule) gtk_modules;
 

--- a/pkgs/applications/networking/browsers/palemoon/bin.nix
+++ b/pkgs/applications/networking/browsers/palemoon/bin.nix
@@ -27,8 +27,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = finalAttrs.passthru.sources."gtk${if withGTK3 then "3" else "2"}";
 
-  preferLocalBuild = true;
-
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/applications/networking/cluster/helm/wrapper.nix
+++ b/pkgs/applications/networking/cluster/helm/wrapper.nix
@@ -37,8 +37,6 @@ let
         pluginsDir
       ];
 
-      preferLocalBuild = true;
-
       nativeBuildInputs = [ makeWrapper ];
       passthru = {
         inherit pluginsDir;

--- a/pkgs/applications/networking/remote/citrix-workspace/generic.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/generic.nix
@@ -119,7 +119,7 @@ stdenv.mkDerivation rec {
   dontBuild = true;
   dontConfigure = true;
   sourceRoot = ".";
-  preferLocalBuild = true;
+
   passthru.icaroot = "${placeholder "out"}/opt/citrix-icaclient";
 
   nativeBuildInputs = [

--- a/pkgs/applications/networking/remote/teamviewer/default.nix
+++ b/pkgs/applications/networking/remote/teamviewer/default.nix
@@ -150,7 +150,6 @@ mkDerivation rec {
 
   dontStrip = true;
   dontWrapQtApps = true;
-  preferLocalBuild = true;
 
   passthru.updateScript = ./update-teamviewer.sh;
 

--- a/pkgs/applications/science/math/wolfram-engine/default.nix
+++ b/pkgs/applications/science/math/wolfram-engine/default.nix
@@ -140,9 +140,6 @@ stdenv.mkDerivation rec {
     installManPage $out/libexec/${dirName}/SystemFiles/SystemDocumentation/Unix/*
   '';
 
-  # This is primarily an IO bound build; there's little benefit to building remotely.
-  preferLocalBuild = true;
-
   # Stripping causes the program to core dump.
   dontStrip = true;
 

--- a/pkgs/applications/version-management/p4v/linux.nix
+++ b/pkgs/applications/version-management/p4v/linux.nix
@@ -106,7 +106,6 @@ stdenv.mkDerivation {
       ln -s ${unwrapped}/bin/$f $out/bin
     done
   '';
-  preferLocalBuild = true;
 
   inherit (unwrapped) meta passthru;
 }

--- a/pkgs/applications/video/mpv/scripts.nix
+++ b/pkgs/applications/video/mpv/scripts.nix
@@ -30,7 +30,7 @@ let
                 runCommand "mpvScripts.${name}.passthru.tests.scriptName-is-valid"
                   {
                     meta.maintainers = with lib.maintainers; [ nicoo ];
-                    preferLocalBuild = true;
+
                   }
                   ''
                     if [ -e "${fullScriptPath}" ]; then
@@ -56,7 +56,7 @@ let
                   runCommand "mpvScripts.${name}.passthru.tests.single-main-in-script-dir"
                     {
                       meta.maintainers = with lib.maintainers; [ nicoo ];
-                      preferLocalBuild = true;
+
                     }
                     ''
                       die() {

--- a/pkgs/applications/video/mpv/scripts/buildLua.nix
+++ b/pkgs/applications/video/mpv/scripts/buildLua.nix
@@ -42,7 +42,6 @@ lib.makeOverridable (
       in
       {
         dontBuild = true;
-        preferLocalBuild = true;
 
         # Prevent `patch` from emitting `.orig` files (that end up in the output)
         patchFlags = [

--- a/pkgs/applications/virtualization/cri-o/wrapper.nix
+++ b/pkgs/applications/virtualization/cri-o/wrapper.nix
@@ -31,8 +31,6 @@ runCommand cri-o-unwrapped.name
     name = "${cri-o-unwrapped.pname}-wrapper-${cri-o-unwrapped.version}";
     inherit (cri-o-unwrapped) pname version passthru;
 
-    preferLocalBuild = true;
-
     meta = removeAttrs cri-o-unwrapped.meta [ "outputsToInstall" ];
 
     outputs = [

--- a/pkgs/applications/window-managers/taffybar/default.nix
+++ b/pkgs/applications/window-managers/taffybar/default.nix
@@ -29,7 +29,6 @@ stdenv.mkDerivation {
 
   # Trivial derivation
   preferLocalBuild = true;
-  allowSubstitutes = false;
 
   # For hacking purposes
   passthru.env = taffybarEnv;

--- a/pkgs/applications/window-managers/taffybar/default.nix
+++ b/pkgs/applications/window-managers/taffybar/default.nix
@@ -27,9 +27,6 @@ stdenv.mkDerivation {
       --set NIX_GHC "${taffybarEnv}/bin/ghc"
   '';
 
-  # Trivial derivation
-  preferLocalBuild = true;
-
   # For hacking purposes
   passthru.env = taffybarEnv;
   buildInputs = [ taffybarEnv ];

--- a/pkgs/applications/window-managers/wayfire/wrapper.nix
+++ b/pkgs/applications/window-managers/wayfire/wrapper.nix
@@ -24,8 +24,6 @@ symlinkJoin {
     done
   '';
 
-  preferLocalBuild = true;
-
   passthru = wayfire.passthru // {
     unwrapped = wayfire;
   };

--- a/pkgs/applications/window-managers/xmonad/wrapper.nix
+++ b/pkgs/applications/window-managers/xmonad/wrapper.nix
@@ -24,5 +24,4 @@ stdenv.mkDerivation {
 
   # trivial derivation
   preferLocalBuild = true;
-  allowSubstitutes = false;
 }

--- a/pkgs/applications/window-managers/xmonad/wrapper.nix
+++ b/pkgs/applications/window-managers/xmonad/wrapper.nix
@@ -21,7 +21,4 @@ stdenv.mkDerivation {
       --set XMONAD_GHC "${xmonadEnv}/bin/ghc" \
       --set XMONAD_XMESSAGE "${xmessage}/bin/xmessage"
   '';
-
-  # trivial derivation
-  preferLocalBuild = true;
 }

--- a/pkgs/build-support/binary-cache/default.nix
+++ b/pkgs/build-support/binary-cache/default.nix
@@ -34,8 +34,6 @@ stdenv.mkDerivation {
 
   exportReferencesGraph.closure = rootPaths;
 
-  preferLocalBuild = true;
-
   nativeBuildInputs = [
     coreutils
     jq

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -167,8 +167,6 @@ stdenvNoCC.mkDerivation {
   pname = targetPrefix + (if name != "" then name else "${bintoolsName}-wrapper");
   version = optionalString (bintools != null) bintoolsVersion;
 
-  preferLocalBuild = true;
-
   outputs = [ "out" ] ++ optionals propagateDoc ([ "man" ] ++ optional (bintools ? info) "info");
 
   passthru = {

--- a/pkgs/build-support/build-fhsenv-chroot/env.nix
+++ b/pkgs/build-support/build-fhsenv-chroot/env.nix
@@ -285,5 +285,5 @@ stdenv.mkDerivation {
     cd $out
     ${lib.optionalString isMultiBuild extraBuildCommandsMulti}
   '';
-  preferLocalBuild = true;
+
 }

--- a/pkgs/build-support/build-fhsenv-chroot/env.nix
+++ b/pkgs/build-support/build-fhsenv-chroot/env.nix
@@ -286,5 +286,4 @@ stdenv.mkDerivation {
     ${lib.optionalString isMultiBuild extraBuildCommandsMulti}
   '';
   preferLocalBuild = true;
-  allowSubstitutes = false;
 }

--- a/pkgs/build-support/buildenv/default.nix
+++ b/pkgs/build-support/buildenv/default.nix
@@ -108,7 +108,7 @@ lib.makeOverridable (
         pathsToLinkJSON = builtins.toJSON pathsToLink;
         pkgs = builtins.toJSON chosenOutputs;
         extraPathsFrom = lib.optional includeClosures (writeClosure pathsForClosure);
-        preferLocalBuild = true;
+
         # XXX: The size is somewhat arbitrary
         passAsFile = if builtins.stringLength pkgs >= 128 * 1024 then [ "pkgs" ] else [ ];
       }

--- a/pkgs/build-support/buildenv/default.nix
+++ b/pkgs/build-support/buildenv/default.nix
@@ -109,7 +109,6 @@ lib.makeOverridable (
         pkgs = builtins.toJSON chosenOutputs;
         extraPathsFrom = lib.optional includeClosures (writeClosure pathsForClosure);
         preferLocalBuild = true;
-        allowSubstitutes = false;
         # XXX: The size is somewhat arbitrary
         passAsFile = if builtins.stringLength pkgs >= 128 * 1024 then [ "pkgs" ] else [ ];
       }

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -397,8 +397,6 @@ stdenvNoCC.mkDerivation {
   pname = targetPrefix + (if name != "" then name else "${ccName}-wrapper");
   version = optionalString (cc != null) ccVersion;
 
-  preferLocalBuild = true;
-
   outputs = [
     "out"
   ]

--- a/pkgs/build-support/closure-info.nix
+++ b/pkgs/build-support/closure-info.nix
@@ -48,8 +48,6 @@ stdenvNoCC.mkDerivation {
 
   exportReferencesGraph.closure = rootPaths;
 
-  preferLocalBuild = true;
-
   nativeBuildInputs = [
     coreutils
     jq

--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -670,7 +670,7 @@ rec {
           pure = writeText "${baseName}-config.json" (
             builtins.toJSON {
               inherit created config architecture;
-              preferLocalBuild = true;
+
               os = "linux";
             }
           );
@@ -678,7 +678,7 @@ rec {
             runCommand "${baseName}-config.json"
               {
                 nativeBuildInputs = [ jq ];
-                preferLocalBuild = true;
+
               }
               ''
                 jq ".created = \"$(TZ=utc date --iso-8601="seconds")\"" ${pure} > $out
@@ -1165,7 +1165,7 @@ rec {
               layersJsonFile
               ;
             imageName = lib.toLower name;
-            preferLocalBuild = true;
+
             passthru.imageTag =
               if tag != null then
                 tag
@@ -1233,7 +1233,7 @@ rec {
             inherit conf;
             inherit (conf) imageName;
             inherit streamScript;
-            preferLocalBuild = true;
+
             passthru = passthru // {
               inherit (conf) imageTag;
               inherit conf;

--- a/pkgs/build-support/docker/nix-prefetch-docker.nix
+++ b/pkgs/build-support/docker/nix-prefetch-docker.nix
@@ -29,8 +29,6 @@ stdenv.mkDerivation {
       --set HOME /homeless-shelter
   '';
 
-  preferLocalBuild = true;
-
   meta = with lib; {
     description = "Script used to obtain source hashes for dockerTools.pullImage";
     mainProgram = "nix-prefetch-docker";

--- a/pkgs/build-support/fetchdocker/default.nix
+++ b/pkgs/build-support/fetchdocker/default.nix
@@ -59,7 +59,6 @@ in
 stdenv.mkDerivation {
   builder = ./fetchdocker-builder.sh;
   buildInputs = [ coreutils ];
-  preferLocalBuild = true;
 
   inherit
     name

--- a/pkgs/build-support/fetchdocker/generic-fetcher.nix
+++ b/pkgs/build-support/fetchdocker/generic-fetcher.nix
@@ -92,8 +92,6 @@ stdenv.mkDerivation {
   outputHashMode = "flat";
   outputHash = sha256;
 
-  preferLocalBuild = true;
-
   impureEnvVars = [
     "DOCKER_USER"
     "DOCKER_PASS"

--- a/pkgs/build-support/fetchfossil/default.nix
+++ b/pkgs/build-support/fetchfossil/default.nix
@@ -30,6 +30,6 @@ lib.fetchers.withNormalizedHash { } (
     outputHashMode = "recursive";
 
     inherit url rev;
-    preferLocalBuild = true;
+
   }
 )

--- a/pkgs/build-support/fetchgitlocal/default.nix
+++ b/pkgs/build-support/fetchgitlocal/default.nix
@@ -16,7 +16,7 @@ lib.makeOverridable (
         {
           nativeBuildInputs = [ git ];
           dummy = builtins.currentTime; # impure, do every time
-          preferLocalBuild = true;
+
         }
         ''
           cd ${srcStr}
@@ -40,7 +40,7 @@ lib.makeOverridable (
       runCommand "put-in-nix"
         {
           nativeBuildInputs = [ git ];
-          preferLocalBuild = true;
+
         }
         ''
           mkdir $out

--- a/pkgs/build-support/fetchgx/default.nix
+++ b/pkgs/build-support/fetchgx/default.nix
@@ -43,6 +43,5 @@ lib.fetchers.withNormalizedHash { } (
       mv vendor $out
     '';
 
-    preferLocalBuild = true;
   }
 )

--- a/pkgs/build-support/fetchrepoproject/default.nix
+++ b/pkgs/build-support/fetchrepoproject/default.nix
@@ -67,7 +67,6 @@ lib.fetchers.withNormalizedHash { } (
     inherit outputHash outputHashAlgo;
     outputHashMode = "recursive";
 
-    preferLocalBuild = true;
     enableParallelBuilding = true;
 
     impureEnvVars = fetchers.proxyImpureEnvVars ++ [

--- a/pkgs/build-support/fetchs3/default.nix
+++ b/pkgs/build-support/fetchs3/default.nix
@@ -38,8 +38,6 @@ lib.fetchers.withNormalizedHash { } (
         inherit outputHash outputHashAlgo;
         outputHashMode = if recursiveHash then "recursive" else "flat";
 
-        preferLocalBuild = true;
-
         AWS_DEFAULT_REGION = region;
       }
       // credentialAttrs

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -26,7 +26,7 @@ let
       name = "mirrors-list";
       strictDeps = true;
       builder = ./write-mirror-list.sh;
-      preferLocalBuild = true;
+
     }
     // mirrors
   );

--- a/pkgs/build-support/mkshell/default.nix
+++ b/pkgs/build-support/mkshell/default.nix
@@ -67,7 +67,6 @@ stdenv.mkDerivation (
       } >> "$out"
     '';
 
-    preferLocalBuild = true;
   }
   // rest
 )

--- a/pkgs/build-support/pkg-config-wrapper/default.nix
+++ b/pkgs/build-support/pkg-config-wrapper/default.nix
@@ -44,8 +44,6 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
-  preferLocalBuild = true;
-
   outputs = [ "out" ] ++ optionals propagateDoc ([ "man" ] ++ optional (pkg-config ? doc) "doc");
 
   passthru = {

--- a/pkgs/build-support/references-by-popularity/default.nix
+++ b/pkgs/build-support/references-by-popularity/default.nix
@@ -10,7 +10,7 @@ runCommand "closure-paths"
   {
     exportReferencesGraph.graph = path;
     __structuredAttrs = true;
-    preferLocalBuild = true;
+
     nativeBuildInputs = [
       coreutils
       python3

--- a/pkgs/build-support/release/default.nix
+++ b/pkgs/build-support/release/default.nix
@@ -128,7 +128,7 @@ rec {
     pkgs.runCommand name
       {
         inherit constituents meta;
-        preferLocalBuild = true;
+
         _hydraAggregate = true;
       }
       ''
@@ -172,7 +172,7 @@ rec {
     }@args:
     stdenv.mkDerivation (
       {
-        preferLocalBuild = true;
+
         _hydraAggregate = true;
 
         dontConfigure = true;

--- a/pkgs/build-support/replace-vars/replace-vars-with.nix
+++ b/pkgs/build-support/replace-vars/replace-vars-with.nix
@@ -80,7 +80,6 @@ let
     doCheck = true;
     dontUnpack = true;
     preferLocalBuild = true;
-    allowSubstitutes = false;
 
     buildPhase = ''
       runHook preBuild

--- a/pkgs/build-support/replace-vars/replace-vars-with.nix
+++ b/pkgs/build-support/replace-vars/replace-vars-with.nix
@@ -79,7 +79,6 @@ let
   forcedAttrs = {
     doCheck = true;
     dontUnpack = true;
-    preferLocalBuild = true;
 
     buildPhase = ''
       runHook preBuild

--- a/pkgs/build-support/rust/rustc-wrapper/default.nix
+++ b/pkgs/build-support/rust/rustc-wrapper/default.nix
@@ -7,7 +7,7 @@
 
 runCommand "${rustc-unwrapped.pname}-wrapper-${rustc-unwrapped.version}"
   {
-    preferLocalBuild = true;
+
     strictDeps = true;
     inherit (rustc-unwrapped) outputs;
 

--- a/pkgs/build-support/setup-hooks/arrayUtilities/isDeclaredArray/tests.nix
+++ b/pkgs/build-support/setup-hooks/arrayUtilities/isDeclaredArray/tests.nix
@@ -12,7 +12,7 @@ let
   commonArgs = {
     __structuredAttrs = true;
     strictDeps = true;
-    preferLocalBuild = true;
+
     nativeBuildInputs = [ isDeclaredArray ];
   };
 

--- a/pkgs/build-support/setup-hooks/arrayUtilities/isDeclaredMap/tests.nix
+++ b/pkgs/build-support/setup-hooks/arrayUtilities/isDeclaredMap/tests.nix
@@ -12,7 +12,7 @@ let
   commonArgs = {
     __structuredAttrs = true;
     strictDeps = true;
-    preferLocalBuild = true;
+
     nativeBuildInputs = [ isDeclaredMap ];
   };
 

--- a/pkgs/build-support/substitute/substitute.nix
+++ b/pkgs/build-support/substitute/substitute.nix
@@ -49,7 +49,6 @@ optionalDeprecationWarning stdenvNoCC.mkDerivation (
     builder = ./substitute.sh;
     inherit (args) src;
     preferLocalBuild = true;
-    allowSubstitutes = false;
   }
   // args
   // lib.optionalAttrs (args ? substitutions) {

--- a/pkgs/build-support/substitute/substitute.nix
+++ b/pkgs/build-support/substitute/substitute.nix
@@ -48,7 +48,7 @@ optionalDeprecationWarning stdenvNoCC.mkDerivation (
     inherit name;
     builder = ./substitute.sh;
     inherit (args) src;
-    preferLocalBuild = true;
+
   }
   // args
   // lib.optionalAttrs (args ? substitutions) {

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -92,7 +92,6 @@ rec {
       }
       // (lib.optionalAttrs runLocal {
         preferLocalBuild = true;
-        allowSubstitutes = false;
       })
       // removeAttrs derivationArgs [ "passAsFile" ]
     );
@@ -108,7 +107,7 @@ rec {
       checkPhase ? "",
       meta ? { },
       passthru ? { },
-      allowSubstitutes ? false,
+      allowSubstitutes ? true,
       preferLocalBuild ? true,
       derivationArgs ? { },
     }:
@@ -343,7 +342,6 @@ rec {
         ;
       executable = true;
       destination = "/bin/${name}";
-      allowSubstitutes = true;
       preferLocalBuild = false;
       text = ''
         #!${runtimeShell}
@@ -402,7 +400,6 @@ rec {
         passAsFile = [ "code" ];
         # Pointless to do this on a remote machine.
         preferLocalBuild = true;
-        allowSubstitutes = false;
         meta = {
           mainProgram = pname;
         };
@@ -581,7 +578,7 @@ rec {
       paths,
       stripPrefix ? "",
       preferLocalBuild ? true,
-      allowSubstitutes ? false,
+      allowSubstitutes ? true,
       postBuild ? "",
       failOnMissing ? stripPrefix == "",
       ...
@@ -676,7 +673,6 @@ rec {
     runCommand name
       {
         preferLocalBuild = true;
-        allowSubstitutes = false;
         passthru.entries = entries';
       }
       ''
@@ -1050,7 +1046,6 @@ rec {
             postPatch
             ;
           preferLocalBuild = true;
-          allowSubstitutes = false;
           phases = "unpackPhase patchPhase installPhase";
           installPhase = "cp -R ./ $out";
         }

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -108,7 +108,7 @@ rec {
       meta ? { },
       passthru ? { },
       allowSubstitutes ? true,
-      preferLocalBuild ? true,
+      preferLocalBuild ? false,
       derivationArgs ? { },
     }:
     assert lib.assertMsg (destination != "" -> (lib.hasPrefix "/" destination && destination != "/")) ''
@@ -398,8 +398,6 @@ rec {
         inherit pname code;
         executable = true;
         passAsFile = [ "code" ];
-        # Pointless to do this on a remote machine.
-        preferLocalBuild = true;
         meta = {
           mainProgram = pname;
         };
@@ -577,7 +575,7 @@ rec {
         "${args_.pname}-${args_.version}",
       paths,
       stripPrefix ? "",
-      preferLocalBuild ? true,
+      preferLocalBuild ? false,
       allowSubstitutes ? true,
       postBuild ? "",
       failOnMissing ? stripPrefix == "",
@@ -672,7 +670,6 @@ rec {
     in
     runCommand name
       {
-        preferLocalBuild = true;
         passthru.entries = entries';
       }
       ''
@@ -1045,7 +1042,6 @@ rec {
             prePatch
             postPatch
             ;
-          preferLocalBuild = true;
           phases = "unpackPhase patchPhase installPhase";
           installPhase = "cp -R ./ $out";
         }

--- a/pkgs/by-name/ad/adapta-gtk-theme/package.nix
+++ b/pkgs/by-name/ad/adapta-gtk-theme/package.nix
@@ -26,8 +26,6 @@ stdenv.mkDerivation rec {
     sha256 = "19skrhp10xx07hbd0lr3d619vj2im35d8p9rmb4v4zacci804q04";
   };
 
-  preferLocalBuild = true;
-
   nativeBuildInputs = [
     autoreconfHook
     pkg-config

--- a/pkgs/by-name/al/alacritty-theme/package.nix
+++ b/pkgs/by-name/al/alacritty-theme/package.nix
@@ -19,7 +19,6 @@ stdenvNoCC.mkDerivation (self: {
 
   dontConfigure = true;
   dontBuild = true;
-  preferLocalBuild = true;
 
   sourceRoot = "${self.src.name}/themes";
   installPhase = ''

--- a/pkgs/by-name/bu/budgie-desktop-with-plugins/package.nix
+++ b/pkgs/by-name/bu/budgie-desktop-with-plugins/package.nix
@@ -31,8 +31,6 @@ stdenv.mkDerivation {
   dontConfigure = true;
   dontBuild = true;
 
-  preferLocalBuild = true;
-
   installPhase = ''
     mkdir -p $out
     for i in $(cat $pathsPath); do

--- a/pkgs/by-name/bu/budgie-desktop-with-plugins/package.nix
+++ b/pkgs/by-name/bu/budgie-desktop-with-plugins/package.nix
@@ -32,7 +32,6 @@ stdenv.mkDerivation {
   dontBuild = true;
 
   preferLocalBuild = true;
-  allowSubstitutes = false;
 
   installPhase = ''
     mkdir -p $out

--- a/pkgs/by-name/bu/budgie-gsettings-overrides/package.nix
+++ b/pkgs/by-name/bu/budgie-gsettings-overrides/package.nix
@@ -61,7 +61,7 @@ let
   ++ extraGSettingsOverridePackages;
 
 in
-runCommand "budgie-gsettings-overrides" { preferLocalBuild = true; } ''
+runCommand "budgie-gsettings-overrides" { } ''
   data_dir="$out/share/gsettings-schemas/nixos-gsettings-overrides"
   schema_dir="$data_dir/glib-2.0/schemas"
   mkdir -p "$schema_dir"

--- a/pkgs/by-name/bu/buildah/package.nix
+++ b/pkgs/by-name/bu/buildah/package.nix
@@ -53,8 +53,6 @@ runCommand buildah-unwrapped.name
     name = "${buildah-unwrapped.pname}-wrapper-${buildah-unwrapped.version}";
     inherit (buildah-unwrapped) pname version passthru;
 
-    preferLocalBuild = true;
-
     meta = removeAttrs buildah-unwrapped.meta [ "outputsToInstall" ];
 
     outputs = [

--- a/pkgs/by-name/ci/cinnamon-gsettings-overrides/package.nix
+++ b/pkgs/by-name/ci/cinnamon-gsettings-overrides/package.nix
@@ -55,7 +55,7 @@ let
 in
 
 # TODO: Having https://github.com/NixOS/nixpkgs/issues/54150 would supersede this
-runCommand "cinnamon-gsettings-overrides" { preferLocalBuild = true; } ''
+runCommand "cinnamon-gsettings-overrides" { } ''
   data_dir="$out/share/gsettings-schemas/nixos-gsettings-overrides"
   schema_dir="$data_dir/glib-2.0/schemas"
 

--- a/pkgs/by-name/cl/clearlooks-phenix/package.nix
+++ b/pkgs/by-name/cl/clearlooks-phenix/package.nix
@@ -19,8 +19,6 @@ stdenv.mkDerivation rec {
     cp -r . $out/share/themes/Clearlooks-Phenix/
   '';
 
-  preferLocalBuild = true;
-
   meta = with lib; {
     description = "GTK3 port of the Clearlooks theme";
     longDescription = ''

--- a/pkgs/by-name/do/dotnetbuildhelpers/package.nix
+++ b/pkgs/by-name/do/dotnetbuildhelpers/package.nix
@@ -3,7 +3,7 @@
   mono,
   pkg-config,
 }:
-runCommand "dotnetbuildhelpers" { preferLocalBuild = true; } ''
+runCommand "dotnetbuildhelpers" { } ''
   target="$out/bin"
   mkdir -p "$target"
 

--- a/pkgs/by-name/fa/factorio/package.nix
+++ b/pkgs/by-name/fa/factorio/package.nix
@@ -191,7 +191,6 @@ let
     pname = "factorio-${if releaseType == "expansion" then "space-age" else releaseType}";
     inherit version src;
 
-    preferLocalBuild = true;
     dontBuild = true;
 
     installPhase = ''

--- a/pkgs/by-name/fa/factorio/utils.nix
+++ b/pkgs/by-name/fa/factorio/utils.nix
@@ -23,7 +23,6 @@ in
     stdenv.mkDerivation {
       name = "factorio-mod-directory";
 
-      preferLocalBuild = true;
       buildCommand = ''
         mkdir -p $out
         for modDrv in ${toString modDrvs}; do
@@ -57,7 +56,6 @@ in
       deps =
         deps ++ optionals allOptionalMods optionalDeps ++ optionals allRecommendedMods recommendedDeps;
 
-      preferLocalBuild = true;
       buildCommand = ''
         mkdir -p $out
         srcBase=$(basename $src)

--- a/pkgs/by-name/ge/geant4/datasets.nix
+++ b/pkgs/by-name/ge/geant4/datasets.nix
@@ -22,7 +22,6 @@ let
         inherit sha256;
       };
 
-      preferLocalBuild = true;
       dontBuild = true;
       dontConfigure = true;
 

--- a/pkgs/by-name/ge/geogebra/package.nix
+++ b/pkgs/by-name/ge/geogebra/package.nix
@@ -71,8 +71,6 @@ let
       desktopItem
       ;
 
-    preferLocalBuild = true;
-
     src = fetchurl {
       urls = [
         "https://download.geogebra.org/installers/5.0/GeoGebra-Linux-Portable-${version}.tar.bz2"
@@ -110,8 +108,6 @@ let
 
   darwinPkg = stdenv.mkDerivation {
     inherit pname version meta;
-
-    preferLocalBuild = true;
 
     src = fetchurl {
       urls = [

--- a/pkgs/by-name/gn/gnome-panel/wrapper.nix
+++ b/pkgs/by-name/gn/gnome-panel/wrapper.nix
@@ -43,7 +43,6 @@ stdenv.mkDerivation {
   dontMoveSystemdUserUnits = true;
 
   preferLocalBuild = true;
-  allowSubstitutes = false;
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/gn/gnome-panel/wrapper.nix
+++ b/pkgs/by-name/gn/gnome-panel/wrapper.nix
@@ -42,8 +42,6 @@ stdenv.mkDerivation {
   # $output/lib/systemd/user is already a symlink
   dontMoveSystemdUserUnits = true;
 
-  preferLocalBuild = true;
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/by-name/gr/gradle-completion/package.nix
+++ b/pkgs/by-name/gr/gradle-completion/package.nix
@@ -23,10 +23,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  # we just move two files into $out,
-  # this shouldn't bother Hydra.
-  preferLocalBuild = true;
-
   dontBuild = true;
 
   installPhase = ''

--- a/pkgs/by-name/lh/lhapdf/pdf_sets.nix
+++ b/pkgs/by-name/lh/lhapdf/pdf_sets.nix
@@ -15,8 +15,6 @@ let
         inherit sha256;
       };
 
-      preferLocalBuild = true;
-
       installPhase = ''
         mkdir -p $out/${name}/
         cp * $out/${name}/

--- a/pkgs/by-name/ma/mathematica/generic.nix
+++ b/pkgs/by-name/ma/mathematica/generic.nix
@@ -220,9 +220,6 @@ stdenv.mkDerivation {
   dontConfigure = true;
   dontBuild = true;
 
-  # This is primarily an IO bound build; there's little benefit to building remotely
-  preferLocalBuild = true;
-
   # All binaries are already stripped
   dontStrip = true;
 

--- a/pkgs/by-name/mu/mullvad-browser/package.nix
+++ b/pkgs/by-name/mu/mullvad-browser/package.nix
@@ -156,7 +156,6 @@ stdenv.mkDerivation rec {
   patchelfFlags = [ "--no-clobber-old-sections" ];
 
   preferLocalBuild = true;
-  allowSubstitutes = false;
 
   desktopItems = [
     (makeDesktopItem {

--- a/pkgs/by-name/mu/mullvad-browser/package.nix
+++ b/pkgs/by-name/mu/mullvad-browser/package.nix
@@ -155,8 +155,6 @@ stdenv.mkDerivation rec {
   # Firefox uses "relrhack" to manually process relocations from a fixed offset
   patchelfFlags = [ "--no-clobber-old-sections" ];
 
-  preferLocalBuild = true;
-
   desktopItems = [
     (makeDesktopItem {
       name = "mullvad-browser";

--- a/pkgs/by-name/ne/neovim-qt/package.nix
+++ b/pkgs/by-name/ne/neovim-qt/package.nix
@@ -32,8 +32,6 @@ stdenvNoCC.mkDerivation {
         ln -s ${unwrapped}/share/icons $out/share/icons
       '';
 
-  preferLocalBuild = true;
-
   nativeBuildInputs = [
     makeWrapper
   ];

--- a/pkgs/by-name/ne/nexus/package.nix
+++ b/pkgs/by-name/ne/nexus/package.nix
@@ -17,8 +17,6 @@ stdenv.mkDerivation rec {
     hash = "sha256-oBappm8WRcgyD5HWqJKPbMHjlwCUo9y5+FtB2Kq1PCE=";
   };
 
-  preferLocalBuild = true;
-
   sourceRoot = "${pname}-${version}";
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/by-name/ni/nim-2_2/package.nix
+++ b/pkgs/by-name/ni/nim-2_2/package.nix
@@ -20,7 +20,7 @@ let
     stdenv.mkDerivation (finalAttrs: {
       name = "${targetPlatformConfig}-nim-wrapper-${nimUnwrapped.version}";
       inherit (nimUnwrapped) version;
-      preferLocalBuild = true;
+
       strictDeps = true;
 
       nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/by-name/on/onlyoffice-documentserver/package.nix
+++ b/pkgs/by-name/on/onlyoffice-documentserver/package.nix
@@ -33,8 +33,6 @@ let
       .${stdenv.hostPlatform.system} or (throw "unsupported system ${stdenv.hostPlatform.system}")
     );
 
-    preferLocalBuild = true;
-
     unpackCmd = "dpkg -x $curSrc source";
 
     nativeBuildInputs = [

--- a/pkgs/by-name/pa/paper-gtk-theme/package.nix
+++ b/pkgs/by-name/pa/paper-gtk-theme/package.nix
@@ -25,8 +25,6 @@ stdenv.mkDerivation {
     substituteInPlace Makefile.am --replace '$(DESTDIR)'/usr $out
   '';
 
-  preferLocalBuild = true;
-
   meta = with lib; {
     description = "Modern desktop theme suite featuring a mostly flat with a minimal use of shadows for depth";
     homepage = "https://snwh.org/paper";

--- a/pkgs/by-name/ph/phoc/package.nix
+++ b/pkgs/by-name/ph/phoc/package.nix
@@ -90,7 +90,6 @@ stdenv.mkDerivation (finalAttrs: {
         name = "0001-Revert-layer-shell-error-on-0-dimension-without-anch.patch";
         inherit (finalAttrs) src;
         preferLocalBuild = true;
-        allowSubstitutes = false;
         installPhase = "cp subprojects/packagefiles/wlroots/$name $out";
       })
     ];

--- a/pkgs/by-name/ph/phoc/package.nix
+++ b/pkgs/by-name/ph/phoc/package.nix
@@ -89,7 +89,7 @@ stdenv.mkDerivation (finalAttrs: {
       (stdenvNoCC.mkDerivation {
         name = "0001-Revert-layer-shell-error-on-0-dimension-without-anch.patch";
         inherit (finalAttrs) src;
-        preferLocalBuild = true;
+
         installPhase = "cp subprojects/packagefiles/wlroots/$name $out";
       })
     ];

--- a/pkgs/by-name/pu/purpur/package.nix
+++ b/pkgs/by-name/pu/purpur/package.nix
@@ -20,8 +20,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  preferLocalBuild = true;
-
   installPhase = ''
     mkdir -p $out/bin $out/lib/minecraft
     cp -v $src $out/lib/minecraft/server.jar

--- a/pkgs/by-name/ro/rofi/package.nix
+++ b/pkgs/by-name/ro/rofi/package.nix
@@ -25,7 +25,6 @@ symlinkJoin {
   ];
   buildInputs = [ gdk-pixbuf ];
 
-  preferLocalBuild = true;
   passthru.unwrapped = rofi-unwrapped;
 
   dontWrapGApps = true;

--- a/pkgs/by-name/sc/schemacrawler/package.nix
+++ b/pkgs/by-name/sc/schemacrawler/package.nix
@@ -30,8 +30,6 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  preferLocalBuild = true;
-
   meta = with lib; {
     description = "Database schema discovery and comprehension tool";
     mainProgram = "schemacrawler";

--- a/pkgs/by-name/si/simutrans/package.nix
+++ b/pkgs/by-name/si/simutrans/package.nix
@@ -87,7 +87,7 @@ let
     stdenv.mkDerivation {
       name = "simutrans-${pakName}";
       dontUnpack = true;
-      preferLocalBuild = true;
+
       installPhase =
         let
           src = fetchurl { inherit url sha256; };

--- a/pkgs/by-name/su/sundtek/package.nix
+++ b/pkgs/by-name/su/sundtek/package.nix
@@ -49,8 +49,6 @@ stdenv.mkDerivation {
       patchelf --set-rpath ${rpath} {} \;
   '';
 
-  preferLocalBuild = true;
-
   meta = with lib; {
     description = "Sundtek MediaTV driver";
     maintainers = [ maintainers.simonvandel ];

--- a/pkgs/by-name/te/termonad/package.nix
+++ b/pkgs/by-name/te/termonad/package.nix
@@ -21,9 +21,6 @@ stdenv.mkDerivation {
       --set NIX_GHC "${termonadEnv}/bin/ghc"
   '';
 
-  # trivial derivation
-  preferLocalBuild = true;
-
   passthru.tests.test = nixosTests.terminal-emulators.termonad;
 
   meta = haskellPackages.termonad.meta // {

--- a/pkgs/by-name/te/termonad/package.nix
+++ b/pkgs/by-name/te/termonad/package.nix
@@ -23,7 +23,6 @@ stdenv.mkDerivation {
 
   # trivial derivation
   preferLocalBuild = true;
-  allowSubstitutes = false;
 
   passthru.tests.test = nixosTests.terminal-emulators.termonad;
 

--- a/pkgs/by-name/to/tor-browser/package.nix
+++ b/pkgs/by-name/to/tor-browser/package.nix
@@ -168,8 +168,6 @@ stdenv.mkDerivation rec {
   # Firefox uses "relrhack" to manually process relocations from a fixed offset
   patchelfFlags = [ "--no-clobber-old-sections" ];
 
-  preferLocalBuild = true;
-
   desktopItems = [
     (makeDesktopItem {
       name = "torbrowser";

--- a/pkgs/by-name/to/tor-browser/package.nix
+++ b/pkgs/by-name/to/tor-browser/package.nix
@@ -169,7 +169,6 @@ stdenv.mkDerivation rec {
   patchelfFlags = [ "--no-clobber-old-sections" ];
 
   preferLocalBuild = true;
-  allowSubstitutes = false;
 
   desktopItems = [
     (makeDesktopItem {

--- a/pkgs/by-name/va/vapoursynth/plugin-interface.nix
+++ b/pkgs/by-name/va/vapoursynth/plugin-interface.nix
@@ -40,7 +40,6 @@ let
       {
         executable = true;
         preferLocalBuild = true;
-        allowSubstitutes = false;
         src = ''
           char const nixPluginDir[] = "${pluginsEnv}/lib/vapoursynth";
         '';

--- a/pkgs/by-name/va/vapoursynth/plugin-interface.nix
+++ b/pkgs/by-name/va/vapoursynth/plugin-interface.nix
@@ -39,7 +39,7 @@ let
     runCommandCC "libvapoursynth-nix-plugins${ext}"
       {
         executable = true;
-        preferLocalBuild = true;
+
         src = ''
           char const nixPluginDir[] = "${pluginsEnv}/lib/vapoursynth";
         '';

--- a/pkgs/by-name/we/wechat-uos/package.nix
+++ b/pkgs/by-name/we/wechat-uos/package.nix
@@ -60,7 +60,7 @@ let
 
       ln -s ${wechat}/opt/* $out/opt/
     '';
-    preferLocalBuild = true;
+
   };
 
   wechat-uos-runtime = with xorg; [

--- a/pkgs/by-name/xd/xdg-utils/package.nix
+++ b/pkgs/by-name/xd/xdg-utils/package.nix
@@ -337,7 +337,7 @@ stdenv.mkDerivation (self: {
     runCommand "xdg-mime-test"
       {
         nativeBuildInputs = [ self.finalPackage ];
-        preferLocalBuild = true;
+
         xenias = lib.mapAttrsToList (hash: urls: fetchurl { inherit hash urls; }) {
           "sha256-SL95tM1AjOi7vDnCyT10s0tvQvc+ZSZBbkNOYXfbOy0=" = [
             "https://static1.e621.net/data/0e/76/0e7672980d48e48c2d1373eb2505db5a.png"

--- a/pkgs/by-name/xm/xmage/package.nix
+++ b/pkgs/by-name/xm/xmage/package.nix
@@ -15,8 +15,6 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-EeaUd81fqiPDqHiMP86E9gtdFi545PIBfCgb1i5Z5i0=";
   };
 
-  preferLocalBuild = true;
-
   nativeBuildInputs = [ unzrip ];
 
   sourceRoot = "source";

--- a/pkgs/desktops/gnome/gdk-pixbuf-cache-builder.nix
+++ b/pkgs/desktops/gnome/gdk-pixbuf-cache-builder.nix
@@ -20,20 +20,16 @@ in
 
 # Generate the cache file by running gdk-pixbuf-query-loaders for each
 # package and concatenating the results.
-runCommand "gdk-pixbuf-loaders.cache"
-  {
-    preferLocalBuild = true;
-  }
-  ''
-    (
-      for package in ${lib.escapeShellArgs loaderPackages}; do
-        module_dir="$package/${gdk-pixbuf.moduleDir}"
-        if [[ ! -d "$module_dir" ]]; then
-          echo "Error: gdkPixbufCacheBuilder: Passed package “''${package}” does not contain GdkPixbuf loaders in “${gdk-pixbuf.moduleDir}”." 1>&2
-          exit 1
-        fi
-        GDK_PIXBUF_MODULEDIR="$module_dir" \
-          ${stdenv.hostPlatform.emulator buildPackages} ${gdk-pixbuf.dev}/bin/gdk-pixbuf-query-loaders
-      done
-    ) > "$out"
-  ''
+runCommand "gdk-pixbuf-loaders.cache" { } ''
+  (
+    for package in ${lib.escapeShellArgs loaderPackages}; do
+      module_dir="$package/${gdk-pixbuf.moduleDir}"
+      if [[ ! -d "$module_dir" ]]; then
+        echo "Error: gdkPixbufCacheBuilder: Passed package “''${package}” does not contain GdkPixbuf loaders in “${gdk-pixbuf.moduleDir}”." 1>&2
+        exit 1
+      fi
+      GDK_PIXBUF_MODULEDIR="$module_dir" \
+        ${stdenv.hostPlatform.emulator buildPackages} ${gdk-pixbuf.dev}/bin/gdk-pixbuf-query-loaders
+    done
+  ) > "$out"
+''

--- a/pkgs/desktops/gnome/nixos/gsettings-overrides/default.nix
+++ b/pkgs/desktops/gnome/nixos/gsettings-overrides/default.nix
@@ -42,7 +42,7 @@ let
 
 in
 
-runCommand "gnome-gsettings-overrides" { preferLocalBuild = true; } ''
+runCommand "gnome-gsettings-overrides" { } ''
   data_dir="$out/share/gsettings-schemas/nixos-gsettings-overrides"
   schema_dir="$data_dir/glib-2.0/schemas"
   mkdir -p "$schema_dir"

--- a/pkgs/desktops/mate/caja/with-extensions.nix
+++ b/pkgs/desktops/mate/caja/with-extensions.nix
@@ -36,7 +36,6 @@ stdenv.mkDerivation {
   dontBuild = true;
 
   preferLocalBuild = true;
-  allowSubstitutes = false;
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/desktops/mate/caja/with-extensions.nix
+++ b/pkgs/desktops/mate/caja/with-extensions.nix
@@ -35,8 +35,6 @@ stdenv.mkDerivation {
   dontConfigure = true;
   dontBuild = true;
 
-  preferLocalBuild = true;
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/desktops/mate/mate-gsettings-overrides/default.nix
+++ b/pkgs/desktops/mate/mate-gsettings-overrides/default.nix
@@ -12,7 +12,7 @@ let
     mate-wayland-session
   ];
 in
-runCommand "mate-gsettings-overrides" { preferLocalBuild = true; } ''
+runCommand "mate-gsettings-overrides" { } ''
   data_dir="$out/share/gsettings-schemas/nixos-gsettings-overrides"
   schema_dir="$data_dir/glib-2.0/schemas"
   mkdir -p "$schema_dir"

--- a/pkgs/desktops/mate/mate-panel/with-applets.nix
+++ b/pkgs/desktops/mate/mate-panel/with-applets.nix
@@ -44,7 +44,6 @@ stdenv.mkDerivation {
   dontBuild = true;
 
   preferLocalBuild = true;
-  allowSubstitutes = false;
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/desktops/mate/mate-panel/with-applets.nix
+++ b/pkgs/desktops/mate/mate-panel/with-applets.nix
@@ -43,8 +43,6 @@ stdenv.mkDerivation {
   dontConfigure = true;
   dontBuild = true;
 
-  preferLocalBuild = true;
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/desktops/pantheon/apps/switchboard/wrapper.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard/wrapper.nix
@@ -45,8 +45,6 @@ stdenv.mkDerivation {
   dontConfigure = true;
   dontBuild = true;
 
-  preferLocalBuild = true;
-
   installPhase = ''
     mkdir -p $out
     for i in $(cat $pathsPath); do

--- a/pkgs/desktops/pantheon/apps/switchboard/wrapper.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard/wrapper.nix
@@ -46,7 +46,6 @@ stdenv.mkDerivation {
   dontBuild = true;
 
   preferLocalBuild = true;
-  allowSubstitutes = false;
 
   installPhase = ''
     mkdir -p $out

--- a/pkgs/desktops/pantheon/desktop/elementary-gsettings-schemas/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-gsettings-schemas/default.nix
@@ -30,7 +30,7 @@ let
 in
 
 # TODO: Having https://github.com/NixOS/nixpkgs/issues/54150 would supersede this
-runCommand "elementary-gsettings-desktop-schemas" { preferLocalBuild = true; } ''
+runCommand "elementary-gsettings-desktop-schemas" { } ''
   data_dir="$out/share/gsettings-schemas/nixos-gsettings-overrides"
   schema_dir="$data_dir/glib-2.0/schemas"
 

--- a/pkgs/desktops/pantheon/desktop/wingpanel/wrapper.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel/wrapper.nix
@@ -43,8 +43,6 @@ stdenv.mkDerivation {
   dontConfigure = true;
   dontBuild = true;
 
-  preferLocalBuild = true;
-
   installPhase = ''
     mkdir -p $out
     for i in $(cat $pathsPath); do

--- a/pkgs/desktops/pantheon/desktop/wingpanel/wrapper.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel/wrapper.nix
@@ -44,7 +44,6 @@ stdenv.mkDerivation {
   dontBuild = true;
 
   preferLocalBuild = true;
-  allowSubstitutes = false;
 
   installPhase = ''
     mkdir -p $out

--- a/pkgs/development/compilers/llvm/common/bintools.nix
+++ b/pkgs/development/compilers/llvm/common/bintools.nix
@@ -15,7 +15,7 @@ let
 in
 runCommand "llvm-binutils-${version}"
   {
-    preferLocalBuild = true;
+
     passthru = {
       isLLVM = true;
       inherit targetPrefix;

--- a/pkgs/development/compilers/mozart/binary.nix
+++ b/pkgs/development/compilers/mozart/binary.nix
@@ -25,8 +25,6 @@ stdenv.mkDerivation {
   pname = "mozart-binary";
   inherit version;
 
-  preferLocalBuild = true;
-
   src =
     binaries.${stdenv.hostPlatform.system}
       or (throw "unsupported system: ${stdenv.hostPlatform.system}");

--- a/pkgs/development/compilers/rust/clippy-wrapper.nix
+++ b/pkgs/development/compilers/rust/clippy-wrapper.nix
@@ -8,7 +8,7 @@
 
 runCommand "${clippy-unwrapped.pname}-wrapper-${clippy-unwrapped.version}"
   {
-    preferLocalBuild = true;
+
     strictDeps = true;
     inherit (clippy-unwrapped) outputs;
 

--- a/pkgs/development/compilers/swift/swiftpm2nix/default.nix
+++ b/pkgs/development/compilers/swift/swiftpm2nix/default.nix
@@ -25,8 +25,6 @@ stdenv.mkDerivation {
       } \
   '';
 
-  preferLocalBuild = true;
-
   passthru = callPackage ./support.nix { };
 
   meta = {

--- a/pkgs/development/haskell-modules/generic-stack-builder.nix
+++ b/pkgs/development/haskell-modules/generic-stack-builder.nix
@@ -61,8 +61,6 @@ stdenv.mkDerivation (
     # Fixes https://github.com/commercialhaskell/stack/issues/2358 krank:ignore-line
     LANG = "en_US.UTF-8";
 
-    preferLocalBuild = true;
-
     preConfigure = ''
       export STACK_ROOT=$NIX_BUILD_TOP/.stack
     '';

--- a/pkgs/development/haskell-modules/hoogle.nix
+++ b/pkgs/development/haskell-modules/hoogle.nix
@@ -46,7 +46,6 @@ buildPackages.stdenv.mkDerivation (finalAttrs: {
 
   # compiling databases takes less time than copying the results
   # between machines.
-  preferLocalBuild = true;
 
   # we still allow substitutes because a database is relatively small and if it
   # is already built downloading is probably faster.  The substitution will only

--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -176,7 +176,6 @@ let
       {
         nativeBuildInputs = [ buildPackages.cabal2nix-unwrapped ];
         preferLocalBuild = true;
-        allowSubstitutes = false;
         LANG = "en_US.UTF-8";
         LOCALE_ARCHIVE = pkgs.lib.optionalString (
           buildPlatform.libc == "glibc"

--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -175,7 +175,7 @@ let
     buildPackages.runCommand "cabal2nix-${name}"
       {
         nativeBuildInputs = [ buildPackages.cabal2nix-unwrapped ];
-        preferLocalBuild = true;
+
         LANG = "en_US.UTF-8";
         LOCALE_ARCHIVE = pkgs.lib.optionalString (
           buildPlatform.libc == "glibc"

--- a/pkgs/development/haskell-modules/with-packages-wrapper.nix
+++ b/pkgs/development/haskell-modules/with-packages-wrapper.nix
@@ -181,7 +181,7 @@ else
       $out/bin/${ghcCommand}-pkg check
     ''
     + postBuild;
-    preferLocalBuild = true;
+
     passthru = {
       inherit (ghc) version meta targetPrefix;
 

--- a/pkgs/development/interpreters/python/editable.nix
+++ b/pkgs/development/interpreters/python/editable.nix
@@ -94,6 +94,6 @@ buildPythonPackage (
     nativeBuildInputs = (derivationArgs.nativeBuildInputs or [ ]) ++ [ tomli-w ];
     pyprojectContents = builtins.toJSON pyproject;
     passAsFile = [ "pyprojectContents" ];
-    preferLocalBuild = true;
+
   }
 )

--- a/pkgs/development/libraries/dbus/make-dbus-conf.nix
+++ b/pkgs/development/libraries/dbus/make-dbus-conf.nix
@@ -18,7 +18,6 @@ runCommand "dbus-1"
   {
     inherit serviceDirectories suidHelper apparmor;
     preferLocalBuild = true;
-    allowSubstitutes = false;
 
     nativeBuildInputs = [
       libxslt.bin

--- a/pkgs/development/libraries/dbus/make-dbus-conf.nix
+++ b/pkgs/development/libraries/dbus/make-dbus-conf.nix
@@ -17,7 +17,6 @@
 runCommand "dbus-1"
   {
     inherit serviceDirectories suidHelper apparmor;
-    preferLocalBuild = true;
 
     nativeBuildInputs = [
       libxslt.bin

--- a/pkgs/development/libraries/fontconfig/make-fonts-cache.nix
+++ b/pkgs/development/libraries/fontconfig/make-fonts-cache.nix
@@ -15,7 +15,7 @@ in
 
 runCommand "fc-cache"
   {
-    preferLocalBuild = true;
+
     passAsFile = [ "fontDirs" ];
     fontDirs = ''
       <!-- Font directories -->

--- a/pkgs/development/libraries/fontconfig/make-fonts-cache.nix
+++ b/pkgs/development/libraries/fontconfig/make-fonts-cache.nix
@@ -16,7 +16,6 @@ in
 runCommand "fc-cache"
   {
     preferLocalBuild = true;
-    allowSubstitutes = false;
     passAsFile = [ "fontDirs" ];
     fontDirs = ''
       <!-- Font directories -->

--- a/pkgs/development/misc/msp430/newlib.nix
+++ b/pkgs/development/misc/msp430/newlib.nix
@@ -11,7 +11,6 @@ stdenvNoCC.mkDerivation {
   inherit msp430GccSupport;
 
   preferLocalBuild = true;
-  allowSubstitutes = false;
 
   buildCommand = ''
     mkdir $out

--- a/pkgs/development/misc/msp430/newlib.nix
+++ b/pkgs/development/misc/msp430/newlib.nix
@@ -10,8 +10,6 @@ stdenvNoCC.mkDerivation {
   inherit newlib;
   inherit msp430GccSupport;
 
-  preferLocalBuild = true;
-
   buildCommand = ''
     mkdir $out
     ${xorg.lndir}/bin/lndir -silent $newlib $out

--- a/pkgs/development/mobile/androidenv/compose-android-packages.nix
+++ b/pkgs/development/mobile/androidenv/compose-android-packages.nix
@@ -68,7 +68,7 @@ in
           stdenvNoCC.mkDerivation {
             name = "androidenv-repo-json";
             buildInputs = [ mkRepoRuby ];
-            preferLocalBuild = true;
+
             unpackPhase = "true";
             buildPhase = ''
               env ruby -e 'load "${./update.rb}"' -- ${lib.escapeShellArgs mkRepoRubyArguments} --input /dev/null --output repo.json

--- a/pkgs/development/mobile/androidenv/deploy-androidpackages.nix
+++ b/pkgs/development/mobile/androidenv/deploy-androidpackages.nix
@@ -94,7 +94,6 @@ stdenv.mkDerivation (
     src = lib.flatten (map (package: package.archives) packages);
     inherit os arch;
     nativeBuildInputs = [ unzip ] ++ nativeBuildInputs;
-    preferLocalBuild = true;
 
     unpackPhase = ''
       runHook preUnpack

--- a/pkgs/development/python-modules/unicodeit/default.nix
+++ b/pkgs/development/python-modules/unicodeit/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
     runCommand "python3-unicodeit-test-entrypoint"
       {
         nativeBuildInputs = [ unicodeit ];
-        preferLocalBuild = true;
+
       }
       ''
         [[ "$(unicodeit "\BbbR")" = "ℝ" ]]

--- a/pkgs/development/r-modules/wrapper-radian.nix
+++ b/pkgs/development/r-modules/wrapper-radian.nix
@@ -12,7 +12,6 @@
 runCommand (radian.name + "-wrapper")
   {
     preferLocalBuild = true;
-    allowSubstitutes = false;
 
     buildInputs = [
       R

--- a/pkgs/development/r-modules/wrapper-radian.nix
+++ b/pkgs/development/r-modules/wrapper-radian.nix
@@ -11,7 +11,6 @@
 
 runCommand (radian.name + "-wrapper")
   {
-    preferLocalBuild = true;
 
     buildInputs = [
       R

--- a/pkgs/development/r-modules/wrapper-rstudio.nix
+++ b/pkgs/development/r-modules/wrapper-rstudio.nix
@@ -12,7 +12,6 @@
 
 runCommand (rstudio.name + "-wrapper")
   {
-    preferLocalBuild = true;
 
     nativeBuildInputs = [ makeWrapper ];
     dontWrapQtApps = true;

--- a/pkgs/development/r-modules/wrapper-rstudio.nix
+++ b/pkgs/development/r-modules/wrapper-rstudio.nix
@@ -13,7 +13,6 @@
 runCommand (rstudio.name + "-wrapper")
   {
     preferLocalBuild = true;
-    allowSubstitutes = false;
 
     nativeBuildInputs = [ makeWrapper ];
     dontWrapQtApps = true;

--- a/pkgs/development/r-modules/wrapper.nix
+++ b/pkgs/development/r-modules/wrapper.nix
@@ -8,7 +8,6 @@
 }:
 symlinkJoin {
   name = R.name + "-wrapper";
-  preferLocalBuild = true;
 
   outputs = [
     "out"

--- a/pkgs/development/r-modules/wrapper.nix
+++ b/pkgs/development/r-modules/wrapper.nix
@@ -9,7 +9,6 @@
 symlinkJoin {
   name = R.name + "-wrapper";
   preferLocalBuild = true;
-  allowSubstitutes = false;
 
   outputs = [
     "out"

--- a/pkgs/development/rocm-modules/6/miopen/default.nix
+++ b/pkgs/development/rocm-modules/6/miopen/default.nix
@@ -111,23 +111,23 @@ let
     )
   );
 
-  gfx900 = runCommand "miopen-gfx900.kdb" { preferLocalBuild = true; } ''
+  gfx900 = runCommand "miopen-gfx900.kdb" { } ''
     ${lbzip2}/bin/lbzip2 -ckd ${src}/src/kernels/gfx900.kdb.bz2 > $out
   '';
 
-  gfx906 = runCommand "miopen-gfx906.kdb" { preferLocalBuild = true; } ''
+  gfx906 = runCommand "miopen-gfx906.kdb" { } ''
     ${lbzip2}/bin/lbzip2 -ckd ${src}/src/kernels/gfx906.kdb.bz2 > $out
   '';
 
-  gfx908 = runCommand "miopen-gfx908.kdb" { preferLocalBuild = true; } ''
+  gfx908 = runCommand "miopen-gfx908.kdb" { } ''
     ${lbzip2}/bin/lbzip2 -ckd ${src}/src/kernels/gfx908.kdb.bz2 > $out
   '';
 
-  gfx90a = runCommand "miopen-gfx90a.kdb" { preferLocalBuild = true; } ''
+  gfx90a = runCommand "miopen-gfx90a.kdb" { } ''
     ${lbzip2}/bin/lbzip2 -ckd ${src}/src/kernels/gfx90a.kdb.bz2 > $out
   '';
 
-  gfx1030 = runCommand "miopen-gfx1030.kdb" { preferLocalBuild = true; } ''
+  gfx1030 = runCommand "miopen-gfx1030.kdb" { } ''
     ${lbzip2}/bin/lbzip2 -ckd ${src}/src/kernels/gfx1030.kdb.bz2 > $out
   '';
 in

--- a/pkgs/development/ruby-modules/bundler-app/default.nix
+++ b/pkgs/development/ruby-modules/bundler-app/default.nix
@@ -30,7 +30,7 @@
   lockfile ? null,
   gemset ? null,
   preferLocalBuild ? false,
-  allowSubstitutes ? false,
+  allowSubstitutes ? true,
   installManpages ? true,
   meta ? { },
   nativeBuildInputs ? [ ],

--- a/pkgs/development/tools/misc/chruby/default.nix
+++ b/pkgs/development/tools/misc/chruby/default.nix
@@ -7,7 +7,7 @@
 }:
 
 let
-  rubiesEnv = runCommand "chruby-env" { preferLocalBuild = true; } ''
+  rubiesEnv = runCommand "chruby-env" { } ''
     mkdir $out
     ${lib.concatStrings (lib.mapAttrsToList (name: path: "ln -s ${path} $out/${name}\n") rubies)}
   '';

--- a/pkgs/development/web/grails/default.nix
+++ b/pkgs/development/web/grails/default.nix
@@ -49,8 +49,6 @@ stdenv.mkDerivation rec {
     sed -i -e '2iJAVA_HOME=${jdk.home}' "$out"/bin/grails
   '';
 
-  preferLocalBuild = true;
-
   meta = with lib; {
     description = "Full stack, web application framework for the JVM";
     mainProgram = "grails";

--- a/pkgs/games/dwarf-fortress/dwarf-therapist/wrapper.nix
+++ b/pkgs/games/dwarf-fortress/dwarf-therapist/wrapper.nix
@@ -132,5 +132,4 @@ stdenv.mkDerivation {
       fi
     '';
 
-  preferLocalBuild = true;
 }

--- a/pkgs/games/dwarf-fortress/wrapper/default.nix
+++ b/pkgs/games/dwarf-fortress/wrapper/default.nix
@@ -214,7 +214,7 @@ lib.throwIf (enableTWBT' && !enableDFHack) "dwarf-fortress: TWBT requires DFHack
 
     dontUnpack = true;
     dontBuild = true;
-    preferLocalBuild = true;
+
     installPhase = ''
       mkdir -p $out/bin
 

--- a/pkgs/games/minecraft-servers/derivation.nix
+++ b/pkgs/games/minecraft-servers/derivation.nix
@@ -16,8 +16,6 @@ stdenv.mkDerivation {
 
   src = fetchurl { inherit url sha1; };
 
-  preferLocalBuild = true;
-
   nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''

--- a/pkgs/games/papermc/derivation.nix
+++ b/pkgs/games/papermc/derivation.nix
@@ -41,7 +41,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   ];
 
   dontUnpack = true;
-  preferLocalBuild = true;
 
   passthru = {
     updateScript = ./update.py;

--- a/pkgs/games/papermc/derivation.nix
+++ b/pkgs/games/papermc/derivation.nix
@@ -42,7 +42,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   dontUnpack = true;
   preferLocalBuild = true;
-  allowSubstitutes = false;
 
   passthru = {
     updateScript = ./update.py;

--- a/pkgs/games/quake3/content/arena.nix
+++ b/pkgs/games/quake3/content/arena.nix
@@ -42,8 +42,6 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s $src $out/baseq3/pak0.pk3
   '';
 
-  preferLocalBuild = true;
-
   meta = {
     description = "Quake 3 Arena content";
     longDescription = ''

--- a/pkgs/games/quake3/content/demo.nix
+++ b/pkgs/games/quake3/content/demo.nix
@@ -23,8 +23,6 @@ stdenv.mkDerivation {
     cp demoq3/*.pk3 $out/baseq3
   '';
 
-  preferLocalBuild = true;
-
   meta = with lib; {
     description = "Demo of Quake 3 Arena, a classic first-person shooter";
     longDescription = ''

--- a/pkgs/games/quake3/content/hires.nix
+++ b/pkgs/games/quake3/content/hires.nix
@@ -63,8 +63,6 @@ stdenv.mkDerivation (finalAttrs: {
     install -Dm444 ${finalAttrs.ioquake3_mac}/extras/zpack-weapons.pk3 $out/baseq3/zpack-weapons.pk3
   '';
 
-  preferLocalBuild = true;
-
   meta = with lib; {
     description = "Quake 3 high-resolution textures";
     license = licenses.cc0;

--- a/pkgs/games/quake3/content/pointrelease.nix
+++ b/pkgs/games/quake3/content/pointrelease.nix
@@ -23,8 +23,6 @@ stdenv.mkDerivation {
     cp baseq3/*.pk3 $out/baseq3
   '';
 
-  preferLocalBuild = true;
-
   meta = with lib; {
     description = "Quake 3 Arena point release";
     license = licenses.unfreeRedistributable;

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -173,7 +173,7 @@ optionalAttrs allowAliases aliases
               nativeBuildInputs = [ jq ];
               value = builtins.toJSON value;
               passAsFile = [ "value" ];
-              preferLocalBuild = true;
+
             }
             ''
               jq . "$valuePath" > $out
@@ -196,7 +196,7 @@ optionalAttrs allowAliases aliases
               nativeBuildInputs = [ remarshal_0_17 ];
               value = builtins.toJSON value;
               passAsFile = [ "value" ];
-              preferLocalBuild = true;
+
             }
             ''
               json2yaml "$valuePath" "$out"
@@ -219,7 +219,7 @@ optionalAttrs allowAliases aliases
               nativeBuildInputs = [ remarshal ];
               value = builtins.toJSON value;
               passAsFile = [ "value" ];
-              preferLocalBuild = true;
+
             }
             ''
               json2yaml "$valuePath" "$out"
@@ -498,7 +498,7 @@ optionalAttrs allowAliases aliases
               nativeBuildInputs = [ remarshal ];
               value = builtins.toJSON value;
               passAsFile = [ "value" ];
-              preferLocalBuild = true;
+
             }
             ''
               json2toml "$valuePath" "$out"
@@ -531,7 +531,7 @@ optionalAttrs allowAliases aliases
               nativeBuildInputs = [ json2cdn ];
               value = builtins.toJSON value;
               passAsFile = [ "value" ];
-              preferLocalBuild = true;
+
             }
             ''
               json2cdn "$valuePath" > $out
@@ -767,7 +767,7 @@ optionalAttrs allowAliases aliases
             value = toConf value;
             passAsFile = [ "value" ];
             nativeBuildInputs = [ elixir ];
-            preferLocalBuild = true;
+
           }
           ''
             cp "$valuePath" "$out"
@@ -815,7 +815,7 @@ optionalAttrs allowAliases aliases
               indentType = if indentUsingTabs then "Tabs" else "Spaces";
               value = toLua { inherit asBindings multiline; } value;
               passAsFile = [ "value" ];
-              preferLocalBuild = true;
+
             }
             ''
               ${optionalString (!asBindings) ''
@@ -1000,7 +1000,7 @@ optionalAttrs allowAliases aliases
                 "value"
                 "pythonGen"
               ];
-              preferLocalBuild = true;
+
             }
             ''
               cat "$valuePath"
@@ -1048,7 +1048,7 @@ optionalAttrs allowAliases aliases
                   "value"
                   "pythonGen"
                 ];
-                preferLocalBuild = true;
+
               }
               ''
                 python3 "$pythonGenPath" > $out

--- a/pkgs/pkgs-lib/formats/hocon/default.nix
+++ b/pkgs/pkgs-lib/formats/hocon/default.nix
@@ -144,7 +144,6 @@ in
               inherit name;
 
               dontUnpack = true;
-              preferLocalBuild = true;
 
               json = builtins.toJSON value;
               passAsFile = [ "json" ];

--- a/pkgs/pkgs-lib/formats/java-properties/default.nix
+++ b/pkgs/pkgs-lib/formats/java-properties/default.nix
@@ -99,7 +99,6 @@ in
             #    libraries, but we can't rely on this in
             #    general.
 
-            preferLocalBuild = true;
             passAsFile = [ "value" ];
             value = builtins.toJSON value;
             nativeBuildInputs = [

--- a/pkgs/pkgs-lib/formats/libconfig/default.nix
+++ b/pkgs/pkgs-lib/formats/libconfig/default.nix
@@ -90,7 +90,6 @@ in
               inherit name;
 
               dontUnpack = true;
-              preferLocalBuild = true;
 
               json = builtins.toJSON value;
               passAsFile = [ "json" ];

--- a/pkgs/servers/dns/knot-resolver/default.nix
+++ b/pkgs/servers/dns/knot-resolver/default.nix
@@ -166,7 +166,7 @@ let
           # used by policy.slice_randomize_psl()
           psl
         ];
-        preferLocalBuild = true;
+
         inherit (unwrapped) meta;
       }
       (

--- a/pkgs/servers/dns/knot-resolver/default.nix
+++ b/pkgs/servers/dns/knot-resolver/default.nix
@@ -167,7 +167,6 @@ let
           psl
         ];
         preferLocalBuild = true;
-        allowSubstitutes = false;
         inherit (unwrapped) meta;
       }
       (

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -367,7 +367,6 @@ rec {
 
         NIX_ENFORCE_NO_NATIVE = false;
 
-        preferLocalBuild = true;
         allowSubstitutes = false;
       });
     });

--- a/pkgs/test/cc-wrapper/hardening.nix
+++ b/pkgs/test/cc-wrapper/hardening.nix
@@ -21,7 +21,7 @@ let
         stdenv = stdenv';
         derivationArgs = {
           inherit codePath;
-          preferLocalBuild = true;
+
         }
         // env;
       }

--- a/pkgs/test/cc-wrapper/hardening.nix
+++ b/pkgs/test/cc-wrapper/hardening.nix
@@ -22,7 +22,6 @@ let
         derivationArgs = {
           inherit codePath;
           preferLocalBuild = true;
-          allowSubstitutes = false;
         }
         // env;
       }

--- a/pkgs/tools/graphics/diagrams-builder/default.nix
+++ b/pkgs/tools/graphics/diagrams-builder/default.nix
@@ -57,7 +57,5 @@ stdenv.mkDerivation {
 
   buildCommand = lib.concatStringsSep "\n" (map exeWrapper allBackends);
 
-  # Will be faster to build the wrapper locally then to fetch it from a binary cache.
-  preferLocalBuild = true;
   meta = diagrams-builder.meta;
 }

--- a/pkgs/tools/nix/info/default.nix
+++ b/pkgs/tools/nix/info/default.nix
@@ -52,8 +52,6 @@ stdenv.mkDerivation {
     cp ./nix-info $out/bin/nix-info
   '';
 
-  preferLocalBuild = true;
-
   meta = {
     platforms = lib.platforms.all;
   };

--- a/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
+++ b/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
@@ -47,8 +47,6 @@ let
           --set HOME /homeless-shelter
       '';
 
-      preferLocalBuild = true;
-
       meta = with lib; {
         description = "Script used to obtain source hashes for fetch${tool}";
         maintainers = with maintainers; [ bennofs ];

--- a/pkgs/top-level/unixtools.nix
+++ b/pkgs/top-level/unixtools.nix
@@ -49,7 +49,7 @@ let
         // lib.optionalAttrs (builtins.hasAttr "binlore" providers) {
           binlore.out = (binlore.synthesize (getBin bins.${cmd}) providers.binlore);
         };
-        preferLocalBuild = true;
+
       }
       ''
         if ! [ -x ${bin} ]; then


### PR DESCRIPTION
This PR removes explicit `allowSubstitutes = false` from 99% of usages in-tree, excluding some special cases like test FODs that we can just leave be for now, and impure derivations that need it for obvious reasons.

Historically, this attribute has caused much more pain compared to any compute time it'd save, so much so that Nix has a flag to completely ignore it!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
