### PR TITLE
rustPlatform.cargoAuditHook: init, run by default

### DIFF
--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -515,6 +515,9 @@ you of the correct hash.
   environment variable. Features can be specified with
   `cargoBuildNoDefaultFeatures` and `cargoBuildFeatures`. Additional
   Cargo build flags can be passed through `cargoBuildFlags`.
+* `cargoAuditHook`: Use [cargo-audit](https://github.com/rustsec/rustsec/tree/main/cargo-audit) to audit a package's dependencies.
+  Uses RustSec's advisory database to analyse dependencies of a package
+  to see if there are CVEs and other vulnerabilities.
 * `maturinBuildHook`: use [Maturin](https://github.com/PyO3/maturin)
   to build a Python wheel. Similar to `cargoBuildHook`, the optional
   variable `buildAndTestSubdir` can be used to build a crate in a

--- a/pkgs/build-support/rust/hooks/cargo-audit-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-audit-hook.sh
@@ -1,0 +1,55 @@
+
+cargoAuditHook() {
+    echo "Executing cargoAuditHook"
+
+    local -a dirsArray
+    concatTo dirsArray "$(getAllOutputNames)"
+
+    # Get all the files created with cargo-auditable
+    local -a auditableFiles
+    mapfile -d $'\0' auditableFiles < <(grep --null -rl "AUDITABLE_VERSION_INFO" "${dirsArray[@]}" )
+    nixDebugLog "cargo-auditable files:"
+    nixDebugLog "$(echo "$auditableFiles")"
+
+    local auditArgs=(
+      # If someone has an old checkout don't complain
+      "--stale"
+      # Don't try to fetch an updated database
+      "--no-fetch"
+      # Output a json report
+      "--json"
+      # Only look at the OS and CPU arch we are building for
+      "--target-os" "@os@"
+      "--target-arch" "@arch@"
+      # Use the Nixpkgs database
+      "--db" "@auditDatabase@"
+      # Ignore yanked because we cannot look that up in the sandbox
+      "--ignore" "yanked"
+      "bin"
+    )
+
+    # Even though we ignore yanked, it still complains, so we must redirect stderr
+    local json
+    json="$(cargo audit "${auditArgs[@]}" "${auditableFiles[@]}" 2> /dev/null)"
+    nixDebugLog "cargo-audit output:"
+    nixDebugLog "$(echo "$json" | jq)"
+
+    # Collect whether vulnerabilities were found or not
+    local auditStatus=$(echo "$json" | jq --exit-status '.vulnerabilities.found')
+
+    if "$auditStatus"; then
+      # Pretty-print the JSON
+      echo "$json" | jq
+
+      if [[ -n "@failOnAuditFail@" ]]; then
+        # Exit
+        exit 1
+      fi
+    fi
+
+    echo "Finished cargoAuditHook"
+}
+
+if [[ ! -v runCargoAudit ]]; then
+  postInstallHooks+=(cargoAuditHook)
+fi

--- a/pkgs/build-support/rust/hooks/default.nix
+++ b/pkgs/build-support/rust/hooks/default.nix
@@ -1,7 +1,9 @@
 {
+  config,
   cargo-nextest,
   clang,
   diffutils,
+  rust-advisory-db,
   lib,
   makeSetupHook,
   rust,
@@ -16,7 +18,20 @@
   tests,
   pkgsCross,
 }:
-{
+lib.fix (self: {
+  cargoAuditHook = makeSetupHook {
+    name = "cargo-audit-hook.sh";
+    substitutions = {
+      inherit (stdenv.targetPlatform.rust.platform) arch os;
+      auditDatabase = rust-advisory-db;
+      failOnAuditFail = toString config.failRustAudit;
+    };
+    propagatedBuildInputs = [
+      pkgsHostTarget.cargo-audit
+      pkgsHostTarget.jq
+    ];
+  } ./cargo-audit-hook.sh;
+
   cargoBuildHook = makeSetupHook {
     name = "cargo-build-hook.sh";
     substitutions = {
@@ -24,6 +39,9 @@
       inherit (rust.envVars) setEnv;
 
     };
+    propagatedBuildInputs = [
+      self.cargoAuditHook
+    ];
     passthru.tests = {
       test = tests.rust-hooks.cargoBuildHook;
       ${if stdenv.hostPlatform.isLinux then "testCross" else null} =
@@ -135,4 +153,4 @@
     };
     meta.license = lib.licenses.mit;
   } ./rust-bindgen-hook.sh;
-}
+})

--- a/pkgs/build-support/rust/hooks/default.nix
+++ b/pkgs/build-support/rust/hooks/default.nix
@@ -32,23 +32,35 @@ lib.fix (self: {
     ];
   } ./cargo-audit-hook.sh;
 
-  cargoBuildHook = makeSetupHook {
-    name = "cargo-build-hook.sh";
-    substitutions = {
-      inherit (stdenv.targetPlatform.rust) rustcTargetSpec;
-      inherit (rust.envVars) setEnv;
+  cargoBuildHook = lib.makeOverridable (
+    {
+      withCargoAuditHook ? true,
+    }:
+    makeSetupHook {
+      name = "cargo-build-hook.sh";
+      substitutions = {
+        inherit (stdenv.targetPlatform.rust) rustcTargetSpec;
+        inherit (rust.envVars) setEnv;
 
-    };
-    propagatedBuildInputs = [
-      self.cargoAuditHook
-    ];
-    passthru.tests = {
-      test = tests.rust-hooks.cargoBuildHook;
-      ${if stdenv.hostPlatform.isLinux then "testCross" else null} =
-        pkgsCross.riscv64.tests.rust-hooks.cargoBuildHook;
-    };
-    meta.license = lib.licenses.mit;
-  } ./cargo-build-hook.sh;
+      };
+
+      # Modify bootstrap config if any are added here
+      propagatedBuildInputs = lib.optionals withCargoAuditHook [
+        self.cargoAuditHook
+      ];
+
+      passthru.bootstrap = self.cargoBuildHook.override {
+        withCargoAuditHook = false;
+      };
+
+      passthru.tests = {
+        test = tests.rust-hooks.cargoBuildHook;
+        ${if stdenv.hostPlatform.isLinux then "testCross" else null} =
+          pkgsCross.riscv64.tests.rust-hooks.cargoBuildHook;
+      };
+      meta.license = lib.licenses.mit;
+    } ./cargo-build-hook.sh
+  ) { };
 
   cargoCheckHook = makeSetupHook {
     name = "cargo-check-hook.sh";

--- a/pkgs/by-name/ca/cargo-audit/package.nix
+++ b/pkgs/by-name/ca/cargo-audit/package.nix
@@ -6,8 +6,14 @@
   openssl,
   zlib,
 }:
-
-rustPlatform.buildRustPackage (finalAttrs: {
+let
+  rustBootstrapPlatform = rustPlatform.overrideScope (
+    _: prev: {
+      cargoBuildHook = prev.cargoBuildHook.bootstrap;
+    }
+  );
+in
+rustBootstrapPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-audit";
   version = "0.22.1";
 

--- a/pkgs/by-name/ca/cargo-auditable/builder.nix
+++ b/pkgs/by-name/ca/cargo-auditable/builder.nix
@@ -7,7 +7,10 @@
   auditable-bootstrap,
 }:
 lib.extendMkDerivation {
-  constructDrv = rustPlatform.buildRustPackage.override { cargo-auditable = auditable-bootstrap; };
+  constructDrv = rustPlatform.buildRustPackage.override (prev: {
+    cargo-auditable = auditable-bootstrap;
+    cargoBuildHook = prev.cargoBuildHook.bootstrap;
+  });
 
   extendDrvArgs =
     finalAttrs:

--- a/pkgs/by-name/ru/rust-advisory-db/package.nix
+++ b/pkgs/by-name/ru/rust-advisory-db/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+stdenvNoCC.mkDerivation {
+  pname = "rust-advisory-db";
+  version = "0-unstable-2025-10-20";
+
+  src = fetchFromGitHub {
+    owner = "rustsec";
+    repo = "advisory-db";
+    rev = "2ada48518d0e12b773af966e411d5e3418951825";
+    hash = "sha256-/BHC9R/M4O2AK2iLXbkeX8koDhG1uR+3koIkOfiJEv0=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontFixup = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r . "$out"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Repository of security advisories filed against Rust crates";
+    homepage = "https://rustsec.org/advisories/";
+    downloadPage = "https://github.com/rustsec/advisory-db";
+    maintainers = [ lib.maintainers.RossSmyth ];
+    license = lib.licenses.cc0;
+  };
+}

--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -19,9 +19,10 @@
 }:
 
 rustPlatform.buildRustPackage.override
-  {
-    cargo-auditable = cargo-auditable.bootstrap;
-  }
+  (prev: {
+    cargo-auditable = prev.cargo-auditable.bootstrap;
+    cargoBuildHook = prev.cargoBuildHook.bootstrap;
+  })
   {
     pname = "cargo";
     inherit (rustc.unwrapped) version src;

--- a/pkgs/development/compilers/rust/make-rust-platform.nix
+++ b/pkgs/development/compilers/rust/make-rust-platform.nix
@@ -64,6 +64,7 @@
             stdenv
             ;
         })
+        cargoAuditHook
         cargoBuildHook
         cargoCheckHook
         cargoInstallHook

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -471,6 +471,12 @@ let
       '';
     };
 
+    failRustAudit = mkOption {
+      description = "Fail builds if cargoAuditHook for a package detects an error";
+      type = types.bool;
+      default = false;
+    };
+
     problems = (import ../stdenv/generic/problems.nix { inherit lib; }).configOptions;
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

1. Add the rust advisory database
2. Add the `rustPlatform.cargoAuditHook` hook
3. Modify `rustPlatform.buildRustPackage` to use the hook

There is a problem with Rust packages in Nixpkgs. Or maybe several.

1. Nixpkgs does not supply security-critical packages

RustTLS is pretty common to use in Rust projects because it integrates well with the Cargo build system. When Nixpkgs builds a crate, it uses whatever version is in the lockfile, not the latest semver-compatible version. So for the packages in Nixpkgs that have not updated their lockfiles, or have not been updated in general, in years, they may have several CVEs that could be exploited.

2. Nixpkgs has no way to know

Currently packages are built with `cargo-auditable` by default. This is great because it embeds audit information into the binaries. But currently there is no tooling to actually use that info. This is the tooling. Running `cargo-audit` at build time means that if packages are insecure, we can let people know. It also means that since every Rust package is built at minimum every Rust compiler version bump, it means that Rust packages will be regularly rebuilt and checked. 


## The Plan

1. Run cargo-audit by default, but do not fail the builds
2. In the future, fail the builds.

For the second step we may need to adjust the auditing so builds aren't failed for silly reasons.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
