### PR TITLE
writeTextFile: pass destination and make it overridable; restructure with `stdenvNoCC.mkDerivation`

### DIFF
--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -112,65 +112,63 @@ rec {
       pos ? builtins.unsafeGetAttrPos "name" args,
     }@args:
 
-    stdenvNoCC.mkDerivation
-      (
-        finalAttrs:
-        {
-          inherit
-            pos
-            name
-            text
-            executable
-            checkPhase
-            allowSubstitutes
-            preferLocalBuild
-            ;
-          destination =
-            assert lib.assertMsg (destination != "" -> (lib.hasPrefix "/" destination && destination != "/")) ''
-              destination must be an absolute path, relative to the derivation's out path,
-              got '${destination}' instead.
+    stdenvNoCC.mkDerivation (
+      finalAttrs:
+      {
+        inherit
+          pos
+          name
+          text
+          executable
+          checkPhase
+          allowSubstitutes
+          preferLocalBuild
+          ;
+        destination =
+          assert lib.assertMsg (destination != "" -> (lib.hasPrefix "/" destination && destination != "/")) ''
+            destination must be an absolute path, relative to the derivation's out path,
+            got '${destination}' instead.
 
-              Ensure that the path starts with a / and specifies at least the filename.
-            '';
-            destination;
-          passAsFile = [ "text" ] ++ derivationArgs.passAsFile or [ ];
+            Ensure that the path starts with a / and specifies at least the filename.
+          '';
+          destination;
+        passAsFile = [ "text" ] ++ derivationArgs.passAsFile or [ ];
 
-          buildCommand =
-            ''
-              target=$out$destination
-              mkdir -p "$(dirname "$target")"
+        buildCommand = ''
+          target=$out$destination
+          mkdir -p "$(dirname "$target")"
 
-              if [ -e "$textPath" ]; then
-                mv "$textPath" "$target"
-              else
-                echo -n "$text" > "$target"
-              fi
+          if [ -e "$textPath" ]; then
+            mv "$textPath" "$target"
+          else
+            echo -n "$text" > "$target"
+          fi
 
-              if [ -n "$executable" ]; then
-                chmod +x "$target"
-              fi
+          if [ -n "$executable" ]; then
+            chmod +x "$target"
+          fi
 
-              eval "$checkPhase"
-            '';
+          eval "$checkPhase"
+        '';
 
-          meta =
-            let
-              matches = builtins.match "/bin/([^/]+)" finalAttrs.destination;
-              isProgram = finalAttrs.executable && matches != null;
-            in
-            {
-              ${if isProgram then "mainProgram" else null} = lib.head matches;
-            }
-            // meta
-            // derivationArgs.meta or { };
-          passthru = passthru // derivationArgs.passthru or { };
-        }
-        // removeAttrs derivationArgs [
-          "passAsFile"
-          "meta"
-          "passthru"
-        ]
-      );
+        meta =
+          let
+            matches = builtins.match "/bin/([^/]+)" finalAttrs.destination;
+            isProgram = finalAttrs.executable && matches != null;
+          in
+          {
+            ${if isProgram then "mainProgram" else null} = lib.head matches;
+          }
+          // meta
+          // derivationArgs.meta or { };
+        passthru = passthru // derivationArgs.passthru or { };
+      }
+      // removeAttrs derivationArgs [
+        "passAsFile"
+        "meta"
+        "passthru"
+      ]
+    );
 
   # See doc/build-helpers/trivial-build-helpers.chapter.md
   # or https://nixos.org/manual/nixpkgs/unstable/#trivial-builder-text-writing

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -135,9 +135,10 @@ rec {
           meta =
             let
               matches = builtins.match "/bin/([^/]+)" destination;
+              isProgram = executable && matches != null;
             in
-            lib.optionalAttrs (executable && matches != null) {
-              mainProgram = lib.head matches;
+            {
+              ${if isProgram then "mainProgram" else null} = lib.head matches;
             }
             // meta
             // derivationArgs.meta or { };

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -112,9 +112,6 @@ rec {
       pos ? builtins.unsafeGetAttrPos "name" args,
     }@args:
 
-    let
-      matches = builtins.match "/bin/([^/]+)" destination;
-    in
     runCommand name
       (
         {
@@ -136,6 +133,9 @@ rec {
             destination;
           passAsFile = [ "text" ] ++ derivationArgs.passAsFile or [ ];
           meta =
+            let
+              matches = builtins.match "/bin/([^/]+)" destination;
+            in
             lib.optionalAttrs (executable && matches != null) {
               mainProgram = lib.head matches;
             }

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -112,11 +112,13 @@ rec {
       pos ? builtins.unsafeGetAttrPos "name" args,
     }@args:
 
-    runCommand name
+    stdenvNoCC.mkDerivation
       (
+        finalAttrs:
         {
           inherit
             pos
+            name
             text
             executable
             checkPhase
@@ -132,6 +134,25 @@ rec {
             '';
             destination;
           passAsFile = [ "text" ] ++ derivationArgs.passAsFile or [ ];
+
+          buildCommand =
+            ''
+              target=$out$destination
+              mkdir -p "$(dirname "$target")"
+
+              if [ -e "$textPath" ]; then
+                mv "$textPath" "$target"
+              else
+                echo -n "$text" > "$target"
+              fi
+
+              if [ -n "$executable" ]; then
+                chmod +x "$target"
+              fi
+
+              eval "$checkPhase"
+            '';
+
           meta =
             let
               matches = builtins.match "/bin/([^/]+)" destination;
@@ -149,23 +170,7 @@ rec {
           "meta"
           "passthru"
         ]
-      )
-      ''
-        target=$out$destination
-        mkdir -p "$(dirname "$target")"
-
-        if [ -e "$textPath" ]; then
-          mv "$textPath" "$target"
-        else
-          echo -n "$text" > "$target"
-        fi
-
-        if [ -n "$executable" ]; then
-          chmod +x "$target"
-        fi
-
-        eval "$checkPhase"
-      '';
+      );
 
   # See doc/build-helpers/trivial-build-helpers.chapter.md
   # or https://nixos.org/manual/nixpkgs/unstable/#trivial-builder-text-writing

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -128,6 +128,7 @@ rec {
             pos
             text
             executable
+            destination
             checkPhase
             allowSubstitutes
             preferLocalBuild
@@ -148,7 +149,7 @@ rec {
         ]
       )
       ''
-        target=$out${lib.escapeShellArg destination}
+        target=$out$destination
         mkdir -p "$(dirname "$target")"
 
         if [ -e "$textPath" ]; then

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -111,12 +111,6 @@ rec {
       derivationArgs ? { },
       pos ? builtins.unsafeGetAttrPos "name" args,
     }@args:
-    assert lib.assertMsg (destination != "" -> (lib.hasPrefix "/" destination && destination != "/")) ''
-      destination must be an absolute path, relative to the derivation's out path,
-      got '${destination}' instead.
-
-      Ensure that the path starts with a / and specifies at least the filename.
-    '';
 
     let
       matches = builtins.match "/bin/([^/]+)" destination;
@@ -128,11 +122,18 @@ rec {
             pos
             text
             executable
-            destination
             checkPhase
             allowSubstitutes
             preferLocalBuild
             ;
+          destination =
+            assert lib.assertMsg (destination != "" -> (lib.hasPrefix "/" destination && destination != "/")) ''
+              destination must be an absolute path, relative to the derivation's out path,
+              got '${destination}' instead.
+
+              Ensure that the path starts with a / and specifies at least the filename.
+            '';
+            destination;
           passAsFile = [ "text" ] ++ derivationArgs.passAsFile or [ ];
           meta =
             lib.optionalAttrs (executable && matches != null) {

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -155,8 +155,8 @@ rec {
 
           meta =
             let
-              matches = builtins.match "/bin/([^/]+)" destination;
-              isProgram = executable && matches != null;
+              matches = builtins.match "/bin/([^/]+)" finalAttrs.destination;
+              isProgram = finalAttrs.executable && matches != null;
             in
             {
               ${if isProgram then "mainProgram" else null} = lib.head matches;


### PR DESCRIPTION
This PR passes the `destination` argument down to `runCommand` (and therefore `stdenvNoCC.mkDerivation`), for the following purposes:
- It make `destination` overridable with `<pkg>.overrideAttrs`. Before this change, there is no way to override `destination`.
- When restructuring `writeTextFile` with `lib.extendMkDerivation`, we hope to pass most arguments down as possible/feasible. By passing `destination` in a separate PR, we reduces the number of rebuilds during restructuring and make errors/incompatibility more discoverable.

This PR also replace `runCommand` with `stdenvNoCC.mkDerivation`, which is also to prepare for `lib.extendMkDerivation` restructure and enhance overriding. I'll adjust the attribute order in a subsequent, non-mass-rebuild PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
