### PR TITLE
python3Packages.ruuvitag-ble: 0.2.1 -> 0.3.0

### DIFF
--- a/pkgs/development/python-modules/ruuvitag-ble/default.nix
+++ b/pkgs/development/python-modules/ruuvitag-ble/default.nix
@@ -8,22 +8,19 @@
   home-assistant-bluetooth,
   pytest-cov-stub,
   pytestCheckHook,
-  pythonOlder,
   sensor-state-data,
 }:
 
 buildPythonPackage rec {
   pname = "ruuvitag-ble";
-  version = "0.2.1";
+  version = "0.3.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "Bluetooth-Devices";
     repo = "ruuvitag-ble";
     tag = "v${version}";
-    hash = "sha256-9aaAKb5Av2OMDGaSM9+tT0s++YYE0g1D01Le6RrMoMk=";
+    hash = "sha256-5hlO2/YCTc65ImwjJVyWhFe2PTPlQ33aNdqEIxH/lms=";
   };
 
   build-system = [ hatchling ];
@@ -42,10 +39,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "ruuvitag_ble" ];
 
-  meta = with lib; {
+  meta = {
+    changelog = "https://github.com/Bluetooth-Devices/ruuvitag-ble/releases/tag/${src.tag}";
     description = "Library for Ruuvitag BLE devices";
     homepage = "https://github.com/Bluetooth-Devices/ruuvitag-ble";
-    license = licenses.mit;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
   };
 }

--- a/pkgs/development/python-modules/sensor-state-data/default.nix
+++ b/pkgs/development/python-modules/sensor-state-data/default.nix
@@ -5,24 +5,21 @@
   poetry-core,
   pytestCheckHook,
   pytest-cov-stub,
-  pythonOlder,
 }:
 
 buildPythonPackage rec {
   pname = "sensor-state-data";
-  version = "2.19.0";
-  format = "pyproject";
-
-  disabled = pythonOlder "3.9";
+  version = "2.20.0";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Bluetooth-Devices";
     repo = "sensor-state-data";
     tag = "v${version}";
-    hash = "sha256-Jl+kyr9WhYEzvsnSdqfeDDWgcEU9Yi6Snd67YQ+1MqQ=";
+    hash = "sha256-ONAM1WxKnzRCJsuJa+4zDaOXPkTj+zcTH54SgktpMR8=";
   };
 
-  nativeBuildInputs = [ poetry-core ];
+  build-system = [ poetry-core ];
 
   nativeCheckInputs = [
     pytestCheckHook


### PR DESCRIPTION
Diff: https://github.com/Bluetooth-Devices/ruuvitag-ble/compare/v0.2.1...v0.3.0

Changelog: https://github.com/Bluetooth-Devices/ruuvitag-ble/releases/tag/v0.3.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
