### PR TITLE
teams/forgejo: init

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -363,6 +363,20 @@ with lib.maintainers;
     shortName = "Flying Circus employees";
   };
 
+  forgejo = {
+    members = [
+      adamcstephens
+      bendlas
+      christoph-heiss
+      emilylange
+      marie
+      pyrox0
+      tebriel
+    ];
+    scope = "Maintain the Forgejo code forge, packages and modules.";
+    shortName = "Forgejo";
+  };
+
   formatter = {
     github = "nix-formatting";
   };

--- a/nixos/modules/services/misc/forgejo.nix
+++ b/nixos/modules/services/misc/forgejo.nix
@@ -849,9 +849,5 @@ in
   };
 
   meta.doc = ./forgejo.md;
-  meta.maintainers = with lib.maintainers; [
-    bendlas
-    emilylange
-    pyrox0
-  ];
+  meta.maintainers = lib.teams.forgejo.members;
 }

--- a/nixos/tests/forgejo.nix
+++ b/nixos/tests/forgejo.nix
@@ -31,11 +31,7 @@ let
 
     {
       name = "forgejo-${type}";
-      meta.maintainers = with lib.maintainers; [
-        bendlas
-        emilylange
-        tebriel
-      ];
+      meta.maintainers = lib.teams.forgejo.members;
 
       nodes = {
         server =

--- a/pkgs/by-name/fo/forgejo-runner/package.nix
+++ b/pkgs/by-name/fo/forgejo-runner/package.nix
@@ -100,13 +100,8 @@ buildGoModule rec {
     homepage = "https://code.forgejo.org/forgejo/runner";
     changelog = "https://code.forgejo.org/forgejo/runner/releases/tag/${src.rev}";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [
-      adamcstephens
-      emilylange
-      christoph-heiss
-      tebriel
-      nrabulinski
-    ];
+    maintainers = with lib.maintainers; [ nrabulinski ];
+    teams = [ lib.teams.forgejo ];
     mainProgram = "forgejo-runner";
   };
 }

--- a/pkgs/by-name/fo/forgejo/generic.nix
+++ b/pkgs/by-name/fo/forgejo/generic.nix
@@ -192,15 +192,7 @@ buildGoModule rec {
     homepage = "https://forgejo.org";
     changelog = "https://codeberg.org/forgejo/forgejo/releases/tag/v${version}";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [
-      emilylange
-      urandom
-      bendlas
-      adamcstephens
-      marie
-      pyrox0
-      tebriel
-    ];
+    teams = [ lib.teams.forgejo ];
     broken = stdenv.hostPlatform.isDarwin;
     mainProgram = "forgejo";
   };


### PR DESCRIPTION
Adopts the two forgejo versions in nixpkgs, the `services.forgejo` module, as well as forgejo-runner, which are all official Forgejo projects. If there is anyone I missed from the maintainers list, please let me know.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
