### PR TITLE
python3Packages.pipenv-poetry-migrate: fix test

### DIFF
--- a/pkgs/by-name/pi/pipenv-poetry-migrate/package.nix
+++ b/pkgs/by-name/pi/pipenv-poetry-migrate/package.nix
@@ -18,15 +18,15 @@ python3Packages.buildPythonApplication rec {
 
   build-system = [ python3Packages.poetry-core ];
 
-  pythonRelaxDeps = [
-    "typer"
-  ];
-
   dependencies = with python3Packages; [
     setuptools # for pkg_resources
     tomlkit
     typer
   ];
+
+  # typer for Click >= 8.2 removed "mix_stderr", upstream pins to 8.1.8
+  # https://typer.tiangolo.com/release-notes/#0160
+  disabledTestPaths = [ "tests/test_cli.py" ];
 
   nativeCheckInputs = [ python3Packages.pytestCheckHook ];
 


### PR DESCRIPTION
Fix test failure due to nixpkgs `click` package being updated to 8.2 while upstream uses 8.1.8.

See release notes for `typer`: https://typer.tiangolo.com/release-notes/#0160

ZHF: #457852

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
