### PR TITLE
python3Packages.slack-sdk: disable tests that require network access

### DIFF
--- a/pkgs/development/python-modules/slack-sdk/default.nix
+++ b/pkgs/development/python-modules/slack-sdk/default.nix
@@ -13,7 +13,6 @@
   sqlalchemy,
   websocket-client,
   websockets,
-  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
@@ -54,6 +53,14 @@ buildPythonPackage rec {
     "test_start_raises_an_error_if_rtm_ws_url_is_not_returned"
     # Requires network access: [Errno 111] Connection refused
     "test_send_message_while_disconnection"
+    # [Errno 61] Connection refused
+    "TestWebClient_HttpRetry"
+    # ConnectionResetError: [Errno 54] Connection reset by peer
+    "test_issue_690_oauth_access"
+    "test_issue_690_oauth_v2_access"
+    "test_error_response"
+    # Assertion Error: unexpectedly None (while accessing instance of slack store)
+    "test_issue_1441_mixing_user_and_bot_installations"
   ];
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/slack-sdk/default.nix
+++ b/pkgs/development/python-modules/slack-sdk/default.nix
@@ -51,15 +51,11 @@ buildPythonPackage rec {
   disabledTests = [
     # Requires internet access (to slack API)
     "test_start_raises_an_error_if_rtm_ws_url_is_not_returned"
-    # Requires network access: [Errno 111] Connection refused
     "test_send_message_while_disconnection"
-    # [Errno 61] Connection refused
     "TestWebClient_HttpRetry"
-    # ConnectionResetError: [Errno 54] Connection reset by peer
     "test_issue_690_oauth_access"
     "test_issue_690_oauth_v2_access"
     "test_error_response"
-    # Assertion Error: unexpectedly None (while accessing instance of slack store)
     "test_issue_1441_mixing_user_and_bot_installations"
   ];
 


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/311310436

Disabled `test_remote_disconnected ` (from Hydra) and two other issues discovered in `nixpkgs-review`.

ZHF: #457852

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
