### PR TITLE
dr14_tmeter: 1.0.16 -> unstable-20250927

### DIFF
--- a/pkgs/by-name/dr/dr14_tmeter/package.nix
+++ b/pkgs/by-name/dr/dr14_tmeter/package.nix
@@ -35,6 +35,6 @@ python3Packages.buildPythonApplication {
     mainProgram = "dr14_tmeter";
     license = lib.licenses.gpl3Plus;
     homepage = "http://dr14tmeter.sourceforge.net/";
-    maintainers = [ ];
+    maintainers = with maintainers; [ sciencentistguy ];
   };
 }

--- a/pkgs/by-name/dr/dr14_tmeter/package.nix
+++ b/pkgs/by-name/dr/dr14_tmeter/package.nix
@@ -33,8 +33,8 @@ python3Packages.buildPythonApplication {
   meta = {
     description = "Compute the DR14 of a given audio file according to the procedure described by the Pleasurize Music Foundation";
     mainProgram = "dr14_tmeter";
+    homepage = "https://github.com/hboetes/dr14_t.meter";
+    maintainers = with lib.maintainers; [ sciencentistguy ];
     license = lib.licenses.gpl3Plus;
-    homepage = "http://dr14tmeter.sourceforge.net/";
-    maintainers = with maintainers; [ sciencentistguy ];
   };
 }

--- a/pkgs/by-name/dr/dr14_tmeter/package.nix
+++ b/pkgs/by-name/dr/dr14_tmeter/package.nix
@@ -5,22 +5,21 @@
   pkgs,
 }:
 
-python3Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication {
   pname = "dr14_tmeter";
-  version = "1.0.16";
+  version = "1.0.16-unstable-2025-09-27";
   format = "setuptools";
 
-  disabled = !python3Packages.isPy3k;
-
   src = fetchFromGitHub {
-    owner = "simon-r";
+    owner = "hboetes";
     repo = "dr14_t.meter";
-    rev = "v${version}";
-    sha256 = "1nfsasi7kx0myxkahbd7rz8796mcf5nsadrsjjpx2kgaaw5nkv1m";
+    rev = "f9d62f60c30d9404d4c4b644931e76049332310c";
+    sha256 = "sha256-3z9Gi32aG6Tk9UHpfT1VqmBZpFJrlKB+NZFu3CH+18U=";
   };
 
   propagatedBuildInputs = with pkgs; [
     python3Packages.numpy
+    python3Packages.mutagen
     flac
     vorbis-tools
     ffmpeg


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The original is unmaintained and no longer runs. Re-pointing to a fork that is and does.

Also adding myself as a maintainer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
