### PR TITLE
fwupd: 2.0.16 -> 2.0.17

### DIFF
--- a/pkgs/by-name/fw/fwupd/0001-Install-fwupdplugin-to-out.patch
+++ b/pkgs/by-name/fw/fwupd/0001-Install-fwupdplugin-to-out.patch
@@ -1,8 +1,11 @@
-commit 3ffe2d7842b62986e2267e6542068e6356b06fdf
-Author: r-vdp <ramses@well-founded.dev>
-Date:   Mon Oct 28 12:07:51 2024 +0100
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: r-vdp <ramses@well-founded.dev>
+Date: Mon, 28 Oct 2024 12:07:51 +0100
+Subject: [PATCH] Install fwupdplugin to out
 
-    Install fwupdplugin to out
+---
+ meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/meson.build b/meson.build
 index 3a163331e..cb66be0cc 100644

--- a/pkgs/by-name/fw/fwupd/0001-Install-fwupdplugin-to-out.patch
+++ b/pkgs/by-name/fw/fwupd/0001-Install-fwupdplugin-to-out.patch
@@ -8,10 +8,10 @@ Subject: [PATCH] Install fwupdplugin to out
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/meson.build b/meson.build
-index 3a163331e..cb66be0cc 100644
+index b711ab04b..7b065f278 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -733,7 +733,7 @@ if build_standalone
+@@ -734,7 +734,7 @@ if build_standalone
    if host_machine.system() == 'windows'
      libdir_pkg = bindir
    else

--- a/pkgs/by-name/fw/fwupd/0002-Add-output-for-installed-tests.patch
+++ b/pkgs/by-name/fw/fwupd/0002-Add-output-for-installed-tests.patch
@@ -1,8 +1,14 @@
-commit 954e41500e1b409a24fca43ae3bdc1c6a890db48
-Author: r-vdp <ramses@well-founded.dev>
-Date:   Tue Oct 15 14:49:53 2024 +0200
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: r-vdp <ramses@well-founded.dev>
+Date: Tue, 15 Oct 2024 14:49:53 +0200
+Subject: [PATCH] Add output for installed tests
 
-    Add output for installed tests
+---
+ data/tests/meson.build             | 2 +-
+ meson.build                        | 5 +++--
+ meson_options.txt                  | 4 ++++
+ src/tests/host-emulate/meson.build | 2 +-
+ 4 files changed, 9 insertions(+), 4 deletions(-)
 
 diff --git a/data/tests/meson.build b/data/tests/meson.build
 index 3eba65eea..cf3931bb7 100644

--- a/pkgs/by-name/fw/fwupd/0002-Add-output-for-installed-tests.patch
+++ b/pkgs/by-name/fw/fwupd/0002-Add-output-for-installed-tests.patch
@@ -6,15 +6,15 @@ Subject: [PATCH] Add output for installed tests
 ---
  data/tests/meson.build             | 2 +-
  meson.build                        | 5 +++--
- meson_options.txt                  | 4 ++++
+ meson_options.txt                  | 5 +++++
  src/tests/host-emulate/meson.build | 2 +-
- 4 files changed, 9 insertions(+), 4 deletions(-)
+ 4 files changed, 10 insertions(+), 4 deletions(-)
 
 diff --git a/data/tests/meson.build b/data/tests/meson.build
-index 3eba65eea..cf3931bb7 100644
+index e15cab2fa..bad033dbf 100644
 --- a/data/tests/meson.build
 +++ b/data/tests/meson.build
-@@ -122,7 +122,7 @@ configure_file(
+@@ -139,7 +139,7 @@ configure_file(
    configuration: con2,
    install: true,
    install_tag: 'tests',
@@ -24,7 +24,7 @@ index 3eba65eea..cf3931bb7 100644
  
  if umockdev_integration_tests.allowed()
 diff --git a/meson.build b/meson.build
-index cb66be0cc..ca431980b 100644
+index 7b065f278..1a4b0ea1f 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -239,8 +239,8 @@ else
@@ -38,7 +38,7 @@ index cb66be0cc..ca431980b 100644
    daemon_dir = join_paths(libexecdir, 'fwupd')
  endif
  mandir = join_paths(prefix, get_option('mandir'))
-@@ -721,6 +721,7 @@ gnome = import('gnome')
+@@ -722,6 +722,7 @@ gnome = import('gnome')
  i18n = import('i18n')
  
  conf.set_quoted('FWUPD_PREFIX', prefix)
@@ -47,20 +47,21 @@ index cb66be0cc..ca431980b 100644
  conf.set_quoted('FWUPD_LIBDIR', libdir)
  conf.set_quoted('FWUPD_LIBEXECDIR', libexecdir)
 diff --git a/meson_options.txt b/meson_options.txt
-index 40103c03e..63c8d288d 100644
+index 18991b983..937578f19 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -174,6 +174,10 @@ option('systemd_unit_user',
+@@ -197,6 +197,11 @@ option(
    value: 'fwupd-refresh',
    description: 'User account to use for fwupd-refresh.service (empty for DynamicUser)',
  )
-+option('installed_test_prefix',
++option(
++  'installed_test_prefix',
 +  type: 'string',
-+  description: 'Prefix for installed tests'
++  description: 'Prefix for installed tests',
 +)
- option('tests',
+ option(
+   'tests',
    type: 'boolean',
-   value: true,
 diff --git a/src/tests/host-emulate/meson.build b/src/tests/host-emulate/meson.build
 index c36da65cd..f0b70d4d6 100644
 --- a/src/tests/host-emulate/meson.build

--- a/pkgs/by-name/fw/fwupd/0003-Add-option-for-installation-sysconfdir.patch
+++ b/pkgs/by-name/fw/fwupd/0003-Add-option-for-installation-sysconfdir.patch
@@ -1,8 +1,18 @@
-commit 56507892ff7a03ed283d7fd2d7ff2000fc9c17d7
-Author: r-vdp <ramses@well-founded.dev>
-Date:   Tue Oct 15 11:46:38 2024 +0200
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: r-vdp <ramses@well-founded.dev>
+Date: Tue, 15 Oct 2024 11:46:38 +0200
+Subject: [PATCH] Add option for installation sysconfdir
 
-    Add option for installation sysconfdir
+---
+ data/bios-settings.d/meson.build |  2 +-
+ data/meson.build                 |  2 +-
+ data/pki/meson.build             |  8 ++++----
+ data/remotes.d/meson.build       |  8 ++++----
+ docs/meson.build                 | 16 ++++++++--------
+ meson.build                      |  6 ++++++
+ meson_options.txt                |  5 +++++
+ plugins/uefi-capsule/meson.build |  4 ++--
+ 8 files changed, 31 insertions(+), 20 deletions(-)
 
 diff --git a/data/bios-settings.d/meson.build b/data/bios-settings.d/meson.build
 index 2a2a07016..99df55afb 100644

--- a/pkgs/by-name/fw/fwupd/0003-Add-option-for-installation-sysconfdir.patch
+++ b/pkgs/by-name/fw/fwupd/0003-Add-option-for-installation-sysconfdir.patch
@@ -10,9 +10,9 @@ Subject: [PATCH] Add option for installation sysconfdir
  data/remotes.d/meson.build       |  8 ++++----
  docs/meson.build                 | 16 ++++++++--------
  meson.build                      |  6 ++++++
- meson_options.txt                |  5 +++++
+ meson_options.txt                |  6 ++++++
  plugins/uefi-capsule/meson.build |  4 ++--
- 8 files changed, 31 insertions(+), 20 deletions(-)
+ 8 files changed, 32 insertions(+), 20 deletions(-)
 
 diff --git a/data/bios-settings.d/meson.build b/data/bios-settings.d/meson.build
 index 2a2a07016..99df55afb 100644
@@ -40,7 +40,7 @@ index 5716669f0..78e754f40 100644
    )
    plugin_quirks += files('cfi.quirk', 'ds20.quirk', 'power.quirk', 'vendors.quirk')
 diff --git a/data/pki/meson.build b/data/pki/meson.build
-index 5b962adf1..b6575f7e4 100644
+index 1072051c0..6ef9c9111 100644
 --- a/data/pki/meson.build
 +++ b/data/pki/meson.build
 @@ -12,12 +12,12 @@ if supported_gpg
@@ -60,13 +60,13 @@ index 5b962adf1..b6575f7e4 100644
  
 @@ -25,11 +25,11 @@ if supported_pkcs7
    install_data(
-     ['LVFS-CA.pem'],
+     ['LVFS-CA.pem', 'LVFS-CA-2025PQ.pem'],
      install_tag: 'runtime',
 -    install_dir: join_paths(sysconfdir, 'pki', 'fwupd'),
 +    install_dir: join_paths(sysconfdir_install, 'pki', 'fwupd'),
    )
    install_data(
-     ['LVFS-CA.pem'],
+     ['LVFS-CA.pem', 'LVFS-CA-2025PQ.pem'],
      install_tag: 'runtime',
 -    install_dir: join_paths(sysconfdir, 'pki', 'fwupd-metadata'),
 +    install_dir: join_paths(sysconfdir_install, 'pki', 'fwupd-metadata'),
@@ -176,7 +176,7 @@ index 787b4387c..b3144757f 100644
    )
  endif
 diff --git a/meson.build b/meson.build
-index ca431980b..d9bab5264 100644
+index 1a4b0ea1f..16c7cad40 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -246,6 +246,12 @@ endif
@@ -193,21 +193,22 @@ index ca431980b..d9bab5264 100644
  gio = dependency(
    'gio-2.0',
 diff --git a/meson_options.txt b/meson_options.txt
-index 63c8d288d..04f6651e6 100644
+index 937578f19..08b26b3ad 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -7,6 +7,11 @@ option('bluez',
+@@ -14,6 +14,12 @@ option(
    type: 'feature',
    description: 'BlueZ support',
  )
-+option('sysconfdir_install',
++option(
++  'sysconfdir_install',
 +  type: 'string',
 +  value: '',
-+  description: 'sysconfdir to use during installation'
++  description: 'sysconfdir to use during installation',
 +)
- option('build',
+ option(
+   'build',
    type: 'combo',
-   choices: [
 diff --git a/plugins/uefi-capsule/meson.build b/plugins/uefi-capsule/meson.build
 index 647ace53e..4ee0192df 100644
 --- a/plugins/uefi-capsule/meson.build

--- a/pkgs/by-name/fw/fwupd/0004-Get-the-efi-app-from-fwupd-efi.patch
+++ b/pkgs/by-name/fw/fwupd/0004-Get-the-efi-app-from-fwupd-efi.patch
@@ -1,8 +1,11 @@
-commit f60f2bf6dd4961bdda742f590bf2d7871db6cdab
-Author: r-vdp <ramses@well-founded.dev>
-Date:   Mon Oct 28 12:08:49 2024 +0100
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: r-vdp <ramses@well-founded.dev>
+Date: Mon, 28 Oct 2024 12:08:49 +0100
+Subject: [PATCH] Get the efi app from fwupd-efi
 
-    Get the efi app from fwupd-efi
+---
+ meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/meson.build b/meson.build
 index d9bab5264..ee91d34b0 100644

--- a/pkgs/by-name/fw/fwupd/0004-Get-the-efi-app-from-fwupd-efi.patch
+++ b/pkgs/by-name/fw/fwupd/0004-Get-the-efi-app-from-fwupd-efi.patch
@@ -8,10 +8,10 @@ Subject: [PATCH] Get the efi app from fwupd-efi
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/meson.build b/meson.build
-index d9bab5264..ee91d34b0 100644
+index 16c7cad40..81804bf3b 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -650,7 +650,7 @@ endif
+@@ -657,7 +657,7 @@ endif
  
  # EFI
  if build_standalone

--- a/pkgs/by-name/fw/fwupd/package.nix
+++ b/pkgs/by-name/fw/fwupd/package.nix
@@ -158,21 +158,21 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     # Install plug-ins and libfwupdplugin to $out output,
     # they are not really part of the library.
-    ./install-fwupdplugin-to-out.patch
+    ./0001-Install-fwupdplugin-to-out.patch
 
     # Installed tests are installed to different output
     # we also cannot have fwupd-tests.conf in $out/etc since it would form a cycle.
-    ./installed-tests-path.patch
+    ./0002-Add-output-for-installed-tests.patch
 
     # Since /etc is the domain of NixOS, not Nix,
     # we cannot install files there.
     # Let’s install the files to $prefix/etc
     # while still reading them from /etc.
     # NixOS module for fwupd will take take care of copying the files appropriately.
-    ./add-option-for-installation-sysconfdir.patch
+    ./0003-Add-option-for-installation-sysconfdir.patch
 
     # EFI capsule is located in fwupd-efi now.
-    ./efi-app-path.patch
+    ./0004-Get-the-efi-app-from-fwupd-efi.patch
   ];
 
   postPatch = ''

--- a/pkgs/by-name/fw/fwupd/package.nix
+++ b/pkgs/by-name/fw/fwupd/package.nix
@@ -3,6 +3,7 @@
 {
   lib,
   stdenv,
+  fetchpatch,
 
   # runPythonCommand
   runCommand,
@@ -134,7 +135,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "fwupd";
-  version = "2.0.16";
+  version = "2.0.17";
 
   # libfwupd goes to lib
   # daemon, plug-ins and libfwupdplugin go to out
@@ -152,7 +153,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "fwupd";
     repo = "fwupd";
     tag = finalAttrs.version;
-    hash = "sha256-fsjW3Idaqg4pNGaRP0bm2R94FcW2MVfPQwPFWrN+Qy8=";
+    hash = "sha256-PhG30TKwOqOCMI3e1D9cbNN6hKiVVyrzi9vG+CG5bY0=";
   };
 
   patches = [
@@ -173,6 +174,12 @@ stdenv.mkDerivation (finalAttrs: {
 
     # EFI capsule is located in fwupd-efi now.
     ./0004-Get-the-efi-app-from-fwupd-efi.patch
+
+    # TODO: drop after 2.0.17
+    (fetchpatch {
+      url = "https://github.com/fwupd/fwupd/commit/7ded10f22875da9b0f5f21cb41f8663049da6311.patch";
+      hash = "sha256-rEoSwcTmxJGX2ZdWAjDvsvgnP2qZp3ErnJVCIQlplhQ=";
+    })
   ];
 
   postPatch = ''
@@ -360,9 +367,11 @@ stdenv.mkDerivation (finalAttrs: {
       "fwupd/remotes.d/vendor-directory.conf"
       "pki/fwupd/GPG-KEY-Linux-Foundation-Firmware"
       "pki/fwupd/GPG-KEY-Linux-Vendor-Firmware-Service"
+      "pki/fwupd/LVFS-CA-2025PQ.pem"
       "pki/fwupd/LVFS-CA.pem"
       "pki/fwupd-metadata/GPG-KEY-Linux-Foundation-Metadata"
       "pki/fwupd-metadata/GPG-KEY-Linux-Vendor-Firmware-Service"
+      "pki/fwupd-metadata/LVFS-CA-2025PQ.pem"
       "pki/fwupd-metadata/LVFS-CA.pem"
       "grub.d/35_fwupd"
     ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
