### PR TITLE
kitty: exclude more tests on darwin to allow building

### DIFF
--- a/pkgs/by-name/ki/kitty/package.nix
+++ b/pkgs/by-name/ki/kitty/package.nix
@@ -218,9 +218,13 @@ buildPythonApplication rec {
 
     substituteInPlace kitty_tests/ssh.py \
       --replace test_ssh_connection_data no_test_ssh_connection_data \
+      --replace test_ssh_shell_integration no_test_ssh_shell_integration \
+      --replace test_ssh_copy no_test_ssh_copy \
+      --replace test_ssh_env_vars no_test_ssh_env_vars
 
     substituteInPlace kitty_tests/shell_integration.py \
-      --replace test_fish_integration no_test_fish_integration
+      --replace test_fish_integration no_test_fish_integration \
+      --replace test_zsh_integration no_test_zsh_integration
 
     substituteInPlace kitty_tests/fonts.py \
       --replace test_fallback_font_not_last_resort no_test_fallback_font_not_last_resort
@@ -236,7 +240,6 @@ buildPythonApplication rec {
 
     # Fontconfig error: Cannot load default config file: No such file: (null)
     export FONTCONFIG_FILE=${fontconfig.out}/etc/fonts/fonts.conf
-
     # Required for `test_ssh_shell_integration` to pass.
     export TERM=kitty
 


### PR DESCRIPTION

There are some new tests of kitty that break in the darwin sandbox, and that blocks it from building there. So, I'm adding them to the list of exclusions, but I don't own a mac so I can't test if that works :crossed_fingers:

#448279 


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
