### PR TITLE
uclibc-ng: improve detection of FPU, endianess and ABI

### DIFF
--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -440,6 +440,11 @@ rec {
     isPE = {
       kernel.execFormat = execFormats.pe;
     };
+
+    isEabi = {
+      abi.eabi = true;
+    };
+
   };
 
   # given two patterns, return a pattern which is their logical AND.

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -662,15 +662,19 @@ rec {
     # On ARM, this corresponds to ARMEABI.
     eabi = {
       float = "soft";
+      eabi = true;
     };
     eabihf = {
       float = "hard";
+      eabi = true;
     };
 
     # Other architectures should use ELF in embedded situations.
     elf = { };
 
-    androideabi = { };
+    androideabi = {
+      eabi = true;
+    };
     android = {
       assertions = [
         {
@@ -684,9 +688,11 @@ rec {
 
     gnueabi = {
       float = "soft";
+      eabi = true;
     };
     gnueabihf = {
       float = "hard";
+      eabi = true;
     };
     gnu = {
       assertions = [
@@ -730,17 +736,21 @@ rec {
 
     musleabi = {
       float = "soft";
+      eabi = true;
     };
     musleabihf = {
       float = "hard";
+      eabi = true;
     };
     musl = { };
 
     uclibceabi = {
       float = "soft";
+      eabi = true;
     };
     uclibceabihf = {
       float = "hard";
+      eabi = true;
     };
     uclibc = { };
 

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1114,6 +1114,13 @@
     githubId = 82811;
     name = "Aldo Borrero";
   };
+  aleclearmind = {
+    email = "ale.nix@clearmind.me";
+    matrix = "@bake.monorail:matrix.org";
+    github = "aleclearmind";
+    githubId = 2545644;
+    name = "Alessandro Di Federico";
+  };
   alejandrosame = {
     email = "alejandrosanchzmedina@gmail.com";
     matrix = "@alejandrosame:matrix.org";

--- a/pkgs/by-name/uc/uclibc-ng/package.nix
+++ b/pkgs/by-name/uc/uclibc-ng/package.nix
@@ -57,7 +57,6 @@ let
     ARCH_BIG_ENDIAN n
     ARCH_WANTS_LITTLE_ENDIAN y
     ARCH_LITTLE_ENDIAN y
-    UCLIBC_HAS_FPU n
   '';
 in
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/by-name/uc/uclibc-ng/package.nix
+++ b/pkgs/by-name/uc/uclibc-ng/package.nix
@@ -26,16 +26,15 @@ let
             echo "parseconfig: removing $NAME"
             sed -i /^$NAME=/d .config
 
-            #if test "$OPTION" != n; then
-                echo "parseconfig: setting $NAME=$OPTION"
-                echo "$NAME=$OPTION" >> .config
-            #fi
+            echo "parseconfig: setting $NAME=$OPTION"
+            echo "$NAME=$OPTION" >> .config
         done
         set +x
     }
   '';
 
   # UCLIBC_SUSV4_LEGACY defines 'tmpnam', needed for gcc libstdc++ builds.
+  # 'ftw' needed to build acl, a coreutils dependency
   nixConfig = ''
     RUNTIME_PREFIX "/"
     DEVEL_PREFIX "/"
@@ -70,7 +69,6 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-X386r92yygj7KVvkVWHAGIQHED10Rs/SZLm4Iv7T7S0=";
   };
 
-  # 'ftw' needed to build acl, a coreutils dependency
   configurePhase = ''
     make defconfig
     ${configParser}

--- a/pkgs/by-name/uc/uclibc-ng/package.nix
+++ b/pkgs/by-name/uc/uclibc-ng/package.nix
@@ -142,7 +142,7 @@ stdenv.mkDerivation (finalAttrs: {
       experimental and need more testing.
     '';
     license = lib.licenses.lgpl2Plus;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ aleclearmind ];
     platforms = lib.platforms.linux;
     badPlatforms = lib.platforms.aarch64;
   };

--- a/pkgs/by-name/uc/uclibc-ng/package.nix
+++ b/pkgs/by-name/uc/uclibc-ng/package.nix
@@ -90,7 +90,7 @@ stdenv.mkDerivation (finalAttrs: {
   makeFlags = [
     "ARCH=${stdenv.hostPlatform.linuxArch}"
     "TARGET_ARCH=${stdenv.hostPlatform.linuxArch}"
-    "VERBOSE=1"
+    "V=1"
   ]
   ++ lib.optionals isCross [
     "CROSS=${stdenv.cc.targetPrefix}"

--- a/pkgs/by-name/uc/uclibc-ng/package.nix
+++ b/pkgs/by-name/uc/uclibc-ng/package.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   configurePhase = ''
-    make defconfig
+    make defconfig ARCH=${stdenv.hostPlatform.linuxArch}
     ${configParser}
     cat << EOF | parseconfig
     ${nixConfig}

--- a/pkgs/by-name/uc/uclibc-ng/package.nix
+++ b/pkgs/by-name/uc/uclibc-ng/package.nix
@@ -51,7 +51,7 @@ let
   + lib.optionalString (stdenv.hostPlatform.gcc.float or "" == "soft") ''
     UCLIBC_HAS_FPU n
   ''
-  + lib.optionalString (stdenv.hostPlatform.isAarch32 && isCross) ''
+  + lib.optionalString stdenv.hostPlatform.isAarch32 ''
     CONFIG_ARM_EABI y
     ARCH_WANTS_BIG_ENDIAN n
     ARCH_BIG_ENDIAN n

--- a/pkgs/by-name/uc/uclibc-ng/package.nix
+++ b/pkgs/by-name/uc/uclibc-ng/package.nix
@@ -51,8 +51,10 @@ let
   + lib.optionalString (stdenv.hostPlatform.gcc.float or "" == "soft") ''
     UCLIBC_HAS_FPU n
   ''
-  + lib.optionalString stdenv.hostPlatform.isAarch32 ''
+  + lib.optionalString stdenv.hostPlatform.isEabi ''
     CONFIG_ARM_EABI y
+  ''
+  + lib.optionalString stdenv.hostPlatform.isAarch32 ''
     ARCH_WANTS_BIG_ENDIAN n
     ARCH_BIG_ENDIAN n
     ARCH_WANTS_LITTLE_ENDIAN y

--- a/pkgs/by-name/uc/uclibc-ng/package.nix
+++ b/pkgs/by-name/uc/uclibc-ng/package.nix
@@ -54,11 +54,17 @@ let
   + lib.optionalString stdenv.hostPlatform.isEabi ''
     CONFIG_ARM_EABI y
   ''
-  + lib.optionalString stdenv.hostPlatform.isAarch32 ''
+  + lib.optionalString stdenv.hostPlatform.isLittleEndian ''
     ARCH_WANTS_BIG_ENDIAN n
     ARCH_BIG_ENDIAN n
     ARCH_WANTS_LITTLE_ENDIAN y
     ARCH_LITTLE_ENDIAN y
+  ''
+  + lib.optionalString stdenv.hostPlatform.isBigEndian ''
+    ARCH_WANTS_BIG_ENDIAN y
+    ARCH_BIG_ENDIAN y
+    ARCH_WANTS_LITTLE_ENDIAN n
+    ARCH_LITTLE_ENDIAN n
   '';
 in
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6993,7 +6993,7 @@ with pkgs;
     else if libc == "bionic" then
       bionic
     else if libc == "uclibc" then
-      uclibc
+      uclibc-ng
     else if libc == "avrlibc" then
       avrlibc
     else if libc == "newlib" && stdenv.hostPlatform.isMsp430 then


### PR DESCRIPTION
This branch improves the support for building toolchains using `uclibc-ng`.

Currently, uclibc-ng seems to have harcoded support for certain configurations, in particular for ARM.

This branch makes the package more generic and automatically configures uclibc-ng in terms of endianess, availability of an FPU and ABI of choice.

The branch also correctly initializes the configuration by specifying the target architecture upon `make defconfig`.

The last commit reports a simple script to test certain toolchains for MIPS and ARM.

Note: this is my first PR, any feedback is highly appreciated.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
