### PR TITLE
python3Packages.torchcrepe: cleanup, add missing torchcodec dependency

### DIFF
--- a/pkgs/development/python-modules/torchcrepe/default.nix
+++ b/pkgs/development/python-modules/torchcrepe/default.nix
@@ -2,24 +2,26 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
   librosa,
-  pytestCheckHook,
-  pythonOlder,
   resampy,
   scipy,
-  setuptools,
   torch,
   torchaudio,
   tqdm,
+
+  # tests
+  pytestCheckHook,
 }:
 
 buildPythonPackage {
   pname = "torchcrepe";
   version = "0.0.24";
   pyproject = true;
-  build-system = [ setuptools ];
-
-  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "maxrmorrison";
@@ -28,6 +30,8 @@ buildPythonPackage {
     rev = "19e2ec3d494c0797a5ff2a11408ec5838fba6681";
     hash = "sha256-w2T8D3ATCHVBCBhMdLSYdV0yb9vUYwZLz+B2X2gteEU=";
   };
+
+  build-system = [ setuptools ];
 
   dependencies = [
     librosa

--- a/pkgs/development/python-modules/torchcrepe/default.nix
+++ b/pkgs/development/python-modules/torchcrepe/default.nix
@@ -12,6 +12,7 @@
   scipy,
   torch,
   torchaudio,
+  torchcodec,
   tqdm,
 
   # tests
@@ -39,6 +40,7 @@ buildPythonPackage {
     scipy
     torch
     torchaudio
+    torchcodec
     tqdm
   ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **python3Packages.torchcrepe: cleanup**
- **python3Packages.torchcrepe: add missing torchcodec dependency**

cc @DerDennisOP

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
