### PR TITLE
{lima,colima}: use pkill from nixpkgs on non-darwin

### DIFF
--- a/pkgs/by-name/co/colima/package.nix
+++ b/pkgs/by-name/co/colima/package.nix
@@ -7,6 +7,7 @@
   installShellFiles,
   lima,
   makeWrapper,
+  procps,
   qemu,
   testers,
   colima,
@@ -42,6 +43,14 @@ buildGoModule rec {
   excludedPackages = "gvproxy";
 
   env.CGO_ENABLED = 1;
+
+  postPatch = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
+    substituteInPlace cmd/daemon/daemon.go \
+      --replace-fail '/usr/bin/pkill' '${lib.getExe' procps "pkill"}'
+
+    substituteInPlace daemon/process/vmnet/vmnet.go \
+      --replace-fail '/usr/bin/pkill' '${lib.getExe' procps "pkill"}'
+  '';
 
   preConfigure = ''
     ldflags="-s -w -X github.com/abiosoft/colima/config.appVersion=${version} \

--- a/pkgs/by-name/li/lima/package.nix
+++ b/pkgs/by-name/li/lima/package.nix
@@ -4,6 +4,7 @@
   buildGoModule,
   callPackage,
   installShellFiles,
+  procps,
   qemu,
   darwin,
   makeWrapper,
@@ -40,6 +41,11 @@ buildGoModule (finalAttrs: {
     substituteInPlace Makefile \
       --replace-fail 'codesign -f -v --entitlements vz.entitlements -s -' 'codesign -f --entitlements vz.entitlements -s -' \
       --replace-fail 'rm -rf _output vendor' 'rm -rf _output'
+  ''
+  # fixed upstream, remove when version >=2.0.0
+  + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
+    substituteInPlace pkg/networks/usernet/recoincile.go \
+      --replace-fail '/usr/bin/pkill' '${lib.getExe' procps "pkill"}'
   '';
 
   # It attaches entitlements with codesign and strip removes those,


### PR DESCRIPTION
`lima` and `colima` have hardcoded `/usr/bin/pkill` paths that cause 
```
colima stop
INFO[0000] stopping colima                              
INFO[0000] stopping ...                                  context=docker
INFO[0000] stopping ...                                  context=vm
> [hostagent] Shutting down QEMU with the power button
> [hostagent] Sending QMP system_powerdown command
> [hostagent] QEMU has exited
> Waiting for the instance to shut down
> The instance colima has shut down
> failed to stop usernet "user-v2": failed to run [/usr/bin/pkill -F /home/mhelton/.config/colima/_lima/_networks/user-v2/usernet_user-v2.pid]: stdout="", stderr="": fork/exec /usr/bin/pkill: no such file or directory
FATA[0002] error stopping vm: error at 'stopping': exit status 1 
error: Recipe `down` failed on line 28 with exit code 1
```
when running `colima stop` on NixOS (or any system without `/usr/bin/pkill`).

This PR patches those paths to use `pkill` from nixpkgs.

On macOS `/usr/bin/pkill` is available, and `procps` on darwin doesn't contain `pkill`, so only making the change for non-darwin systems.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
