### PR TITLE
freecad: improve FEM mesher logic

### DIFF
--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -33,21 +33,22 @@
   orocos-kdl,
 }:
 let
-  pythonDeps = with python3Packages; [
+  pythonCoreDeps = with python3Packages; [
     boost
     gitpython # for addon manager
-    ifcopenshell
-    matplotlib
-    opencamlib
-    pivy
-    ply # for openSCAD file support
-    pybind11
-    pycollada
-    pyside6
+    ifcopenshell # BIM
+    matplotlib # detected by cmake, used for BIM
+    netgen-mesher # netgen FEM plugin for meshing
+    opencamlib # CAM
+    pivy # coin bindings
+    ply # openSCAD file format support
+    pybind11 # qt bindings
+    pycollada # collada file format support (BIM)
+    pyside6 # qt bindings
     python
-    pyyaml # (at least for) PyrateWorkbench
-    scipy
-    shiboken6
+    pyyaml # PyrateWorkbench, CAM
+    scipy # BIM
+    shiboken6 # qt bindings
     vtk
   ];
 
@@ -104,7 +105,7 @@ freecad-utils.makeCustomizable (
       qt6.qtwayland
       qt6.qtwebengine
     ]
-    ++ pythonDeps;
+    ++ pythonCoreDeps;
 
     patches = [
       ./0001-NIXOS-don-t-ignore-PYTHONPATH.patch
@@ -162,7 +163,7 @@ freecad-utils.makeCustomizable (
     qtWrapperArgs = [
       "--set COIN_GL_NO_CURRENT_CONTEXT_CHECK 1"
       "--prefix PATH : ${lib.makeBinPath externalTools}"
-      "--prefix PYTHONPATH : ${python3Packages.makePythonPath pythonDeps}"
+      "--prefix PYTHONPATH : ${python3Packages.makePythonPath pythonCoreDeps}"
     ];
 
     postFixup = ''

--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -51,6 +51,12 @@ let
     vtk
   ];
 
+  externalTools = [
+    libredwg
+    gmsh # gmsh FEM plugin for meshing
+    which # for locating tools
+  ];
+
   freecad-utils = callPackage ./freecad-utils.nix { inherit (python3Packages) python; };
 in
 freecad-utils.makeCustomizable (
@@ -116,12 +122,31 @@ freecad-utils.makeCustomizable (
         url = "https://github.com/FreeCAD/FreeCAD/commit/60aa5ff3730d77037ffad0c77ba96b99ef0c7df3.patch?full_index=1";
         hash = "sha256-K6PWQ1U+/fsjDuir7MiAKq71CAIHar3nKkO6TKYl32k=";
       })
+      # required for gmsh path patch to apply, preference entry to set Gmsh log verbosity
+      (fetchpatch {
+        url = "https://github.com/FreeCAD/FreeCAD/commit/be8dfbfc7e4435faf84c20d641ba67330e35cdab.patch?full_index=1";
+        hash = "sha256-ERRrIaARL8xC8j5dhQ6Dvvs1tysHyvFEcLUNG0BAZzQ=";
+      })
+      # required for gmsh patch to apply, preference entry to set Gmsh number of threads
+      (fetchpatch {
+        url = "https://github.com/FreeCAD/FreeCAD/commit/ad414a1878634c82a773ec6a9f95a29f2914b625.patch?full_index=1";
+        hash = "sha256-cEgG1c6VqEiklEHIQQ2FF2aTb9d9OwII+6K8PQK6O/o=";
+      })
+      # required for gmsh path patch to apply, updates some UI strings
+      (fetchpatch {
+        url = "https://github.com/FreeCAD/FreeCAD/commit/dd702da1bc014ca8282d8da2ea24674ff8120b59.patch?full_index=1";
+        hash = "sha256-pnutlGBoUpws5kfjcOgUJ6Lty5LatPkl2qeSOgpShfE=";
+        includes = [
+          "src/Mod/Fem/Gui/DlgSettingsFemGmsh.ui"
+          "src/Mod/Fem/Gui/DlgSettingsFemGmshImp.cpp"
+        ];
+      })
+      # allow loading gmsh from PATH
+      (fetchpatch {
+        url = "https://github.com/FreeCAD/FreeCAD/commit/8a7314631131339d58d3b00626875969a5298bd2.patch?full_index=1";
+        hash = "sha256-RWZ3ndED2OSvUcfwCUO19Q73OOLSy7U0mridKfJx1RI=";
+      })
     ];
-
-    postPatch = ''
-      substituteInPlace src/Mod/Fem/femmesh/gmshtools.py \
-        --replace-fail 'self.gmsh_bin = "gmsh"' 'self.gmsh_bin = "${lib.getExe gmsh}"'
-    '';
 
     cmakeFlags = [
       "-Wno-dev" # turns off warnings which otherwise makes it hard to see what is going on
@@ -134,18 +159,11 @@ freecad-utils.makeCustomizable (
       "-DREECAD_USE_EXTERNAL_KDL=ON"
     ];
 
-    qtWrapperArgs =
-      let
-        binPath = lib.makeBinPath [
-          libredwg
-          which # for locating tools
-        ];
-      in
-      [
-        "--set COIN_GL_NO_CURRENT_CONTEXT_CHECK 1"
-        "--prefix PATH : ${binPath}"
-        "--prefix PYTHONPATH : ${python3Packages.makePythonPath pythonDeps}"
-      ];
+    qtWrapperArgs = [
+      "--set COIN_GL_NO_CURRENT_CONTEXT_CHECK 1"
+      "--prefix PATH : ${lib.makeBinPath externalTools}"
+      "--prefix PYTHONPATH : ${python3Packages.makePythonPath pythonDeps}"
+    ];
 
     postFixup = ''
       mv $out/share/doc $out

--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -164,6 +164,11 @@ freecad-utils.makeCustomizable (
       "--set COIN_GL_NO_CURRENT_CONTEXT_CHECK 1"
       "--prefix PATH : ${lib.makeBinPath externalTools}"
       "--prefix PYTHONPATH : ${python3Packages.makePythonPath pythonCoreDeps}"
+
+      # use new python netgen bindings instead of shelling to binary
+      "--add-flag '--set-config'"
+      "--add-flag UseLegacyNetgen"
+      "--add-flag 0"
     ];
 
     postFixup = ''

--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -30,6 +30,7 @@
   nix-update-script,
   gmsh,
   which,
+  orocos-kdl,
 }:
 let
   pythonDeps = with python3Packages; [
@@ -90,6 +91,7 @@ freecad-utils.makeCustomizable (
       zlib
       opencascade-occt
       microsoft-gsl
+      orocos-kdl
       qt6.qtbase
       qt6.qtsvg
       qt6.qttools
@@ -129,6 +131,7 @@ freecad-utils.makeCustomizable (
       "-DFREECAD_USE_PYBIND11=ON"
       "-DBUILD_QT5=OFF"
       "-DBUILD_QT6=ON"
+      "-DREECAD_USE_EXTERNAL_KDL=ON"
     ];
 
     qtWrapperArgs =


### PR DESCRIPTION
needs a bit more testing, but should be an improvement.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
