### PR TITLE
http-nu: init at 0.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4337,6 +4337,12 @@
     githubId = 3471749;
     name = "Claudio Bley";
   };
+  cboecking = {
+    email = "chuck@chuboe.com";
+    github = "cboecking";
+    githubId = 16024854;
+    name = "Chuck Boecking";
+  };
   cbrewster = {
     email = "cbrewster@hey.com";
     github = "cbrewster";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4031,6 +4031,12 @@
       { fingerprint = "1EBC648C64D6045463013B3EB7EFFC271D55DB8A"; }
     ];
   };
+  cablehead = {
+    email = "andy@thecablelounge.com";
+    github = "cablehead";
+    githubId = 1394;
+    name = "Andy Gayton";
+  };
   CactiChameleon9 = {
     email = "h19xjkkp@duck.com";
     github = "CactiChameleon9";

--- a/pkgs/by-name/ht/http-nu/package.nix
+++ b/pkgs/by-name/ht/http-nu/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  stdenvNoCC,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "http-nu";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "cablehead";
+    repo = "http-nu";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Ri0/HnTINXGrdzh26uT+JD32sbKLnbzq8ps2+LUbbI8=";
+  };
+
+  cargoHash = "sha256-C4VYE6dLHwYaJ9LI4A+R1AvK3Qu8lV2ISy+8ymFKQg8=";
+
+  nativeBuildInputs = lib.optionals stdenvNoCC.hostPlatform.isDarwin [
+    rustPlatform.bindgenHook
+  ];
+
+  # Most tests require sandbox-incompatible operations:
+  # - Integration tests (server_test, server_missing_host) require network and curl binary
+  # - test_handler requires temporary filesystem writes
+  # - Only test_engine could run in sandbox, but selective enablement adds maintenance burden
+  doCheck = false;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Serve a Nushell closure over HTTP";
+    longDescription = ''
+      http-nu is a tool that allows you to serve Nushell closures over HTTP,
+      making it easy to create web services using Nushell's powerful scripting
+      capabilities.
+    '';
+    homepage = "https://github.com/cablehead/http-nu";
+    changelog = "https://github.com/cablehead/http-nu/blob/v${finalAttrs.version}/changes/v${finalAttrs.version}.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      cablehead
+      cboecking
+    ];
+    mainProgram = "http-nu";
+  };
+})


### PR DESCRIPTION
## Description

Adds http-nu, a tool to serve Nushell closures over HTTP.

## Testing

- [x] Built on x86_64-linux
- [x] Tested `http-nu --version` (returns: http-nu 0.5.0)
- [x] Tested `http-nu --help` (displays usage information)
- [x] Binary executes successfully

## Notes

- Tests are disabled (`doCheck = false`) as they fail in the Nix sandbox due to file system and network access requirements
- This is a new package with no reverse dependencies
- Upstream project: https://github.com/cablehead/http-nu
- License: MIT