### PR TITLE
python3Packages.tree-sitter-zeek: 0.2.9 -> 0.2.11; zeekscript: 1.3.2-unstable-2025-09-29 -> 1.3.2-unstable-2025-11-10

### DIFF
--- a/pkgs/by-name/ze/zeekscript/package.nix
+++ b/pkgs/by-name/ze/zeekscript/package.nix
@@ -7,14 +7,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "zeekscript";
-  version = "1.3.2-unstable-2025-09-29";
+  version = "1.3.2-unstable-2025-11-10";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "zeek";
     repo = "zeekscript";
-    rev = "f0fa5746633a709759a94695fcc81b43feb8e2d9";
-    hash = "sha256-g4Iv9xw6Owuqi+UudRzWatK09mjNDWdp0cBvH7iuV+U=";
+    rev = "7f3d41b495cc87ee0db5cc90ccd0f5c9a23487df";
+    hash = "sha256-IpoDSLPDF2p/Yuijb3xtvs1zivtYrKny/pY5dRL56QA=";
   };
 
   build-system = with python3.pkgs; [ setuptools ];

--- a/pkgs/by-name/ze/zeekscript/package.nix
+++ b/pkgs/by-name/ze/zeekscript/package.nix
@@ -2,6 +2,7 @@
   lib,
   python3,
   fetchFromGitHub,
+  unstableGitUpdater,
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -34,6 +35,8 @@ python3.pkgs.buildPythonApplication rec {
   pythonImportsCheck = [
     "zeekscript"
   ];
+
+  passthru.updateScript = unstableGitUpdater { tagPrefix = "v"; };
 
   meta = {
     description = "Zeek script formatter and analyzer";

--- a/pkgs/development/python-modules/tree-sitter-zeek/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-zeek/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "tree-sitter-zeek";
-  version = "0.2.9";
+  version = "0.2.11";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "zeek";
     repo = "tree-sitter-zeek";
     tag = "v${version}";
-    hash = "sha256-0ixZAJ940mYIPD//RJVJ3PAVdY/jtYNJ5+WIlq+zfnY=";
+    hash = "sha256-8ki1FRE1HSaG0180UWgEZxlmbOORvo3QlpLb9rMdmIQ=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
- **python3Packages.tree-sitter-zeek: 0.2.9 -> 0.2.11**
    Diff: https://github.com/zeek/tree-sitter-zeek/compare/v0.2.9...v0.2.11
- **zeekscript: set updateScript**
    Upstream doesn't seem to be tagging releases anymore.
- **zeekscript: 1.3.2-unstable-2025-09-29 -> 1.3.2-unstable-2025-11-10**
    Changelog: https://github.com/zeek/zeekscript/blob/02d6428b08e3f2453f2ee75ffe40f76fff365498/CHANGES
    Diff: https://github.com/zeek/tree-sitter-zeek/compare/f0fa5746633a709759a94695fcc81b43feb8e2d9...02d6428b08e3f2453f2ee75ffe40f76fff365498

* Closes: #458921
* Closes: #457796

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
