### PR TITLE
Update LXQt to version 2.3.0

### DIFF
--- a/pkgs/desktops/lxqt/libfm-qt/default.nix
+++ b/pkgs/desktops/lxqt/libfm-qt/default.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   libXdmcp,
   libexif,
@@ -16,7 +15,7 @@
   qttools,
   wrapQtAppsHook,
   gitUpdater,
-  version ? "2.2.0",
+  version ? "2.3.0",
   qtx11extras ? null,
 }:
 
@@ -31,20 +30,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash =
       {
         "1.4.0" = "sha256-QxPYSA7537K+/dRTxIYyg+Q/kj75rZOdzlUsmSdQcn4=";
-        "2.2.0" = "sha256-xLXHwrcMJ8PObZ2qWVZTf9FREcjUi5qtcCJgNHj391Q=";
+        "2.3.0" = "sha256-A0kBwLiPvHIsJWQvg6lwb5lrojU8oDDQYHuC2pTXdPc=";
       }
       ."${finalAttrs.version}";
   };
-
-  patches = lib.optionals (finalAttrs.version == "2.2.0") [
-    # fix build against Qt >= 6.10 (https://github.com/lxqt/libfm-qt/pull/1060)
-    # TODO: drop when upgrading beyond version 2.2.0
-    (fetchpatch {
-      name = "cmake-fix-build-with-Qt-6.10.patch";
-      url = "https://github.com/lxqt/libfm-qt/commit/3bcbae5831f5ce3d2f06dc370f0c2ad0026ae82a.patch";
-      hash = "sha256-nTuPXlkP7AzC8R4OHfQx6/kxPsDjaw7tGzQGyiYqQSQ=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/desktops/lxqt/liblxqt/default.nix
+++ b/pkgs/desktops/lxqt/liblxqt/default.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "liblxqt";
-  version = "2.2.0";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "liblxqt";
     rev = version;
-    hash = "sha256-04t6wssTuSKlqSuUTmcDU66NVGikWh7p2irWBngN494=";
+    hash = "sha256-KAteTQRJ7xfh21tYcNoZjvLfWSiUYboasqL5D4YKARo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/libqtxdg/default.nix
+++ b/pkgs/desktops/lxqt/libqtxdg/default.nix
@@ -2,14 +2,13 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   qtbase,
   qtsvg,
   lxqt-build-tools,
   wrapQtAppsHook,
   gitUpdater,
-  version ? "4.2.0",
+  version ? "4.3.0",
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -23,20 +22,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash =
       {
         "3.12.0" = "sha256-y+3noaHubZnwUUs8vbMVvZPk+6Fhv37QXUb//reedCU=";
-        "4.2.0" = "sha256-TSyVYlWsmB/6gxJo+CjROBQaWsmYZAwkM8BwiWP+XBI=";
+        "4.3.0" = "sha256-aec+NjKkaH8dI0cFVxGehdRGO2aH6BD+aix+IvD+2LI=";
       }
       ."${finalAttrs.version}";
   };
-
-  patches = lib.optionals (finalAttrs.version == "4.2.0") [
-    # fix build against Qt >= 6.10 (https://github.com/lxqt/libqtxdg/pull/313)
-    # TODO: drop when upgrading beyond version 4.2.0
-    (fetchpatch {
-      name = "cmake-fix-build-with-Qt-6.10.patch";
-      url = "https://github.com/lxqt/libqtxdg/commit/b01a024921acdfd5b0e97d5fda2933c726826e99.patch";
-      hash = "sha256-njpn6pU9BHlfYfkw/jEwh8w3Wo1F8MlRU8iQB+Tz2zU=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/desktops/lxqt/lximage-qt/default.nix
+++ b/pkgs/desktops/lxqt/lximage-qt/default.nix
@@ -21,13 +21,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lximage-qt";
-  version = "2.2.0";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "lximage-qt";
     rev = version;
-    hash = "sha256-4j/5z+kePFXubYXAbIaWYVU+plJv1xEpHHI1IXqbQog=";
+    hash = "sha256-RJKXcaZJe5gyDubdglOmzmJ9XCH0gAW4fc7OR3anCoU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/lxqt-about/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-about/default.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lxqt-about";
-  version = "2.2.0";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "lxqt-about";
     rev = version;
-    hash = "sha256-StPepm6XWaK1kDAspnBJ4X1/QGqHmSj48RBobJ46Sao=";
+    hash = "sha256-EP0Sd/VvLufqtn/7ZQwdI/h+BJhkGks7jTlEoEqYWgk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/lxqt-admin/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-admin/default.nix
@@ -18,13 +18,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lxqt-admin";
-  version = "2.2.0";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "lxqt-admin";
     rev = version;
-    hash = "sha256-Yne4EWP/bgWXa4XNP8oyUtkOfxBRcT4iuV8CpSq2ooY=";
+    hash = "sha256-FzYKmqCd61jLfbyPknsWuf7KpdF+SoAMqeSEZPOYc8w=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/lxqt-archiver/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-archiver/default.nix
@@ -18,13 +18,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lxqt-archiver";
-  version = "1.2.0";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "lxqt-archiver";
     rev = version;
-    hash = "sha256-4xGP/3ft29PFzJ3ty/9wJbv/hqcdTw9U+4xDneKHF8g=";
+    hash = "sha256-57ufvirD1YYEVoFtX/JY8EnMRWZ4ouhbxNm8przg5XA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/lxqt-build-tools/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-build-tools/default.nix
@@ -9,7 +9,7 @@
   perl,
   wrapQtAppsHook,
   gitUpdater,
-  version ? "2.2.1",
+  version ? "2.3.0",
 }:
 
 stdenv.mkDerivation rec {
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     hash =
       {
         "0.13.0" = "sha256-4/hVlEdqqqd6CNitCRkIzsS1R941vPJdirIklp4acXA=";
-        "2.2.1" = "sha256-dewsmkma8QHgb3LzRGvfntI48bOaFFsrEDrOznaC8eg=";
+        "2.3.0" = "sha256-lbDcIOrOkGU/n0bPPAlZSsdBYMlBh3afXwwTkTWQLpo=";
       }
       ."${version}";
   };
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     substituteInPlace cmake/modules/LXQtCompilerSettings.cmake \
       --replace-fail AppleClang Clang
   ''
-  + lib.optionalString (lib.versionOlder version "2.2.1") ''
+  + lib.optionalString (lib.versionOlder version "2.3.0") ''
     substituteInPlace CMakeLists.txt \
       --replace-fail "cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)" "cmake_minimum_required(VERSION 3.10)"
   '';

--- a/pkgs/desktops/lxqt/lxqt-config/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-config/default.nix
@@ -28,13 +28,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lxqt-config";
-  version = "2.2.0";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "lxqt-config";
     rev = version;
-    hash = "sha256-iyAqdAWcg94a65lPjq412slvSKdP3W62LTyyvYdWipA=";
+    hash = "sha256-2CAQeX2X0DPmgOaAEJoCLtgjFT+Z6epc/dUCbaEIlB0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/lxqt-globalkeys/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-globalkeys/default.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lxqt-globalkeys";
-  version = "2.2.0";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "lxqt-globalkeys";
     rev = version;
-    hash = "sha256-xVirPi0UD4lzOA1+Gw7SgUvFRIc1KYFUJtljNA7xAWo=";
+    hash = "sha256-ahRKkWmr6BkSByE5Vm5oqkkgQQ0Hyh4Ka7PYI8Es7AY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/lxqt-menu-data/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-menu-data/default.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lxqt-menu-data";
-  version = "2.2.0";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "lxqt-menu-data";
     rev = version;
-    hash = "sha256-kFgrR7BSl08REC9SgBvLYFhJ9H++FCDQdqQaoAm5Oyw=";
+    hash = "sha256-9TYW3VA4qGlrkUzgZGkxf8RkIW2cTLkY6H8JHGDnoLg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/lxqt-notificationd/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-notificationd/default.nix
@@ -18,13 +18,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lxqt-notificationd";
-  version = "2.2.0";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "lxqt-notificationd";
     rev = version;
-    hash = "sha256-pMBshwqfG/8tvpwuR3wCQ/N5IT1rXJl+nZfcSqxMjM0=";
+    hash = "sha256-VmPVGqCmkTkib2T5ysov1hUY3J74GTuXdJsn5Sivreo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/lxqt-openssh-askpass/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-openssh-askpass/default.nix
@@ -17,13 +17,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lxqt-openssh-askpass";
-  version = "2.2.0";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "lxqt-openssh-askpass";
     rev = version;
-    hash = "sha256-ktB8zlrK3ymnwoGSnWNHM6EGcwn4btdlyBQzBLQdqmY=";
+    hash = "sha256-f8v9HBuL78YOauipCnMRIEydudFilpFJz+KgMlnJWGU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/lxqt-panel/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-panel/default.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   pkg-config,
   alsa-lib,
@@ -36,24 +35,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lxqt-panel";
-  version = "2.2.2";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "lxqt-panel";
     tag = finalAttrs.version;
-    hash = "sha256-ui+HD2igPiyIOgIKPbgfO4dnfm2rFP/R6oG2pH5g5VY=";
+    hash = "sha256-cwemHe092vNRDeseXkGoWAEXawNTVbSiB87owfaLeAo=";
   };
-
-  patches = [
-    # fix build against Qt >= 6.10 (https://github.com/lxqt/lxqt-panel/pull/2306)
-    # TODO: drop when upgrading beyond version 2.2.2
-    (fetchpatch {
-      name = "cmake-fix-build-with-Qt-6.10.patch";
-      url = "https://github.com/lxqt/lxqt-panel/commit/fce8cd99a1de0e637e8539c4d8ac68832a40fa6d.patch";
-      hash = "sha256-KXxV6SZqdpvZSn+zbBZ32Qs6XKfFXEej1F4qBt+MzxA=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/desktops/lxqt/lxqt-policykit/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-policykit/default.nix
@@ -20,13 +20,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lxqt-policykit";
-  version = "2.2.0";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "lxqt-policykit";
     rev = version;
-    hash = "sha256-TVgrr+Qakkk0rr7qwQPQNO7p5Wx6eVW8lK2gJ/HysZY=";
+    hash = "sha256-Hk8ig9x1UIKpugbJ2x16DsbCmRT0I1AnX/Y5lvP5u4Q=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/lxqt-powermanagement/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-powermanagement/default.nix
@@ -20,13 +20,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lxqt-powermanagement";
-  version = "2.2.1";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "lxqt-powermanagement";
     rev = version;
-    hash = "sha256-Awk/NlYd8HldmEL0G/LUgj101Y1BTQBrDJfG56Y/aX4=";
+    hash = "sha256-1TA9v2zrPoHiKUy6P4enmzvxWTD+/rGjrChE5WGMt3c=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/lxqt-qtplugin/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-qtplugin/default.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   libdbusmenu-lxqt,
   libfm-qt,
@@ -17,24 +16,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lxqt-qtplugin";
-  version = "2.2.0";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "lxqt-qtplugin";
     tag = finalAttrs.version;
-    hash = "sha256-qXadz9JBk4TURAWj6ByP/lGV1u0Z6rNJ/VraBh5zY+Q=";
+    hash = "sha256-3rY9VpZKnl1E3ma1ioiKECpazeymQYVuXrLXhRL407o=";
   };
-
-  patches = [
-    # fix build against Qt >= 6.10 (https://github.com/lxqt/lxqt-qtplugin/pull/100)
-    # TODO: drop when upgrading beyond version 2.2.0
-    (fetchpatch {
-      name = "cmake-fix-build-with-Qt-6.10.patch";
-      url = "https://github.com/lxqt/lxqt-qtplugin/commit/90473945206dbf21816a00dfba27426a5b5a9e25.patch";
-      hash = "sha256-cCghOJHsveR5IYisEFv3h8WreRDi0kuyj/2YBD+ATsc=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/desktops/lxqt/lxqt-runner/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-runner/default.nix
@@ -22,13 +22,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lxqt-runner";
-  version = "2.2.0";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "lxqt-runner";
     rev = version;
-    hash = "sha256-lvJuqwBqR/OqDsk2XdjIakxIrnOZjgWrY5DtMUV5XEM=";
+    hash = "sha256-h+pZiSuCdQknsyfUb9Ve1yxVyOUqNgYhIpO7kD5z3pQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/lxqt-session/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-session/default.nix
@@ -24,13 +24,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lxqt-session";
-  version = "2.2.0";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "lxqt-session";
     rev = version;
-    hash = "sha256-AwL7X8ygBkVINMCEcyImUrbwmk/T6/fwk0PEEu6iBb8=";
+    hash = "sha256-5VJxRho6qdPvBFr0RkYaajvVZRwhc1emzqpII+lUyOQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/lxqt-sudo/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-sudo/default.nix
@@ -18,13 +18,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lxqt-sudo";
-  version = "2.2.0";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "lxqt-sudo";
     rev = version;
-    hash = "sha256-H2uprArYfiX1KyoWx3RRHkLcA0z9LKGDeghD+085VC4=";
+    hash = "sha256-skxPI6KEHXJReadxQinBArkCx/FjpTYDFdEpRRiqx8E=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/lxqt-themes/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-themes/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lxqt-themes";
-  version = "2.2.0";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "lxqt-themes";
     rev = version;
-    hash = "sha256-oarj+byRfe9xHvtw80kifA2AspXHfigbuDwvi5xqrMQ=";
+    hash = "sha256-sdfLwLYE29Qh0QCU6t5pKIyW2RYx32WRNvNV46nCaXo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/lxqt-wayland-session/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-wayland-session/default.nix
@@ -20,13 +20,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lxqt-wayland-session";
-  version = "0.2.0";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "lxqt-wayland-session";
     rev = version;
-    hash = "sha256-VjOLw6ByS0se9jy1VY4xhBSs26yvoffFVAc1v0gMyYk=";
+    hash = "sha256-MmiYPclMW8Y9VMZsY8wx52S3fN3RzUVrhQAGs5qSTfI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/pavucontrol-qt/default.nix
+++ b/pkgs/desktops/lxqt/pavucontrol-qt/default.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "pavucontrol-qt";
-  version = "2.2.0";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "pavucontrol-qt";
     rev = version;
-    hash = "sha256-D8x3CqzttlNqQgy6k4hfjJkD/MjAG4eeCn68TQA8NSM=";
+    hash = "sha256-6t7nbuC/13S+Q9mINP1WuyaDqZUKp4s9LObcbSRuJ1c=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/pcmanfm-qt/default.nix
+++ b/pkgs/desktops/lxqt/pcmanfm-qt/default.nix
@@ -21,13 +21,13 @@
 
 stdenv.mkDerivation rec {
   pname = "pcmanfm-qt";
-  version = "2.2.0";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "pcmanfm-qt";
     rev = version;
-    hash = "sha256-mYjbOb9c7Qc3qhVYt1EHy50YOVguLnwg0NJg2zBgwOM=";
+    hash = "sha256-Pv3N/JfUbLyCBpnmnEHL7i2du1q8vSKxTR1uIEsEe/U=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/qlipper/default.nix
+++ b/pkgs/desktops/lxqt/qlipper/default.nix
@@ -12,7 +12,7 @@
 
 stdenv.mkDerivation {
   pname = "qlipper";
-  version = "5.1.2-unstable-2025-10-29";
+  version = "5.1.2";
 
   src = fetchFromGitHub {
     owner = "pvanek";

--- a/pkgs/desktops/lxqt/qps/default.nix
+++ b/pkgs/desktops/lxqt/qps/default.nix
@@ -17,13 +17,13 @@
 
 stdenv.mkDerivation rec {
   pname = "qps";
-  version = "2.11.1";
+  version = "2.12.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "qps";
     rev = version;
-    hash = "sha256-uWKTcFO5CoTU5jXB9x5tQ0goEvUpMaeUlMlTG2/xvYg=";
+    hash = "sha256-npTkPcjcxi/hAxUtyayEZeUnVx41iRJThKzhidC+4bQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/qterminal/default.nix
+++ b/pkgs/desktops/lxqt/qterminal/default.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "qterminal";
-  version = "2.2.1";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "qterminal";
     rev = version;
-    hash = "sha256-H1UmPIZG8KiVNPW3GqgnSq39JsZeowiAVwwEKwCkWoM=";
+    hash = "sha256-HwWgVcO9swywei8Z3ifoGJjZ785gdF2A/kBHm4zgzFc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/qtermwidget/default.nix
+++ b/pkgs/desktops/lxqt/qtermwidget/default.nix
@@ -8,7 +8,7 @@
   lxqt-build-tools,
   wrapQtAppsHook,
   gitUpdater,
-  version ? "2.2.0",
+  version ? "2.3.0",
 }:
 
 stdenv.mkDerivation rec {
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     hash =
       {
         "1.4.0" = "sha256-wYUOqAiBjnupX1ITbFMw7sAk42V37yDz9SrjVhE4FgU=";
-        "2.2.0" = "sha256-tzgHNGB063rgFB15lHTKQplNhwJZtrRprUhMm5H62AA=";
+        "2.3.0" = "sha256-l+IFXiUst9PDNuD/KGzxYCUjymhWvcpMY9CF60gIfKg=";
       }
       ."${version}";
   };

--- a/pkgs/desktops/lxqt/qtxdg-tools/default.nix
+++ b/pkgs/desktops/lxqt/qtxdg-tools/default.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "qtxdg-tools";
-  version = "4.2.0";
+  version = "4.3.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "qtxdg-tools";
     rev = version;
-    hash = "sha256-hVX1UfPWa1KHMhjazSopAc1/Kk3tnUQzwtG4P7K32eE=";
+    hash = "sha256-v6mIpGuZ3YFb+P9FLlgNp5xf0ceAaVnMxRG+sQLP72Y=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/screengrab/default.nix
+++ b/pkgs/desktops/lxqt/screengrab/default.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   autoPatchelfHook,
   gitUpdater,
@@ -23,24 +22,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "screengrab";
-  version = "3.0.0";
+  version = "3.1.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "screengrab";
     tag = finalAttrs.version;
-    hash = "sha256-6cGj3Ijv4DsAdJjcHKUg5et+yYc5miIHHZOTD2D9ASk=";
+    hash = "sha256-LORWv3qLgQF2feKodOg72g5DCfWZvB8vi0bw9jbr+tQ=";
   };
-
-  patches = [
-    # fix build against Qt >= 6.10 (https://github.com/lxqt/screengrab/pull/434)
-    # TODO: drop when upgrading beyond version 3.0.0
-    (fetchpatch {
-      name = "cmake-fix-build-with-Qt-6.10.patch";
-      url = "https://github.com/lxqt/screengrab/commit/1621ef5df9461cdd1dcef3faee36e9419f1ca08c.patch";
-      hash = "sha256-+rpCDLnHmgy/1PME3QaN+978W+jR6PDmiZ/5hAx8Djg=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/desktops/lxqt/xdg-desktop-portal-lxqt/default.nix
+++ b/pkgs/desktops/lxqt/xdg-desktop-portal-lxqt/default.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   kwindowsystem,
   libexif,
@@ -17,24 +16,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xdg-desktop-portal-lxqt";
-  version = "1.2.0";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "xdg-desktop-portal-lxqt";
     tag = finalAttrs.version;
-    hash = "sha256-y3VqDuFagKcG8O5m5qjRGtlUZXfIXV0tclvZLChhWkg=";
+    hash = "sha256-DNlvqZzTzZURuHTURBUXaLvMKy2HxVpgI9JwJq6A5Sw=";
   };
-
-  patches = [
-    # fix build against Qt >= 6.10 (https://github.com/lxqt/xdg-desktop-portal-lxqt/pull/50)
-    # TODO: drop when upgrading beyond version 1.2.0
-    (fetchpatch {
-      name = "cmake-fix-build-with-Qt-6.10.patch";
-      url = "https://github.com/lxqt/xdg-desktop-portal-lxqt/commit/15fae3c57a8e8149ef19a8c919f5728016390e3f.patch";
-      hash = "sha256-oReYMEr+tBDHtnFDZahBwTtzgtL/BABZO64yob9tem4=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
Update LXQt to version [3.2.0](https://lxqt-project.org/release/2025/11/05/release-lxqt-2-3-0/).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
