### PR TITLE
maintainers: drop modulistic

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17355,12 +17355,6 @@
     githubId = 14153763;
     name = "modderme123";
   };
-  modulistic = {
-    email = "modulistic@gmail.com";
-    github = "modulistic";
-    githubId = 1902456;
-    name = "Pablo Costa";
-  };
   mog = {
     email = "mog-lists@rldn.net";
     github = "mogorman";

--- a/pkgs/applications/window-managers/i3/default.nix
+++ b/pkgs/applications/window-managers/i3/default.nix
@@ -154,10 +154,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Tiling window manager";
     homepage = "https://i3wm.org";
-    maintainers = with lib.maintainers; [
-      modulistic
-      fpletz
-    ];
+    maintainers = with lib.maintainers; [ fpletz ];
     mainProgram = "i3";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;


### PR DESCRIPTION
Doesn't seem to be in the GitHub org anymore and therefore  is unable to receive pings from CI.
Hasn't commented since [Nov 2, 2014](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Amodulistic), hasn't opened any tickets themselves since [Aug 23, 2013](https://github.com/NixOS/nixpkgs/issues?q=author%3Amodulistic), both of which are longer than the 3 months, specified in the [maintainer README](https://github.com/NixOS/nixpkgs/tree/6d40c7d426c102023aae52888215699bc024cfd3/maintainers#losing-maintainer-status), which makes them eligible for removal from Nixpkgs.

@modulistic, you have a week (**_until Nov 12, 2025_**) to object this. Even if you don't make it, you're still welcome back.
```
rg "modulistic"
maintainers/maintainer-list.nix
17358:  modulistic = {
17359:    email = "modulistic@gmail.com";
17360:    github = "modulistic";

pkgs/applications/window-managers/i3/default.nix
158:      modulistic
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
