### PR TITLE
arc_unpacker: fix aarch64 build

### DIFF
--- a/pkgs/by-name/ar/arc_unpacker/fix-test-float-variance.patch
+++ b/pkgs/by-name/ar/arc_unpacker/fix-test-float-variance.patch
@@ -1,0 +1,101 @@
+diff --git a/tests/test_support/audio_support.cc b/tests/test_support/audio_support.cc
+index c26022e9..5f50d035 100644
+--- a/tests/test_support/audio_support.cc
++++ b/tests/test_support/audio_support.cc
+@@ -16,6 +16,7 @@
+ // along with arc_unpacker. If not, see <http://www.gnu.org/licenses/>.
+ 
+ #include "test_support/audio_support.h"
++#include <cstdlib>
+ #include "algo/format.h"
+ #include "algo/range.h"
+ #include "dec/microsoft/wav_audio_decoder.h"
+@@ -44,13 +45,42 @@ res::Audio tests::get_test_audio()
+ void tests::compare_audio(
+     const res::Audio &actual, const res::Audio &expected)
+ {
++    // Allow for minor variances in audio samples within the specified
++    // threshold. Floating point calculations in some audio decoders yields
++    // slightly differing results across different CPU architectures.
++    //
++    // Affected tests:
++    //   * tests/dec/cri/hca_audio_decoder_test.cc
++    //   * tests/dec/entis/mio_audio_decoder_test.cc
++    static constexpr int tolerance = 1;
++
+     REQUIRE(actual.codec == expected.codec);
+     REQUIRE(actual.channel_count == expected.channel_count);
+     REQUIRE(actual.sample_rate == expected.sample_rate);
+     REQUIRE(actual.bits_per_sample == expected.bits_per_sample);
+     REQUIRE(actual.extra_codec_headers == expected.extra_codec_headers);
+     REQUIRE(actual.samples.size() == expected.samples.size());
++
++#ifdef __x86_64__
+     tests::compare_binary(actual.samples, expected.samples);
++#else
++    tests::compare_binary(
++      actual.samples,
++      expected.samples,
++      [](const bstr& bytes1, const bstr& bytes2) -> bool {
++        const auto samples1 = reinterpret_cast<const s16*>(bytes1.c_str());
++        const auto samples2 = reinterpret_cast<const s16*>(bytes2.c_str());
++        const auto n_samples = bytes1.size() / sizeof(*samples1);
++        // algo::range is a bit incomplete to work with std::all_of
++        for (const int i : algo::range(n_samples)) {
++          if (std::abs(samples1[i] - samples2[i]) > tolerance) {
++            return false;
++          }
++        }
++        return true;
++      }
++    );
++#endif
+ 
+     REQUIRE(actual.loops.size() == expected.loops.size());
+     for (const auto i : algo::range(expected.loops.size()))
+diff --git a/tests/test_support/common.cc b/tests/test_support/common.cc
+index b63ffa89..265ef7b1 100644
+--- a/tests/test_support/common.cc
++++ b/tests/test_support/common.cc
+@@ -40,3 +40,19 @@ void au::tests::compare_binary(const bstr &actual, const bstr &expected)
+     INFO(actual_dump << " != " << expected_dump);
+     REQUIRE(actual == expected);
+ }
++
++void au::tests::compare_binary(
++    const bstr &actual,
++    const bstr &expected,
++    std::function<bool(const bstr &, const bstr &)> compare)
++{
++    const auto max_size = 10000;
++    auto actual_dump = algo::hex(actual);
++    auto expected_dump = algo::hex(expected);
++    if (actual_dump.size() > max_size)
++        actual_dump = actual_dump.substr(0, max_size) + "(...)";
++    if (expected_dump.size() > max_size)
++        expected_dump = expected_dump.substr(0, max_size) + "(...)";
++    INFO(actual_dump << " != " << expected_dump);
++    REQUIRE(compare(actual, expected));
++}
+diff --git a/tests/test_support/common.h b/tests/test_support/common.h
+index 7d8be579..ecd5dcf8 100644
+--- a/tests/test_support/common.h
++++ b/tests/test_support/common.h
+@@ -17,6 +17,7 @@
+ 
+ #pragma once
+ 
++#include <functional>
+ #include "io/path.h"
+ #include "types.h"
+ 
+@@ -27,4 +28,9 @@ namespace tests {
+ 
+     void compare_binary(const bstr &actual, const bstr &expected);
+ 
++    void compare_binary(
++        const bstr &actual,
++        const bstr &expected,
++        std::function<bool(const bstr &, const bstr &)> compare);
++
+ } }

--- a/pkgs/by-name/ar/arc_unpacker/package.nix
+++ b/pkgs/by-name/ar/arc_unpacker/package.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation {
   };
 
   patches = [
+    ./fix-test-float-variance.patch
     (fetchpatch {
       name = "failing_tests.patch";
       url = "https://aur.archlinux.org/cgit/aur.git/plain/failing_tests.patch?h=arc_unpacker-git&id=bda1ad9f69e6802e703b2e6913d71a36d76cfef9";
@@ -88,8 +89,7 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  # A few tests fail on aarch64-linux
-  doCheck = !(stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64);
+  doCheck = true;
 
   meta = with lib; {
     description = "Tool to extract files from visual novel archives";
@@ -98,8 +98,5 @@ stdenv.mkDerivation {
     maintainers = with maintainers; [ midchildan ];
     platforms = platforms.all;
     mainProgram = "arc_unpacker";
-
-    # unit test failures
-    broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64;
   };
 }

--- a/pkgs/by-name/ar/arc_unpacker/package.nix
+++ b/pkgs/by-name/ar/arc_unpacker/package.nix
@@ -5,6 +5,7 @@
   fetchpatch,
   cmake,
   makeWrapper,
+  ninja,
   boost,
   libpng,
   libiconv,
@@ -54,6 +55,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     cmake
     makeWrapper
+    ninja
     catch2
   ];
 

--- a/pkgs/by-name/ar/arc_unpacker/package.nix
+++ b/pkgs/by-name/ar/arc_unpacker/package.nix
@@ -60,23 +60,30 @@ stdenv.mkDerivation {
     zlib
   ];
 
-  checkPhase = ''
-    # Specify test targets
-    # https://catch2-temp.readthedocs.io/en/latest/command-line.html#specifying-which-tests-to-run
-    checkTarget=('~CatSystem INT archives')
+  checkPhase =
+    let
+      checkTarget = [
+        "~CatSystem INT archives"
+      ]
+      ++ lib.optionals (stdenv.hostPlatform.system == "aarch64-linux") [ "~Ivory WADY audio" ];
+    in
+    ''
+      # Specify test targets
+      # https://catch2-temp.readthedocs.io/en/latest/command-line.html#specifying-which-tests-to-run
+      checkTarget=(${lib.escapeShellArgs checkTarget})
 
-    runHook preCheck
+      runHook preCheck
 
-    local flagsArray=()
-    concatTo flagsArray checkFlags checkFlagsArray checkTarget
+      local flagsArray=()
+      concatTo flagsArray checkFlags checkFlagsArray checkTarget
 
-    pushd ..
-    echoCmd 'check flags' "''${flagsArray[@]}"
-    ./build/run_tests "''${flagsArray[@]}"
-    popd
+      pushd ..
+      echoCmd 'check flags' "''${flagsArray[@]}"
+      ./build/run_tests "''${flagsArray[@]}"
+      popd
 
-    runHook postCheck
-  '';
+      runHook postCheck
+    '';
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
This fixes the arc_unpacker unit tests, enables tests, and removes the broken status on all platforms. It builds upon ~a modified version of~ #457462, which addresses compatibility with CMake 4.

The failing tests involved two separate audio decoders for formats used by some games. On aarch64, a small number of audio sample values within the decoded audio waves were off by 1. Both decoders rely on floating-point calculations to derive these values, which I suspect contributes to the discrepancies observed compared to x86_64. Since audio sample values are expressed as signed 16-bit integers, a difference of 1 is negligible. So I modified the tests to accept this variance.

However, as I’m not an expert in audio decoding, I would greatly appreciate it if someone with more expertise could review the changes, if possible.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
