### PR TITLE
kanata-tray: init at 0.7.1

### DIFF
--- a/pkgs/by-name/ka/kanata-tray/package.nix
+++ b/pkgs/by-name/ka/kanata-tray/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+  makeWrapper,
+  libayatana-appindicator,
+  gtk3,
+  stdenv,
+  pkg-config,
+}:
+buildGoModule (finalAttrs: {
+  pname = "kanata-tray";
+  version = "0.7.1";
+
+  src = fetchFromGitHub {
+    owner = "rszyma";
+    repo = "kanata-tray";
+    rev = "v${finalAttrs.version}";
+    sha256 = "sha256-IR8mWt8pLBZ24+6xY8OBFRYAYLwcRKfbGTAE0bOcLuk=";
+  };
+
+  vendorHash = "sha256-tW8NszrttoohW4jExWxI1sNxRqR8PaDztplIYiDoOP8=";
+
+  flags = [ "-trimpath" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.buildVersion=${finalAttrs.version}"
+    "-X main.buildHash=${finalAttrs.src.rev}"
+  ];
+  nativeBuildInputs = lib.optional stdenv.isLinux pkg-config;
+
+  buildInputs = [
+    makeWrapper
+  ]
+  ++ lib.optionals stdenv.isLinux [
+    libayatana-appindicator
+    gtk3
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/kanata-tray \
+    --run 'export KANATA_TRAY_LOG_DIR=''${KANATA_TRAY_LOG_DIR-$HOME/.cache}' \
+    --prefix PATH : $out/bin
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = with lib; {
+    description = "Tray Icon for Kanata";
+    homepage = "https://github.com/rszyma/kanata-tray";
+    changelog = "https://github.com/rszyma/kanata-tray/releases/tag/v${finalAttrs.version}";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ auscyber ];
+    platforms = platforms.unix;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
adds [kanata-tray](https://github.com/rszyma/kanata-tray) a tray application for kanata

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
