### PR TITLE
clash-rs: 0.9.1 -> 0.9.2

### DIFF
--- a/pkgs/by-name/cl/clash-rs/Cargo.patch
+++ b/pkgs/by-name/cl/clash-rs/Cargo.patch
@@ -1,24 +1,24 @@
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -1250,7 +1250,7 @@
+@@ -1249,7 +1249,7 @@
   "sha2",
   "shadowquic",
   "shadowsocks",
 - "smoltcp 0.12.0 (git+https://github.com/smoltcp-rs/smoltcp.git?rev=ac32e64)",
-+ "smoltcp 0.12.0",
-  "socket2 0.6.0",
++ "smoltcp",
+  "sock2proc",
+  "socket2 0.6.1",
   "tempfile",
-  "thiserror 2.0.17",
-@@ -4096,7 +4096,7 @@
+@@ -4234,7 +4234,7 @@
   "etherparse 0.16.0",
   "futures",
   "rand 0.8.5",
 - "smoltcp 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
-+ "smoltcp 0.12.0",
++ "smoltcp",
   "spin 0.9.8",
   "tokio",
   "tokio-util",
-@@ -6487,20 +6487,6 @@
+@@ -6632,20 +6632,6 @@
  ]
  
  [[package]]
@@ -36,15 +36,15 @@
 -]
 -
 -[[package]]
- name = "socket2"
- version = "0.4.10"
- source = "registry+https://github.com/rust-lang/crates.io-index"
-@@ -8792,7 +8778,7 @@
+ name = "sock2proc"
+ version = "0.1.0"
+ source = "git+https://github.com/Watfaq/sock2proc.git?rev=1097e6b#1097e6ba692025f80567446e0035af1222f5231f"
+@@ -8964,7 +8950,7 @@
   "netstack-lwip",
   "netstack-smoltcp",
   "rand 0.9.2",
 - "smoltcp 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
-+ "smoltcp 0.12.0",
-  "socket2 0.6.0",
++ "smoltcp",
+  "socket2 0.6.1",
   "tokio",
   "tracing",

--- a/pkgs/by-name/cl/clash-rs/package.nix
+++ b/pkgs/by-name/cl/clash-rs/package.nix
@@ -10,16 +10,16 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "clash-rs";
-  version = "0.9.1";
+  version = "0.9.2";
 
   src = fetchFromGitHub {
     owner = "Watfaq";
     repo = "clash-rs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-asD7veAYdIF5biCbSXYvAyW/qBra3tvON9TQYCw6nB8=";
+    hash = "sha256-FFbRopIaAOpfb+Wbj+EUXRr89EQE108h8OMn+fpL+ew=";
   };
 
-  cargoHash = "sha256-9zCQKxkjiskkBGxfnq2ANpqWobs+UJ5qCsbME2Z7GY4=";
+  cargoHash = "sha256-JYvITscH1K6xLE6XZpMrEFZWcbue7x7xuPxVQW/Vjb0=";
 
   cargoPatches = [ ./Cargo.patch ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/Watfaq/clash-rs/releases/tag/v0.9.2
https://github.com/Watfaq/clash-rs/compare/v0.9.1...v0.9.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
