### PR TITLE
zbar: patch out segfault from overoptimization on darwin

### DIFF
--- a/pkgs/tools/graphics/zbar/darwin-segfault-optimized-pointer-assignment.patch
+++ b/pkgs/tools/graphics/zbar/darwin-segfault-optimized-pointer-assignment.patch
@@ -1,0 +1,47 @@
+From 3fa414aa82375648635281924904557cbe4d2d83 Mon Sep 17 00:00:00 2001
+From: sasdf <asdf79852@gmail.com>
+Date: Fri, 18 Oct 2024 00:22:36 +0800
+Subject: [PATCH] Fix pointer wrap around undefined behavior
+
+---
+ zbar/img_scanner.c | 13 +++++++------
+ 1 file changed, 7 insertions(+), 6 deletions(-)
+
+diff --git a/zbar/img_scanner.c b/zbar/img_scanner.c
+index d1bf8a3c..58436f16 100644
+--- a/zbar/img_scanner.c
++++ b/zbar/img_scanner.c
+@@ -33,6 +33,7 @@
+ #endif
+ 
+ #include <assert.h>
++#include <stddef.h>
+ #include <stdlib.h> /* malloc, free */
+ #include <string.h> /* memcmp, memset, memcpy */
+ 
+@@ -50,7 +51,7 @@
+ #include "svg.h"
+ 
+ #if 1
+-#define ASSERT_POS assert(p == data + x + y * (intptr_t)w)
++#define ASSERT_POS assert(p == data + x + y * (ptrdiff_t)w)
+ #else
+ #define ASSERT_POS
+ #endif
+@@ -858,11 +859,11 @@ static void zbar_send_code_via_dbus(zbar_image_scanner_t *iscn,
+ }
+ #endif
+ 
+-#define movedelta(dx, dy)                \
+-    do {                                 \
+-	x += (dx);                       \
+-	y += (dy);                       \
+-	p += (dx) + ((uintptr_t)(dy)*w); \
++#define movedelta(dx, dy)                  \
++    do {                                   \
++        x += (dx);                         \
++        y += (dy);                         \
++        p += (dx) + ((dy)*(ptrdiff_t)(w)); \
+     } while (0);
+ 
+ static void *_zbar_scan_image(zbar_image_scanner_t *iscn, zbar_image_t *img)

--- a/pkgs/tools/graphics/zbar/default.nix
+++ b/pkgs/tools/graphics/zbar/default.nix
@@ -62,6 +62,11 @@ stdenv.mkDerivation rec {
       url = "https://github.com/mchehab/zbar/commit/a549566ea11eb03622bd4458a1728ffe3f589163.patch";
       hash = "sha256-NY3bAElwNvGP9IR6JxUf62vbjx3hONrqu9pMSqaZcLY=";
     })
+    # PR from fork not yet merged into upstream
+    # See PR: https://github.com/mchehab/zbar/pull/299
+    # Remove this patch if the PR is merged or if the issue is solved another way.
+    # See https://github.com/NixOS/nixpkgs/issues/456461 for discussion of the root issue
+    ./darwin-segfault-optimized-pointer-assignment.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
Apply a patch proposed to upstream that avoids over-optimization from latest clang leading to a segfault on Darwin.

Upstream PR (unmerged): https://github.com/mchehab/zbar/pull/299. Credit to @booxter for pointing me at the correct patch.

Fixes #456461.
Supersedes #458999.
ZHF: #457852

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
