### PR TITLE
tidy-viewer: refactor and adopt

### DIFF
--- a/pkgs/by-name/ti/tidy-viewer/package.nix
+++ b/pkgs/by-name/ti/tidy-viewer/package.nix
@@ -29,6 +29,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/alexhallam/tv";
     changelog = "https://github.com/alexhallam/tv/blob/${version}/CHANGELOG.md";
     license = lib.licenses.unlicense;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ phanirithvij ];
   };
 }

--- a/pkgs/by-name/ti/tidy-viewer/package.nix
+++ b/pkgs/by-name/ti/tidy-viewer/package.nix
@@ -17,12 +17,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-HF7M4s2OHCAyVkbCIBxGButAxbxrhjmY3YE/do8et1s=";
 
-  # this test parses command line arguments
-  # error: Found argument '--test-threads' which wasn't expected, or isn't valid in this context
-  checkFlags = [
-    "--skip=build_reader_can_create_reader_without_file_specified"
-  ];
-
   meta = {
     changelog = "https://github.com/alexhallam/tv/blob/${finalAttrs.version}/CHANGELOG.md";
     description = "Cross-platform CLI csv pretty printer that uses column styling to maximize viewer enjoyment";

--- a/pkgs/by-name/ti/tidy-viewer/package.nix
+++ b/pkgs/by-name/ti/tidy-viewer/package.nix
@@ -4,14 +4,14 @@
   fetchFromGitHub,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "tidy-viewer";
   version = "1.8.93";
 
   src = fetchFromGitHub {
     owner = "alexhallam";
     repo = "tv";
-    rev = version;
+    tag = finalAttrs.version;
     sha256 = "sha256-wiVcdTnjEFh5kSyxmK+ab0LkEAbQaygmLdrFfM12DyM=";
   };
 
@@ -24,11 +24,11 @@ rustPlatform.buildRustPackage rec {
   ];
 
   meta = {
+    changelog = "https://github.com/alexhallam/tv/blob/${finalAttrs.version}/CHANGELOG.md";
     description = "Cross-platform CLI csv pretty printer that uses column styling to maximize viewer enjoyment";
-    mainProgram = "tidy-viewer";
     homepage = "https://github.com/alexhallam/tv";
-    changelog = "https://github.com/alexhallam/tv/blob/${version}/CHANGELOG.md";
     license = lib.licenses.unlicense;
+    mainProgram = "tidy-viewer";
     maintainers = with lib.maintainers; [ phanirithvij ];
   };
-}
+})


### PR DESCRIPTION
Tracking: #458096

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
