### PR TITLE
defold: init at 1.13.1

### DIFF
--- a/pkgs/by-name/de/defold/package.nix
+++ b/pkgs/by-name/de/defold/package.nix
@@ -1,0 +1,186 @@
+{
+  addDriverRunpath,
+  buildFHSEnv,
+  cairo,
+  copyDesktopItems,
+  fetchurl,
+  fontconfig,
+  freetype,
+  gdk-pixbuf,
+  git,
+  glib,
+  gnused,
+  gobject-introspection,
+  gtk3,
+  lib,
+  libGL,
+  libGLU,
+  libx11,
+  libxcursor,
+  libxext,
+  libxi,
+  libxrandr,
+  libxrender,
+  libxtst,
+  libxxf86vm,
+  makeDesktopItem,
+  makeWrapper,
+  openal,
+  openjdk25,
+  pango,
+  stdenv,
+  writeScript,
+  zlib,
+  uiScale ? "1.0",
+}:
+let
+  pname = "defold";
+  version = "1.12.4";
+
+  defold = stdenv.mkDerivation {
+    inherit pname version;
+
+    src = fetchurl {
+      url = "https://github.com/defold/defold/releases/download/${version}/Defold-x86_64-linux.tar.gz";
+      hash = "sha256-VRCCuwcTODYx9CzH/tna5OfKlnslswEsiHHQIM5FEYg=";
+    };
+
+    dontBuild = true;
+    dontConfigure = true;
+    dontStrip = true;
+
+    nativeBuildInputs = [
+      addDriverRunpath
+      copyDesktopItems
+      gnused
+      openjdk25
+      makeWrapper
+    ];
+
+    installPhase = ''
+      runHook preInstall
+      # Install Defold assets, but not the bundled JDK
+      install -m 755 -D Defold $out/share/defold/Defold
+      install -m 644 -D config $out/share/defold/config
+      install -m 444 -D logo_blue.png $out/share/defold/logo_blue.png
+      install -m 444 -D logo_blue.png \
+          $out/share/icons/hicolor/512x512/apps/defold.png
+      mkdir -p $out/share/defold/packages
+      cp -a packages/defold-*.jar $out/share/defold/packages/
+      runHook postInstall
+    '';
+
+    postFixup = ''
+      # Devendor bundled JDK; it segfaults on NixOS
+      JDK_VER=$(sed -n 's/.*\/\(jdk-[^/]*\).*/\1/p' $out/share/defold/config)
+      ln -s ${openjdk25} $out/share/defold/packages/${openjdk25.name}
+      sed -i "s|packages/$JDK_VER|packages/${openjdk25.name}|" $out/share/defold/config
+      # Disable editor updates; Nix will handle updates
+      sed -i 's/\(channel = \).*/\1/' $out/share/defold/config
+      # Scale the UI
+      sed -i "s|^linux =|linux = -Dglass.gtk.uiScale=${uiScale}|" $out/share/defold/config
+      addDriverRunpath $out/share/defold/Defold
+      makeWrapper "$out/share/defold/Defold" "$out/bin/Defold"
+    '';
+
+    desktopItems = [
+      (makeDesktopItem {
+        name = "defold-editor";
+        desktopName = "Defold";
+        comment = "An out of the box, turn-key solution for multi-platform game development";
+        keywords = [
+          "Game"
+          "Development"
+        ];
+        exec = "defold";
+        terminal = false;
+        type = "Application";
+        icon = "defold";
+        categories = [
+          "Development"
+          "IDE"
+        ];
+        startupNotify = true;
+        startupWMClass = "com.defold.editor.Start";
+      })
+    ];
+  };
+in
+(buildFHSEnv {
+  name = pname;
+
+  targetPkgs = pkgs: [
+    cairo
+    defold
+    fontconfig
+    freetype
+    gdk-pixbuf
+    git
+    glib
+    gobject-introspection
+    gtk3
+    libGL
+    libGLU
+    libx11
+    libxcursor
+    libxext
+    libxi
+    libxrandr
+    libxrender
+    libxtst
+    libxxf86vm
+    openal
+    pango
+    zlib
+  ];
+
+  runScript = "Defold";
+
+  extraInstallCommands = ''
+    mkdir -p $out/share/applications $out/share/icons/hicolor/512x512/apps
+    ln -s ${defold}/share/applications/*.desktop \
+      $out/share/applications/
+    ln -s ${defold}/share/icons/hicolor/512x512/apps/defold.png \
+      $out/share/icons/hicolor/512x512/apps/defold.png
+  '';
+
+  passthru = {
+    updateScript = writeScript "update-defold" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p curl jq nix-update
+      version=$(curl -s https://d.defold.com/editor-alpha/info.json | jq -r .version)
+      nix-update defold --version "$version"
+    '';
+  };
+
+  meta = {
+    description = "Game engine for high-performance cross-platform games";
+    longDescription = ''
+      Defold is a completely free to use game engine for development
+      of desktop, mobile, console and web games.
+    '';
+    homepage = "https://www.defold.com";
+    license = {
+      fullName = "Defold License";
+      /**
+        The Defold License is derived from Apache-2.0 but prohibits commercializing
+        the engine itself (or derivatives) as a "Game Engine Product"
+        (authoring + runtime software).
+      */
+      free = false;
+      redistributable = true;
+      url = "https://defold.com/license/";
+    };
+    sourceProvenance = with lib.sourceTypes; [
+      binaryBytecode
+      binaryNativeCode
+    ];
+    maintainers = with lib.maintainers; [ atomicptr ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "defold";
+  };
+}).overrideAttrs
+  (_: {
+    strictDeps = true;
+    __structuredAttrs = true;
+  })

--- a/pkgs/by-name/de/defold/package.nix
+++ b/pkgs/by-name/de/defold/package.nix
@@ -1,0 +1,192 @@
+{
+  addDriverRunpath,
+  buildFHSEnv,
+  cairo,
+  copyDesktopItems,
+  fetchurl,
+  fontconfig,
+  freetype,
+  gdk-pixbuf,
+  git,
+  glib,
+  gnused,
+  gobject-introspection,
+  gtk3,
+  lib,
+  libGL,
+  libGLU,
+  libgbm,
+  libx11,
+  libxcursor,
+  libxext,
+  libxi,
+  libxrandr,
+  libxrender,
+  libxtst,
+  libxxf86vm,
+  makeDesktopItem,
+  makeWrapper,
+  openal,
+  openjdk25,
+  pango,
+  stdenv,
+  writeScript,
+  zlib,
+  uiScale ? "1.0",
+}:
+let
+  pname = "defold";
+  version = "1.13.1";
+
+  defold = stdenv.mkDerivation {
+    inherit pname version;
+
+    src = fetchurl {
+      url = "https://github.com/defold/defold/releases/download/${version}/Defold-x86_64-linux.tar.gz";
+      hash = "sha256-WgXAEnOe1KksgjipUfxFuCqYqlffS9yrpLIyXkiLwos=";
+    };
+
+    dontBuild = true;
+    dontConfigure = true;
+    dontStrip = true;
+
+    nativeBuildInputs = [
+      addDriverRunpath
+      copyDesktopItems
+      gnused
+      openjdk25
+      makeWrapper
+    ];
+
+    installPhase = ''
+      runHook preInstall
+      # Install Defold assets, but not the bundled JDK
+      install -m 755 -D Defold $out/share/defold/Defold
+      install -m 644 -D config $out/share/defold/config
+      install -m 444 -D logo_blue.png $out/share/defold/logo_blue.png
+      install -m 444 -D logo_blue.png \
+          $out/share/icons/hicolor/512x512/apps/defold.png
+      mkdir -p $out/share/defold/packages
+      cp -a packages/defold-*.jar $out/share/defold/packages/
+      runHook postInstall
+    '';
+
+    postFixup = ''
+      # Devendor bundled JDK; it segfaults on NixOS
+      JDK_VER=$(sed -n 's/.*\/\(jdk-[^/]*\).*/\1/p' $out/share/defold/config)
+      ln -s ${openjdk25} $out/share/defold/packages/${openjdk25.name}
+      sed -i "s|packages/$JDK_VER|packages/${openjdk25.name}|" $out/share/defold/config
+
+      # Disable editor updates; Nix will handle updates
+      sed -i 's/\(channel = \).*/\1/' $out/share/defold/config
+
+      # Scale the UI
+      sed -i "s|^linux =|linux = -Dglass.gtk.uiScale=${uiScale}|" $out/share/defold/config
+      addDriverRunpath $out/share/defold/Defold
+
+      makeWrapper "$out/share/defold/Defold" "$out/bin/Defold" \
+        --prefix LD_LIBRARY_PATH : ${openjdk25}/lib/openjdk/lib
+    '';
+
+    desktopItems = [
+      (makeDesktopItem {
+        name = "defold-editor";
+        desktopName = "Defold";
+        comment = "An out of the box, turn-key solution for multi-platform game development";
+        keywords = [
+          "Game"
+          "Development"
+        ];
+        exec = "defold";
+        terminal = false;
+        type = "Application";
+        icon = "defold";
+        categories = [
+          "Development"
+          "IDE"
+        ];
+        startupNotify = true;
+        startupWMClass = "com.defold.editor.Start";
+      })
+    ];
+  };
+in
+(buildFHSEnv {
+  name = pname;
+
+  targetPkgs = pkgs: [
+    cairo
+    defold
+    fontconfig
+    freetype
+    gdk-pixbuf
+    git
+    glib
+    gobject-introspection
+    gtk3
+    libGL
+    libGLU
+    libgbm
+    libx11
+    libxcursor
+    libxext
+    libxi
+    libxrandr
+    libxrender
+    libxtst
+    libxxf86vm
+    openal
+    pango
+    zlib
+  ];
+
+  runScript = "Defold";
+
+  extraInstallCommands = ''
+    mkdir -p $out/share/applications $out/share/icons/hicolor/512x512/apps
+    ln -s ${defold}/share/applications/*.desktop \
+      $out/share/applications/
+    ln -s ${defold}/share/icons/hicolor/512x512/apps/defold.png \
+      $out/share/icons/hicolor/512x512/apps/defold.png
+  '';
+
+  passthru = {
+    updateScript = writeScript "update-defold" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p curl jq nix-update
+      version=$(curl -s https://d.defold.com/editor-alpha/info.json | jq -r .version)
+      nix-update defold --version "$version"
+    '';
+  };
+
+  meta = {
+    description = "Game engine for high-performance cross-platform games";
+    longDescription = ''
+      Defold is a completely free to use game engine for development
+      of desktop, mobile, console and web games.
+    '';
+    homepage = "https://www.defold.com";
+    license = {
+      fullName = "Defold License";
+      /**
+        The Defold License is derived from Apache-2.0 but prohibits commercializing
+        the engine itself (or derivatives) as a "Game Engine Product"
+        (authoring + runtime software).
+      */
+      free = false;
+      redistributable = true;
+      url = "https://defold.com/license/";
+    };
+    sourceProvenance = with lib.sourceTypes; [
+      binaryBytecode
+      binaryNativeCode
+    ];
+    maintainers = with lib.maintainers; [ atomicptr ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "defold";
+  };
+}).overrideAttrs
+  (_: {
+    strictDeps = true;
+    __structuredAttrs = true;
+  })


### PR DESCRIPTION
Add Defold 1.13.1 - Defold is a free to use game engine for development of desktop, mobile and web games.

Based on https://github.com/NixOS/nixpkgs/pull/408992

I've been running this in my own configuration for quite a while, since the prior PR seems abandoned and I really want this to be in the repository so here is another attempt.

- Devendors the bundled JDK.
- Disables the Defold auto-update so that updates are only provided via Nixpkgs
This protects against an OTA update downloading the vendor's JDK, which results in segfaults on start-up.
- Includes updateScript.
- Related https://github.com/defold/defold/issues/8150, https://github.com/NixOS/nixpkgs/issues/95761

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
