### PR TITLE
Corretto{11,17,21}: update to latest release & build with Gradle8

### DIFF
--- a/pkgs/development/compilers/corretto/11.nix
+++ b/pkgs/development/compilers/corretto/11.nix
@@ -1,6 +1,6 @@
 {
   fetchFromGitHub,
-  gradle_7,
+  gradle_8,
   jdk11,
   lib,
   stdenv,
@@ -19,20 +19,25 @@ let
       testers
       ;
     jdk = jdk11;
-    gradle = gradle_7;
+    gradle = gradle_8;
     extraConfig = [
       # jdk11 is built with --disable-warnings-as-errors (see openjdk/11.nix)
       # because of several compile errors. We need to include this parameter for
       # Corretto, too.
       "--disable-warnings-as-errors"
     ];
-    version = "11.0.26.4.1";
+    version = "11.0.29.7.1";
     src = fetchFromGitHub {
       owner = "corretto";
       repo = "corretto-11";
       rev = version;
-      hash = "sha256-buJlSvmyOVeMwaP9oDcHhG+Sabr1exf0nRUt4O7MaIY=";
+      hash = "sha256-/VlV8tAo1deOZ5Trc4VlLNtpjWx352qUGZmfVbj7HuU=";
     };
   };
 in
-corretto
+corretto.overrideAttrs (oldAttrs: {
+  patches = (oldAttrs.patches or [ ]) ++ [
+    ./corretto11-gradle8.patch
+  ];
+
+})

--- a/pkgs/development/compilers/corretto/17.nix
+++ b/pkgs/development/compilers/corretto/17.nix
@@ -1,7 +1,7 @@
 {
   fetchFromGitHub,
   fetchurl,
-  gradle_7,
+  gradle_8,
   jdk17,
   lib,
   stdenv,
@@ -20,13 +20,13 @@ let
       testers
       ;
     jdk = jdk17;
-    gradle = gradle_7;
-    version = "17.0.14.7.1";
+    gradle = gradle_8;
+    version = "17.0.17.10.1";
     src = fetchFromGitHub {
       owner = "corretto";
       repo = "corretto-17";
       rev = version;
-      hash = "sha256-ohQrguEJ8QvTaNjyQxKFujGhXNxCQTGkLILurzD7cy0=";
+      hash = "sha256-Z8+g5jXjcWNTYU9Xvze7scu348okMauGMhSZwX1sS9w=";
     };
   };
 in
@@ -35,9 +35,11 @@ corretto.overrideAttrs (
     # Corretto17 has incorporated this patch already so it fails to apply.
     # We thus skip it here.
     # See https://github.com/corretto/corretto-17/pull/158
-    patches = lib.remove (fetchurl {
-      url = "https://git.alpinelinux.org/aports/plain/community/openjdk17/FixNullPtrCast.patch?id=41e78a067953e0b13d062d632bae6c4f8028d91c";
-      sha256 = "sha256-LzmSew51+DyqqGyyMw2fbXeBluCiCYsS1nCjt9hX6zo=";
-    }) (prev.patches or [ ]);
+    patches =
+      lib.remove (fetchurl {
+        url = "https://git.alpinelinux.org/aports/plain/community/openjdk17/FixNullPtrCast.patch?id=41e78a067953e0b13d062d632bae6c4f8028d91c";
+        sha256 = "sha256-LzmSew51+DyqqGyyMw2fbXeBluCiCYsS1nCjt9hX6zo=";
+      }) (prev.patches or [ ])
+      ++ [ ./corretto17-gradle8.patch ];
   }
 )

--- a/pkgs/development/compilers/corretto/21.nix
+++ b/pkgs/development/compilers/corretto/21.nix
@@ -1,7 +1,6 @@
 {
-  corretto21,
   fetchFromGitHub,
-  gradle_7,
+  gradle_8,
   jdk21,
   lib,
   stdenv,
@@ -20,14 +19,19 @@ let
       testers
       ;
     jdk = jdk21;
-    gradle = gradle_7;
-    version = "21.0.6.7.1";
+    gradle = gradle_8;
+    version = "21.0.9.11.1";
     src = fetchFromGitHub {
       owner = "corretto";
       repo = "corretto-21";
       rev = version;
-      hash = "sha256-kF7Quf8bU5scfunmwfEYLkje/jEJOx7CFnBIUWCovzI=";
+      hash = "sha256-d62rXVgVlOM3M18c8GioFtMi/GhmCEMLQwy/EWAJW7I=";
     };
   };
 in
-corretto
+corretto.overrideAttrs (oldAttrs: {
+  patches = (oldAttrs.patches or [ ]) ++ [
+    ./corretto21-gradle8.patch
+  ];
+
+})

--- a/pkgs/development/compilers/corretto/corretto11-gradle8.patch
+++ b/pkgs/development/compilers/corretto/corretto11-gradle8.patch
@@ -1,0 +1,337 @@
+diff --git a/build.gradle b/build.gradle
+index a589bb568..6e0164562 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -240,7 +240,7 @@ project(':prebuild') {
+     def generateToolMain = "build.tools.generatecacerts.GenerateCacerts"
+ 
+     task copyToolSrc(type: Copy) {
+-        description 'Copy utility tool source to the project root'
++        description = 'Copy utility tool source to the project root'
+         from fileTree("$rootDir/make/jdk/src/classes") {
+             include 'build/tools/generatecacerts/*'
+         }
+@@ -250,7 +250,7 @@ project(':prebuild') {
+     task buildTool(type: JavaCompile) {
+         dependsOn copyToolSrc
+         source = fileTree(dir: preBuildSrc, include: '**/*.java')
+-        destinationDir = file(classPath)
++        destinationDirectory = file(classPath)
+         classpath = files(classPath)
+     }
+ 
+@@ -260,7 +260,7 @@ project(':prebuild') {
+ 
+         description = 'Generate Cacerts from JDK source'
+         classpath = files(classPath)
+-        main = generateToolMain
++        mainClass = generateToolMain
+         args = [jdkCaDir, project.caCerts]
+     }
+ 
+@@ -291,9 +291,9 @@ project(':openjdksrc') {
+      * Compresses a snapshot of the source code used to perform the build.
+      */
+     task sourceDistributionTarball(type: Tar) {
+-        description 'Assemble source files required for building and distributing Corretto.'
+-        compression Compression.GZIP
+-        archiveName sourceTar
++        description = 'Assemble source files required for building and distributing Corretto.'
++        compression = Compression.GZIP
++        archiveFileName = sourceTar
+         from fileTree(rootDir) {
+             include 'LICENSE',
+                     'ADDITIONAL_LICENSE_INFO',
+diff --git a/installers/linux/al2/spec/build.gradle b/installers/linux/al2/spec/build.gradle
+index 598d658de..b99e94d83 100644
+--- a/installers/linux/al2/spec/build.gradle
++++ b/installers/linux/al2/spec/build.gradle
+@@ -62,8 +62,8 @@ task inflateRpmSpec {
+ 
+ task copySourceTar(type: Tar) {
+     dependsOn project.configurations.compile, inflateRpmSpec
+-    compression Compression.GZIP
+-    archiveName project.configurations.compile.singleFile.name
++    compression = Compression.GZIP
++    archiveFileName = project.configurations.compile.singleFile.name
+     from("$buildDir") {
+         include "java-${project.version.major}-amazon-corretto.spec"
+         into 'rpm'
+@@ -121,8 +121,8 @@ task inflateRpmSpecModular {
+ 
+ task copySourceTarModular(type: Tar) {
+     dependsOn project.configurations.compile, inflateRpmSpecModular
+-    compression Compression.GZIP
+-    archiveName project.configurations.compile.singleFile.name
++    compression = Compression.GZIP
++    archiveFileName = project.configurations.compile.singleFile.name
+     from("$buildDir") {
+         include "java-${project.version.major}-amazon-corretto-modular.spec"
+         into 'rpm'
+diff --git a/installers/linux/alpine/tar/build.gradle b/installers/linux/alpine/tar/build.gradle
+index 4867205e5..0c850d15f 100644
+--- a/installers/linux/alpine/tar/build.gradle
++++ b/installers/linux/alpine/tar/build.gradle
+@@ -143,9 +143,9 @@ task createTestImage(type: Exec) {
+ 
+ task packageTestImage(type: Tar) {
+     dependsOn createTestImage
+-    description 'Package test results'
+-    archiveName "amazon-corretto-testimage-${project.version.full}-alpine-linux-${arch_alias}.tar.gz"
+-    compression Compression.GZIP
++    description = 'Package test results'
++    archiveFileName = "amazon-corretto-testimage-${project.version.full}-alpine-linux-${arch_alias}.tar.gz"
++    compression = Compression.GZIP
+     from(testResultingImage) {
+         include '**'
+     }
+@@ -155,9 +155,9 @@ task packageTestImage(type: Tar) {
+ 
+ task packageDebugSymbols(type: Tar) {
+     dependsOn packageTestImage
+-    description 'Package debug symbols'
+-    archiveName "amazon-corretto-debugsymbols-${project.version.full}-alpine-linux-${arch_alias}.tar.gz"
+-    compression Compression.GZIP
++    description = 'Package debug symbols'
++    archiveFileName = "amazon-corretto-debugsymbols-${project.version.full}-alpine-linux-${arch_alias}.tar.gz"
++    compression = Compression.GZIP
+     from(jdkResultingImage) {
+         include 'bin/*.diz'
+         include 'lib/*.diz'
+@@ -167,12 +167,12 @@ task packageDebugSymbols(type: Tar) {
+ }
+ 
+ task packageBuildResults(type: Tar) {
+-    description 'Compresses the JDK image and puts the results in build/distributions.'
++    description = 'Compresses the JDK image and puts the results in build/distributions.'
+     dependsOn packageDebugSymbols
+     dependsOn bundleThirdPartyBinaries
+     dependsOn importAmazonCacerts
+-    archiveName "amazon-corretto-${project.version.full}-alpine-linux-${arch_alias}.tar.gz"
+-    compression Compression.GZIP
++    archiveFileName = "amazon-corretto-${project.version.full}-alpine-linux-${arch_alias}.tar.gz"
++    compression = Compression.GZIP
+     from(buildRoot) {
+         include 'ADDITIONAL_LICENSE_INFO'
+         include 'ASSEMBLY_EXCEPTION'
+@@ -196,7 +196,7 @@ task packageBuildResults(type: Tar) {
+     // See https://github.com/corretto/corretto-11/issues/129
+     from(jdkResultingImage) {
+         include 'legal/**'
+-        fileMode 0444
++        fileMode = 0444
+     }
+     into "amazon-corretto-${project.version.full}-alpine-linux-${arch_alias}"
+ }
+diff --git a/installers/linux/universal/deb/build.gradle b/installers/linux/universal/deb/build.gradle
+index 565cd7c2b..f2cc09982 100644
+--- a/installers/linux/universal/deb/build.gradle
++++ b/installers/linux/universal/deb/build.gradle
+@@ -20,7 +20,7 @@
+  */
+ 
+ plugins {
+-    id 'nebula.ospackage' version 'latest.release'
++    id 'com.netflix.nebula.ospackage' version 'latest.release'
+ }
+ 
+ dependencies {
+@@ -57,22 +57,22 @@ def jinfoName = ".${jdkInstallationDirName}.jinfo"
+ ospackage {
+     // Valid version must start with a digit and only contain [A-Za-z0-9.+:~-]
+     // See http://manpages.ubuntu.com/manpages/artful/en/man5/deb-version.5.html
+-    version project.version.upstream
+-    release project.version.revision
+-
+-    url "${packageInfo.url}"
+-    vendor "${packageInfo.vendor}"
+-    packager "${packageInfo.packager}"
+-    license "${packageInfo.license}"
+-    buildHost "${packageInfo.buildHost}"
+-    maintainer "${packageInfo.maintainer}"
+-    packageGroup 'java'
+-    priority 'optional'
+-    user 'root'
+-    permissionGroup 'root'
+-    epoch 1
+-    arch arch_deb
+-    multiArch SAME
++    version = project.version.upstream
++    release = project.version.revision
++
++    url = "${packageInfo.url}"
++    vendor = "${packageInfo.vendor}"
++    packager = "${packageInfo.packager}"
++    license = "${packageInfo.license}"
++    buildHost = "${packageInfo.buildHost}"
++    maintainer = "${packageInfo.maintainer}"
++    packageGroup = 'java'
++    priority = 'optional'
++    user = 'root'
++    permissionGroup = 'root'
++    epoch = 1
++    arch = arch_deb
++    multiArch = SAME
+ }
+ 
+ /**
+@@ -129,13 +129,13 @@ task inflateJinfoTemplate(type: Copy) {
+  * distributions folder.
+  */
+ task generateJdkDeb(type: Deb) {
+-    description 'Create the DEB package for Corretto JDK'
++    description = 'Create the DEB package for Corretto JDK'
+     dependsOn inflateDebScriptTemplate
+     dependsOn inflateJinfoTemplate
+ 
+-    packageName jdkPackageName
+-    packageDescription "Amazon Corretto\'s packaging of the OpenJDK ${project.version.major} code."
+-    summary "Amazon Corretto ${project.version.major} development environment"
++    packageName = jdkPackageName
++    packageDescription = "Amazon Corretto\'s packaging of the OpenJDK ${project.version.major} code."
++    summary = "Amazon Corretto ${project.version.major} development environment"
+ 
+     postInstall file("$buildRoot/scripts/postin_jdk.sh")
+     preUninstall file("$buildRoot/scripts/preun_jdk.sh")
+diff --git a/installers/linux/universal/rpm/build.gradle b/installers/linux/universal/rpm/build.gradle
+index c309c8ddb..346bcc21e 100644
+--- a/installers/linux/universal/rpm/build.gradle
++++ b/installers/linux/universal/rpm/build.gradle
+@@ -20,7 +20,7 @@
+  */
+ 
+ plugins {
+-    id 'nebula.ospackage' version 'latest.release'
++    id 'com.netflix.nebula.ospackage' version 'latest.release'
+ }
+ 
+ dependencies {
+@@ -51,20 +51,20 @@ def jdkBinaryDir = "${buildRoot}/${project.correttoJdkArchiveName}"
+ def jdkPackageName = "java-${project.version.major}-amazon-corretto-devel"
+ 
+ ospackage {
+-    version project.version.upstream
+-    release project.version.revision
+-
+-    url "${packageInfo.url}"
+-    vendor "${packageInfo.vendor}"
+-    packager "${packageInfo.packager}"
+-    license "${packageInfo.license}"
+-    buildHost "${packageInfo.buildHost}"
+-    user 'root'
+-    permissionGroup 'root'
+-    epoch 1
+-    arch arch_redline
+-    os LINUX
+-    type BINARY
++    version = project.version.upstream
++    release = project.version.revision
++
++    url = "${packageInfo.url}"
++    vendor = "${packageInfo.vendor}"
++    packager = "${packageInfo.packager}"
++    license = "${packageInfo.license}"
++    buildHost = "${packageInfo.buildHost}"
++    user = 'root'
++    permissionGroup = 'root'
++    epoch = 1
++    arch = arch_redline
++    os = LINUX
++    type = BINARY
+ }
+ 
+ /**
+@@ -101,14 +101,14 @@ task inflateRpmScriptTemplate(type: Copy) {
+  * distributions folder.
+  */
+ task generateJdkRpm(type: Rpm) {
+-    description 'Create the RPM package for Corretto JDK'
++    description = 'Create the RPM package for Corretto JDK'
+     dependsOn inflateRpmScriptTemplate
+-    packageName jdkPackageName
+-    packageDescription packageInfo.description
+-    summary "Amazon Corretto ${project.version.major} development environment"
+-    packageGroup 'Development/Tools'
++    packageName = jdkPackageName
++    packageDescription = packageInfo.description
++    summary = "Amazon Corretto ${project.version.major} development environment"
++    packageGroup = 'Development/Tools'
+     // Remove after https://github.com/nebula-plugins/gradle-ospackage-plugin/issues/401 is merged and released
+-    sourcePackage "${jdkPackageName}-${project.version.major}.${project.version.minor}.${project.version.security}.${project.version.build}-${project.version.revision}.src.rpm"
++    sourcePackage = "${jdkPackageName}-${project.version.major}.${project.version.minor}.${project.version.security}.${project.version.build}-${project.version.revision}.src.rpm"
+ 
+     prefix(jdkHome)
+     postInstall file("$buildRoot/scripts/postin_java.sh")
+diff --git a/installers/linux/universal/tar/build.gradle b/installers/linux/universal/tar/build.gradle
+index 72236d92c..e825a7594 100644
+--- a/installers/linux/universal/tar/build.gradle
++++ b/installers/linux/universal/tar/build.gradle
+@@ -85,7 +85,7 @@ task copySource(type: Exec) {
+             "${project.rootDir}/", buildRoot
+ }
+ 
+-/** 
++/**
+  * Scan the patches folder for any .patch that needs
+  * to be applied before start building.
+  */
+@@ -106,7 +106,7 @@ task configureBuild(type: Exec) {
+     workingDir "$buildRoot"
+ 
+     def isArmv7 = project.hasProperty("armv7") ? Boolean.valueOf("${project.getProperty('armv7')}") : false
+-    def zlibFlag = isArmv7 ? "--with-zlib=bundled" : "--with-zlib=system" 
++    def zlibFlag = isArmv7 ? "--with-zlib=bundled" : "--with-zlib=system"
+ 
+     // Platform specific flags
+     def command = ['bash', 'configure',
+@@ -156,9 +156,9 @@ task createTestImage(type: Exec) {
+ 
+ task packageTestImage(type: Tar) {
+     dependsOn createTestImage
+-    description 'Package test results'
+-    archiveName "${project.correttoTestImageArchiveName}.tar.gz"
+-    compression Compression.GZIP
++    description = 'Package test results'
++    archiveFileName = "${project.correttoTestImageArchiveName}.tar.gz"
++    compression = Compression.GZIP
+     from(testResultingImage) {
+         include '**'
+     }
+@@ -166,10 +166,10 @@ task packageTestImage(type: Tar) {
+ }
+ 
+ task packageDebugSymbols(type: Tar) {
+-    description 'Package debug results'
++    description = 'Package debug results'
+     dependsOn packageTestImage
+-    archiveName "${project.correttoDebugSymbolsArchiveName}.tar.gz"
+-    compression Compression.GZIP
++    archiveFileName = "${project.correttoDebugSymbolsArchiveName}.tar.gz"
++    compression = Compression.GZIP
+     from(jdkResultingImage) {
+         include 'bin/*.diz'
+         include 'lib/*.diz'
+@@ -179,11 +179,11 @@ task packageDebugSymbols(type: Tar) {
+ }
+ 
+ task packageBuildResults(type: Tar) {
+-    description 'Compresses the JDK image and puts the results in build/distributions.'
++    description = 'Compresses the JDK image and puts the results in build/distributions.'
+     dependsOn packageDebugSymbols
+     dependsOn bundleThirdPartyBinaries
+-    archiveName "${project.correttoJdkArchiveName}.tar.gz"
+-    compression Compression.GZIP
++    archiveFileName = "${project.correttoJdkArchiveName}.tar.gz"
++    compression = Compression.GZIP
+     from(buildRoot) {
+         include 'ADDITIONAL_LICENSE_INFO'
+         include 'ASSEMBLY_EXCEPTION'
+@@ -209,7 +209,7 @@ task packageBuildResults(type: Tar) {
+     // See https://github.com/corretto/corretto-11/issues/129
+     from("${jdkResultingImage}/legal") {
+         include '**'
+-        fileMode 0444
++        fileMode = 0444
+         into "${project.correttoJdkArchiveName}/legal"
+     }
+ }

--- a/pkgs/development/compilers/corretto/corretto17-gradle8.patch
+++ b/pkgs/development/compilers/corretto/corretto17-gradle8.patch
@@ -1,0 +1,290 @@
+diff --git a/build.gradle b/build.gradle
+index f678379aa..62df526d4 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -231,7 +231,7 @@ project(':prebuild') {
+     def generateToolMain = "build.tools.generatecacerts.GenerateCacerts"
+ 
+     task copyToolSrc(type: Copy) {
+-        description 'Copy utility tool source to the project root'
++        description = 'Copy utility tool source to the project root'
+         from fileTree("$rootDir/make/jdk/src/classes") {
+             include 'build/tools/generatecacerts/*'
+         }
+@@ -241,7 +241,7 @@ project(':prebuild') {
+     task buildTool(type: JavaCompile) {
+         dependsOn copyToolSrc
+         source = fileTree(dir: preBuildSrc, include: '**/*.java')
+-        destinationDir = file(classPath)
++        destinationDirectory = file(classPath)
+         classpath = files(classPath)
+     }
+ 
+@@ -282,9 +282,9 @@ project(':openjdksrc') {
+      * Compresses a snapshot of the source code used to perform the build.
+      */
+     task sourceDistributionTarball(type: Tar) {
+-        description 'Assemble source files required for building and distributing Corretto.'
+-        compression Compression.GZIP
+-        archiveName sourceTar
++        description = 'Assemble source files required for building and distributing Corretto.'
++        compression = Compression.GZIP
++        archiveFileName = sourceTar
+         from fileTree(rootDir) {
+             include 'LICENSE',
+                     'ADDITIONAL_LICENSE_INFO',
+diff --git a/installers/linux/al2/spec/build.gradle b/installers/linux/al2/spec/build.gradle
+index a5a1b9a7c..201283213 100644
+--- a/installers/linux/al2/spec/build.gradle
++++ b/installers/linux/al2/spec/build.gradle
+@@ -62,8 +62,8 @@ task inflateRpmSpec {
+ 
+ task copySourceTar(type: Tar) {
+     dependsOn project.configurations.compile, inflateRpmSpec
+-    compression Compression.GZIP
+-    archiveName project.configurations.compile.singleFile.name
++    compression = Compression.GZIP
++    archiveFileName = project.configurations.compile.singleFile.name
+     from("$buildDir") {
+         include "java-${project.version.major}-amazon-corretto.spec"
+         into 'rpm'
+diff --git a/installers/linux/alpine/tar/build.gradle b/installers/linux/alpine/tar/build.gradle
+index d0f95bd42..60bc9d40a 100644
+--- a/installers/linux/alpine/tar/build.gradle
++++ b/installers/linux/alpine/tar/build.gradle
+@@ -132,9 +132,9 @@ task bundleThirdPartyBinaries {
+ 
+ task packageTestImage(type: Tar) {
+     dependsOn createTestImage
+-    description 'Package test results'
+-    archiveName "amazon-corretto-testimage-${project.version.full}-alpine-linux-${arch_alias}.tar.gz"
+-    compression Compression.GZIP
++    description = 'Package test results'
++    archiveFileName = "amazon-corretto-testimage-${project.version.full}-alpine-linux-${arch_alias}.tar.gz"
++    compression = Compression.GZIP
+     from(testResultingImage) {
+         include '**'
+     }
+@@ -143,9 +143,9 @@ task packageTestImage(type: Tar) {
+ 
+ task packageDebugSymbols(type: Tar) {
+     dependsOn packageTestImage
+-    description 'Package debug symbols'
+-    archiveName "amazon-corretto-debugsymbols-${project.version.full}-alpine-linux-${arch_alias}.tar.gz"
+-    compression Compression.GZIP
++    description = 'Package debug symbols'
++    archiveFileName = "amazon-corretto-debugsymbols-${project.version.full}-alpine-linux-${arch_alias}.tar.gz"
++    compression = Compression.GZIP
+     from(jdkResultingImage) {
+         include 'bin/*.diz'
+         include 'lib/*.diz'
+@@ -155,12 +155,12 @@ task packageDebugSymbols(type: Tar) {
+ }
+ 
+ task packageBuildResults(type: Tar) {
+-    description 'Compresses the JDK image and puts the results in build/distributions.'
++    description = 'Compresses the JDK image and puts the results in build/distributions.'
+     dependsOn packageDebugSymbols
+     dependsOn executeBuild
+     dependsOn bundleThirdPartyBinaries
+-    archiveName "amazon-corretto-${project.version.full}-alpine-linux-${arch_alias}.tar.gz"
+-    compression Compression.GZIP
++    archiveFileName = "amazon-corretto-${project.version.full}-alpine-linux-${arch_alias}.tar.gz"
++    compression = Compression.GZIP
+     from(buildRoot) {
+         include 'ADDITIONAL_LICENSE_INFO'
+         include 'ASSEMBLY_EXCEPTION'
+diff --git a/installers/linux/universal/deb/build.gradle b/installers/linux/universal/deb/build.gradle
+index 118ad0b74..54f7e0c50 100644
+--- a/installers/linux/universal/deb/build.gradle
++++ b/installers/linux/universal/deb/build.gradle
+@@ -20,7 +20,7 @@
+  */
+ 
+ plugins {
+-    id 'nebula.ospackage' version 'latest.release'
++    id 'com.netflix.nebula.ospackage' version 'latest.release'
+ }
+ 
+ dependencies {
+@@ -54,22 +54,22 @@ def jinfoName = ".${jdkInstallationDirName}.jinfo"
+ ospackage {
+     // Valid version must start with a digit and only contain [A-Za-z0-9.+:~-]
+     // See http://manpages.ubuntu.com/manpages/artful/en/man5/deb-version.5.html
+-    version project.version.upstream
+-    release project.version.revision
+-
+-    url "${packageInfo.url}"
+-    vendor "${packageInfo.vendor}"
+-    packager "${packageInfo.packager}"
+-    license "${packageInfo.license}"
+-    buildHost "${packageInfo.buildHost}"
+-    maintainer "${packageInfo.maintainer}"
+-    packageGroup 'java'
+-    priority 'optional'
+-    user 'root'
+-    permissionGroup 'root'
+-    epoch 1
+-    arch arch_deb
+-    multiArch SAME
++    version = project.version.upstream
++    release = project.version.revision
++
++    url = "${packageInfo.url}"
++    vendor = "${packageInfo.vendor}"
++    packager = "${packageInfo.packager}"
++    license = "${packageInfo.license}"
++    buildHost = "${packageInfo.buildHost}"
++    maintainer = "${packageInfo.maintainer}"
++    packageGroup = 'java'
++    priority = 'optional'
++    user = 'root'
++    permissionGroup = 'root'
++    epoch = 1
++    arch = arch_deb
++    multiArch = SAME
+ }
+ 
+ /**
+@@ -124,13 +124,13 @@ task inflateJinfoTemplate(type: Copy) {
+  * distributions folder.
+  */
+ task generateJdkDeb(type: Deb) {
+-    description 'Create the DEB package for Corretto JDK'
++    description = 'Create the DEB package for Corretto JDK'
+     dependsOn inflateDebScriptTemplate
+     dependsOn inflateJinfoTemplate
+ 
+-    packageName jdkPackageName
+-    packageDescription "Amazon Corretto\'s packaging of the OpenJDK ${project.version.major} code."
+-    summary "Amazon Corretto ${project.version.major} development environment"
++    packageName = jdkPackageName
++    packageDescription = "Amazon Corretto\'s packaging of the OpenJDK ${project.version.major} code."
++    summary = "Amazon Corretto ${project.version.major} development environment"
+ 
+     postInstall file("$buildRoot/scripts/postin_jdk.sh")
+     preUninstall file("$buildRoot/scripts/preun_jdk.sh")
+diff --git a/installers/linux/universal/rpm/build.gradle b/installers/linux/universal/rpm/build.gradle
+index 2883b16ac..ed914b679 100644
+--- a/installers/linux/universal/rpm/build.gradle
++++ b/installers/linux/universal/rpm/build.gradle
+@@ -20,7 +20,7 @@
+  */
+ 
+ plugins {
+-    id 'nebula.ospackage' version 'latest.release'
++    id 'com.netflix.nebula.ospackage' version 'latest.release'
+ }
+ 
+ dependencies {
+@@ -48,20 +48,20 @@ def jdkBinaryDir = "${buildRoot}/${project.correttoJdkArchiveName}"
+ def jdkPackageName = "java-${project.version.major}-amazon-corretto-devel"
+ 
+ ospackage {
+-    version project.version.upstream
+-    release project.version.revision
+-
+-    url "${packageInfo.url}"
+-    vendor "${packageInfo.vendor}"
+-    packager "${packageInfo.packager}"
+-    license "${packageInfo.license}"
+-    buildHost "${packageInfo.buildHost}"
+-    user 'root'
+-    permissionGroup 'root'
+-    epoch 1
+-    arch arch_redline
+-    os LINUX
+-    type BINARY
++    version = project.version.upstream
++    release = project.version.revision
++
++    url = "${packageInfo.url}"
++    vendor = "${packageInfo.vendor}"
++    packager = "${packageInfo.packager}"
++    license = "${packageInfo.license}"
++    buildHost = "${packageInfo.buildHost}"
++    user = 'root'
++    permissionGroup = 'root'
++    epoch = 1
++    arch = arch_redline
++    os = LINUX
++    type = BINARY
+ }
+ 
+ /**
+@@ -97,14 +97,14 @@ task inflateRpmScriptTemplate(type: Copy) {
+  * distributions folder.
+  */
+ task generateJdkRpm(type: Rpm) {
+-    description 'Create the RPM package for Corretto JDK'
++    description = 'Create the RPM package for Corretto JDK'
+     dependsOn inflateRpmScriptTemplate
+-    packageName jdkPackageName
+-    packageDescription packageInfo.description
+-    summary "Amazon Corretto ${project.version.major} development environment"
+-    packageGroup 'Development/Tools'
++    packageName = jdkPackageName
++    packageDescription = packageInfo.description
++    summary = "Amazon Corretto ${project.version.major} development environment"
++    packageGroup = 'Development/Tools'
+     // Remove after https://github.com/nebula-plugins/gradle-ospackage-plugin/issues/401 is merged and released
+-    sourcePackage "${jdkPackageName}-${project.version.major}.${project.version.minor}.${project.version.security}.${project.version.build}-${project.version.revision}.src.rpm"
++    sourcePackage = "${jdkPackageName}-${project.version.major}.${project.version.minor}.${project.version.security}.${project.version.build}-${project.version.revision}.src.rpm"
+ 
+     prefix(jdkHome)
+     postInstall file("$buildRoot/scripts/postin_java.sh")
+diff --git a/installers/linux/universal/tar/build.gradle b/installers/linux/universal/tar/build.gradle
+index 17491d830..9ec3280e6 100644
+--- a/installers/linux/universal/tar/build.gradle
++++ b/installers/linux/universal/tar/build.gradle
+@@ -122,9 +122,9 @@ task bundleThirdPartyBinaries {
+ 
+ task packageTestImage(type: Tar) {
+     dependsOn createTestImage
+-    description 'Package test results'
+-    archiveName "${project.correttoTestImageArchiveName}.tar.gz"
+-    compression Compression.GZIP
++    description = 'Package test results'
++    archiveFileName = "${project.correttoTestImageArchiveName}.tar.gz"
++    compression = Compression.GZIP
+     from(testResultingImage) {
+         include '**'
+     }
+@@ -132,10 +132,10 @@ task packageTestImage(type: Tar) {
+ }
+ 
+ task packageDebugSymbols(type: Tar) {
+-    description 'Package debug results'
++    description = 'Package debug results'
+     dependsOn packageTestImage
+-    archiveName "${project.correttoDebugSymbolsArchiveName}.tar.gz"
+-    compression Compression.GZIP
++    archiveFileName = "${project.correttoDebugSymbolsArchiveName}.tar.gz"
++    compression = Compression.GZIP
+     from(jdkResultingImage) {
+         include 'bin/*.diz'
+         include 'lib/*.diz'
+@@ -145,11 +145,11 @@ task packageDebugSymbols(type: Tar) {
+ }
+ 
+ task packageBuildResults(type: Tar) {
+-    description 'Compresses the JDK image and puts the results in build/distributions.'
++    description = 'Compresses the JDK image and puts the results in build/distributions.'
+     dependsOn packageDebugSymbols
+     dependsOn bundleThirdPartyBinaries
+-    archiveName "${project.correttoJdkArchiveName}.tar.gz"
+-    compression Compression.GZIP
++    archiveFileName = "${project.correttoJdkArchiveName}.tar.gz"
++    compression = Compression.GZIP
+     from(buildRoot) {
+         include 'ADDITIONAL_LICENSE_INFO'
+         include 'ASSEMBLY_EXCEPTION'
+@@ -175,7 +175,7 @@ task packageBuildResults(type: Tar) {
+     // See https://github.com/corretto/corretto-11/issues/129
+     from("${jdkResultingImage}/legal") {
+         include '**'
+-        fileMode 0444
++        fileMode = 0444
+         into "${project.correttoJdkArchiveName}/legal"
+     }
+ }

--- a/pkgs/development/compilers/corretto/corretto21-gradle8.patch
+++ b/pkgs/development/compilers/corretto/corretto21-gradle8.patch
@@ -1,0 +1,340 @@
+diff --git a/build.gradle b/build.gradle
+index 61d5c8f8b48..2102e8921bd 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -257,7 +257,7 @@ project(':prebuild') {
+     def generateToolMain = "build.tools.generatecacerts.GenerateCacerts"
+ 
+     task copyToolSrc(type: Copy) {
+-        description 'Copy utility tool source to the project root'
++        description = 'Copy utility tool source to the project root'
+         from fileTree("$rootDir/make/jdk/src/classes") {
+             include 'build/tools/generatecacerts/*'
+         }
+@@ -267,7 +267,7 @@ project(':prebuild') {
+     task buildTool(type: JavaCompile) {
+         dependsOn copyToolSrc
+         source = fileTree(dir: preBuildSrc, include: '**/*.java')
+-        destinationDir = file(classPath)
++        destinationDirectory = file(classPath)
+         classpath = files(classPath)
+     }
+ 
+@@ -280,7 +280,7 @@ project(':prebuild') {
+ 
+         // See commit for [JDK-8275252](https://github.com/corretto/corretto-jdk/commit/bd2b41dd7062c50f3aaebec2137d5fdd9546c120)
+         jvmArgs = ['-Dkeystore.pkcs12.certProtectionAlgorithm=NONE', '-Dkeystore.pkcs12.macAlgorithm=NONE']
+-        main = generateToolMain
++        mainClass = generateToolMain
+         args = [jdkCaDir, project.caCerts]
+     }
+ 
+@@ -311,9 +311,9 @@ project(':openjdksrc') {
+      * Compresses a snapshot of the source code used to perform the build.
+      */
+     task sourceDistributionTarball(type: Tar) {
+-        description 'Assemble source files required for building and distributing Corretto.'
+-        compression Compression.GZIP
+-        archiveName sourceTar
++        description = 'Assemble source files required for building and distributing Corretto.'
++        compression = Compression.GZIP
++        archiveFileName = sourceTar
+         def sourceTarRootFiles = ['LICENSE',
+                     'ADDITIONAL_LICENSE_INFO',
+                     'README',
+diff --git a/installers/linux/al2/spec/build.gradle b/installers/linux/al2/spec/build.gradle
+index 1df0004cbac..1b5dd56d7fd 100644
+--- a/installers/linux/al2/spec/build.gradle
++++ b/installers/linux/al2/spec/build.gradle
+@@ -63,8 +63,8 @@ task inflateRpmSpec {
+ 
+ task copySourceTar(type: Tar) {
+     dependsOn project.configurations.compile, inflateRpmSpec
+-    compression Compression.GZIP
+-    archiveName project.configurations.compile.singleFile.name
++    compression = Compression.GZIP
++    archiveFileName = project.configurations.compile.singleFile.name
+     from("$buildDir") {
+         include "java-${project.version.major}-amazon-corretto.spec"
+         into 'rpm'
+diff --git a/installers/linux/alpine/tar/build.gradle b/installers/linux/alpine/tar/build.gradle
+index 5b88041eebb..5b0c05f81d0 100644
+--- a/installers/linux/alpine/tar/build.gradle
++++ b/installers/linux/alpine/tar/build.gradle
+@@ -131,9 +131,9 @@ task bundleThirdPartyBinaries {
+ 
+ task packageTestImage(type: Tar) {
+     dependsOn createTestImage
+-    description 'Package test results'
+-    archiveName "amazon-corretto-testimage-${project.version.full}-alpine-linux-${arch_alias}.tar.gz"
+-    compression Compression.GZIP
++    description = 'Package test results'
++    archiveFileName = "amazon-corretto-testimage-${project.version.full}-alpine-linux-${arch_alias}.tar.gz"
++    compression = Compression.GZIP
+     from(testResultingImage) {
+         include '**'
+     }
+@@ -142,9 +142,9 @@ task packageTestImage(type: Tar) {
+ 
+ task packageDebugSymbols(type: Tar) {
+     dependsOn packageTestImage
+-    description 'Package debug symbols'
+-    archiveName "amazon-corretto-debugsymbols-${project.version.full}-alpine-linux-${arch_alias}.tar.gz"
+-    compression Compression.GZIP
++    description = 'Package debug symbols'
++    archiveFileName = "amazon-corretto-debugsymbols-${project.version.full}-alpine-linux-${arch_alias}.tar.gz"
++    compression = Compression.GZIP
+     from(jdkResultingImage) {
+         include 'bin/*.diz'
+         include 'lib/*.diz'
+@@ -154,12 +154,12 @@ task packageDebugSymbols(type: Tar) {
+ }
+ 
+ task packageBuildResults(type: Tar) {
+-    description 'Compresses the JDK image and puts the results in build/distributions.'
++    description = 'Compresses the JDK image and puts the results in build/distributions.'
+     dependsOn packageDebugSymbols
+     dependsOn executeBuild
+     dependsOn bundleThirdPartyBinaries
+-    archiveName "amazon-corretto-${project.version.full}-alpine-linux-${arch_alias}.tar.gz"
+-    compression Compression.GZIP
++    archiveFileName = "amazon-corretto-${project.version.full}-alpine-linux-${arch_alias}.tar.gz"
++    compression = Compression.GZIP
+     from(buildRoot) {
+         include project.rootFiles
+     }
+@@ -178,7 +178,7 @@ task packageBuildResults(type: Tar) {
+     // See https://github.com/corretto/corretto-11/issues/129
+     from(jdkResultingImage) {
+         include 'legal/**'
+-        fileMode 0444
++        fileMode = 0444
+     }
+     into "amazon-corretto-${project.version.full}-alpine-linux-${arch_alias}"
+ }
+diff --git a/installers/linux/universal/deb/build.gradle b/installers/linux/universal/deb/build.gradle
+index 4daf46e8b14..3376e3c58d1 100644
+--- a/installers/linux/universal/deb/build.gradle
++++ b/installers/linux/universal/deb/build.gradle
+@@ -20,7 +20,7 @@
+  */
+ 
+ plugins {
+-    id 'nebula.ospackage' version 'latest.release'
++    id 'com.netflix.nebula.ospackage' version 'latest.release'
+ }
+ 
+ dependencies {
+@@ -57,22 +57,22 @@ def jinfoName = ".${jdkInstallationDirName}.jinfo"
+ ospackage {
+     // Valid version must start with a digit and only contain [A-Za-z0-9.+:~-]
+     // See http://manpages.ubuntu.com/manpages/artful/en/man5/deb-version.5.html
+-    version project.version.upstream
+-    release project.version.revision
+-
+-    url "${packageInfo.url}"
+-    vendor "${packageInfo.vendor}"
+-    packager "${packageInfo.packager}"
+-    license "${packageInfo.license}"
+-    buildHost "${packageInfo.buildHost}"
+-    maintainer "${packageInfo.maintainer}"
+-    packageGroup 'java'
+-    priority 'optional'
+-    user 'root'
+-    permissionGroup 'root'
+-    epoch 1
+-    arch arch_deb
+-    multiArch SAME
++    version = project.version.upstream
++    release = project.version.revision
++
++    url = "${packageInfo.url}"
++    vendor = "${packageInfo.vendor}"
++    packager = "${packageInfo.packager}"
++    license = "${packageInfo.license}"
++    buildHost = "${packageInfo.buildHost}"
++    maintainer = "${packageInfo.maintainer}"
++    packageGroup = 'java'
++    priority = 'optional'
++    user = 'root'
++    permissionGroup = 'root'
++    epoch = 1
++    arch = arch_deb
++    multiArch = SAME
+ }
+ 
+ /**
+@@ -127,13 +127,13 @@ task inflateJinfoTemplate(type: Copy) {
+  * distributions folder.
+  */
+ task generateJdkDeb(type: Deb) {
+-    description 'Create the DEB package for Corretto JDK'
++    description = 'Create the DEB package for Corretto JDK'
+     dependsOn inflateDebScriptTemplate
+     dependsOn inflateJinfoTemplate
+ 
+-    packageName jdkPackageName
+-    packageDescription "Amazon Corretto\'s packaging of the OpenJDK ${project.version.major} code."
+-    summary "Amazon Corretto ${project.version.major} development environment"
++    packageName = jdkPackageName
++    packageDescription = "Amazon Corretto\'s packaging of the OpenJDK ${project.version.major} code."
++    summary = "Amazon Corretto ${project.version.major} development environment"
+ 
+     postInstall file("$buildRoot/scripts/postin_jdk.sh")
+     preUninstall file("$buildRoot/scripts/preun_jdk.sh")
+@@ -191,13 +191,13 @@ task generateJdkDeb(type: Deb) {
+     // See https://github.com/corretto/corretto-11/issues/129
+     from("${jdkBinaryDir}/legal") {
+         into "${jdkHome}/legal"
+-        fileMode 0444
++        fileMode = 0444
+     }
+ 
+     if (!project.excludeReadmeJavaSE) {
+         from("${jdkBinaryDir}/README.JAVASE") {
+             into jdkHome
+-            fileMode 0444
++            fileMode = 0444
+         }
+     }
+ 
+diff --git a/installers/linux/universal/rpm/build.gradle b/installers/linux/universal/rpm/build.gradle
+index 50f55bb52c0..fbbe8f44bca 100644
+--- a/installers/linux/universal/rpm/build.gradle
++++ b/installers/linux/universal/rpm/build.gradle
+@@ -20,7 +20,7 @@
+  */
+ 
+ plugins {
+-    id 'nebula.ospackage' version 'latest.release'
++    id 'com.netflix.nebula.ospackage' version 'latest.release'
+ }
+ 
+ dependencies {
+@@ -51,20 +51,20 @@ def jdkBinaryDir = "${buildRoot}/${project.correttoJdkArchiveName}"
+ def jdkPackageName = "java-${project.version.major}-amazon-corretto-devel"
+ 
+ ospackage {
+-    version project.version.upstream
+-    release project.version.revision
+-
+-    url "${packageInfo.url}"
+-    vendor "${packageInfo.vendor}"
+-    packager "${packageInfo.packager}"
+-    license "${packageInfo.license}"
+-    buildHost "${packageInfo.buildHost}"
+-    user 'root'
+-    permissionGroup 'root'
+-    epoch 1
+-    arch arch_redline
+-    os LINUX
+-    type BINARY
++    version = project.version.upstream
++    release = project.version.revision
++
++    url = "${packageInfo.url}"
++    vendor = "${packageInfo.vendor}"
++    packager = "${packageInfo.packager}"
++    license = "${packageInfo.license}"
++    buildHost = "${packageInfo.buildHost}"
++    user = 'root'
++    permissionGroup = 'root'
++    epoch = 1
++    arch = arch_redline
++    os = LINUX
++    type = BINARY
+ }
+ 
+ /**
+@@ -100,14 +100,14 @@ task inflateRpmScriptTemplate(type: Copy) {
+  * distributions folder.
+  */
+ task generateJdkRpm(type: Rpm) {
+-    description 'Create the RPM package for Corretto JDK'
++    description = 'Create the RPM package for Corretto JDK'
+     dependsOn inflateRpmScriptTemplate
+-    packageName jdkPackageName
+-    packageDescription packageInfo.description
+-    summary "Amazon Corretto ${project.version.major} development environment"
+-    packageGroup 'Development/Tools'
++    packageName = jdkPackageName
++    packageDescription = packageInfo.description
++    summary = "Amazon Corretto ${project.version.major} development environment"
++    packageGroup = 'Development/Tools'
+     // Remove after https://github.com/nebula-plugins/gradle-ospackage-plugin/issues/401 is merged and released
+-    sourcePackage "${jdkPackageName}-${project.version.major}.${project.version.minor}.${project.version.security}.${project.version.build}-${project.version.revision}.src.rpm"
++    sourcePackage = "${jdkPackageName}-${project.version.major}.${project.version.minor}.${project.version.security}.${project.version.build}-${project.version.revision}.src.rpm"
+ 
+     prefix(jdkHome)
+     postInstall file("$buildRoot/scripts/postin_java.sh")
+@@ -146,13 +146,13 @@ task generateJdkRpm(type: Rpm) {
+     // See https://github.com/corretto/corretto-11/issues/129
+     from("${jdkBinaryDir}/legal") {
+         into "${jdkHome}/legal"
+-        fileMode 0444
++        fileMode = 0444
+     }
+ 
+     if (!project.excludeReadmeJavaSE) {
+         from("${jdkBinaryDir}/README.JAVASE") {
+             into jdkHome
+-            fileMode 0444
++            fileMode = 0444
+         }
+     }   
+ }
+diff --git a/installers/linux/universal/tar/build.gradle b/installers/linux/universal/tar/build.gradle
+index be5be844e38..0480a6a34c9 100644
+--- a/installers/linux/universal/tar/build.gradle
++++ b/installers/linux/universal/tar/build.gradle
+@@ -121,9 +121,9 @@ task bundleThirdPartyBinaries {
+ 
+ task packageTestImage(type: Tar) {
+     dependsOn createTestImage
+-    description 'Package test results'
+-    archiveName "${project.correttoTestImageArchiveName}.tar.gz"
+-    compression Compression.GZIP
++    description = 'Package test results'
++    archiveFileName = "${project.correttoTestImageArchiveName}.tar.gz"
++    compression = Compression.GZIP
+     from(testResultingImage) {
+         include '**'
+     }
+@@ -131,10 +131,10 @@ task packageTestImage(type: Tar) {
+ }
+ 
+ task packageDebugSymbols(type: Tar) {
+-    description 'Package debug results'
++    description = 'Package debug results'
+     dependsOn packageTestImage
+-    archiveName "${project.correttoDebugSymbolsArchiveName}.tar.gz"
+-    compression Compression.GZIP
++    archiveFileName = "${project.correttoDebugSymbolsArchiveName}.tar.gz"
++    compression = Compression.GZIP
+     from(jdkResultingImage) {
+         include 'bin/*.diz'
+         include 'lib/*.diz'
+@@ -144,11 +144,11 @@ task packageDebugSymbols(type: Tar) {
+ }
+ 
+ task packageBuildResults(type: Tar) {
+-    description 'Compresses the JDK image and puts the results in build/distributions.'
++    description = 'Compresses the JDK image and puts the results in build/distributions.'
+     dependsOn packageDebugSymbols
+     dependsOn bundleThirdPartyBinaries
+-    archiveName "${project.correttoJdkArchiveName}.tar.gz"
+-    compression Compression.GZIP
++    archiveFileName = "${project.correttoJdkArchiveName}.tar.gz"
++    compression = Compression.GZIP
+     from(buildRoot) {
+         include project.rootFiles
+         into project.correttoJdkArchiveName
+@@ -169,7 +169,7 @@ task packageBuildResults(type: Tar) {
+     // See https://github.com/corretto/corretto-11/issues/129
+     from("${jdkResultingImage}/legal") {
+         include '**'
+-        fileMode 0444
++        fileMode = 0444
+         into "${project.correttoJdkArchiveName}/legal"
+     }
+ }


### PR DESCRIPTION
This PR updates corretto{11,17,21} to their respective latest versions. Currently, corretto builds fail because Gradle7 is EOL'ed and not supported in nixpkgs anymore. Thus, this PR also converts corretto builds to Gradle8.

[Upstream does not plan to support Gradle8 for corretto <=21](https://github.com/corretto/corretto-21/issues/114#issuecomment-3198171683). I have created patches for each corretto version that allow to build with Gradle8. Unfortunately, the patches differ so we now have 3 of them. The patches are based on the changes in https://github.com/corretto/corretto-jdk/pull/135 (actual [commit](https://github.com/corretto/corretto-jdk/pull/135/commits/cc5a546d2091690b1dfab59d351993ca1e771b12)) but did not apply cleanly. I have manually fixed remaining issues and used only the minimal diff (of the original commit) for my patches. The actual diff to review is 3x the 10 similar lines for each corretto version. The 990+ lines in the diff stem from the patches.

I also tried to `corretto25: init at 25.0.1.9.1` but that build failed and I haven't yet looked into it. I decided to keep this PR smaller for now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
