### PR TITLE
ci/github-script/bot: fix scheduled bot with older artifacts

### DIFF
--- a/ci/github-script/bot.js
+++ b/ci/github-script/bot.js
@@ -375,6 +375,17 @@ module.exports = async ({ github, context, core, dry }) => {
       })
 
       if (!pull_request.draft) {
+        let owners = []
+        try {
+          // TODO: Create owner map similar to maintainer map.
+          owners = (await readFile(`${pull_number}/owners.txt`, 'utf-8')).split(
+            '\n',
+          )
+        } catch (e) {
+          // Older artifacts don't have the owners.txt, yet.
+          if (e.code !== 'ENOENT') throw e
+        }
+
         // We set this label earlier already, but the current PR state can be very different
         // after handleReviewers has requested reviews, so update it in this case to prevent
         // this label from flip-flopping.
@@ -392,10 +403,7 @@ module.exports = async ({ github, context, core, dry }) => {
               await readFile(`${pull_number}/maintainers.json`, 'utf-8'),
             ),
           ).map((id) => parseInt(id)),
-          // TODO: Create owner map similar to maintainer map.
-          owners: (await readFile(`${pull_number}/owners.txt`, 'utf-8')).split(
-            '\n',
-          ),
+          owners,
           getTeamMembers,
           getUser,
         })


### PR DESCRIPTION
We only recently introduced the owners.txt file to the comparison artifact, so once the bot runs on a schedule it will it older artifacts very quickly - and then can't find the owners file.

We can fallback to an empty owners list in this case, because an older artifact also means an older workflow run previously, so this will have pinged owners already.

Fixes https://github.com/NixOS/nixpkgs/pull/458604#issuecomment-3495955995

## Things done

- [x] Tested locally.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
