### PR TITLE
ghidra-gamecube-loader: init at 0-unstable

### DIFF
--- a/pkgs/tools/security/ghidra/extensions.nix
+++ b/pkgs/tools/security/ghidra/extensions.nix
@@ -19,6 +19,8 @@ lib.makeScope newScope (self: {
 
   ghidra-firmware-utils = self.callPackage ./extensions/ghidra-firmware-utils { };
 
+  ghidra-gamecube-loader = self.callPackage ./extensions/ghidra-gamecube-loader { };
+
   ghidra-golanganalyzerextension = self.callPackage ./extensions/ghidra-golanganalyzerextension { };
 
   ghidraninja-ghidra-scripts = self.callPackage ./extensions/ghidraninja-ghidra-scripts { };

--- a/pkgs/tools/security/ghidra/extensions/ghidra-gamecube-loader/default.nix
+++ b/pkgs/tools/security/ghidra/extensions/ghidra-gamecube-loader/default.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  fetchFromGitHub,
+
+  gradle,
+  ghidra,
+  buildGhidraExtension,
+}:
+buildGhidraExtension (finalAttrs: {
+  pname = "ghidra-gamecube-loader";
+  version = "0-unstable";
+
+  src = fetchFromGitHub {
+    owner = "Cuyler36";
+    repo = "Ghidra-GameCube-Loader";
+    rev = "0ff5e888526cd8cbc03660445c0dcd1105c8883a";
+    hash = "sha256-kwgm3xf1VLm6N4icY2LHsL01mxqqR5djUd/Bw2hkFTg=";
+  };
+
+  postPatch = ''
+    substituteInPlace build.gradle \
+      --replace-fail \
+        '-''${getGitHash()}' \
+        '-${builtins.substring 0 8 finalAttrs.src.rev}'
+    substituteInPlace data/buildLanguage.xml \
+        --replace-fail \
+        'file="../.antProperties.xml" optional="false"' \
+        'file="../.antProperties.xml" optional="true"'
+  '';
+
+  configurePhase = ''
+    runHook preConfigure
+
+    pushd data
+    touch sleighArgs.txt
+    ant -f buildLanguage.xml -Dghidra.install.dir=${ghidra}/lib/ghidra sleighCompile
+    popd
+
+    runHook postConfigure
+  '';
+
+  mitmCache = gradle.fetchDeps {
+    pkg = finalAttrs.finalPackage;
+    data = ./deps.json;
+  };
+
+  meta = {
+    description = "A Nintendo GameCube binary loader for Ghidra";
+    homepage = "https://github.com/Cuyler36/Ghidra-GameCube-Loader";
+    downloadPage = "https://github.com/Cuyler36/Ghidra-GameCube-Loader/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ jchw ];
+  };
+})

--- a/pkgs/tools/security/ghidra/extensions/ghidra-gamecube-loader/deps.json
+++ b/pkgs/tools/security/ghidra/extensions/ghidra-gamecube-loader/deps.json
@@ -1,0 +1,10 @@
+{
+ "!comment": "This is a nixpkgs Gradle dependency lockfile. For more details, refer to the Gradle section in the nixpkgs manual.",
+ "!version": 1,
+ "https://repo.maven.apache.org": {
+  "maven2/org/lz4#lz4-java/1.5.1": {
+   "jar": "sha256-JqVYBaKrcd7omY9iu6qtCtxxhSfs+PMiRG6IKGgZ9PM=",
+   "pom": "sha256-R8IrXQlK3hM6FO/S3j5tMLMmF5K1I3RIJs5o1YYE2NM="
+  }
+ }
+}


### PR DESCRIPTION
Extension for Ghidra that adds various helpers for GameCube/Wii/etc. reverse engineering (loading DOL files, demangling CodeWarrior symbols, etc.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
