### PR TITLE
xsstrike: init at 3.1.6

### DIFF
--- a/pkgs/by-name/xs/xsstrike/package.nix
+++ b/pkgs/by-name/xs/xsstrike/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  fetchpatch2,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "xsstrike";
+  version = "3.1.6";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "s0md3v";
+    repo = "XSStrike";
+    tag = version;
+    hash = "sha256-6U0e9JkYYIt+APZ6B4+kNO/hcC3BAfrn+QXbCnLqpbs=";
+  };
+
+  __structuredAttrs = true;
+
+  patches = [
+    (fetchpatch2 {
+      # https://github.com/s0md3v/XSStrike/pull/435
+      url = "https://github.com/s0md3v/XSStrike/commit/101ad7d789583e3aa99461e864377b0683d4f29c.patch";
+      hash = "sha256-5ONL5nUyi/tEiINnVmmWbQd1vY8zNqS0ryFf/6k+7Lc=";
+    })
+  ];
+
+  build-system = [ python3Packages.setuptools ];
+
+  dependencies = with python3Packages; [
+    tld
+    fuzzywuzzy
+    requests
+  ];
+
+  postPatch = ''
+    substituteInPlace xsstrike.py \
+      --replace-fail "sys.path[0] + '/db/" "'$out/${python3Packages.python.sitePackages}/db/"
+    substituteInPlace core/wafDetector.py \
+      --replace-fail "sys.path[0] + '/db/" "'$out/${python3Packages.python.sitePackages}/db/"
+
+    substituteInPlace xsstrike.py \
+      --replace-fail 'v3.1.5' 'v${version}'
+  '';
+
+  postInstall = ''
+    mv $out/bin/xsstrike{.py,}
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Most advanced XSS scanner";
+    homepage = "https://github.com/s0md3v/XSStrike";
+    license = with lib.licenses; [
+      gpl3Only
+      # sqlmap WAF rules
+      gpl2Plus
+      # retirejslib
+      asl20
+    ];
+    maintainers = with lib.maintainers; [ letgamer ];
+    mainProgram = "xsstrike";
+  };
+}

--- a/pkgs/by-name/xs/xsstrike/package.nix
+++ b/pkgs/by-name/xs/xsstrike/package.nix
@@ -7,7 +7,7 @@
   versionCheckHook,
 }:
 
-python3Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "xsstrike";
   version = "3.1.6";
   pyproject = true;
@@ -15,7 +15,7 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "s0md3v";
     repo = "XSStrike";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-6U0e9JkYYIt+APZ6B4+kNO/hcC3BAfrn+QXbCnLqpbs=";
   };
 
@@ -29,14 +29,6 @@ python3Packages.buildPythonApplication rec {
     })
   ];
 
-  build-system = [ python3Packages.setuptools ];
-
-  dependencies = with python3Packages; [
-    tld
-    fuzzywuzzy
-    requests
-  ];
-
   postPatch = ''
     substituteInPlace xsstrike.py \
       --replace-fail "sys.path[0] + '/db/" "'$out/${python3Packages.python.sitePackages}/db/"
@@ -44,21 +36,33 @@ python3Packages.buildPythonApplication rec {
       --replace-fail "sys.path[0] + '/db/" "'$out/${python3Packages.python.sitePackages}/db/"
 
     substituteInPlace xsstrike.py \
-      --replace-fail 'v3.1.5' 'v${version}'
+      --replace-fail 'v3.1.5' 'v${finalAttrs.version}'
   '';
+
+  build-system = with python3Packages; [ setuptools ];
+
+  dependencies = with python3Packages; [
+    tld
+    fuzzywuzzy
+    requests
+  ];
 
   postInstall = ''
     mv $out/bin/xsstrike{.py,}
   '';
 
   nativeInstallCheckInputs = [ versionCheckHook ];
+
   doInstallCheck = true;
+
+  versionCheckProgramArg = [ "-h" ];
 
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "Most advanced XSS scanner";
+    description = "Advanced XSS scanner";
     homepage = "https://github.com/s0md3v/XSStrike";
+    changelog = "https://github.com/s0md3v/XSStrike/releases/tag/${finalAttrs.src.tag}";
     license = with lib.licenses; [
       gpl3Only
       # sqlmap WAF rules
@@ -69,4 +73,4 @@ python3Packages.buildPythonApplication rec {
     maintainers = with lib.maintainers; [ letgamer ];
     mainProgram = "xsstrike";
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This PR packages **XSStrike** to NixOS: https://github.com/s0md3v/XSStrike.

XSStrike is an advanced tool used in penetration testing to fuzz and detect XSS (Cross-Site Scripting) vulnerabilities on websites.  
It is widely used in training environments such as the Hack The Box Academy XSS chapter: [forum discussion](https://forum.hackthebox.com/t/issue-xxs-strike-no-vectors-were-crafted/281653)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
