### PR TITLE
lima: 1.2.1 -> 1.2.2

### DIFF
--- a/pkgs/by-name/li/lima/source.nix
+++ b/pkgs/by-name/li/lima/source.nix
@@ -3,7 +3,7 @@
 }:
 
 let
-  version = "1.2.1";
+  version = "1.2.2";
 in
 {
   inherit version;
@@ -12,7 +12,7 @@ in
     owner = "lima-vm";
     repo = "lima";
     tag = "v${version}";
-    hash = "sha256-90fFsS5jidaovE2iqXfe4T2SgZJz6ScOwPPYxCsCk/k=";
+    hash = "sha256-bIYF/bsOMuWTkjD6fe6by220/WQGL+VWEBXmUzyXU98=";
   };
 
   vendorHash = "sha256-8S5tAL7GY7dxNdyC+WOrOZ+GfTKTSX84sG8WcSec2Os=";


### PR DESCRIPTION
Release: https://github.com/lima-vm/lima/releases/tag/v1.2.2
Diff: https://github.com/lima-vm/lima/compare/v1.2.1...v1.2.2

Lima has released both 1.2.2 and 2.0.0.
I may send a separate PR or wait for the 2.0.0 PR from the nixpkgs-update bot.
However, we should not stay on 1.2.1.
Version 1.2.2 and later includes security fixes for the guest images.

> Update containerd to v2.2.0 for fixing CVE-2024-25621 and CVE-2025-64329
> Update runc to v1.3.3 for fixing https://github.com/advisories/GHSA-9493-h29p-rfm2, https://github.com/advisories/GHSA-qw9x-cqr3-wc7r, and https://github.com/advisories/GHSA-cgrx-mc8f-2prm

After this change

```console
> limactl --version
limactl version 1.2.2
> limactl create test-default
> limactl start test-default
> limactl shell test-default
> nerdctl --version
nerdctl version 2.2.0
> runc --version
runc version 1.3.3
commit: v1.3.3-0-gd842d77
spec: 1.2.1
go: go1.25.4
libseccomp: 2.6.0
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc: @voanhduy1512

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
