### PR TITLE
maintainers: drop various inactive maintainers

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10098,12 +10098,6 @@
     githubId = 79340822;
     keys = [ { fingerprint = "3582 5B85 66C8 4F36 45C7  EC42 809F 7938 9CB1 8650"; } ];
   };
-  havvy = {
-    email = "ryan.havvy@gmail.com";
-    github = "Havvy";
-    githubId = 731722;
-    name = "Ryan Scheel";
-  };
   hawkw = {
     email = "eliza@elizas.website";
     github = "hawkw";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14455,12 +14455,6 @@
     githubId = 736291;
     name = "Lee Machin";
   };
-  leenaars = {
-    email = "ml.software@leenaa.rs";
-    github = "leenaars";
-    githubId = 4158274;
-    name = "Michiel Leenaars";
-  };
   legojames = {
     github = "jrobinson-uk";
     githubId = 4701504;

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13253,12 +13253,6 @@
     githubId = 54859825;
     keys = [ { fingerprint = "B2D0 AA53 8DBE 60B0 0811  3FC0 2D52 5F67 791E 5834"; } ];
   };
-  kampfschlaefer = {
-    email = "arnold@arnoldarts.de";
-    github = "kampfschlaefer";
-    githubId = 3831860;
-    name = "Arnold Krille";
-  };
   kanashimia = {
     email = "chad@redpilled.dev";
     github = "kanashimia";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15585,12 +15585,6 @@
     githubId = 1433367;
     name = "Marc Fontaine";
   };
-  magenbluten = {
-    email = "magenbluten@codemonkey.cc";
-    github = "magenbluten";
-    githubId = 1140462;
-    name = "magenbluten";
-  };
   magicquark = {
     name = "magicquark";
     github = "magicquark";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11390,12 +11390,6 @@
     githubId = 8095978;
     name = "j-mendez";
   };
-  j03 = {
-    email = "github@johannesloetzsch.de";
-    github = "johannesloetzsch";
-    githubId = 175537;
-    name = "Johannes Lötzsch";
-  };
   j0hax = {
     name = "Johannes Arnold";
     email = "johannes.arnold@stud.uni-hannover.de";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3218,12 +3218,6 @@
     githubId = 10439709;
     name = "Bert Moens";
   };
-  berdario = {
-    email = "berdario@gmail.com";
-    github = "berdario";
-    githubId = 752835;
-    name = "Dario Bertini";
-  };
   bergey = {
     email = "bergey@teallabs.org";
     github = "bergey";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -620,7 +620,6 @@ with lib.maintainers;
   mate = {
     members = [
       bobby285271
-      j03
       romildo
     ];
     scope = "Maintain Mate desktop environment and related packages.";

--- a/nixos/tests/containers-bridge.nix
+++ b/nixos/tests/containers-bridge.nix
@@ -12,7 +12,6 @@ in
     maintainers = with lib.maintainers; [
       aristid
       aszlig
-      kampfschlaefer
     ];
   };
 

--- a/nixos/tests/containers-extra_veth.nix
+++ b/nixos/tests/containers-extra_veth.nix
@@ -2,7 +2,6 @@
 {
   name = "containers-extra_veth";
   meta = {
-    maintainers = with lib.maintainers; [ kampfschlaefer ];
   };
 
   nodes.machine =

--- a/nixos/tests/containers-imperative.nix
+++ b/nixos/tests/containers-imperative.nix
@@ -5,7 +5,6 @@
     maintainers = with lib.maintainers; [
       aristid
       aszlig
-      kampfschlaefer
     ];
   };
 

--- a/nixos/tests/containers-ip.nix
+++ b/nixos/tests/containers-ip.nix
@@ -19,7 +19,6 @@ in
     maintainers = with lib.maintainers; [
       aristid
       aszlig
-      kampfschlaefer
     ];
   };
 

--- a/nixos/tests/containers-physical_interfaces.nix
+++ b/nixos/tests/containers-physical_interfaces.nix
@@ -2,7 +2,6 @@
 {
   name = "containers-physical_interfaces";
   meta = {
-    maintainers = with lib.maintainers; [ kampfschlaefer ];
   };
 
   nodes = {

--- a/nixos/tests/containers-portforward.nix
+++ b/nixos/tests/containers-portforward.nix
@@ -12,7 +12,6 @@ in
     maintainers = with lib.maintainers; [
       aristid
       aszlig
-      kampfschlaefer
       ianwookim
     ];
   };

--- a/nixos/tests/containers-restart_networking.nix
+++ b/nixos/tests/containers-restart_networking.nix
@@ -2,7 +2,6 @@
 {
   name = "containers-restart_networking";
   meta = {
-    maintainers = with lib.maintainers; [ kampfschlaefer ];
   };
 
   nodes = {

--- a/pkgs/applications/misc/xygrib/default.nix
+++ b/pkgs/applications/misc/xygrib/default.nix
@@ -77,6 +77,5 @@ stdenv.mkDerivation {
     '';
     license = licenses.gpl3;
     platforms = platforms.all;
-    maintainers = with maintainers; [ j03 ];
   };
 }

--- a/pkgs/applications/networking/sync/rsync/default.nix
+++ b/pkgs/applications/networking/sync/rsync/default.nix
@@ -94,7 +94,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     mainProgram = "rsync";
     maintainers = with lib.maintainers; [
-      kampfschlaefer
       ivan
     ];
     platforms = platforms.unix;

--- a/pkgs/by-name/_9/_90secondportraits/package.nix
+++ b/pkgs/by-name/_9/_90secondportraits/package.nix
@@ -78,7 +78,6 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Silly speed painting game";
     mainProgram = "90secondportraits";
-    maintainers = with maintainers; [ leenaars ];
     platforms = platforms.linux;
     license = with licenses; [
       zlib

--- a/pkgs/by-name/ai/aileron/package.nix
+++ b/pkgs/by-name/ai/aileron/package.nix
@@ -31,7 +31,6 @@ stdenvNoCC.mkDerivation {
     description = "Helvetica font in nine weights";
     platforms = platforms.all;
     maintainers = with maintainers; [
-      leenaars
       minijackson
     ];
     license = licenses.cc0;

--- a/pkgs/by-name/ar/argus-clients/package.nix
+++ b/pkgs/by-name/ar/argus-clients/package.nix
@@ -59,7 +59,6 @@ stdenv.mkDerivation rec {
     '';
     homepage = "http://qosient.com/argus";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ leenaars ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/ar/argus/package.nix
+++ b/pkgs/by-name/ar/argus/package.nix
@@ -71,7 +71,6 @@ stdenv.mkDerivation rec {
     '';
     homepage = "http://qosient.com/argus";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ leenaars ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/ar/arpa2cm/package.nix
+++ b/pkgs/by-name/ar/arpa2cm/package.nix
@@ -34,7 +34,6 @@ stdenv.mkDerivation rec {
     homepage = "https://gitlab.com/arpa2/arpa2cm";
     license = licenses.bsd2;
     maintainers = with maintainers; [
-      leenaars
       fufexan
     ];
   };

--- a/pkgs/by-name/b6/b612/package.nix
+++ b/pkgs/by-name/b6/b612/package.nix
@@ -46,7 +46,6 @@ stdenvNoCC.mkDerivation rec {
       epl10
       bsd3
     ];
-    maintainers = with maintainers; [ leenaars ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/by-name/cs/csv2odf/package.nix
+++ b/pkgs/by-name/cs/csv2odf/package.nix
@@ -34,6 +34,5 @@ python3.pkgs.buildPythonApplication rec {
       template file that you can design in your office application of choice.
     '';
     license = licenses.gpl3;
-    maintainers = with maintainers; [ leenaars ];
   };
 }

--- a/pkgs/by-name/cu/cutee/package.nix
+++ b/pkgs/by-name/cu/cutee/package.nix
@@ -25,7 +25,6 @@ stdenv.mkDerivation rec {
     mainProgram = "cutee";
     homepage = "https://www.codesink.org/cutee_unit_testing.html";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ leenaars ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/da/datefudge/package.nix
+++ b/pkgs/by-name/da/datefudge/package.nix
@@ -45,7 +45,6 @@ stdenv.mkDerivation rec {
     homepage = "https://packages.qa.debian.org/d/datefudge.html";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ leenaars ];
     mainProgram = "datefudge";
   };
 }

--- a/pkgs/by-name/dp/dpdk/package.nix
+++ b/pkgs/by-name/dp/dpdk/package.nix
@@ -113,7 +113,6 @@ stdenv.mkDerivation rec {
     ];
     platforms = platforms.linux;
     maintainers = with maintainers; [
-      magenbluten
       orivej
       mic92
       zhaofengli

--- a/pkgs/by-name/e2/e2tools/package.nix
+++ b/pkgs/by-name/e2/e2tools/package.nix
@@ -32,6 +32,5 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Utilities to read/write/manipulate files in an ext2/ext3 filesystem";
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.linux;
-    maintainers = [ lib.maintainers.leenaars ];
   };
 })

--- a/pkgs/by-name/eo/eot_utilities/package.nix
+++ b/pkgs/by-name/eo/eot_utilities/package.nix
@@ -20,7 +20,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.w3.org/Tools/eot-utils/";
     description = "Create Embedded Open Type from OpenType or TrueType font";
     license = lib.licenses.w3c;
-    maintainers = with lib.maintainers; [ leenaars ];
     platforms = with lib.platforms; unix;
   };
 }

--- a/pkgs/by-name/eu/eunomia/package.nix
+++ b/pkgs/by-name/eu/eunomia/package.nix
@@ -31,7 +31,6 @@ stdenvNoCC.mkDerivation {
     description = "Futuristic decorative font";
     platforms = platforms.all;
     maintainers = with maintainers; [
-      leenaars
       minijackson
     ];
     license = licenses.ofl;

--- a/pkgs/by-name/f5/f5_6/package.nix
+++ b/pkgs/by-name/f5/f5_6/package.nix
@@ -31,7 +31,6 @@ stdenvNoCC.mkDerivation {
     description = "Weighted decorative font";
     platforms = platforms.all;
     maintainers = with maintainers; [
-      leenaars
       minijackson
     ];
     license = licenses.ofl;

--- a/pkgs/by-name/fe/ferrum/package.nix
+++ b/pkgs/by-name/fe/ferrum/package.nix
@@ -31,7 +31,6 @@ stdenvNoCC.mkDerivation {
     description = "Decorative font";
     platforms = platforms.all;
     maintainers = with maintainers; [
-      leenaars
       minijackson
     ];
     license = licenses.cc0;

--- a/pkgs/by-name/ge/getdns/package.nix
+++ b/pkgs/by-name/ge/getdns/package.nix
@@ -64,8 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
       their applications.
     '';
     homepage = "https://getdnsapi.net";
-    maintainers = with lib.maintainers; [
-      leenaars
+    maintainers = [
     ];
     license = lib.licenses.bsd3;
     platforms = lib.platforms.all;

--- a/pkgs/by-name/gi/github-release/package.nix
+++ b/pkgs/by-name/gi/github-release/package.nix
@@ -38,7 +38,6 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/github-release/github-release";
     maintainers = with lib.maintainers; [
       ardumont
-      j03
     ];
   };
 })

--- a/pkgs/by-name/ha/hash-slinger/package.nix
+++ b/pkgs/by-name/ha/hash-slinger/package.nix
@@ -60,6 +60,5 @@ stdenv.mkDerivation rec {
     description = "Various tools to generate special DNS records";
     homepage = "https://github.com/letoams/hash-slinger";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ leenaars ];
   };
 }

--- a/pkgs/by-name/he/hexio/package.nix
+++ b/pkgs/by-name/he/hexio/package.nix
@@ -47,6 +47,5 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/vanrein/hexio";
     license = licenses.bsd2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ leenaars ];
   };
 }

--- a/pkgs/by-name/hy/hyperscrypt-font/package.nix
+++ b/pkgs/by-name/hy/hyperscrypt-font/package.nix
@@ -41,7 +41,6 @@ stdenvNoCC.mkDerivation rec {
       layouts.
     '';
     license = licenses.ofl;
-    maintainers = with maintainers; [ leenaars ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/by-name/in/inriafonts/package.nix
+++ b/pkgs/by-name/in/inriafonts/package.nix
@@ -38,7 +38,6 @@ stdenvNoCC.mkDerivation rec {
       serif. Both members comes in 3 weights with matching italics.
     '';
     license = licenses.ofl;
-    maintainers = with maintainers; [ leenaars ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/by-name/ip/ipgrep/package.nix
+++ b/pkgs/by-name/ip/ipgrep/package.nix
@@ -40,7 +40,6 @@ python3Packages.buildPythonApplication rec {
       from text, resolves host names, and prints them, sorted by ASN.
     '';
     license = licenses.mit;
-    maintainers = with maintainers; [ leenaars ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/by-name/ja/jackmix/package.nix
+++ b/pkgs/by-name/ja/jackmix/package.nix
@@ -53,7 +53,6 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "jackmix";
     homepage = "https://github.com/kampfschlaefer/jackmix";
     license = licenses.gpl2Only;
-    maintainers = with maintainers; [ kampfschlaefer ];
     platforms = platforms.linux;
   };
 })

--- a/pkgs/by-name/kc/kcgi/package.nix
+++ b/pkgs/by-name/kc/kcgi/package.nix
@@ -35,7 +35,6 @@ stdenv.mkDerivation rec {
     description = "Minimal CGI and FastCGI library for C/C++";
     license = licenses.isc;
     platforms = platforms.all;
-    maintainers = [ maintainers.leenaars ];
     mainProgram = "kfcgi";
   };
 }

--- a/pkgs/by-name/kr/krop/package.nix
+++ b/pkgs/by-name/kr/krop/package.nix
@@ -49,7 +49,6 @@ python3Packages.buildPythonApplication rec {
       interface.
     '';
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ leenaars ];
     platforms = lib.platforms.linux;
     mainProgram = "krop";
   };

--- a/pkgs/by-name/li/liberation-sans-narrow/package.nix
+++ b/pkgs/by-name/li/liberation-sans-narrow/package.nix
@@ -44,6 +44,5 @@ stdenv.mkDerivation rec {
 
     license = licenses.gpl2;
     homepage = "https://github.com/liberationfonts";
-    maintainers = [ maintainers.leenaars ];
   };
 }

--- a/pkgs/by-name/lw/lwan/package.nix
+++ b/pkgs/by-name/lw/lwan/package.nix
@@ -48,6 +48,5 @@ stdenv.mkDerivation rec {
     homepage = "https://lwan.ws/";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ leenaars ];
   };
 }

--- a/pkgs/by-name/md/mdbook/package.nix
+++ b/pkgs/by-name/md/mdbook/package.nix
@@ -44,7 +44,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/rust-lang/mdBook/blob/v${version}/CHANGELOG.md";
     license = [ lib.licenses.mpl20 ];
     maintainers = with lib.maintainers; [
-      havvy
       Frostman
       matthiasbeyer
     ];

--- a/pkgs/by-name/me/medio/package.nix
+++ b/pkgs/by-name/me/medio/package.nix
@@ -36,7 +36,6 @@ stdenvNoCC.mkDerivation {
     '';
     platforms = platforms.all;
     maintainers = with maintainers; [
-      leenaars
       minijackson
     ];
     license = licenses.cc0;

--- a/pkgs/by-name/mi/mimetic/package.nix
+++ b/pkgs/by-name/mi/mimetic/package.nix
@@ -30,7 +30,6 @@ stdenv.mkDerivation rec {
     description = "MIME handling library";
     homepage = "https://www.codesink.org/mimetic_mime_library.html";
     license = licenses.mit;
-    maintainers = with maintainers; [ leenaars ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/no/norwester-font/package.nix
+++ b/pkgs/by-name/no/norwester-font/package.nix
@@ -26,7 +26,6 @@ stdenvNoCC.mkDerivation rec {
   meta = with lib; {
     homepage = "http://jamiewilson.io/norwester";
     description = "Condensed geometric sans serif by Jamie Wilson";
-    maintainers = with maintainers; [ leenaars ];
     license = licenses.ofl;
     platforms = platforms.all;
   };

--- a/pkgs/by-name/op/openpa/package.nix
+++ b/pkgs/by-name/op/openpa/package.nix
@@ -22,7 +22,6 @@ stdenv.mkDerivation rec {
     description = "Atomic primitives for high performance, concurrent software";
     homepage = "https://trac.mpich.org/projects/openpa";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ leenaars ];
     platforms = lib.platforms.unix;
     longDescription = ''
       OPA (or sometimes OpenPA or Open Portable Atomics) is an

--- a/pkgs/by-name/or/orbitron/package.nix
+++ b/pkgs/by-name/or/orbitron/package.nix
@@ -48,7 +48,6 @@ stdenvNoCC.mkDerivation {
     license = licenses.ofl;
     platforms = platforms.all;
     maintainers = with lib.maintainers; [
-      leenaars
       minijackson
     ];
   };

--- a/pkgs/by-name/or/orthorobot/package.nix
+++ b/pkgs/by-name/or/orthorobot/package.nix
@@ -80,7 +80,6 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Recharge the robot";
     mainProgram = "orthorobot";
-    maintainers = with lib.maintainers; [ leenaars ];
     platforms = lib.platforms.linux;
     license = lib.licenses.wtfpl;
     downloadPage = "https://stabyourself.net/orthorobot/";

--- a/pkgs/by-name/pd/pdftag/package.nix
+++ b/pkgs/by-name/pd/pdftag/package.nix
@@ -37,7 +37,6 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Edit metadata found in PDFs";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ leenaars ];
     platforms = platforms.unix;
     mainProgram = "pdftag";
   };

--- a/pkgs/by-name/pe/penna/package.nix
+++ b/pkgs/by-name/pe/penna/package.nix
@@ -36,7 +36,6 @@ stdenvNoCC.mkDerivation {
     '';
     platforms = platforms.all;
     maintainers = with maintainers; [
-      leenaars
       minijackson
     ];
     license = licenses.cc0;

--- a/pkgs/by-name/pe/pew/package.nix
+++ b/pkgs/by-name/pe/pew/package.nix
@@ -37,6 +37,5 @@ python3.pkgs.buildPythonApplication rec {
     mainProgram = "pew";
     license = licenses.mit;
     platforms = platforms.all;
-    maintainers = with maintainers; [ berdario ];
   };
 }

--- a/pkgs/by-name/pi/pipenv/package.nix
+++ b/pkgs/by-name/pi/pipenv/package.nix
@@ -111,7 +111,6 @@ buildPythonApplication rec {
     description = "Python Development Workflow for Humans";
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ berdario ];
     mainProgram = "pipenv";
   };
 }

--- a/pkgs/by-name/qs/qstopmotion/package.nix
+++ b/pkgs/by-name/qs/qstopmotion/package.nix
@@ -91,7 +91,6 @@ stdenv.mkDerivation (finalAttrs: {
       animation to different video formats such as mpeg or avi.
     '';
     license = lib.licenses.gpl2Plus;
-    maintainers = [ lib.maintainers.leenaars ];
     platforms = lib.platforms.gnu ++ lib.platforms.linux;
     mainProgram = "qstopmotion";
   };

--- a/pkgs/by-name/qu/quickder/package.nix
+++ b/pkgs/by-name/qu/quickder/package.nix
@@ -77,6 +77,5 @@ stdenv.mkDerivation rec {
     homepage = "https://gitlab.com/arpa2/quick-der/";
     license = licenses.bsd2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ leenaars ];
   };
 }

--- a/pkgs/by-name/re/redis/package.nix
+++ b/pkgs/by-name/re/redis/package.nix
@@ -131,7 +131,6 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.all;
     changelog = "https://github.com/redis/redis/releases/tag/${finalAttrs.version}";
     maintainers = with lib.maintainers; [
-      berdario
       globin
     ];
     mainProgram = "redis-cli";

--- a/pkgs/by-name/ro/rocksdb/package.nix
+++ b/pkgs/by-name/ro/rocksdb/package.nix
@@ -123,7 +123,6 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = platforms.all;
     maintainers = with maintainers; [
       adev
-      magenbluten
     ];
   };
 })

--- a/pkgs/by-name/ro/route159/package.nix
+++ b/pkgs/by-name/ro/route159/package.nix
@@ -31,7 +31,6 @@ stdenvNoCC.mkDerivation {
     description = "Weighted sans serif font";
     platforms = platforms.all;
     maintainers = with maintainers; [
-      leenaars
       minijackson
     ];
     license = licenses.ofl;

--- a/pkgs/by-name/se/seshat/package.nix
+++ b/pkgs/by-name/se/seshat/package.nix
@@ -41,7 +41,6 @@ stdenvNoCC.mkDerivation {
     '';
     platforms = platforms.all;
     maintainers = with maintainers; [
-      leenaars
       minijackson
     ];
     license = licenses.cc0;

--- a/pkgs/by-name/sh/sha1collisiondetection/package.nix
+++ b/pkgs/by-name/sh/sha1collisiondetection/package.nix
@@ -37,7 +37,6 @@ stdenv.mkDerivation rec {
       of time as regular SHA-1.
     '';
     platforms = platforms.all;
-    maintainers = with maintainers; [ leenaars ];
     license = licenses.mit;
     mainProgram = "sha1dcsum";
   };

--- a/pkgs/by-name/si/sienna/package.nix
+++ b/pkgs/by-name/si/sienna/package.nix
@@ -56,7 +56,6 @@ stdenv.mkDerivation rec {
     description = "Fast-paced one button platformer";
     mainProgram = "sienna";
     homepage = "https://tangramgames.dk/games/sienna";
-    maintainers = with maintainers; [ leenaars ];
     platforms = platforms.linux;
     license = licenses.free;
   };

--- a/pkgs/by-name/so/softhsm/package.nix
+++ b/pkgs/by-name/so/softhsm/package.nix
@@ -58,7 +58,6 @@ stdenv.mkDerivation rec {
       programme of The Commons Conservancy.
     ";
     license = licenses.bsd2;
-    maintainers = [ maintainers.leenaars ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/ss/ssrc/package.nix
+++ b/pkgs/by-name/ss/ssrc/package.nix
@@ -39,7 +39,6 @@ stdenv.mkDerivation rec {
     version = version;
     homepage = "https://shibatch.sourceforge.net/";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ leenaars ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/su/suricata/package.nix
+++ b/pkgs/by-name/su/suricata/package.nix
@@ -174,6 +174,5 @@ stdenv.mkDerivation rec {
     homepage = "https://suricata.io";
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ magenbluten ];
   };
 }

--- a/pkgs/by-name/te/tenderness/package.nix
+++ b/pkgs/by-name/te/tenderness/package.nix
@@ -31,7 +31,6 @@ stdenvNoCC.mkDerivation {
     description = "Serif font designed by Sora Sagano with old-style figures";
     platforms = platforms.all;
     maintainers = with maintainers; [
-      leenaars
       minijackson
     ];
     license = licenses.ofl;

--- a/pkgs/by-name/te/termtekst/package.nix
+++ b/pkgs/by-name/te/termtekst/package.nix
@@ -40,7 +40,6 @@ python3Packages.buildPythonApplication rec {
       graphics.
     '';
     license = licenses.mit;
-    maintainers = with maintainers; [ leenaars ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/by-name/th/thonny/package.nix
+++ b/pkgs/by-name/th/thonny/package.nix
@@ -84,7 +84,6 @@ python3.pkgs.buildPythonApplication rec {
     '';
     homepage = "https://www.thonny.org/";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ leenaars ];
     platforms = lib.platforms.unix;
     mainProgram = "thonny";
   };

--- a/pkgs/by-name/to/todoman/package.nix
+++ b/pkgs/by-name/to/todoman/package.nix
@@ -115,7 +115,6 @@ python3.pkgs.buildPythonApplication rec {
     }";
     license = lib.licenses.isc;
     maintainers = with lib.maintainers; [
-      leenaars
       antonmosich
     ];
     mainProgram = "todo";

--- a/pkgs/by-name/wa/wavrsocvt/package.nix
+++ b/pkgs/by-name/wa/wavrsocvt/package.nix
@@ -36,7 +36,6 @@ stdenv.mkDerivation {
     '';
     homepage = "https://bricxcc.sourceforge.net/";
     license = licenses.mpl11;
-    maintainers = with maintainers; [ leenaars ];
     platforms = with platforms; linux;
   };
 }

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -436,7 +436,6 @@ stdenv.mkDerivation (finalAttrs: {
   meta = with lib; {
     homepage = "https://www.rust-lang.org/";
     description = "Safe, concurrent, practical language";
-    maintainers = with maintainers; [ havvy ];
     teams = [ teams.rust ];
     license = [
       licenses.mit

--- a/pkgs/development/python-modules/asn1ate/default.nix
+++ b/pkgs/development/python-modules/asn1ate/default.nix
@@ -24,6 +24,5 @@ buildPythonPackage rec {
     mainProgram = "asn1ate";
     license = licenses.bsd3;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ leenaars ];
   };
 }

--- a/pkgs/development/python-modules/asttokens/default.nix
+++ b/pkgs/development/python-modules/asttokens/default.nix
@@ -43,6 +43,5 @@ buildPythonPackage rec {
     description = "Annotate Python AST trees with source text and token information";
     homepage = "https://github.com/gristlabs/asttokens";
     license = licenses.asl20;
-    maintainers = with maintainers; [ leenaars ];
   };
 }

--- a/pkgs/development/python-modules/authres/default.nix
+++ b/pkgs/development/python-modules/authres/default.nix
@@ -29,6 +29,5 @@ buildPythonPackage rec {
     '';
     homepage = "https://launchpad.net/authentication-results-python";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ leenaars ];
   };
 }

--- a/pkgs/development/python-modules/dkimpy/default.nix
+++ b/pkgs/development/python-modules/dkimpy/default.nix
@@ -48,6 +48,5 @@ buildPythonPackage rec {
     '';
     homepage = "https://launchpad.net/dkimpy";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ leenaars ];
   };
 }

--- a/pkgs/development/python-modules/dockerfile-parse/default.nix
+++ b/pkgs/development/python-modules/dockerfile-parse/default.nix
@@ -32,6 +32,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/DBuildService/dockerfile-parse";
     changelog = "https://github.com/containerbuildsystem/dockerfile-parse/releases/tag/${version}";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ leenaars ];
   };
 }

--- a/pkgs/development/python-modules/fire/default.nix
+++ b/pkgs/development/python-modules/fire/default.nix
@@ -65,6 +65,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/google/python-fire";
     changelog = "https://github.com/google/python-fire/releases/tag/v${version}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ leenaars ];
   };
 }

--- a/pkgs/development/python-modules/pybluez/default.nix
+++ b/pkgs/development/python-modules/pybluez/default.nix
@@ -35,7 +35,6 @@ buildPythonPackage {
     description = "Bluetooth Python extension module";
     homepage = "https://github.com/pybluez/pybluez";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ leenaars ];
     broken = stdenv.hostPlatform.isDarwin; # requires pyobjc-core, pyobjc-framework-Cocoa
   };
 }

--- a/pkgs/development/python-modules/pyunbound/default.nix
+++ b/pkgs/development/python-modules/pyunbound/default.nix
@@ -85,7 +85,6 @@ buildPythonPackage rec {
     description = "Python library for Unbound, the validating, recursive, and caching DNS resolver";
     license = licenses.bsd3;
     homepage = "https://www.unbound.net";
-    maintainers = with maintainers; [ leenaars ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/python-modules/sievelib/default.nix
+++ b/pkgs/development/python-modules/sievelib/default.nix
@@ -48,6 +48,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/tonioo/sievelib";
     changelog = "https://github.com/tonioo/sievelib/releases/tag/${version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ leenaars ];
   };
 }

--- a/pkgs/development/python-modules/ydiff/default.nix
+++ b/pkgs/development/python-modules/ydiff/default.nix
@@ -55,7 +55,6 @@ buildPythonPackage rec {
     '';
     homepage = "https://github.com/ymattw/ydiff";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ leenaars ];
     teams = [ teams.deshaw ];
   };
 }

--- a/pkgs/development/tools/asn2quickder/default.nix
+++ b/pkgs/development/tools/asn2quickder/default.nix
@@ -50,6 +50,5 @@ buildPythonApplication rec {
     homepage = "https://gitlab.com/arpa2/quick-der";
     license = licenses.bsd3;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ leenaars ];
   };
 }

--- a/pkgs/games/duckmarines/default.nix
+++ b/pkgs/games/duckmarines/default.nix
@@ -55,7 +55,6 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Duck-themed action puzzle video game";
-    maintainers = with maintainers; [ leenaars ];
     platforms = platforms.linux;
     hydraPlatforms = [ ];
     license = licenses.free;

--- a/pkgs/tools/networking/spoofer/default.nix
+++ b/pkgs/tools/networking/spoofer/default.nix
@@ -54,7 +54,6 @@ stdenv.mkDerivation rec {
     '';
     platforms = platforms.all;
     license = licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ leenaars ];
     mainProgram = "spoofer-prober";
   };
 }


### PR DESCRIPTION
These maintainers have not been active / not been responding to maintainer pings for quite some time. They were all reported via warnings in the reviewer script, because they are not members of the @NixOS/nixpkgs-maintainers team, so can't be requested for review properly, among other problems.

Dropping them according to the contribution guidelines: https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status.

@Havvy @berdario @johannesloetzsch @kampfschlaefer @leenaars @magenbluten if any of you plans to stay an active maintainer of their packages, please speak up within one week.

Even if you are removed, you will of course be welcome back any time.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
