### PR TITLE
ci/github-script/bot: fix needs reviewer label

### DIFF
--- a/ci/github-script/reviewers.js
+++ b/ci/github-script/reviewers.js
@@ -64,14 +64,6 @@ async function handleReviewers({
   ).filter(Boolean)
   log('reviewers - reviewers', reviewers.join(', '))
 
-  if (reviewers.length > 15) {
-    log(
-      `Too many reviewers (${reviewers.join(', ')}), skipping review requests.`,
-    )
-    // false indicates, that we do have reviewers and don't need the "needs: reviewers" label.
-    return false
-  }
-
   const requested_reviewers = new Set(
     pull_request.requested_reviewers.map(({ login }) => login),
   )
@@ -87,6 +79,14 @@ async function handleReviewers({
     'reviewers - existing_reviewers',
     Array.from(existing_reviewers).join(', '),
   )
+
+  if (reviewers.length > 15) {
+    log(
+      `Too many reviewers (${reviewers.join(', ')}), skipping review requests.`,
+    )
+    // Return a boolean on whether the "needs: reviewers" label should be set.
+    return existing_reviewers.size === 0 && requested_reviewers.size === 0
+  }
 
   const non_requested_reviewers = new Set(reviewers)
     .difference(requested_reviewers)
@@ -117,7 +117,7 @@ async function handleReviewers({
 
   // Return a boolean on whether the "needs: reviewers" label should be set.
   return (
-    new_reviewers.size === 0 &&
+    non_requested_reviewers.size === 0 &&
     existing_reviewers.size === 0 &&
     requested_reviewers.size === 0
   )


### PR DESCRIPTION
The recent change to use the result of requesting reviewers for setting the `needs: reviewer` label caused a regression: It would not set the label for PRs where no reviewers were requested, because *too many were eligible*. Still - these PRs don't have reviewers, so they need attention otherwise - via the label.

## Things done

- [x] Tested locally.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
