### PR TITLE
wmiexec-pro: init at 0.4.1

### DIFF
--- a/pkgs/by-name/wm/wmiexec-pro/package.nix
+++ b/pkgs/by-name/wm/wmiexec-pro/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  fetchpatch2,
+  nix-update-script,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "wmiexec-pro";
+  version = "0.4.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "XiaoliChan";
+    repo = "wmiexec-Pro";
+    tag = "v${version}";
+    hash = "sha256-jOqXIShd7Q5YZzF7woKdObtDJgeQgDeQXEPcHJJoT4Q=";
+  };
+
+  __structuredAttrs = true;
+
+  build-system = [ python3Packages.setuptools ];
+
+  dependencies = with python3Packages; [
+    impacket
+    numpy
+    rich
+  ];
+
+  patches = [
+    (fetchpatch2 {
+      # https://github.com/XiaoliChan/wmiexec-Pro/pull/19
+      url = "https://github.com/XiaoliChan/wmiexec-Pro/commit/e0f9b4afcf9f7532f536d4599a764a80f3656e99.patch";
+      hash = "sha256-fjbCZvsHDiWSNaZnIqUMIhK2fG5XKxhJJQqFxLzjZQY=";
+    })
+  ];
+
+  postInstall = ''
+    mv $out/bin/wmiexec-pro{.py,}
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "New generation of wmiexec.py with AV evasion features";
+    homepage = "https://github.com/XiaoliChan/wmiexec-Pro";
+    changelog = "https://github.com/XiaoliChan/wmiexec-Pro/releases/tag/${src.tag}";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ letgamer ];
+    mainProgram = "wmiexec-pro";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This adds wmiexec-pro: https://github.com/XiaoliChan/wmiexec-Pro

A modernized and enhanced version of impacket’s `wmiexec.py` tool with AV evasion features and multiple remote execution modules.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
