### PR TITLE
workflows: remove owner app

### DIFF
--- a/.github/workflows/pull-request-target.yml
+++ b/.github/workflows/pull-request-target.yml
@@ -12,9 +12,6 @@ on:
         required: true
       NIXPKGS_CI_APP_PRIVATE_KEY:
         required: true
-      OWNER_APP_PRIVATE_KEY:
-        # The Test workflow should not actually request reviews from owners.
-        required: false
 
 concurrency:
   group: pr-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}

--- a/.github/workflows/teams.yml
+++ b/.github/workflows/teams.yml
@@ -16,13 +16,17 @@ jobs:
   sync:
     runs-on: ubuntu-24.04-arm
     steps:
+      # Use a GitHub App to create the PR so that CI gets triggered and to
+      # request team member lists.
       - uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
-        id: team-token
+        id: app-token
         with:
-          app-id: ${{ vars.OWNER_APP_ID }}
-          private-key: ${{ secrets.OWNER_APP_PRIVATE_KEY }}
+          app-id: ${{ vars.NIXPKGS_CI_APP_ID }}
+          private-key: ${{ secrets.NIXPKGS_CI_APP_PRIVATE_KEY }}
           permission-administration: read
+          permission-contents: write
           permission-members: read
+          permission-pull-requests: write
 
       - name: Fetch source
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -38,7 +42,7 @@ jobs:
       - name: Synchronise teams
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
-          github-token: ${{ steps.team-token.outputs.token }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             require('./ci/github-script/get-teams.js')({
               github,
@@ -47,20 +51,11 @@ jobs:
               outFile: "maintainers/github-teams.json"
             })
 
-      # Use a GitHub App to create the PR so that CI gets triggered
-      - uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
-        id: sync-token
-        with:
-          app-id: ${{ vars.NIXPKGS_CI_APP_ID }}
-          private-key: ${{ secrets.NIXPKGS_CI_APP_PRIVATE_KEY }}
-          permission-contents: write
-          permission-pull-requests: write
-
       - name: Get GitHub App User Git String
         id: user
         env:
-          GH_TOKEN: ${{ steps.sync-token.outputs.token }}
-          APP_SLUG: ${{ steps.sync-token.outputs.app-slug }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
         run: |
           name="${APP_SLUG}[bot]"
           userId=$(gh api "/users/$name" --jq .id)
@@ -70,7 +65,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
-          token: ${{ steps.sync-token.outputs.token }}
+          token: ${{ steps.app-token.outputs.token }}
           add-paths: maintainers/github-teams.json
           author: ${{ steps.user.outputs.git-string }}
           committer: ${{ steps.user.outputs.git-string }}


### PR DESCRIPTION
The separate owners app was obsoleted in #458604, so we can remove its traces and usage.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
