### PR TITLE
ci/github-script/merge: add hint about stuck GitHub

### DIFF
--- a/ci/github-script/merge.js
+++ b/ci/github-script/merge.js
@@ -182,7 +182,9 @@ async function handleMerge({
         }`,
         { node_id: pull_request.node_id, sha: pull_request.head.sha },
       )
-      return `[Queued](${resp.enqueuePullRequest.mergeQueueEntry.mergeQueue.url}) for merge`
+      return [
+        `:heavy_check_mark: [Queued](${resp.enqueuePullRequest.mergeQueueEntry.mergeQueue.url}) for merge (#306934)`,
+      ]
     } catch (e) {
       log('Enqueing failed', e.response.errors[0].message)
     }
@@ -201,7 +203,12 @@ async function handleMerge({
         }`,
         { node_id: pull_request.node_id, sha: pull_request.head.sha },
       )
-      return 'Enabled Auto Merge'
+      return [
+        `:heavy_check_mark: Enabled Auto Merge (#306934)`,
+        '',
+        '> [!TIP]',
+        '> Sometimes GitHub gets stuck after enabling Auto Merge. In this case, leaving another approval should trigger the merge.',
+      ]
     } catch (e) {
       log('Auto Merge failed', e.response.errors[0].message)
       throw new Error(e.response.errors[0].message)
@@ -287,7 +294,7 @@ async function handleMerge({
     if (result) {
       await react('ROCKET')
       try {
-        body.push(`:heavy_check_mark: ${await merge()} (#306934)`)
+        body.push(...(await merge()))
       } catch (e) {
         // Remove the HTML comment with node_id reference to allow retrying this merge on the next run.
         body.shift()


### PR DESCRIPTION
Unfortunately it still happens frequently that, after enabling auto-merge, GitHub is stuck even though all checks have passed, and doesn't merge the PR. Any contributor can trigger GitHub again with an approval of the PR - this will then immediately queue the PR for merge.

Adding a hint to the posted comment, should help users through this without my intervention.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
