### PR TITLE
lib.extendMkDerivation: add argument excludeFunctionArgNames and improve argument documentation

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -763,11 +763,21 @@ rec {
     # Inputs
 
     `extendMkDerivation`-specific configurations
-    : `constructDrv` (required): Base build helper, the `mkDerivation`-like build helper to extend.
-    : `excludeDrvArgNames` (default to `[ ]`): Argument names not to pass from the input fixed-point arguments to `constructDrv`. Note: It doesn't apply to the updating arguments returned by `extendDrvArgs`.
-    : `extendDrvArgs` (required): An extension (overlay) of the argument set, like the one taken by [overrideAttrs](#sec-pkg-overrideAttrs) but applied before passing to `constructDrv`.
-    : `inheritFunctionArgs` (default to `true`): Whether to inherit `__functionArgs` from the base build helper.
-    : `transformDrv` (default to `lib.id`): Function to apply to the result derivation.
+    : `constructDrv` (required)
+      : Base build helper, the `mkDerivation`-like build helper to extend.
+
+      `excludeDrvArgNames` (default to `[ ]`)
+      : Argument names not to pass from the input fixed-point arguments to `constructDrv`.
+        It doesn't apply to the updating arguments returned by `extendDrvArgs`.
+
+      `extendDrvArgs` (required)
+      : An extension (overlay) of the argument set, like the one taken by [overrideAttrs](#sec-pkg-overrideAttrs) but applied before passing to `constructDrv`.
+
+      `inheritFunctionArgs` (default to `true`)
+      : Whether to inherit `__functionArgs` from the base build helper.
+
+      `transformDrv` (default to `lib.id`)
+      : Function to apply to the result derivation.
 
     # Type
 

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -775,6 +775,7 @@ rec {
 
       `inheritFunctionArgs` (default to `true`)
       : Whether to inherit `__functionArgs` from the base build helper.
+        Set `inheritFunctionArgs` to `false` when `extendDrvArgs`'s `args` set pattern does not contain an ellipsis.
 
       `transformDrv` (default to `lib.id`)
       : Function to apply to the result derivation.

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -763,11 +763,11 @@ rec {
     # Inputs
 
     `extendMkDerivation`-specific configurations
-    : `constructDrv`: Base build helper, the `mkDerivation`-like build helper to extend.
-    : `excludeDrvArgNames`: Argument names not to pass from the input fixed-point arguments to `constructDrv`. Note: It doesn't apply to the updating arguments returned by `extendDrvArgs`.
-    : `extendDrvArgs` : An extension (overlay) of the argument set, like the one taken by [overrideAttrs](#sec-pkg-overrideAttrs) but applied before passing to `constructDrv`.
-    : `inheritFunctionArgs`: Whether to inherit `__functionArgs` from the base build helper (default to `true`).
-    : `transformDrv`: Function to apply to the result derivation (default to `lib.id`).
+    : `constructDrv` (required): Base build helper, the `mkDerivation`-like build helper to extend.
+    : `excludeDrvArgNames` (default to `[ ]`): Argument names not to pass from the input fixed-point arguments to `constructDrv`. Note: It doesn't apply to the updating arguments returned by `extendDrvArgs`.
+    : `extendDrvArgs` (required): An extension (overlay) of the argument set, like the one taken by [overrideAttrs](#sec-pkg-overrideAttrs) but applied before passing to `constructDrv`.
+    : `inheritFunctionArgs` (default to `true`): Whether to inherit `__functionArgs` from the base build helper.
+    : `transformDrv` (default to `lib.id`): Function to apply to the result derivation.
 
     # Type
 


### PR DESCRIPTION
- Add an optional `excludeFunctionArgNames` argument to `lib.customisation.extendMkDerivation` to remove deprecated/does-not-mean-to-be-specified build helper arguments from `__functionArgs`.
  - For projects supporting multiple Nixpkgs channels, `lib.functionArgs` can be used as a way to check whether an argument is supported by a function. For example, nixpkgs-review uses `lib.functionArgs` to detect if `pkgs.buildEnv` supports argument `ignoreSingleFileOutputs` for Nixpkgs revision under review (see PR Mic92/nixpkgs-review#427).
  - Deprecated arguments usually need to stay usable for some period of time for backward compatibility purposes, but we want tooling to know early that the support is already dropped. `excludeFunctionArgNames` provides such mechanism.
- Improve documentation about the default value of each argument of `lib.extendMkDerivation`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
