### PR TITLE
helix-db: init at 2.0.5

### DIFF
--- a/pkgs/by-name/he/helix-db/disable-updates.patch
+++ b/pkgs/by-name/he/helix-db/disable-updates.patch
@@ -1,0 +1,36 @@
+diff --git a/helix-cli/src/main.rs b/helix-cli/src/main.rs
+index 18e279fd..a3ec271c 100644
+--- a/helix-cli/src/main.rs
++++ b/helix-cli/src/main.rs
+@@ -121,13 +121,6 @@ enum Commands {
+         action: MetricsAction,
+     },
+ 
+-    /// Update to the latest version
+-    Update {
+-        /// Force update even if already on latest version
+-        #[clap(long)]
+-        force: bool,
+-    },
+-
+     /// Migrate v1 project to v2 format
+     Migrate {
+         /// Project directory to migrate (defaults to current directory)
+@@ -253,9 +246,6 @@ async fn main() -> Result<()> {
+     // Send CLI install event (only first time)
+     metrics_sender.send_cli_install_event_if_first_time();
+ 
+-    // Check for updates before processing commands
+-    update::check_for_updates().await?;
+-
+     let cli = Cli::parse();
+ 
+     let result = match cli.command {
+@@ -280,7 +270,6 @@ async fn main() -> Result<()> {
+         Commands::Prune { instance, all } => commands::prune::run(instance, all).await,
+         Commands::Delete { instance } => commands::delete::run(instance).await,
+         Commands::Metrics { action } => commands::metrics::run(action).await,
+-        Commands::Update { force } => commands::update::run(force).await,
+         Commands::Migrate {
+             path,
+             queries_dir,

--- a/pkgs/by-name/he/helix-db/package.nix
+++ b/pkgs/by-name/he/helix-db/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  versionCheckHook,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "helix-db";
+  version = "2.0.5";
+
+  src = fetchFromGitHub {
+    repo = "helix-db";
+    owner = "HelixDB";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-lNAaOpF6g2yunGP9bgsMVvVc7YMfZ44WfkumR+8Btlg=";
+  };
+
+  cargoHash = "sha256-YCBTSm252eUJeOyMIEcZ+0AyHoYM1QceYSHhp+qwf6Q=";
+
+  patches = [
+    #There are no feature yet
+    ./disable-updates.patch
+  ];
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ pkg-config ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ openssl ];
+
+  env.OPENSSL_NO_VENDOR = true;
+
+  cargoBuildFlags = [
+    "-p"
+    "helix-cli"
+  ];
+
+  #There are no tests
+  doCheck = false;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  doInstallCheck = true;
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Open-source graph-vector database built from scratch in Rust";
+    homepage = "https://github.com/HelixDB/helix-db";
+    changelog = "https://github.com/HelixDB/helix-db/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ nartsiss ];
+    mainProgram = "helix";
+  };
+})


### PR DESCRIPTION
[CLI](https://github.com/HelixDB/helix-db/tree/main/helix-cli) for [HelixDB](https://github.com/HelixDB/helix-db) - graph-vector database built from scratch in Rust.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
