### PR TITLE
chromium,chromedriver: 142.0.7444.59 -> 142.0.7444.134

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,10 +1,10 @@
 {
   "chromium": {
-    "version": "142.0.7444.59",
+    "version": "142.0.7444.134",
     "chromedriver": {
-      "version": "142.0.7444.60",
-      "hash_darwin": "sha256-5Atr7h0jIneU4VbSF20j+3tcYVneYvqOsJ0GG8sD7r4=",
-      "hash_darwin_aarch64": "sha256-sh2BTEKJaAYbiuNYiSW6iChiCroo95EHoGqxVgX6Jw0="
+      "version": "142.0.7444.135",
+      "hash_darwin": "sha256-i34SR1pfHcAA4N4ppIioa7r33PnvY0OYA8/+U1bQFs8=",
+      "hash_darwin_aarch64": "sha256-dsbjEDkZ0AVghazgF5w9O3aUWZNSy8R9WiHn9m/Sa9g="
     },
     "deps": {
       "depot_tools": {
@@ -21,8 +21,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "4b8153ab58d3c3f4c9f7e4baad9616ecf80db5fa",
-        "hash": "sha256-RZQD9aL/YglC8chM7tqtB1Y2u6DF+6kkgwklUohaBXc=",
+        "rev": "b6965f826881a60c51151cfc0a0175966a0a4e81",
+        "hash": "sha256-NTBQrGihsT7kuY/Mac5s4oH1xEn3CFEAR6eOEvZwmYs=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -132,8 +132,8 @@
       },
       "src/third_party/dawn": {
         "url": "https://dawn.googlesource.com/dawn.git",
-        "rev": "cee9cb0d67e749bf42f5e90cb3b8a6f525dbb920",
-        "hash": "sha256-loKRLJfTxBxlTbPVWZqGdx0DyPvEopbs2zIf4gaxoLo="
+        "rev": "95f9c2b375395cc82941babdf1e9f0cf60a32831",
+        "hash": "sha256-BFJsVt7hkSyyPQiX7QCN7Fu6CgTF/2xwAQbWCkJVq6M="
       },
       "src/third_party/dawn/third_party/glfw": {
         "url": "https://chromium.googlesource.com/external/github.com/glfw/glfw",
@@ -257,8 +257,8 @@
       },
       "src/third_party/devtools-frontend/src": {
         "url": "https://chromium.googlesource.com/devtools/devtools-frontend",
-        "rev": "38cfe98a56a034da33ee62a5f1ea235fe47f58a7",
-        "hash": "sha256-bUJuFEDqgUFdMfmMyroX4s2ky/2n37PsTWaV+iQHCJg="
+        "rev": "f063edc91e3610a60fb9d486ae8694f2a11fcd17",
+        "hash": "sha256-qiucde85rKA7TefveIa++sOF+MzT56pe8pHUUCj9Zeo="
       },
       "src/third_party/dom_distiller_js/dist": {
         "url": "https://chromium.googlesource.com/chromium/dom-distiller/dist.git",
@@ -807,8 +807,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "bb294624702efbb17691b642333f06bf5108e600",
-        "hash": "sha256-ovlKdiBYD9RAjA1XI0PLp/pt25LAvm3fn5AqWlJQfgs="
+        "rev": "4427aa4a9c14d3d542866c0ed2ae8a8554cfd68d",
+        "hash": "sha256-SL9YaplMFA1Ez11bIzAfl/F5qQob/PvCP1uknP1LiLs="
       }
     }
   },


### PR DESCRIPTION
https://chromereleases.googleblog.com/2025/11/stable-channel-update-for-desktop.html

This update includes 5 security fixes.

CVEs:
CVE-2025-12725 CVE-2025-12726 CVE-2025-12727 CVE-2025-12728 CVE-2025-12729

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
