### PR TITLE
workflows/bot: improve for treewides

### DIFF
--- a/ci/github-script/bot.js
+++ b/ci/github-script/bot.js
@@ -576,7 +576,10 @@ module.exports = async ({ github, context, core, dry }) => {
 
   // Controls level of parallelism. Applies to both the number of concurrent requests
   // as well as the number of concurrent workers going through the list of PRs.
-  const maxConcurrent = 20
+  // We'll only boost concurrency when we're running many PRs in parallel on a schedule,
+  // but not for single PRs. This avoids things going wild, when we accidentally make
+  // too many API requests on treewides.
+  const maxConcurrent = context.eventName === 'pull_request' ? 1 : 20
 
   await withRateLimit({ github, core, maxConcurrent }, async (stats) => {
     if (context.payload.pull_request) {

--- a/ci/github-script/reviewers.js
+++ b/ci/github-script/reviewers.js
@@ -13,6 +13,34 @@ async function handleReviewers({
 }) {
   const pull_number = pull_request.number
 
+  const requested_reviewers = new Set(
+    pull_request.requested_reviewers.map(({ login }) => login),
+  )
+  log(
+    'reviewers - requested_reviewers',
+    Array.from(requested_reviewers).join(', '),
+  )
+
+  const existing_reviewers = new Set(
+    reviews.map(({ user }) => user?.login).filter(Boolean),
+  )
+  log(
+    'reviewers - existing_reviewers',
+    Array.from(existing_reviewers).join(', '),
+  )
+
+  // Early sanity check, before we start making any API requests. The list of maintainers
+  // does not have duplicates so the only user to filter out from this list would be the
+  // PR author. Therefore, we check for a limit of 15+1, where 15 is the limit we check
+  // further down again.
+  // This is to protect against huge treewides consuming all our API requests for no
+  // reason.
+  if (maintainers.length > 16) {
+    core.warning('Too many potential reviewers, skipping review requests.')
+    // Return a boolean on whether the "needs: reviewers" label should be set.
+    return existing_reviewers.size === 0 && requested_reviewers.size === 0
+  }
+
   const users = new Set([
     ...(await Promise.all(
       maintainers.map(async (id) => (await getUser(id)).login),
@@ -64,24 +92,8 @@ async function handleReviewers({
   ).filter(Boolean)
   log('reviewers - reviewers', reviewers.join(', '))
 
-  const requested_reviewers = new Set(
-    pull_request.requested_reviewers.map(({ login }) => login),
-  )
-  log(
-    'reviewers - requested_reviewers',
-    Array.from(requested_reviewers).join(', '),
-  )
-
-  const existing_reviewers = new Set(
-    reviews.map(({ user }) => user?.login).filter(Boolean),
-  )
-  log(
-    'reviewers - existing_reviewers',
-    Array.from(existing_reviewers).join(', '),
-  )
-
   if (reviewers.length > 15) {
-    log(
+    core.warning(
       `Too many reviewers (${reviewers.join(', ')}), skipping review requests.`,
     )
     // Return a boolean on whether the "needs: reviewers" label should be set.

--- a/ci/github-script/reviewers.js
+++ b/ci/github-script/reviewers.js
@@ -75,6 +75,9 @@ async function handleReviewers({
   const reviewers = (
     await Promise.all(
       Array.from(new_reviewers, async (username) => {
+        // TODO: Restructure this file to only do the collaborator check for those users
+        // who were not already part of a team. Being a member of a team makes them
+        // collaborators by definition.
         try {
           await github.rest.repos.checkCollaborator({
             ...context.repo,


### PR DESCRIPTION
We rolled out quite some new features in the last week for the `bot` - merge-bot and reviewer requests. These were not optimized for treewide PRs, yet - I quickly hit some API limits in https://github.com/NixOS/nixpkgs/actions/runs/19138420544/job/54697328168?pr=443046.

Fixes https://github.com/NixOS/nixpkgs/pull/458604#discussion_r2499168666 and more.

## Things done

- [x] Tested locally
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
