### PR TITLE
xfce.xfce4-screenshooter: 1.11.2 -> 1.11.3

### DIFF
--- a/pkgs/desktops/xfce/applications/xfce4-screenshooter/default.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-screenshooter/default.nix
@@ -11,6 +11,7 @@
   wrapGAppsHook3,
   exo,
   gtk3,
+  gtk-layer-shell,
   libX11,
   libXext,
   libXfixes,
@@ -21,23 +22,19 @@
   wlr-protocols,
   xfce4-panel,
   xfconf,
-  curl,
-  zenity,
-  jq,
-  xclip,
   gitUpdater,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xfce4-screenshooter";
-  version = "1.11.2";
+  version = "1.11.3";
 
   src = fetchFromGitLab {
     domain = "gitlab.xfce.org";
     owner = "apps";
     repo = "xfce4-screenshooter";
     tag = "xfce4-screenshooter-${finalAttrs.version}";
-    hash = "sha256-LELPY3SU25e3Dk9/OljWMLIbZYrDiQD1h6dMq+jRaH8=";
+    hash = "sha256-VN9j5Ieg3MZwhS4mE4LMRbQ5AM9F8O2n5lx/V0Qk0Po=";
   };
 
   strictDeps = true;
@@ -59,6 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     exo
     gtk3
+    gtk-layer-shell
     libX11
     libXext
     libXfixes
@@ -70,21 +68,6 @@ stdenv.mkDerivation (finalAttrs: {
     xfce4-panel
     xfconf
   ];
-
-  preFixup = ''
-    # For Imgur upload action
-    # https://gitlab.xfce.org/apps/xfce4-screenshooter/-/merge_requests/51
-    gappsWrapperArgs+=(
-      --prefix PATH : ${
-        lib.makeBinPath [
-          curl
-          zenity
-          jq
-          xclip
-        ]
-      }
-    )
-  '';
 
   passthru.updateScript = gitUpdater { rev-prefix = "xfce4-screenshooter-"; };
 


### PR DESCRIPTION
https://gitlab.xfce.org/apps/xfce4-screenshooter/-/compare/xfce4-screenshooter-1.11.2...xfce4-screenshooter-1.11.3

Imgur custom action has been dropped in 1.11.2.



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

