### PR TITLE
nixos/crowdsec-firewall-bouncer: add CAP_NET_RAW

### DIFF
--- a/nixos/modules/services/security/crowdsec-firewall-bouncer.nix
+++ b/nixos/modules/services/security/crowdsec-firewall-bouncer.nix
@@ -371,7 +371,8 @@ in
               AmbientCapabilities = [
                 # Needed to be able to manipulate the rulesets
                 "CAP_NET_ADMIN"
-              ];
+              ]
+              ++ lib.optional ((cfg.settings.mode == "iptables") || (cfg.settings.mode == "ipset")) "CAP_NET_RAW";
               CapabilityBoundingSet = AmbientCapabilities;
               SystemCallFilter = [
                 "@system-service"


### PR DESCRIPTION
Without the `CAP_NET_RAW` capibility, the Crowdsec firewall bouncer
didn't seem to create the intended firewall rules. I saw logs like this:

```
level=error msg="error while inserting set entry in iptables : exit status 1 --> ip6tables v1.8.11 (nf_tables): Can't open socket to ipset.\n\n"
```

And some manual testing verified that my rules weren't being enabled.
With this change everything seems to be working. But it's concerning
that despite the logs `systemctl status crowdsec-firewall-bouncer`
reported everything was healthy. @nicomem did you verify that this was
working for you?


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
