### PR TITLE
zatackax: enable on darwin

### DIFF
--- a/pkgs/by-name/za/zatackax/0001-Fix-SDL_main-redefinition-issue-on-macOS.patch
+++ b/pkgs/by-name/za/zatackax/0001-Fix-SDL_main-redefinition-issue-on-macOS.patch
@@ -1,0 +1,25 @@
+From 9cf8d3f1025689f3765da2f0a27561a6bfe5c3cb Mon Sep 17 00:00:00 2001
+From: Moraxyc <i@qaq.li>
+Date: Fri, 7 Nov 2025 00:23:44 +0800
+Subject: [PATCH] Fix SDL_main redefinition issue on macOS
+
+---
+ src/zatackax.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/zatackax.c b/src/zatackax.c
+index dad2fa9..47a8bd7 100644
+--- a/src/zatackax.c
++++ b/src/zatackax.c
+@@ -16,6 +16,8 @@
+  */
+ 
+ #include "zatackax.h"
++// override SDL_main.h redefining main to SDL_main on darwin
++#define main main
+ 
+ static const unsigned int FPS_CAP = 100;
+ 
+-- 
+2.51.0
+

--- a/pkgs/by-name/za/zatackax/package.nix
+++ b/pkgs/by-name/za/zatackax/package.nix
@@ -21,6 +21,17 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-1m99hi0kjpj5Yl1nAmwSMMdQWcP0rfLLPFJPkU4oVbM=";
   };
 
+  # src/zatackax.c:2069:5: error: conflicting types for 'SDL_main'
+  # Fix SDL_main redefinition issue on darwin
+  patches = lib.optional stdenv.hostPlatform.isDarwin ./0001-Fix-SDL_main-redefinition-issue-on-macOS.patch;
+
+  # malloc.h is not needed because stdlib.h is already included.
+  # On darwin, malloc.h does not even exist, resulting in an error.
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace src/zatackax.h \
+      --replace-fail '#include <malloc.h>' ""
+  '';
+
   strictDeps = true;
 
   nativeBuildInputs = [
@@ -45,6 +56,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Plus;
     maintainers = [ lib.maintainers.alch-emi ];
     mainProgram = "zatackax";
-    platforms = lib.platforms.linux;
+    platforms = with lib.platforms; linux ++ darwin;
   };
 })


### PR DESCRIPTION
Tested on aarch64-darwin

<img width="800" height="628" alt="1" src="https://github.com/user-attachments/assets/4e5b4571-5b7d-4984-9a51-ccf69f4ef3b4" />
<img width="800" height="628" alt="2" src="https://github.com/user-attachments/assets/eeae7ca3-59d6-40df-899d-dc5fc249be9a" />


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
