### PR TITLE
ci/github-script/bot: fix concurrency limit

### DIFF
--- a/ci/github-script/bot.js
+++ b/ci/github-script/bot.js
@@ -579,7 +579,7 @@ module.exports = async ({ github, context, core, dry }) => {
   // We'll only boost concurrency when we're running many PRs in parallel on a schedule,
   // but not for single PRs. This avoids things going wild, when we accidentally make
   // too many API requests on treewides.
-  const maxConcurrent = context.eventName === 'pull_request' ? 1 : 20
+  const maxConcurrent = context.payload.pull_request ? 1 : 20
 
   await withRateLimit({ github, core, maxConcurrent }, async (stats) => {
     if (context.payload.pull_request) {


### PR DESCRIPTION
This was introduced as part of the hotfix PR to avoid hitting API rate limits - but the condition was wrong. It was supposed to trigger in all PR contexts, not only for the Test workflow.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
