### PR TITLE
kdePackages: Gear 25.08.2 -> 25.08.3

### DIFF
--- a/pkgs/development/libraries/libquotient/default.nix
+++ b/pkgs/development/libraries/libquotient/default.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   olm,
   openssl,
@@ -12,7 +13,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libquotient";
-  version = "0.9.1";
+  version = "0.9.5";
 
   outputs = [
     "out"
@@ -23,8 +24,17 @@ stdenv.mkDerivation rec {
     owner = "quotient-im";
     repo = "libQuotient";
     rev = version;
-    hash = "sha256-R9ms3sYGdHaYKUMnZyBjw5KCik05k93vlvXMRtAXh5Y=";
+    hash = "sha256-wdIE5LI4l3WUvpGfoJBL8sjBl2k8NfZTh9CjfJc9FIA=";
   };
+
+  patches = [
+    # Qt 6.10 compat
+    # FIXME: remove in next update
+    (fetchpatch {
+      url = "https://github.com/quotient-im/libQuotient/commit/ea83157eed37ff97ab275a5d14c971f0a5a70595.diff";
+      hash = "sha256-JMdcywGgZ0Gev/Nce4oPiMJQxTBJYPoq+WoT3WLWWNQ=";
+    })
+  ];
 
   nativeBuildInputs = [ cmake ];
 

--- a/pkgs/kde/gear/angelfish/default.nix
+++ b/pkgs/kde/gear/angelfish/default.nix
@@ -31,4 +31,7 @@ mkKdeDerivation rec {
     corrosion
     qcoro
   ];
+
+  # FIXME: work around Qt 6.10 cmake API changes
+  cmakeFlags = [ "-DQT_FIND_PRIVATE_MODULES=1" ];
 }

--- a/pkgs/kde/generated/sources/gear.json
+++ b/pkgs/kde/generated/sources/gear.json
@@ -1,1247 +1,1247 @@
 {
   "accessibility-inspector": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/accessibility-inspector-25.08.2.tar.xz",
-    "hash": "sha256-Z8RYiX+GK+aoQ0zI5x5By5974VtHT0t7a0TwC6+2UmE="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/accessibility-inspector-25.08.3.tar.xz",
+    "hash": "sha256-qu5u3kDAOYIAffLouVLn/mxTFOFBhFCU4ox1U3NEeQA="
   },
   "akonadi": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/akonadi-25.08.2.tar.xz",
-    "hash": "sha256-Qc/q3+h7Ao1yAGjAReuebLId+p7bJHpUiNmz/GExww4="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/akonadi-25.08.3.tar.xz",
+    "hash": "sha256-+Gf9HhbZ1jepLaszTcQXDyD1i+EzZzkglOxTnj7uAXo="
   },
   "akonadi-calendar": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/akonadi-calendar-25.08.2.tar.xz",
-    "hash": "sha256-wnrtySzylXBjazodxARKvuKaajbTU23usy1VjXmzVGE="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/akonadi-calendar-25.08.3.tar.xz",
+    "hash": "sha256-vuMRKJCiHyq2AFholD0lbHnFGPwbWyR/AUy4vazdQMI="
   },
   "akonadi-calendar-tools": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/akonadi-calendar-tools-25.08.2.tar.xz",
-    "hash": "sha256-nIS+nz+VDOV1oyjUrKia/3v8f5CijPRCNqgzUoTmOog="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/akonadi-calendar-tools-25.08.3.tar.xz",
+    "hash": "sha256-jHkM7gF8fMMx97aQqCe9MsW0kmB5Z47CS7gA0mxPHqY="
   },
   "akonadi-contacts": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/akonadi-contacts-25.08.2.tar.xz",
-    "hash": "sha256-ZQwDTN8qq15TqL5XnK1nep2PzDXttwTncgLpBbD44gI="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/akonadi-contacts-25.08.3.tar.xz",
+    "hash": "sha256-OEAOvm4cudm/U2vNwym9ZI0r2HviMn0EtJNhxmzz0k0="
   },
   "akonadi-import-wizard": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/akonadi-import-wizard-25.08.2.tar.xz",
-    "hash": "sha256-ORQ1Jp8sBhoJ6KcnpbpuOdPFkItpF6EYRthEbkmgO9U="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/akonadi-import-wizard-25.08.3.tar.xz",
+    "hash": "sha256-X9O1offbeIUoyXR/70tz8KjKfHvCzw41uC3ODK/tE5k="
   },
   "akonadi-mime": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/akonadi-mime-25.08.2.tar.xz",
-    "hash": "sha256-AAdRMbRrwa/L6qP86IUvdr7W8FMVeY6GEY4PyuDE3ks="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/akonadi-mime-25.08.3.tar.xz",
+    "hash": "sha256-ciKSy8ewUeaLC3wFo3H6VarzHqi8Z/LdHOcz4O2xImY="
   },
   "akonadi-search": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/akonadi-search-25.08.2.tar.xz",
-    "hash": "sha256-K+VinvzH8BNP22Gp+QYrxZsAq1XoG478dq8Yy11mpYg="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/akonadi-search-25.08.3.tar.xz",
+    "hash": "sha256-PI19LYADtJYBgxaA/BG6kNp5xRaYbMJscWALud5531E="
   },
   "akonadiconsole": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/akonadiconsole-25.08.2.tar.xz",
-    "hash": "sha256-OFPxGuQUZSF2SolzPnCJxmfpyntD/ckTsmTKWTdVIpE="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/akonadiconsole-25.08.3.tar.xz",
+    "hash": "sha256-CJAdImBZ5k6kcUXw/g6XEEqf7no9SbHWnOeVxGnvRNo="
   },
   "akregator": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/akregator-25.08.2.tar.xz",
-    "hash": "sha256-0KZvccUVnLv+N+B2LRVXBRVpL4ZG+1WhkYDW1Sms/O4="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/akregator-25.08.3.tar.xz",
+    "hash": "sha256-HGe7qUnvN2xwfUOV5qo3mNFy67cwOuNHIt/m1cCbD4M="
   },
   "alligator": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/alligator-25.08.2.tar.xz",
-    "hash": "sha256-QIZjRzpKuUJWnSeo1SfkroUrK8vDyhpHQcY+HX64P2Y="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/alligator-25.08.3.tar.xz",
+    "hash": "sha256-OAbXqoE/jrw061PPelDgaXObSbaR1Yt8kGOAXDTcuPo="
   },
   "analitza": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/analitza-25.08.2.tar.xz",
-    "hash": "sha256-124Mohk8mQPyBUYStMz2tPPU4VxeV37/M+9UV/arcGk="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/analitza-25.08.3.tar.xz",
+    "hash": "sha256-Gr50HD8Ymz2MuM80tRaJD9ZM8hunXQ9VizcRlWuD5NE="
   },
   "angelfish": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/angelfish-25.08.2.tar.xz",
-    "hash": "sha256-NWH87SN49oIUteK8qAEXpgosCPpdUiOoHwzIN4mr28Q="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/angelfish-25.08.3.tar.xz",
+    "hash": "sha256-ccSns9ZlDrW9mn0ILOA++s4LtegG2POZ561nW7BkN2w="
   },
   "arianna": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/arianna-25.08.2.tar.xz",
-    "hash": "sha256-DsL4hIjZhP+cy7pDEfffP7SI+L3HRIAJwctGrSbAdCg="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/arianna-25.08.3.tar.xz",
+    "hash": "sha256-Ou6H67yjIW6oZ2A2JmMSpeekrzQGwg3soS76n4tb2rQ="
   },
   "ark": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/ark-25.08.2.tar.xz",
-    "hash": "sha256-dj6r7B6ABQ80Q7t6C8Ntd3soqwcgDvsWYwvzP32wy8o="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/ark-25.08.3.tar.xz",
+    "hash": "sha256-yk+3KV8JAoDfAtJLZPET4QxvYYE4s4e8H9eixWHeVU8="
   },
   "artikulate": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/artikulate-25.08.2.tar.xz",
-    "hash": "sha256-y6ybg9tGEp5egY+CYTdRcyxuMuenWWd8S5F8cWSgX1M="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/artikulate-25.08.3.tar.xz",
+    "hash": "sha256-B8BF81lWTN5ri6U4xtDCq72pKDQekypFy0CBxMFdqOU="
   },
   "audex": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/audex-25.08.2.tar.xz",
-    "hash": "sha256-n4N+u12L0E8Jr5uyKIGfWl/ismllto5tcm5vJDJvPGM="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/audex-25.08.3.tar.xz",
+    "hash": "sha256-eaECo9FOa12Sa+DQpmNF/VtYHDwCHlqbZSCBfugT7I4="
   },
   "audiocd-kio": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/audiocd-kio-25.08.2.tar.xz",
-    "hash": "sha256-rnWN3W+r6i2Af0qLcbmLGtLwtTCu6+O1eUtRhxYvkL8="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/audiocd-kio-25.08.3.tar.xz",
+    "hash": "sha256-buOBRu17YVBH2wPhQgXqkiEknm64RyS9ZgmvmC9X7qw="
   },
   "audiotube": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/audiotube-25.08.2.tar.xz",
-    "hash": "sha256-PmPdKaJwsP95Xk9QeoMlYa5XKinYomjVubBV4B4PSlA="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/audiotube-25.08.3.tar.xz",
+    "hash": "sha256-7g7PpDufa5qrtYPe4OIB8paScfp3ua28HauzSsFJte4="
   },
   "baloo-widgets": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/baloo-widgets-25.08.2.tar.xz",
-    "hash": "sha256-XGzTy29NC2ifxCNnxUGKxr8XiXhxQ5T/tbzV86c0G80="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/baloo-widgets-25.08.3.tar.xz",
+    "hash": "sha256-/AqOxTIbP0uw4fFlzY51dwGbkNV1UXCAJjSmjfw858s="
   },
   "blinken": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/blinken-25.08.2.tar.xz",
-    "hash": "sha256-AsermlIShX8/KOoR4BPs7kf6vYbQ3o9yCi8HTqNzq8w="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/blinken-25.08.3.tar.xz",
+    "hash": "sha256-dwWY8ifoy7abSw3eTjum3qEHTj4Kin8H5CQ6GL+HbW0="
   },
   "bomber": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/bomber-25.08.2.tar.xz",
-    "hash": "sha256-VOdFXk4nte9CtcFL1H0jmvZGP7z6eTrp7VlWT6xqibY="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/bomber-25.08.3.tar.xz",
+    "hash": "sha256-eMHM10FRXCpUIJATB7hz/FLIb0xaHlGHBHIhX4zpzJs="
   },
   "bovo": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/bovo-25.08.2.tar.xz",
-    "hash": "sha256-dOqMcZHDqZtkkOxQmMqzrVFrxE7h59673zfK4a7t2/s="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/bovo-25.08.3.tar.xz",
+    "hash": "sha256-3+YkhXzh3seAlgygDr7mFe5rULouf6DBSF7NGFVxzeY="
   },
   "calendarsupport": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/calendarsupport-25.08.2.tar.xz",
-    "hash": "sha256-Lzw9pv9gDFccli4YyrfSpseA154oK5TextcKbwhNbUY="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/calendarsupport-25.08.3.tar.xz",
+    "hash": "sha256-g0NzWYHoxBRm1w06SOcOHOIyipKO3QvtLa6QOaPPna0="
   },
   "calindori": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/calindori-25.08.2.tar.xz",
-    "hash": "sha256-9eH0pexsT220s+BRUgNKetlffanC4IvCsnrMjMI+aok="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/calindori-25.08.3.tar.xz",
+    "hash": "sha256-t7ylpu88XTa6qK6cVg+/V9mlPmkl1qJIYa7MKn3mzLw="
   },
   "calligra": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/calligra-25.08.2.tar.xz",
-    "hash": "sha256-319aPsI+evmPOAW0vYQmlH4AyNdeP0QU1dpYDgdwCUg="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/calligra-25.08.3.tar.xz",
+    "hash": "sha256-dPrHglPEKYU+mfrgC88rhDMtvDqPU4zPcGdCWSZrklE="
   },
   "cantor": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/cantor-25.08.2.tar.xz",
-    "hash": "sha256-JZxEFr/CtgzpSZodoP70jVNpsLY+/nW8sNDIkGovIAA="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/cantor-25.08.3.tar.xz",
+    "hash": "sha256-VjUAf7nFDYLojez5Jk/0D7n07mWydHTFkwsbUZ6yS3I="
   },
   "colord-kde": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/colord-kde-25.08.2.tar.xz",
-    "hash": "sha256-Sks0OGQoIidW6TM+EobQA6+syy/szKkmhffRQruatgk="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/colord-kde-25.08.3.tar.xz",
+    "hash": "sha256-KaawondaAKO9WxsTjHc3LlOviARYDB5BK4edSOXQrt8="
   },
   "dolphin": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/dolphin-25.08.2.tar.xz",
-    "hash": "sha256-BvTxaY9kB/00uMmyED2RohzKtkZ0hbtfoj4jc26mZ5E="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/dolphin-25.08.3.tar.xz",
+    "hash": "sha256-Gr1jLr44N99WFiFvacPKn2JAFl+fhFAkIiAydeqo7gk="
   },
   "dolphin-plugins": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/dolphin-plugins-25.08.2.tar.xz",
-    "hash": "sha256-QxHdWblKASYl5/tlh9Tw7AENslccsrUIevAZCc8VD8g="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/dolphin-plugins-25.08.3.tar.xz",
+    "hash": "sha256-KESdFeCqzndWPztvE/R7oGhUFgoHXfQjh/wD9nCousU="
   },
   "dragon": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/dragon-25.08.2.tar.xz",
-    "hash": "sha256-AUNDWenG/kqX8fkgPlF7OCqpI3RrR85rJSs23wuBiug="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/dragon-25.08.3.tar.xz",
+    "hash": "sha256-nh0v6TAYFmQYy/yC/C+ThNHFyZvBtQDGkHLI/iz50Dg="
   },
   "elisa": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/elisa-25.08.2.tar.xz",
-    "hash": "sha256-4HUIsISk9d8bzqdYynBailPJDcAfb1Q1qe84eF0bEcE="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/elisa-25.08.3.tar.xz",
+    "hash": "sha256-Y2dLvQWKUY10C9mIDWWpr2qBb8M/uQTMHwwMJIRH3RM="
   },
   "eventviews": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/eventviews-25.08.2.tar.xz",
-    "hash": "sha256-bcE4iCT+WrVtG+FbOX6IhKvo4dujel19PGsXQ8TXYjU="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/eventviews-25.08.3.tar.xz",
+    "hash": "sha256-6hbNGZOcfU9bna+575N2PosvJsLfIsZw9qV4LdEOOD4="
   },
   "falkon": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/falkon-25.08.2.tar.xz",
-    "hash": "sha256-+39ozZTvJPdq86HkoHEZV+7nqVI5ubnEIjZ2maPMEVM="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/falkon-25.08.3.tar.xz",
+    "hash": "sha256-FiUtikICi/VLiOHkpa+5WHUwneRPIDFWyZxKZDcg4Sk="
   },
   "ffmpegthumbs": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/ffmpegthumbs-25.08.2.tar.xz",
-    "hash": "sha256-0vF4G82w8cov5qu83pPA2EUH8M7iNlDf2U64obfpTIw="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/ffmpegthumbs-25.08.3.tar.xz",
+    "hash": "sha256-hOzRMaUHmYFfQUUi/BJwxW4O5Fu/r5b54dLJJ43ISWI="
   },
   "filelight": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/filelight-25.08.2.tar.xz",
-    "hash": "sha256-nKR/6/reraoRurzmXBngNaW8dmYA0JeM5JRNnkFmFVU="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/filelight-25.08.3.tar.xz",
+    "hash": "sha256-ijqCXFocTzZi17eG91v4+u9qyfZyPI6M0p5s8VvagIA="
   },
   "francis": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/francis-25.08.2.tar.xz",
-    "hash": "sha256-PBqs9qoCAlgigzMMtuih1OHlfvyc/JpUkqoGBlePKxM="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/francis-25.08.3.tar.xz",
+    "hash": "sha256-o71EolKHj7XhRRZYBqG6pxt+QL6T7ZTVvYd3GHWV/jE="
   },
   "ghostwriter": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/ghostwriter-25.08.2.tar.xz",
-    "hash": "sha256-Xw0aUeB8pYZbM1I5qiDeV15M1XpJMpZtWpbY3/Pb1nY="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/ghostwriter-25.08.3.tar.xz",
+    "hash": "sha256-OZlp7wcHz0iD/OFy1qIt+vKSlKmw+tLnFq1oBFICsAY="
   },
   "granatier": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/granatier-25.08.2.tar.xz",
-    "hash": "sha256-UjN/T3EdDkojbKyL2njB4JUjTEZfQdQL+SaF9dMfl4Q="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/granatier-25.08.3.tar.xz",
+    "hash": "sha256-9JMa+NH6DVZaEsPsiANiSih1cWxalCsWzIgZOuEBYm8="
   },
   "grantlee-editor": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/grantlee-editor-25.08.2.tar.xz",
-    "hash": "sha256-+02OZHw2YaMGQ80yrUb1PJcuxvyAN2xNxRSx9lyj8M4="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/grantlee-editor-25.08.3.tar.xz",
+    "hash": "sha256-atnws3Sd5VfsR8SdqRR1Q5JIWmZGHA1o9R/XcYhaVbU="
   },
   "grantleetheme": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/grantleetheme-25.08.2.tar.xz",
-    "hash": "sha256-xdtSGNuv2SXkaScoRYFBt6cbnpZ0usEchcho15LCTFQ="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/grantleetheme-25.08.3.tar.xz",
+    "hash": "sha256-ZJ3pmbthKI/JtK7T6+Ix5FIBzWz9TyR2Nqf9Jw74euA="
   },
   "gwenview": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/gwenview-25.08.2.tar.xz",
-    "hash": "sha256-wYmWeg4h8HU1YOjYc4HoiPPZQ3AdtMHyG+2LW7ivHlo="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/gwenview-25.08.3.tar.xz",
+    "hash": "sha256-IADELUDuPpLONV+C0v3dB9J/YT9xzy5laZz+eUp27KE="
   },
   "incidenceeditor": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/incidenceeditor-25.08.2.tar.xz",
-    "hash": "sha256-CWWB/XaMWwcaxK/mfJ6zdB4wm2AKcku6wSr2l0bGgJg="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/incidenceeditor-25.08.3.tar.xz",
+    "hash": "sha256-0MFcN1FyOrzxAaI6axYtMp4IkknpS9/UKD1o3s8hGpg="
   },
   "isoimagewriter": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/isoimagewriter-25.08.2.tar.xz",
-    "hash": "sha256-wfRRmrvrqtUlGa+V6Zr3jN4ZNv4Zl3BJWkY2hxpaLWA="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/isoimagewriter-25.08.3.tar.xz",
+    "hash": "sha256-hhC0t4mo11DG9PKOHStfmE7/1+uCKDJeZzrU9CJRLi4="
   },
   "itinerary": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/itinerary-25.08.2.tar.xz",
-    "hash": "sha256-VXA9YIjiWgrbgiSYJYnUl4TpIL6MDnnl9QwTzDKu1z4="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/itinerary-25.08.3.tar.xz",
+    "hash": "sha256-KPjO9H+UnOSDJvbSiC1YwceXpuMkxR9dNRDn2yIWH4c="
   },
   "juk": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/juk-25.08.2.tar.xz",
-    "hash": "sha256-KzlqgDeK5ygT0CmGtqNQLJdQZbSan+rzgkJsepZaSKA="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/juk-25.08.3.tar.xz",
+    "hash": "sha256-uVwfu1rgZ0U7KrUrnA6MCNW7V+4+Xtyx0fsMcC+P/ok="
   },
   "k3b": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/k3b-25.08.2.tar.xz",
-    "hash": "sha256-tOsu4GmpaPfcPsSCU5Wvdea/tInZaiiUjyLuUaNq+jU="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/k3b-25.08.3.tar.xz",
+    "hash": "sha256-Vx4fWYGeYwv/2pbJbGMm1fEoqkVW4oK+UZ9MhAkQXSU="
   },
   "kaccounts-integration": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kaccounts-integration-25.08.2.tar.xz",
-    "hash": "sha256-peBuAWaUm/LemVdTUX7bVT+iXu3Z7uWsMJ8vOsHZiO4="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kaccounts-integration-25.08.3.tar.xz",
+    "hash": "sha256-f6A0Pww/WTdcSBfL0psP7X5Fy7MfSVbm0/YsCr4qHIs="
   },
   "kaccounts-providers": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kaccounts-providers-25.08.2.tar.xz",
-    "hash": "sha256-+XmuS9Ih7rybPEnNRmIE+R7xjBkVpNzoMgbzhK3Rr9M="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kaccounts-providers-25.08.3.tar.xz",
+    "hash": "sha256-EipO8htZau91+iu0HM2XxzMt/NYjSiYCrubBPFhFEG8="
   },
   "kaddressbook": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kaddressbook-25.08.2.tar.xz",
-    "hash": "sha256-RbP8niU57R/LvM1FzkXpw2t1AQiSZZmCCRVfvOcaWNU="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kaddressbook-25.08.3.tar.xz",
+    "hash": "sha256-hTXzTM0UKGKQcq/V4uc5xZ4p5KDGfkRPCZF8pDAXqlc="
   },
   "kajongg": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kajongg-25.08.2.tar.xz",
-    "hash": "sha256-vYNzVfQl5SDcST64u8YpC134OIQPiCuLou9dHHucHBQ="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kajongg-25.08.3.tar.xz",
+    "hash": "sha256-R9WGyP0U6ZG/snih9ahTOH681PEhgdLVyc3rQ9+udXg="
   },
   "kalarm": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kalarm-25.08.2.tar.xz",
-    "hash": "sha256-f/WKJYoX31DqPaetfc3O4VBySBEU4+uxuFXrhcBl1nc="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kalarm-25.08.3.tar.xz",
+    "hash": "sha256-NHufVkcecLTDNe6WvHan1cFIut/RRgzQDoi9s/9sZ1k="
   },
   "kalgebra": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kalgebra-25.08.2.tar.xz",
-    "hash": "sha256-Igi0+WWHbrSz9C6q4GxvNn/wc1skXZq6zy8sl1pxTxA="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kalgebra-25.08.3.tar.xz",
+    "hash": "sha256-PcUwwsjUpIuhwtcRfS3hxH4GVCVfo8jUX2xtqs+bHUE="
   },
   "kalk": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kalk-25.08.2.tar.xz",
-    "hash": "sha256-9DlieqCYApCiu/eLYbGgPTi33hwaqnFwiGe7Xt190IM="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kalk-25.08.3.tar.xz",
+    "hash": "sha256-8hip+c2oPhJECwgyxb7V18VNgLM1vHeFpjT4eSm53NA="
   },
   "kalm": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kalm-25.08.2.tar.xz",
-    "hash": "sha256-0u6i7yr7oRkUpb3WPOBfePV7bsE8ShfJpVbEIkilb64="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kalm-25.08.3.tar.xz",
+    "hash": "sha256-z9QK5UcuKGaN295py/dxCV6eKP/oDPMHxDl1MiSnT2k="
   },
   "kalzium": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kalzium-25.08.2.tar.xz",
-    "hash": "sha256-mfHaPrBK7jG0XZKLXdMKFnXcIEGUumQ/iXP0rm/bz+0="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kalzium-25.08.3.tar.xz",
+    "hash": "sha256-NubE9G4aXaqs4U67Wx9trDQprV3z1PwfCt6uw+KOQgs="
   },
   "kamera": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kamera-25.08.2.tar.xz",
-    "hash": "sha256-/wOWIlPyoQjrDh9STSrPLZzJNFYUafuY9sgOkDKUoPQ="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kamera-25.08.3.tar.xz",
+    "hash": "sha256-Tca4sPtHkoi2V3tEbEVDF14hM2THkb1lC2HsevhV7RI="
   },
   "kamoso": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kamoso-25.08.2.tar.xz",
-    "hash": "sha256-Ry/NTfUXrzf5g+8RaJYcJzk8JeTFPwTkGibgfPRQTV8="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kamoso-25.08.3.tar.xz",
+    "hash": "sha256-QhlpQxS3w15yyFAI++GFmuKLuAIHsdI/tHf5v8LzGLc="
   },
   "kanagram": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kanagram-25.08.2.tar.xz",
-    "hash": "sha256-57vmAV82DPVzR/pSaAa5QewDQ3AYGD1EizRk++34apc="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kanagram-25.08.3.tar.xz",
+    "hash": "sha256-wVoqCywIzvdFUiDu3fzDCV027qFNaE/F+5/y8dCly7w="
   },
   "kapman": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kapman-25.08.2.tar.xz",
-    "hash": "sha256-uz9Imc5G1AScr2Kr0aEOQl7xVsdLFncVhFjlHFmz0pQ="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kapman-25.08.3.tar.xz",
+    "hash": "sha256-m2RJ6npbJ9Ih50cU3aLyd2Rcz0MJFVJGhD6lv/9FKXM="
   },
   "kapptemplate": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kapptemplate-25.08.2.tar.xz",
-    "hash": "sha256-qbfvgHc8d+nIHI9Rl5Cr2kD2rKF93sJA6cL0zcp8+UI="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kapptemplate-25.08.3.tar.xz",
+    "hash": "sha256-NQbkTNMLdIgsoQgkqsUsXOJqs5axBSqOVSQcU20MXno="
   },
   "kasts": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kasts-25.08.2.tar.xz",
-    "hash": "sha256-sNpJl2/RJszypKty9VDIs079tYgwwMHvRDcaaFt9O5k="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kasts-25.08.3.tar.xz",
+    "hash": "sha256-zMyOMsnPIG8t/J2zYZaGQ5w+BbnTUr6KyVHJnJrYYnM="
   },
   "kate": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kate-25.08.2.tar.xz",
-    "hash": "sha256-te76UZaQmD75K+jMMOr6zh/IyfIl2dhRpcGBmlJjR3A="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kate-25.08.3.tar.xz",
+    "hash": "sha256-yS64tbgcm13JG1xG0gtPOuC3gREUd5/Y+S8VMjP8qQs="
   },
   "katomic": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/katomic-25.08.2.tar.xz",
-    "hash": "sha256-JborSTaM/p0tQTlvB9A3M0g57rZQLnHi+o+bpld9PWs="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/katomic-25.08.3.tar.xz",
+    "hash": "sha256-kCG+G+/Nog0lOCy1xiDNZsu/DqOqYhsKrkCpBVOrQsw="
   },
   "kbackup": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kbackup-25.08.2.tar.xz",
-    "hash": "sha256-VMeu3w0exMzduCL4MwM10Mv07ED2RJmRXwD+8MAwuLE="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kbackup-25.08.3.tar.xz",
+    "hash": "sha256-/4keGs/pu0IApPaBZUAlWbsAzs2HkTQc1NQClpVf/CQ="
   },
   "kblackbox": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kblackbox-25.08.2.tar.xz",
-    "hash": "sha256-fh+GT6gzJpOlE3WiDvxX1Nk94rRLhj/vi2ApFChZNiQ="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kblackbox-25.08.3.tar.xz",
+    "hash": "sha256-7wCVZaokDWZI4FF7vp7Sh7wfWkpEBdbyHT7t4+2/oV8="
   },
   "kblocks": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kblocks-25.08.2.tar.xz",
-    "hash": "sha256-VGwjpKn5b7PLTGjFvZlosuDdwX37vRjeHDPvM2YOnv0="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kblocks-25.08.3.tar.xz",
+    "hash": "sha256-CRr+lf/Wh/tIU1d1X3QbRKQYCZOhZpUvtbopUO7OBK0="
   },
   "kbounce": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kbounce-25.08.2.tar.xz",
-    "hash": "sha256-4PVacun5C/s3yq6n08UTxbj/U/c51P4D//X17As6rbg="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kbounce-25.08.3.tar.xz",
+    "hash": "sha256-8UGeSUSGMiO1ontayzIo61giS26vTwyUFkwEYaw9kBo="
   },
   "kbreakout": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kbreakout-25.08.2.tar.xz",
-    "hash": "sha256-R8dSNSna4mN2vizPmOteMW7oVqrFLjamurUepf0+7gA="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kbreakout-25.08.3.tar.xz",
+    "hash": "sha256-BYvwHpN/rc0ykS6ARVh1ZulPfAXQrXE/TmXW01GwT0A="
   },
   "kbruch": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kbruch-25.08.2.tar.xz",
-    "hash": "sha256-sLTn/am2A7rMLGKau82RQGnGxkonQX+tIjzYMl2j0Sw="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kbruch-25.08.3.tar.xz",
+    "hash": "sha256-j9VTZXEbvtWe285Mg5fqPoMWyASGYnyiky095Eg7s1w="
   },
   "kcachegrind": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kcachegrind-25.08.2.tar.xz",
-    "hash": "sha256-jVDAcaI9tirOzfItbpQ5aqA+TV/5esx9K+hIY7NPv8g="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kcachegrind-25.08.3.tar.xz",
+    "hash": "sha256-rsg436gGtDjRmPW7ZqKpkl7NuG0J2obFk6ITAgUrC74="
   },
   "kcalc": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kcalc-25.08.2.tar.xz",
-    "hash": "sha256-kn1cs9Z+MS8UeAWYhvsXqH9iGKArOFlN8WQ/fFi/B4E="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kcalc-25.08.3.tar.xz",
+    "hash": "sha256-DoQslASW5H9avR7GCB9cbPKIvh3XPttQcdhPBOyhg4o="
   },
   "kcalutils": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kcalutils-25.08.2.tar.xz",
-    "hash": "sha256-t7YK2AjaF3f2+QWzPodNp3oG4L0jVb9XejDpTjDGCKM="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kcalutils-25.08.3.tar.xz",
+    "hash": "sha256-zqA3tnpRC6TjwJE6kLor/3JAcLKSUSSN8jr1+wuxii0="
   },
   "kcharselect": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kcharselect-25.08.2.tar.xz",
-    "hash": "sha256-3RUCQnrobAS5PVPUwrqQaaYMtSZ21CAQtAMdGQghjlA="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kcharselect-25.08.3.tar.xz",
+    "hash": "sha256-r+4jbl4Dda7gOO1CkqOhiPpRJR2Sq46HLNn+cTzeOuM="
   },
   "kclock": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kclock-25.08.2.tar.xz",
-    "hash": "sha256-4u4DWOAWgHim49h2bntnOyLFvHhkASoFt5Je3bnpGtw="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kclock-25.08.3.tar.xz",
+    "hash": "sha256-2Kz8qjb/jdQk3oKuFja63Zqi9QpsTj41eI7VzDliduI="
   },
   "kcolorchooser": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kcolorchooser-25.08.2.tar.xz",
-    "hash": "sha256-tj/Nphft9sIOA6Qqh8zKB+C5pSKslGBV4/mPVjlDcxU="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kcolorchooser-25.08.3.tar.xz",
+    "hash": "sha256-as7OA7OASmEIItBY+7vNq+w/4a2mqL/+1tNpUmkwvmc="
   },
   "kcron": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kcron-25.08.2.tar.xz",
-    "hash": "sha256-8Ity7bspzLYaizfEPC8lMDovNo38HT+cZfdDTpzRloM="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kcron-25.08.3.tar.xz",
+    "hash": "sha256-UqVAID6bKN6+UkBefDEpzia1OvHdwXFlt7UlVcx1e2c="
   },
   "kde-dev-scripts": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kde-dev-scripts-25.08.2.tar.xz",
-    "hash": "sha256-4dcrwyEPtWjy7/2xuz+aWMTad4rxuksAXhOOmqF6Nek="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kde-dev-scripts-25.08.3.tar.xz",
+    "hash": "sha256-8J52s97VzHa5nCa8sCdVONWQJn8IySG1JAwISjy75H0="
   },
   "kde-dev-utils": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kde-dev-utils-25.08.2.tar.xz",
-    "hash": "sha256-JobJjo+CfOM3Rjp0ZVQ1djK/6aXfo6hOXFX273stMkc="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kde-dev-utils-25.08.3.tar.xz",
+    "hash": "sha256-6BlfM4lgpNXvJHxmDkYrntQFPGB40jrtN8AptiWBKkM="
   },
   "kde-inotify-survey": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kde-inotify-survey-25.08.2.tar.xz",
-    "hash": "sha256-R75EgYmcWinoSEm5/1ZLQyBBhvwGnekCXqCUiY+8n2w="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kde-inotify-survey-25.08.3.tar.xz",
+    "hash": "sha256-s5wSm5a4CQT0p7X4KOzZiJHDK2G5SW6NYxBYnakeuVs="
   },
   "kdebugsettings": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kdebugsettings-25.08.2.tar.xz",
-    "hash": "sha256-Brt+QdxF28yKOBwxbSPw+yAKnMbH8Zrrm021dg4e8+0="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kdebugsettings-25.08.3.tar.xz",
+    "hash": "sha256-dpkOq4FsRfEWyCMdsz8Wr5VezHM8TrfIn+g5d/MpPaA="
   },
   "kdeconnect-kde": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kdeconnect-kde-25.08.2.tar.xz",
-    "hash": "sha256-5CRbagY9bfDhI/1nwGX1wkmU4hs0lYnNplleSAuRawk="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kdeconnect-kde-25.08.3.tar.xz",
+    "hash": "sha256-bkHx8i6F9ecKkt1so+aWg2SJbeN6/l2ut82lmfA+Xis="
   },
   "kdeedu-data": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kdeedu-data-25.08.2.tar.xz",
-    "hash": "sha256-sTjppV2QE87JhoPVml0BD50xk9jOFj9Z1aYSa58B+m8="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kdeedu-data-25.08.3.tar.xz",
+    "hash": "sha256-cfhXK1fQ7bBzQp4vOUFFkRwINosgyqNoXPZMrbxvoqo="
   },
   "kdegraphics-mobipocket": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kdegraphics-mobipocket-25.08.2.tar.xz",
-    "hash": "sha256-eZrzukGQMTOXOJMwZFw/oA9CkBf3M4QzyNSr7lWtZNI="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kdegraphics-mobipocket-25.08.3.tar.xz",
+    "hash": "sha256-pPj/FjInDBFpUJVzJmGZXZY5+DM8jWNzBlTXh9zDtVQ="
   },
   "kdegraphics-thumbnailers": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kdegraphics-thumbnailers-25.08.2.tar.xz",
-    "hash": "sha256-AuH8XSp3rZxXFz3q4jM6Cj8ERG58z2gvH2awmQLwGt8="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kdegraphics-thumbnailers-25.08.3.tar.xz",
+    "hash": "sha256-FfwrsleMfFhGNTPr1tjU6j7D2er0fgT3TpMiwTXJfoQ="
   },
   "kdenetwork-filesharing": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kdenetwork-filesharing-25.08.2.tar.xz",
-    "hash": "sha256-km5A7fwYnOWlBDwyO4NqzOoPXU+RFwj/QUWYQLmWYO4="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kdenetwork-filesharing-25.08.3.tar.xz",
+    "hash": "sha256-0s71ZEOEO4KlwhDsWm5MKh7RoqhtUX5Xc4VZU7qWpI8="
   },
   "kdenlive": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kdenlive-25.08.2.tar.xz",
-    "hash": "sha256-RkUpuuXF++dHPb0DCPqMNYj2jye1yZZErRgynaVXuNk="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kdenlive-25.08.3.tar.xz",
+    "hash": "sha256-gbpOkRFH1dvTO89GSy8K6fV7iCTb/H+rIfPBG7ZDN4M="
   },
   "kdepim-addons": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kdepim-addons-25.08.2.tar.xz",
-    "hash": "sha256-0UWCSIgZZTZgMFE+DheJzTiqB62Zfua3vB18Y42Wz4c="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kdepim-addons-25.08.3.tar.xz",
+    "hash": "sha256-uqhcF0fJ54ly0aVNe7ezAN2/VAc0UsM4g1a8V21HnNc="
   },
   "kdepim-runtime": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kdepim-runtime-25.08.2.tar.xz",
-    "hash": "sha256-wDD5iFTjHZJwcc1LS7wtl3ktTO+6xUiqbNddsGAlEso="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kdepim-runtime-25.08.3.tar.xz",
+    "hash": "sha256-mLes8HJxZY09kWmlEWdlE74GWbc/XLH7RjCutU+mX4U="
   },
   "kdesdk-kio": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kdesdk-kio-25.08.2.tar.xz",
-    "hash": "sha256-C5y8kWb0mC4JsQmNvLEB0xl5/08HLQ1kqepj9SwmSXU="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kdesdk-kio-25.08.3.tar.xz",
+    "hash": "sha256-QKNbsC0nMV0BKbgYHnpvy47k9MDMa4T4GMEPo/i31nE="
   },
   "kdesdk-thumbnailers": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kdesdk-thumbnailers-25.08.2.tar.xz",
-    "hash": "sha256-WL9S2IGmTuQosO6dAo7f8G6+h9kiWE4m13r86B7Aw7M="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kdesdk-thumbnailers-25.08.3.tar.xz",
+    "hash": "sha256-QWKweV1VrfvJ98G6jpZaYYqleygFiPQ9CkrbRc4I6HQ="
   },
   "kdev-php": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kdev-php-25.08.2.tar.xz",
-    "hash": "sha256-7m4IJU6vEeZ97LsY5sFyxQMELahAOAmTgryhJm47mQ0="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kdev-php-25.08.3.tar.xz",
+    "hash": "sha256-9S7yko0u+dyyHzGtKNuc5DCcatT0+8ap0J6gc3KG1MY="
   },
   "kdev-python": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kdev-python-25.08.2.tar.xz",
-    "hash": "sha256-ESl9BcQX+ecQjtOh8gVDbnWbqUWcPG9PlHNZ1nZRQsU="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kdev-python-25.08.3.tar.xz",
+    "hash": "sha256-VroTp+FyGuF6AVE4ZJ7270lw6Z1/9HMi8pamnxc0+z4="
   },
   "kdevelop": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kdevelop-25.08.2.tar.xz",
-    "hash": "sha256-uHkj1tN95TiPNsLprmbhsJa59CW/n6D7+WNo9q9GWyk="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kdevelop-25.08.3.tar.xz",
+    "hash": "sha256-TSuSzzepozJN2RNwdcX1UgR72IpnNCCqFIT83nm6zpI="
   },
   "kdf": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kdf-25.08.2.tar.xz",
-    "hash": "sha256-fFri8/WEG706a2XjBN+QUjAcY+Bj6dFeyf+oW34bAds="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kdf-25.08.3.tar.xz",
+    "hash": "sha256-fldlaE/uQm/eytp6lJoXF/maikdnsv1mnJoDZrFF+mU="
   },
   "kdialog": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kdialog-25.08.2.tar.xz",
-    "hash": "sha256-+cJGtN4tfkBqHJk2G41/qaOm1uzewuVVhmceq0zmQqY="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kdialog-25.08.3.tar.xz",
+    "hash": "sha256-0sn8M+y0ii0TVkO4PnALkhLR6A/WUZccA1v68yjfurQ="
   },
   "kdiamond": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kdiamond-25.08.2.tar.xz",
-    "hash": "sha256-ZpqXyFs43+4gmu2zWEP1oiDw8zPRZIp15mm7jLsb7e0="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kdiamond-25.08.3.tar.xz",
+    "hash": "sha256-6iRNvZWgW+NJLqNH2wOFeAAuYCRa4EsJBt4MErgrN1U="
   },
   "keditbookmarks": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/keditbookmarks-25.08.2.tar.xz",
-    "hash": "sha256-wwkul/fh0cKxEUJvgT4frYjqc/zbn4vO/lRBj6LyLf8="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/keditbookmarks-25.08.3.tar.xz",
+    "hash": "sha256-T1ehKu1z/OzDBZoGRZMdG4NrRCZxlClHY3QhMbIdOvo="
   },
   "keysmith": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/keysmith-25.08.2.tar.xz",
-    "hash": "sha256-ZiiqtMwrtCeLdNAeffv0KV113Ve10gqvPvCOWmDx4vM="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/keysmith-25.08.3.tar.xz",
+    "hash": "sha256-wYi87L4GV7fNU6bcZKLyyvveFH58m9LJC1hFr9CMFSU="
   },
   "kfind": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kfind-25.08.2.tar.xz",
-    "hash": "sha256-HvgdtBOG/MaAXz/zf1AqY42kEJVNBQ+v40y3bCDu1QE="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kfind-25.08.3.tar.xz",
+    "hash": "sha256-dW1PmJOSCGzSEVU9WGE9X+tBMQczuOo1xQxYaTgMlRg="
   },
   "kfourinline": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kfourinline-25.08.2.tar.xz",
-    "hash": "sha256-7I6wYJoswqS7FKz4MjTdNsRgYOHoi04VtfVnr/+VIss="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kfourinline-25.08.3.tar.xz",
+    "hash": "sha256-xVivDA8SiiV0wTNwsLIiWJ4tTKV4pUE6qDWmENyplxI="
   },
   "kgeography": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kgeography-25.08.2.tar.xz",
-    "hash": "sha256-V7sE53RPoB4rO5sqMy9DTHkgOUbg4yaNt5oC8intIj0="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kgeography-25.08.3.tar.xz",
+    "hash": "sha256-jIBortFwkZanbey9t33GHyq/U5vzwrJgcCR1vy4sZ7I="
   },
   "kget": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kget-25.08.2.tar.xz",
-    "hash": "sha256-YhTVgBrOpaen8eh8JoxhdjchMpe9OqgXCKbpfDs3ch8="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kget-25.08.3.tar.xz",
+    "hash": "sha256-veDkZTVSqOs5qNMiCs214QQsdv7XcbgWJ4lTPwOn440="
   },
   "kgoldrunner": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kgoldrunner-25.08.2.tar.xz",
-    "hash": "sha256-ePuHxhhHeX79SfLh0QeEu+ez/+TBiU6GXXwhjQcLERY="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kgoldrunner-25.08.3.tar.xz",
+    "hash": "sha256-7l+twe+Oytb2acTGLnZ6NwrzQPDAkoL/m/V6gL+Jtcw="
   },
   "kgpg": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kgpg-25.08.2.tar.xz",
-    "hash": "sha256-OZTEwUaMAoaLWLImYLuqyEX9QgNIjWj2rJFcBKYWfEo="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kgpg-25.08.3.tar.xz",
+    "hash": "sha256-5B6fbhRohlNM2G8UnlgWyiz2bavHuCTw81AGkxhC+K8="
   },
   "kgraphviewer": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kgraphviewer-25.08.2.tar.xz",
-    "hash": "sha256-bqzj6xA9HmILLYMuU5CTIwHc/aKgwUSdWyw2oVY3Kyc="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kgraphviewer-25.08.3.tar.xz",
+    "hash": "sha256-jyT6eUpePzAig6CHv2y81QqYxAI646ol4ve0lx6oZgU="
   },
   "khangman": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/khangman-25.08.2.tar.xz",
-    "hash": "sha256-rIodkzSHyWdcaQp5NW2/BXXIjTSmWzby5vzGqgIMF/0="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/khangman-25.08.3.tar.xz",
+    "hash": "sha256-tF9Vxx+l4tBbyPmM/anQduONRlwyXLQ9OZQu62dBr3I="
   },
   "khealthcertificate": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/khealthcertificate-25.08.2.tar.xz",
-    "hash": "sha256-bngpKnIR2pcd/jazEd9RcwDRvibhavaehlCUA9UPJ6U="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/khealthcertificate-25.08.3.tar.xz",
+    "hash": "sha256-bO0XoVXevMHhn0DO4sccX0g882bUgx3rxewyI/slbdo="
   },
   "khelpcenter": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/khelpcenter-25.08.2.tar.xz",
-    "hash": "sha256-63nlRUk3t7r0REJKwCqXV5q4B1OQjbvrVR7dcfZ4sNo="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/khelpcenter-25.08.3.tar.xz",
+    "hash": "sha256-T7S7Qk2u8xUxtR0fr5NZTIdvMBwP0gsIzXiFwT1Jm6A="
   },
   "kidentitymanagement": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kidentitymanagement-25.08.2.tar.xz",
-    "hash": "sha256-15I5E6TYsNn+7L4th4Pd4PcRcLNRIzzkfdrL3bC965E="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kidentitymanagement-25.08.3.tar.xz",
+    "hash": "sha256-+7Ie/0TQAgZuOsSmkFrZFeetNVqn00+OYwcwizhP99s="
   },
   "kig": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kig-25.08.2.tar.xz",
-    "hash": "sha256-YNOAQBVvOwEmOI2UBegNRrUu/E+4lUMuTmGHnQuz+fM="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kig-25.08.3.tar.xz",
+    "hash": "sha256-ETHgBXmdAOo0/q2zlMaPj7hrvbwBuYLNKjD3BsV1ToY="
   },
   "kigo": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kigo-25.08.2.tar.xz",
-    "hash": "sha256-lyv55XsYItZ2YmFl+/E7pBhidSe82VxgtbrI5M/3Jp8="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kigo-25.08.3.tar.xz",
+    "hash": "sha256-BTrTCeGvGk9rQVOv7D/qqUhm+x6V08ag/FLH9jV/OTs="
   },
   "killbots": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/killbots-25.08.2.tar.xz",
-    "hash": "sha256-PhdZcV0F3Fz3OnJ646bEeqPZ0RI0fMehXk5ZelHgzPA="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/killbots-25.08.3.tar.xz",
+    "hash": "sha256-yqVxIJ52AmiLaAS3o44ET9IkVhaOYdwXWFqBFWSqOqs="
   },
   "kimagemapeditor": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kimagemapeditor-25.08.2.tar.xz",
-    "hash": "sha256-+DnGsk2X0PDdqP4btWB9h+ya7kddRD8Fuj0e7J9dY1M="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kimagemapeditor-25.08.3.tar.xz",
+    "hash": "sha256-tmqzf7iiIBTjkxCY9fRU/TDJHHcr94sV1Hqm0BlMVpI="
   },
   "kimap": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kimap-25.08.2.tar.xz",
-    "hash": "sha256-/9Sud0FwN/NldnKqLKFBXQr1V64pwad6hJbmFqYw6Gc="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kimap-25.08.3.tar.xz",
+    "hash": "sha256-1rgwfLK4gzqN9IW4d4PVgVGiiQW3tueQgnxSQzSJqz0="
   },
   "kio-admin": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kio-admin-25.08.2.tar.xz",
-    "hash": "sha256-tY42MP0RT5pEPXKcJjdAIT8QiAL2E2S5yVlZ0zi7n+c="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kio-admin-25.08.3.tar.xz",
+    "hash": "sha256-WrOsvyja0G9myC+mhqVaFKAT9cXFbsFgfKhHp/RtIU0="
   },
   "kio-extras": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kio-extras-25.08.2.tar.xz",
-    "hash": "sha256-ho+fLg9XJyU4fqMR8ZnS+gRKzANlbzdR58omQAhhN18="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kio-extras-25.08.3.tar.xz",
+    "hash": "sha256-mflm3MZjvoyzyQZ3jIKzLaSxeL0pbYzYW54/VujpwtI="
   },
   "kio-gdrive": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kio-gdrive-25.08.2.tar.xz",
-    "hash": "sha256-5sNxWCRU9TqbgH8ODDQMFV1h+so88aJHwY+g5PDRYyU="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kio-gdrive-25.08.3.tar.xz",
+    "hash": "sha256-LA8ct2X1wA3B6f77GEnscJ4zTi9WGO3k3UqGzeLkS5M="
   },
   "kio-zeroconf": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kio-zeroconf-25.08.2.tar.xz",
-    "hash": "sha256-eD33N5dHimorDVSrxm27wZeKqKnaSCWxw8h+TYHrCrI="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kio-zeroconf-25.08.3.tar.xz",
+    "hash": "sha256-3nuyMp3bkMBKjBt6t+EiXico7Yu3VUAp5LS0HkS1c+A="
   },
   "kirigami-gallery": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kirigami-gallery-25.08.2.tar.xz",
-    "hash": "sha256-t6orBu29tawT/o0ogVd4S0BlLEaResFP1ryMYosqEug="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kirigami-gallery-25.08.3.tar.xz",
+    "hash": "sha256-3+flmIXsSBpn6IeivvGgkSj8OoYuALRKTJYv2HJmFoY="
   },
   "kiriki": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kiriki-25.08.2.tar.xz",
-    "hash": "sha256-/F7pUItS+uwL8dzbRhcMCy7+erPzm3vfY3T7XOQIS0Y="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kiriki-25.08.3.tar.xz",
+    "hash": "sha256-gmEkYfdbe/aT9Vf5PbxsAncG+8Kv5mpcqSUWmWchYxU="
   },
   "kiten": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kiten-25.08.2.tar.xz",
-    "hash": "sha256-YeytqWt3xmvWJQBiIomo13Aaho73170w+mIIH7iDZXI="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kiten-25.08.3.tar.xz",
+    "hash": "sha256-7pUwcbfbzCkMg32KHlF3ZCELpdWJim8VcAgTF28LvFQ="
   },
   "kitinerary": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kitinerary-25.08.2.tar.xz",
-    "hash": "sha256-4P2xwp88du5RlyeOVbasLB7AuB6Awmhb3TSzDLWSWG0="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kitinerary-25.08.3.tar.xz",
+    "hash": "sha256-s3QG/balE1+8F8iMy38tCIjm1T4W9C2BlOphiRH0ciA="
   },
   "kjournald": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kjournald-25.08.2.tar.xz",
-    "hash": "sha256-JJU+F9pt+tjGN8ScimR7xim8aM9h8lDcEDbReJuXM50="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kjournald-25.08.3.tar.xz",
+    "hash": "sha256-Ce6AgQJxJgc/jP6/v7+Jh+PQsGEsHnxSXa3Tt8w6X24="
   },
   "kjumpingcube": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kjumpingcube-25.08.2.tar.xz",
-    "hash": "sha256-kf+2hyOpB2BJ2yyunbHBMBwSR/BMnfcPPdtNeoUI1aU="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kjumpingcube-25.08.3.tar.xz",
+    "hash": "sha256-oAWb720t3hH0WNbd9NXqnoCfcyPC9nsEG9tByJr0QOM="
   },
   "kldap": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kldap-25.08.2.tar.xz",
-    "hash": "sha256-kgZ7nNBjw/2X9nBheHgZUbmmKGG/MWBK+/P9BMS35Uk="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kldap-25.08.3.tar.xz",
+    "hash": "sha256-YheAQ/cjuVme+G1EZmJ9VTeAd4LJzu/kq3lZGxr3wDI="
   },
   "kleopatra": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kleopatra-25.08.2.tar.xz",
-    "hash": "sha256-FoNYJnSLT/+cuube0YGbGMNCL/YNohxqat3Sff7rT8w="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kleopatra-25.08.3.tar.xz",
+    "hash": "sha256-PC9lIH7KzW9yYx6DKpM0KmxDJg6JevzChdGAO1HMZ2Y="
   },
   "klettres": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/klettres-25.08.2.tar.xz",
-    "hash": "sha256-p7VvRvkeAnJGQrkys1AgubxlL+ARJuHwEfz55sxEkMM="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/klettres-25.08.3.tar.xz",
+    "hash": "sha256-cGUurM+AAXa6P1Ep/ROoKSuXF8MISYgBtV5VOk8XmHM="
   },
   "klickety": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/klickety-25.08.2.tar.xz",
-    "hash": "sha256-JmhLJpoHKmdssz6KwkkCcoCvBvaEyilYq4b/8Zzn0lo="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/klickety-25.08.3.tar.xz",
+    "hash": "sha256-/GWRi1rRBOVXLmG/xa+kbWi6MU0V8gjukGBEPJEv7Jg="
   },
   "klines": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/klines-25.08.2.tar.xz",
-    "hash": "sha256-CXCgFkpD0ydEF+IRKbqTQI29A8sizHeOEersrmeY7l0="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/klines-25.08.3.tar.xz",
+    "hash": "sha256-CRE1uZF2YFpBpHI3L0umm8vqLzYFMTEEmu2ecYfJmnc="
   },
   "kmag": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kmag-25.08.2.tar.xz",
-    "hash": "sha256-8zQ5mKa4hEU/yXOOek9WD3FuNKUyj58N8SXutTJ0wIE="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kmag-25.08.3.tar.xz",
+    "hash": "sha256-xDB5Dlk7g0ZXFyuUq9oP8MElv2rESUayR8c32yGqtGg="
   },
   "kmahjongg": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kmahjongg-25.08.2.tar.xz",
-    "hash": "sha256-7ER5SNKpmgc5pjjpJIVi5FRQOXgFElXTMlCOnoTh3wY="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kmahjongg-25.08.3.tar.xz",
+    "hash": "sha256-KWpQulk5yUiDSoUU8u9rr7E3auUFpc+CmO7sMRnp8SM="
   },
   "kmail": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kmail-25.08.2.tar.xz",
-    "hash": "sha256-I+Z9+IMbvLKh9SZA51CQBFW1FFl3VjwCFJWmL/MdH/8="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kmail-25.08.3.tar.xz",
+    "hash": "sha256-pUTofOL63026oJnAGKGeWTu7gC4KmTAWvD6RTt1qkfQ="
   },
   "kmail-account-wizard": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kmail-account-wizard-25.08.2.tar.xz",
-    "hash": "sha256-dQeRJ0qN3JkUL0vd5lMixbmL7IY0puRxk5yVlI3lM7c="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kmail-account-wizard-25.08.3.tar.xz",
+    "hash": "sha256-M2XxYVMgGinDF5mxCPwI4/aUwjOuFwQmiJ+BUcSYw0Q="
   },
   "kmailtransport": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kmailtransport-25.08.2.tar.xz",
-    "hash": "sha256-9vnYr/JlTGqjE1gFlom5sQhGz+BeU0Rfy5WLKw/lt5Q="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kmailtransport-25.08.3.tar.xz",
+    "hash": "sha256-IfuF62TtJcrtJx0plwDxBmqTQxKYZH9drDbotvMlN64="
   },
   "kmbox": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kmbox-25.08.2.tar.xz",
-    "hash": "sha256-KImwM4BLm7vEzonJEmPx1mHmUZX9PnywKcza6vLhuSs="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kmbox-25.08.3.tar.xz",
+    "hash": "sha256-MWGF+jh+OFYb3S4KC5hKP8AIMqYicdBtz+vOHcfwVYw="
   },
   "kmime": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kmime-25.08.2.tar.xz",
-    "hash": "sha256-99K6VbOqEukEiSIJrZ/icc1aOljCnDiibdIQA6pVDq8="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kmime-25.08.3.tar.xz",
+    "hash": "sha256-H0/KO/+Zn9hNnPPYBz3308FpOthVS1YAF05KmqGDfwE="
   },
   "kmines": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kmines-25.08.2.tar.xz",
-    "hash": "sha256-FWhc4f+cJOm+6U3rnDnTXyfnVh/LDdjN5W9xnqjw+sU="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kmines-25.08.3.tar.xz",
+    "hash": "sha256-mfDaPNivn6Y0qPfTTkM77bxL+9okiGzV4L3eSOCtSj8="
   },
   "kmix": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kmix-25.08.2.tar.xz",
-    "hash": "sha256-YPjTZTDBdqImDq5nSqwuckFQjcrWKH/7v6r6V5QqZec="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kmix-25.08.3.tar.xz",
+    "hash": "sha256-+EKMFgrbaM2foA026VQ65PRPNk/VmTJ+dpSrYzEI95w="
   },
   "kmousetool": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kmousetool-25.08.2.tar.xz",
-    "hash": "sha256-5GBrMRCNh7v6c1oJ3P0AWEI3of+NcIxSN91mLQFK6r8="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kmousetool-25.08.3.tar.xz",
+    "hash": "sha256-edPgAyHPZPEONVe1MdELxYc11r6qI3JDv3mG43Ak4I8="
   },
   "kmouth": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kmouth-25.08.2.tar.xz",
-    "hash": "sha256-FC72jT0PxfKA0geHYZVdBaa7tZ6yxZrX0wwAk/JTaw4="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kmouth-25.08.3.tar.xz",
+    "hash": "sha256-L+9tjvkyAqLaysO7l/AtN3kMxiFMxtlJY7G7M7Hu034="
   },
   "kmplot": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kmplot-25.08.2.tar.xz",
-    "hash": "sha256-Anyx9LAOPTpQYseR7pEIul6DcX/iMQ1vM9j87uoNkeI="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kmplot-25.08.3.tar.xz",
+    "hash": "sha256-JCNo7aVqMy9SmVKvC2JYw67GpZuQNQzfb+/OoNpnuIM="
   },
   "knavalbattle": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/knavalbattle-25.08.2.tar.xz",
-    "hash": "sha256-An4NjaYLt44qC7j3tBAwtWxd6jxHtJOUyD6QTgtfdso="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/knavalbattle-25.08.3.tar.xz",
+    "hash": "sha256-DYbxF2HZhYrbqgFua+uGfibr+f9SsxLXnNIm/xi+1i8="
   },
   "knetwalk": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/knetwalk-25.08.2.tar.xz",
-    "hash": "sha256-v8GAwbqLVEzPC16JS9uyN5VAp3YxFrxWDiuaUgVBBPM="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/knetwalk-25.08.3.tar.xz",
+    "hash": "sha256-z62yo0fxZqLOPpG2InFkXj7FSQb99tgCaS2aLhSjoW8="
   },
   "knights": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/knights-25.08.2.tar.xz",
-    "hash": "sha256-S3SYsOFeGYRiLK6tFiKZEbAyIVZawc35XCmWm5BK+g4="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/knights-25.08.3.tar.xz",
+    "hash": "sha256-ygibJTDdrR6CVpWgVwnGi6pwO5lu61hjrSabY30RKD0="
   },
   "koko": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/koko-25.08.2.tar.xz",
-    "hash": "sha256-xhtQqEo94Iph7je7fmIER5X57EyGXrNXqFSSvRRSGn4="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/koko-25.08.3.tar.xz",
+    "hash": "sha256-zWcEO5aclGnZ6cEGfPQsLqPiLgInq+86d2INj80ll1c="
   },
   "kolf": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kolf-25.08.2.tar.xz",
-    "hash": "sha256-0fLsgPZaEWVCtBECQfGdKT8Qhb+jV//OeglYp6TIx6s="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kolf-25.08.3.tar.xz",
+    "hash": "sha256-PZStjMm19A8cMJj7UPm1ZPbVlwhDaqo8G6ouXpR0UJ0="
   },
   "kollision": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kollision-25.08.2.tar.xz",
-    "hash": "sha256-WPQsUDkCUE5NhULz4i2dU7d/b4FEuVqlZxnG+E4/70o="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kollision-25.08.3.tar.xz",
+    "hash": "sha256-nfXBZsVK6K14Y8fxV06df7C2V8HfXNzuTk/1Dtyilzo="
   },
   "kolourpaint": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kolourpaint-25.08.2.tar.xz",
-    "hash": "sha256-Ltr6ld26OUX1TzTlxhgnLsrNTGDV9avnCBnM8Gz2Sc0="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kolourpaint-25.08.3.tar.xz",
+    "hash": "sha256-7ffBmyNhxQ2VVknbE8/JOVIwi1mpQKCUWO2JjE6xtAw="
   },
   "kompare": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kompare-25.08.2.tar.xz",
-    "hash": "sha256-B46EKx+MKyfJwZUvoTRo4Luxa3cPy0KG6C/IkTlWk7I="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kompare-25.08.3.tar.xz",
+    "hash": "sha256-zkMG4+6PIQ0f64h+SZgVcCt9OMT9OioKp1BJWc1BT+I="
   },
   "kongress": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kongress-25.08.2.tar.xz",
-    "hash": "sha256-HCo0kD444lchYnb0vDhzL50Wvd0Lqk7G3vT5kEE1ttc="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kongress-25.08.3.tar.xz",
+    "hash": "sha256-nX9eeJU1U6Z/GAPe57DG4xgmhtwXPHZU8j86wtxVVds="
   },
   "konqueror": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/konqueror-25.08.2.tar.xz",
-    "hash": "sha256-M29xFdQPIevLT/De9T6428ZRVEpbN9OE7F5xSuFfqKA="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/konqueror-25.08.3.tar.xz",
+    "hash": "sha256-PPJVeXyJh2kuq+/pS4bibpSurJB/ZZMISOB/YQRMQmQ="
   },
   "konquest": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/konquest-25.08.2.tar.xz",
-    "hash": "sha256-0noUGcNQNv/pyzTzooafXo7PV40Bq7A9DVrRWiE93A8="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/konquest-25.08.3.tar.xz",
+    "hash": "sha256-CpDVgw6MY22JJWByJS453CkPZ81ZC1yDv0W+RO/DXvk="
   },
   "konsole": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/konsole-25.08.2.tar.xz",
-    "hash": "sha256-Ig+0SgLl3TEQvH2KBPTXyRC8mbWxh3o2vv0G0eZf43c="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/konsole-25.08.3.tar.xz",
+    "hash": "sha256-CVp/8Q3zxwd5s1b7O1mEBiu8aYu+2WYjDj28z2rzZhU="
   },
   "kontact": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kontact-25.08.2.tar.xz",
-    "hash": "sha256-G31bfbQu2P8D3eWnpUm8/ni5o9t792zn7Tl+ZJrAeRI="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kontact-25.08.3.tar.xz",
+    "hash": "sha256-qEEb6WO4KCFWcStbsgs93mo743dpg3VY5ZCm1e0Fsvo="
   },
   "kontactinterface": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kontactinterface-25.08.2.tar.xz",
-    "hash": "sha256-6l6yL+uHVMUO1KGn4WWYZ2wGtS15/mMln+/iHlLJcyk="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kontactinterface-25.08.3.tar.xz",
+    "hash": "sha256-e1nQOAevvoku0A58Im/Yft6Mp+Ond6EcIoaYs9gFl4g="
   },
   "kontrast": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kontrast-25.08.2.tar.xz",
-    "hash": "sha256-tuyd5u/iPFvgx9lFqeLgq4bgP3+WQPwe+YFc+FZOBa0="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kontrast-25.08.3.tar.xz",
+    "hash": "sha256-UgvgiPpNWS34GYRybm5Ti3hvOx7MYoE/soArpzh1nGo="
   },
   "konversation": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/konversation-25.08.2.tar.xz",
-    "hash": "sha256-Sg5j1we9Of9uqRXXVMvKKvEcqNapO7atEGrFbiK086k="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/konversation-25.08.3.tar.xz",
+    "hash": "sha256-XkW3jDLY9ydczcUNl4DFrpA0GO2MeXTV2Ylo3DaFgI0="
   },
   "kopeninghours": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kopeninghours-25.08.2.tar.xz",
-    "hash": "sha256-D605x3tytxSpxbax4qsP2NI+8Uib/PvfG0ff6pmMcUM="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kopeninghours-25.08.3.tar.xz",
+    "hash": "sha256-DmCIXSzbiP4L9C/jnwHJ4oTddVcnxYVxSDLrqYwRy3M="
   },
   "korganizer": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/korganizer-25.08.2.tar.xz",
-    "hash": "sha256-kGDTsN99L6BpkaPh6z+q6lYRj7kZ3L4wTFWh3zNNTEU="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/korganizer-25.08.3.tar.xz",
+    "hash": "sha256-YqGg0VhbkthlL/GU/Mlrsog7zAGOy9T16u9ukPawuXU="
   },
   "kosmindoormap": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kosmindoormap-25.08.2.tar.xz",
-    "hash": "sha256-Oaf0CUc1Kj5EnO+ARfeAqU1a9NleGAD2pjGaZSkoMZs="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kosmindoormap-25.08.3.tar.xz",
+    "hash": "sha256-Giziw+UUv+Aeex/elDvwmRIcrYKoj0RL2sA7V1Cb498="
   },
   "kpat": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kpat-25.08.2.tar.xz",
-    "hash": "sha256-esAFdA2SXLEsrCrb/k8YwFLuE/V+C8y5gm7RijH2DZY="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kpat-25.08.3.tar.xz",
+    "hash": "sha256-ZeAz17mquql1cBLUtQurzJG1wslBdMM05wQ7Z4WDJu4="
   },
   "kpimtextedit": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kpimtextedit-25.08.2.tar.xz",
-    "hash": "sha256-jZVgQsnSVZoOFpU6OAtD+QdqTAnueYofNcCL2h2lx7E="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kpimtextedit-25.08.3.tar.xz",
+    "hash": "sha256-Qpv/phStKz6nQkcCwcSBL4zC5C7iEM1av3yd1//kbUY="
   },
   "kpkpass": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kpkpass-25.08.2.tar.xz",
-    "hash": "sha256-RZnluLHbBHxHTMTPWiO/fUloCCdCmGJEoTh1q+hjQfM="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kpkpass-25.08.3.tar.xz",
+    "hash": "sha256-OAKm8j7dkBvpdcA7PrY+R46ThDhtiDsiiftZjt8+dYs="
   },
   "kpmcore": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kpmcore-25.08.2.tar.xz",
-    "hash": "sha256-OQJDaeAQARGaX+ylwjD39y6ktiX08nZ8SPbjPAepVVU="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kpmcore-25.08.3.tar.xz",
+    "hash": "sha256-QwIiSYs6DdS7YdryYfBkg4+NHoNzMGOk9je1knHtaOM="
   },
   "kpublictransport": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kpublictransport-25.08.2.tar.xz",
-    "hash": "sha256-st7J5F/WMcjW34HAjUufRwbuPUeBFlQxoEpLTAyMLtM="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kpublictransport-25.08.3.tar.xz",
+    "hash": "sha256-7Yh98j0EoevRcbWcmd+uwm1iJU6aesT4pwhLowFYbBc="
   },
   "kqtquickcharts": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kqtquickcharts-25.08.2.tar.xz",
-    "hash": "sha256-hpkzB8squHs1bX51SuAvSuBJ8ekigMcrzOEoexJmthI="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kqtquickcharts-25.08.3.tar.xz",
+    "hash": "sha256-jympyxr341HoW7d+ZtCC0wToWdJbtVDnTWX3WfARDBE="
   },
   "krdc": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/krdc-25.08.2.tar.xz",
-    "hash": "sha256-4y1lDpMyV1ZuDBuErgz87W3WpN/zOgR5Wk43W/hwXno="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/krdc-25.08.3.tar.xz",
+    "hash": "sha256-qjF7iiHANitt3WnxIsoX9ETt/uui9CK3XOUcZmlQkGo="
   },
   "krecorder": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/krecorder-25.08.2.tar.xz",
-    "hash": "sha256-BZWm2fMYmGn6sVtu3zyOlAL9oEA1hdXXfKO5zo6yCNE="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/krecorder-25.08.3.tar.xz",
+    "hash": "sha256-Mnj73af7xEC2+SK2RKyNMtzGPU1EO3ecwssIMXomM2E="
   },
   "kreversi": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kreversi-25.08.2.tar.xz",
-    "hash": "sha256-NCj2A/q58mHBwbn5J5ZpB7Pkrx1fuz5002ecbiBiLSk="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kreversi-25.08.3.tar.xz",
+    "hash": "sha256-gf/rj2ABjRLqKCvgKhd0Xkv2ofFsBnWulyG9+cNSlSQ="
   },
   "krfb": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/krfb-25.08.2.tar.xz",
-    "hash": "sha256-iBuKQpM+LVfMGZ1jq59KuQ9WeqX6Kn9JzV4RQ64rKNo="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/krfb-25.08.3.tar.xz",
+    "hash": "sha256-4S+HkIm2qdS4/HK4IB5SIj6kUGZNKLo6Qxk6Yeud/0I="
   },
   "kruler": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kruler-25.08.2.tar.xz",
-    "hash": "sha256-m/X4uMG0zOER3PHys7I8EJUYcGuglewKAyoeHI7SSCE="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kruler-25.08.3.tar.xz",
+    "hash": "sha256-lrIrTlkMtnaGcfEZlOENqUL4JS+sYvq57/0VYR0seaw="
   },
   "ksanecore": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/ksanecore-25.08.2.tar.xz",
-    "hash": "sha256-i62zyKTV1GapIpvEbrH0+woW84IAjmOZkDQT2PoKmLE="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/ksanecore-25.08.3.tar.xz",
+    "hash": "sha256-4VZZmUGT7mDSn64J4n0uRT/DLkSfr4gIpXysip6rqZc="
   },
   "kshisen": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kshisen-25.08.2.tar.xz",
-    "hash": "sha256-pTDUxgJmT8AoSA/M+7zzzjACMWNS2r7SkAJUkRPoGqU="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kshisen-25.08.3.tar.xz",
+    "hash": "sha256-0P9OhTLCd7Mptkd25Ye/dacIbX20RkL3cCve7GcIHqg="
   },
   "ksirk": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/ksirk-25.08.2.tar.xz",
-    "hash": "sha256-ZxJoE+D01cb91gDyJxsPSJmfm9LQwj0Xpugtrd7VgZ8="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/ksirk-25.08.3.tar.xz",
+    "hash": "sha256-mSoRZ1ldy2px3lORdTFeQ0W3mSYu6Wa3UYv3c21N58Y="
   },
   "ksmtp": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/ksmtp-25.08.2.tar.xz",
-    "hash": "sha256-iF+C0SgxTPThJouZd0bDXExHspJmMkbNjKP7+Eqm2fA="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/ksmtp-25.08.3.tar.xz",
+    "hash": "sha256-FQdBgHcj8c7ka8HoY5TXhf79ffgiUj1f5TgyouQVzOY="
   },
   "ksnakeduel": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/ksnakeduel-25.08.2.tar.xz",
-    "hash": "sha256-LyFMQpXR5o+bufyNNaIjVzHPbAmUBBYr82xU1Ugsy1I="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/ksnakeduel-25.08.3.tar.xz",
+    "hash": "sha256-G/5kAJ9iPfUDr1cZxzquUJNO31jBl3RjGGp8/8mjxsY="
   },
   "kspaceduel": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kspaceduel-25.08.2.tar.xz",
-    "hash": "sha256-9vEntOUi6jJ4v3r8WNYmmxSVWMowt8SZ2/sii97d8Ug="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kspaceduel-25.08.3.tar.xz",
+    "hash": "sha256-txLcpESv/zejpFdAwDcJSHwjaj+cjb4NiaezzFPz1P4="
   },
   "ksquares": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/ksquares-25.08.2.tar.xz",
-    "hash": "sha256-l1VFaidEq1YNqI10vawKQa7QuDMJCDLyz7LklL2ojdE="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/ksquares-25.08.3.tar.xz",
+    "hash": "sha256-Wnc8jDtRj6LMXYzfvlBe6C1sDCvSeCiTeyKXcwrdtc8="
   },
   "ksudoku": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/ksudoku-25.08.2.tar.xz",
-    "hash": "sha256-PTSj/+mLMgaieN/dz7QQw6pH18s9xLF3oT2/OtQixRc="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/ksudoku-25.08.3.tar.xz",
+    "hash": "sha256-1XexTOqFRtyLdIC1K5PT4LV+coySYjfVxoQQ7Ll9vdQ="
   },
   "ksystemlog": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/ksystemlog-25.08.2.tar.xz",
-    "hash": "sha256-ou6JXgOweo/vK4iIaWo34nv9ItDZ1vQkj024B0ED7zw="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/ksystemlog-25.08.3.tar.xz",
+    "hash": "sha256-41APVe04Ju1RhPzzd6R2ISHTbTBIso9DfVLeZZKzPnE="
   },
   "kteatime": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kteatime-25.08.2.tar.xz",
-    "hash": "sha256-sk+Wq6kwX/yEqt9BKsj4O5ehPMySTMrfc4srd6Dotjw="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kteatime-25.08.3.tar.xz",
+    "hash": "sha256-aKghjWcg/U4zlTJwdZbX0e7l7xizFE448nZW8Ntqp80="
   },
   "ktimer": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/ktimer-25.08.2.tar.xz",
-    "hash": "sha256-stCkPaE7XECnso9xa/7wTC+hM9Vl1ng8d6dbAv39i68="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/ktimer-25.08.3.tar.xz",
+    "hash": "sha256-pLQm1jQcE9i0yYO2JBjK2npmA8c4E1chOgPIXfmF4hg="
   },
   "ktnef": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/ktnef-25.08.2.tar.xz",
-    "hash": "sha256-v+lFg1qWMJSghJJ9xkcO878j3dsbRJC+ZB2pwrAyeMc="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/ktnef-25.08.3.tar.xz",
+    "hash": "sha256-cBVHeVARnN252bTmuUMGsbaHb0YE9Jb+voJMpicF4hM="
   },
   "ktorrent": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/ktorrent-25.08.2.tar.xz",
-    "hash": "sha256-m6Ku92a7EnBcHNEnHaK2NZpxslo396QxQHti+OsV4r0="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/ktorrent-25.08.3.tar.xz",
+    "hash": "sha256-YsslNCYnT3YZYCgn0d4kaf/+2kN+9dlNyqTXyi3/TT4="
   },
   "ktouch": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/ktouch-25.08.2.tar.xz",
-    "hash": "sha256-DgY7FX5goroYjH6oWB+zx6J85fqg2nxtZjPknke9p4U="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/ktouch-25.08.3.tar.xz",
+    "hash": "sha256-RxvGm+NjhpVzekatA4FHHVLy/desOfZIaxgIChqZ+Bw="
   },
   "ktrip": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/ktrip-25.08.2.tar.xz",
-    "hash": "sha256-DwQm3LD8tQa5BakTSzY6X1f9esKzscVNBB5YGYAclX4="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/ktrip-25.08.3.tar.xz",
+    "hash": "sha256-67XWgzjhKR80NFaRfB0nfelXJWRjv390MAXUUnUCIL8="
   },
   "ktuberling": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/ktuberling-25.08.2.tar.xz",
-    "hash": "sha256-54aMMBo2G8NG5wxpJUnYdFJFmU7ZNAl5CB9BvwtpLlE="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/ktuberling-25.08.3.tar.xz",
+    "hash": "sha256-kn2uK63lPdEODGRlKSX34qr94ELSTuc8McfguntAYU0="
   },
   "kturtle": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kturtle-25.08.2.tar.xz",
-    "hash": "sha256-Ye/bDT78I8F8YlcSeNLc6LEANOMg/aKdTn9pmzN4u9k="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kturtle-25.08.3.tar.xz",
+    "hash": "sha256-niNZcCEncHPReW2prJ7ejD2G+huipyN+NyvBGuJrDgs="
   },
   "kubrick": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kubrick-25.08.2.tar.xz",
-    "hash": "sha256-SmMwjK7l9kxcpFe2vKi/8wnu5d8/MLoJ2hNqGNBNhUY="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kubrick-25.08.3.tar.xz",
+    "hash": "sha256-wv90F0c7FKK17TONQ5AnsHGdM8CNnflPOa0SGfLsmRI="
   },
   "kunifiedpush": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kunifiedpush-25.08.2.tar.xz",
-    "hash": "sha256-KlxqGjB0dMqVAreaZf0c9GYhguCDGkfQOLBkDCBXiDI="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kunifiedpush-25.08.3.tar.xz",
+    "hash": "sha256-6MkkQ41TWfD6CTCrNREQEgduOg/06VnWkpWVVxODMgo="
   },
   "kwalletmanager": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kwalletmanager-25.08.2.tar.xz",
-    "hash": "sha256-uqll+OnUbp5MKwzPqxn0KvAVaDJGNkrbstYzSffW+3I="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kwalletmanager-25.08.3.tar.xz",
+    "hash": "sha256-VLa2PrVf1VTTEhUxnCC7r9Lhv5SKtrT6TYS1YUttxS0="
   },
   "kwave": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kwave-25.08.2.tar.xz",
-    "hash": "sha256-4A4alB1WAj1QPt7G0nRozvLcF5T3IQKACiRJ3U8Mlwo="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kwave-25.08.3.tar.xz",
+    "hash": "sha256-SNx4aADdyclG/OxxJY8896Ot7pHBMEuF2gVtJs6MolQ="
   },
   "kweather": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kweather-25.08.2.tar.xz",
-    "hash": "sha256-aB1RpiWotF09h+QnYZpeGMteME6Ky/esKHcH2Rtyw+s="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kweather-25.08.3.tar.xz",
+    "hash": "sha256-KNoeLq1scm5iMiMOqo8eDluaa5C3VgMOx/kVHRkNcy0="
   },
   "kweathercore": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kweathercore-25.08.2.tar.xz",
-    "hash": "sha256-DRSR2AEa6T1iku6bjie5YTiVM7K+/cVIIZ9fQtHsDRU="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kweathercore-25.08.3.tar.xz",
+    "hash": "sha256-aTVzoCRb9l2s6rEnrEXJrPuznmt8UW2BevVBzTElsls="
   },
   "kwordquiz": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/kwordquiz-25.08.2.tar.xz",
-    "hash": "sha256-vvWWexyIiySBx36rX1HxBiOEvIYiirtBmF9TnoUl0j8="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/kwordquiz-25.08.3.tar.xz",
+    "hash": "sha256-FD3tCu6gIDbeeq29O2zoENAGanPcyC02excZYqgSFoQ="
   },
   "libgravatar": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/libgravatar-25.08.2.tar.xz",
-    "hash": "sha256-K9uwLdAQIwdbkDJBFCTUFazYsiolpKLgSs51khJrweY="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/libgravatar-25.08.3.tar.xz",
+    "hash": "sha256-lMd3JgKzraqLTUSiJ2mdlDCXAFrr/u9WPK6tt15vI/s="
   },
   "libkcddb": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/libkcddb-25.08.2.tar.xz",
-    "hash": "sha256-lgI1UJaRwh39juHFSTru5YWRK98YBqa0tZuPafmVqnE="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/libkcddb-25.08.3.tar.xz",
+    "hash": "sha256-HYXr8890TjVv8g/fADgyeUT+pDN4Yo2jvYuZDmXTdpc="
   },
   "libkcompactdisc": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/libkcompactdisc-25.08.2.tar.xz",
-    "hash": "sha256-dq+OIjKMN5hFpLxS1csdH2Bllz8stTGDUwK8pSjMZyg="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/libkcompactdisc-25.08.3.tar.xz",
+    "hash": "sha256-PXqeirTcFJcIukWb7gumW+hU6ux4yX97p/j2YyrjhnA="
   },
   "libkdcraw": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/libkdcraw-25.08.2.tar.xz",
-    "hash": "sha256-CuQpKsI3YpMXGSUubaHgRDkNTwuJtOaBsSuH5q9EnSA="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/libkdcraw-25.08.3.tar.xz",
+    "hash": "sha256-Uvp40BPhPHLGL7TWho7xCowR2JlIptJEFWR+kXqnLN8="
   },
   "libkdegames": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/libkdegames-25.08.2.tar.xz",
-    "hash": "sha256-Q/PP34LkbAdkrHeb/L48eHKOyfiA5x/PWH+zwFGV9Oc="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/libkdegames-25.08.3.tar.xz",
+    "hash": "sha256-RvMFZ3+zeXjGtHvRerZVO1chUaYymbt7jccY03+0SKQ="
   },
   "libkdepim": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/libkdepim-25.08.2.tar.xz",
-    "hash": "sha256-k2tPCnF3aFQttGnj1Z/x5FB1XSTaNBWaPQFtu6JcvSg="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/libkdepim-25.08.3.tar.xz",
+    "hash": "sha256-OspVtxvjWrNpkwXy9/x2bUvQDETrt2Mb/WQcEkzQsek="
   },
   "libkeduvocdocument": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/libkeduvocdocument-25.08.2.tar.xz",
-    "hash": "sha256-1lHduat2IaOR2pW8YvnR1zVOIcbaVius51z20lJcCt4="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/libkeduvocdocument-25.08.3.tar.xz",
+    "hash": "sha256-tNzEPB2PcR1bmsCinXji7HcQtbzYDx7GJTTosbDr3cU="
   },
   "libkexiv2": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/libkexiv2-25.08.2.tar.xz",
-    "hash": "sha256-G4rqeHNmYq8X1q4DkTRZM3VPmM/8oVNSBIE+sn7/YiI="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/libkexiv2-25.08.3.tar.xz",
+    "hash": "sha256-CAaJhVS2Km+DTTO7SBkj2CvekbFpK6exRv7JS5pQPQM="
   },
   "libkgapi": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/libkgapi-25.08.2.tar.xz",
-    "hash": "sha256-hQrGcoBVEPy7aKg4SiEsOMP/7COOWIebxVt0keLpAac="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/libkgapi-25.08.3.tar.xz",
+    "hash": "sha256-WmWQ2gTPSgw7U/Kgx9fJfN9X9jhUoKSXjAhZJDv70V4="
   },
   "libkleo": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/libkleo-25.08.2.tar.xz",
-    "hash": "sha256-vGuWNkTUx8AAAtoN8UPIze2k0/EusUCbZyEvq93g17g="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/libkleo-25.08.3.tar.xz",
+    "hash": "sha256-BVOxiilctfv/X66ZA0p4KuTQfUPSwWN+r2ejHKZQuBY="
   },
   "libkmahjongg": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/libkmahjongg-25.08.2.tar.xz",
-    "hash": "sha256-yZl1Nl3DRkvO16RnBW3KQ9XxdHAXgz0/Vq0RXKGoBww="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/libkmahjongg-25.08.3.tar.xz",
+    "hash": "sha256-SC+c76Nbpi0ScbOpsvC+zPDpVOt/2ECmHeTMSxi9xlc="
   },
   "libkomparediff2": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/libkomparediff2-25.08.2.tar.xz",
-    "hash": "sha256-TVM+fXS+K2EnvZBvpNff4ejrRZ6QhnfmQS6L0LShwac="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/libkomparediff2-25.08.3.tar.xz",
+    "hash": "sha256-bpNvhmHzNsuaz/eeJG4d+yhPnNVmoBxlq1oliec2yew="
   },
   "libksane": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/libksane-25.08.2.tar.xz",
-    "hash": "sha256-2mtzd2CfB4lgB9sF4zIykbsW/NLWzZwsG1jg+Zn/ujM="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/libksane-25.08.3.tar.xz",
+    "hash": "sha256-cwv078ybgjupjGgUkuQTk3mrDD5gLh5u/ynATxdtb2g="
   },
   "libksieve": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/libksieve-25.08.2.tar.xz",
-    "hash": "sha256-nw7m3ljGe4FYhz6X6GmUojjLYrkeW5HQK0BB6WbOJHg="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/libksieve-25.08.3.tar.xz",
+    "hash": "sha256-bgZj63oMQAfFZE+rg8Q2cTO7YbeuO3J4vINpcXdf/5k="
   },
   "libktorrent": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/libktorrent-25.08.2.tar.xz",
-    "hash": "sha256-RdgIjGzXU3iDZn4Ry/6Tf5ZMvYBw196l05vZOhG1WDY="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/libktorrent-25.08.3.tar.xz",
+    "hash": "sha256-z6TZb062gnpK1mzAr3JNF3PLUW3uKYgjIEzEXgrRzWk="
   },
   "lokalize": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/lokalize-25.08.2.tar.xz",
-    "hash": "sha256-DjrFQUgDyJAe9KSOivqT4qWHNtX9OxTFEdbZ0gGNMNo="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/lokalize-25.08.3.tar.xz",
+    "hash": "sha256-B54/zaOnTvessbMGPu6xAjfnNkZr1JlTdipl0I7xFIM="
   },
   "lskat": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/lskat-25.08.2.tar.xz",
-    "hash": "sha256-8qz6IhIZWoZj+btqE1H9RTeQ9er+dOm0VnHrYfI8IoA="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/lskat-25.08.3.tar.xz",
+    "hash": "sha256-lTKIRVfvJGj4K2WmzlT9y8DfPKGS/njKy44k97coKb0="
   },
   "mailcommon": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/mailcommon-25.08.2.tar.xz",
-    "hash": "sha256-6miyUOO6PjsiwhvEDOTtQBUC0eWejtz3DFsfydSzTcc="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/mailcommon-25.08.3.tar.xz",
+    "hash": "sha256-PEaG+HOUDgC3UlmT+s1aU+LH8tlECMb2inaqE7EXQ/o="
   },
   "mailimporter": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/mailimporter-25.08.2.tar.xz",
-    "hash": "sha256-z++flxJoJFGItEFfjn0boPfvqPmSXHpNsIhzZ/IPuEg="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/mailimporter-25.08.3.tar.xz",
+    "hash": "sha256-8MsBq+JLOlMydW3tUZMSgT/w43lx1r+xk3wLe8xv2qk="
   },
   "marble": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/marble-25.08.2.tar.xz",
-    "hash": "sha256-ZV1wp2j/xn1dPy2CAAXepX/5r10Jg346urz/Evy3df8="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/marble-25.08.3.tar.xz",
+    "hash": "sha256-ZcA02sx6LVu/U0/KZXQonosdvyvVDk9j/00atk/wcZg="
   },
   "markdownpart": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/markdownpart-25.08.2.tar.xz",
-    "hash": "sha256-8I1iQ2m+EP2VY6Ofatb88gDgmfD4Ov45AKhPeE7k50I="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/markdownpart-25.08.3.tar.xz",
+    "hash": "sha256-WVJLI3e+0JYjSotHHzwXVFU9HT8SI53rN3ycAtVDZT0="
   },
   "massif-visualizer": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/massif-visualizer-25.08.2.tar.xz",
-    "hash": "sha256-88nqICyX5ajDQ1pc0op5blDT9Fo7GNzJXwWQy8uSmhQ="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/massif-visualizer-25.08.3.tar.xz",
+    "hash": "sha256-Bx3Rj+LLsJIkmDpmByXVlvCbauZwM+7ATilZQbQAZ3U="
   },
   "mbox-importer": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/mbox-importer-25.08.2.tar.xz",
-    "hash": "sha256-J58Kp9PpK8qtVym/UP728LQ9WOMhwoJ96y/Lnm9vz2A="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/mbox-importer-25.08.3.tar.xz",
+    "hash": "sha256-vULK64dpOrPKzHxC2flA4iyHWvTU0wSyZWCT3kjZuCI="
   },
   "merkuro": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/merkuro-25.08.2.tar.xz",
-    "hash": "sha256-6n6ZhJO8a0bnNyMXO1882rOclclcrpA8sXz+KoeOs0U="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/merkuro-25.08.3.tar.xz",
+    "hash": "sha256-oCHLfVogUZN1pWv/hUH8Kzvd1evkhaub0l4wayETEq0="
   },
   "messagelib": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/messagelib-25.08.2.tar.xz",
-    "hash": "sha256-RkVrc9bN0QxdHduP5T/A/2HhzjjJXC/CEpnb6eSmR+4="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/messagelib-25.08.3.tar.xz",
+    "hash": "sha256-p8h4gwpdeQdSyYs9lWPHbhowtqKM7FPL1Ka2ATL1Z/g="
   },
   "mimetreeparser": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/mimetreeparser-25.08.2.tar.xz",
-    "hash": "sha256-+jLUHCaEdMDkUk9WXEgyXl0dkIJ5bdZ2CKm+pRRr7bI="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/mimetreeparser-25.08.3.tar.xz",
+    "hash": "sha256-6hbPP8h+HKlQpBSUvRbvoHBdAGG1W1RaiZeYQ8g1uXc="
   },
   "minuet": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/minuet-25.08.2.tar.xz",
-    "hash": "sha256-qV49m/Of++FJ5vy5pk5Cv1+7V/FyPriSGKDlaoB0iEo="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/minuet-25.08.3.tar.xz",
+    "hash": "sha256-ECs5JaDltDem8+Ezq8roZ2I4lyqdaMRmbBqnblG5ukQ="
   },
   "neochat": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/neochat-25.08.2.tar.xz",
-    "hash": "sha256-VDkkfJtnT2/U9yQOlJitwhlyxvw1BCrrs0K8/K84Q/U="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/neochat-25.08.3.tar.xz",
+    "hash": "sha256-X62WRyoLV3qfK9fMVe1/b0gcRIv3duPVlsoJV6/MjDU="
   },
   "okular": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/okular-25.08.2.tar.xz",
-    "hash": "sha256-3kAc00N21nihajYUc1FIRPeIALOY47Dba96FoJ5jU5I="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/okular-25.08.3.tar.xz",
+    "hash": "sha256-Ay496PxUZ5YUGFlpEYjm+ALG3kmLZczLzmCqYNhlcU8="
   },
   "palapeli": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/palapeli-25.08.2.tar.xz",
-    "hash": "sha256-EF2bCUncy3yN8hbvoyMgHlfLKfoY70sE5kjC6yZn1zk="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/palapeli-25.08.3.tar.xz",
+    "hash": "sha256-j8fuZ+QiXLEvFh4ePo3evMLuH1Bo/eEM/QbuWkFgiUU="
   },
   "parley": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/parley-25.08.2.tar.xz",
-    "hash": "sha256-WUmrWVoRgeYYheHfCkOIzpq5FrRh6a55w+cCjFIxjhQ="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/parley-25.08.3.tar.xz",
+    "hash": "sha256-BMtueE6ChA1sp3mvriE+baW/7k3Kgrl3Er+4/RrFBWQ="
   },
   "partitionmanager": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/partitionmanager-25.08.2.tar.xz",
-    "hash": "sha256-gRfiToA45dMk7pNCnxeslklg40aFTCYut4MNhWrZBHs="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/partitionmanager-25.08.3.tar.xz",
+    "hash": "sha256-19HbCJIZgzqVzt0yp3hZxziuzqh6smc6ym5oCaH3sXE="
   },
   "picmi": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/picmi-25.08.2.tar.xz",
-    "hash": "sha256-GIqd3LbO/COPRpafbTQiHOLXUJVb2oFynhsBITY+sh8="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/picmi-25.08.3.tar.xz",
+    "hash": "sha256-3VzAh7jTcPHiWpNvsKjqzupoel/UnzDQASNItedoqXA="
   },
   "pim-data-exporter": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/pim-data-exporter-25.08.2.tar.xz",
-    "hash": "sha256-m45H9SxFMmLJOaT6pKP4zEmd2RgFZMBHdRtsWp3wTyc="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/pim-data-exporter-25.08.3.tar.xz",
+    "hash": "sha256-dHbHp7hZT53QhllmCh7zBCDIDUiWFIkjDMhQVosjags="
   },
   "pim-sieve-editor": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/pim-sieve-editor-25.08.2.tar.xz",
-    "hash": "sha256-+6zJfq56Br9N8Rqc3rvJ+lainoz8zABylY6OJKN0YnU="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/pim-sieve-editor-25.08.3.tar.xz",
+    "hash": "sha256-nqMohVofxgLs4gvODqLJ4zHzvkFsbmro+YUYsCkqJoQ="
   },
   "pimcommon": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/pimcommon-25.08.2.tar.xz",
-    "hash": "sha256-3jQUmUBvMX2v6fo+XutgC70Oxp804o6OC7j/2r6OlQs="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/pimcommon-25.08.3.tar.xz",
+    "hash": "sha256-/oIGtot4tVXO7YPPLmjlNIQGxZrBW8Qzkotlv56He4g="
   },
   "plasmatube": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/plasmatube-25.08.2.tar.xz",
-    "hash": "sha256-TE8PZNcu4YvsAzNvs5G9uX54AKKqgLcZXmjnsNYlAlQ="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/plasmatube-25.08.3.tar.xz",
+    "hash": "sha256-qJ4ZBtN7Fvp2+ACWQO69jj29hzp+tjly594Jhj6MO1g="
   },
   "poxml": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/poxml-25.08.2.tar.xz",
-    "hash": "sha256-tCJsUSeByP5roUMZHzS0lUeuXysB1ISBqrqYQpi3ftU="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/poxml-25.08.3.tar.xz",
+    "hash": "sha256-EpZ7UxNgVADo3jzzlHgTb1tmFrK0V3TcGFu2tcuue30="
   },
   "qmlkonsole": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/qmlkonsole-25.08.2.tar.xz",
-    "hash": "sha256-vskxw9ASMG/BaH8BBjF+jrnl+d9TeLUGiJVYmqyGjbI="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/qmlkonsole-25.08.3.tar.xz",
+    "hash": "sha256-SFD6lJeC2zMctKqFz2fXJ+3YBrd3Gr6C1KfVag6+/E0="
   },
   "qrca": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/qrca-25.08.2.tar.xz",
-    "hash": "sha256-A2VLarfZSiSj9ysHaUwpHHjpguo49WNY1aSJ4dwuFwU="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/qrca-25.08.3.tar.xz",
+    "hash": "sha256-6lwXkYjD2pI5o1Ayw2USltVXtT2r5RNNpMFNi+qCMtc="
   },
   "rocs": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/rocs-25.08.2.tar.xz",
-    "hash": "sha256-BL+zxhB4ZTvHiZTSNiK6Qt08sDUJoMIhhXg5UfH6blU="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/rocs-25.08.3.tar.xz",
+    "hash": "sha256-R6dDofPt1J2LZwKjXyoOBV0E4FB7/wCf/dteQmEySss="
   },
   "signon-kwallet-extension": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/signon-kwallet-extension-25.08.2.tar.xz",
-    "hash": "sha256-amAuEs3fuSZqOLVID6yo5LeJkrhASqLIspsGl5qm51w="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/signon-kwallet-extension-25.08.3.tar.xz",
+    "hash": "sha256-R+ee39uX2SQOIu2fpiTrrDzSGeSi7ncMaGm4abU7mv8="
   },
   "skanlite": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/skanlite-25.08.2.tar.xz",
-    "hash": "sha256-YIJ16zKwEcfdNAARieNLADr+iblM3d8Uq5m4Dw2ICKg="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/skanlite-25.08.3.tar.xz",
+    "hash": "sha256-ga/hMhLF7a7sSlfBChBdMdwg2jteCO9l+/P3Q8CPAnY="
   },
   "skanpage": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/skanpage-25.08.2.tar.xz",
-    "hash": "sha256-G93TK6+yj1zKatkBBFUrdCmnxN1DBI7IH7PPU/LyBHk="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/skanpage-25.08.3.tar.xz",
+    "hash": "sha256-6EMcc/YpAduT5HAM7LdieZq94Far+P2Ar4cH0SnG1Fg="
   },
   "skladnik": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/skladnik-25.08.2.tar.xz",
-    "hash": "sha256-AmxD4/iLvoz6Ue9wOHlbWwclocI0RAymqoqyBKrFJ6c="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/skladnik-25.08.3.tar.xz",
+    "hash": "sha256-5NjDXHJpOcnaeX4c1F1W0KDQSnnasfwtp6ztZqMPzo8="
   },
   "step": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/step-25.08.2.tar.xz",
-    "hash": "sha256-wA0k//FkXrJJamFejkc2VE7jX9OMwbhLc15aJRrILDM="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/step-25.08.3.tar.xz",
+    "hash": "sha256-sd3OT1Kgt1GIYWwGK+T6etXT13JcIR7AEXGamtJ+hvk="
   },
   "svgpart": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/svgpart-25.08.2.tar.xz",
-    "hash": "sha256-T8+uQ8Q/RfnUS2VSM550FI8sXAd6jUh9H/9Oo+9tvKY="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/svgpart-25.08.3.tar.xz",
+    "hash": "sha256-l/b9tP8xEOQdjfayXw0YT1I12InYx8FcfGu7Gi8G3hc="
   },
   "sweeper": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/sweeper-25.08.2.tar.xz",
-    "hash": "sha256-4KCSw/g0cVCHo4knw8J/Thz/xZYkBNjj/vacO6bto60="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/sweeper-25.08.3.tar.xz",
+    "hash": "sha256-brC3wxqfvh+Q5NRyVIj4KFStA4lPnp/rVvYdOdBFZZ0="
   },
   "telly-skout": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/telly-skout-25.08.2.tar.xz",
-    "hash": "sha256-nf76OvOoHAUrpFlTlKKgnKb/MYYCL8oBeqj4ATwFQMA="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/telly-skout-25.08.3.tar.xz",
+    "hash": "sha256-RP12+uGbvD+ApoylGFN7n3B7SIQDBWSmmGYYM7RvYXA="
   },
   "tokodon": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/tokodon-25.08.2.tar.xz",
-    "hash": "sha256-8yYWdcDGq0IbSwGk/1WesUw+40xsxx5uoj77EQY7ojQ="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/tokodon-25.08.3.tar.xz",
+    "hash": "sha256-MyaPh3sIWJ6QF2UwsVr6u9V6uuZodPSQc+3zcGreoiE="
   },
   "umbrello": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/umbrello-25.08.2.tar.xz",
-    "hash": "sha256-7BQbgzSFFKXxRZbtV9Kt5J9ze07a/Y6G8Cv1FU55TH4="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/umbrello-25.08.3.tar.xz",
+    "hash": "sha256-kEimFZyEhiSKlblW7QjBlUrCFwi4moH+ajsKp6Ugeiw="
   },
   "yakuake": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/yakuake-25.08.2.tar.xz",
-    "hash": "sha256-cL7+ptmgaPbc67q/HrBYR4+dAEgDHdT4DPjcCH8MRRw="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/yakuake-25.08.3.tar.xz",
+    "hash": "sha256-2NPw/+z9mPAMhhin3PXPhe90X3BHF9+BmPYyHYNFHuw="
   },
   "zanshin": {
-    "version": "25.08.2",
-    "url": "mirror://kde/stable/release-service/25.08.2/src/zanshin-25.08.2.tar.xz",
-    "hash": "sha256-S5Ind8wxaE/NsKD3+seQ8g7k3iKSe8GQn/7TpCqpE5A="
+    "version": "25.08.3",
+    "url": "mirror://kde/stable/release-service/25.08.3/src/zanshin-25.08.3.tar.xz",
+    "hash": "sha256-3A0QGC8qE1f+8jlbXo79rsTsTl9hZVEKNRKDjAspbYE="
   }
 }


### PR DESCRIPTION
+ a couple Qt 6.10 fixes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
