### PR TITLE
[Backport release-25.05] lima: add meta.knownVulnerabilities

### DIFF
--- a/pkgs/applications/virtualization/lima/default.nix
+++ b/pkgs/applications/virtualization/lima/default.nix
@@ -91,5 +91,13 @@ buildGoModule rec {
     changelog = "https://github.com/lima-vm/lima/releases/tag/v${version}";
     license = licenses.asl20;
     maintainers = with maintainers; [ anhduy ];
+    knownVulnerabilities = [
+      "There are some CVEs in the nerdctl dependency. Has been fixed in Nixpkgs unstable."
+      "CVE-2024-25621"
+      "CVE-2025-64329"
+      "CVE-2025-31133"
+      "CVE-2025-52565"
+      "CVE-2025-52881"
+    ];
   };
 }


### PR DESCRIPTION
Adding this field is a much smaller change than manually backporting https://github.com/NixOS/nixpkgs/pull/459093.

The current version 1.0.7 (in release-25.05) is related to these CVEs.

However, updating to 1.2.2 is not suitable for stable channels. This is because version 1.1.1 is not compatible, especially on the package manager side.

I considered just copying `pkg/limayaml/containerd.yaml` from 1.2.2 to 1.0.7. But I'm not certain about that ad-hoc change.

refs:
  * 1.0.7 -> 1.1.1: #415093 and following refactor: #437460
  * 1.2.1 -> 1.2.2: #459093

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc: @voanhduy1512

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
