### PR TITLE
python3Packages.yamlloader: cleanup, disable broken test

### DIFF
--- a/pkgs/development/python-modules/yamlloader/default.nix
+++ b/pkgs/development/python-modules/yamlloader/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   hatch-vcs,
   hatchling,
   pytestCheckHook,
@@ -14,9 +14,11 @@ buildPythonPackage rec {
   version = "1.5.2";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-wQrBMhpiaxyosJ0/Ov6YVbgYORxZmSp2tl5KLZXqxBs=";
+  src = fetchFromGitHub {
+    owner = "Phynix";
+    repo = "yamlloader";
+    tag = version;
+    hash = "sha256-SNb1iXao+TNW872qDtEldZj6S+yJxRlsnw6ye92RFSk=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/yamlloader/default.nix
+++ b/pkgs/development/python-modules/yamlloader/default.nix
@@ -7,15 +7,12 @@
   pytestCheckHook,
   pyyaml,
   hypothesis,
-  pythonOlder,
 }:
 
 buildPythonPackage rec {
   pname = "yamlloader";
   version = "1.5.2";
   pyproject = true;
-
-  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
@@ -39,11 +36,11 @@ buildPythonPackage rec {
     "yamlloader"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Case-insensitive list for Python";
     homepage = "https://github.com/Phynix/yamlloader";
     changelog = "https://github.com/Phynix/yamlloader/releases/tag/${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ freezeboy ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ freezeboy ];
   };
 }

--- a/pkgs/development/python-modules/yamlloader/default.nix
+++ b/pkgs/development/python-modules/yamlloader/default.nix
@@ -49,6 +49,9 @@ buildPythonPackage rec {
     homepage = "https://github.com/Phynix/yamlloader";
     changelog = "https://github.com/Phynix/yamlloader/releases/tag/${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ freezeboy ];
+    maintainers = with lib.maintainers; [
+      freezeboy
+      sarahec
+    ];
   };
 }

--- a/pkgs/development/python-modules/yamlloader/default.nix
+++ b/pkgs/development/python-modules/yamlloader/default.nix
@@ -33,6 +33,12 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  disabledTestPaths = [
+    # TypeError: cannot pickle '_thread.RLock' object
+    # https://github.com/Phynix/yamlloader/issues/64
+    "tests/test_ordereddict.py"
+  ];
+
   pythonImportsCheck = [
     "yaml"
     "yamlloader"


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/310691324

1. Cleanup: remove `pythonOlder 3.7` and `with lib;`
2. fetchPypi -> fetchFromGitHub
3. Disabled unloadable test file: TypeError: cannot pickle '_thread.RLock' object and updated https://github.com/Phynix/yamlloader/issues/64

ZHF: #457852

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
