### PR TITLE
lib.lists: add uniqueByString

### DIFF
--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -4841,4 +4841,193 @@ runTests {
       ];
     }
   );
+
+  # lib.lists.uniqueByString
+
+  testUniqueByStringBasic = {
+    expr = lists.uniqueByString (x: x) [
+      "a"
+      "b"
+      "a"
+      "c"
+      "b"
+    ];
+    expected = [
+      "a"
+      "b"
+      "c"
+    ];
+  };
+
+  testUniqueByStringEmpty = {
+    expr = lists.uniqueByString (x: x) [ ];
+    expected = [ ];
+  };
+
+  testUniqueByStringNoDuplicates = {
+    expr = lists.uniqueByString (x: x) [
+      "a"
+      "b"
+      "c"
+    ];
+    expected = [
+      "a"
+      "b"
+      "c"
+    ];
+  };
+
+  testUniqueByStringAllDuplicates = {
+    expr = lists.uniqueByString (x: x) [
+      "a"
+      "a"
+      "a"
+    ];
+    expected = [ "a" ];
+  };
+
+  testUniqueByStringPreservesOrder = {
+    expr = lists.uniqueByString (x: x) [
+      "z"
+      "a"
+      "m"
+      "z"
+      "b"
+      "a"
+    ];
+    expected = [
+      "z"
+      "a"
+      "m"
+      "b"
+    ];
+  };
+
+  testUniqueByStringCustomKey = {
+    expr = lists.uniqueByString (x: x.id) [
+      {
+        id = "1";
+        value = "first";
+      }
+      {
+        id = "2";
+        value = "second";
+      }
+      {
+        id = "1";
+        value = "duplicate";
+      }
+      {
+        id = "3";
+        value = "third";
+      }
+    ];
+    expected = [
+      {
+        id = "1";
+        value = "first";
+      }
+      {
+        id = "2";
+        value = "second";
+      }
+      {
+        id = "3";
+        value = "third";
+      }
+    ];
+  };
+
+  testUniqueByStringNumbers = {
+    expr = lists.uniqueByString toString [
+      1
+      2
+      1
+      3
+      2
+      4
+    ];
+    expected = [
+      1
+      2
+      3
+      4
+    ];
+  };
+
+  testUniqueByStringWithContext = {
+    expr =
+      let
+        drv1 = derivation {
+          name = "foo";
+          system = "x86_64-linux";
+          builder = "/bin/sh";
+        };
+        drv2 = derivation {
+          name = "bar";
+          system = "x86_64-linux";
+          builder = "/bin/sh";
+        };
+        drv3 = derivation {
+          name = "foo";
+          system = "x86_64-linux";
+          builder = "/bin/sh";
+        }; # same as drv1
+      in
+      lists.uniqueByString (d: d.drvPath) [
+        drv1
+        drv2
+        drv3
+      ];
+    expected =
+      let
+        drv1 = derivation {
+          name = "foo";
+          system = "x86_64-linux";
+          builder = "/bin/sh";
+        };
+        drv2 = derivation {
+          name = "bar";
+          system = "x86_64-linux";
+          builder = "/bin/sh";
+        };
+      in
+      [
+        drv1
+        drv2
+      ];
+  };
+
+  testUniqueByStringSingleElement = {
+    expr = lists.uniqueByString (x: x) [ "only" ];
+    expected = [ "only" ];
+  };
+
+  testUniqueByStringKeepsFirstOccurrence = {
+    expr = lists.uniqueByString (x: x.key) [
+      {
+        key = "a";
+        order = 1;
+      }
+      {
+        key = "b";
+        order = 2;
+      }
+      {
+        key = "a";
+        order = 3;
+      }
+    ];
+    expected = [
+      {
+        key = "a";
+        order = 1;
+      }
+      {
+        key = "b";
+        order = 2;
+      }
+    ];
+  };
+
 }


### PR DESCRIPTION
Adds a new function to remove duplicates based on a string key function. This provides stable deduplication that preserves input order, unlike `uniqueStrings`, which doesn't preserve order, and allows custom key extraction unlike unique which compares elements directly.

Also adds docs cross-references between `unique`, `uniqueStrings`, and `uniqueByString` to help users discover the appropriate function for their use case.

## Context

- First written for https://github.com/NixOS/nix/pull/14489
  - deduplicating a large number of build inputs gathered from multiple derivations, so that the resulting devShell is reviewable, and doesn't waste the finite env+args space in processes.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
