### PR TITLE
go-away: add meta.mainProgram, passthru.updateScript

### DIFF
--- a/pkgs/by-name/go/go-away/package.nix
+++ b/pkgs/by-name/go/go-away/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitea,
+  nix-update-script,
 
   # asset compression
   brotli,
@@ -56,6 +57,12 @@ buildGoModule (finalAttrs: {
     mkdir -p $out/lib/go-away
     cp -rv examples/snippets $out/lib/go-away/
   '';
+
+  passthru.updateScript = nix-update-script {
+    # the main repository does not have the releases feed enabled, so use the
+    # codeberg mirror
+    url = "https://codeberg.org/gone/go-away";
+  };
 
   meta = {
     changelog = "https://git.gammaspectra.live/git/go-away/releases/tag/${finalAttrs.src.tag}";

--- a/pkgs/by-name/go/go-away/package.nix
+++ b/pkgs/by-name/go/go-away/package.nix
@@ -72,5 +72,6 @@ buildGoModule (finalAttrs: {
     homepage = "https://git.gammaspectra.live/git/go-away";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ hexa ];
+    mainProgram = "go-away";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Two small quality-of-life improvements for go-away:

- add `meta.mainProgram`
- add `passthru.updateScript` to automate package updates

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
