### PR TITLE
Ship correct NFS modules when mounting from initrd

### DIFF
--- a/nixos/modules/tasks/filesystems/nfs.nix
+++ b/nixos/modules/tasks/filesystems/nfs.nix
@@ -153,7 +153,7 @@ in
 
         system.fsPackages = [ pkgs.nfs-utils ];
 
-        boot.initrd.kernelModules = lib.mkIf inInitrd [ "nfs" ];
+        boot.initrd.availableKernelModules = lib.optional inInitrd "nfsv3";
 
         systemd.packages = [ pkgs.nfs-utils ];
 

--- a/nixos/modules/tasks/filesystems/nfs.nix
+++ b/nixos/modules/tasks/filesystems/nfs.nix
@@ -6,7 +6,9 @@
 }:
 let
 
-  inInitrd = config.boot.initrd.supportedFilesystems.nfs or false;
+  nfsInInitrd = config.boot.initrd.supportedFilesystems.nfs or false;
+
+  nfs4InInitrd = config.boot.initrd.supportedFilesystems.nfs4 or false;
 
   nfsStateDir = "/var/lib/nfs";
 
@@ -153,7 +155,8 @@ in
 
         system.fsPackages = [ pkgs.nfs-utils ];
 
-        boot.initrd.availableKernelModules = lib.optional inInitrd "nfsv3";
+        boot.initrd.availableKernelModules =
+          lib.optional nfsInInitrd "nfsv3" ++ lib.optional nfs4InInitrd "nfsv4";
 
         systemd.packages = [ pkgs.nfs-utils ];
 

--- a/nixos/tests/nfs/kerberos.nix
+++ b/nixos/tests/nfs/kerberos.nix
@@ -45,9 +45,8 @@ import ../make-test-python.nix (
           virtualisation.fileSystems = {
             "/data" = {
               device = "server.nfs.test:/";
-              fsType = "nfs";
+              fsType = "nfs4";
               options = [
-                "nfsvers=4"
                 "sec=krb5p"
                 "noauto"
               ];

--- a/nixos/tests/nfs/simple.nix
+++ b/nixos/tests/nfs/simple.nix
@@ -1,5 +1,6 @@
 import ../make-test-python.nix (
   {
+    lib,
     pkgs,
     version ? 4,
     ...
@@ -13,9 +14,9 @@ import ../make-test-python.nix (
         virtualisation.fileSystems = {
           "/data" = {
             # nfs4 exports the export with fsid=0 as a virtual root directory
-            device = if (version == 4) then "server:/" else "server:/data";
-            fsType = "nfs";
-            options = [ "vers=${toString version}" ];
+            device = if version == 4 then "server:/" else "server:/data";
+            fsType = if version == 4 then "nfs4" else "nfs";
+            options = lib.mkIf (version != 4) [ "vers=${toString version}" ];
           };
         };
         networking.firewall.enable = false; # FIXME: only open statd


### PR DESCRIPTION
Currently, when a file system is needed for boot, and its type is `nfs`, the `nfs` Linux module is added to the initial RAM disk. But this is not enough when `nfsv3` and `nfsv4` are built as modules instead of built-ins.

In the same vein, when a file system is needed for boot, and its type is `nfs4`, no Linux module is added to the initial RAM disk. In this case, we should rather ship the `nfsv4` Linux module. It fixes the issue encountered by the author of [this blog post](https://xyno.space/posts/nix-store-nfs/), in which he needed to explicitly add `nfsv4` to `boot.initrd.availableKernelModules`, even if his `fileSystems."/nix/.ro-store".fsType` is set to `nfs4`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
