### PR TITLE
python3Packages.ratarmountcore: disable test that needs sample files from the test directory

### DIFF
--- a/pkgs/development/python-modules/ratarmountcore/default.nix
+++ b/pkgs/development/python-modules/ratarmountcore/default.nix
@@ -8,7 +8,6 @@
   libarchive-c,
   pytestCheckHook,
   python-xz,
-  pythonOlder,
   writableTmpDirAsHomeHook,
   rapidgzip,
   rarfile,
@@ -21,8 +20,6 @@ buildPythonPackage rec {
   pname = "ratarmountcore";
   version = "1.1.2";
   pyproject = true;
-
-  disabled = pythonOlder "3.10";
 
   src = fetchFromGitHub {
     owner = "mxmlnkn";
@@ -82,11 +79,11 @@ buildPythonPackage rec {
     "test_URL"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Library for accessing archives by way of indexing";
     homepage = "https://github.com/mxmlnkn/ratarmount/tree/master/core";
     changelog = "https://github.com/mxmlnkn/ratarmount/blob/core-${src.tag}/core/CHANGELOG.md";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ mxmlnkn ];
   };
 }

--- a/pkgs/development/python-modules/ratarmountcore/default.nix
+++ b/pkgs/development/python-modules/ratarmountcore/default.nix
@@ -68,6 +68,8 @@ buildPythonPackage rec {
     # on a system with 96 GB RAM. In order to avoid build errors on "low"-memory systems, this
     # test is disabled for now.
     "tests/test_BlockParallelReaders.py"
+    # Depends on data files embedded in the test directory
+    "tests/test_AutoMountLayer.py"
   ];
 
   disabledTests = [


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/310719982

`python3Packages.ratarmountcore` looks for certain sample files in the `/test` directory, but `sourceRoot` is `src/core` and the files aren't found. Disabled the broken test path. 

ZHF: #457852

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
