### PR TITLE
nixos/tests/restic{,-rest-server}: fix setting time in tests

### DIFF
--- a/nixos/tests/restic-rest-server.nix
+++ b/nixos/tests/restic-rest-server.nix
@@ -86,7 +86,7 @@ in
         "touch /opt/excluded_file_1 /opt/excluded_file_2",
 
         # test that remotebackup runs custom commands and produces a snapshot
-        "timedatectl set-time '2016-12-13 13:45'",
+        "date -s '2016-12-13 13:45'",
         "systemctl start restic-backups-remotebackup.service",
         "rm /root/backupCleanupCommand",
         'restic-remotebackup snapshots --json | ${pkgs.jq}/bin/jq "length | . == 1"',
@@ -97,23 +97,23 @@ in
         "diff -ru ${testDir} /tmp/restore-1/opt",
 
         # test that we can create four snapshots in remotebackup and rclonebackup
-        "timedatectl set-time '2017-12-13 13:45'",
+        "date -s '2017-12-13 13:45'",
         "systemctl start restic-backups-remotebackup.service",
         "rm /root/backupCleanupCommand",
 
-        "timedatectl set-time '2018-12-13 13:45'",
+        "date -s '2018-12-13 13:45'",
         "systemctl start restic-backups-remotebackup.service",
         "rm /root/backupCleanupCommand",
 
-        "timedatectl set-time '2018-12-14 13:45'",
+        "date -s '2018-12-14 13:45'",
         "systemctl start restic-backups-remotebackup.service",
         "rm /root/backupCleanupCommand",
 
-        "timedatectl set-time '2018-12-15 13:45'",
+        "date -s '2018-12-15 13:45'",
         "systemctl start restic-backups-remotebackup.service",
         "rm /root/backupCleanupCommand",
 
-        "timedatectl set-time '2018-12-16 13:45'",
+        "date -s '2018-12-16 13:45'",
         "systemctl start restic-backups-remotebackup.service",
         "rm /root/backupCleanupCommand",
 

--- a/nixos/tests/restic.nix
+++ b/nixos/tests/restic.nix
@@ -247,7 +247,7 @@ in
 
     restic.succeed(
         # test that remotebackup runs custom commands and produces a snapshot
-        "timedatectl set-time '2016-12-13 13:45'",
+        "date -s '2016-12-13 13:45'",
         "systemctl start restic-backups-remotebackup.service",
         "rm /root/backupCleanupCommand",
         'restic-remotebackup snapshots --json | ${pkgs.jq}/bin/jq "length | . == 1"',
@@ -255,7 +255,7 @@ in
 
     restic.succeed(
         # test that remotebackup runs custom commands and produces a snapshot
-        "timedatectl set-time '2016-12-13 13:45'",
+        "date -s '2016-12-13 13:45'",
         "systemctl start restic-backups-remotebackup.service",
         "rm /root/backupCleanupCommand",
         'restic-remotebackup snapshots --json | ${pkgs.jq}/bin/jq "length | . == 1"',
@@ -297,27 +297,27 @@ in
         "grep 'check.* --some-check-option' /root/fake-restic.log",
 
         # test that we can create four snapshots in remotebackup and rclonebackup
-        "timedatectl set-time '2017-12-13 13:45'",
+        "date -s '2017-12-13 13:45'",
         "systemctl start restic-backups-remotebackup.service",
         "rm /root/backupCleanupCommand",
         "systemctl start restic-backups-rclonebackup.service",
 
-        "timedatectl set-time '2018-12-13 13:45'",
+        "date -s '2018-12-13 13:45'",
         "systemctl start restic-backups-remotebackup.service",
         "rm /root/backupCleanupCommand",
         "systemctl start restic-backups-rclonebackup.service",
 
-        "timedatectl set-time '2018-12-14 13:45'",
+        "date -s '2018-12-14 13:45'",
         "systemctl start restic-backups-remotebackup.service",
         "rm /root/backupCleanupCommand",
         "systemctl start restic-backups-rclonebackup.service",
 
-        "timedatectl set-time '2018-12-15 13:45'",
+        "date -s '2018-12-15 13:45'",
         "systemctl start restic-backups-remotebackup.service",
         "rm /root/backupCleanupCommand",
         "systemctl start restic-backups-rclonebackup.service",
 
-        "timedatectl set-time '2018-12-16 13:45'",
+        "date -s '2018-12-16 13:45'",
         "systemctl start restic-backups-remotebackup.service",
         "rm /root/backupCleanupCommand",
         "systemctl start restic-backups-rclonebackup.service",


### PR DESCRIPTION
Use `date -s` instead of `timedatectl set-time` because it fails with `Failed to set time: Requested to set the clock to time before build time, refusing.`

ZHF: #457852


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
