### PR TITLE
mullvad-vpn: 2025.7 -> 2025.13, fix update.sh

### DIFF
--- a/pkgs/by-name/mu/mullvad-vpn/package.nix
+++ b/pkgs/by-name/mu/mullvad-vpn/package.nix
@@ -67,7 +67,7 @@ let
     systemd
   ];
 
-  version = "2025.7";
+  version = "2025.13";
 
   selectSystem =
     attrs:
@@ -79,8 +79,8 @@ let
   };
 
   hash = selectSystem {
-    x86_64-linux = "sha256-wKmwCLF+H/ByZFYGQMEJT6gmAt2Aa0vZalqaMptPjhU=";
-    aarch64-linux = "sha256-lsHpbxVxThxi+eKY+9c7VcXlDdxBTds6NQKrS0rxt34=";
+    x86_64-linux = "sha256-zgU6pBujCXBhDO9XAqpUSDNuQt5daQ1gVwopXwc0nGo=";
+    aarch64-linux = "sha256-BDrH99li0GWJ+/9QUrHfKxC1JExG3jvd0ujXPKhGM1c=";
   };
 in
 
@@ -158,6 +158,7 @@ stdenv.mkDerivation {
     changelog = "https://github.com/mullvad/mullvadvpn-app/blob/${version}/CHANGELOG.md";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.gpl3Only;
+    mainProgram = "mullvad-vpn";
     platforms = lib.platforms.unix;
     badPlatforms = [ lib.systems.inspect.patterns.isDarwin ];
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/mu/mullvad-vpn/update.sh
+++ b/pkgs/by-name/mu/mullvad-vpn/update.sh
@@ -1,24 +1,19 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl gnused gawk jq nix-prefetch
+#!nix-shell -i bash -p curl gnused gawk jq nix-prefetch-scripts
 
 set -euo pipefail
 
 ROOT="$(dirname "$(readlink -f "$0")")"
-NIX_DRV="$ROOT/default.nix"
+NIX_DRV="$ROOT/package.nix"
 if [ ! -f "$NIX_DRV" ]; then
-  echo "ERROR: cannot find default.nix in $ROOT"
+  echo "ERROR: cannot find package.nix in $ROOT"
   exit 1
 fi
 
 fetch_arch() {
   VER="$1"; ARCH="$2"
   URL="https://github.com/mullvad/mullvadvpn-app/releases/download/${VER}/MullvadVPN-${VER}_${ARCH}.deb"
-  nix-prefetch "{ stdenv, fetchzip }:
-stdenv.mkDerivation rec {
-  pname = \"mullvad-vpn\"; version = \"${VER}\";
-  src = fetchurl { url = \"$URL\"; };
-}
-"
+  nix-prefetch-url --type sha256 "$URL" | xargs nix-hash --type sha256 --to-sri
 }
 
 replace_sha() {


### PR DESCRIPTION
Updates mullvad-vpn from 2025.7 to 2025.10 (latest stable for Linux).

Also fixes the `update.sh` script which seems to have been broken since migration to `pkgs/by-name/`:
- Changed `default.nix` → `package.nix`
- Changed `nix-prefetch` → `nix-prefetch-scripts` with SRI hash conversion
- Adds `mainProgram` metadata attribute

Probably replaces #445572, which was a helpful reference.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
