### PR TITLE
nixos/traccar:  update module defaults

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1531,6 +1531,7 @@ in
   tor = runTest ./tor.nix;
   tpm-ek = handleTest ./tpm-ek { };
   tpm2 = runTest ./tpm2.nix;
+  traccar = runTest ./traccar.nix;
   # tracee requires bpf
   tracee = handleTestOn [ "x86_64-linux" ] ./tracee.nix { };
   traefik = runTestOn [ "aarch64-linux" "x86_64-linux" ] ./traefik.nix;

--- a/nixos/tests/traccar.nix
+++ b/nixos/tests/traccar.nix
@@ -1,0 +1,51 @@
+{
+  pkgs,
+  lib,
+  ...
+}:
+{
+  name = "traccar";
+  meta = {
+    maintainers = with lib.maintainers; [ frederictobiasc ];
+  };
+  nodes.machine = {
+    services.traccar = {
+      enable = true;
+      settings.mail.smtp.host = "$SMTP_HOST";
+      environmentFile = pkgs.writeText "traccar.env" ''
+        SMTP_HOST=smtp.example.com
+      '';
+    };
+  };
+  testScript = ''
+    machine.wait_for_unit("traccar.service")
+
+    # Check that environment variables were substituted
+    t.assertIn("smtp.example.com", machine.succeed("cat /var/lib/traccar/config.xml"), "environment substitution failed")
+
+    machine.wait_for_open_port(8082)
+
+    # Check that we get the traccar login page
+    t.assertIn("Traccar", machine.wait_until_succeeds("curl -sf http://localhost:8082/"), "Traccar frontend seems unreachable")
+
+    # Register the first admin user
+    register_data = """
+    {
+        "email": "admin@example.com",
+        "name": "admin",
+        "password": "admin123"
+    }
+    """
+
+    t.assertIn(
+      "\"administrator\":true",
+      machine.succeed(
+        "curl -s -X POST "
+        "-H 'Content-Type: application/json' "
+        f"-d '{register_data}' "
+        "http://localhost:8082/api/users"
+      ),
+      "Unexpected registration response"
+    )
+  '';
+}


### PR DESCRIPTION
Due to an upstream change, traccar tries to create an `override` directory in it's working directory. Since traccar's working directory is read-only in this NixOS module, traccar crashes. 

This contribution resolves this by setting the `web.override` configuration to a directory below traccar's state directory.

As well as some minor cleanups.

Additionally, this introduces a nixos test.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Closes: https://github.com/NixOS/nixpkgs/issues/437817

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


