### PR TITLE
temporal: Add versionCheckHook

### DIFF
--- a/pkgs/by-name/te/temporal/darwin-sandbox-fix.patch
+++ b/pkgs/by-name/te/temporal/darwin-sandbox-fix.patch
@@ -1,0 +1,20 @@
+--- vendor/modernc.org/libc/honnef.co/go/netdb/netdb.go
++++ vendor/modernc.org/libc/honnef.co/go/netdb/netdb.go
+@@ -696,7 +696,7 @@ func init() {
+ 	// Load protocols
+ 	data, err := ioutil.ReadFile("/etc/protocols")
+ 	if err != nil {
+-		if !os.IsNotExist(err) {
++		if !os.IsNotExist(err) && !os.IsPermission(err) {
+ 			panic(err)
+ 		}
+ 
+@@ -732,7 +732,7 @@ func init() {
+ 	// Load services
+ 	data, err = ioutil.ReadFile("/etc/services")
+ 	if err != nil {
+-		if !os.IsNotExist(err) {
++		if !os.IsNotExist(err) && !os.IsPermission(err) {
+ 			panic(err)
+ 		}
+ 

--- a/pkgs/by-name/te/temporal/package.nix
+++ b/pkgs/by-name/te/temporal/package.nix
@@ -19,7 +19,14 @@ buildGoModule rec {
     hash = "sha256-WiiezZ/2FgRte4BStIGHQhb5bHtfldi3TaIRG0xFtW0=";
   };
 
-  vendorHash = "sha256-HW2j8swbaWwU1i3udqlT8VyFreML6ZH14zWxF8L5NTQ=";
+  vendorHash = "sha256-CdzcOE/J0gqUbq7BXPpLFyNPNbFTziR5j9GPdYPzv50=";
+
+  overrideModAttrs = old: {
+    # netdb.go allows /etc/protocols and /etc/services to not exist and happily proceeds, but it panic()s if they exist but return permission denied.
+    postBuild = ''
+      patch -p0 < ${./darwin-sandbox-fix.patch}
+    '';
+  };
 
   excludedPackages = [ "./build" ];
 

--- a/pkgs/by-name/te/temporal/package.nix
+++ b/pkgs/by-name/te/temporal/package.nix
@@ -8,14 +8,14 @@
   versionCheckHook,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "temporal";
   version = "1.29.2";
 
   src = fetchFromGitHub {
     owner = "temporalio";
     repo = "temporal";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-WiiezZ/2FgRte4BStIGHQhb5bHtfldi3TaIRG0xFtW0=";
   };
 
@@ -71,9 +71,9 @@ buildGoModule rec {
   meta = {
     description = "Microservice orchestration platform which enables developers to build scalable applications without sacrificing productivity or reliability";
     homepage = "https://temporal.io";
-    changelog = "https://github.com/temporalio/temporal/releases/tag/v${version}";
+    changelog = "https://github.com/temporalio/temporal/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ jpds ];
     mainProgram = "temporal-server";
   };
-}
+})

--- a/pkgs/by-name/te/temporal/package.nix
+++ b/pkgs/by-name/te/temporal/package.nix
@@ -5,6 +5,7 @@
   nixosTests,
   testers,
   temporal,
+  versionCheckHook,
 }:
 
 buildGoModule rec {
@@ -46,6 +47,12 @@ buildGoModule rec {
 
     runHook postInstall
   '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
 
   passthru.tests = {
     inherit (nixosTests) temporal;


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
