### PR TITLE
docker-language-server: cleanup

### DIFF
--- a/pkgs/by-name/do/docker-language-server/package.nix
+++ b/pkgs/by-name/do/docker-language-server/package.nix
@@ -4,16 +4,17 @@
   buildGoModule,
   docker,
   gotestsum,
+  versionCheckHook,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "docker-language-server";
   version = "0.20.1";
 
   src = fetchFromGitHub {
     owner = "docker";
     repo = "docker-language-server";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-OSAySCTK2temrVxmkRnrl5YWVbmkp8DRlXFVxTzEW3Q=";
   };
 
@@ -30,23 +31,35 @@ buildGoModule rec {
     # disable some tests because of sandbox
     excludedPackages="e2e-tests|/buildkit$|/scout$"
     packages=$(go list ./... | grep -vE "$excludedPackages")
-    gotestsum -- $packages -timeout 30s -skip "TestCollectDiagnostics|TestCompletion_ImageTags|TestInlayHint"
-    go test ./e2e-tests/... -timeout 120s -skip "TestPublishDiagnostics|TestHover"
+
+    gotestsum -- $packages \
+      -timeout 30s \
+      -skip "TestCollectDiagnostics|TestCompletion_ImageTags|TestInlayHint"
+
+    go test ./e2e-tests/... \
+      -timeout 120s \
+      -skip "TestPublishDiagnostics|TestHover"
 
     runHook postCheck
   '';
 
   ldflags = [
     "-s"
-    "-w"
-    "-X 'github.com/docker/docker-language-server/internal/pkg/cli/metadata.Version=${version}'"
+    "-X 'github.com/docker/docker-language-server/internal/pkg/cli/metadata.Version=${finalAttrs.version}'"
   ];
 
-  meta = with lib; {
-    homepage = "https://github.com/docker/docker-language-server";
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  meta = {
     description = "Language server for providing language features for file types in the Docker ecosystem (Dockerfiles, Compose files, and Bake files)";
+    homepage = "https://github.com/docker/docker-language-server";
+    changelog = "https://github.com/docker/docker-language-server/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     mainProgram = "docker-language-server";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ baongoc124 ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ baongoc124 ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

cc @baongoc124

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
