### PR TITLE
flamerobin: 0.9.3.12 -> 0.9.14

### DIFF
--- a/pkgs/by-name/fl/flamerobin/package.nix
+++ b/pkgs/by-name/fl/flamerobin/package.nix
@@ -2,31 +2,22 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   wxGTK32,
   boost,
   firebird,
 }:
 
-stdenv.mkDerivation rec {
-  version = "0.9.3.12";
+stdenv.mkDerivation (finalAttrs: {
+  version = "0.9.14";
   pname = "flamerobin";
 
   src = fetchFromGitHub {
     owner = "mariuz";
     repo = "flamerobin";
-    rev = version;
-    sha256 = "sha256-uWx3riRc79VKh7qniWFjxxc7v6l6cW0i31HxoN1BSdA=";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-IwJEFF3vP0BC9PoMoY+XPLT+ygXnFXP/TWaqjdQWs8s=";
   };
-
-  patches = [
-    # rely on compiler command line for __int128 and std::decimal::decimal128
-    (fetchpatch {
-      url = "https://github.com/mariuz/flamerobin/commit/8e0ea6d42aa28a4baeaa8c8b8b57c56eb9ae3540.patch";
-      sha256 = "sha256-l6LWXA/sRQGQKi798bzl0iIJ2vdvXHOjG7wdFSXv+NM=";
-    })
-  ];
 
   enableParallelBuilding = true;
 
@@ -38,12 +29,12 @@ stdenv.mkDerivation rec {
     firebird
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Database administration tool for Firebird RDBMS";
     homepage = "https://github.com/mariuz/flamerobin";
-    license = licenses.bsdOriginal;
-    maintainers = with maintainers; [ uralbash ];
-    platforms = platforms.unix;
+    license = lib.licenses.bsdOriginal;
+    maintainers = with lib.maintainers; [ uralbash ];
+    platforms = lib.platforms.unix;
     mainProgram = "flamerobin";
   };
-}
+})


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/457852
- https://github.com/NixOS/nixpkgs/issues/445447

Changelog: https://github.com/mariuz/flamerobin/releases/tag/0.9.14 (It says pre-release, but all tags say that)
Diff: https://github.com/mariuz/flamerobin/compare/0.9.3.12...0.9.14

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
