### PR TITLE
python3Packages.func-timeout: disable timing tests that fail in Hydra due to load

### DIFF
--- a/pkgs/development/python-modules/func-timeout/default.nix
+++ b/pkgs/development/python-modules/func-timeout/default.nix
@@ -18,6 +18,15 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  disabledTests = [
+    # Calculates the amount of time the machine slept but doesn't account for heavy loads
+    "test_retry"
+    "test_funcSetTimeout"
+    "test_funcSetTimeCalculate"
+    "test_funcSetTimeCalculateWithOverride"
+    "test_setFuncTimeoutetry"
+  ];
+
   pythonImportsCheck = [ "func_timeout" ];
 
   meta = {

--- a/pkgs/development/python-modules/func-timeout/default.nix
+++ b/pkgs/development/python-modules/func-timeout/default.nix
@@ -20,10 +20,10 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "func_timeout" ];
 
-  meta = with lib; {
+  meta = {
     description = "Allows you to specify timeouts when calling any existing function. Also provides support for stoppable-threads";
     homepage = "https://github.com/kata198/func_timeout";
-    license = licenses.lgpl3Only;
+    license = lib.licenses.lgpl3Only;
     maintainers = [ ];
   };
 }


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/310701815

Several tests calculate an expected sleep time and then compare with the wall clock time. Unfortunately, these fail if the system is heavily loaded. Disabled.

ZHF: #457852


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
