### PR TITLE
python3Packages.ssdpy: mark as broken on Darwin

### DIFF
--- a/pkgs/development/python-modules/ssdpy/default.nix
+++ b/pkgs/development/python-modules/ssdpy/default.nix
@@ -39,11 +39,13 @@ buildPythonPackage rec {
     "test_server_extra_fields"
   ];
 
-  meta = with lib; {
+  __darwinAllowLocalNetworking = true;
+
+  meta = {
     changelog = "https://github.com/MoshiBin/ssdpy/releases/tag/${version}";
     description = "Lightweight, compatible SSDP library for Python";
     homepage = "https://github.com/MoshiBin/ssdpy";
-    license = licenses.mit;
-    maintainers = with maintainers; [ mjm ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ mjm ];
   };
 }

--- a/pkgs/development/python-modules/ssdpy/default.nix
+++ b/pkgs/development/python-modules/ssdpy/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,
@@ -39,13 +40,13 @@ buildPythonPackage rec {
     "test_server_extra_fields"
   ];
 
-  __darwinAllowLocalNetworking = true;
-
   meta = {
     changelog = "https://github.com/MoshiBin/ssdpy/releases/tag/${version}";
     description = "Lightweight, compatible SSDP library for Python";
     homepage = "https://github.com/MoshiBin/ssdpy";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ mjm ];
+    # Darwin's network interface names have changed since the package was last updated
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/310723213

This package released in 2020 and the network interfaces on Darwin have changed since then.

ZHF: #457852

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
