### PR TITLE
python3Packages.redshift-connector: 2.1.8 -> 2.1.9, fixes

### DIFF
--- a/pkgs/development/python-modules/redshift-connector/default.nix
+++ b/pkgs/development/python-modules/redshift-connector/default.nix
@@ -1,25 +1,30 @@
 {
-  beautifulsoup4,
-  boto3,
+  lib,
   buildPythonPackage,
   fetchFromGitHub,
-  lib,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  beautifulsoup4,
+  boto3,
+  botocore,
   lxml,
   packaging,
-  pytest-mock,
-  pytestCheckHook,
-  pythonOlder,
   pytz,
   requests,
   scramp,
+
+  # test
+  pytest-mock,
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "redshift-connector";
   version = "2.1.8";
-  format = "setuptools";
-
-  disabled = pythonOlder "3.6";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "aws";
@@ -33,7 +38,9 @@ buildPythonPackage rec {
     substituteInPlace setup.cfg --replace 'addopts =' 'no-opts ='
   '';
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     beautifulsoup4
     boto3
     lxml
@@ -42,6 +49,8 @@ buildPythonPackage rec {
     requests
     scramp
   ];
+
+  pythonRelaxDeps = [ "lxml" ];
 
   nativeCheckInputs = [
     pytest-mock

--- a/pkgs/development/python-modules/redshift-connector/default.nix
+++ b/pkgs/development/python-modules/redshift-connector/default.nix
@@ -23,14 +23,14 @@
 
 buildPythonPackage rec {
   pname = "redshift-connector";
-  version = "2.1.8";
+  version = "2.1.9";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "aws";
     repo = "amazon-redshift-python-driver";
     tag = "v${version}";
-    hash = "sha256-q8TQYiPmm3w9Bh4+gvVW5XAa4FZ3+/MZqZL0RCgl77E=";
+    hash = "sha256-x0VhICEtZZz4Q7btCl7nP0D+YHPIKqbEUWnrEekJpt0=";
   };
 
   # remove addops as they add test directory and coverage parameters to pytest
@@ -43,6 +43,7 @@ buildPythonPackage rec {
   dependencies = [
     beautifulsoup4
     boto3
+    botocore
     lxml
     packaging
     pytz

--- a/pkgs/development/python-modules/redshift-connector/default.nix
+++ b/pkgs/development/python-modules/redshift-connector/default.nix
@@ -60,6 +60,18 @@ buildPythonPackage rec {
   # integration tests require a Redshift cluster
   enabledTestPaths = [ "test/unit" ];
 
+  disabledTests = [
+    # AttributeError: 'itertools._tee' object has no attribute 'status_code'
+    # This is due to a broken pytest_mock.
+    # TODO Remove once pytest-mock 3.15.1 lands.
+    "test_form_based_authentication_uses_user_set_login_to_rp"
+    "test_form_based_authentication_payload_is_correct"
+    "test_form_based_authentication_login_fails_should_fail"
+    "test_azure_oauth_based_authentication_payload_is_correct"
+    "test_okta_authentication_payload_is_correct"
+    "test_set_cluster_identifier_calls_describe_custom_domain_associations"
+  ];
+
   __darwinAllowLocalNetworking = true; # required for tests
 
   meta = {


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/310720142

Tests were failing with `AttributeError: 'itertools._tee' object has no attribute 'status_code'` for tests that should have been integration tests (they depend on a form submission). Disabled.

Also modernized the derivation and bumped the version to 2.1.9. 

ZHF: #457852

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
