### PR TITLE
python3Packages.pmdarima: disable broken tests

### DIFF
--- a/ci/github-script/bot.js
+++ b/ci/github-script/bot.js
@@ -579,7 +579,7 @@ module.exports = async ({ github, context, core, dry }) => {
   // We'll only boost concurrency when we're running many PRs in parallel on a schedule,
   // but not for single PRs. This avoids things going wild, when we accidentally make
   // too many API requests on treewides.
-  const maxConcurrent = context.eventName === 'pull_request' ? 1 : 20
+  const maxConcurrent = context.payload.pull_request ? 1 : 20
 
   await withRateLimit({ github, core, maxConcurrent }, async (stats) => {
     if (context.payload.pull_request) {

--- a/pkgs/development/python-modules/pmdarima/default.nix
+++ b/pkgs/development/python-modules/pmdarima/default.nix
@@ -11,7 +11,6 @@
   scipy,
   statsmodels,
   urllib3,
-  pythonOlder,
   python,
   pytest7CheckHook,
   setuptools,
@@ -21,8 +20,6 @@ buildPythonPackage rec {
   pname = "pmdarima";
   version = "2.0.4";
   pyproject = true;
-
-  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "alkaline-ml";
@@ -76,6 +73,11 @@ buildPythonPackage rec {
   disabledTests = [
     # touches internet
     "test_load_from_web"
+    # assert "'force_all_f...moved in 1.8." == 'information_...terion = aic.'
+    # namely, picks up UserWarning from sklearn about deprecated parameter
+    "test_oob_with_zero_out_of_sample_size"
+    # assert 3 == 1
+    "test_issue_351"
   ];
 
   pythonImportsCheck = [ "pmdarima" ];


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/310675264

This is a 2023 package and has some broken tests due to dependency updates. Disabled the broken tests.

ZHF: #457852


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
