### PR TITLE
python3Packages.matlink-gpapi, python3Packages.gplaycli: cleanup, fix build dependency on old protoc

### DIFF
--- a/pkgs/development/python-modules/gplaycli/default.nix
+++ b/pkgs/development/python-modules/gplaycli/default.nix
@@ -1,27 +1,30 @@
 {
   lib,
-  args,
   buildPythonPackage,
-  clint,
   fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  args,
+  clint,
   libffi,
   matlink-gpapi,
   ndg-httpsclient,
   protobuf,
   pyasn1,
   pyaxmlparser,
-  pytestCheckHook,
-  pythonOlder,
   requests,
-  setuptools,
+
+  # test
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "gplaycli";
   version = "3.29";
-  format = "setuptools";
-
-  disabled = pythonOlder "3.6";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "matlink";
@@ -30,17 +33,18 @@ buildPythonPackage rec {
     hash = "sha256-uZBrIxnDSaJDOPcD7J4SCPr9nvecDDR9h+WnIjIP7IE=";
   };
 
-  propagatedBuildInputs = [
-    libffi
-    pyasn1
+  build-system = [ setuptools ];
+
+  dependencies = [
+    args
     clint
+    libffi
+    matlink-gpapi
     ndg-httpsclient
     protobuf
-    requests
-    args
-    matlink-gpapi
+    pyasn1
     pyaxmlparser
-    setuptools
+    requests
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];
@@ -64,12 +68,12 @@ buildPythonPackage rec {
     "test_update"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Google Play Downloader via Command line";
     mainProgram = "gplaycli";
     homepage = "https://github.com/matlink/gplaycli";
-    changelog = "https://github.com/matlink/gplaycli/releases/tag/${version}";
-    license = licenses.agpl3Plus;
+    changelog = "https://github.com/matlink/gplaycli/releases/tag/${src.tag}";
+    license = lib.licenses.agpl3Plus;
     maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/gplaycli/default.nix
+++ b/pkgs/development/python-modules/gplaycli/default.nix
@@ -35,6 +35,11 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
+  # the expected protoc is too old, so fall back to the pure python implementation
+  preBuild = ''
+    export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
+  '';
+
   dependencies = [
     args
     clint

--- a/pkgs/development/python-modules/matlink-gpapi/default.nix
+++ b/pkgs/development/python-modules/matlink-gpapi/default.nix
@@ -25,6 +25,11 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
+  # the expected protoc is too old, so fall back to the pure python implementation
+  preBuild = ''
+    export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
+  '';
+
   dependencies = [
     cryptography
     protobuf

--- a/pkgs/development/python-modules/matlink-gpapi/default.nix
+++ b/pkgs/development/python-modules/matlink-gpapi/default.nix
@@ -1,8 +1,13 @@
 {
-  buildPythonPackage,
-  cryptography,
-  fetchPypi,
   lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  cryptography,
   protobuf,
   pycryptodome,
   requests,
@@ -10,13 +15,22 @@
 
 buildPythonPackage rec {
   version = "0.4.4.5";
-  format = "setuptools";
   pname = "matlink-gpapi";
+  pyproject = true;
 
   src = fetchPypi {
     inherit version pname;
     sha256 = "0s45yb2xiq3pc1fh4bygfgly0fsjk5fkc4wckbckn3ddl7v7vz8c";
   };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    cryptography
+    protobuf
+    pycryptodome
+    requests
+  ];
 
   # package doesn't contain unit tests
   # scripts in ./test require networking
@@ -24,17 +38,10 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "gpapi.googleplay" ];
 
-  propagatedBuildInputs = [
-    cryptography
-    protobuf
-    pycryptodome
-    requests
-  ];
-
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/NoMore201/googleplay-api";
-    license = licenses.gpl3Only;
+    license = lib.licenses.gpl3Only;
     description = "Google Play Unofficial Python API";
-    maintainers = with maintainers; [ schnusch ];
+    maintainers = with lib.maintainers; [ schnusch ];
   };
 }


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/310669445

Both packages expected an obsolete `protoc`. Set them to use the pure python implementation instead.

ZHF: #457852

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
