### PR TITLE
python3Packages.py-cid: 0.3.0 -> 0.3.1, python3Packages.py-multiaddr: 0.0.10 -> 0.1.0

### DIFF
--- a/pkgs/development/python-modules/py-cid/default.nix
+++ b/pkgs/development/python-modules/py-cid/default.nix
@@ -52,5 +52,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/ipld/py-cid";
     license = licenses.mit;
     maintainers = with maintainers; [ Luflosi ];
+    broken = true; # depends on pymultihash, now archived with no releases
   };
 }

--- a/pkgs/development/python-modules/py-multiaddr/default.nix
+++ b/pkgs/development/python-modules/py-multiaddr/default.nix
@@ -50,5 +50,6 @@ buildPythonPackage rec {
       asl20
     ];
     maintainers = with maintainers; [ Luflosi ];
+    broken = true; # depends on py-cid, now broken
   };
 }


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/310676060

`python3Packages.py-cid` -- cleanup and version bump to support `py-multiaddr`
`python3Packages.py-multiaddr` -- cleanup and bump to modern release 0.1.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
