### PR TITLE
models-dev: 0-unstable-2025-11-04 -> 0-unstable-2025-11-06

### DIFF
--- a/pkgs/by-name/mo/models-dev/package.nix
+++ b/pkgs/by-name/mo/models-dev/package.nix
@@ -8,12 +8,12 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "models-dev";
-  version = "0-unstable-2025-11-04";
+  version = "0-unstable-2025-11-06";
   src = fetchFromGitHub {
     owner = "sst";
     repo = "models.dev";
-    rev = "234ba091f2d37ea925e4e38fecd7b3ed661b52a9";
-    hash = "sha256-7djp/VoAWK29tcwD9mDPCTZiGeJKB8puOnlbEMgOqKQ=";
+    rev = "db75a6d97efdd7a3f73cc2c0ebc3f362ebce608c";
+    hash = "sha256-pl6Ra7QPmM15ndl/skxE+XTqWP9oD2olcs+EQFW0U/0=";
   };
 
   node_modules = stdenvNoCC.mkDerivation {


### PR DESCRIPTION
Automatic update generated by [nixpkgs-update-gha](https://github.com/delafthi/nixpkgs-update-gha). This update was made based on information from `passthru.updateScript`.

meta.description for models-dev is: Comprehensive open-source database of AI model specifications, pricing, and capabilities

meta.homepage for models-dev is: https://github.com/sst/models-dev

meta.changelog for models-dev is: 

###### Updates performed

- Ran `passthru.updateScript`

###### To inspect upstream changes

https://github.com/sst/models-dev

###### Impact

<b>Checks done</b>

---

- built on NixOS
- found 0-unstable-2025-11-06 in filename of file in /nix/store/wjk59a0b0fpjc0w7zkwqyqjxsyhx24j1-models-dev-0-unstable-2025-11-06
- nixpkgs-review-gha triggered for multi-platform testing ([view workflow runs](https://github.com/delafthi/nixpkgs-review-gha/actions))

---

<details>
<summary>
<b>Rebuild report</b> (if merged into master) (click to expand)
</summary>

```
Build logs: https://github.com/delafthi/nixpkgs-update-gha/actions/runs/19157087368
```

</details>

### Pre-merge build results

We have automatically built all packages that will get rebuilt due to
this change.

This gives evidence on whether the upgrade will break dependent packages.
Note sometimes packages show up as _failed to build_ independent of the
change, simply because they are already broken on the target branch.

## `nixpkgs-review` result

### `x86_64-linux`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>models-dev</li>
    <li>opencode</li>
  </ul>
</details>

###### Maintainer pings

cc @delafthi for [testing](https://github.com/ryantm/nixpkgs-update/blob/main/doc/nixpkgs-maintainer-faq.md#r-ryantm-opened-a-pr-for-my-package-what-do-i-do).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.com/blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
