### PR TITLE
python3Packages.brotli: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/by-name/br/brotli/package.nix
+++ b/pkgs/by-name/br/brotli/package.nix
@@ -4,11 +4,10 @@
   fetchFromGitHub,
   fetchpatch,
   cmake,
+  python3Packages,
   staticOnly ? stdenv.hostPlatform.isStatic,
   testers,
 }:
-
-# ?TODO: there's also python lib in there
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "brotli";
@@ -54,7 +53,10 @@ stdenv.mkDerivation (finalAttrs: {
     cp ../docs/*.3 $out/share/man/man3/
   '';
 
-  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  passthru.tests = {
+    pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    python = python3Packages.brotli;
+  };
 
   meta = with lib; {
     homepage = "https://github.com/google/brotli";

--- a/pkgs/development/python-modules/brotli/default.nix
+++ b/pkgs/development/python-modules/brotli/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  brotli,
   buildPythonPackage,
   fetchFromGitHub,
   pkgconfig,
@@ -28,6 +29,12 @@ buildPythonPackage rec {
 
   # only returns information how to really build
   dontConfigure = true;
+
+  env.USE_SYSTEM_BROTLI = 1;
+
+  buildInputs = [
+    brotli
+  ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/brotli/default.nix
+++ b/pkgs/development/python-modules/brotli/default.nix
@@ -2,25 +2,29 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  pkgconfig,
   pytestCheckHook,
   setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "brotli";
-  version = "1.1.0";
+  version = "1.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "brotli";
     tag = "v${version}";
-    hash = "sha256-U1vAupUthD5W0xvlOKdgm9MAVLqsVyZUaFdeLsDAbDM=";
+    hash = "sha256-ePfllKdY12hOPuO9uHuXFZ3Bdib6BLD4ghiaeurJZ28=";
     # .gitattributes is not correct or GitHub does not parse it correct and the archive is missing the test data
     forceFetchGit = true;
   };
 
-  build-system = [ setuptools ];
+  build-system = [
+    pkgconfig
+    setuptools
+  ];
 
   # only returns information how to really build
   dontConfigure = true;
@@ -29,10 +33,11 @@ buildPythonPackage rec {
 
   enabledTestPaths = [ "python/tests" ];
 
-  meta = with lib; {
+  meta = {
+    changelog = "https://github.com/google/brotli/blob/${src.tag}/CHANGELOG.md";
     homepage = "https://github.com/google/brotli";
     description = "Generic-purpose lossless compression algorithm";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     maintainers = [ ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2189,7 +2189,9 @@ self: super: with self; {
 
   brother-ql = callPackage ../development/python-modules/brother-ql { };
 
-  brotli = callPackage ../development/python-modules/brotli { };
+  brotli = callPackage ../development/python-modules/brotli {
+    inherit (pkgs) brotli;
+  };
 
   brotli-asgi = callPackage ../development/python-modules/brotli-asgi { };
 


### PR DESCRIPTION
Diff: https://github.com/google/brotli/compare/v1.1.0...v1.2.0

Changelog: https://github.com/google/brotli/blob/v1.2.0/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
