### PR TITLE
brotli: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/by-name/br/brotli/package.nix
+++ b/pkgs/by-name/br/brotli/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   python3Packages,
   staticOnly ? stdenv.hostPlatform.isStatic,
@@ -11,25 +10,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "brotli";
-  version = "1.1.0";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "brotli";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-MvceRcle2dSkkucC2PlsCizsIf8iv95d8Xjqew266wc=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-kl8ZHt71v17QR2bDP+ad/5uixf+GStEPLQ5ooFoC5i8=";
   };
-
-  patches = [
-    # revert runpath change, breaks curl on darwin:
-    #   https://github.com/NixOS/nixpkgs/pull/254532#issuecomment-1722337476
-    (fetchpatch {
-      name = "revert-runpath.patch";
-      url = "https://github.com/google/brotli/commit/f842c1bcf9264431cd3b15429a72b7dafbe80509.patch";
-      hash = "sha256-W3LY3EjoHP74YsKOOcYQrzo+f0HbooOvEbnOibtN6TM=";
-      revert = true;
-    })
-  ];
 
   nativeBuildInputs = [ cmake ];
 
@@ -60,6 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     homepage = "https://github.com/google/brotli";
+    changelog = "https://github.com/google/brotli/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     description = "General-purpose lossless compression library with CLI";
     longDescription = ''
       Brotli is a generic-purpose lossless compression algorithm that

--- a/pkgs/development/python-modules/brotli/default.nix
+++ b/pkgs/development/python-modules/brotli/default.nix
@@ -10,17 +10,8 @@
 
 buildPythonPackage rec {
   pname = "brotli";
-  version = "1.2.0";
+  inherit (brotli) version src;
   pyproject = true;
-
-  src = fetchFromGitHub {
-    owner = "google";
-    repo = "brotli";
-    tag = "v${version}";
-    hash = "sha256-ePfllKdY12hOPuO9uHuXFZ3Bdib6BLD4ghiaeurJZ28=";
-    # .gitattributes is not correct or GitHub does not parse it correct and the archive is missing the test data
-    forceFetchGit = true;
-  };
 
   build-system = [
     pkgconfig


### PR DESCRIPTION
Diff: https://github.com/google/brotli/compare/v1.1.0...v1.2.0

Changelog: https://github.com/google/brotli/blob/v1.2.0/CHANGELOG.md

depends on https://github.com/NixOS/nixpkgs/pull/459351

The patch added in https://github.com/NixOS/nixpkgs/pull/255630 no longer applies.
It looks like we can just drop it though since curl builds fine without on aarch64-darwin.
cc @trofi

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
