### PR TITLE
netatop: 3.1 -> 3.2.2 and fix build

### DIFF
--- a/pkgs/os-specific/linux/netatop/default.nix
+++ b/pkgs/os-specific/linux/netatop/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
   kernel,
   kernelModuleMakeFlags,
   kmod,
@@ -9,15 +10,17 @@
 }:
 
 let
-  version = "3.1";
+  version = "3.2.2";
 in
 
 stdenv.mkDerivation {
+  pname = "netatop";
+  inherit version;
   name = "netatop-${kernel.version}-${version}";
 
   src = fetchurl {
-    url = "http://www.atoptool.nl/download/netatop-${version}.tar.gz";
-    sha256 = "0qjw8glfdmngfvbn1w63q128vxdz2jlabw13y140ga9i5ibl6vvk";
+    url = "https://www.atoptool.nl/download/netatop-${version}.tar.gz";
+    hash = "sha256-UIqJd809HN1nWHoTwl46QUZHtI+S0c44/BOLWRSuo/Y=";
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
@@ -27,34 +30,30 @@ stdenv.mkDerivation {
   ];
 
   hardeningDisable = [ "pic" ];
-  env.NIX_CFLAGS_COMPILE = toString [ "-Wno-error=implicit-fallthrough" ];
 
   patches = [
     # fix paths in netatop.service
     ./fix-paths.patch
-    # Specify PIDFile in /run, not /var/run to silence systemd warning
-    ./netatop.service.patch
+    # fix install paths and install the .ko instead of trying to invoke dkms
+    ./fix-makefile-install.patch
+    # replace init_module as needed by Linux 6.15 and above (backwards compatible)
+    (fetchpatch {
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/netatop_kernel_6.15.patch?h=netatop-dkms&id=e5da6fa4fee5499c3e437cdd34281dd2b200508f";
+      hash = "sha256-JyNQNyDJQkM/hLpb/hp3Sw2tMA8XnYogduGDFqTQ3nQ=";
+    })
   ];
   preConfigure = ''
     patchShebangs mkversion
-    sed -i -e 's,^KERNDIR.*,KERNDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build,' \
-        */Makefile
-    sed -i -e 's,/lib/modules.*extra,'$out'/lib/modules/${kernel.modDirVersion}/extra,' \
-        -e s,/usr,$out, \
-        -e /init.d/d \
-        -e /depmod/d \
-        -e s,/lib/systemd,$out/lib/systemd, \
-        Makefile
-
     kmod=${kmod} substituteAllInPlace netatop.service
   '';
 
-  makeFlags = kernelModuleMakeFlags;
-
-  preInstall = ''
-    mkdir -p $out/lib/systemd/system $out/bin $out/sbin $out/share/man/man{4,8}
-    mkdir -p $out/lib/modules/${kernel.modDirVersion}/extra
-  '';
+  makeFlags = kernelModuleMakeFlags ++ [
+    "KERNDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "KMODDIRVERSION=${kernel.modDirVersion}"
+    # netatop builds both the module and daemon at once, and the daemon needs a wrapped cc to build
+    # pkgs/os-specific/linux/kernel/common-flags.nix unwraps the cc for kernel build, but we need the wrapped one
+    "CC=${stdenv.cc}/bin/cc"
+  ];
 
   meta = {
     description = "Network monitoring module for atop";

--- a/pkgs/os-specific/linux/netatop/fix-makefile-install.patch
+++ b/pkgs/os-specific/linux/netatop/fix-makefile-install.patch
@@ -1,0 +1,23 @@
+diff --color -ruN netatop-3.2.2.orig/Makefile netatop-3.2.2/Makefile
+--- netatop-3.2.2.orig/Makefile	2025-11-07 13:09:10.106363095 -0500
++++ netatop-3.2.2/Makefile	2025-11-07 16:25:35.251434714 -0500
+@@ -20,14 +20,12 @@
+ 
+ 
+ install:		netatop.ko netatopd
+-			cd /usr/src; dkms add -m netatop -v $(CURVERS)
+-			dkms build   -m netatop -v $(CURVERS)
+-			dkms install -m netatop -v $(CURVERS)
++			install -m 0644 netatop.ko -Dt $(out)/lib/modules/$(KMODDIRVERSION)/extra
+ 			#
+-			install netatopd -t /usr/sbin
+-			install -m 0644 netatop.service -t /lib/systemd/system
+-			install man/netatop.4 -t /usr/share/man/man4
+-			install man/netatopd.8 -t /usr/share/man/man8
++			install netatopd -Dt $(out)/sbin
++			install -m 0644 netatop.service -Dt $(out)/lib/systemd/system
++			install man/netatop.4 -Dt $(out)/share/man/man4
++			install man/netatopd.8 -Dt $(out)/share/man/man8
+ 
+ clean:
+ 			rm -f *.o *.ko

--- a/pkgs/os-specific/linux/netatop/netatop.service.patch
+++ b/pkgs/os-specific/linux/netatop/netatop.service.patch
@@ -1,7 +1,0 @@
---- a/netatop.service
-+++ b/netatop.service
-@@ -11,3 +11,3 @@
- ExecStopPost=@kmod@/bin/rmmod netatop
--PIDFile=/var/run/netatop.pid
-+PIDFile=/run/netatop.pid
- RemainAfterExit=yes


### PR DESCRIPTION
netatop was failing to build for two reasons:
- Linux 6.15 removed support for init_module. I pulled [a small patch from the AUR](https://aur.archlinux.org/cgit/aur.git/tree/netatop_kernel_6.15.patch?h=netatop-dkms) to fix this.
- The daemon needs a wrapped cc to build, but the kernel common-flags.nix [no longer provides this](https://github.com/NixOS/nixpkgs/blob/779544516bf50bbce96865d57d90719a4a76dd6c/pkgs/os-specific/linux/kernel/common-flags.nix#L10). The netatop build now overrides cc to the wrapped one.

I also bumped the version to 3.2.2 while I was at it. The 3.2.2 makefile uses dkms, which I patched out and instead manually installed the kernel module in the postInstall.

Changelog: https://www.atoptool.nl/downloadnetatop.php

ZHF: #457852

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
