### PR TITLE
heroic-unwrapped: bump electron version

### DIFF
--- a/pkgs/by-name/he/heroic-unwrapped/package.nix
+++ b/pkgs/by-name/he/heroic-unwrapped/package.nix
@@ -9,7 +9,7 @@
   python3,
   makeWrapper,
   # Electron updates frequently break Heroic, so pin same version as upstream, or newest non-EOL.
-  electron_36,
+  electron_37,
   vulkan-helper,
   gogdl,
   nile,
@@ -21,7 +21,7 @@ let
   legendary = callPackage ./legendary.nix { };
   epic-integration = callPackage ./epic-integration.nix { };
   comet-gog = comet-gog_heroic;
-  electron = electron_36;
+  electron = electron_37;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "heroic-unwrapped";
@@ -119,12 +119,12 @@ stdenv.mkDerivation (finalAttrs: {
     inherit epic-integration legendary;
   };
 
-  meta = with lib; {
+  meta = {
     description = "Native GOG, Epic, and Amazon Games Launcher for Linux, Windows and Mac";
     homepage = "https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher";
     changelog = "https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases/tag/v${finalAttrs.version}";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ iedame ];
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ iedame ];
     # Heroic may work on nix-darwin, but it needs a dedicated maintainer for the platform.
     # It may also work on other Linux targets, but all the game stores only
     # support x86 Linux, so it would require extra hacking to run games via QEMU


### PR DESCRIPTION
Pinned Electron version is EOL. Prompted by https://github.com/NixOS/nixpkgs/pull/458485, which was already merged after 2 days of notice.

Upstream is still using 36, but from my testing bumping to 37 doesn't break anything. 
I would have preferred to dedicate a little more time to bump this with more testing since I just adopted this package, but considering it will be marked as insecure soon, I decided to bump it and fix any issues later.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
