### PR TITLE
fcitx5-arc-theme

### DIFF
--- a/pkgs/by-name/fc/fcitx5-arc-theme/package.nix
+++ b/pkgs/by-name/fc/fcitx5-arc-theme/package.nix
@@ -1,0 +1,32 @@
+{
+    stdenvNoCC,
+    fetchFromGitHub,
+    lib,
+}:
+
+stdenvNoCC.mkDerivation {
+    pname = "fcitx5-arc-theme";
+    version = "0-unstable-2025-11-07";
+
+    src = fetchFromGitHub {
+        owner = "Kienyew";
+        repo = "fcitx5-arc-theme";
+        rev = "78a54e89a8d3717ab149976c26d6b4b2fde13f11";
+        hash = "sha256-Fb5nP099D/hvw+WrJ2VxvwiNqaG4SzrLNhsPUe1j/6Q=";
+    };
+
+    installPhase = ''
+        runHook preInstall
+        mkdir -pv $out/share/fcitx5/themes/
+        cp -rv Arc* $out/share/fcitx5/themes
+        runHook postInstall
+    '';
+
+    meta = with lib; {
+        description = "Fcitx5 theme based on Arc theme";
+        homepage = "https://github.com/Kienyew/fcitx5-arc-theme";
+        license = licenses.mit;
+        maintainers = with maintainers; [ Che-0129 ];
+        platforms = platforms.all;
+    };
+}


### PR DESCRIPTION
I migrated from Arch Linux, but since NixOS doesn't have fcitx-skin-arc from the AUR, I added it.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
