### PR TITLE
ratarmountcore: 1.1.2 -> 1.2.0; ratarmount: 1.1.2 -> 1.2.0

### DIFF
--- a/pkgs/development/python-modules/mfusepy/default.nix
+++ b/pkgs/development/python-modules/mfusepy/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  stdenvNoCC,
+  pkgs,
+  nix-update-script,
+}:
+
+buildPythonPackage rec {
+  pname = "mfusepy";
+  version = "3.0.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-7dreM+QnusnEVUZM0KfRLWPAMyVexrHg1q2hQ6lFxvI=";
+  };
+
+  build-system = [ setuptools ];
+
+  propagatedBuildInputs = [ pkgs.fuse ];
+
+  patchPhase = lib.optionalString (!stdenvNoCC.hostPlatform.isDarwin) ''
+    substituteInPlace mfusepy.py --replace-fail \
+      "find_library('fuse')" "'${lib.getLib pkgs.fuse}/lib/libfuse.so'"
+  '';
+
+  pythonImportsCheck = [ "mfusepy" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Ctypes bindings for the high-level API in libfuse 2 and 3";
+    homepage = "https://pypi.org/project/mfusepy";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "mfusepy";
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/ratarmount/default.nix
+++ b/pkgs/development/python-modules/ratarmount/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  fusepy,
+  mfusepy,
   indexed-gzip,
   indexed-zstd,
   libarchive-c,
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "ratarmount";
-  version = "1.1.2";
+  version = "1.2.0";
   pyproject = true;
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-XiwtmZ7HGZwjJJrUD3TOP3o19RBwB/Yu09xdwK13+hk=";
+    hash = "sha256-rMpOWAPHX1D5TUx16tX0SqTEZhyed9UOsl0Ydub03sk=";
   };
 
   pythonRelaxDeps = [ "python-xz" ];
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   build-system = [ setuptools ];
 
   dependencies = [
-    fusepy
+    mfusepy
     indexed-gzip
     indexed-zstd
     libarchive-c
@@ -56,5 +56,6 @@ buildPythonPackage rec {
     license = licenses.mit;
     maintainers = with lib.maintainers; [ mxmlnkn ];
     mainProgram = "ratarmount";
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/ratarmountcore/default.nix
+++ b/pkgs/development/python-modules/ratarmountcore/default.nix
@@ -19,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "ratarmountcore";
-  version = "1.1.2";
+  version = "1.2.0";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -28,7 +28,7 @@ buildPythonPackage rec {
     owner = "mxmlnkn";
     repo = "ratarmount";
     tag = "v${version}";
-    hash = "sha256-8DjmYYTb0BR5KvtSeI2s7VtYdbRSI+QCjhZfDwqnk3M=";
+    hash = "sha256-X7P06+wsK+Zli0t/T+8ybHz737xz94xbVwaUHoqbn/o=";
     fetchSubmodules = true;
   };
 
@@ -71,14 +71,14 @@ buildPythonPackage rec {
     # on a system with 96 GB RAM. In order to avoid build errors on "low"-memory systems, this
     # test is disabled for now.
     "tests/test_BlockParallelReaders.py"
+    # ratarmountcore.utils.RatarmountError: Mount source does not exist: /build/t...
+    "tests/test_AutoMountLayer.py"
   ];
 
+  # Tests with issues
   disabledTests = [
-    # Tests with issues
-    "test_file_versions"
     "test_stream_compressed"
     "test_chimera_file"
-    "test_URLContextManager"
     "test_URL"
   ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9377,6 +9377,8 @@ self: super: with self; {
 
   mficlient = callPackage ../development/python-modules/mficlient { };
 
+  mfusepy = callPackage ../development/python-modules/mfusepy { };
+
   mhcflurry = callPackage ../development/python-modules/mhcflurry { };
 
   mhcgnomes = callPackage ../development/python-modules/mhcgnomes { };


### PR DESCRIPTION
Resolves #452758

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
