### PR TITLE
todds: fix cuda build, cleanup

### DIFF
--- a/pkgs/by-name/to/todds/package.nix
+++ b/pkgs/by-name/to/todds/package.nix
@@ -1,16 +1,30 @@
 {
   lib,
+  config,
   stdenv,
+  fetchFromGitHub,
+
+  # nativeBuildInputs
   cmake,
+  ispc,
   ninja,
   pkg-config,
-  ispc,
+  cudaPackages,
+
+  # buildInputs
   boost,
   fmt,
   hyperscan,
-  opencv,
   onetbb,
-  fetchFromGitHub,
+  opencv,
+
+  # tests
+  versionCheckHook,
+
+  # passthru
+  nix-update-script,
+
+  cudaSupport ? config.cudaSupport,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "todds";
@@ -22,30 +36,44 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "todds-encoder";
     repo = "todds";
     tag = finalAttrs.version;
-    hash = "sha256-nyYFYym9ZZskkaTPV30+QavdqpvVopnIXXZC6zkeu7c=";
     fetchSubmodules = true;
+    hash = "sha256-nyYFYym9ZZskkaTPV30+QavdqpvVopnIXXZC6zkeu7c=";
   };
 
   nativeBuildInputs = [
     cmake
+    ispc
     ninja
     pkg-config
-    ispc
+  ]
+  ++ lib.optionals cudaSupport [
+    (lib.getBin cudaPackages.cuda_nvcc)
   ];
 
   buildInputs = [
     boost
     fmt
     hyperscan
-    opencv
     onetbb
+    opencv
+  ]
+  ++ lib.optionals cudaSupport [
+    cudaPackages.cuda_cudart
   ];
 
   strictDeps = true;
 
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "CPU-based DDS encoder optimized for fast batch conversions with high encoding quality";
     homepage = "https://github.com/todds-encoder/todds";
+    changelog = "https://github.com/todds-encoder/todds/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mpl20;
     maintainers = with lib.maintainers; [ weirdrock ];
     mainProgram = "todds";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Required by `opencv` when `cudaSupport = true`.

cc @weirdrock

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
