### PR TITLE
topydo: modernize Python packaging

### DIFF
--- a/pkgs/by-name/to/topydo/package.nix
+++ b/pkgs/by-name/to/topydo/package.nix
@@ -1,14 +1,14 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchFromGitHub,
   glibcLocales,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "topydo";
   version = "0.16";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "topydo";
@@ -17,7 +17,17 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     hash = "sha256-f31tp4VBMv1usViYN50IaGeyQpo3oRSf/WDz99UEpss=";
   };
 
-  propagatedBuildInputs = with python3.pkgs; [
+  postPatch = ''
+    # Strip deprecated pytest-runner from pyproject.toml build requirements
+    substituteInPlace pyproject.toml \
+      --replace-fail 'requires = ["setuptools", "wheel", "pytest-runner"]' 'requires = ["setuptools", "wheel"]'
+  '';
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
     arrow
     glibcLocales
     icalendar
@@ -26,7 +36,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     watchdog
   ];
 
-  nativeCheckInputs = with python3.pkgs; [
+  nativeCheckInputs = with python3Packages; [
     freezegun
     unittestCheckHook
   ];
@@ -43,7 +53,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     description = "Cli todo application compatible with the todo.txt format";
     mainProgram = "topydo";
     homepage = "https://github.com/topydo/topydo";
-    changelog = "https://github.com/topydo/topydo/blob/${finalAttrs.src.rev}/CHANGES.md";
+    changelog = "https://github.com/topydo/topydo/blob/${finalAttrs.src.tag}/CHANGES.md";
     license = lib.licenses.gpl3Plus;
     maintainers = [ ];
   };


### PR DESCRIPTION
This pull request refactors the `topydo` package definition to use the modern Python packaging style in Nix, aligning it with current best practices and improving maintainability. The changes include switching to `pyproject`-based builds, updating dependencies, and cleaning up deprecated build requirements.

**Migration to modern Python packaging:**

* Switched from using `python3.pkgs.buildPythonApplication` to `python3Packages.buildPythonApplication`, and enabled `pyproject`-based builds for better compatibility with current Python packaging standards.
* Replaced the deprecated `format = "setuptools"` with `pyproject = true`, and introduced `build-system` and `dependencies` using `python3Packages` instead of the older `propagatedBuildInputs`.

**Build and test improvements:**

* Added a `postPatch` step to strip the deprecated `pytest-runner` from `pyproject.toml` build requirements, ensuring a cleaner build process.
* Updated `nativeCheckInputs` to use `python3Packages` for consistency.

**Metadata correction:**

* Fixed the `changelog` URL to use the correct attribute (`tag` instead of `rev`) for more accurate referencing.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
