### PR TITLE
treewide: mark as broken haskellPackages last successful Hydra build from 2015 to 2024

### DIFF
--- a/pkgs/development/haskell-modules/configuration-darwin.nix
+++ b/pkgs/development/haskell-modules/configuration-darwin.nix
@@ -346,6 +346,33 @@ self: super:
           "/rdrand/rngAddEntropy/"
         ]);
     }) super.botan-low;
+
+    # 2025-11-07: Broken since 2015 - https://github.com/NixOS/nixpkgs/pull/459465
+    hamid = markBroken super.hamid;
+    # 2025-11-07: Broken since 2016 - https://github.com/NixOS/nixpkgs/pull/459465
+    huckleberry = markBroken super.huckleberry;
+    log = markBroken super.log;
+    # 2025-11-07: Broken since 2017 - https://github.com/NixOS/nixpkgs/pull/459465
+    gtk-traymanager = markBroken super.gtk-traymanager;
+    pipes-zlib = markBroken super.pipes-zlib;
+    pthread = markBroken super.pthread;
+    # 2025-11-07: Broken since 2018 - https://github.com/NixOS/nixpkgs/pull/459465
+    system-linux-proc = markBroken super.system-linux-proc;
+    # 2025-11-07: Broken since 2021 - https://github.com/NixOS/nixpkgs/pull/459465
+    gerrit = markBroken super.gerrit;
+    # 2025-11-07: Broken since 2023 - https://github.com/NixOS/nixpkgs/pull/459465
+    copilot-c99 = markBroken super.copilot-c99;
+    error-codes = markBroken super.error-codes;
+    epub-metadata = markBroken super.epub-metadata;
+    HsHTSLib = markBroken super.HsHTSLib;
+    zlib-bytes = markBroken super.zlib-bytes;
+    # 2025-11-07: Broken since 2024 - https://github.com/NixOS/nixpkgs/pull/459465
+    bytestring-encoding = markBroken super.bytestring-encoding;
+    duckdb-haskell = markBroken super.duckdb-haskell;
+    freetype2 = markBroken super.freetype2;
+    memzero = markBroken super.memzero;
+    rawfilepath = markBroken super.rawfilepath;
+    reform-blaze = markBroken super.reform-blaze;
   }
   // lib.optionalAttrs pkgs.stdenv.hostPlatform.isAarch64 {
     # aarch64-darwin
@@ -448,5 +475,8 @@ self: super:
         "!/issue-108/"
       ];
     }) super.ad;
+
+    # 2025-11-07: Broken since 2024 - https://github.com/NixOS/nixpkgs/pull/459465
+    hlibgit2 = markBroken super.hlibgit2;
   }
 )

--- a/pkgs/development/haskell-modules/configuration-darwin.nix
+++ b/pkgs/development/haskell-modules/configuration-darwin.nix
@@ -351,7 +351,6 @@ self: super:
     hamid = markBroken super.hamid;
     # 2025-11-07: Broken since 2016 - https://github.com/NixOS/nixpkgs/pull/459465
     huckleberry = markBroken super.huckleberry;
-    log = markBroken super.log;
     # 2025-11-07: Broken since 2017 - https://github.com/NixOS/nixpkgs/pull/459465
     gtk-traymanager = markBroken super.gtk-traymanager;
     pipes-zlib = markBroken super.pipes-zlib;
@@ -367,12 +366,12 @@ self: super:
     HsHTSLib = markBroken super.HsHTSLib;
     zlib-bytes = markBroken super.zlib-bytes;
     # 2025-11-07: Broken since 2024 - https://github.com/NixOS/nixpkgs/pull/459465
+    # https://github.com/msakai/bytestring-encoding/issues/15
     bytestring-encoding = markBroken super.bytestring-encoding;
     duckdb-haskell = markBroken super.duckdb-haskell;
     freetype2 = markBroken super.freetype2;
     memzero = markBroken super.memzero;
     rawfilepath = markBroken super.rawfilepath;
-    reform-blaze = markBroken super.reform-blaze;
   }
   // lib.optionalAttrs pkgs.stdenv.hostPlatform.isAarch64 {
     # aarch64-darwin

--- a/pkgs/development/haskell-modules/configuration-darwin.nix
+++ b/pkgs/development/haskell-modules/configuration-darwin.nix
@@ -355,8 +355,6 @@ self: super:
     gtk-traymanager = markBroken super.gtk-traymanager;
     pipes-zlib = markBroken super.pipes-zlib;
     pthread = markBroken super.pthread;
-    # 2025-11-07: Broken since 2018 - https://github.com/NixOS/nixpkgs/pull/459465
-    system-linux-proc = markBroken super.system-linux-proc;
     # 2025-11-07: Broken since 2021 - https://github.com/NixOS/nixpkgs/pull/459465
     gerrit = markBroken super.gerrit;
     # 2025-11-07: Broken since 2023 - https://github.com/NixOS/nixpkgs/pull/459465

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -765,6 +765,7 @@ unsupported-platforms:
   sockets:                                      [ platforms.darwin ] # depends on posix-api
   spade:                                        [ platforms.darwin ] # depends on sdl2-mixer, which doesn't work on darwin
   synthesizer-alsa:                             [ platforms.darwin ]
+  system-linux-proc:                            [ platforms.darwin ]
   taffybar:                                     [ platforms.darwin ]
   termonad:                                     [ platforms.darwin ]
   tokyotyrant-haskell:                          [ platforms.darwin ]


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/457852

Actions Taken:
- Identified haskellPackages Darwin builds on Hydra that were last successful from 2015 to 2024.
- Checked each identified build to see if it currently has any open Pull Requests.
- Verified whether the failures for these builds are due to being outdated.

```
haskellPackages.bytestring-encoding
haskellPackages.copilot-c99
haskellPackages.duckdb-haskell
haskellPackages.epub-metadata
haskellPackages.error-codes
haskellPackages.freetype2
haskellPackages.gerrit
haskellPackages.gtk-traymanager
haskellPackages.hamid
haskellPackages.hlibgit2
haskellPackages.HsHTSLib
haskellPackages.huckleberry
haskellPackages.log
haskellPackages.memzero
haskellPackages.pipes-zlib
haskellPackages.pthread
haskellPackages.rawfilepath
haskellPackages.reform-blaze
haskellPackages.system-linux-proc
haskellPackages.zlib-bytes
```
Given how cryptic and niche the troubleshooting for Darwin failures can be, and considering the extended period these builds have been failing, this PR marks them as broken.

This action is necessary to conserve compute resources and avoid further waste on inevitable build failures.

Hydra logs:
#### 2024
https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.bytestring-encoding.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.bytestring-encoding.aarch64-darwin

https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.duckdb-haskell.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.duckdb-haskell.aarch64-darwin

https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.freetype2.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.freetype2.aarch64-darwin

https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.hlibgit2.x86_64-darwin (aarch64 seems fine)

https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.memzero.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.memzero.aarch64-darwin (no last know)

https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.rawfilepath.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.rawfilepath.aarch64-darwin

https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.reform-blaze.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.reform-blaze.aarch64-darwin

#### 2023
https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.HsHTSLib.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.HsHTSLib.aarch64-darwin

https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.copilot-c99.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.copilot-c99.aarch64-darwin

https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.epub-metadata.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.epub-metadata.aarch64-darwin

https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.error-codes.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.error-codes.aarch64-darwin

https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.zlib-bytes.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.zlib-bytes.aarch64-darwin

#### 2021
https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.gerrit.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.gerrit.aarch64-darwin (no last know)

#### 2018
https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.system-linux-proc.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.system-linux-proc.aarch64-darwin (no last know)

#### 2017
https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.gtk-traymanager.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.gtk-traymanager.aarch64-darwin (no last know)

https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.pipes-zlib.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.pipes-zlib.aarch64-darwin (no last know)

https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.pthread.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.pthread.aarch64-darwin (no last know)

#### 2016
https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.huckleberry.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.huckleberry.aarch64-darwin (no last know)

https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.log.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.log.aarch64-darwin (no last know)

#### 2015
https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.hamid.x86_64-darwin
https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.hamid.aarch64-darwin (no last know)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
