### PR TITLE
fetchurl: fix overrideAttrs working as expect with hash

### DIFF
--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -190,7 +190,7 @@ lib.extendMkDerivation {
         if hash != "" then
           {
             outputHashAlgo = null;
-            outputHash = hash;
+            outputHash = finalAttrs.hash;
           }
         else if outputHash != "" then
           if outputHashAlgo != "" then
@@ -200,17 +200,17 @@ lib.extendMkDerivation {
         else if sha512 != "" then
           {
             outputHashAlgo = "sha512";
-            outputHash = sha512;
+            outputHash = finalAttrs.sha512;
           }
         else if sha256 != "" then
           {
             outputHashAlgo = "sha256";
-            outputHash = sha256;
+            outputHash = finalAttrs.sha256;
           }
         else if sha1 != "" then
           {
             outputHashAlgo = "sha1";
-            outputHash = sha1;
+            outputHash = finalAttrs.sha1;
           }
         else if cacert != null then
           {
@@ -260,6 +260,14 @@ lib.extendMkDerivation {
 
       # New-style output content requirements.
       inherit (hash_) outputHashAlgo outputHash;
+
+      # Make overrideAttrs behave as expected
+      inherit
+        hash
+        sha1
+        sha256
+        sha512
+        ;
 
       # Disable TLS verification only when we know the hash and no credentials are
       # needed to access the resource


### PR DESCRIPTION
The following example did not work before and does with this change:

```
(fetchurl {
  url = "...";
  hash = "sha256-..."
}).overrideAttrs (_: {
  hash = lib.fakeHash;
}
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
