### PR TITLE
ocamlPackages.pgsolver: 4.1 -> 4.4

### DIFF
--- a/pkgs/development/ocaml-modules/pgsolver/default.nix
+++ b/pkgs/development/ocaml-modules/pgsolver/default.nix
@@ -1,45 +1,36 @@
 {
   lib,
   fetchFromGitHub,
-  fetchpatch,
-  buildOasisPackage,
-  ounit,
-  tcs-lib,
+  buildDunePackage,
   extlib,
   ocaml-sat-solvers,
+  tcs-lib,
 }:
 
-buildOasisPackage rec {
+buildDunePackage (finalAttrs: {
   pname = "pgsolver";
-  version = "4.1";
+  version = "4.4";
 
   src = fetchFromGitHub {
     owner = "tcsprojects";
     repo = "pgsolver";
-    rev = "v${version}";
-    sha256 = "16skrn8qql9djpray25xv66rjgfl20js5wqnxyq1763nmyizyj8a";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-VQWXvZXfGHCfzz46aARyFXO/xlJ/7s39HFIfisEamXw=";
   };
 
-  # Compatibility with ocaml-sat-solvers 0.8
-  patches = fetchpatch {
-    url = "https://github.com/tcsprojects/pgsolver/commit/e57a4fc5c8050b8d4ada5583a6c65ecf8cd65141.patch";
-    hash = "sha256-QFKxWByptnCl1SfleNASyXmKM2gkh1OE66L8PAZX+TU=";
-    includes = [
-      "src/solvers/*.ml"
-      "src/tools/*.ml"
-    ];
-  };
-
-  # Compatibility with tcs-lib ≥ 0.6
-  postPatch = ''
-    substituteInPlace _oasis --replace-fail TCSLib tcs-lib
+  # upstream missing `public_names` within `executables` stanza
+  # adding this back to automatically install binaries
+  patchPhase = ''
+    runHook prePatch
+    sed -i '/^ (names /{ p; s/names/public_names/ }' src/apps/pgsolver/dune
+    sed -i '/^ (names /{ p; s/names/public_names/ }' src/apps/tools/dune
+    runHook postPatch
   '';
 
-  buildInputs = [ ounit ];
   propagatedBuildInputs = [
     extlib
-    tcs-lib
     ocaml-sat-solvers
+    tcs-lib
   ];
 
   meta = {
@@ -47,6 +38,6 @@ buildOasisPackage rec {
     homepage = "https://github.com/tcsprojects/pgsolver";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ mgttlinger ];
-    mainProgram = "pgsolver-bin";
+    mainProgram = "pgsolver";
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/tcsprojects/pgsolver/releases/tag/v4.4

pgsolver bump, and... they dropped oasis

so oasis deprecation warning is added to address https://github.com/NixOS/nixpkgs/pull/446007#issuecomment-3333650756

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
