### PR TITLE
openrazer: 3.10.3 -> 3.11.0

### DIFF
--- a/pkgs/development/python-modules/openrazer/common.nix
+++ b/pkgs/development/python-modules/openrazer/common.nix
@@ -1,13 +1,13 @@
 { lib, fetchFromGitHub }:
 rec {
-  version = "3.10.3";
+  version = "3.11.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "openrazer";
     repo = "openrazer";
     tag = "v${version}";
-    hash = "sha256-M5g3Rn9WuyudhWQfDooopjexEgGVB0rzfJsPg+dqwn4=";
+    hash = "sha256-pk3nghd16jhdf7zokwMzBGwGtBU7ta4nSHsOoGxjD4w=";
   };
 
   meta = {


### PR DESCRIPTION
Updates OpenRazer to 3.11.0.
This release adds support for several new Razer devices and includes multiple bug fixes and internal improvements.

* **New Device Support:**
  * Razer Blade 14/16/18 (2025)
  * Razer Pro Click V2 / V2 Vertical Edition
  * Razer Firefly V2 Pro
  * Razer Tomahawk ATX
  * Razer Huntsman V3 Pro TKL
  * Razer Basilisk V3 Pro 35K Phantom Green Edition
  * Razer DeathAdder V4 Pro (wired & wireless)
  * Razer BlackWidow V4 Mini HyperSpeed
* **Fixes & Improvements:**
  * `razerkbd`: handle 48-byte raw events, fix Ornata V3 Tenkeyless keymap
  * `razermouse`: fix compile warning with `W=2`
  * `daemon`: introduce `DRIVER_MODE`, fix mypy issues, and clean up inheritance
  * enable driver mode for Basilisk V3 X HyperSpeed
  * fix media keys for DeathStalker V2 Pro
  * remove redundant transaction ID defaults

Upstream Changelog: [https://github.com/openrazer/openrazer/releases/tag/v3.11.0](https://github.com/openrazer/openrazer/releases/tag/v3.11.0)

* Built on platform:
  * [x] x86_64-linux
* Tested, as applicable:
  * [x] basic functionality tested (`razer-daemon`, device detection)

