### PR TITLE
python3Packages.click: fix SystemExit(1) when using click.File's stdin support

### DIFF
--- a/pkgs/development/python-modules/click/default.nix
+++ b/pkgs/development/python-modules/click/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   importlib-metadata,
   pytestCheckHook,
 
@@ -25,6 +26,15 @@ buildPythonPackage rec {
     tag = version;
     hash = "sha256-3FfLKwpfkiGfY2+H2fQoZwLBqfPlV46xw2Bc4YEsyps=";
   };
+
+  patches = [
+    # https://github.com/pallets/click/pull/2940
+    (fetchpatch {
+      name = "fix-SystemExit-when-using-stdin.patch";
+      url = "https://github.com/pallets/click/commit/93c6966eb3a575c2b600434d1cc9f4b3aee505ac.patch";
+      hash = "sha256-DkVF0JnKbcsdAhgVjWJEDZZ8vr2sf6wba8P3SyRUy6o=";
+    })
+  ];
 
   build-system = [ flit-core ];
 

--- a/pkgs/development/python-modules/swh-core/default.nix
+++ b/pkgs/development/python-modules/swh-core/default.nix
@@ -18,6 +18,7 @@
   hypothesis,
   iso8601,
   lzip,
+  moto,
   msgpack,
   postgresql,
   postgresqlTestHook,
@@ -29,7 +30,9 @@
   pytest-postgresql,
   pytz,
   requests-mock,
+  swh-model,
   systemd,
+  tqdm,
   types-deprecated,
   types-psycopg2,
   types-pytz,
@@ -41,7 +44,7 @@
 
 buildPythonPackage rec {
   pname = "swh-core";
-  version = "4.5.2";
+  version = "4.6.0";
   pyproject = true;
 
   src = fetchFromGitLab {
@@ -50,12 +53,17 @@ buildPythonPackage rec {
     owner = "devel";
     repo = "swh-core";
     tag = "v${version}";
-    hash = "sha256-yNWij9GclQCysQe9Bukr4cHlZgSQqLAuX1KwGWzAK+0=";
+    hash = "sha256-dI+xfj0DnUbBdYIVycyJQg3B/jnH/eg/Ju8YX2k8Qkc=";
   };
 
   build-system = [
     setuptools
     setuptools-scm
+  ];
+
+  pythonRelaxDeps = [
+    # we patched click 8.2.1
+    "click"
   ];
 
   dependencies = [
@@ -79,6 +87,7 @@ buildPythonPackage rec {
     hypothesis
     iso8601
     lzip
+    moto
     msgpack
     postgresql
     postgresqlTestHook
@@ -90,7 +99,9 @@ buildPythonPackage rec {
     pytest-postgresql
     pytz
     requests-mock
+    swh-model
     systemd
+    tqdm
     types-deprecated
     types-psycopg2
     types-pytz
@@ -111,6 +122,7 @@ buildPythonPackage rec {
   ];
 
   meta = {
+    changelog = "https://gitlab.softwareheritage.org/swh/devel/swh-core/-/tags/${src.tag}";
     description = "Low-level utilities and helpers used by almost all other modules in the stack";
     homepage = "https://gitlab.softwareheritage.org/swh/devel/swh-core";
     license = lib.licenses.gpl3Only;

--- a/pkgs/development/python-modules/swh-objstorage/default.nix
+++ b/pkgs/development/python-modules/swh-objstorage/default.nix
@@ -18,7 +18,7 @@
   tenacity,
   swh-core,
   swh-model,
-  swh-perfecthash,
+  swh-shard,
   aiohttp,
   azure-core,
   azure-storage-blob,
@@ -40,7 +40,7 @@
 
 buildPythonPackage rec {
   pname = "swh-objstorage";
-  version = "4.0.0";
+  version = "5.1.0";
   pyproject = true;
 
   src = fetchFromGitLab {
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     owner = "devel";
     repo = "swh-objstorage";
     tag = "v${version}";
-    hash = "sha256-c0ZH2PMT9DVnpTV5PDyX0Yw4iHiJSolEgq/bMXEwXG8=";
+    hash = "sha256-NnNT9Lt/LGDIJpUmfkfPn6JnF3k8Usf2UVa88zHPKlg=";
   };
 
   build-system = [
@@ -71,7 +71,7 @@ buildPythonPackage rec {
     tenacity
     swh-core
     swh-model
-    swh-perfecthash
+    swh-shard
   ];
 
   preCheck = ''
@@ -110,6 +110,7 @@ buildPythonPackage rec {
   ];
 
   meta = {
+    changelog = "https://gitlab.softwareheritage.org/swh/devel/swh-objstorage/-/tags/${src.tag}";
     description = "Content-addressable object storage for the Software Heritage project";
     homepage = "https://gitlab.softwareheritage.org/swh/devel/swh-objstorage";
     license = lib.licenses.gpl3Only;

--- a/pkgs/development/python-modules/swh-scanner/default.nix
+++ b/pkgs/development/python-modules/swh-scanner/default.nix
@@ -81,8 +81,9 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    description = "Implementation of the Data model of the Software Heritage project, used to archive source code artifacts";
-    homepage = "https://gitlab.softwareheritage.org/swh/devel/swh-model";
+    changelog = "https://gitlab.softwareheritage.org/swh/devel/swh-scanner/-/tags/${src.tag}";
+    description = "Source code scanner to analyze code bases and compare them with source code artifacts archived by Software Heritage";
+    homepage = "https://gitlab.softwareheritage.org/swh/devel/swh-scanner";
     license = lib.licenses.gpl3Only;
     maintainers = [ ];
   };

--- a/pkgs/development/python-modules/swh-scanner/default.nix
+++ b/pkgs/development/python-modules/swh-scanner/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitLab,
-  fetchpatch,
   setuptools,
   setuptools-scm,
   requests,
@@ -35,15 +34,6 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-baUUuYFapBD7iuDaDP8CSR9f4glVZcS5qBpZddVf7z8=";
   };
-
-  patches = [
-    # To be removed at the next release
-    # See https://gitlab.softwareheritage.org/swh/devel/swh-scanner/-/merge_requests/160
-    (fetchpatch {
-      url = "https://gitlab.softwareheritage.org/swh/devel/swh-scanner/-/commit/0eb273475826b0074844c7619b767c052562cfe4.patch";
-      hash = "sha256-i3hpaQJmHpIYgix+/npICQGtJ/IKVRXcCTm2O1VsR9M=";
-    })
-  ];
 
   build-system = [
     setuptools
@@ -78,6 +68,8 @@ buildPythonPackage rec {
   disabledTestPaths = [
     # pytestRemoveBytecodePhase fails with: "error (ignored): error: opening directory "/tmp/nix-build-python3.12-swh-scanner-0.8.3.drv-5/build/pytest-of-nixbld/pytest-0/test_randomdir_policy_info_cal0/big-directory/dir/dir/dir/ ......"
     "swh/scanner/tests/test_policy.py"
+    # TypeError: CliRunner.__init__() got an unexpected keyword argument 'mix_stderr'
+    "swh/scanner/tests/test_cli.py"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/swh-scheduler/default.nix
+++ b/pkgs/development/python-modules/swh-scheduler/default.nix
@@ -30,7 +30,7 @@
 
 buildPythonPackage rec {
   pname = "swh-scheduler";
-  version = "3.1.0";
+  version = "3.3.0";
   pyproject = true;
 
   src = fetchFromGitLab {
@@ -39,12 +39,17 @@ buildPythonPackage rec {
     owner = "devel";
     repo = "swh-scheduler";
     tag = "v${version}";
-    hash = "sha256-YpMHeZVHK8IPIiuBaPNR0D/yB9lIQ3DK7NEAiBmjWpA=";
+    hash = "sha256-Kv5QH3sj/InKOSjxGtwVxtoAluHx5eIxO5GqcbOs0NY=";
   };
 
   build-system = [
     setuptools
     setuptools-scm
+  ];
+
+  pythonRelaxDeps = [
+    # we patched click 8.2.1
+    "click"
   ];
 
   dependencies = [
@@ -80,6 +85,7 @@ buildPythonPackage rec {
   disabledTests = [ "test_setup_log_handler_with_env_configuration" ];
 
   meta = {
+    changelog = "https://gitlab.softwareheritage.org/swh/devel/swh-scheduler/-/tags/${src.tag}";
     description = "Job scheduler for the Software Heritage project";
     homepage = "https://gitlab.softwareheritage.org/swh/devel/swh-scheduler";
     license = lib.licenses.gpl3Only;

--- a/pkgs/development/python-modules/swh-shard/default.nix
+++ b/pkgs/development/python-modules/swh-shard/default.nix
@@ -1,0 +1,72 @@
+{
+  buildPythonPackage,
+  click,
+  cmake,
+  cmph,
+  fetchFromGitLab,
+  lib,
+  ninja,
+  pkg-config,
+  pybind11,
+  pytest-mock,
+  pytestCheckHook,
+  scikit-build-core,
+  setuptools-scm,
+}:
+
+buildPythonPackage rec {
+  pname = "swh-shard";
+  version = "2.2.0";
+  pyproject = true;
+
+  src = fetchFromGitLab {
+    domain = "gitlab.softwareheritage.org";
+    group = "swh";
+    owner = "devel";
+    repo = "swh-shard";
+    tag = "v${version}";
+    hash = "sha256-97oZ+Wa8GmyL2V4CnlSvaTbQZJ+mPbg6uVmWd0oxv1Q=";
+  };
+
+  build-system = [
+    cmake
+    ninja
+    pybind11
+    scikit-build-core
+    setuptools-scm
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  buildInputs = [
+    cmph
+  ];
+
+  dependencies = [
+    click
+  ];
+
+  pythonImportsCheck = [ "swh.shard" ];
+
+  nativeCheckInputs = [
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    # import from $out
+    rm src/swh/shard/*.py
+  '';
+
+  meta = {
+    changelog = "https://gitlab.softwareheritage.org/swh/devel/swh-shard/-/tags/v2.2.0";
+    description = "Shard File Format for the Software Heritage Object Storage";
+    homepage = "https://gitlab.softwareheritage.org/swh/devel/swh-shard";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.dotlambda ];
+  };
+}

--- a/pkgs/development/python-modules/swh-storage/default.nix
+++ b/pkgs/development/python-modules/swh-storage/default.nix
@@ -12,6 +12,8 @@
   iso8601,
   mypy-extensions,
   psycopg,
+  psycopg-pool,
+  pyasyncore,
   redis,
   tenacity,
   swh-core,
@@ -30,7 +32,7 @@
 
 buildPythonPackage rec {
   pname = "swh-storage";
-  version = "3.1.0";
+  version = "4.1.0";
   pyproject = true;
 
   src = fetchFromGitLab {
@@ -39,12 +41,17 @@ buildPythonPackage rec {
     owner = "devel";
     repo = "swh-storage";
     tag = "v${version}";
-    hash = "sha256-Bxwc8OccmqadLjHtmhToHBYHGkD7Fw3Cl3go9VLV/Bs=";
+    hash = "sha256-JXeHE/wZ3Wcf1I1eGyCNlCGsreiQH6kCYZoDXV1h0A0=";
   };
 
   build-system = [
     setuptools
     setuptools-scm
+  ];
+
+  pythonRelaxDeps = [
+    # we patched click 8.2.1
+    "click"
   ];
 
   dependencies = [
@@ -56,13 +63,14 @@ buildPythonPackage rec {
     iso8601
     mypy-extensions
     psycopg
+    psycopg-pool
+    pyasyncore
     redis
     tenacity
     swh-core
     swh-model
     swh-objstorage
-  ]
-  ++ psycopg.optional-dependencies.pool;
+  ];
 
   pythonImportsCheck = [ "swh.storage" ];
 
@@ -88,11 +96,13 @@ buildPythonPackage rec {
     "swh/storage/tests/test_cassandra_migration.py"
     "swh/storage/tests/test_cassandra_ttl.py"
     "swh/storage/tests/test_cli_cassandra.py"
+    "swh/storage/tests/test_cli_object_references_cassandra.py"
     # Failing tests
     "swh/storage/tests/test_cli_object_references.py"
   ];
 
   meta = {
+    changelog = "https://gitlab.softwareheritage.org/swh/devel/swh-storage/-/tags/${src.tag}";
     description = "Abstraction layer over the archive, allowing to access all stored source code artifacts as well as their metadata";
     homepage = "https://gitlab.softwareheritage.org/swh/devel/swh-storage";
     license = lib.licenses.gpl3Only;

--- a/pkgs/development/python-modules/swh-web-client/default.nix
+++ b/pkgs/development/python-modules/swh-web-client/default.nix
@@ -37,6 +37,11 @@ buildPythonPackage rec {
     setuptools-scm
   ];
 
+  pythonRelaxDeps = [
+    # we patched click 8.2.1
+    "click"
+  ];
+
   dependencies = [
     click
     dateutils

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18077,6 +18077,8 @@ self: super: with self; {
 
   swh-scheduler = callPackage ../development/python-modules/swh-scheduler { };
 
+  swh-shard = callPackage ../development/python-modules/swh-shard { };
+
   swh-storage = callPackage ../development/python-modules/swh-storage { };
 
   swh-web-client = callPackage ../development/python-modules/swh-web-client { };


### PR DESCRIPTION
This fixes upstream issue https://github.com/pallets/click/issues/2939 which e.g. breaks swh.
See also https://github.com/NixOS/nixpkgs/pull/454434#issuecomment-3485685749.
Should I target staging-next?

ZHF: https://github.com/NixOS/nixpkgs/issues/457852

closes https://github.com/NixOS/nixpkgs/pull/458890
cc @drupol who I can't request a review from (maybe they blocked me?)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
