### PR TITLE
check-meta: init packageType

### DIFF
--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -161,6 +161,48 @@
   "julec-hook-variables": [
     "index.html#julec-hook-variables"
   ],
+  "lib.packageTypes.application": [
+    "index.html#lib.packageTypes.application"
+  ],
+  "lib.packageTypes.container": [
+    "index.html#lib.packageTypes.container"
+  ],
+  "lib.packageTypes.data": [
+    "index.html#lib.packageTypes.data"
+  ],
+  "lib.packageTypes.device-driver": [
+    "index.html#lib.packageTypes.device-driver"
+  ],
+  "lib.packageTypes.documentation": [
+    "index.html#lib.packageTypes.documentation"
+  ],
+  "lib.packageTypes.executable": [
+    "index.html#lib.packageTypes.executable"
+  ],
+  "lib.packageTypes.file": [
+    "index.html#lib.packageTypes.file"
+  ],
+  "lib.packageTypes.filesystem-image": [
+    "index.html#lib.packageTypes.filesystem-image"
+  ],
+  "lib.packageTypes.firmware": [
+    "index.html#lib.packageTypes.firmware"
+  ],
+  "lib.packageTypes.framework": [
+    "index.html#lib.packageTypes.framework"
+  ],
+  "lib.packageTypes.library": [
+    "index.html#lib.packageTypes.library"
+  ],
+  "lib.packageTypes.operating-system": [
+    "index.html#lib.packageTypes.operating-system"
+  ],
+  "lib.packageTypes.patch": [
+    "index.html#lib.packageTypes.patch"
+  ],
+  "lib.packageTypes.runtime": [
+    "index.html#lib.packageTypes.runtime"
+  ],
   "major-ghc-deprecation": [
     "index.html#major-ghc-deprecation"
   ],
@@ -276,6 +318,9 @@
   ],
   "sec-meta-identifiers-cpe": [
     "index.html#sec-meta-identifiers-cpe"
+  ],
+  "sec-meta-package-type": [
+    "index.html#sec-meta-package-type"
   ],
   "sec-modify-via-packageOverrides": [
     "index.html#sec-modify-via-packageOverrides"

--- a/doc/stdenv/meta.chapter.md
+++ b/doc/stdenv/meta.chapter.md
@@ -249,6 +249,68 @@ Code to be executed on a peripheral device or embedded controller, built by a th
 
 Code to run on a VM interpreter or JIT compiled into bytecode by a third party. This includes packages which download Java `.jar` files from another source.
 
+## Package Types {#sec-meta-package-type}
+
+As derivations can output various kinds of artifacts, it is difficult to determinate what kind of package a derivation is.
+To solve this, the `packageType` attribute in `meta` exists. This takes the form of a list of attributes of strings.
+Various package types are already defined in `lib.packageTypes`. These support [CycloneDX SBOM](https://cyclonedx.org) & [SPDX SBOM](https://spdx.dev/) but may support more formats in the future.
+
+### `lib.packageTypes.application` {#lib.packageTypes.application}
+
+A generic application, commonly a GUI or CLI tool.
+
+### `lib.packageTypes.framework` {#lib.packageTypes.framework}
+
+A framework used for developing or running applications.
+
+### `lib.packageTypes.library` {#lib.packageTypes.library}
+
+A library, applications and frameworks usually depends on these.
+
+### `lib.packageTypes.container` {#lib.packageTypes.container}
+
+A derivation which contains a runtime format. An example would be a Docker or OCI container as a tarball.
+
+### `lib.packageTypes.runtime` {#lib.packageTypes.runtime}
+
+A derivation which contains a runtime environment. A wrapped environment produced by something like `buildEnv` is an example of this.
+
+### `lib.packageTypes.operating-system` {#lib.packageTypes.operating-system}
+
+A software operating system, a NixOS toplevel derivation is an example of an operating-system type.
+
+### `lib.packageTypes.firmware` {#lib.packageTypes.firmware}
+
+Firmware is a special type of software which provides low-level control of hardware.
+
+### `lib.packageTypes.device-driver` {#lib.packageTypes.device-driver}
+
+A device driver is a piece of software which is loaded in to provide software access to various hardware devices.
+
+### `lib.packageTypes.file` {#lib.packageTypes.file}
+
+A derivation which outputs a file.
+
+### `lib.packageTypes.data` {#lib.packageTypes.data}
+
+A derivation containing data.
+
+### `lib.packageTypes.documentation` {#lib.packageTypes.documentation}
+
+A derivation containing documentation. Maps to the `documentation` purpose in SPDX and the `file` type in CycloneDX.
+
+### `lib.packageTypes.executable` {#lib.packageTypes.executable}
+
+A derivation containing documentation. Maps to the `executable` purpose in SPDX and the `application` type in CycloneDX.
+
+### `lib.packageTypes.filesystem-image` {#lib.packageTypes.filesystem-image}
+
+A derivation containing documentation. Maps to the `filesystemImage` purpose in SPDX and the `file` type in CycloneDX.
+
+### `lib.packageTypes.patch` {#lib.packageTypes.patch}
+
+A derivation containing documentation. Maps to the `patch` purpose in SPDX and the `file` type in CycloneDX.
+
 ## Software identifiers {#sec-meta-identifiers}
 
 Package's `meta.identifiers` attribute specifies information about software identifiers associated with this package. Software identifiers are used, for example:

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -75,6 +75,7 @@ let
       # constants
       licenses = callLibs ./licenses.nix;
       sourceTypes = callLibs ./source-types.nix;
+      packageTypes = callLibs ./package-types.nix;
       systems = callLibs ./systems;
 
       # serialization

--- a/lib/package-types.nix
+++ b/lib/package-types.nix
@@ -1,0 +1,52 @@
+{ lib }:
+# Types of packages
+# A series of attribute sets which map different package types between various SBOM formats.
+# Supporting:
+# - CycloneDX Component Type: https://cyclonedx.org/docs/1.7/json/#components_items_type
+# - SPDX Software Purpose vocab: https://spdx.github.io/spdx-spec/v3.0.1/model/Software/Vocabularies/SoftwarePurpose/
+lib.genAttrs
+  [
+    "application"
+    "framework"
+    "library"
+    "container"
+    "platform"
+    "device"
+    "firmware"
+    "file"
+    "data"
+  ]
+  (name: {
+    cyclonedx = name;
+    spdx = name;
+  })
+// {
+  operating-system = {
+    cyclonedx = "operating-system";
+    spdx = "operatingSystem";
+  };
+  device-driver = {
+    cyclonedx = "device-driver";
+    spdx = "deviceDriver";
+  };
+  disk-image = {
+    cyclonedx = "file";
+    spdx = "diskImage";
+  };
+  documentation = {
+    cyclonedx = "file";
+    spdx = "documentation";
+  };
+  executable = {
+    cyclonedx = "application";
+    spdx = "executable";
+  };
+  filesystem-image = {
+    cyclonedx = "file";
+    spdx = "filesystemImage";
+  };
+  patch = {
+    cyclonedx = "file";
+    spdx = "patch";
+  };
+}

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -73,6 +73,8 @@ let
       nixosLabel = config.system.nixos.label;
 
       inherit (config.system) extraDependencies;
+
+      meta.packageType = [ lib.packageTypes.operating-system ];
     }
     // config.system.systemBuilderArgs
   );

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -393,6 +393,10 @@ let
       isIbusEngine = bool;
       isGutenprint = bool;
 
+      # Can be a list of values in `lib.packageTypes`
+      # Or can be a list of attrs, where each key is an SBOM format name
+      packageType = listOf (attrsOf str);
+
       # Used for the original location of the maintainer and team attributes to assist with pings.
       maintainersPosition = any;
       teamsPosition = any;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Adds a new attribute to meta: `type`. This describes what type of package a derivation is. I didn't add any release notes as I'm expecting this to cut too close to 25.11 so this should merge after branch-off.

This differs widely from categorization, categorization describes a specific category (like file manager, text editor, web server, etc.). Types are things like application, library, and describes what the type of things to expect in the output rather than how they'll likely be used.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
