### PR TITLE
ocaml-pds: init at 6.55

### DIFF
--- a/pkgs/by-name/oc/ocaml-pds/package.nix
+++ b/pkgs/by-name/oc/ocaml-pds/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  stdenv,
+  fetchhg,
+  ocaml,
+  ocaml-crunch,
+  ocamlPackages,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ocaml-pds";
+  version = "6.55";
+
+  src = fetchhg {
+    url = "https://hg.sr.ht/~mmatalka/pds";
+    rev = finalAttrs.version;
+    sha256 = "sha256-a6sMFzAwqLsLOq75JTyFxZiXuQvmOZG0bPzPehzLcws=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    ocaml
+    ocaml-crunch
+    ocamlPackages.findlib
+  ];
+
+  buildInputs = with ocamlPackages; [
+    cmdliner
+    containers
+    crunch
+    fmt
+    logs
+    ppx_deriving
+    process
+    sedlex
+    toml
+    ocaml_sqlite3
+  ];
+
+  buildFlags = [ "all" ];
+
+  preInstall = ''
+    mkdir -p $out/bin
+  '';
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    $out/bin/pds --help
+    runHook postInstallCheck
+  '';
+
+  meta = with lib; {
+    description = "A tool to build Makefiles for OCaml projects";
+    longDescription = ''
+      pds is a build system for Ocaml that is meant to make it easy to build a project that follows a particular layout by generating a makefile for the project. The input to pds is a config file, pds.conf, and a directory structure, which is always the current working directory, and the output is the build description.
+    '';
+    homepage = "https://hg.sr.ht/~mmatalka/pds";
+    changelog = "https://hg.sr.ht/~mmatalka/pds#changelog";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ mtrsk ];
+    platforms = ocaml.meta.platforms;
+  };
+})


### PR DESCRIPTION
Adds [pds](https://hg.sr.ht/~mmatalka/pds) as an ocaml package. Note that `pds` does not use `dune` as a build tool, that's why I went with the plain `mkDerivation`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
