### PR TITLE
yadb: init at 0.3.4

### DIFF
--- a/pkgs/by-name/ya/yadb/package.nix
+++ b/pkgs/by-name/ya/yadb/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "yadb";
+  version = "0.3.4";
+  src = fetchFromGitHub {
+    owner = "izya4ka";
+    repo = "yadb";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-kIqVPzYvmj9JXQ06GRkS1sxJJ6DTex6BPK6JK9oMmhI=";
+  };
+  cargoHash = "sha256-HlXZkmdgglSvmzCUIeUYCj/sc15OBOzio3V7fU4Uk9s=";
+  nativeBuildInputs = [
+    pkg-config
+  ];
+  passthru.updateScript = nix-update-script { };
+  meta = {
+    changelog = "https://github.com/izya4ka/yadb/releases/tag/v${finalAttrs.version}";
+    description = "Directory brute-forcing tool written in Rust, inspired by gobuster";
+    homepage = "https://github.com/izya4ka/yadb";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "yadb-cli";
+    maintainers = with lib.maintainers; [ linuxmobile ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
[YADB](https://github.com/izya4ka/yadb) is a directory brute-forcing tool written in Rust, inspired by gobuster. It provides both CLI and TUI interfaces for web directory discovery.

<img width="800" height="500" alt="image" src="https://github.com/user-attachments/assets/f1fd7a50-4aa0-4c4a-a438-a22dd5b5be23" />

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.