### PR TITLE
cudaPackages.cuda-samples: Build cuda-samples 13.0 for CUDA 13

### DIFF
--- a/pkgs/development/cuda-modules/packages/cuda-samples.nix
+++ b/pkgs/development/cuda-modules/packages/cuda-samples.nix
@@ -3,6 +3,7 @@
   _cuda,
   cmake,
   cuda_cccl,
+  cuda_culibos,
   cuda_cudart,
   cuda_nvcc,
   cuda_nvrtc,
@@ -29,7 +30,7 @@ backendStdenv.mkDerivation (finalAttrs: {
 
   name = "${cudaNamePrefix}-${finalAttrs.pname}-${finalAttrs.version}";
   pname = "cuda-samples";
-  version = "12.8";
+  version = if cudaAtLeast "13" then "13.0" else "12.8";
 
   # We should be able to use samples from the latest version of CUDA
   # on most of the CUDA package sets we have.
@@ -38,10 +39,17 @@ backendStdenv.mkDerivation (finalAttrs: {
     owner = "NVIDIA";
     repo = "cuda-samples";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Ba0Fi0v/sQ+1iJ4mslgyIAE+oK5KO0lMoTQCC91vpiA=";
+    hash = lib.getAttr finalAttrs.version {
+      "13.0" = "sha256-bOcAE/OzOI6MWTh+bFZfq1en6Yawu+HI8W+xK+XaCqg=";
+      "12.8" = "sha256-Ba0Fi0v/sQ+1iJ4mslgyIAE+oK5KO0lMoTQCC91vpiA=";
+    };
   };
 
   prePatch =
+    let
+      samplesAtLeast = lib.versionAtLeast finalAttrs.version;
+      samplesOlder = lib.versionOlder finalAttrs.version;
+    in
     # https://github.com/NVIDIA/cuda-samples/issues/333
     ''
       nixLog "removing sample 0_Introduction/UnifiedMemoryStreams which requires OpenMP support for CUDA"
@@ -52,7 +60,7 @@ backendStdenv.mkDerivation (finalAttrs: {
           '# add_subdirectory(UnifiedMemoryStreams)'
     ''
     # This sample tries to use a relative path, which doesn't work for our splayed installation.
-    + ''
+    + lib.optionalString (samplesOlder "13") ''
       nixLog "patching sample 0_Introduction/matrixMul_nvrtc"
       substituteInPlace \
         "$NIX_BUILD_TOP/$sourceRoot/Samples/0_Introduction/matrixMul_nvrtc/CMakeLists.txt" \
@@ -64,6 +72,20 @@ backendStdenv.mkDerivation (finalAttrs: {
           "${lib.getOutput "include" cuda_cccl}/include/nv" \
         --replace-fail \
           "\''${CUDAToolkit_BIN_DIR}/../include/cuda" \
+          "${lib.getOutput "include" cuda_cccl}/include/cuda"
+    ''
+    + lib.optionalString (samplesAtLeast "13") ''
+      nixLog "patching sample 0_Introduction/matrixMul_nvrtc"
+      substituteInPlace \
+        "$NIX_BUILD_TOP/$sourceRoot/Samples/0_Introduction/matrixMul_nvrtc/CMakeLists.txt" \
+        --replace-fail \
+          "\''${CUDA_INCLUDE_DIR}/cooperative_groups" \
+          "${lib.getOutput "include" cuda_cudart}/include/cooperative_groups" \
+        --replace-fail \
+          "\''${CUDA_INCLUDE_DIR}/cccl/nv" \
+          "${lib.getOutput "include" cuda_cccl}/include/nv" \
+        --replace-fail \
+          "\''${CUDA_INCLUDE_DIR}/cccl/cuda" \
           "${lib.getOutput "include" cuda_cccl}/include/cuda"
     ''
     # These three samples give undefined references, like
@@ -108,7 +130,7 @@ backendStdenv.mkDerivation (finalAttrs: {
           "add_subdirectory(jitLto)" \
           "# add_subdirectory(jitLto)"
     ''
-    + lib.optionalString (cudaAtLeast "12.4") ''
+    + lib.optionalString (samplesOlder "13") ''
       nixLog "patching sample 4_CUDA_Libraries/jitLto to use correct path to libnvJitLink.so"
       substituteInPlace \
         "$NIX_BUILD_TOP/$sourceRoot/Samples/4_CUDA_Libraries/jitLto/CMakeLists.txt" \
@@ -172,7 +194,8 @@ backendStdenv.mkDerivation (finalAttrs: {
     libnpp
     libnvjitlink
     libnvjpeg
-  ];
+  ]
+  ++ lib.optionals (cudaAtLeast "13") [ cuda_culibos ];
 
   cmakeFlags = [
     (lib.cmakeFeature "CMAKE_CUDA_ARCHITECTURES" flags.cmakeCudaArchitecturesString)


### PR DESCRIPTION
Add fixups for the 13.0 release of cuda-samples and build it when targeting CUDA 13.

## Things done

- Built on platform:
  - [x] x86_64-linux (cudaPackages_12.cuda-samples and cudaPackages_13.cuda-samples)
  - [x] aarch64-linux (cudaPackages_12.cuda-samples and cudaPackages_13.cuda-samples)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
