### PR TITLE
python3Packages.pyhanko: 0.25.3 -> 0.31.0

### DIFF
--- a/pkgs/by-name/py/pyhanko-cli/package.nix
+++ b/pkgs/by-name/py/pyhanko-cli/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+  nix-update-script,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "pyhanko-cli";
+  version = "0.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "MatthiasValvekens";
+    repo = "pyhanko";
+    tag = "pyhanko-cli/v${version}";
+    hash = "sha256-ZDHAcI2yoiVifYt05V85lz8mJmoyi10g4XoLQ+LhLHE=";
+  };
+
+  sourceRoot = "${src.name}/pkgs/pyhanko-cli";
+
+  postPatch = ''
+    substituteInPlace src/pyhanko/cli/version.py \
+      --replace-fail "0.0.0.dev1" "${version}" \
+      --replace-fail "(0, 0, 0, 'dev1')" "tuple(\"${version}\".split(\".\"))"
+    substituteInPlace pyproject.toml \
+      --replace-fail "0.0.0.dev1" "${version}"
+  '';
+
+  build-system = [ python3Packages.setuptools ];
+
+  dependencies =
+    with python3Packages;
+    [
+      asn1crypto
+      tzlocal
+      pyhanko
+      pyhanko-certvalidator
+      click
+      platformdirs
+    ]
+    ++ lib.flatten (lib.attrValues pyhanko.optional-dependencies);
+
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+    pyhanko.testData
+    requests-mock
+    freezegun
+    certomancer
+    aiohttp
+  ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex=pyhanko-cli/v(.*)"
+    ];
+  };
+
+  meta = {
+    description = "Sign and stamp PDF files";
+    mainProgram = "pyhanko";
+    homepage = "https://github.com/MatthiasValvekens/pyHanko/tree/master/pkgs/pyhanko-cli";
+    changelog = "https://github.com/MatthiasValvekens/pyHanko/blob/pyhanko-cli/${src.tag}/docs/changelog.rst#pyhanko-cli";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.antonmosich ];
+  };
+}

--- a/pkgs/development/python-modules/pyhanko-certvalidator/default.nix
+++ b/pkgs/development/python-modules/pyhanko-certvalidator/default.nix
@@ -1,33 +1,42 @@
 {
   lib,
-  aiohttp,
-  asn1crypto,
   buildPythonPackage,
-  cryptography,
   fetchFromGitHub,
-  freezegun,
+  nix-update-script,
+
+  asn1crypto,
+  cryptography,
   oscrypto,
+  requests,
+  uritools,
+
+  aiohttp,
+  freezegun,
   pytest-asyncio,
   pytestCheckHook,
-  pythonOlder,
-  requests,
   setuptools,
-  uritools,
 }:
 
 buildPythonPackage rec {
   pname = "pyhanko-certvalidator";
-  version = "0.26.8";
+  version = "0.29.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "MatthiasValvekens";
-    repo = "certvalidator";
-    tag = "v${version}";
-    hash = "sha256-Gvahyuz3n/CNAEzMXS5Z0Z85yDqLUQu8Yis5oJ2jaKc=";
+    repo = "pyhanko";
+    tag = "pyhanko-certvalidator/v${version}";
+    hash = "sha256-ZDHAcI2yoiVifYt05V85lz8mJmoyi10g4XoLQ+LhLHE=";
   };
+
+  sourceRoot = "${src.name}/pkgs/pyhanko-certvalidator";
+
+  postPatch = ''
+    substituteInPlace src/pyhanko_certvalidator/version.py \
+      --replace-fail "0.0.0.dev1" "${version}" \
+      --replace-fail "(0, 0, 0, 'dev1')" "tuple(\"${version}\".split(\".\"))"
+    substituteInPlace pyproject.toml --replace-fail "0.0.0.dev1" "${version}"
+  '';
 
   build-system = [ setuptools ];
 
@@ -48,11 +57,17 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pyhanko_certvalidator" ];
 
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex=pyhanko-certvalidator/v(.*)"
+    ];
+  };
+
   meta = with lib; {
     description = "Python library for validating X.509 certificates and paths";
-    homepage = "https://github.com/MatthiasValvekens/certvalidator";
-    changelog = "https://github.com/MatthiasValvekens/certvalidator/blob/v${version}/changelog.md";
+    homepage = "https://github.com/MatthiasValvekens/pyHanko/tree/master/pkgs/pyhanko-certvalidator";
+    changelog = "https://github.com/MatthiasValvekens/pyhanko/blob/pyhanko-certvalidator/${src.tag}/docs/changelog.rst#pyhanko-certvalidator";
     license = licenses.mit;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.antonmosich ];
   };
 }

--- a/pkgs/development/python-modules/pyhanko/default.nix
+++ b/pkgs/development/python-modules/pyhanko/default.nix
@@ -9,17 +9,14 @@
 
   # dependencies
   asn1crypto,
-  click,
   cryptography,
+  lxml,
   pyhanko-certvalidator,
   pyyaml,
-  qrcode,
   requests,
   tzlocal,
 
   # optional-dependencies
-  oscrypto,
-  defusedxml,
   fonttools,
   uharfbuzz,
   pillow,
@@ -27,6 +24,7 @@
   python-pkcs11,
   aiohttp,
   xsdata,
+  qrcode,
 
   # tests
   certomancer,
@@ -35,40 +33,44 @@
   pytestCheckHook,
   python-pae,
   requests-mock,
+  signxml,
 }:
 
 buildPythonPackage rec {
   pname = "pyhanko";
-  version = "0.25.3";
+  version = "0.31.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "MatthiasValvekens";
     repo = "pyHanko";
     tag = "v${version}";
-    hash = "sha256-HJkCQ5YDVr17gtY4PW89ep7GwFdP21/ruBEKm7j3+Qo=";
+    hash = "sha256-ZDHAcI2yoiVifYt05V85lz8mJmoyi10g4XoLQ+LhLHE=";
   };
+
+  sourceRoot = "${src.name}/pkgs/pyhanko";
+
+  postPatch = ''
+    substituteInPlace src/pyhanko/version/__init__.py \
+      --replace-fail "0.0.0.dev1" "${version}" \
+      --replace-fail "(0, 0, 0, 'dev1')" "tuple(\"${version}\".split(\".\"))"
+    substituteInPlace pyproject.toml \
+      --replace-fail "0.0.0.dev1" "${version}"
+  '';
 
   build-system = [ setuptools ];
 
-  pythonRelaxDeps = [
-    "cryptography"
-  ];
-
   dependencies = [
     asn1crypto
-    click
     cryptography
     pyhanko-certvalidator
     pyyaml
-    qrcode
     requests
     tzlocal
+    lxml
   ];
 
   optional-dependencies = {
-    extra-pubkey-algs = [ oscrypto ];
-    xmp = [ defusedxml ];
     opentype = [
       fonttools
       uharfbuzz
@@ -79,7 +81,11 @@ buildPythonPackage rec {
     ];
     pkcs11 = [ python-pkcs11 ];
     async-http = [ aiohttp ];
-    etsi = [ xsdata ];
+    etsi = [
+      xsdata
+      signxml
+    ];
+    qr = [ qrcode ];
   };
 
   nativeCheckInputs = [
@@ -90,16 +96,18 @@ buildPythonPackage rec {
     pytestCheckHook
     python-pae
     requests-mock
+    passthru.testData
+    signxml
   ]
   ++ lib.flatten (lib.attrValues optional-dependencies);
 
   disabledTestPaths = [
     # ModuleNotFoundError: No module named 'csc_dummy'
-    "pyhanko_tests/test_csc.py"
+    "tests/test_csc.py"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # OSError: One or more parameters passed to a function were not valid.
-    "pyhanko_tests/cli_tests"
+    "tests/cli_tests"
   ];
 
   disabledTests = [
@@ -126,6 +134,10 @@ buildPythonPackage rec {
     "test_ocsp_embed"
     "test_ts_fetch_aiohttp"
     "test_ts_fetch_requests"
+
+    # https://github.com/MatthiasValvekens/pyHanko/pull/595
+    "test_simple_text_stamp_on_page_with_leaky_graphics_state"
+    "test_simple_text_stamp_on_page_with_leaky_graphics_state_without_coord_correction"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # OSError: One or more parameters passed to a function were not valid.
@@ -139,12 +151,33 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pyhanko" ];
 
+  passthru = {
+    testData = buildPythonPackage {
+      pname = "common-test-utils";
+      inherit version pyproject src;
+
+      sourceRoot = "${src.name}/internal/common-test-utils";
+      # Include the test pdf/xml files etc. in the build output
+      postPatch = ''
+        echo "graft src/test_data" > MANIFEST.in
+      '';
+
+      build-system = [ setuptools ];
+
+      dependencies = [
+        certomancer
+        pyhanko-certvalidator
+      ];
+
+      pythonRemoveDeps = [ "pyhanko" ];
+    };
+  };
+
   meta = {
     description = "Sign and stamp PDF files";
-    mainProgram = "pyhanko";
     homepage = "https://github.com/MatthiasValvekens/pyHanko";
-    changelog = "https://github.com/MatthiasValvekens/pyHanko/blob/v${version}/docs/changelog.rst";
+    changelog = "https://github.com/MatthiasValvekens/pyHanko/blob/${src.tag}/docs/changelog.rst#pyhanko";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.antonmosich ];
   };
 }


### PR DESCRIPTION
pyhanko-certvalidator was moved into the pyhanko repository, see
https://docs.pyhanko.eu/en/latest/changelog.html#certvalidator-release-0-27-0. cli functionality was moved into it's own package, I packaged as `pyhanko-cli`.
I also adopted pyhanko and pyhanko-certvalidator.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
