### PR TITLE
teetty: init at 0.4.0

### DIFF
--- a/pkgs/by-name/te/teetty/package.nix
+++ b/pkgs/by-name/te/teetty/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "teetty";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "mitsuhiko";
+    repo = "teetty";
+    rev = version;
+    hash = "sha256-L5GlmbscAt6aqt79qq5UAeMeDscvpYUwjJZcSESMVj4=";
+  };
+
+  cargoHash = "sha256-fJ4TgQddr+OrvhSZFWcKyOvwkfBVQODHmq8E7nBOEZk=";
+
+  meta = {
+    description = "A bit like tee, a bit like script, but all with a fake tty. Lets you remote control and watch a process";
+    homepage = "https://github.com/mitsuhiko/teetty";
+    changelog = "https://github.com/mitsuhiko/teetty/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ rehno-lindeque ];
+    mainProgram = "teetty";
+  };
+}


### PR DESCRIPTION
A straightforward way to run a command in a pty and communicate with it via named pipes.

https://github.com/mitsuhiko/teetty/blob/main/README.md

Example:

```
$ teetty -i /tmp/nix-stdin -o /tmp/nix-stdout --truncate -- nix repl
```

```
$ echo 'true' > /tmp/nix-stdin

$ tail -n 100 /tmp/nix-repl-stdout | tac | grep -m 2 -B 100 'nix-repl>' | sed -n '/nix-repl>/,$p' | tac
nix-repl> true
true
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
