### PR TITLE
kernel: modules-closure: allowMissing can be an array of module names

### DIFF
--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -265,7 +265,10 @@ in
     };
 
     boot.initrd.allowMissingModules = mkOption {
-      type = types.bool;
+      type = types.oneOf [
+        types.bool
+        (types.listOf types.str)
+      ];
       default = false;
       description = ''
         Whether the initrd can be built even though modules listed in


### PR DESCRIPTION
I am building a minified kernel for an arm64 machine without autoModules = true and which has LUKS enabled. LUKS would like to make cryptd available to loaded in the initrd and [does so by adding](https://github.com/NixOS/nixpkgs/blob/63b93d777c5c593eb25aa5331810823bd373d3d3/nixos/modules/system/boot/luksroot.nix#L1135-L1140) it to boot.initrd.availableKernelModules. The default configuration for arm64 does not enable CONFIG_CRYPTD and the module is not built. makeModuleClosure does not allow modules to be missing by default, thus the shrunk modules closure fails to build. I can set boot.initrd.allowMissingModules = true, but I'd still like to audit/understand which modules are missing and either bless them to be missing or ensure the module is built. Update "allowMissing" to be either a bool or (new) a list of modules which can be missing.

## Things done

I played with nixos/tests/systemd-repart.nix to add a stand-in driver (e.g. foobar) and tested `allowMissingModules = false`, `= true`, `= [ "foobar" ]`, `= [ "foo" ]`

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
