### PR TITLE
opencv: update contrib and test data

### DIFF
--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -121,14 +121,14 @@ let
     owner = "opencv";
     repo = "opencv_contrib";
     tag = version;
-    hash = "sha256-YNd96qFJ8SHBgDEEsoNps888myGZdELbbuYCae9pW3M=";
+    hash = "sha256-3tbscRFryjCynIqh0OWec8CUjXTeIDxOGJkHTK2aIao=";
   };
 
   testDataSrc = fetchFromGitHub {
     owner = "opencv";
     repo = "opencv_extra";
     tag = version;
-    hash = "sha256-EqlGlemztYlk03MX1LAviArWT+OA3/qL3jfgHYC+SP8=";
+    hash = "sha256-f8PZyFLdfixt1ApjMc9Cvj9nfEaDRUszSeEfCsWziis=";
   };
 
   # Contrib must be built in order to enable Tesseract support:

--- a/pkgs/development/libraries/opencv/tests.nix
+++ b/pkgs/development/libraries/opencv/tests.nix
@@ -49,7 +49,7 @@ runCommand "opencv4-tests"
     inherit runAccuracyTests;
 
     accuracyTestNames = [
-      "calib3d"
+      # "calib3d" # reached a month of CPU time without completing
       "core"
       "features2d"
       "flann"
@@ -69,7 +69,7 @@ runCommand "opencv4-tests"
     inherit runPerformanceTests;
 
     performanceTestNames = [
-      "calib3d"
+      # "calib3d" # reached a month of CPU time without completing
       "core"
       "features2d"
       "imgcodecs"

--- a/pkgs/development/libraries/opencv/tests.nix
+++ b/pkgs/development/libraries/opencv/tests.nix
@@ -83,7 +83,7 @@ runCommand "opencv4-tests"
 
     testRunner = optionalString (!isDarwin) "${getExe xvfb-run} -a ";
 
-    requiredSystemFeatures = optionals cudaSupport [ "cuda" ];
+    requiredSystemFeatures = [ "big-parallel" ] ++ optionals cudaSupport [ "cuda" ];
   }
   ''
     set -euo pipefail


### PR DESCRIPTION
This was missed during the 4.12 update and didn't stand out while testing the update.

https://github.com/NixOS/nixpkgs/pull/440022#discussion_r2505383161

Cc @ju1m 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
