### PR TITLE
python3Packages.cocotbext-axi: 0.1.26

### DIFF
--- a/pkgs/development/python-modules/cocotbext-axi/default.nix
+++ b/pkgs/development/python-modules/cocotbext-axi/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  cocotb,
+  cocotb-bus,
+}:
+
+buildPythonPackage {
+  pname = "cocotbext-axi";
+  version = "0.1.26";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "alexforencich";
+    repo = "cocotbext-axi";
+    rev = "33f510688ab9ab7aa5f01f9c04430b7ce4885cb5";
+    hash = "sha256-NmYN87b754GxaRePLDZihns6G6hhcx3deScn5+7e7nU=";
+  };
+
+  dependencies = [
+    cocotb
+    cocotb-bus
+  ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "AXI interface modules for Cocotb";
+    homepage = "https://github.com/alexforencich/cocotbext-axi";
+    license = licenses.mit;
+    maintainers = with maintainers; [ oskarwires ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2818,6 +2818,10 @@ self: super: with self; {
 
   cocotb-bus = callPackage ../development/python-modules/cocotb-bus { };
 
+  cocotbext-axi = callPackage ../development/python-modules/cocotbext-axi {
+    inherit (self) cocotb cocotb-bus;
+  };
+
   codepy = callPackage ../development/python-modules/codepy { };
 
   coffea = callPackage ../development/python-modules/coffea { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This PR introduces the `cocotbext-axi` package, which provides AXI interface modules for cocotb.

Homepage: https://github.com/alexforencich/cocotbext-axi

This PR **depends on #458167** being merged first.

The dependency is necessary because this package (`cocotbext-axi`) uses  `cocotb-bus`, in which the current nixpkg version is incompatible with the latest `cocotb`, which is what PR #458167 fixes.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
