### PR TITLE
supercell-wx: fix build for Qt 6.10

### DIFF
--- a/pkgs/by-name/su/supercell-wx/package.nix
+++ b/pkgs/by-name/su/supercell-wx/package.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [ aware70 ];
   };
 
-  env.CXXFLAGS = "-Wno-error=restrict -Wno-error=maybe-uninitialized -Wno-error=deprecated-declarations -Wno-error=stringop-overflow";
+  env.CXXFLAGS = "-Wno-error=restrict -Wno-error=maybe-uninitialized -Wno-error=deprecated-declarations -Wno-error=stringop-overflow -DQT_NO_USE_NODISCARD_FILE_OPEN";
   env.GTEST_FILTER = "-${lib.concatStringsSep ":" gtestSkip}";
 
   doCheck = true;
@@ -104,6 +104,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     # These may be or already are submitted upstream {{{
     ./patches/explicit-link-aws-crt.patch # fix missing symbols from aws-crt-cpp
+    ./patches/fix-qt-6.10.patch
     # }}}
   ];
 

--- a/pkgs/by-name/su/supercell-wx/patches/fix-qt-6.10.patch
+++ b/pkgs/by-name/su/supercell-wx/patches/fix-qt-6.10.patch
@@ -1,0 +1,13 @@
+diff --git a/external/qt6ct.cmake b/external/qt6ct.cmake
+index 665b5368..9e6ed0e9 100644
+--- a/external/qt6ct.cmake
++++ b/external/qt6ct.cmake
+@@ -5,7 +5,7 @@ find_package(QT NAMES Qt6
+              COMPONENTS Gui Widgets
+              REQUIRED)
+ find_package(Qt${QT_VERSION_MAJOR}
+-             COMPONENTS Gui Widgets
++             COMPONENTS Gui Widgets WidgetsPrivate
+              REQUIRED)
+ 
+ #extract version from qt6ct.h


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This fixes the build failure of `supercell-wx` discovered in: https://github.com/NixOS/nixpkgs/pull/428369

It appears to have been caused by the recent Qt6 update to 6.10.0.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
