### PR TITLE
nixVersions.git: 2.32pre20250919_07b96c1d -> 2.33pre20251107_479b6b73

### DIFF
--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -194,14 +194,14 @@ lib.makeExtensible (
       nix_2_32 = addTests "nix_2_32" self.nixComponents_2_32.nix-everything;
 
       nixComponents_git = nixDependencies.callPackage ./modular/packages.nix rec {
-        version = "2.32pre20250919_${lib.substring 0 8 src.rev}";
+        version = "2.33pre20251107_${lib.substring 0 8 src.rev}";
         inherit maintainers teams;
         otherSplices = generateSplicesForNixComponents "nixComponents_git";
         src = fetchFromGitHub {
           owner = "NixOS";
           repo = "nix";
-          rev = "07b96c1d14ab8695e5071fb73e19049fce8f3b6b";
-          hash = "sha256-9tR08zFwQ9JNohdfeb40wcLfRnicXpKrHF+FHFva/WA=";
+          rev = "479b6b73a9576452c14ca66b7f3cd4873969077e";
+          hash = "sha256-eBjgsauQXFz2yeiNoPEzgkf7uyV+S8HYCQgZhPVx/9I=";
         };
       };
 

--- a/pkgs/tools/package-management/nix/modular/doc/manual/package.nix
+++ b/pkgs/tools/package-management/nix/modular/doc/manual/package.nix
@@ -10,6 +10,7 @@
   jq,
   python3,
   rsync,
+  json-schema-for-humans,
   nix-cli,
 
   # Configuration Options
@@ -39,6 +40,9 @@ mkMesonDerivation (finalAttrs: {
     jq
     python3
     rsync
+  ]
+  ++ lib.optional (lib.versionAtLeast (lib.versions.majorMinor version) "2.33") [
+    json-schema-for-humans
   ];
 
   nativeBuildInputs = finalAttrs.passthru.externalNativeBuildInputs ++ [

--- a/pkgs/tools/package-management/nix/modular/src/libstore/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libstore/package.nix
@@ -9,6 +9,7 @@
   boost,
   curl,
   aws-sdk-cpp,
+  aws-crt-cpp,
   libseccomp,
   nlohmann_json,
   sqlite,
@@ -37,9 +38,10 @@ mkMesonLibrary (finalAttrs: {
   ]
   ++ lib.optional stdenv.hostPlatform.isLinux libseccomp
   # There have been issues building these dependencies
-  ++ lib.optional (
-    stdenv.hostPlatform == stdenv.buildPlatform && (stdenv.isLinux || stdenv.isDarwin)
-  ) aws-sdk-cpp;
+  ++
+    lib.optional (stdenv.hostPlatform == stdenv.buildPlatform && (stdenv.isLinux || stdenv.isDarwin))
+      # Nix >=2.33 doesn't depend on aws-sdk-cpp and only requires aws-crt-cpp for authenticated s3:// requests.
+      (if lib.versionAtLeast (lib.versions.majorMinor version) "2.33" then aws-crt-cpp else aws-sdk-cpp);
 
   propagatedBuildInputs = [
     nix-util


### PR DESCRIPTION
Git version was lagging behind 2.32 a lot. A lot of commits to catch up on. There are some notable changes like dropping the aws-sdk-cpp in favor of the much lighter aws-crt-cpp.

Diff: https://github.com/NixOS/nix/compare/07b96c1d14ab8695e5071fb73e19049fce8f3b6b...479b6b73a9576452c14ca66b7f3cd4873969077e


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
