### PR TITLE
_1password-gui-beta: 8.11.18-30.BETA -> 8.11.18-34.BETA

### DIFF
--- a/pkgs/by-name/_1/_1password-gui/sources.json
+++ b/pkgs/by-name/_1/_1password-gui/sources.json
@@ -29,28 +29,28 @@
   },
   "beta": {
     "linux": {
-      "version": "8.11.18-30.BETA",
+      "version": "8.11.18-34.BETA",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/linux/tar/beta/x86_64/1password-8.11.18-30.BETA.x64.tar.gz",
-          "hash": "sha256-rCb54NhczM5Us6DRd1DgA7xGem4Ri4GIcJ0FFCiNAvo="
+          "url": "https://downloads.1password.com/linux/tar/beta/x86_64/1password-8.11.18-34.BETA.x64.tar.gz",
+          "hash": "sha256-1x0FwxQ6oWGdcJ7Up9S+f423IpFAMEJ08WQnbgaesVU="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/linux/tar/beta/aarch64/1password-8.11.18-30.BETA.arm64.tar.gz",
-          "hash": "sha256-qL6Xa8g2qgyl+UfDThH18rbaXxkt+bN0y2TcQ8C214Y="
+          "url": "https://downloads.1password.com/linux/tar/beta/aarch64/1password-8.11.18-34.BETA.arm64.tar.gz",
+          "hash": "sha256-ita34logGU5zd6USi4XgOQosWooebHssyIobPZ8wlVg="
         }
       }
     },
     "darwin": {
-      "version": "8.11.18-30.BETA",
+      "version": "8.11.18-34.BETA",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.11.18-30.BETA-x86_64.zip",
-          "hash": "sha256-xkCTyFxZhCKsCTTyWz3SPA9XKhR5p7GT3hwBwXQVb40="
+          "url": "https://downloads.1password.com/mac/1Password-8.11.18-34.BETA-x86_64.zip",
+          "hash": "sha256-NONcgqasLQd9nQnEQfibcYLPagvt2VuIFUxgkTMVRxE="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.11.18-30.BETA-aarch64.zip",
-          "hash": "sha256-Ou3GSMTNmaz+sbYCYqmxH9qrQMDmUBfTUPVcvdNDt6k="
+          "url": "https://downloads.1password.com/mac/1Password-8.11.18-34.BETA-aarch64.zip",
+          "hash": "sha256-SVPXpEFBI0mutj/J5vvb2o20za+5d/zzB7altIHADYw="
         }
       }
     }


### PR DESCRIPTION
Changelog
Linux: https://releases.1password.com/linux/beta/
Mac: https://releases.1password.com/mac/beta/

Created using update script since bot doesn't seem to be picking up beta releases yet.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
