### PR TITLE
[Backport release-25.05] {libtorrent,rtorrent}: 0.15.5 -> 0.15.6

### DIFF
--- a/pkgs/by-name/li/libtorrent/package.nix
+++ b/pkgs/by-name/li/libtorrent/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rakshasa-libtorrent";
-  version = "0.15.5";
+  version = "0.15.6";
 
   src = fetchFromGitHub {
     owner = "rakshasa";
     repo = "libtorrent";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-iFndmET8bQUg3iZ6c6WDCzSS2tx6sYJt+fEkPAaNm18=";
+    hash = "sha256-udEe9VyUzPXuCTrB3U3+XCbVWvfTT7xNvJJkLSQrRt4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/rt/rtorrent/package.nix
+++ b/pkgs/by-name/rt/rtorrent/package.nix
@@ -20,13 +20,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rakshasa-rtorrent";
-  version = "0.15.5";
+  version = "0.15.6";
 
   src = fetchFromGitHub {
     owner = "rakshasa";
     repo = "rtorrent";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-ZUZR/ydGhxLbjMEDAlbU5IbAxU1dCd0vvATdsn0NMQc=";
+    hash = "sha256-B/5m1JXdUpczUMNN4cy5p6YurjmRFxMQHG3cQFSmZSs=";
   };
 
   outputs = [


### PR DESCRIPTION
Manual backport of https://github.com/NixOS/nixpkgs/pull/440174, https://github.com/NixOS/nixpkgs/pull/439431 to `release-25.05`.

* [x]  Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
   * Even as a non-committer, if you find that it is not acceptable, leave a comment.