### PR TITLE
bash: fix cpe eval

### DIFF
--- a/pkgs/shells/bash/5.nix
+++ b/pkgs/shells/bash/5.nix
@@ -278,7 +278,7 @@ lib.warnIf (withDocs != null)
       mainProgram = "bash";
       identifiers.cpeParts =
         let
-          versionSplit = lib.split "p" version;
+          versionSplit = lib.split "p" fa.version;
         in
         {
           vendor = "gnu";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Fixes this error:
```
nix-repl> legacyPackages.aarch64-linux.bash.meta.identifiers
error:
       … while evaluating the attribute 'aarch64-linux.bash.meta.identifiers'
         at /nix/store/ckxdfcfyawnhwpqzgf7z8s53a4fsmina-source/pkgs/stdenv/generic/check-meta.nix:673:7:
          672|
          673|       identifiers =
             |       ^
          674|         let

       … in the left operand of the update (//) operator
         at /nix/store/ckxdfcfyawnhwpqzgf7z8s53a4fsmina-source/pkgs/stdenv/generic/check-meta.nix:719:9:
          718|         v1
          719|         // {
             |         ^
          720|           inherit v1;

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: 'builtins.elemAt' called with index 2 on a list of size 1
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
