### PR TITLE
odamex: 0.9.5 -> 11.1.1; add eljamm to maintainers

### DIFF
--- a/pkgs/by-name/od/odamex/package.nix
+++ b/pkgs/by-name/od/odamex/package.nix
@@ -1,62 +1,209 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
+  fetchpatch,
+
   cmake,
-  pkg-config,
+  copyDesktopItems,
+  deutex,
+  makeDesktopItem,
   makeWrapper,
-  SDL,
-  SDL_mixer,
-  SDL_net,
+  pkg-config,
+  wrapGAppsHook3,
+
+  SDL2,
+  SDL2_mixer,
+  SDL2_net,
+  alsa-lib,
+  cpptrace,
+  curl,
+  expat,
+  fltk,
+  libdwarf,
+  libselinux,
+  libsepol,
+  libsysprof-capture,
+  libuuid,
+  libxdmcp,
+  libxkbcommon,
+  pcre2,
+  portmidi,
+  wayland-scanner,
+  waylandpp,
   wxGTK32,
+  xorg,
+  zstd,
+
+  nix-update-script,
+
+  withX11 ? stdenv.hostPlatform.isLinux,
+  withWayland ? stdenv.hostPlatform.isLinux,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "odamex";
-  version = "0.9.5";
+  version = "11.1.1";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/${pname}/${pname}-src-${version}.tar.bz2";
-    sha256 = "sha256-WBqO5fWzemw1kYlY192v0nnZkbIEVuWmjWYMy+1ODPQ=";
+  src = fetchFromGitHub {
+    owner = "odamex";
+    repo = "odamex";
+    tag = finalAttrs.version;
+    hash = "sha256-UUUavIaU65vU80Bp2cVjHg8IubpA6qMqZmDYvTDjfEw=";
+    fetchSubmodules = true;
   };
+
+  patches = [
+    # fix file-open panel on Darwin
+    # https://github.com/odamex/odamex/pull/1402
+    # TODO: remove on next release
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/odamex/odamex/pull/1402.patch";
+      hash = "sha256-JrcQ0rYkaFP5aKNWeXbrY2TN4r8nHpue19qajNXJXg4=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake
-    pkg-config
+    copyDesktopItems
+    deutex
     makeWrapper
+    pkg-config
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    wrapGAppsHook3
   ];
 
   buildInputs = [
-    SDL
-    SDL_mixer
-    SDL_net
+    SDL2
+    SDL2_mixer
+    SDL2_net
+    cpptrace
+    curl
+    expat
+    fltk
+    libdwarf
+    libsysprof-capture
+    pcre2
+    portmidi
     wxGTK32
+    zstd
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    alsa-lib
+    libselinux
+    libuuid
+    libxdmcp
+    libsepol
+  ]
+  ++ lib.optionals withX11 [
+    xorg.libX11
+    xorg.xorgproto
+  ]
+  ++ lib.optionals withWayland [
+    libxkbcommon
+    wayland-scanner
+    waylandpp
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "USE_INTERNAL_CPPTRACE" false)
+    (lib.cmakeFeature "ODAMEX_INSTALL_BINDIR" "$ODAMEX_BINDIR") # set by wrapper
   ];
 
   installPhase = ''
     runHook preInstall
-  ''
-  + (
-    if stdenv.hostPlatform.isDarwin then
-      ''
-        mkdir -p $out/{Applications,bin}
-        mv odalaunch/odalaunch.app $out/Applications
-        makeWrapper $out/{Applications/odalaunch.app/Contents/MacOS,bin}/odalaunch
-      ''
-    else
-      ''
-        make install
-      ''
-  )
-  + ''
+
+    ${
+      if stdenv.hostPlatform.isDarwin then
+        # bash
+        ''
+          mkdir -p $out/{Applications,bin}
+
+          mv client odamex
+          for name in odamex odalaunch; do
+            contents="Applications/$name.app/Contents/MacOS"
+            mv $name/*.app $out/Applications
+            makeWrapper $out/{"$contents",bin}/"$name" \
+              --set ODAMEX_BINDIR "${placeholder "out"}/Applications"
+          done
+
+          cp server/odasrv $out/Applications
+          ln -s $out/Applications/odamex.app/Contents/MacOS/odamex.wad $out/Applications
+          makeWrapper $out/{Applications,bin}/odasrv
+        ''
+      else
+        # bash
+        ''
+          make install
+
+          # copy desktop file icons
+          for name in odamex odalaunch odasrv; do
+            for size in 96 128 256 512; do
+              install -Dm644 ../media/icon_"$name"_"$size".png \
+                $out/share/icons/hicolor/"$size"x"$size"/"$name".png
+            done
+
+            install -Dm644 ../media/icon_"$name"_128.png \
+              $out/share/pixmaps/"$name".png
+          done
+        ''
+    }
+
     runHook postInstall
   '';
+
+  preFixup = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
+    gappsWrapperArgs+=(
+      --set ODAMEX_BINDIR "${placeholder "out"}/bin"
+    )
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "odamex";
+      icon = "odamex";
+      exec = "odamex";
+      desktopName = "Odamex Client";
+      comment = "A Doom multiplayer game engine";
+      categories = [
+        "ActionGame"
+        "Game"
+        "Shooter"
+      ];
+    })
+    (makeDesktopItem {
+      name = "odalaunch";
+      icon = "odalaunch";
+      exec = "odalaunch";
+      desktopName = "Odamex Launcher";
+      comment = "Server Browser for Odamex";
+      categories = [
+        "ActionGame"
+        "Game"
+        "Shooter"
+      ];
+    })
+    (makeDesktopItem {
+      name = "odasrv";
+      icon = "odasrv";
+      exec = "odasrv";
+      desktopName = "Odamex Server";
+      comment = "Run an Odamex game server";
+      categories = [
+        "Network"
+      ];
+    })
+  ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "http://odamex.net/";
     description = "Client/server port for playing old-school Doom online";
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.unix;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ eljamm ];
+    mainProgram = "odalaunch";
   };
-}
+})

--- a/pkgs/by-name/od/odamex/package.nix
+++ b/pkgs/by-name/od/odamex/package.nix
@@ -41,6 +41,15 @@
   withWayland ? stdenv.hostPlatform.isLinux,
 }:
 
+let
+  # TODO: remove when this is resolved, likely at the next cpptrace bump
+  cpptrace' = cpptrace.overrideAttrs {
+    # tests are failing on darwin
+    # https://hydra.nixos.org/build/310535948
+    doCheck = !stdenv.hostPlatform.isDarwin;
+  };
+in
+
 stdenv.mkDerivation (finalAttrs: {
   pname = "odamex";
   version = "11.1.1";
@@ -78,7 +87,7 @@ stdenv.mkDerivation (finalAttrs: {
     SDL2
     SDL2_mixer
     SDL2_net
-    cpptrace
+    cpptrace'
     curl
     expat
     fltk


### PR DESCRIPTION
So I may have forgotten to check for already-open PRs when I started working on this, but I think the result is good enough that it can probably supersede:

- https://github.com/NixOS/nixpkgs/pull/388093
- https://github.com/NixOS/nixpkgs/pull/457213
- https://github.com/NixOS/nixpkgs/pull/432760 (I took the desktop files from this PR, also from [upstream](https://github.com/odamex/odamex/tree/7ad320576029763e8094bcd231fa2daffaae53f3/installer/arch))

Tested Odamex with [Freedoom](https://freedoom.github.io/download.html), and although I didn't find any active players, everything seemed to be working fine.

ZHF: https://github.com/NixOS/nixpkgs/issues/457852

<img width="1280" height="971" alt="image" src="https://github.com/user-attachments/assets/a5404573-b80a-422b-abab-25ff184dc85f" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc