### PR TITLE
swww: rename to awww, 0.11.2 -> 0.12.0

### DIFF
--- a/pkgs/by-name/aw/awww/package.nix
+++ b/pkgs/by-name/aw/awww/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitHub,
+  fetchFromGitea,
   rustPlatform,
   pkg-config,
   lz4,
@@ -14,17 +14,18 @@
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
-  pname = "swww";
-  version = "0.11.2";
+  pname = "awww";
+  version = "0.12.0";
 
-  src = fetchFromGitHub {
+  src = fetchFromGitea {
+    domain = "codeberg.org";
     owner = "LGFae";
-    repo = "swww";
+    repo = "awww";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-X2ptpXRo6ps5RxDe5RS7qfTaHWqBbBNw/aSdC2tzUG8=";
+    hash = "sha256-bvO+gfuUOVUiBEwAJ5A2RjpysPzCfyXD+DM8piOa1+4=";
   };
 
-  cargoHash = "sha256-5KZWsdo37NbFFkK8XFc0XI9iwBkpV8KsOaOc0y287Io=";
+  cargoHash = "sha256-4ApaMiVqXD4RlyWFMk2wKsyo37FT/OeVly/H88pF7oc=";
 
   buildInputs = [
     lz4
@@ -49,10 +50,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
       installManPage "$page"
     done
 
-    installShellCompletion --cmd swww \
-      --bash completions/swww.bash \
-      --fish completions/swww.fish \
-      --zsh completions/_swww
+    installShellCompletion --cmd awww \
+      --bash completions/awww.bash \
+      --fish completions/awww.fish \
+      --zsh completions/_awww
   '';
 
   postFixup = ''
@@ -64,13 +65,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Efficient animated wallpaper daemon for wayland, controlled at runtime";
-    homepage = "https://github.com/LGFae/swww";
+    homepage = "https://codeberg.org/LGFae/awww";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [
       mateodd25
       donovanglover
     ];
     platforms = lib.platforms.linux;
-    mainProgram = "swww";
+    mainProgram = "awww";
   };
 })

--- a/pkgs/by-name/hy/hyprpanel/package.nix
+++ b/pkgs/by-name/hy/hyprpanel/package.nix
@@ -3,6 +3,7 @@
   config,
   ags,
   astal,
+  awww,
   bluez,
   bluez-tools,
   brightnessctl,
@@ -27,14 +28,25 @@
   python3,
   pywal16,
   stdenv,
-  swww,
   upower,
   wireplumber,
   wl-clipboard,
   writeShellScript,
+  writeShellScriptBin,
 
   enableCuda ? config.cudaSupport,
 }:
+
+let
+  # TODO: Remove once hyprpanel updates to use `awww`
+  swww-compat = writeShellScriptBin "swww" ''
+    exec awww "$@"
+  '';
+  swww-daemon-compat = writeShellScriptBin "swww-daemon" ''
+    exec awww-daemon "$@"
+  '';
+in
+
 ags.bundle {
   pname = "hyprpanel";
   version = "0-unstable-2026-01-07";
@@ -63,6 +75,7 @@ ags.bundle {
     astal.tray
     astal.wireplumber
 
+    awww
     bluez
     bluez-tools
     brightnessctl
@@ -80,7 +93,8 @@ ags.bundle {
     matugen
     networkmanager
     pywal16
-    swww
+    swww-compat
+    swww-daemon-compat
     upower
     wireplumber
     wl-clipboard

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1879,6 +1879,7 @@ mapAliases {
   swig4 = throw "'swig4' has been renamed to/replaced by 'swig'"; # Converted to throw 2025-10-27
   swiProlog = throw "'swiProlog' has been renamed to/replaced by 'swi-prolog'"; # Converted to throw 2025-10-27
   swiPrologWithGui = throw "'swiPrologWithGui' has been renamed to/replaced by 'swi-prolog-gui'"; # Converted to throw 2025-10-27
+  swww = warnAlias "'swww' has been renamed to 'awww'" awww; # Added 2026-03-22
   Sylk = throw "'Sylk' has been renamed to/replaced by 'sylk'"; # Converted to throw 2025-10-27
   symbiyosys = throw "'symbiyosys' has been renamed to/replaced by 'sby'"; # Converted to throw 2025-10-27
   syn2mas = throw "'syn2mas' has been removed. It has been integrated into the main matrix-authentication-service CLI as a subcommand: 'mas-cli syn2mas'."; # Added 2025-07-07


### PR DESCRIPTION
Resolves https://github.com/NixOS/nixpkgs/issues/459434.

Archived repo: https://github.com/LGFae/swww
New repo: https://codeberg.org/LGFae/awww

Changelog: https://codeberg.org/LGFae/awww/releases/tag/v0.12.0
Diff: https://codeberg.org/LGFae/awww/compare/v0.11.2...v0.12.0
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
