### PR TITLE
unison: 2.53.7 -> 2.53.8

### DIFF
--- a/pkgs/by-name/un/unison/fix-ocamlfind-env.patch
+++ b/pkgs/by-name/un/unison/fix-ocamlfind-env.patch
@@ -1,0 +1,14 @@
+diff --git a/src/make_tools.ml b/src/make_tools.ml
+index a5792b6..4f4d037 100644
+--- a/src/make_tools.ml
++++ b/src/make_tools.ml
+@@ -475,7 +475,7 @@ let shell_internal ?(err_null = false) ?exit_status ?(input_str = "") cmd =
+     Unix.handle_unix_error (fun () ->
+       if err_null || input_str <> "" then
+         let (sh_out, sh_in, _) as sh_full =
+-          Unix.open_process_full cmd [|"PATH=" ^ env.$("PATH")|] in
++          Unix.open_process_full cmd (Array.append (Unix.environment ()) [|"PATH=" ^ env.$("PATH")|]) in
+         if input_str <> "" then begin
+           output_string sh_in input_str;
+           flush sh_in
+

--- a/pkgs/by-name/un/unison/package.nix
+++ b/pkgs/by-name/un/unison/package.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "unison";
-  version = "2.53.7";
+  version = "2.53.8";
 
   src = fetchFromGitHub {
     owner = "bcpierce00";
     repo = "unison";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-QmYcxzsnbRDQdqkLh82OLWrLF6v3qzf1aOIcnz0kwEk=";
+    hash = "sha256-ynsu9jLGFtjlzmHZtOdLEH5G6eXFAhZs9UayYrmKqp0=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/un/unison/package.nix
+++ b/pkgs/by-name/un/unison/package.nix
@@ -21,6 +21,9 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-ynsu9jLGFtjlzmHZtOdLEH5G6eXFAhZs9UayYrmKqp0=";
   };
 
+  # Allow the build scripts to correctly call ocamlfind & detect dependencies
+  patches = [ ./fix-ocamlfind-env.patch ];
+
   strictDeps = true;
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- Supercedes #458700
- Unbreak gui builds

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 459671`
Commit: `562c635fb716f0872e909df822707817ca9b3c66`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>unison</li>
    <li>usync</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
