### PR TITLE
python3Packages.protobuf: check version compatibility

### DIFF
--- a/pkgs/development/python-modules/protobuf/6.nix
+++ b/pkgs/development/python-modules/protobuf/6.nix
@@ -23,8 +23,12 @@ buildPythonPackage rec {
     protobuf
   ];
 
-  # the pypi source archive does not ship tests
-  doCheck = false;
+  doCheck =
+    # https://protobuf.dev/support/cross-version-runtime-guarantee/#backwards
+    # The non-python protobuf provides the protoc binary which must not be newer.
+    assert lib.versionAtLeast version ("6." + protobuf.version);
+    # the pypi source archive does not ship tests
+    false;
 
   pythonImportsCheck = [
     "google.protobuf"
@@ -45,7 +49,9 @@ buildPythonPackage rec {
   meta = {
     description = "Protocol Buffers are Google's data interchange format";
     homepage = "https://developers.google.com/protocol-buffers/";
-    changelog = "https://github.com/protocolbuffers/protobuf/releases/v${version}";
+    changelog = "https://github.com/protocolbuffers/protobuf/releases/v${
+      builtins.substring 2 (-1) version
+    }";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ GaetanLepage ];
   };


### PR DESCRIPTION
Let's avoid situations from #459656 early, e.g. log https://hydra.nixos.org/build/312538974/nixlog/1/tail

Note that python3Packages.protobuf is in protobuf.tests, so that we should notice when updating protobuf in particular.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

_The usual checklist doesn't seem relevant here._

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
