### PR TITLE
python3Packages.streamingjson: init at 0.0.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7945,6 +7945,11 @@
       { fingerprint = "2E51 F618 39D1 FA94 7A73  00C2 34C0 4305 D581 DBFE"; }
     ];
   };
+  ethanthoma = {
+    name = "Ethan Thoma";
+    github = "ethanthoma";
+    githubId = 4424467;
+  };
   ethercrow = {
     email = "ethercrow@gmail.com";
     github = "ethercrow";

--- a/pkgs/development/python-modules/streamingjson/default.nix
+++ b/pkgs/development/python-modules/streamingjson/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "streamingjson";
+  version = "0.0.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "karminski";
+    repo = "streaming-json-py";
+    tag = version;
+    hash = "sha256-XKqW5gbK55OKoAWftoh5CmGc0Sn5FOvGKmrAbsEvIMo=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "streamingjson" ];
+
+  meta = {
+    description = "Streamlined, user-friendly JSON streaming preprocessor";
+    homepage = "https://github.com/karminski/streaming-json-py";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ethanthoma ];
+  };
+}

--- a/pkgs/development/python-modules/streamingjson/default.nix
+++ b/pkgs/development/python-modules/streamingjson/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  __structuredAttrs = true;
+
+  pname = "streamingjson";
+  version = "0.0.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "karminski";
+    repo = "streaming-json-py";
+    tag = version;
+    hash = "sha256-XKqW5gbK55OKoAWftoh5CmGc0Sn5FOvGKmrAbsEvIMo=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "streamingjson" ];
+
+  meta = {
+    description = "Streamlined, user-friendly JSON streaming preprocessor";
+    homepage = "https://github.com/karminski/streaming-json-py";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ethanthoma ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17929,6 +17929,8 @@ self: super: with self; {
 
   streaming-form-data = callPackage ../development/python-modules/streaming-form-data { };
 
+  streamingjson = callPackage ../development/python-modules/streamingjson { };
+
   streamlabswater = callPackage ../development/python-modules/streamlabswater { };
 
   streamlit = callPackage ../development/python-modules/streamlit { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19966,6 +19966,8 @@ self: super: with self; {
 
   streaming-form-data = callPackage ../development/python-modules/streaming-form-data { };
 
+  streamingjson = callPackage ../development/python-modules/streamingjson { };
+
   streamlabswater = callPackage ../development/python-modules/streamlabswater { };
 
   streamlit = callPackage ../development/python-modules/streamlit { };


### PR DESCRIPTION
streamingjson is a JSON streaming preprocessor library

## Things done:
- Built on platform:
    - [x] x86_64-linux
    - [ ] aarch64-linux
    - [ ] x86_64-darwin
    - [ ] aarch64-darwin
- Tested, as applicable:
    - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests).
    - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at passthru.tests.
    - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and "core" functionality.
- [ ] Ran nixpkgs-review on this PR. See [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage).
- [ ] Tested basic functionality of all binary files, usually in ./result/bin/.
- Nixpkgs Release Notes
    - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
    - [ ] Module addition: when adding a new NixOS module.
    - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.
---
Add a 👍 [reaction](https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to [pull requests you find important](https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).