### PR TITLE
gimp: 3.0.4 -> 3.0.6

### DIFF
--- a/pkgs/applications/graphics/gimp/default.nix
+++ b/pkgs/applications/graphics/gimp/default.nix
@@ -47,7 +47,7 @@
   vala,
   gi-docgen,
   perl,
-  appstream-glib,
+  appstream,
   desktop-file-utils,
   xorg,
   glib-networking,
@@ -79,7 +79,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gimp";
-  version = "3.0.4";
+  version = "3.0.6";
 
   outputs = [
     "out"
@@ -90,10 +90,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://download.gimp.org/gimp/v${lib.versions.majorMinor finalAttrs.version}/gimp-${finalAttrs.version}.tar.xz";
-    hash = "sha256-jKouwnW/CTJldWVKwnavwIP4SR58ykXRnPKeaWrsqyU=";
+    hash = "sha256-JGwiU4PHLvnw3HcDt9cHCEu/F3vSkA6UzkZqYoYuKWs=";
   };
 
   patches = [
+    # https://gitlab.gnome.org/GNOME/gimp/-/issues/15257
+    (fetchpatch {
+      name = "fix-gegl-bevel-test.patch";
+      url = "https://gitlab.gnome.org/GNOME/gimp/-/commit/2fd12847496a9a242ca8edc448d400d3660b8009.patch";
+      hash = "sha256-pjOjyzZxxl+zRqThXBwCBfYHdGhgaMI/IMKaL3XGAMs=";
+    })
+
     # to remove compiler from the runtime closure, reference was retained via
     # gimp --version --verbose output
     (replaceVars ./remove-cc-reference.patch {
@@ -112,13 +119,6 @@ stdenv.mkDerivation (finalAttrs: {
     # so we need to pick up the one from the package.
     (replaceVars ./tests-dbus-conf.patch {
       session_conf = "${dbus.out}/share/dbus-1/session.conf";
-    })
-
-    # Fix a crash that occurs when trying to pick a color for text outline
-    # TODO: remove after GIMP 3.2 is released, per https://gitlab.gnome.org/GNOME/gimp/-/issues/14047#note_2491655
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gimp/-/commit/1685c86af5d6253151d0056a9677ba469ea10164.diff";
-      hash = "sha256-Rb3ANXWki21thByEIWkBgWEml4x9Qq2HAIB9ho1bygw=";
     })
   ];
 
@@ -148,7 +148,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    appstream-glib # for library
+    appstream # for library
     babl
     cfitsio
     gegl

--- a/pkgs/applications/graphics/gimp/tests-dbus-conf.patch
+++ b/pkgs/applications/graphics/gimp/tests-dbus-conf.patch
@@ -1,5 +1,5 @@
---- a/build/meson/run_test_env.sh
-+++ b/build/meson/run_test_env.sh
+--- a/tools/run_test_env.sh
++++ b/tools/run_test_env.sh
 @@ -33,7 +33,7 @@ if [ -n "${UI_TEST}" ]; then
      OPT="--auto-servernum"
    fi


### PR DESCRIPTION
Fixes CVE-2025-10934.
https://gitlab.gnome.org/GNOME/gimp/-/issues/14814

https://gitlab.gnome.org/GNOME/gimp/-/issues?release_tag=GIMP_3_0_6&scope=all&state=closed


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 459702`
Commit: `0a80dadf9dc092dde5d3077996d5f031b9ced848`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 10 packages built:</summary>
  <ul>
    <li>gimp (gimpPlugins.gimp)</li>
    <li>gimp-with-plugins</li>
    <li>gimp-with-plugins.man</li>
    <li>gimp.dev (gimpPlugins.gimp.dev)</li>
    <li>gimp.devdoc (gimpPlugins.gimp.devdoc)</li>
    <li>gimp.man (gimpPlugins.gimp.man)</li>
    <li>gimpPlugins.gmic</li>
    <li>gimpPlugins.lightning</li>
    <li>gimpPlugins.resynthesizer</li>
    <li>xapp-thumbnailers</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
