### PR TITLE
iceshelf: update 0-unstable-2019-07-03 -> 0-unstable-2025-06-30

### DIFF
--- a/pkgs/by-name/ic/iceshelf/package.nix
+++ b/pkgs/by-name/ic/iceshelf/package.nix
@@ -3,31 +3,54 @@
   fetchFromGitHub,
   git,
   awscli,
+  par2cmdline,
   python3,
+  sshpass,
+  openssh,
 }:
 
 python3.pkgs.buildPythonApplication {
   pname = "iceshelf";
-  version = "0-unstable-2019-07-03";
+  version = "0-unstable-2025-06-30";
 
   format = "other";
 
   src = fetchFromGitHub {
     owner = "mrworf";
     repo = "iceshelf";
-    rev = "26768dde3fc54fa412e523eb8f8552e866b4853b";
-    sha256 = "08rcbd14vn7312rmk2hyvdzvhibri31c4r5lzdrwb1n1y9q761qm";
+    rev = "5380c49e3f7f3df04b61a494b2d94db2f2c65e25";
+    sha256 = "09bbjlkb9kvsb5hrnm36gcgjw5rwchvyq4dza9jazsf6l5gmj8l6";
   };
 
+  postPatch = ''
+    substituteInPlace iceshelf --replace-fail "Popen(['git'" "Popen(['${git}/bin/git'"
+    substituteInPlace modules/fileutils.py --replace-fail "cmd = [\"par2\"" "cmd = ['${par2cmdline}/bin/par2'"
+    substituteInPlace modules/configuration.py --replace-fail "which(\"par2\")" "which('${par2cmdline}/bin/par2')"
+    substituteInPlace modules/providers/sftp.py \
+      --replace-fail "base += ['sshpass'" "base += ['${sshpass}/bin/sshpass'" \
+      --replace-fail "sftp_cmd = ['sftp'" "sftp_cmd = ['${openssh}/bin/sftp'" \
+      --replace-fail "_which('sshpass')" "_which('${sshpass}/bin/sshpass')" \
+      --replace-fail "_which('sftp')" "_which('${openssh}/bin/sftp')"
+    substituteInPlace modules/providers/scp.py \
+      --replace-fail "base += ['sshpass'" "base += ['${sshpass}/bin/sshpass'" \
+      --replace-fail "scp_cmd = ['scp'" "scp_cmd = ['${openssh}/bin/scp'" \
+      --replace-fail "_which('sshpass')" "_which('${sshpass}/bin/sshpass')" \
+      --replace-fail "_which('scp')" "_which('${openssh}/bin/scp')"
+    substituteInPlace modules/providers/s3.py \
+      --replace-fail "cmd = ['aws'" "cmd = ['${awscli}/bin/aws'" \
+      --replace-fail "_which('aws')" "_which('${awscli}/bin/aws')"
+    substituteInPlace modules/providers/glacier.py --replace-fail "_which('aws')" "_which('${awscli}/bin/aws')"
+    substituteInPlace modules/aws.py --replace-fail "cmd = ['aws'" "cmd = ['${awscli}/bin/aws'"
+  '';
+
   propagatedBuildInputs = [
-    git
-    awscli
     python3.pkgs.python-gnupg
+    python3.pkgs.boto3
   ];
 
   installPhase = ''
     mkdir -p $out/bin $out/share/doc/iceshelf $out/${python3.sitePackages}
-    cp -v iceshelf iceshelf-restore $out/bin
+    cp -v iceshelf iceshelf-restore iceshelf-retrieve iceshelf-inspect $out/bin
     cp -v iceshelf.sample.conf $out/share/doc/iceshelf/
     cp -rv modules $out/${python3.sitePackages}
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Updated iceshelf from 2019-07-03 to 2025-06-30
  - Version was written for python2, but was packaged with python3, and so it did not run at all. New version was updated to python3.
  - Fixes #459073
  - Diff https://github.com/mrworf/iceshelf/compare/26768dde3fc54fa412e523eb8f8552e866b4853b..5380c49e3f7f3df04b61a494b2d94db2f2c65e25
  - Breaking changes:
    - py2 -> py3
    - Glacier vault -> different providers (glacier, s3, scp, etc.)
      - https://github.com/mrworf/iceshelf/blob/5380c49e3f7f3df04b61a494b2d94db2f2c65e25/README.md?plain=1#L55
- Added par2cmdline dependency
  - Optional dependency, needed for parity feature of iceshelf, will run fine without par2cmdline, as long as parity is not enabled in config
  - par2 dependency listed here https://github.com/mrworf/iceshelf/blob/5380c49e3f7f3df04b61a494b2d94db2f2c65e25/README.md?plain=1#L8
  - Depends on command line version of par2, not libpar2 https://github.com/mrworf/iceshelf/blob/5380c49e3f7f3df04b61a494b2d94db2f2c65e25/modules/fileutils.py#L30
- Added boto3 dependency
  - Listed here: https://github.com/mrworf/iceshelf/blob/5380c49e3f7f3df04b61a494b2d94db2f2c65e25/requirements.txt#L3
  - Imported here: https://github.com/mrworf/iceshelf/blob/5380c49e3f7f3df04b61a494b2d94db2f2c65e25/iceshelf-retrieve#L18
- Exported/exposed iceshelf-retrieve executable
  - Intended for async retrievals from aws glacier vaults
- Exported/exposed iceshelf-inspect executable
  - Intended for inspecting/querying current backups/stored metadata

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
