### PR TITLE
webcord(-vencord): bump electron to v37

### DIFF
--- a/pkgs/by-name/we/webcord-vencord/package.nix
+++ b/pkgs/by-name/we/webcord-vencord/package.nix
@@ -1,6 +1,6 @@
 {
   # allow overriding electron
-  electron_36,
+  electron_37,
   webcord,
   replaceVars,
   lib,
@@ -8,7 +8,7 @@
 }:
 
 # nixpkgs-update: no auto update
-(webcord.override { inherit electron_36; }).overrideAttrs (old: {
+(webcord.override { inherit electron_37; }).overrideAttrs (old: {
   pname = "webcord-vencord";
 
   patches = (old.patches or [ ]) ++ [

--- a/pkgs/by-name/we/webcord/package.nix
+++ b/pkgs/by-name/we/webcord/package.nix
@@ -5,7 +5,7 @@
   copyDesktopItems,
   python3,
   xdg-utils,
-  electron_36,
+  electron_37,
   makeDesktopItem,
 }:
 
@@ -55,7 +55,7 @@ buildNpmPackage rec {
       install -Dm644 sources/assets/icons/app.png $out/share/icons/hicolor/256x256/apps/webcord.png
 
       # Add xdg-utils to path via suffix, per PR #181171
-      makeWrapper '${lib.getExe electron_36}' $out/bin/webcord \
+      makeWrapper '${lib.getExe electron_37}' $out/bin/webcord \
         --suffix PATH : "${binPath}" \
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
         --add-flags $out/lib/node_modules/webcord/

--- a/pkgs/by-name/we/webcord/update.sh
+++ b/pkgs/by-name/we/webcord/update.sh
@@ -12,4 +12,4 @@ latestVersion="$(expr "$latestTag" : 'v\(.*\)')"
 
 nix-update --version "$latestVersion" webcord
 electronVersion=$(curl_github "https://raw.githubusercontent.com/SpacingBat3/WebCord/v$latestVersion/package.json" | jq -r ".devDependencies.electron" | sed -r 's|^\^([0-9]+).*|\1|')
-sed -r "/webcord = / s|(electron_)[0-9]+|\1$electronVersion|" -i pkgs/top-level/all-packages.nix
+sed -r "s|(electron_)[0-9]+|\1$electronVersion|" -i pkgs/by-name/we/webcord{,-vencord}/package.nix


### PR DESCRIPTION
Tracking PR / issue: #458485.
I managed to build the package on darwin as well, but I'm not able to test it right now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
