### PR TITLE
coredns: fix compile errors with externalPlugins

### DIFF
--- a/pkgs/by-name/co/coredns/package.nix
+++ b/pkgs/by-name/co/coredns/package.nix
@@ -77,6 +77,7 @@ buildGoModule (finalAttrs: {
     diff -u plugin.cfg.orig plugin.cfg || true
     for src in ${toString (attrsToSources externalPlugins)}; do go get $src; done
     GOOS= GOARCH= go generate
+    go mod tidy
     go mod vendor
   '';
 


### PR DESCRIPTION
Runs `go mod tidy` to resolve issues like
```
go: github.com/coredns/coredns/plugin/trace imports
        github.com/DataDog/dd-trace-go/v2/ddtrace/tracer imports
        golang.org/x/xerrors: missing go.sum entry for module providing package golang.org/x/xerrors (imported by github.com/DataDog/dd-trace-go/v2/ddtrace/tracer); to add:
        go get github.com/DataDog/dd-trace-go/v2/ddtrace/tracer@v2.2.3
go: github.com/coredns/coredns/plugin/kubernetes imports
        k8s.io/client-go/kubernetes imports
        k8s.io/client-go/discovery imports
        k8s.io/client-go/openapi imports
        k8s.io/kube-openapi/pkg/validation/spec imports
        github.com/go-openapi/jsonreference: missing go.sum entry for module providing package github.com/go-openapi/jsonreference (imported by k8s.io/kube-openapi/pkg/validation/spec); to add:
        go get k8s.io/kube-openapi/pkg/validation/spec@v0.0.0-20250710124328-f3f2b991d03b
```
when using `externalPlugins`.

Resolves #307750

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
