### PR TITLE
`meta.outputs`

### DIFF
--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -155,6 +155,36 @@
   "julec-hook-variables": [
     "index.html#julec-hook-variables"
   ],
+  "lib.packageTypes.application": [
+    "index.html#lib.packageTypes.application"
+  ],
+  "lib.packageTypes.container": [
+    "index.html#lib.packageTypes.container"
+  ],
+  "lib.packageTypes.data": [
+    "index.html#lib.packageTypes.data"
+  ],
+  "lib.packageTypes.device-driver": [
+    "index.html#lib.packageTypes.device-driver"
+  ],
+  "lib.packageTypes.file": [
+    "index.html#lib.packageTypes.file"
+  ],
+  "lib.packageTypes.firmware": [
+    "index.html#lib.packageTypes.firmware"
+  ],
+  "lib.packageTypes.framework": [
+    "index.html#lib.packageTypes.framework"
+  ],
+  "lib.packageTypes.library": [
+    "index.html#lib.packageTypes.library"
+  ],
+  "lib.packageTypes.operating-system": [
+    "index.html#lib.packageTypes.operating-system"
+  ],
+  "lib.packageTypes.runtime": [
+    "index.html#lib.packageTypes.runtime"
+  ],
   "major-ghc-deprecation": [
     "index.html#major-ghc-deprecation"
   ],
@@ -267,6 +297,9 @@
   ],
   "sec-meta-identifiers-cpe": [
     "index.html#sec-meta-identifiers-cpe"
+  ],
+  "sec-meta-type": [
+    "index.html#sec-meta-type"
   ],
   "sec-modify-via-packageOverrides": [
     "index.html#sec-modify-via-packageOverrides"

--- a/doc/stdenv/meta.chapter.md
+++ b/doc/stdenv/meta.chapter.md
@@ -249,6 +249,52 @@ Code to be executed on a peripheral device or embedded controller, built by a th
 
 Code to run on a VM interpreter or JIT compiled into bytecode by a third party. This includes packages which download Java `.jar` files from another source.
 
+## Types {#sec-meta-type}
+
+As derivations are synonymous with packages in nixpkgs, it is difficult to determine what kind of package a derivation is. To solve this, the `type` attribute exists.
+These types are based on the [component type](https://cyclonedx.org/docs/1.7/json/#components_items_type) in the [CycloneDX SBOM](https://cyclonedx.org) format.
+More types may be added in the future.
+
+### `lib.packageTypes.application` {#lib.packageTypes.application}
+
+A generic application, commonly a GUI or CLI tool.
+
+### `lib.packageTypes.framework` {#lib.packageTypes.framework}
+
+A framework used for developing or running applications.
+
+### `lib.packageTypes.library` {#lib.packageTypes.library}
+
+A library, applications and frameworks usually depends on these.
+
+### `lib.packageTypes.container` {#lib.packageTypes.container}
+
+A derivation which contains a runtime format. An example would be a Docker or OCI container as a tarball.
+
+### `lib.packageTypes.runtime` {#lib.packageTypes.runtime}
+
+A derivation which contains a runtime environment. A wrapped environment produced by something like `buildEnv` is an example of this.
+
+### `lib.packageTypes.operating-system` {#lib.packageTypes.operating-system}
+
+A software operating system, a NixOS toplevel derivation is an example of an operating-system type.
+
+### `lib.packageTypes.firmware` {#lib.packageTypes.firmware}
+
+Firmware is a special type of software which provides low-level control of hardware.
+
+### `lib.packageTypes.device-driver` {#lib.packageTypes.device-driver}
+
+A device driver is a piece of software which is loaded in to provide software access to various hardware devices.
+
+### `lib.packageTypes.file` {#lib.packageTypes.file}
+
+A derivation which outputs a file.
+
+### `lib.packageTypes.data` {#lib.packageTypes.data}
+
+A derivation containing data.
+
 ## Software identifiers {#sec-meta-identifiers}
 
 Package's `meta.identifiers` attribute specifies information about software identifiers associated with this package. Software identifiers are used, for example:

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -412,6 +412,9 @@ rec {
               assert condition;
               drv.${outputName}.outPath;
           }
+          // optionalAttrs (passthru ? meta) {
+            meta = commonAttrs.meta // passthru.meta.outputs.${outputName} or { };
+          }
           //
             # TODO: give the derivation control over the outputs.
             #       `overrideAttrs` may not be the only attribute that needs
@@ -432,6 +435,9 @@ rec {
       outPath =
         assert condition;
         drv.outPath;
+    }
+    // optionalAttrs (passthru ? meta) {
+      meta = commonAttrs.meta // passthru.meta.outputs.${drv.outputName or "out"} or { };
     };
 
   /**

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -75,6 +75,7 @@ let
       # constants
       licenses = callLibs ./licenses.nix;
       sourceTypes = callLibs ./source-types.nix;
+      packageTypes = callLibs ./package-types.nix;
       systems = callLibs ./systems;
 
       # serialization

--- a/lib/package-types.nix
+++ b/lib/package-types.nix
@@ -1,0 +1,15 @@
+{ lib }:
+# Types of packages
+# Based on the CycloneDX component type - https://cyclonedx.org/docs/1.7/json/#components_items_type
+lib.genAttrs [
+  "application"
+  "framework"
+  "library"
+  "container"
+  "runtime"
+  "operating-system"
+  "device-driver"
+  "firmware"
+  "file"
+  "data"
+] lib.id

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -169,6 +169,18 @@ runTests {
           version = "1.0";
           meta = {
             description = "Fake derivation that's an input for the unit test";
+            longDescription = "The default long description.";
+            outputs = {
+              out = {
+                # Maybe use a more detailed type from https://github.com/NixOS/nixpkgs/pull/459543
+                type = "program";
+                mainProgram = "examplectl";
+              };
+              lib = {
+                type = "library";
+                longDescription = "A library for computation tree logic.";
+              };
+            };
           };
         };
         drv = derivation {
@@ -209,11 +221,24 @@ runTests {
             "lib"
           ];
         assert p.meta.description == "Fake derivation that's an input for the unit test";
+
+        # `meta` output inheriting logic
+        assert p.outputName == "out" -> p.meta.type == "program";
+        assert p.outputName == "lib" -> p.meta.type == "library";
+        assert p.outputName == "out" -> p.meta.mainProgram == "examplectl";
+        assert p.outputName == "lib" -> !p.meta ? mainProgram;
+
+        assert p.outputName == "out" -> p.meta.longDescription == "The default long description.";
+        assert p.outputName == "lib" -> p.meta.longDescription == "A library for computation tree logic.";
+        assert p.outputName == "out" -> p.meta.mainProgram == "examplectl";
+        assert p.outputName == "lib" -> !p.meta ? mainProgram;
+
         true
       );
 
       assert lib.strings.hasSuffix "example-1.0" example.outPath;
       assert lib.strings.hasSuffix "example-1.0-lib" example.lib.outPath;
+      # Significant: this "activates" the `p.outputName == "out" ->` implications in the assertions above.
       assert example.outputName == "out";
       assert example ? outputSpecified == false;
 

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -75,6 +75,8 @@ let
       nixosLabel = config.system.nixos.label;
 
       inherit (config.system) extraDependencies;
+
+      meta.type = [ lib.packageTypes.operating-system ];
     }
     // config.system.systemBuilderArgs
   );

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -27,6 +27,7 @@ let
     isAttrs
     isString
     mapAttrs
+    packageTypes
     ;
 
   inherit (lib.lists)
@@ -363,6 +364,7 @@ let
         any
         listOf
         bool
+        enum
         ;
       platforms = listOf (union [
         str
@@ -438,6 +440,8 @@ let
       isFcitxEngine = bool;
       isIbusEngine = bool;
       isGutenprint = bool;
+
+      type = listOf (enum (attrNames packageTypes));
 
       # Used for the original location of the maintainer and team attributes to assist with pings.
       maintainersPosition = any;
@@ -659,6 +663,8 @@ let
       # or nix-env complains: https://github.com/NixOS/nix/blob/2.18.8/src/nix-env/nix-env.cc#L963
       ${if maintainersPosition == null then null else "maintainersPosition"} = maintainersPosition;
       ${if teamsPosition == null then null else "teamsPosition"} = teamsPosition;
+
+      type = [ ];
     }
     // attrs.meta or { }
     // {

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -448,6 +448,9 @@ let
       teamsPosition = any;
 
       identifiers = attrs;
+
+      # Output-specific metadata (shallow check, because cyclic)
+      outputs = attrsOf attrs;
     };
 
   checkMetaAttr =

--- a/pkgs/stdenv/generic/meta-types.nix
+++ b/pkgs/stdenv/generic/meta-types.nix
@@ -95,4 +95,12 @@ lib.fix (self: {
       name = "union<${concatStringsSep "," (map (t: t.name) types)}>";
       verify = v: any (func: func v) funcs;
     };
+
+  enum =
+    values:
+    assert isList values;
+    {
+      name = "enum<${concatStringsSep "," (map toString values)}>";
+      verify = v: any (i: i == v) values;
+    };
 })

--- a/pkgs/tools/compression/bzip2/default.nix
+++ b/pkgs/tools/compression/bzip2/default.nix
@@ -79,6 +79,15 @@ stdenv.mkDerivation (
       pkgConfigModules = [ "bzip2" ];
       platforms = platforms.all;
       maintainers = with maintainers; [ mic92 ];
+      outputs = {
+        bin = {
+          type = packageTypes.application;
+          mainProgram = "bzip2";
+        };
+        out = {
+          type = packageTypes.library;
+        };
+      };
     };
   }
 )


### PR DESCRIPTION
A per-output `meta` support prototype, in support of
- https://github.com/NixOS/nixpkgs/pull/459543

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
