### PR TITLE
[25.05] containerd: 2.1.4 -> 2.1.5

### DIFF
--- a/pkgs/by-name/co/containerd/package.nix
+++ b/pkgs/by-name/co/containerd/package.nix
@@ -16,7 +16,7 @@
 
 buildGoModule rec {
   pname = "containerd";
-  version = "2.1.4";
+  version = "2.1.5";
 
   outputs = [
     "out"
@@ -28,7 +28,7 @@ buildGoModule rec {
     owner = "containerd";
     repo = "containerd";
     tag = "v${version}";
-    hash = "sha256-eC9mfB/FWDxOGucNizHBiRkhkEFDdSxu9vRnXZp5Tug=";
+    hash = "sha256-P948Rn11kAENAX3qHrSmIdV6VgybbuHdOTAgcYWk2bg=";
   };
 
   postPatch = "patchShebangs .";


### PR DESCRIPTION
Fixes CVE-2024-25621 and CVE-2025-64329.

https://github.com/containerd/containerd/releases/tag/v2.1.5

Not-cherry-picked-because: unstable will be bumped to the 2.2.x branch see #459282


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 459787`
Commit: `965963559e3f46771775aea0d01c5dd0b32c4406`

---
### `aarch64-linux`
<details>
  <summary>:white_check_mark: 25 packages built:</summary>
  <ul>
    <li>airlift</li>
    <li>airlift.dist</li>
    <li>charliecloud</li>
    <li>containerd</li>
    <li>containerd.doc</li>
    <li>containerd.man</li>
    <li>devcontainer</li>
    <li>docker (docker_27)</li>
    <li>docker-gc</li>
    <li>docker-language-server</li>
    <li>docker-sbom</li>
    <li>docker-vackup</li>
    <li>docker_25</li>
    <li>docker_26</li>
    <li>docker_28</li>
    <li>flintlock</li>
    <li>fn-cli</li>
    <li>nomad-driver-containerd</li>
    <li>pipework</li>
    <li>python312Packages.jupyter-repo2docker</li>
    <li>python312Packages.jupyter-repo2docker.dist</li>
    <li>python313Packages.jupyter-repo2docker</li>
    <li>python313Packages.jupyter-repo2docker.dist</li>
    <li>tests.devShellTools.nixos</li>
    <li>wrkflw</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
