### PR TITLE
polari: Switch to girepository-2.0

### DIFF
--- a/pkgs/by-name/po/polari/package.nix
+++ b/pkgs/by-name/po/polari/package.nix
@@ -3,6 +3,7 @@
   lib,
   itstool,
   fetchurl,
+  fetchpatch,
   gdk-pixbuf,
   telepathy-glib,
   gjs,
@@ -42,6 +43,13 @@ stdenv.mkDerivation rec {
     # If we wrap it in a shell script, gjs can no longer run it.
     # Let’s change the code to run the script directly by making it executable and having gjs in shebang.
     ./make-thumbnailer-wrappable.patch
+
+    # Switch to girepository-2.0
+    # https://gitlab.gnome.org/GNOME/polari/-/merge_requests/356
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/polari/-/commit/d7946c7fe39f112cd3f751bb95b170446022980d.patch";
+      hash = "sha256-naRzZ5Iple11HJ+d8DL9oJy3C4VKLkz+FdMuhO7sc7k=";
+    })
   ];
 
   propagatedUserEnvPkgs = [ telepathy-idle ];


### PR DESCRIPTION
gjs-1.85 switched to girepository-2.0

```
(process:91134): GLib-GObject-CRITICAL **: 00:05:55.036: cannot register existing type 'GIRepository'
```

*I haven't checked other gjs reverse deps yet, I found this when randomly browsing [Solus's patches](https://github.com/search?q=repo%3Agetsolus%2Fpackages+girepository+language%3ADiff&type=code&l=Diff).*

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

