### PR TITLE
dosage: 3.0 -> 3.2

### DIFF
--- a/pkgs/by-name/do/dosage/package.nix
+++ b/pkgs/by-name/do/dosage/package.nix
@@ -2,15 +2,16 @@
   lib,
   python3Packages,
   fetchPypi,
+  nix-update-script,
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "dosage";
-  version = "3.0";
+  version = "3.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-mHV/U9Vqv7fSsLYNrCXckkJ1YpsccLd8HsJ78IwLX0Y=";
+    sha256 = "sha256-MHikoqbsQ2WkDi+S+1fhHuJy/cwzHu6PVy/JfALNJUI=";
   };
 
   pyproject = true;
@@ -24,21 +25,16 @@ python3Packages.buildPythonApplication rec {
   build-system = [ python3Packages.setuptools-scm ];
 
   dependencies = with python3Packages; [
-    colorama
+    brotli
     imagesize
     lxml
-    requests
-    six
     platformdirs
+    requests
+    rich
+    zstandard
   ];
 
-  disabledTests = [
-    # need network connect to api.github.com
-    "test_update_available"
-    "test_no_update_available"
-    "test_update_broken"
-    "test_current"
-  ];
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Comic strip downloader and archiver";


### PR DESCRIPTION
Update dosage from 3.0 to 3.2

Changes:
- Changelog: https://github.com/webcomics/dosage/blob/main/CHANGELOG.md#32---2025-11-04
- Fixes [CVE-2025-64184](https://github.com/webcomics/dosage/security/advisories/GHSA-4vcx-3pj3-44m7)
- Add nix-update-script for future auto-update
- Update dependencies (brotli & zstandard are optional, but highly recommended)
- Remove disabled tests (they use mocked networking)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
