### PR TITLE
mpv: backport fix high CPU usage with Wayland clipboard

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -121,6 +121,20 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/mpv-player/mpv/commit/26b29fba02a2782f68e2906f837d21201fc6f1b9.patch";
       hash = "sha256-ANNoTtIJBARHbm5IgrE0eEZyzmNhOnbVgve7iqCBzQg=";
     })
+    # clipboard-wayland: prevent reading from hung up fd:
+    #   https://github.com/mpv-player/mpv/pull/16140
+    (fetchpatch {
+      name = "clipboard-wayland-prevent-hung-up-fd.patch";
+      url = "https://github.com/mpv-player/mpv/commit/d20ded876d27497d3fe6a9494add8106b507a45c.patch";
+      hash = "sha256-sll4BpeVW6OA+/vbH7ZfIh0/vePfPEX87vzUu/GCj44=";
+    })
+    # clipboard-wayland: read already sent data when the fd is hung up:
+    #   https://github.com/mpv-player/mpv/pull/16236
+    (fetchpatch {
+      name = "clipboard-wayland-read-sent-data-on-hangup.patch";
+      url = "https://github.com/mpv-player/mpv/commit/896b3400f3cad286533dbb9cc3658ce18ed9966c.patch";
+      hash = "sha256-GU0VdYC/Q0RCS/I2h4gBVNhScDLSAB2KxN3Ca6CGBMM=";
+    })
   ];
 
   postPatch = lib.concatStringsSep "\n" [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Backport of an upstream patch that fixes high CPU usage (100% on one core) related to the Wayland clipboard. Without this patch on KDE Plasma 6, after a fresh boot with an empty clipboard, one core stays at 100% until you copy something. After copying, CPU usage returns to normal.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
