### PR TITLE
maintainers: drop builditluc

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3914,13 +3914,6 @@
     githubId = 7214361;
     name = "Roman Gerasimenko";
   };
-  builditluc = {
-    email = "git@builditluc.eu";
-    github = "Builditluc";
-    githubId = 37375448;
-    name = "Builditluc";
-    keys = [ { fingerprint = "FF16E475723B8C1E57A6B2569374074AE2D6F20E"; } ];
-  };
   burmudar = {
     email = "william.bezuidenhout@gmail.com";
     github = "burmudar";

--- a/pkgs/by-name/co/codecrafters-cli/package.nix
+++ b/pkgs/by-name/co/codecrafters-cli/package.nix
@@ -48,7 +48,7 @@ buildGoModule rec {
     description = "CodeCrafters CLI to run tests";
     mainProgram = "codecrafters";
     homepage = "https://github.com/codecrafters-io/cli";
-    maintainers = with maintainers; [ builditluc ];
+    maintainers = [ ];
     license = licenses.mit;
   };
 }

--- a/pkgs/by-name/ho/hoard/package.nix
+++ b/pkgs/by-name/ho/hoard/package.nix
@@ -30,9 +30,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/hyde46/hoard";
     changelog = "https://github.com/Hyde46/hoard/blob/${src.rev}/CHANGES.md";
     license = licenses.mit;
-    maintainers = with maintainers; [
-      builditluc
-    ];
+    maintainers = [ ];
     mainProgram = "hoard";
   };
 }

--- a/pkgs/by-name/wi/wiki-tui/package.nix
+++ b/pkgs/by-name/wi/wiki-tui/package.nix
@@ -34,7 +34,6 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       lom
-      builditluc
       matthiasbeyer
     ];
     mainProgram = "wiki-tui";

--- a/pkgs/by-name/yo/youki/package.nix
+++ b/pkgs/by-name/yo/youki/package.nix
@@ -60,7 +60,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://containers.github.io/youki/";
     changelog = "https://github.com/containers/youki/releases/tag/v${version}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ builditluc ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
     mainProgram = "youki";
   };


### PR DESCRIPTION
Inactive for the last 6+ months, despite multiple requested reviews.

Dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/tree/a7808b41c3cfd040fbe03e12a68654db3c02d5bc/maintainers#losing-maintainer-status)

@Builditluc: if you'd like to stay involved, please respond saying so within a week. Even if you don't make it, you are of course welcome back whenever you would like!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
