### PR TITLE
maintainers: drop aristid

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2088,12 +2088,6 @@
     githubId = 8049011;
     name = "Arik Grahl";
   };
-  aristid = {
-    email = "aristidb@gmail.com";
-    github = "aristidb";
-    githubId = 30712;
-    name = "Aristid Breitkreuz";
-  };
   ariutta = {
     email = "anders.riutta@gmail.com";
     github = "ariutta";

--- a/nixos/tests/containers-bridge.nix
+++ b/nixos/tests/containers-bridge.nix
@@ -10,7 +10,6 @@ in
   name = "containers-bridge";
   meta = {
     maintainers = with lib.maintainers; [
-      aristid
       aszlig
     ];
   };

--- a/nixos/tests/containers-imperative.nix
+++ b/nixos/tests/containers-imperative.nix
@@ -3,7 +3,6 @@
   name = "containers-imperative";
   meta = {
     maintainers = with lib.maintainers; [
-      aristid
       aszlig
     ];
   };

--- a/nixos/tests/containers-ip.nix
+++ b/nixos/tests/containers-ip.nix
@@ -17,7 +17,6 @@ in
   name = "containers-ipv4-ipv6";
   meta = {
     maintainers = with lib.maintainers; [
-      aristid
       aszlig
     ];
   };

--- a/nixos/tests/containers-portforward.nix
+++ b/nixos/tests/containers-portforward.nix
@@ -10,7 +10,6 @@ in
   name = "containers-portforward";
   meta = {
     maintainers = with lib.maintainers; [
-      aristid
       aszlig
       ianwookim
     ];

--- a/pkgs/by-name/id/ideviceinstaller/package.nix
+++ b/pkgs/by-name/id/ideviceinstaller/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ aristid ];
+    maintainers = [ ];
     mainProgram = "ideviceinstaller";
   };
 }

--- a/pkgs/by-name/is/ispc/package.nix
+++ b/pkgs/by-name/is/ispc/package.nix
@@ -109,7 +109,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/ispc/ispc/releases/tag/${finalAttrs.version}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
-      aristid
       thoughtpolice
       athas
       alexfmpe

--- a/pkgs/by-name/jp/jpegoptim/package.nix
+++ b/pkgs/by-name/jp/jpegoptim/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     description = "Optimize JPEG files";
     homepage = "https://www.kokkonen.net/tjko/projects.html";
     license = licenses.gpl3Plus;
-    maintainers = [ maintainers.aristid ];
+    maintainers = [ ];
     platforms = platforms.all;
     mainProgram = "jpegoptim";
   };

--- a/pkgs/by-name/mo/mozjpeg/package.nix
+++ b/pkgs/by-name/mo/mozjpeg/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://github.com/mozilla/mozjpeg";
     license = lib.licenses.bsd3;
-    maintainers = [ lib.maintainers.aristid ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/rq/rq/package.nix
+++ b/pkgs/by-name/rq/rq/package.nix
@@ -47,9 +47,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     mainProgram = "rq";
     homepage = "https://github.com/dflemstr/rq";
     license = with lib.licenses; [ asl20 ];
-    maintainers = with lib.maintainers; [
-      aristid
-      Br1ght0ne
-    ];
+    maintainers = with lib.maintainers; [ Br1ght0ne ];
   };
 })


### PR DESCRIPTION
Inactive since 2022, despite multiple requested reviews.

Dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/tree/a7808b41c3cfd040fbe03e12a68654db3c02d5bc/maintainers#losing-maintainer-status)

@aristidb: if you'd like to stay involved, please respond saying so within a week. Even if you don't make it, you are of course welcome back whenever you would like!
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
