### PR TITLE
gst_all_1.gst-plugins-bad: don't build with gtk3 by default

### DIFF
--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -108,7 +108,8 @@
   # Checks meson.is_cross_build(), so even canExecute isn't enough.
   enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform,
   hotdoc,
-  guiSupport ? true,
+  # causes gtk4 to depend on gtk3 and makes little sense
+  guiSupport ? false,
   gst-plugins-bad,
   apple-sdk_gstreamer,
 }:
@@ -356,8 +357,10 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals (!gst-plugins-base.glEnabled) [
     "-Dgl=disabled"
   ]
-  ++ lib.optionals (!gst-plugins-base.waylandEnabled || !guiSupport) [
+  ++ lib.optionals (!guiSupport) [
     "-Dgtk3=disabled" # Wayland-based GTK sink
+  ]
+  ++ lib.optionals (!gst-plugins-base.waylandEnabled) [
     "-Dwayland=disabled"
   ]
   ++ lib.optionals (!gst-plugins-base.glEnabled) [


### PR DESCRIPTION
gtk4 pulling in gtk3 is silly and stupid. The only reason it is there is gst-plugins-bad for some gtk3 video sink support. We should not be building this...

I am not fully confident with this one, so lets do this after branch-off

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
