### PR TITLE
la-capitaine-icon-theme: fix dangling symlinks

### DIFF
--- a/pkgs/data/icons/la-capitaine-icon-theme/default.nix
+++ b/pkgs/data/icons/la-capitaine-icon-theme/default.nix
@@ -15,8 +15,8 @@ stdenvNoCC.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "keeferrourke";
     repo = "la-capitaine-icon-theme";
-    rev = "v${version}";
-    sha256 = "0id2dddx6rl71472l47vafx968wnklmq6b980br68w82kcvqczzs";
+    tag = "v${version}";
+    hash = "sha256-+n+GN5sCcWTyAigtgyudliOTulP7ECoOCYdm01trokU=";
   };
 
   propagatedBuildInputs = [
@@ -40,6 +40,7 @@ stdenvNoCC.mkDerivation rec {
     mkdir -p $out/share/icons/$pname
     cp -a * $out/share/icons/$pname
     rm $out/share/icons/$pname/{configure,COPYING,LICENSE,*.md}
+    cp "$out/share/icons/$pname/places/scalable/"distributor-logo-{archlinux,debian,kubuntu}.svg "$out/share/icons/$pname/apps/scalable/"
     runHook postInstall
   '';
 


### PR DESCRIPTION
This pull request fixes the build of `la-capitaine-icon-theme` by copying the missing files in place.

ZHF: #457852

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
