### PR TITLE
OpencloudOIDCwebfingerproxy: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9959,6 +9959,12 @@
     githubId = 1162118;
     name = "Harald Gliebe";
   };
+  hajoha = {
+    email = "hajoha@bar0.foo";
+    github = "hajoha";
+    githubId = 9853102;
+    name = "Johann Hackler";
+  };
   hakan-demirli = {
     email = "ehdemirli@proton.me";
     github = "hakan-demirli";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1299,6 +1299,7 @@
   ./services/networking/oidentd.nix
   ./services/networking/oink.nix
   ./services/networking/onedrive.nix
+  ./services/networking/opencloud-oidc-webfinger-proxy.nix
   ./services/networking/openconnect.nix
   ./services/networking/opengfw.nix
   ./services/networking/openvpn.nix

--- a/nixos/modules/services/networking/opencloud-oidc-webfinger-proxy.nix
+++ b/nixos/modules/services/networking/opencloud-oidc-webfinger-proxy.nix
@@ -1,0 +1,76 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.services.opencloudOidcWebfingerProxy;
+in
+{
+  options.services.opencloudOidcWebfingerProxy = {
+    enable = lib.mkEnableOption "opencloud-oidc-webfinger-proxy service";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      defaultText = "pkgs.opencloud-oidc-webfinger-proxy";
+      default = pkgs.callPackage /path/to/opencloud-oidc-webfinger-proxy.nix { };
+      description = "The package to use for the WebFinger proxy.";
+    };
+
+    listenPort = lib.mkOption {
+      type = lib.types.int;
+      default = 9210;
+      description = "Port on which the proxy listens.";
+    };
+
+    upstreamUrl = lib.mkOption {
+      type = lib.types.str;
+      example = "https://cloud.domain.com";
+      description = "Base URL of the real WebFinger endpoint (including schema)";
+    };
+
+    hrefPattern = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      example = "https://auth.domain.com/application/o/";
+      description = "The part of the href URL to be matched and replaced";
+    };
+
+    hrefReplacement = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      example = "https://auth.domain.com/application/o/";
+      description = "The base part to replace the matched pattern with";
+    };
+
+    defaultSuffix = lib.mkOption {
+      type = lib.types.str;
+      default = "opencloud";
+      example = "opencloud";
+      description = "Default issuer suffix when none is provided via header";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.opencloudOidcWebfingerProxy = {
+      description = "OpenCloud OIDC WebFinger Proxy";
+      after = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Environment = [
+          "PORT=${toString cfg.listenPort}"
+          "UPSTREAM_URL=${cfg.upstreamUrl}"
+          "HREF_PATTERN=${cfg.hrefPattern}"
+          "HREF_REPLACEMENT=${cfg.hrefReplacement}"
+          "DEFAULT_SUFFIX=${cfg.defaultSuffix}"
+        ];
+        ExecStart = "${cfg.package}/bin/opencloud-oidc-webfinger-proxy";
+        Restart = "on-failure";
+      };
+    };
+  };
+  meta.maintainers = with lib.maintainers; [ hajoha ];
+}

--- a/pkgs/by-name/op/opencloud-oidc-webfinger-proxy/package.nix
+++ b/pkgs/by-name/op/opencloud-oidc-webfinger-proxy/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  makeWrapper,
+}:
+
+buildGoModule rec {
+  pname = "opencloud-oidc-webfinger-proxy";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "2bros-group";
+    repo = "opencloud-oidc-webfinger-proxy";
+    rev = "v${version}";
+    hash = "sha256-dI8rm/7Xly0cDjRYxKv6l6b2003YMcwz0k77KxBu/AU=";
+  };
+
+  # Generate a minimal go.mod before building because upstream does not provide one.
+  preBuild = ''
+    if [ ! -f go.mod ]; then
+      echo "module github.com/2bros-group/opencloud-oidc-webfinger-proxy" > go.mod
+      go mod tidy
+    fi
+  '';
+
+  vendorHash = null;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  meta = {
+    description = "A lightweight Go-based reverse proxy that dynamically rewrites href fields in WebFinger responses for OpenID Connect (OIDC) clients.";
+    homepage = "https://github.com/2bros-group/opencloud-oidc-webfinger-proxy";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ hajoha ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This PR adds the [opencloud-oidc-webfinger-proxy](https://github.com/2bros-group/opencloud-oidc-webfinger-proxy) package and module to the Nixpkgs repository. 

This is necessary because OpenCloud currently requires static configuration of client IDs, which most OIDC providers do not support. In theory, it should work for other services too, but I have not tried this. 
See the related OpenCloud issue: https://github.com/opencloud-eu/desktop/issues/246.

P.S. This is my first contribution to Nixpkgs. If I have missed something, I apologise and will try to incorporate it into this PR so it can be merged.  
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
