### PR TITLE
python3Packages.pygame-ce: 2.5.5 -> 2.5.6

### DIFF
--- a/pkgs/development/python-modules/pygame-ce/default.nix
+++ b/pkgs/development/python-modules/pygame-ce/default.nix
@@ -25,13 +25,14 @@
   SDL2_mixer,
   SDL2_ttf,
   numpy,
+  astroid,
 
   pygame-gui,
 }:
 
 buildPythonPackage rec {
   pname = "pygame-ce";
-  version = "2.5.5";
+  version = "2.5.6";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -40,7 +41,7 @@ buildPythonPackage rec {
     owner = "pygame-community";
     repo = "pygame-ce";
     tag = version;
-    hash = "sha256-OWC063N7G8t2ai/Qyz8DwP76BrFve5ZCbLD/mQwVbi4=";
+    hash = "sha256-0DNvAs1E6OhN6wTvbMCDt9YAEFoBZp1r7hI4GSnJUl8=";
     # Unicode files cause different checksums on HFS+ vs. other filesystems
     postFetch = "rm -rf $out/docs/reST";
   };
@@ -71,12 +72,13 @@ buildPythonPackage rec {
     # cython was pinned to fix windows build hangs (pygame-community/pygame-ce/pull/3015)
     substituteInPlace pyproject.toml \
       --replace-fail '"pyproject-metadata!=0.9.1",' '"pyproject-metadata",' \
-      --replace-fail '"meson<=1.7.0",' '"meson",' \
-      --replace-fail '"meson-python<=0.17.1",' '"meson-python",' \
-      --replace-fail '"ninja<=1.12.1",' "" \
-      --replace-fail '"cython<=3.0.11",' '"cython",' \
-      --replace-fail '"sphinx<=8.1.3",' "" \
-      --replace-fail '"sphinx-autoapi<=3.3.2",' ""
+      --replace-fail '"meson<=1.9.1",' '"meson",' \
+      --replace-fail '"meson-python<=0.18.0",' '"meson-python",' \
+      --replace-fail '"ninja<=1.13.0",' "" \
+      --replace-fail '"astroid<4.0.0",' "" \
+      --replace-fail '"cython<=3.1.4",' '"cython",' \
+      --replace-fail '"sphinx<=8.2.3",' "" \
+      --replace-fail '"sphinx-autoapi<=3.6.0",' ""
     substituteInPlace buildconfig/config_{unix,darwin}.py \
       --replace-fail 'from distutils' 'from setuptools._distutils'
     substituteInPlace src_py/sysfont.py \
@@ -109,6 +111,7 @@ buildPythonPackage rec {
     (SDL2_image.override { enableSTB = false; })
     SDL2_mixer
     SDL2_ttf
+    astroid
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Relevant to: #475732
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
