### PR TITLE
SDL_audiolib: fix build on darwin

### DIFF
--- a/pkgs/by-name/sd/SDL_audiolib/package.nix
+++ b/pkgs/by-name/sd/SDL_audiolib/package.nix
@@ -6,6 +6,7 @@
   pkg-config,
   stdenv,
   flac,
+  fmt,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -29,9 +30,19 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     SDL2
     flac
+    fmt
   ];
 
   strictDeps = true;
+
+  postPatch = ''
+    # Remove the bundled fmt directory
+    rm -rf 3rdparty/fmt
+
+    # Patch CMakeLists.txt to replace bundled fmt with provided library
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'add_bundled_fmtlib()' 'find_package(fmt REQUIRED)'
+  '';
 
   cmakeFlags = [
     (lib.cmakeBool "USE_DEC_ADLMIDI" false)


### PR DESCRIPTION
Fix broken SDL_audiolib package on darwin.

ZHF: #457852

## Things done

There was an issue with the vendored `fmt` library on darwin. Fixed by bringing in explicit `fmt` package and replacing the vendored library on darwin platforms only.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
