### PR TITLE
{deprecated-crypt-alternative,standard-crypt}: init at 3.13.0

### DIFF
--- a/pkgs/development/python-modules/deprecated-crypt-alternative/default.nix
+++ b/pkgs/development/python-modules/deprecated-crypt-alternative/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  rustPlatform,
+  libxcrypt-legacy,
+}:
+buildPythonPackage rec {
+  pname = "deprecated-crypt-alternative";
+  version = "3.13.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "youknowone";
+    repo = "python-deadlib";
+    tag = "v${version}";
+    hash = "sha256-vhGFTd1yXL4Frqli5D1GwOatwByDjvcP8sxgkdu6Jqg=";
+  };
+
+  sourceRoot = "${src.name}/_crypt";
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit
+      pname
+      version
+      src
+      sourceRoot
+      ;
+    hash = "sha256-KR1fOqextBFpGLytZsEyBQALEhAnP3LT2E5VaaOqkS0=";
+  };
+
+  build-system = [
+    rustPlatform.cargoSetupHook
+    rustPlatform.maturinBuildHook
+  ];
+
+  buildInputs = [ libxcrypt-legacy ];
+
+  nativeCheckInputs = [ rustPlatform.cargoCheckHook ];
+
+  meta = {
+    homepage = "https://github.com/youknowone/python-deadlib";
+    license = lib.licenses.lgpl2;
+    maintainers = [ lib.maintainers.quantenzitrone ];
+  };
+}

--- a/pkgs/development/python-modules/standard-crypt/default.nix
+++ b/pkgs/development/python-modules/standard-crypt/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  deprecated-crypt-alternative,
+  unittestCheckHook,
+}:
+buildPythonPackage rec {
+  pname = "standard-crypt";
+  version = "3.13.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "youknowone";
+    repo = "python-deadlib";
+    tag = "v${version}";
+    hash = "sha256-vhGFTd1yXL4Frqli5D1GwOatwByDjvcP8sxgkdu6Jqg=";
+  };
+
+  sourceRoot = "${src.name}/crypt";
+
+  build-system = [ setuptools ];
+
+  dependencies = [ deprecated-crypt-alternative ];
+
+  nativeCheckInputs = [ unittestCheckHook ];
+
+  meta = {
+    description = "python crypt module - removed from standard library in 3.13";
+    homepage = "https://github.com/youknowone/python-deadlib";
+    license = lib.licenses.psfl;
+    maintainers = [ lib.maintainers.quantenzitrone ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3671,6 +3671,10 @@ self: super: with self; {
 
   deprecated = callPackage ../development/python-modules/deprecated { };
 
+  deprecated-crypt-alternative =
+    callPackage ../development/python-modules/deprecated-crypt-alternative
+      { };
+
   deprecation = callPackage ../development/python-modules/deprecation { };
 
   deprecation-alias = callPackage ../development/python-modules/deprecation-alias { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17781,6 +17781,9 @@ self: super: with self; {
   standard-chunk =
     if pythonAtLeast "3.13" then callPackage ../development/python-modules/standard-chunk { } else null;
 
+  standard-crypt =
+    if pythonAtLeast "3.13" then callPackage ../development/python-modules/standard-crypt { } else null;
+
   standard-imghdr =
     if pythonAtLeast "3.13" then
       callPackage ../development/python-modules/standard-imghdr { }


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
