### PR TITLE
melmatcheq-lv2: 0.1 -> 0.1-unstable-2025-01-30

### DIFF
--- a/pkgs/by-name/me/melmatcheq-lv2/package.nix
+++ b/pkgs/by-name/me/melmatcheq-lv2/package.nix
@@ -9,15 +9,15 @@
   pkg-config,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "MelMatchEQ.lv2";
-  version = "0.1";
+  version = "0.1-unstable-2025-01-30";
 
   src = fetchFromGitHub {
     owner = "brummer10";
     repo = "MelMatchEQ.lv2";
-    rev = "v${version}";
-    sha256 = "1s805jgb9msxfq9047s7pxrngizb00w8sm4z94iii80ba65rd20x";
+    rev = "bee24593209d5c53fdafa62cb43aeeab6c5e880f";
+    hash = "sha256-eceY79s1X0gv0SsC4jJsFh7tq3VxQhcY9/bfJqYUxmk=";
   };
 
   nativeBuildInputs = [ pkg-config ];
@@ -30,11 +30,11 @@ stdenv.mkDerivation rec {
 
   installFlags = [ "INSTALL_DIR=$(out)/lib/lv2" ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/brummer10/MelMatchEQ.lv2";
     description = "Profiling EQ using a 26 step Mel Frequency Band";
-    maintainers = with maintainers; [ magnetophon ];
-    license = licenses.gpl2Plus;
-    platforms = platforms.linux;
+    maintainers = with lib.maintainers; [ magnetophon ];
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
fixes https://github.com/NixOS/nixpkgs/pull/459822

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
