### PR TITLE
ipp-usb: fix man page being installed into double PREFIX, use --replace-fail everywhere

### DIFF
--- a/pkgs/by-name/ip/ipp-usb/package.nix
+++ b/pkgs/by-name/ip/ipp-usb/package.nix
@@ -21,11 +21,13 @@ buildGoModule rec {
   postPatch = ''
     # rebuild with patched paths
     rm ipp-usb.8
-    substituteInPlace Makefile --replace "install: all" "install: man"
-    substituteInPlace systemd-udev/ipp-usb.service --replace "/sbin" "$out/bin"
-    for i in Makefile paths.go ipp-usb.8.md; do
-      substituteInPlace $i --replace "/usr" "$out"
-      substituteInPlace $i --replace "/var/ipp-usb" "/var/lib/ipp-usb"
+    substituteInPlace Makefile \
+      --replace-fail "install: all" "install: man" \
+      --replace-fail "/usr/" "/"
+    substituteInPlace systemd-udev/ipp-usb.service --replace-fail "/sbin" "$out/bin"
+    for i in paths.go ipp-usb.8.md; do
+      substituteInPlace $i --replace-fail "/usr" "$out"
+      substituteInPlace $i --replace-fail "/var/ipp-usb" "/var/lib/ipp-usb"
     done
   '';
 
@@ -43,7 +45,7 @@ buildGoModule rec {
   doInstallCheck = true;
 
   postInstall = ''
-    # to accomodate the makefile
+    # to accommodate the makefile
     cp $out/bin/ipp-usb .
     make install DESTDIR=$out
   '';


### PR DESCRIPTION
Before:

```
 ➜ tree result/
 result
├──  bin
│   └──  ipp-usb
├──  etc
│   └──  ipp-usb
│       └──  ipp-usb.conf
├──  lib
│   ├──  systemd
│   │   └──  system
│   │       └──  ipp-usb.service
│   └──  udev
│       └──  rules.d
│           └──  71-ipp-usb.rules
├──  nix
│   └──  store
│       └──  plvmb2gbjspdgbv5shfkwwv5f1lg7ps3-ipp-usb-0.9.30
│           └──  share
│               ├──  ipp-usb
│               │   └──  quirks
│               │       ├──  blacklist.conf
│               │       ├──  Brother.conf
│               │       ├──  Canon.conf
│               │       ├──  default.conf
│               │       ├──  HP.conf
│               │       ├──  Pantum.conf
│               │       └──  README
│               └──  man
│                   └──  man8
│                       └──  ipp-usb.8.gz
└──  sbin ⇒ bin
```

After:
```
 ➜ tree result/
 result
├──  bin
│   └──  ipp-usb
├──  etc
│   └──  ipp-usb
│       └──  ipp-usb.conf
├──  lib
│   ├──  systemd
│   │   └──  system
│   │       └──  ipp-usb.service
│   └──  udev
│       └──  rules.d
│           └──  71-ipp-usb.rules
├──  sbin ⇒ bin
└──  share
    ├──  ipp-usb
    │   └──  quirks
    │       ├──  blacklist.conf
    │       ├──  Brother.conf
    │       ├──  Canon.conf
    │       ├──  default.conf
    │       ├──  HP.conf
    │       ├──  Pantum.conf
    │       └──  README
    └──  man
        └──  man8
            └──  ipp-usb.8.gz
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
