### PR TITLE
monodraw: init at 1.7.1

### DIFF
--- a/pkgs/by-name/mo/monodraw/package.nix
+++ b/pkgs/by-name/mo/monodraw/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  stdenvNoCC,
+  unzip,
+  fetchurl,
+  writeShellScript,
+  curl,
+  xmlstarlet,
+  gnused,
+  common-updater-scripts,
+}:
+
+let
+  # Monodraw uses build numbers (tracked via Sparkle appcast)
+  # Appcast: https://updates.helftone.com/monodraw/appcast-beta.xml
+  build = "118";
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "monodraw";
+  version = "1.7.1";
+
+  src = fetchurl {
+    url = "https://updates.helftone.com/monodraw/downloads/Monodraw-b${build}.zip";
+    hash = "sha256-7ti/FXoxNMhSYV7TWTeP8mAnCdqukI0SgDdW6RRQsFc=";
+  };
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [ unzip ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    cp -R ./Monodraw.app $out/Applications
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    inherit build;
+    updateScript = writeShellScript "monodraw-update-script" ''
+      set -euo pipefail
+      export PATH="${
+        lib.makeBinPath [
+          curl
+          xmlstarlet
+          gnused
+          common-updater-scripts
+        ]
+      }"
+
+      xml=$(curl -s "https://updates.helftone.com/monodraw/appcast-beta.xml")
+
+      version=$(echo "$xml" | xmlstarlet sel -t -v '//enclosure/@sparkle:shortVersionString')
+      build=$(echo "$xml" | xmlstarlet sel -t -v '//enclosure/@sparkle:version')
+
+      # Update build number in let binding
+      sed -i "s/build = \"[0-9]*\"/build = \"$build\"/" pkgs/by-name/mo/monodraw/package.nix
+
+      # Update version and hash
+      update-source-version monodraw "$version"
+    '';
+  };
+
+  meta = {
+    description = "Powerful ASCII art editor designed for the Mac";
+    homepage = "https://monodraw.helftone.com/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ delafthi ];
+    platforms = [
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
