### PR TITLE
rovium: init at 0.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16388,6 +16388,12 @@
     githubId = 65052855;
     name = "maxicode";
   };
+  maximiliancf = {
+    email = "maximiliancf.dev@icloud.com";
+    github = "MaximilianCF";
+    githubId = 92341177;
+    name = "Maximilian Canez Fernandes";
+  };
   maximsmol = {
     email = "maximsmol@gmail.com";
     github = "maximsmol";

--- a/pkgs/by-name/ro/rovium/package.nix
+++ b/pkgs/by-name/ro/rovium/package.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  autoPatchelfHook,
+  makeBinaryWrapper,
+  wrapGAppsHook3,
+  dpkg,
+  alsa-lib,
+  mesa,
+  gtk3,
+  nss,
+  libxkbfile,
+  libsecret,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "rovium";
+  version = "0.4.0";
+
+  src = fetchurl {
+    url = "https://github.com/rovium/rovium-beta/releases/download/v${finalAttrs.version}/rovium-${finalAttrs.version}-amd64.deb";
+    hash = "sha256-JHFD82MSyvQMYRzzLBFdO8G1RHUKU5sHk5qgYyMqWVE=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeBinaryWrapper
+    wrapGAppsHook3
+    dpkg
+  ];
+
+  buildInputs = [
+    alsa-lib
+    mesa
+    gtk3
+    nss
+    libxkbfile
+    libsecret
+  ];
+
+  autoPatchelfIgnoreMissingDeps = [
+    # Rovium binary is musl-static, libc is embedded
+    "libc.musl-x86_64.so.1"
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+    dpkg-deb -x $src .
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    substituteInPlace usr/share/applications/rovium.desktop \
+      --replace-fail "/opt/Rovium/rovium" "$out/bin/rovium"
+
+    install -D --mode=644 usr/share/applications/rovium.desktop \
+      --target-directory=$out/share/applications
+
+    install -D --mode=644 usr/share/icons/hicolor/512x512/apps/rovium.png \
+      --target-directory=$out/share/icons/hicolor/512x512/apps
+
+    cp --recursive opt $out
+
+    makeWrapper $out/opt/Rovium/rovium $out/bin/rovium \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath finalAttrs.buildInputs}" \
+      --set ELECTRON_ENABLE_LOGGING 0 \
+      --set ELECTRON_NO_UPDATER 1 \
+      --set DBUS_SESSION_BUS_ADDRESS "unix:path=/run/user/\$(id -u)/bus" \
+      --add-flags "--no-sandbox" \
+      --add-flags "--ozone-platform=x11" \
+      --add-flags "--disable-update" \
+      --add-flags "--disable-component-update" \
+      --add-flags "--disable-breakpad" \
+      --add-flags "--disable-background-networking" \
+      --add-flags "--enable-features=UseOzonePlatform"
+
+    runHook postInstall
+  '';
+
+  dontWrapQtApps = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Integrated Development Environment for ROS and Robotics";
+    homepage = "https://rovium.dev";
+    license = lib.licenses.unfreeRedistributable;
+    maintainers = with lib.maintainers; [ maximiliancf ];
+    mainProgram = "rovium";
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
## Description

Rovium is an integrated development environment for ROS and robotics development, built on Electron and Eclipse Theia.

This package repackages the official .deb release for use on NixOS.

## Motivation

Adds support for Rovium IDE, a specialized development environment for robotics projects using ROS/ROS2. This fills a gap for robotics developers using NixOS who need a modern, integrated IDE for their workflows.

## Things done

- [x] Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Added myself as maintainer in `maintainers/maintainer-list.nix`
- [x] Tested basic functionality (package builds and runs)
- [x] Fits [CONTRIBUTING guidelines](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)

## Additional context

- **Homepage:** https://rovium.dev
- **Source:** Official .deb binary release (redistributable)
- **License:** `unfreeRedistributable`
- **Related:** https://github.com/MaximilianCF/rovium-ide-nix

**Note:** This is an unfree package that requires `allowUnfree = true` to install.

## Testing
```bash
# Build the package
nix-build -A rovium

# Run the IDE
./result/bin/rovium
```

Tested successfully on NixOS unstable (x86_64-linux).