### PR TITLE
lmms: fix cmake 4 compatibility

### DIFF
--- a/pkgs/applications/audio/lmms/default.nix
+++ b/pkgs/applications/audio/lmms/default.nix
@@ -91,10 +91,7 @@ mkDerivation rec {
     mainProgram = "lmms";
     homepage = "https://lmms.io";
     license = licenses.gpl2Plus;
-    platforms = [
-      "x86_64-linux"
-      "i686-linux"
-    ];
+    platforms = platforms.linux;
     maintainers = [ ];
   };
 }

--- a/pkgs/applications/audio/lmms/default.nix
+++ b/pkgs/applications/audio/lmms/default.nix
@@ -70,7 +70,21 @@ mkDerivation rec {
     })
   ];
 
-  cmakeFlags = [ "-DWANT_QT5=ON" ];
+  prePatch = ''
+    # Update CMake minimum required version and policies
+    substituteInPlace CMakeLists.txt --replace 'CMAKE_MINIMUM_REQUIRED(VERSION 2.8.7)' 'CMAKE_MINIMUM_REQUIRED(VERSION 3.10)'
+    substituteInPlace CMakeLists.txt --replace 'CMAKE_POLICY(SET CMP0026 OLD)' 'CMAKE_POLICY(SET CMP0026 NEW)'
+    substituteInPlace CMakeLists.txt --replace 'CMAKE_POLICY(SET CMP0050 OLD)' 'CMAKE_POLICY(SET CMP0050 NEW)'
+    substituteInPlace CMakeLists.txt --replace 'GET_TARGET_PROPERTY(BIN2RES bin2res LOCATION)' 'SET(BIN2RES $<TARGET_FILE:bin2res>)'
+  '';
+
+  cmakeFlags = [
+    "-DWANT_QT5=ON"
+  ]
+  ++ lib.optionals (lib.versionOlder version "11.4") [
+    # Fix the build with CMake 4.
+    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+  ];
 
   meta = with lib; {
     description = "DAW similar to FL Studio (music production software)";


### PR DESCRIPTION
Fix LMMS build failure due to cmake4 : #445447
fixes : #450908
ZHF: #457852
Revert changes made at #73558 since now LMMS also builds successfully on AArch64.

Hydra current build fail logs :
https://hydra.nixos.org/build/302895876

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
