### PR TITLE
evil-winrm-py: init at 1.5.0

### DIFF
--- a/pkgs/by-name/ev/evil-winrm-py/package.nix
+++ b/pkgs/by-name/ev/evil-winrm-py/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  libkrb5,
+  versionCheckHook,
+  nix-update-script,
+  enableKerberos ? true,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "evil-winrm-py";
+  version = "1.5.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "adityatelange";
+    repo = "evil-winrm-py";
+    tag = "v${version}";
+    hash = "sha256-IACFPPlkgyJh78p6Jy740CQqcySkMTV/8VVPSRJKTPI=";
+  };
+
+  # Removes the additional binary ewp
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail '"ewp = evil_winrm_py.evil_winrm_py:main",' ""
+  '';
+
+  build-system = [ python3Packages.setuptools ];
+
+  dependencies =
+    with python3Packages;
+    [
+      pypsrp
+      prompt-toolkit
+      tqdm
+    ]
+    ++ lib.optionals enableKerberos pypsrp.optional-dependencies.kerberos;
+
+  # Add the C library if Kerberos is enabled
+  buildInputs = lib.optionals enableKerberos [ libkrb5 ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Execute commands interactively on remote Windows machines using the WinRM protocol";
+    homepage = "https://github.com/adityatelange/evil-winrm-py";
+    changelog = "https://github.com/adityatelange/evil-winrm-py/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ letgamer ];
+    mainProgram = "evil-winrm-py";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This adds evil-winrm-py: https://github.com/adityatelange/evil-winrm-py

A python-based tool for executing commands on remote Windows machines using the WinRM (Windows Remote Management) protocol. It is essentially a python-based rewrite of the popular evil-winrm tool.

To enable Kerberos Support add the following to your nix config:
```nix
(pkgs.evil-winrm-py.override { enableKerberos = true; })
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
