### PR TITLE
mate: add man outputs to all packages that have man pages

### DIFF
--- a/pkgs/desktops/mate/caja/default.nix
+++ b/pkgs/desktops/mate/caja/default.nix
@@ -21,6 +21,10 @@
 stdenv.mkDerivation rec {
   pname = "caja";
   version = "1.28.0";
+  outputs = [
+    "out"
+    "man"
+  ];
 
   src = fetchurl {
     url = "https://pub.mate-desktop.org/releases/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";

--- a/pkgs/desktops/mate/caja/with-extensions.nix
+++ b/pkgs/desktops/mate/caja/with-extensions.nix
@@ -15,13 +15,14 @@ let
 in
 stdenv.mkDerivation {
   pname = "${caja.pname}-with-extensions";
-  version = caja.version;
+  inherit (caja) version outputs;
 
   src = null;
 
   nativeBuildInputs = [
     glib
     wrapGAppsHook3
+    xorg.lndir
   ];
 
   buildInputs =
@@ -41,7 +42,8 @@ stdenv.mkDerivation {
     runHook preInstall
 
     mkdir -p $out
-    ${xorg.lndir}/bin/lndir -silent ${caja} $out
+    lndir -silent ${caja.out} $out
+    lndir -silent ${caja.man} $out
 
     dbus_service_path="share/dbus-1/services/org.mate.freedesktop.FileManager1.service"
     rm -f $out/share/applications/* "$out/$dbus_service_path"

--- a/pkgs/desktops/mate/mate-applets/default.nix
+++ b/pkgs/desktops/mate/mate-applets/default.nix
@@ -28,6 +28,10 @@
 stdenv.mkDerivation rec {
   pname = "mate-applets";
   version = "1.28.1";
+  outputs = [
+    "out"
+    "man"
+  ];
 
   src = fetchurl {
     url = "https://pub.mate-desktop.org/releases/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";

--- a/pkgs/desktops/mate/mate-desktop/default.nix
+++ b/pkgs/desktops/mate/mate-desktop/default.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
   outputs = [
     "out"
     "dev"
+    "man"
   ];
 
   src = fetchurl {

--- a/pkgs/desktops/mate/mate-media/default.nix
+++ b/pkgs/desktops/mate/mate-media/default.nix
@@ -20,6 +20,10 @@
 stdenv.mkDerivation rec {
   pname = "mate-media";
   version = "1.28.1";
+  outputs = [
+    "out"
+    "man"
+  ];
 
   src = fetchurl {
     url = "https://pub.mate-desktop.org/releases/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";

--- a/pkgs/desktops/mate/mate-netbook/default.nix
+++ b/pkgs/desktops/mate/mate-netbook/default.nix
@@ -16,6 +16,10 @@
 stdenv.mkDerivation rec {
   pname = "mate-netbook";
   version = "1.26.0";
+  outputs = [
+    "out"
+    "man"
+  ];
 
   src = fetchurl {
     url = "https://pub.mate-desktop.org/releases/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";

--- a/pkgs/desktops/mate/mate-notification-daemon/default.nix
+++ b/pkgs/desktops/mate/mate-notification-daemon/default.nix
@@ -23,6 +23,10 @@
 stdenv.mkDerivation rec {
   pname = "mate-notification-daemon";
   version = "1.28.5";
+  outputs = [
+    "out"
+    "man"
+  ];
 
   src = fetchFromGitHub {
     owner = "mate-desktop";

--- a/pkgs/desktops/mate/mate-panel/default.nix
+++ b/pkgs/desktops/mate/mate-panel/default.nix
@@ -32,6 +32,10 @@
 stdenv.mkDerivation rec {
   pname = "mate-panel";
   version = "1.28.7";
+  outputs = [
+    "out"
+    "man"
+  ];
 
   src = fetchFromGitHub {
     owner = "mate-desktop";

--- a/pkgs/desktops/mate/mate-panel/with-applets.nix
+++ b/pkgs/desktops/mate/mate-panel/with-applets.nix
@@ -16,11 +16,15 @@ let
 in
 stdenv.mkDerivation {
   pname = "${mate-panel.pname}-with-applets";
-  version = mate-panel.version;
+  inherit (mate-panel) version outputs;
 
   src = null;
 
-  paths = [ mate-panel ] ++ selectedApplets;
+  paths = [
+    mate-panel.out
+    mate-panel.man
+  ]
+  ++ selectedApplets;
   passAsFile = [ "paths" ];
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/mate-power-manager/default.nix
+++ b/pkgs/desktops/mate/mate-power-manager/default.nix
@@ -24,6 +24,10 @@
 stdenv.mkDerivation rec {
   pname = "mate-power-manager";
   version = "1.28.1";
+  outputs = [
+    "out"
+    "man"
+  ];
 
   src = fetchurl {
     url = "https://pub.mate-desktop.org/releases/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";

--- a/pkgs/desktops/mate/mate-settings-daemon/default.nix
+++ b/pkgs/desktops/mate/mate-settings-daemon/default.nix
@@ -25,6 +25,10 @@
 stdenv.mkDerivation rec {
   pname = "mate-settings-daemon";
   version = "1.28.0";
+  outputs = [
+    "out"
+    "man"
+  ];
 
   src = fetchurl {
     url = "https://pub.mate-desktop.org/releases/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";

--- a/pkgs/desktops/mate/mate-settings-daemon/wrapped.nix
+++ b/pkgs/desktops/mate/mate-settings-daemon/wrapped.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation {
   pname = "${mate.mate-settings-daemon.pname}-wrapped";
-  version = mate.mate-settings-daemon.version;
+  inherit (mate.mate-settings-daemon) version outputs;
 
   nativeBuildInputs = [
     wrapGAppsHook3
@@ -25,6 +25,9 @@ stdenv.mkDerivation {
   installPhase = ''
     mkdir -p $out/etc/xdg/autostart
     cp ${mate.mate-settings-daemon}/etc/xdg/autostart/mate-settings-daemon.desktop $out/etc/xdg/autostart
+
+    mkdir -p $out/share/man
+    cp -r ${mate.mate-settings-daemon.man}/share/man/* $out/share/man/
   '';
 
   postFixup = ''
@@ -32,7 +35,7 @@ stdenv.mkDerivation {
     makeWrapper ${mate.mate-settings-daemon}/libexec/mate-settings-daemon $out/libexec/mate-settings-daemon \
       "''${gappsWrapperArgs[@]}"
     substituteInPlace $out/etc/xdg/autostart/mate-settings-daemon.desktop \
-      --replace "${mate.mate-settings-daemon}/libexec/mate-settings-daemon" "$out/libexec/mate-settings-daemon"
+      --replace-fail "${mate.mate-settings-daemon}/libexec/mate-settings-daemon" "$out/libexec/mate-settings-daemon"
   '';
 
   meta = mate.mate-settings-daemon.meta // {

--- a/pkgs/desktops/mate/mate-utils/default.nix
+++ b/pkgs/desktops/mate/mate-utils/default.nix
@@ -24,6 +24,10 @@
 stdenv.mkDerivation rec {
   pname = "mate-utils";
   version = "1.28.0";
+  outputs = [
+    "out"
+    "man"
+  ];
 
   src = fetchurl {
     url = "https://pub.mate-desktop.org/releases/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
