### PR TITLE
assorted UI applications: add man output

### DIFF
--- a/pkgs/applications/graphics/gimp/2.0/default.nix
+++ b/pkgs/applications/graphics/gimp/2.0/default.nix
@@ -64,6 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
   outputs = [
     "out"
     "dev"
+    "man"
   ];
 
   src = fetchurl {

--- a/pkgs/applications/graphics/gimp/default.nix
+++ b/pkgs/applications/graphics/gimp/default.nix
@@ -85,6 +85,7 @@ stdenv.mkDerivation (finalAttrs: {
     "out"
     "dev"
     "devdoc"
+    "man"
   ];
 
   src = fetchurl {

--- a/pkgs/applications/graphics/gimp/wrapper.nix
+++ b/pkgs/applications/graphics/gimp/wrapper.nix
@@ -25,6 +25,10 @@ let
 in
 symlinkJoin {
   name = "gimp-with-plugins-${gimp.version}";
+  outputs = [
+    "out"
+    "man"
+  ];
 
   paths = [ gimp ] ++ selectedPlugins;
 
@@ -41,6 +45,8 @@ symlinkJoin {
     for each in gimp gimp-console; do
       ln -sf "$each-${exeVersion}" $out/bin/$each
     done
+
+    ln -s ${gimp.man} $man
   '';
 
   inherit (gimp) meta;

--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -75,6 +75,10 @@ in
 stdenv.mkDerivation (finalAttrs: {
   pname = "inkscape";
   version = "1.4.2";
+  outputs = [
+    "out"
+    "man"
+  ];
 
   src = fetchurl {
     url = "https://inkscape.org/release/inkscape-${finalAttrs.version}/source/archive/xz/dl/inkscape-${finalAttrs.version}.tar.xz";

--- a/pkgs/applications/graphics/inkscape/with-extensions.nix
+++ b/pkgs/applications/graphics/inkscape/with-extensions.nix
@@ -17,6 +17,11 @@ in
 symlinkJoin {
   name = "inkscape-with-extensions-${lib.getVersion inkscape}";
 
+  outputs = [
+    "out"
+    "man"
+  ];
+
   paths = [ inkscape ] ++ selectedExtensions;
 
   nativeBuildInputs = [ makeWrapper ];
@@ -24,6 +29,8 @@ symlinkJoin {
   postBuild = ''
     rm -f $out/bin/inkscape
     makeWrapper "${inkscape}/bin/inkscape" "$out/bin/inkscape" --set INKSCAPE_DATADIR "$out/share"
+
+    ln -s ${inkscape.man} $man
   '';
 
   inherit (inkscape) meta;

--- a/pkgs/applications/networking/mailreaders/evolution/evolution/default.nix
+++ b/pkgs/applications/networking/mailreaders/evolution/evolution/default.nix
@@ -48,6 +48,11 @@ stdenv.mkDerivation rec {
   pname = "evolution";
   version = "3.58.1";
 
+  outputs = [
+    "out"
+    "man"
+  ];
+
   src = fetchurl {
     url = "mirror://gnome/sources/evolution/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     hash = "sha256-A9jQzM0QKqGnPDHZ4vN0yz24Os3fwRJskYavY9psvsw=";

--- a/pkgs/applications/window-managers/wayfire/default.nix
+++ b/pkgs/applications/window-managers/wayfire/default.nix
@@ -35,6 +35,11 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "wayfire";
   version = "0.10.0";
 
+  outputs = [
+    "out"
+    "man"
+  ];
+
   src = fetchFromGitHub {
     owner = "WayfireWM";
     repo = "wayfire";

--- a/pkgs/applications/window-managers/wayfire/wf-shell.nix
+++ b/pkgs/applications/window-managers/wayfire/wf-shell.nix
@@ -17,6 +17,10 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "wf-shell";
   version = "0.10.0";
+  outputs = [
+    "out"
+    "man"
+  ];
 
   src = fetchFromGitHub {
     owner = "WayfireWM";

--- a/pkgs/by-name/ne/nemo/package.nix
+++ b/pkgs/by-name/ne/nemo/package.nix
@@ -53,6 +53,7 @@ stdenv.mkDerivation rec {
   outputs = [
     "out"
     "dev"
+    "man"
   ];
 
   buildInputs = [


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
