### PR TITLE
assorted UI applications: add man output

### DIFF
--- a/pkgs/applications/gis/qgis/default.nix
+++ b/pkgs/applications/gis/qgis/default.nix
@@ -14,14 +14,12 @@
 }:
 let
   qgis-unwrapped = libsForQt5.callPackage ./unwrapped.nix {
-    withGrass = withGrass;
-    withServer = withServer;
-    withWebKit = withWebKit;
+    inherit withGrass withServer withWebKit;
   };
 in
 
 symlinkJoin {
-  inherit (qgis-unwrapped) version src;
+  inherit (qgis-unwrapped) version outputs src;
   pname = "qgis";
 
   paths = [ qgis-unwrapped ];
@@ -42,6 +40,8 @@ symlinkJoin {
         --prefix PATH : $program_PATH \
         --set PYTHONPATH $program_PYTHONPATH
     done
+
+    ln -s ${qgis-unwrapped.man} $man
   '';
 
   passthru = {

--- a/pkgs/applications/gis/qgis/unwrapped.nix
+++ b/pkgs/applications/gis/qgis/unwrapped.nix
@@ -84,6 +84,10 @@ in
 mkDerivation rec {
   version = "3.44.3";
   pname = "qgis-unwrapped";
+  outputs = [
+    "out"
+    "man"
+  ];
 
   src = fetchFromGitHub {
     owner = "qgis";
@@ -180,7 +184,7 @@ mkDerivation rec {
   dontWrapGApps = true; # wrapper params passed below
 
   postFixup = lib.optionalString withGrass ''
-    # GRASS has to be availble on the command line even though we baked in
+    # GRASS has to be available on the command line even though we baked in
     # the path at build time using GRASS_PREFIX.
     # Using wrapGAppsHook also prevents file dialogs from crashing the program
     # on non-NixOS.

--- a/pkgs/applications/radio/gnuradio/shared.nix
+++ b/pkgs/applications/radio/gnuradio/shared.nix
@@ -27,6 +27,10 @@ let
   cross = stdenv.hostPlatform != stdenv.buildPlatform;
 in
 {
+  outputs = [
+    "out"
+    "man"
+  ];
   src =
     if overrideSrc != { } then
       overrideSrc

--- a/pkgs/applications/radio/gnuradio/wrapper.nix
+++ b/pkgs/applications/radio/gnuradio/wrapper.nix
@@ -79,7 +79,7 @@ let
   pythonEnv = unwrapped.python.withPackages (ps: pythonPkgs);
 
   pname = unwrapped.pname + "-wrapped";
-  inherit (unwrapped) version;
+  inherit (unwrapped) outputs version;
   makeWrapperArgs = builtins.concatStringsSep " " (
     [
     ]
@@ -214,15 +214,21 @@ let
   self =
     if doWrap then
       stdenv.mkDerivation {
-        inherit pname version passthru;
-        nativeBuildInputs = [ makeWrapper ];
-        buildInputs = [
+        inherit
+          pname
+          outputs
+          version
+          passthru
+          ;
+        nativeBuildInputs = [
+          makeWrapper
           xorg.lndir
         ];
         buildCommand = ''
           mkdir $out
           cd $out
-          lndir -silent ${unwrapped}
+          lndir -silent ${unwrapped.out}
+          lndir -silent ${unwrapped.man}
           ${lib.optionalString (extraPackages != [ ]) (
             builtins.concatStringsSep "\n" (
               map (pkg: ''

--- a/pkgs/applications/science/math/R/default.nix
+++ b/pkgs/applications/science/math/R/default.nix
@@ -59,6 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   outputs = [
     "out"
+    "man"
     "tex"
   ];
 

--- a/pkgs/development/python-modules/ipython/default.nix
+++ b/pkgs/development/python-modules/ipython/default.nix
@@ -37,6 +37,10 @@
 buildPythonPackage rec {
   pname = "ipython";
   version = "9.5.0";
+  outputs = [
+    "out"
+    "man"
+  ];
   pyproject = true;
 
   src = fetchPypi {

--- a/pkgs/development/r-modules/wrapper.nix
+++ b/pkgs/development/r-modules/wrapper.nix
@@ -11,6 +11,11 @@ symlinkJoin {
   preferLocalBuild = true;
   allowSubstitutes = false;
 
+  outputs = [
+    "out"
+    "man"
+  ];
+
   buildInputs = [ R ] ++ recommendedPackages ++ packages;
   paths = [ R ];
 
@@ -24,6 +29,8 @@ symlinkJoin {
       makeWrapper "${R}/bin/$exe" "$out/bin/$exe" \
         --prefix "R_LIBS_SITE" ":" "$R_LIBS_SITE"
     done
+
+    ln -s ${R.man} $man
   '';
 
   # Make the list of recommended R packages accessible to other packages such as rpy2

--- a/pkgs/misc/lilypond/default.nix
+++ b/pkgs/misc/lilypond/default.nix
@@ -45,6 +45,10 @@
 stdenv.mkDerivation rec {
   pname = "lilypond";
   version = "2.24.4";
+  outputs = [
+    "out"
+    "man"
+  ];
 
   src = fetchzip {
     url = "http://lilypond.org/download/sources/v${lib.versions.majorMinor version}/lilypond-${version}.tar.gz";

--- a/pkgs/misc/lilypond/with-fonts.nix
+++ b/pkgs/misc/lilypond/with-fonts.nix
@@ -7,7 +7,12 @@
 }:
 
 lib.appendToName "with-fonts" (symlinkJoin {
-  inherit (lilypond) meta name version;
+  inherit (lilypond)
+    pname
+    outputs
+    version
+    meta
+    ;
 
   paths = [ lilypond ] ++ openlilylib-fonts.all;
 
@@ -15,7 +20,9 @@ lib.appendToName "with-fonts" (symlinkJoin {
 
   postBuild = ''
     for p in $out/bin/*; do
-        wrapProgram "$p" --set LILYPOND_DATADIR "$out/share/lilypond/${lilypond.version}"
+      wrapProgram "$p" --set LILYPOND_DATADIR "$out/share/lilypond/${lilypond.version}"
     done
+
+    ln -s ${lilypond.man} $man
   '';
 })


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
