### PR TITLE
nixosTests.nix-config: fix build by unsetting NIX_PATH

### DIFF
--- a/nixos/tests/nix-config.nix
+++ b/nixos/tests/nix-config.nix
@@ -14,7 +14,8 @@
     start_all()
     machine.wait_for_unit("nix-daemon.socket")
     # regression test for the workaround for https://github.com/NixOS/nix/issues/9487
-    print(machine.succeed("nix-instantiate --find-file extra"))
-    print(machine.succeed("nix-instantiate --find-file nonextra"))
+    # unset NIX_PATH because environtment overrides the config
+    print(machine.succeed("env -u NIX_PATH nix-instantiate --find-file extra"))
+    print(machine.succeed("env -u NIX_PATH nix-instantiate --find-file nonextra"))
   '';
 }


### PR DESCRIPTION
This fixes the build failure of `nixosTests.nix-config`.
The test was failing because NIX_PATH overrides the contents of config.
See also: https://github.com/NixOS/nix/issues/13849

This was the first commit the issue was found: 9a94e073bfc38ad5dcb1d5f35e9c6fbb3886ead4

ZHF: #457852

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
