### PR TITLE
casacore: init at 3.7.1

### DIFF
--- a/pkgs/by-name/ca/casacore/package.nix
+++ b/pkgs/by-name/ca/casacore/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  gfortran,
+  flex,
+  bison,
+  blas,
+  lapack,
+  cfitsio,
+  wcslib,
+  fftw,
+  fftwFloat,
+  readline,
+  gsl,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "casacore";
+  version = "3.7.1";
+
+  src = fetchFromGitHub {
+    owner = "casacore";
+    repo = "casacore";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6zgTSGNKp2hHsh3GFl+o6ElavSNYnQvLsfb1xUrgNZI=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    gfortran
+    flex
+    bison
+  ];
+
+  buildInputs = [
+    blas
+    lapack
+    cfitsio
+    wcslib
+    fftw
+    fftwFloat
+    readline
+    gsl
+  ];
+
+  enableParallelBuilding = true;
+
+  strictDeps = true;
+
+  cmakeFlags = [
+    (lib.cmakeBool "ENABLE_SHARED" (!stdenv.hostPlatform.isStatic))
+    (lib.cmakeBool "BUILD_PYTHON3" false) # TODO: If/when we package python-casacore, this will change
+  ];
+
+  meta = {
+    homepage = "https://casacore.github.io/casacore/";
+    changelog = "https://github.com/casacore/casacore/blob/master/CHANGES.md";
+    description = "Suite of C++ libraries for radio astronomy data processing";
+    maintainers = with lib.maintainers; [ kiranshila ];
+    license = lib.licenses.lgpl2Only;
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Adds the [casacore](https://github.com/casacore/casacore) C++ library, a fundamental building block in radio astronomy software

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
