### PR TITLE
umami: 2.19.0 -> 3.0.0

### DIFF
--- a/nixos/modules/services/web-apps/umami.nix
+++ b/nixos/modules/services/web-apps/umami.nix
@@ -36,7 +36,6 @@ in
       apply =
         pkg:
         pkg.override {
-          databaseType = cfg.settings.DATABASE_TYPE;
           collectApiEndpoint = optionalString (
             cfg.settings.COLLECT_API_ENDPOINT != null
           ) cfg.settings.COLLECT_API_ENDPOINT;

--- a/nixos/modules/services/web-apps/umami.nix
+++ b/nixos/modules/services/web-apps/umami.nix
@@ -94,10 +94,7 @@ in
             type = types.nullOr (
               types.str
               // {
-                check =
-                  it:
-                  isString it
-                  && ((hasPrefix "postgresql://" it) || (hasPrefix "postgres://" it) || (hasPrefix "mysql://" it));
+                check = it: isString it && ((hasPrefix "postgresql://" it) || (hasPrefix "postgres://" it));
               }
             );
             # For some reason, Prisma requires the username in the connection string
@@ -110,8 +107,7 @@ in
             defaultText = literalExpression ''if config.services.umami.createPostgresqlDatabase then "postgresql://umami@localhost/umami?host=/run/postgresql" else null'';
             example = "postgresql://root:root@localhost/umami";
             description = ''
-              Connection string for the database. Must start with `postgresql://`, `postgres://`
-              or `mysql://`.
+              Connection string for the database. Must start with `postgresql://` or `postgres://`.
             '';
           };
           DATABASE_URL_FILE = mkOption {
@@ -127,29 +123,9 @@ in
             example = "/run/secrets/umamiDatabaseUrl";
             description = ''
               A file containing a connection string for the database. The connection string
-              must start with `postgresql://`, `postgres://` or `mysql://`.
-              If using this, then DATABASE_TYPE must be set to the appropriate value.
+              must start with `postgresql://` or `postgres://`.
               The contents of the file are read through systemd credentials, therefore the
               user running umami does not need permissions to read the file.
-            '';
-          };
-          DATABASE_TYPE = mkOption {
-            type = types.nullOr (
-              types.enum [
-                "postgresql"
-                "mysql"
-              ]
-            );
-            default =
-              if cfg.settings.DATABASE_URL != null && hasPrefix "mysql://" cfg.settings.DATABASE_URL then
-                "mysql"
-              else
-                "postgresql";
-            defaultText = literalExpression ''if config.services.umami.settings.DATABASE_URL != null && hasPrefix "mysql://" config.services.umami.settings.DATABASE_URL then "mysql" else "postgresql"'';
-            example = "mysql";
-            description = ''
-              The type of database to use. This is automatically inferred from DATABASE_URL, but
-              must be set manually if you are using DATABASE_URL_FILE.
             '';
           };
           COLLECT_API_ENDPOINT = mkOption {
@@ -237,6 +213,10 @@ in
           cfg.createPostgresqlDatabase
           -> cfg.settings.DATABASE_URL == "postgresql://umami@localhost/umami?host=/run/postgresql";
         message = "The option config.services.umami.createPostgresqlDatabase is enabled, but config.services.umami.settings.DATABASE_URL has been modified.";
+      }
+      {
+        assertion = cfg.settings.DATABASE_TYPE or null != "mysql";
+        message = "Umami only supports PostgreSQL as of 3.0.0. Follow migration instructions if you are using MySQL: https://umami.is/docs/guides/migrate-mysql-postgresql";
       }
     ];
 

--- a/pkgs/by-name/um/umami/package.nix
+++ b/pkgs/by-name/um/umami/package.nix
@@ -2,16 +2,17 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
+  fetchpatch,
   fetchurl,
   makeWrapper,
   nixosTests,
   nodejs,
   pnpm_10,
+  prisma,
   prisma-engines,
   openssl,
   rustPlatform,
   # build variables
-  databaseType ? "postgresql",
   collectApiEndpoint ? "",
   trackerScriptNames ? [ ],
   basePath ? "",
@@ -41,14 +42,14 @@ let
   # Pin the specific version of prisma to the one used by upstream
   # to guarantee compatibility.
   prisma-engines' = prisma-engines.overrideAttrs (old: rec {
-    version = "6.7.0";
+    version = "6.18.0";
     src = fetchFromGitHub {
       owner = "prisma";
       repo = "prisma-engines";
-      tag = version;
-      hash = "sha256-Ty8BqWjZluU6a5xhSAVb2VoTVY91UUj6zoVXMKeLO4o=";
+      rev = version;
+      hash = "sha256-p198o8ON5mGPCxK+gE0mW+JVyQlNsCsqwa8D4MNBkpA=";
     };
-    cargoHash = "sha256-HjDoWa/JE6izUd+hmWVI1Yy3cTBlMcvD9ANsvqAoHBI=";
+    cargoHash = "sha256-bNl04GoxLX+B8dPgqWL/VarreBVebjwNDwQjtQcJnsg=";
 
     cargoDeps = rustPlatform.fetchCargoVendor {
       inherit (old) pname;
@@ -56,10 +57,23 @@ let
       hash = cargoHash;
     };
   });
+  prisma' = (prisma.override { prisma-engines = prisma-engines'; }).overrideAttrs (old: rec {
+    version = "6.18.0";
+    src = fetchFromGitHub {
+      owner = "prisma";
+      repo = "prisma";
+      rev = version;
+      hash = "sha256-+WRWa59HlHN2CsYZfr/ptdW3iOuOPfDil8sLR5dWRA4=";
+    };
+    pnpmDeps = old.pnpmDeps.override {
+      inherit src version;
+      hash = "sha256-Et1UiZO2zyw9FHW0OuYK7AMfhIy5j7Q7GDQjaL6gjyg=";
+    };
+  });
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "umami";
-  version = "2.19.0";
+  version = "3.0.0";
 
   nativeBuildInputs = [
     makeWrapper
@@ -71,8 +85,16 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     owner = "umami-software";
     repo = "umami";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-luiwGmCujbFGWANSCOiHIov56gsMQ6M+Bj0stcz9he8=";
+    hash = "sha256-z8YsHTx5k+imeuVALF6Lx+Ksho35+r7tWo863zqUFzI=";
   };
+
+  patches = [
+    # Fix tests on v3.0.0. Remove on the next version.
+    (fetchpatch {
+      url = "https://github.com/umami-software/umami/commit/6135ef9dd218186ed663f89a511fa66bfecc6aec.patch";
+      hash = "sha256-uakKh8M8oC0fqQyPhosefg05+atRU3SVi7Y/xgIWq8M=";
+    })
+  ];
 
   # install dev dependencies as well, for rollup
   pnpmInstallFlags = [ "--prod=false" ];
@@ -85,28 +107,25 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       src
       ;
     fetcherVersion = 2;
-    hash = "sha256-2GiCeCt/mU5Dm5YHQgJF3127WPHq5QLX8JRcUv6B6lE=";
+    hash = "sha256-0E2grcK8n4Xi30eCAVQtmWSQna0B1A/lctP+rEzxQ3A=";
   };
 
   env.CYPRESS_INSTALL_BINARY = "0";
   env.NODE_ENV = "production";
   env.NEXT_TELEMETRY_DISABLED = "1";
 
-  # copy-db-files uses this variable to decide which Prisma schema to use
-  env.DATABASE_TYPE = databaseType;
-
   env.COLLECT_API_ENDPOINT = collectApiEndpoint;
   env.TRACKER_SCRIPT_NAME = lib.concatStringsSep "," trackerScriptNames;
   env.BASE_PATH = basePath;
 
   # Allow prisma-cli to find prisma-engines without having to download them
+  # Only needed at build time for `prisma generate`.
   env.PRISMA_QUERY_ENGINE_LIBRARY = "${prisma-engines'}/lib/libquery_engine.node";
   env.PRISMA_SCHEMA_ENGINE_BINARY = "${prisma-engines'}/bin/schema-engine";
 
   buildPhase = ''
     runHook preBuild
 
-    pnpm copy-db-files
     pnpm build-db-client # prisma generate
 
     pnpm build-tracker
@@ -131,22 +150,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     mv .next/standalone $out
     mv .next/static $out/.next/static
 
-    # Include prisma cli in next standalone build.
-    # This is preferred to using the prisma in nixpkgs because it guarantees
-    # the version matches.
-    # See https://nextjs-forum.com/post/1280550687998083198
-    # and https://nextjs.org/docs/pages/api-reference/config/next-config-js/output#caveats
-    # Unfortunately, using outputFileTracingIncludes doesn't work because of pnpm's symlink structure,
-    # so we just copy the files manually.
-    mkdir -p $out/node_modules/.bin
-    cp node_modules/.bin/prisma $out/node_modules/.bin
-    cp -a node_modules/prisma $out/node_modules
-    cp -a node_modules/.pnpm/@prisma* $out/node_modules/.pnpm
-    cp -a node_modules/.pnpm/prisma* $out/node_modules/.pnpm
-    # remove broken symlinks (some dependencies that are not relevant for running migrations)
-    find "$out"/node_modules/.pnpm/@prisma* -xtype l -exec rm {} \;
-    find "$out"/node_modules/.pnpm/prisma* -xtype l -exec rm {} \;
-
     cp -R public $out/public
     cp -R prisma $out/prisma
 
@@ -159,8 +162,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     makeWrapper ${nodejs}/bin/node $out/bin/umami-server  \
       --set NODE_ENV production \
       --set NEXT_TELEMETRY_DISABLED 1 \
-      --set PRISMA_QUERY_ENGINE_LIBRARY "${prisma-engines'}/lib/libquery_engine.node" \
-      --set PRISMA_SCHEMA_ENGINE_BINARY "${prisma-engines'}/bin/schema-engine" \
       --prefix PATH : ${
         lib.makeBinPath [
           openssl
@@ -168,7 +169,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
         ]
       } \
       --chdir $out \
-      --run "$out/node_modules/.bin/prisma migrate deploy" \
+      --run "${lib.getExe prisma'} migrate deploy" \
       --add-flags "$out/server.js"
 
     runHook postInstall
@@ -182,6 +183,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       sources
       geocities
       ;
+    prisma = prisma';
     prisma-engines = prisma-engines';
     updateScript = ./update.sh;
   };

--- a/pkgs/by-name/um/umami/sources.json
+++ b/pkgs/by-name/um/umami/sources.json
@@ -1,7 +1,7 @@
 {
   "geocities": {
-    "rev": "0817bc800279e26e9ff045b7b129385e5b23012e",
-    "date": "2025-07-29",
-    "hash": "sha256-Rw9UEvUu7rtXFvHEqKza6kn9LwT6C17zJ/ljoN+t6Ek="
+    "rev": "57b66ab58d27b6f5445d88335d39a1e042c82b42",
+    "date": "2025-11-08",
+    "hash": "sha256-quiGzD+rjpcIv4InJ5lbYnLn2AOmdlIW0cYCgPkShMM="
   }
 }

--- a/pkgs/by-name/um/umami/update.sh
+++ b/pkgs/by-name/um/umami/update.sh
@@ -48,3 +48,4 @@ prisma_version=$(grep "@prisma/engines@" "$lock" | head -n1 |  awk -F"[@']" '{pr
 rm "$lock"
 
 nix-update --version "$prisma_version" umami.prisma-engines
+nix-update --version "$prisma_version" umami.prisma


### PR DESCRIPTION
https://github.com/umami-software/umami/releases/tag/v3.0.0

Breaking changes:
- MySQL is no longer supported

Not adding anything to the 25.11 release notes because umami has never been available in 25.05.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
