### PR TITLE
kimi-cli: init at 1.25.0

### DIFF
--- a/pkgs/by-name/ki/kimi-cli/package.nix
+++ b/pkgs/by-name/ki/kimi-cli/package.nix
@@ -1,0 +1,139 @@
+{
+  lib,
+  stdenv,
+  python3Packages,
+  fetchFromGitHub,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+  ripgrep,
+  bash,
+}:
+
+let
+  version = "1.25.0";
+  src = fetchFromGitHub {
+    owner = "MoonshotAI";
+    repo = "kimi-cli";
+    rev = version;
+    hash = "sha256-yuoqaH/H36mEon2Xsxm/mH6+N4u49cQJg5etqWyUwPk=";
+  };
+in
+python3Packages.buildPythonApplication {
+  pname = "kimi-cli";
+  inherit version src;
+  pyproject = true;
+
+  build-system = [ python3Packages.uv-build ];
+  pythonRelaxDeps = true;
+
+  patches = [ ./test-run-kimi-cli-without-uv.patch ];
+
+  dependencies = (
+    with python3Packages;
+    [
+      kosong
+      pykaos
+
+      agent-client-protocol
+      aiofiles
+      aiohttp
+      typer
+      loguru
+      prompt-toolkit
+      pillow
+      pyyaml
+      rich
+      ripgrepy
+      streamingjson
+      trafilatura
+      lxml
+      tenacity
+      # fastmcp -> py-key-value-aio -> aioboto3 -> cfn-lint -> aws-sam-translator
+      # aws-sam-translator-1.103.0 not supported for interpreter python3.14
+      # This creates a dependency conflict with batrachian-toad
+      fastmcp
+      pydantic
+      httpx
+      # batrachian-toad package is required for the `kimi term` feature
+      # but cannot be included due Python version incompatibility
+      # batrachian-toad requires Python >= 3.14
+      # fastmcp's dependency chain breaks with Python 3.14 (aws-sam-translator incompatibility)
+      # batrachian-toad
+      tomlkit
+      jinja2
+      fastapi
+      uvicorn
+      scalar-fastapi
+      websockets
+      keyring
+      setproctitle
+    ]
+    ++ (lib.optionals stdenv.hostPlatform.isDarwin [
+      pyobjc-framework-Cocoa
+    ])
+  );
+
+  postFixup = ''
+    wrapProgram $out/bin/kimi \
+      --prefix PATH : ${lib.makeBinPath [ ripgrep ]} \
+      --set KIMI_CLI_NO_AUTO_UPDATE "1"
+
+    wrapProgram $out/bin/kimi-cli \
+      --prefix PATH : ${lib.makeBinPath [ ripgrep ]} \
+      --set KIMI_CLI_NO_AUTO_UPDATE "1"
+  '';
+
+  preCheck = ''
+    substituteInPlace tests/conftest.py \
+                      tests/tools/test_tool_descriptions.py \
+                      tests/background/test_manager.py \
+                      tests/background/test_worker.py \
+      --replace-fail "/bin/bash" "${lib.getExe bash}"
+
+    substituteInPlace tests/e2e/test_basic_e2e.py tests/e2e/test_media_e2e.py tests_e2e/wire_helpers.py \
+      --replace-fail "@KIMI_CLI@" "$out/bin/kimi-cli"
+    substituteInPlace tests/acp/conftest.py \
+      --replace-fail '_repo_root() / ".venv" / "bin" / "kimi"' "\"$out/bin/kimi-cli\""
+  '';
+
+  enabledTestPaths = [
+    "tests/"
+    "tests_e2e/"
+  ];
+  disabledTestPaths = [
+    # network required
+    "tests/tools/test_fetch_url.py"
+    # no need to test pyinstaller
+    # it requires the file '/nix/store/...-kimi-cli/lib/python3.13/site-packages/kimi_cli/tools/shell/bash.md'
+    # to be located under the '/build/source'.
+    "tests/utils/test_pyinstaller_utils.py"
+    # version incompatibility
+    # kimi-cli requires fastmcp==2.12.5, but nixpkgs provides newer one.
+    "tests/acp/test_protocol_v1.py"
+  ];
+  disabledTests = [
+    "test_mcp_stdio_management"
+    "test_mcp_http_management_and_auth_errors"
+    # timeout
+    "test_mcp_tool_call"
+  ];
+  nativeCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+    python3Packages.pytestCheckHook
+    python3Packages.inline-snapshot
+    python3Packages.pytest-asyncio
+    python3Packages.respx
+    ripgrep
+  ];
+  pythonImportsCheck = [ "kimi_cli" ];
+
+  meta = {
+    description = "Your next CLI agent by MoonshotAI";
+    homepage = "https://github.com/MoonshotAI/kimi-cli";
+    changelog = "https://github.com/MoonshotAI/kimi-cli/blob/${version}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ jinser ];
+    mainProgram = "kimi";
+  };
+}

--- a/pkgs/by-name/ki/kimi-cli/test-run-kimi-cli-without-uv.patch
+++ b/pkgs/by-name/ki/kimi-cli/test-run-kimi-cli-without-uv.patch
@@ -1,0 +1,76 @@
+diff --git a/tests/e2e/test_basic_e2e.py b/tests/e2e/test_basic_e2e.py
+index a092002..401b94a 100644
+--- a/tests/e2e/test_basic_e2e.py
++++ b/tests/e2e/test_basic_e2e.py
+@@ -30,9 +30,7 @@ def _collect_stdout(process: subprocess.Popen[str]) -> list[str]:
+ 
+ def _run_print_mode(config_path: Path, work_dir: Path, user_prompt: str) -> tuple[int, list[str]]:
+     cmd = [
+-        "uv",
+-        "run",
+-        "kimi",
++        "@KIMI_CLI@",
+         "--print",
+         "--yolo",
+         "--input-format",
+@@ -62,9 +60,7 @@ def _run_print_mode(config_path: Path, work_dir: Path, user_prompt: str) -> tupl
+ 
+ def _run_shell_mode(config_path: Path, work_dir: Path, user_prompt: str) -> tuple[int, list[str]]:
+     cmd = [
+-        "uv",
+-        "run",
+-        "kimi",
++        "@KIMI_CLI@",
+         "--yolo",
+         "--prompt",
+         user_prompt,
+@@ -143,9 +139,7 @@ def _run_wire_mode(
+     config_path: Path, work_dir: Path, user_prompt: str
+ ) -> tuple[int, dict[str, object], list[dict[str, object]]]:
+     cmd = [
+-        "uv",
+-        "run",
+-        "kimi",
++        "@KIMI_CLI@",
+         "--wire",
+         "--yolo",
+         "--config-file",
+diff --git a/tests/e2e/test_media_e2e.py b/tests/e2e/test_media_e2e.py
+index 317105e..5d8b490 100644
+--- a/tests/e2e/test_media_e2e.py
++++ b/tests/e2e/test_media_e2e.py
+@@ -126,9 +126,7 @@ def _run_print_mode(
+     config_path: Path, work_dir: Path, messages: list[dict[str, object]]
+ ) -> tuple[int, list[str]]:
+     cmd = [
+-        "uv",
+-        "run",
+-        "kimi",
++        "@KIMI_CLI@",
+         "--print",
+         "--yolo",
+         "--input-format",
+@@ -245,9 +243,7 @@ def test_scripted_echo_media_e2e(temp_work_dir: KaosPath, tmp_path: Path, mode:
+         assert _content_has_text(parsed_contents[1], "The video appears to be a short clip.")
+     elif mode == "wire":
+         cmd = [
+-            "uv",
+-            "run",
+-            "kimi",
++            "@KIMI_CLI@",
+             "--wire",
+             "--yolo",
+             "--config-file",
+diff --git a/tests_e2e/wire_helpers.py b/tests_e2e/wire_helpers.py
+index 51ef94e..a758d95 100644
+--- a/tests_e2e/wire_helpers.py
++++ b/tests_e2e/wire_helpers.py
+@@ -509,7 +509,7 @@ def base_command() -> list[str]:
+     override = os.getenv(WIRE_COMMAND_ENV)
+     if override is not None:
+         override = override.strip()
+-    parts = shlex.split(override, posix=os.name != "nt") if override else ["uv", "run", "kimi"]
++    parts = shlex.split(override, posix=os.name != "nt") if override else ["@KIMI_CLI@"]
+     return [part for part in parts if part != "--wire"]
+ 
+ 

--- a/pkgs/development/python-modules/kosong/default.nix
+++ b/pkgs/development/python-modules/kosong/default.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  buildPythonPackage,
+  kimi-cli,
+  uv-build,
+  jsonschema,
+  loguru,
+  openai,
+  pydantic,
+  python-dotenv,
+  typing-extensions,
+  mcp,
+  anthropic,
+  google-genai,
+  pytestCheckHook,
+  pytest-asyncio,
+  inline-snapshot,
+  respx,
+}:
+
+let
+  inherit (kimi-cli) version src;
+in
+buildPythonPackage (finalAttrs: {
+  pname = "kosong";
+  inherit version;
+  src = src + /packages/kosong;
+  pyproject = true;
+
+  build-system = [ uv-build ];
+  pythonRelaxDeps = true;
+
+  dependencies = [
+    jsonschema
+    loguru
+    openai
+    pydantic
+    python-dotenv
+    typing-extensions
+    mcp
+  ]
+  ++ finalAttrs.passthru.optional-dependencies.contrib;
+  optional-dependencies = {
+    contrib = [
+      anthropic
+      google-genai
+    ];
+  };
+
+  pytestFlags = [ "--asyncio-mode=auto" ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    inline-snapshot
+    pytest-asyncio
+    respx
+  ];
+  pythonImportsCheck = [ "kosong" ];
+
+  meta = {
+    description = "Streaming-first LLM-abstraction layer designed for modern agentic applications";
+    homepage = "https://github.com/MoonshotAI/kimi-cli/tree/main/packages/kosong";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ jinser ];
+  };
+})

--- a/pkgs/development/python-modules/pygrepy/default.nix
+++ b/pkgs/development/python-modules/pygrepy/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  wheel,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "ripgrepy";
+  version = "2.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "securisec";
+    repo = "ripgrepy";
+    rev = finalAttrs.version;
+    hash = "sha256-+Q9O6sLXgdhjxN6+cTJvNhVg6cr0jByETJrlpnc+FEQ=";
+  };
+
+  build-system = [
+    setuptools
+    wheel
+  ];
+
+  pythonImportsCheck = [ "ripgrepy" ];
+
+  meta = {
+    description = "Python module for ripgrep";
+    homepage = "https://github.com/securisec/ripgrepy";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ jinser ];
+  };
+})

--- a/pkgs/development/python-modules/pykaos/default.nix
+++ b/pkgs/development/python-modules/pykaos/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  kimi-cli,
+  uv-build,
+  aiofiles,
+  asyncssh,
+  pytestCheckHook,
+  pytest-asyncio,
+  inline-snapshot,
+}:
+
+let
+  inherit (kimi-cli) version src;
+in
+buildPythonPackage {
+  pname = "kaos";
+  inherit version;
+  src = src + /packages/kaos;
+  pyproject = true;
+
+  # Remove this phase
+  # after the PR https://github.com/MoonshotAI/kimi-cli/pull/743/ is merged and released.
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build>=0.8.5,<0.9.0" "uv_build>=0.8.5,<0.10.0"
+  '';
+
+  build-system = [ uv-build ];
+  pythonRelaxDeps = true;
+
+  dependencies = [
+    aiofiles
+    asyncssh
+  ];
+
+  pytestFlags = [ "--asyncio-mode=auto" ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    inline-snapshot
+    pytest-asyncio
+  ];
+  pythonImportsCheck = [ "kaos" ];
+
+  meta = {
+    description = "A lightweight Python library providing an abstraction layer for agents to interact with operating systems";
+    homepage = "https://github.com/MoonshotAI/kimi-cli/tree/main/packages/kaos";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ jinser ];
+  };
+}

--- a/pkgs/development/python-modules/ripgrepy/default.nix
+++ b/pkgs/development/python-modules/ripgrepy/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  wheel,
+}:
+
+buildPythonPackage rec {
+  pname = "ripgrepy";
+  version = "2.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "securisec";
+    repo = "ripgrepy";
+    rev = version;
+    hash = "sha256-+Q9O6sLXgdhjxN6+cTJvNhVg6cr0jByETJrlpnc+FEQ=";
+  };
+
+  build-system = [
+    setuptools
+    wheel
+  ];
+
+  pythonImportsCheck = [ "ripgrepy" ];
+
+  meta = {
+    description = "Python module for ripgrep";
+    homepage = "https://github.com/securisec/ripgrepy";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ jinser ];
+  };
+}

--- a/pkgs/development/python-modules/streamingjson/default.nix
+++ b/pkgs/development/python-modules/streamingjson/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "streamingjson";
+  version = "0.0.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "karminski";
+    repo = "streaming-json-py";
+    rev = version;
+    hash = "sha256-XKqW5gbK55OKoAWftoh5CmGc0Sn5FOvGKmrAbsEvIMo=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  pythonImportsCheck = [
+    "streamingjson"
+  ];
+
+  meta = {
+    description = "A streamlined, user-friendly JSON streaming preprocessor, crafted in Python";
+    homepage = "https://github.com/karminski/streaming-json-py";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jinser ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8201,6 +8201,8 @@ self: super: with self; {
 
   kornia-rs = callPackage ../development/python-modules/kornia-rs { };
 
+  kosong = callPackage ../development/python-modules/kosong { };
+
   kotsu = callPackage ../development/python-modules/kotsu { };
 
   krakenex = callPackage ../development/python-modules/krakenex { };
@@ -13758,6 +13760,8 @@ self: super: with self; {
 
   pykalman = callPackage ../development/python-modules/pykalman { };
 
+  pykaos = callPackage ../development/python-modules/pykaos { };
+
   pykcs11 = callPackage ../development/python-modules/pykcs11 { };
 
   pykdebugparser = callPackage ../development/python-modules/pykdebugparser { };
@@ -16591,6 +16595,8 @@ self: super: with self; {
 
   ripe-atlas-sagan = callPackage ../development/python-modules/ripe-atlas-sagan { };
 
+  ripgrepy = callPackage ../development/python-modules/ripgrepy { };
+
   riprova = callPackage ../development/python-modules/riprova { };
 
   ripser = callPackage ../development/python-modules/ripser { };
@@ -18315,6 +18321,8 @@ self: super: with self; {
   streamdeck = callPackage ../development/python-modules/streamdeck { };
 
   streaming-form-data = callPackage ../development/python-modules/streaming-form-data { };
+
+  streamingjson = callPackage ../development/python-modules/streamingjson { };
 
   streamlabswater = callPackage ../development/python-modules/streamlabswater { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

[kimi-cli](https://github.com/MoonshotAI/kimi-cli) is an LLM CLI agent developed by MoonshotAI.

DRAFT Note:
- [x] Waiting for the release of a new version of kimi-cli, whose dependency kosong needs to include [this update](https://github.com/MoonshotAI/kosong/pull/15); kosong depends on a deprecated Python libraries.
- [ ] ~~https://github.com/MoonshotAI/kimi-cli/pull/743~~ substituted by `postPatch`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
