### PR TITLE
nixos/xscreensaver: init hooks options

### DIFF
--- a/nixos/modules/services/x11/xscreensaver.nix
+++ b/nixos/modules/services/x11/xscreensaver.nix
@@ -13,6 +13,22 @@ in
     enable = lib.mkEnableOption "xscreensaver user service";
 
     package = lib.mkPackageOption pkgs "xscreensaver" { };
+
+    hooks = lib.mkOption {
+      type = with lib.types; attrsOf lines;
+      description = ''
+        An attrset of events and commands to run upon each event.
+        Refer to <https://www.jwz.org/xscreensaver/man3.html> for supported events.
+      '';
+      defaultText = lib.literalExpression "{ }";
+      default = { };
+      example = lib.literalExpression ''
+        # Reconfigure autorandr on screen wake up
+        {
+          "RUN" = "''${lib.getExe pkgs.autorandr} --change --ignore-lid";
+        };
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -25,14 +41,48 @@ in
       source = "${pkgs.xscreensaver}/libexec/xscreensaver/xscreensaver-auth";
     };
 
-    systemd.user.services.xscreensaver = {
-      enable = true;
-      description = "XScreenSaver";
-      after = [ "graphical-session-pre.target" ];
-      partOf = [ "graphical-session.target" ];
-      wantedBy = [ "graphical-session.target" ];
-      path = [ cfg.package ];
-      serviceConfig.ExecStart = "${cfg.package}/bin/xscreensaver -no-splash";
+    systemd.user.services = {
+      xscreensaver = {
+        enable = true;
+        description = "XScreenSaver";
+        after = [ "graphical-session-pre.target" ];
+        partOf = [ "graphical-session.target" ];
+        wantedBy = [ "graphical-session.target" ];
+        path = [ cfg.package ];
+        serviceConfig.ExecStart = "${cfg.package}/bin/xscreensaver -no-splash";
+      };
+
+      xscreensaver-hooks = lib.mkIf (cfg.enable && cfg.hooks != { }) {
+        enable = true;
+        description = "Run commands on XScreenSaver events";
+        after = [
+          "graphical-session.target"
+          "xscreensaver.service"
+        ];
+        partOf = [ "graphical-session.target" ];
+        wantedBy = [ "graphical-session.target" ];
+        path = [ cfg.package ];
+        serviceConfig = {
+          Restart = "always";
+        };
+        script =
+          let
+            handlers = lib.concatMapAttrsStringSep "\n" (event: action: ''
+              "${event}")
+                      ( ${action}
+                      )
+                      ;;
+            '') cfg.hooks;
+          in
+          ''
+            xscreensaver-command -watch | while read event rest; do
+              echo "XScreenSaver handler script got \"$event\""
+              case $event in
+                ${handlers}
+              esac
+            done
+          '';
+      };
     };
   };
 

--- a/nixos/tests/xscreensaver.nix
+++ b/nixos/tests/xscreensaver.nix
@@ -1,6 +1,6 @@
 { lib, ... }:
 {
-  name = "pass-secret-service";
+  name = "xscreensaver";
   meta.maintainers = with lib.maintainers; [
     vancluever
   ];
@@ -54,9 +54,25 @@
           })
         ];
       };
+
+    hooks =
+      { lib, ... }:
+      {
+        imports = [
+          ./common/x11.nix
+          ./common/user-account.nix
+        ];
+        test-support.displayManager.auto.user = "alice";
+        services.xscreensaver = {
+          enable = true;
+          hooks = {
+            "UNBLANK" = ":> /home/alice/xscreensaver-works";
+          };
+        };
+      };
   };
 
-  testScript = ''
+  testScript = /* python */ ''
     ok.wait_for_x()
     ok.wait_for_unit("xscreensaver", "alice")
     _, output_ok = ok.systemctl("status xscreensaver", "alice")
@@ -77,5 +93,10 @@
     assert 'To prevent the kernel from randomly unlocking' in output_bad_wrapperPrefix
     assert 'your screen via the out-of-memory killer' in output_bad_wrapperPrefix
     assert '"xscreensaver-auth" must be setuid root' in output_bad_wrapperPrefix
+
+    hooks.wait_for_x()
+    hooks.wait_for_unit("xscreensaver", "alice")
+    hooks.wait_for_unit("xscreensaver-hooks", "alice")
+    hooks.wait_for_file("/home/alice/xscreensaver-works")
   '';
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
This PR adds a "hooks" option that allows users to specify a bash script segment to be run on each xscreensaver event. For example, one could pause the music when the screen locks.

c.f. "--watch" flag in https://www.jwz.org/xscreensaver/man3.html



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
