### PR TITLE
home-assistant: 2025.11.0 -> 2025.11.1

### DIFF
--- a/pkgs/development/python-modules/aioamazondevices/default.nix
+++ b/pkgs/development/python-modules/aioamazondevices/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "aioamazondevices";
-  version = "6.5.6";
+  version = "8.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "chemelli74";
     repo = "aioamazondevices";
     tag = "v${version}";
-    hash = "sha256-OgcOsRKqSU3k4myfHmOYaXW259LDgYWj0gXPLwabVIM=";
+    hash = "sha256-q8wmBBXZSu69BAZ1wY4/tlW/usiWwlwVCnAEOOZs5TE=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/onedrive-personal-sdk/default.nix
+++ b/pkgs/development/python-modules/onedrive-personal-sdk/default.nix
@@ -9,14 +9,14 @@
 
 buildPythonPackage rec {
   pname = "onedrive-personal-sdk";
-  version = "0.0.15";
+  version = "0.0.16";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "zweckj";
     repo = "onedrive-personal-sdk";
     tag = "v${version}";
-    hash = "sha256-XKFTwaerAtN0GEZGpJ4Uq81cIrENEkNFhqqqM+eNVII=";
+    hash = "sha256-zGzJtfgOuEfAaL+26jnEZzhKJLhRpBTYPBWzIHqwtXw=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/tuya-device-sharing-sdk/default.nix
+++ b/pkgs/development/python-modules/tuya-device-sharing-sdk/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   setuptools,
   requests,
   paho-mqtt,
@@ -9,21 +9,20 @@
 }:
 let
   pname = "tuya-device-sharing-sdk";
-  version = "0.2.4";
+  version = "0.2.5";
 in
 buildPythonPackage {
   inherit pname version;
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-4RwsuFg2ukvM0rplCZKJx85DbJTpJnhkCVDnfT4r4A8=";
+  src = fetchFromGitHub {
+    owner = "tuya";
+    repo = "tuya-device-sharing-sdk";
+    # no tags on GitHub: https://github.com/tuya/tuya-device-sharing-sdk/issues/2
+    # no sdist on PyPI: https://github.com/tuya/tuya-device-sharing-sdk/issues/41
+    rev = "b2156585daefa39fcd2feff964e9be53124697f1";
+    hash = "sha256-ypAS8tzO4Wyc8pVjSiGaNNl+2fkFNcC3Ftql3l2B8k8=";
   };
-
-  # workaround needed, upstream issue: https://github.com/tuya/tuya-device-sharing-sdk/issues/10
-  postPatch = ''
-    touch requirements.txt
-  '';
 
   build-system = [ setuptools ];
 

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2025.11.0";
+  version = "2025.11.1";
   components = {
     "3_day_blinds" =
       ps: with ps; [

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -299,7 +299,7 @@ let
   extraBuildInputs = extraPackages python.pkgs;
 
   # Don't forget to run update-component-packages.py after updating
-  hassVersion = "2025.11.0";
+  hassVersion = "2025.11.1";
 
 in
 python.pkgs.buildPythonApplication rec {
@@ -320,13 +320,13 @@ python.pkgs.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     tag = version;
-    hash = "sha256-+syn/y2ukZKsnCniZxodRWVcCE3AcvUKt80L2XslKKI=";
+    hash = "sha256-39OY9lKlqnv3QdIdJ698cMTBrF41SxbqQfz6N32mD5s=";
   };
 
   # Secondary source is pypi sdist for translations
   sdist = fetchPypi {
     inherit pname version;
-    hash = "sha256-JSWr+yGvpXYc6Bw3B+xVLpYokVM11dsJZBWYy+W4bH4=";
+    hash = "sha256-W9xuWfz9lCQXaPg+O313mzMxvBfY64CrU7vwNjra/3k=";
   };
 
   build-system = with python.pkgs; [

--- a/pkgs/servers/home-assistant/intents.nix
+++ b/pkgs/servers/home-assistant/intents.nix
@@ -22,7 +22,7 @@
 
 buildPythonPackage rec {
   pname = "home-assistant-intents";
-  version = "2025.10.28";
+  version = "2025.11.7";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -32,7 +32,7 @@ buildPythonPackage rec {
     repo = "intents-package";
     tag = version;
     fetchSubmodules = true;
-    hash = "sha256-Svnw9Jd0E4pMFfa/Do7YsFzdXLzsGmhu8amo+zYDvus=";
+    hash = "sha256-F6QctdjF6xoQ3d49MdOUb/8CHgV84wxZHUrGGmiYYcs=";
   };
 
   build-system = [

--- a/pkgs/servers/home-assistant/stubs.nix
+++ b/pkgs/servers/home-assistant/stubs.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "homeassistant-stubs";
-  version = "2025.11.0";
+  version = "2025.11.1";
   pyproject = true;
 
   disabled = python.version != home-assistant.python.version;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "KapJI";
     repo = "homeassistant-stubs";
     tag = version;
-    hash = "sha256-/A/25x0FMu4MXMHhOZ1MF9Qpw+UgA2OUc/HZaJm9bsQ=";
+    hash = "sha256-OuW2hsYQ/KvCiu1Hfq6g/nryQ5R0Th5GmoR574DMXfU=";
   };
 
   build-system = [

--- a/pkgs/servers/home-assistant/update-component-packages.py
+++ b/pkgs/servers/home-assistant/update-component-packages.py
@@ -69,7 +69,9 @@ EXTRA_COMPONENT_DEPS = {
 OUR_VERSION_IS_NEWER_THAN = {
     "blinkstick": "1.2.0",
     "gps3": "0.33.3",
+    "proxmoxer": "2.2.0",
     "pybluez": "0.22",
+    "pyps4-2ndscreen": "1.3.1",
 }
 
 


### PR DESCRIPTION
Diff: https://github.com/home-assistant/core/compare/2025.11.0...2025.11.1

Changelog: https://github.com/home-assistant/core/releases/tag/2025.11.1

closes https://github.com/NixOS/nixpkgs/pull/459174
closes https://github.com/NixOS/nixpkgs/pull/457513

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
