### PR TITLE
onnxruntime: use --compile-no-warning-as-error for clang&ROCm

### DIFF
--- a/pkgs/by-name/on/onnxruntime/package.nix
+++ b/pkgs/by-name/on/onnxruntime/package.nix
@@ -228,6 +228,10 @@ effectiveStdenv.mkDerivation rec {
     (lib.cmakeBool "onnxruntime_USE_ROCM" rocmSupport)
     (lib.cmakeBool "onnxruntime_ENABLE_LTO" (!cudaSupport || cudaPackages.cudaOlder "12.8"))
   ]
+  ++ lib.optionals (effectiveStdenv.cc.isClang || rocmSupport) [
+    # Disable -Werror from COMPILE_WARNING_AS_ERROR target property
+    "--compile-no-warning-as-error"
+  ]
   ++ lib.optionals pythonSupport [
     (lib.cmakeBool "onnxruntime_ENABLE_PYTHON" true)
   ]
@@ -238,8 +242,6 @@ effectiveStdenv.mkDerivation rec {
     (lib.cmakeFeature "onnxruntime_NVCC_THREADS" "1")
   ]
   ++ lib.optionals rocmSupport [
-    # Werror combines with rocprim header issues to cause errors (warp size const deprecation)
-    "--compile-no-warning-as-error"
     (lib.cmakeFeature "CMAKE_HIP_ARCHITECTURES" (
       builtins.concatStringsSep ";" rocmPackages.clr.localGpuTargets or rocmPackages.clr.gpuTargets
     ))
@@ -249,25 +251,21 @@ effectiveStdenv.mkDerivation rec {
     (lib.cmakeBool "onnxruntime_USE_COMPOSABLE_KERNEL_CK_TILE" false)
   ];
 
-  env =
-    lib.optionalAttrs effectiveStdenv.cc.isClang {
-      NIX_CFLAGS_COMPILE = "-Wno-error";
-    }
-    // lib.optionalAttrs rocmSupport {
-      MIOPEN_PATH = rocmPackages.miopen;
-      # HIP steps fail to find ROCm libs when not in HIPFLAGS, causing
-      # fatal error: 'rocrand/rocrand.h' file not found
-      HIPFLAGS = lib.concatMapStringsSep " " (pkg: "-I${lib.getInclude pkg}/include") [
-        rocmPackages.hipblas
-        rocmPackages.hipcub
-        rocmPackages.hiprand
-        rocmPackages.hipsparse
-        rocmPackages.rocblas
-        rocmPackages.rocprim
-        rocmPackages.rocrand
-        rocmPackages.rocthrust
-      ];
-    };
+  env = lib.optionalAttrs rocmSupport {
+    MIOPEN_PATH = rocmPackages.miopen;
+    # HIP steps fail to find ROCm libs when not in HIPFLAGS, causing
+    # fatal error: 'rocrand/rocrand.h' file not found
+    HIPFLAGS = lib.concatMapStringsSep " " (pkg: "-I${lib.getInclude pkg}/include") [
+      rocmPackages.hipblas
+      rocmPackages.hipcub
+      rocmPackages.hiprand
+      rocmPackages.hipsparse
+      rocmPackages.rocblas
+      rocmPackages.rocprim
+      rocmPackages.rocrand
+      rocmPackages.rocthrust
+    ];
+  };
 
   doCheck =
     !(


### PR DESCRIPTION
We were using two different approaches to ask for no `-Werror`, let's clean up by using the `cmakeFlags` approach consistently.

Fixes: 27767283176858b2786fd485b1a99535a47a05ed

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
