### PR TITLE
linuxPackages.rtl8814au: mark broken on kernel versions < 5.2 and > 6.14

### DIFF
--- a/pkgs/os-specific/linux/rtl8814au/default.nix
+++ b/pkgs/os-specific/linux/rtl8814au/default.nix
@@ -42,5 +42,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/morrownr/8814au";
     license = licenses.gpl2Only;
     maintainers = [ maintainers.lassulus ];
+    broken = kernel.kernelOlder "5.2" || kernel.kernelAtLeast "6.15";
   };
 }


### PR DESCRIPTION
### Mark `linuxPackages.rtl8814au` as broken on kernel versions < 5.2 and > 6.14

- On Hydra, builds for kernel version  5_10, 5_15, 6_1, 6_6 and 6_12 succeed, but the build for the latest latest kernel version 6_17 is failing.

- The upstream provider of the driver only supports kernel versions between version 5.2 and 6.14, inclusive. This is partly because a driver has been up-streamed into the kernel, so the package is not needed for recent kernels, [reference](https://github.com/morrownr/8814au).

- Because of this, mark the driver as broken on the relevant kernel versions.

### Tracking
#457852

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
