### PR TITLE
plemoljp, plemoljp-{nf,hs}: refine updateScript

### DIFF
--- a/pkgs/by-name/pl/plemoljp-hs/package.nix
+++ b/pkgs/by-name/pl/plemoljp-hs/package.nix
@@ -1,15 +1,18 @@
 {
-  lib,
   stdenvNoCC,
   fetchzip,
+  plemoljp,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "plemoljp-hs";
-  version = "3.0.0";
+
+  # plemoljp's updateScript also updates this version.
+  # nixpkgs-update: no auto update
+  inherit (plemoljp) version;
 
   src = fetchzip {
-    url = "https://github.com/yuru7/PlemolJP/releases/download/v${version}/PlemolJP_HS_v${version}.zip";
+    url = "https://github.com/yuru7/PlemolJP/releases/download/v${finalAttrs.version}/PlemolJP_HS_v${finalAttrs.version}.zip";
     hash = "sha256-V21T8ktNZE4nq3SH6aN9iIJHmGTkZuMsvT84yHbwSqI=";
   };
 
@@ -24,11 +27,7 @@ stdenvNoCC.mkDerivation rec {
     runHook postInstall
   '';
 
-  meta = {
+  meta = plemoljp.meta // {
     description = "Composite font of IBM Plex Mono, IBM Plex Sans JP and hidden full-width space";
-    homepage = "https://github.com/yuru7/PlemolJP";
-    license = lib.licenses.ofl;
-    platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ kachick ];
   };
-}
+})

--- a/pkgs/by-name/pl/plemoljp-nf/package.nix
+++ b/pkgs/by-name/pl/plemoljp-nf/package.nix
@@ -1,15 +1,18 @@
 {
-  lib,
   stdenvNoCC,
   fetchzip,
+  plemoljp,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "plemoljp-nf";
-  version = "3.0.0";
+
+  # plemoljp's updateScript also updates this version.
+  # nixpkgs-update: no auto update
+  inherit (plemoljp) version;
 
   src = fetchzip {
-    url = "https://github.com/yuru7/PlemolJP/releases/download/v${version}/PlemolJP_NF_v${version}.zip";
+    url = "https://github.com/yuru7/PlemolJP/releases/download/v${finalAttrs.version}/PlemolJP_NF_v${finalAttrs.version}.zip";
     hash = "sha256-m8zR9ySl88DnVzG4fKJtc9WjSLDMLU4YDX+KXhcP2WU=";
   };
 
@@ -22,11 +25,7 @@ stdenvNoCC.mkDerivation rec {
     runHook postInstall
   '';
 
-  meta = {
+  meta = plemoljp.meta // {
     description = "Composite font of IBM Plex Mono, IBM Plex Sans JP and nerd-fonts";
-    homepage = "https://github.com/yuru7/PlemolJP";
-    license = lib.licenses.ofl;
-    platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ kachick ];
   };
-}
+})

--- a/pkgs/by-name/pl/plemoljp/package.nix
+++ b/pkgs/by-name/pl/plemoljp/package.nix
@@ -2,14 +2,15 @@
   lib,
   stdenvNoCC,
   fetchzip,
+  nix-update-script,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "plemoljp";
   version = "3.0.0";
 
   src = fetchzip {
-    url = "https://github.com/yuru7/PlemolJP/releases/download/v${version}/PlemolJP_v${version}.zip";
+    url = "https://github.com/yuru7/PlemolJP/releases/download/v${finalAttrs.version}/PlemolJP_v${finalAttrs.version}.zip";
     hash = "sha256-R4zC1pnM72FVqBQ5d03z8vyVccsM163BE15m2hdEnSA=";
   };
 
@@ -24,6 +25,12 @@ stdenvNoCC.mkDerivation rec {
     runHook postInstall
   '';
 
+  passthru = {
+    updateScript = nix-update-script {
+      extraArgs = [ "--version-regex=^v([0-9.]+)$" ];
+    };
+  };
+
   meta = {
     description = "Composite font of IBM Plex Mono and IBM Plex Sans JP";
     homepage = "https://github.com/yuru7/PlemolJP";
@@ -31,4 +38,4 @@ stdenvNoCC.mkDerivation rec {
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ kachick ];
   };
-}
+})


### PR DESCRIPTION
* Share `version` and `meta` in font variants
  While fonts have fewer restrictions than executables, the motivation is essentially the same as https://github.com/NixOS/nixpkgs/pull/437460.
  There is no reason to update these packages individually.

* Add `updateScript`
  Upstream used `-beta*` tags for the 2.0.0 release.
  The script now only targets tags for stable versions.

* Prefer `finalAttrs` over `rec`'
  I included this modernization in the same commit because it relates to the version reference.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
