### PR TITLE
zlcompressor: init at 0.2.1

### DIFF
--- a/pkgs/by-name/zl/zlcompressor/package.nix
+++ b/pkgs/by-name/zl/zlcompressor/package.nix
@@ -1,0 +1,120 @@
+{
+  lib,
+  clangStdenv,
+  fetchFromGitHub,
+
+  # nativeBuildInputs
+  cmake,
+  darwin,
+  ninja,
+  pkg-config,
+  writableTmpDirAsHomeHook,
+
+  # buildInputs
+  alsa-lib,
+  curl,
+  expat,
+  fontconfig,
+  freetype,
+  libGL,
+  libXcursor,
+  libXext,
+  libXinerama,
+  libXrandr,
+  libepoxy,
+  libjack2,
+  libxkbcommon,
+  lv2,
+}:
+
+clangStdenv.mkDerivation (finalAttrs: {
+  pname = "zlcompressor";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "ZL-Audio";
+    repo = "ZLCompressor";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-0Z29+jLtAtThFaVVqvuqUJkj1VRI69WOvIbEfE45db4=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    writableTmpDirAsHomeHook
+  ]
+  ++ lib.optionals clangStdenv.hostPlatform.isDarwin [ darwin.sigtool ];
+
+  buildInputs = [
+    curl
+    expat
+    fontconfig
+    freetype
+    lv2
+  ]
+  ++ lib.optionals clangStdenv.hostPlatform.isLinux [
+    alsa-lib
+    libGL
+    libXcursor
+    libXext
+    libXinerama
+    libXrandr
+    libepoxy
+    libjack2
+    libxkbcommon
+  ];
+
+  # JUCE dlopen's these at runtime, crashes without them
+  NIX_LDFLAGS = lib.optionalString clangStdenv.hostPlatform.isLinux (toString [
+    "-lX11"
+    "-lXext"
+    "-lXcursor"
+    "-lXinerama"
+    "-lXrandr"
+  ]);
+
+  # LTO needs special setup on Linux
+  postPatch = lib.optionalString clangStdenv.hostPlatform.isLinux ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'juce::juce_recommended_lto_flags' '# Not forcing LTO'
+  '';
+
+  cmakeFlags = [
+    # see: https://github.com/ZL-Audio/ZlEqualizer#clone-and-build
+    (lib.cmakeFeature "KFR_ARCHS" (
+      if clangStdenv.hostPlatform.isAarch64 then "neon64" else "sse2;avx;avx2"
+    ))
+    (lib.cmakeBool "ZL_JUCE_COPY_PLUGIN" false)
+  ];
+
+  installPhase = ''
+    runHook preInstall
+  ''
+  + lib.optionalString clangStdenv.hostPlatform.isLinux ''
+    mkdir -p $out/lib/{lv2,vst3}
+    mkdir -p $out/bin/
+    cp -r "ZLCompressor_artefacts/Release/LV2/ZL Compressor.lv2" $out/lib/lv2/
+    cp -r "ZLCompressor_artefacts/Release/VST3/ZL Compressor.vst3" $out/lib/vst3/
+    install -Dm755 "ZLCompressor_artefacts/Release/Standalone/ZL Compressor" $out/bin/
+  ''
+  + lib.optionalString clangStdenv.hostPlatform.isDarwin ''
+    mkdir -p $out/Applications
+    cp -r ZLCompressor_artefacts/Release/{AU,VST3} $out/
+    cp -r ZLCompressor_artefacts/Release/Standalone/* $out/Applications/
+  ''
+  + ''
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://zl-audio.github.io/plugins/zlcompressor/";
+    description = "Versatile compressor plugin for VST3, LV2 and standalone";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [
+      magnetophon
+    ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
https://zl-audio.github.io/plugins/zlcompressor/

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
