### PR TITLE
systemd: 258.1 -> 258.2

### DIFF
--- a/nixos/tests/systemd-shutdown.nix
+++ b/nixos/tests/systemd-shutdown.nix
@@ -27,7 +27,7 @@ in
     # automatically and that 'systemd-shutdown' runs our script.
     machine.wait_for_unit("multi-user.target")
     # .shutdown() would wait for the machine to power off
-    machine.succeed("systemctl poweroff")
+    machine.execute("systemctl poweroff", check_return=False)
     # Message printed by systemd-shutdown
     machine.wait_for_console_text("Unmounting '/oldroot'")
     machine.wait_for_console_text("${msg}")

--- a/pkgs/os-specific/linux/systemd/0012-path-util.h-add-placeholder-for-DEFAULT_PATH_NORMAL.patch
+++ b/pkgs/os-specific/linux/systemd/0012-path-util.h-add-placeholder-for-DEFAULT_PATH_NORMAL.patch
@@ -6,24 +6,26 @@ Subject: [PATCH] path-util.h: add placeholder for DEFAULT_PATH_NORMAL
 This will be the $PATH used to lookup ExecStart= etc. options, which
 systemd itself uses extensively.
 ---
- src/basic/path-util.h | 6 +++---
- 1 file changed, 3 insertions(+), 3 deletions(-)
+ src/basic/path-util.h | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/src/basic/path-util.h b/src/basic/path-util.h
-index 45518c07e5..94bef2f4b4 100644
+index a3a82574dd..b836dba7f1 100644
 --- a/src/basic/path-util.h
 +++ b/src/basic/path-util.h
-@@ -9,10 +9,10 @@
+@@ -9,11 +9,11 @@
  #define PATH_MERGED_BIN(x) x "bin"
  #define PATH_MERGED_BIN_NULSTR(x) x "bin\0"
  
--#define DEFAULT_PATH_WITH_SBIN PATH_SPLIT_BIN("/usr/local/") ":" PATH_SPLIT_BIN("/usr/")
+-#define DEFAULT_PATH_WITH_FULL_SBIN PATH_SPLIT_BIN("/usr/local/") ":" PATH_SPLIT_BIN("/usr/")
+-#define DEFAULT_PATH_WITH_LOCAL_SBIN PATH_SPLIT_BIN("/usr/local/") ":" PATH_MERGED_BIN("/usr/")
 -#define DEFAULT_PATH_WITHOUT_SBIN PATH_MERGED_BIN("/usr/local/") ":" PATH_MERGED_BIN("/usr/")
-+#define DEFAULT_PATH_WITH_SBIN "@defaultPathNormal@"
-+#define DEFAULT_PATH_WITHOUT_SBIN DEFAULT_PATH_WITH_SBIN
++#define DEFAULT_PATH_WITH_FULL_SBIN "@defaultPathNormal@"
++#define DEFAULT_PATH_WITH_LOCAL_SBIN DEFAULT_PATH_WITH_FULL_SBIN
++#define DEFAULT_PATH_WITHOUT_SBIN DEFAULT_PATH_WITH_FULL_SBIN
  
--#define DEFAULT_PATH_COMPAT PATH_SPLIT_BIN("/usr/local/") ":" PATH_SPLIT_BIN("/usr/") ":" PATH_SPLIT_BIN("/")
-+#define DEFAULT_PATH_COMPAT DEFAULT_PATH_WITH_SBIN
+-#define DEFAULT_PATH_COMPAT DEFAULT_PATH_WITH_FULL_SBIN ":" PATH_SPLIT_BIN("/")
++#define DEFAULT_PATH_COMPAT DEFAULT_PATH_WITH_FULL_SBIN
  
  const char* default_PATH(void);
  

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -203,13 +203,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   inherit pname;
-  version = "258.1";
+  version = "258.2";
 
   src = fetchFromGitHub {
     owner = "systemd";
     repo = "systemd";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-LA+6/d9W3CxK0G2sXsPHM4BVLf8IzsWW6IxJFby6/JU=";
+    hash = "sha256-1iWeuNefDOIEUSTzxzvt+jfcs6sSMPhxQfdwp0mqUjQ=";
   };
 
   # On major changes, or when otherwise required, you *must* :
@@ -221,16 +221,6 @@ stdenv.mkDerivation (finalAttrs: {
   # Use `find . -name "*.patch" | sort` to get an up-to-date listing of all
   # patches
   patches = [
-    # https://github.com/systemd/systemd/pull/39094
-    (fetchpatch {
-      url = "https://github.com/systemd/systemd/commit/8b4ee3d68d2e70d9a396b74d155eab3b11763311.patch";
-      hash = "sha256-JJDaSHQjd1QZ18CQHq40viB0AF/0MiescmZUcc/6LDg=";
-    })
-    (fetchpatch {
-      url = "https://github.com/systemd/systemd/commit/13b0e7fc6d2623800ba04b104f3b628388c9f5e6.patch";
-      hash = "sha256-X+tY3NjfRJpF6wvd++xEps0DIFTbX/6Zw9oO4Y9FmNI=";
-    })
-
     ./0001-Start-device-units-for-uninitialised-encrypted-devic.patch
     ./0002-Don-t-try-to-unmount-nix-or-nix-store.patch
     ./0003-Fix-NixOS-containers.patch


### PR DESCRIPTION


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
