### PR TITLE
nixos/tests/h2o: some refactoring

### DIFF
--- a/nixos/tests/web-servers/h2o/basic.nix
+++ b/nixos/tests/web-servers/h2o/basic.nix
@@ -36,12 +36,8 @@ in
 
   nodes = {
     server =
-      { pkgs, config, ... }:
+      { config, ... }:
       {
-        environment.systemPackages = [
-          pkgs.curl
-        ];
-
         services.h2o = {
           enable = true;
           defaultHTTPListenPort = 8080;
@@ -111,12 +107,30 @@ in
             ];
           };
           extraHosts = ''
-            127.0.0.1 ${domain.HTTP}
-            127.0.0.1 ${domain.TLS}
+            ${config.networking.primaryIPAddress} ${domain.HTTP}
+            ${config.networking.primaryIPAddress} ${domain.TLS}
           '';
         };
       };
+
+    client =
+      { nodes, pkgs, ... }:
+      {
+        environment.systemPackages = [
+          pkgs.curl
+        ];
+
+        security.pki.certificates = [
+          (builtins.readFile ../../common/acme/server/ca.cert.pem)
+        ];
+
+        networking.extraHosts = ''
+          ${nodes.server.networking.primaryIPAddress} ${domain.HTTP}
+          ${nodes.server.networking.primaryIPAddress} ${domain.TLS}
+        '';
+      };
   };
+
   testScript =
     { nodes, ... }:
     let
@@ -126,30 +140,32 @@ in
     in
     # python
     ''
+      start_all()
+
       server.wait_for_unit("h2o.service")
       server.wait_for_open_port(${portStrHTTP})
       server.wait_for_open_port(${portStrTLS})
 
-      assert "${sawatdi_chao_lok}" in server.succeed("curl --fail-with-body 'http://${domain.HTTP}:${portStrHTTP}/hello_world.txt'")
+      assert "${sawatdi_chao_lok}" in client.succeed("curl --fail-with-body 'http://${domain.HTTP}:${portStrHTTP}/hello_world.txt'")
 
-      tls_hello_world_head = server.succeed("curl -v --head --compressed --http2 --tlsv1.3 --fail-with-body 'https://${domain.TLS}:${portStrTLS}/hello_world.rst'").lower()
+      tls_hello_world_head = client.succeed("curl -v --head --compressed --http2 --tlsv1.3 --fail-with-body 'https://${domain.TLS}:${portStrTLS}/hello_world.rst'").lower()
       assert "http/2 200" in tls_hello_world_head
       assert "server: h2o" in tls_hello_world_head
       assert "content-type: text/x-rst" in tls_hello_world_head
 
-      assert "${sawatdi_chao_lok}" in server.succeed("curl -v --http2 --tlsv1.3 --compressed --fail-with-body 'https://${domain.TLS}:${portStrTLS}/hello_world.rst'")
+      assert "${sawatdi_chao_lok}" in client.succeed("curl -v --http2 --tlsv1.3 --compressed --fail-with-body 'https://${domain.TLS}:${portStrTLS}/hello_world.rst'")
 
-      quic_hello_world_head = server.succeed("curl -v --head --compressed --http3-only --fail-with-body 'https://${domain.TLS}:${portStrTLS}/hello_world.rst'").lower()
+      quic_hello_world_head = client.succeed("curl -v --head --compressed --http3-only --fail-with-body 'https://${domain.TLS}:${portStrTLS}/hello_world.rst'").lower()
       assert "http/3 200" in quic_hello_world_head
       assert "server: h2o" in quic_hello_world_head
       assert "content-type: text/x-rst" in quic_hello_world_head
 
-      assert "${sawatdi_chao_lok}" in server.succeed("curl -v --http3-only --compressed --fail-with-body 'https://${domain.TLS}:${portStrTLS}/hello_world.rst'")
+      assert "${sawatdi_chao_lok}" in client.succeed("curl -v --http3-only --compressed --fail-with-body 'https://${domain.TLS}:${portStrTLS}/hello_world.rst'")
 
-      assert "redirected" in server.succeed("curl -v --head --fail-with-body 'http://${domain.TLS}:${portStrHTTP}/hello_world.rst'").lower()
+      assert "redirected" in client.succeed("curl -v --head --fail-with-body 'http://${domain.TLS}:${portStrHTTP}/hello_world.rst'").lower()
 
-      server.fail("curl --location --max-redirs 0 'http://${domain.TLS}:${portStrHTTP}/hello_world.rst'")
+      client.fail("curl --location --max-redirs 0 'http://${domain.TLS}:${portStrHTTP}/hello_world.rst'")
 
-      assert "${sawatdi_chao_lok}" in server.succeed("curl -v --location --fail-with-body 'http://${domain.TLS}:${portStrHTTP}/hello_world.rst'")
+      assert "${sawatdi_chao_lok}" in client.succeed("curl -v --location --fail-with-body 'http://${domain.TLS}:${portStrHTTP}/hello_world.rst'")
     '';
 }

--- a/nixos/tests/web-servers/h2o/mruby.nix
+++ b/nixos/tests/web-servers/h2o/mruby.nix
@@ -3,8 +3,6 @@
 let
   domain = "h2o.local";
 
-  port = 8080;
-
   sawatdi_chao_lok = "สวัสดีชาวโลก";
 in
 {
@@ -22,7 +20,7 @@ in
           enable = true;
           package = pkgs.h2o.override { withMruby = true; };
           settings = {
-            listen = port;
+            listen = 8080;
             hosts = {
               "${domain}" = {
                 paths = {
@@ -50,8 +48,10 @@ in
   };
 
   testScript =
+    { nodes, ... }:
     let
-      portStr = builtins.toString port;
+      inherit (nodes) server;
+      portStr = builtins.toString server.services.h2o.settings.listen;
     in
     # python
     ''

--- a/nixos/tests/web-servers/h2o/tls-recommendations.nix
+++ b/nixos/tests/web-servers/h2o/tls-recommendations.nix
@@ -2,7 +2,6 @@
 
 let
   domain = "acme.test";
-  port = 8443;
 
   hello_txt =
     name:
@@ -13,7 +12,12 @@ let
 
   mkH2OServer =
     recommendations:
-    { pkgs, lib, ... }:
+    {
+      pkgs,
+      lib,
+      config,
+      ...
+    }:
     {
       services.h2o = {
         enable = true;
@@ -31,7 +35,8 @@ let
         hosts = {
           "${domain}" = {
             tls = {
-              inherit port recommendations;
+              inherit recommendations;
+              port = 8443;
               policy = "force";
               identity = [
                 {
@@ -59,7 +64,9 @@ let
       ];
 
       networking = {
-        firewall.allowedTCPPorts = [ port ];
+        firewall.allowedTCPPorts = [
+          config.services.h2o.hosts.${domain}.tls.port
+        ];
         extraHosts = "127.0.0.1 ${domain}";
       };
     };
@@ -78,43 +85,47 @@ in
   };
 
   testScript =
+    { nodes, ... }:
     let
-      portStr = builtins.toString port;
+      inherit (nodes) server_modern server_intermediate server_old;
+      modernPortStr = builtins.toString server_modern.services.h2o.hosts.${domain}.tls.port;
+      intermediatePortStr = builtins.toString server_intermediate.services.h2o.hosts.${domain}.tls.port;
+      oldPortStr = builtins.toString server_old.services.h2o.hosts.${domain}.tls.port;
     in
     # python
     ''
-      curl_basic = "curl -v --tlsv1.3 --http2 'https://${domain}:${portStr}/'"
-      curl_head = "curl -v --head 'https://${domain}:${portStr}/'"
-      curl_max_tls1_2 ="curl -v --tlsv1.0 --tls-max 1.2 'https://${domain}:${portStr}/'"
-      curl_max_tls1_2_intermediate_cipher ="curl -v --tlsv1.0 --tls-max 1.2 --ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256' 'https://${domain}:${portStr}/'"
-      curl_max_tls1_2_old_cipher ="curl -v --tlsv1.0 --tls-max 1.2 --ciphers 'ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA256' 'https://${domain}:${portStr}/'"
+      curl_basic = "curl -v --tlsv1.3 --http2 'https://${domain}:{port}/'"
+      curl_head = "curl -v --head 'https://${domain}:{port}/'"
+      curl_max_tls1_2 ="curl -v --tlsv1.0 --tls-max 1.2 'https://${domain}:{port}/'"
+      curl_max_tls1_2_intermediate_cipher ="curl -v --tlsv1.0 --tls-max 1.2 --ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256' 'https://${domain}:{port}/'"
+      curl_max_tls1_2_old_cipher ="curl -v --tlsv1.0 --tls-max 1.2 --ciphers 'ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA256' 'https://${domain}:{port}/'"
 
       server_modern.wait_for_unit("h2o.service")
-      server_modern.wait_for_open_port(${portStr})
-      modern_response = server_modern.succeed(curl_basic)
+      server_modern.wait_for_open_port(${modernPortStr})
+      modern_response = server_modern.succeed(curl_basic.format(port="${modernPortStr}"))
       assert "Hello, modern!" in modern_response
-      modern_head = server_modern.succeed(curl_head)
+      modern_head = server_modern.succeed(curl_head.format(port="${modernPortStr}"))
       assert "strict-transport-security" in modern_head
-      server_modern.fail(curl_max_tls1_2)
+      server_modern.fail(curl_max_tls1_2.format(port="${modernPortStr}"))
 
       server_intermediate.wait_for_unit("h2o.service")
-      server_intermediate.wait_for_open_port(${portStr})
-      intermediate_response = server_intermediate.succeed(curl_basic)
+      server_intermediate.wait_for_open_port(${intermediatePortStr})
+      intermediate_response = server_intermediate.succeed(curl_basic.format(port="${intermediatePortStr}"))
       assert "Hello, intermediate!" in intermediate_response
-      intermediate_head = server_modern.succeed(curl_head)
+      intermediate_head = server_modern.succeed(curl_head.format(port="${intermediatePortStr}"))
       assert "strict-transport-security" in intermediate_head
-      server_intermediate.succeed(curl_max_tls1_2)
-      server_intermediate.succeed(curl_max_tls1_2_intermediate_cipher)
-      server_intermediate.fail(curl_max_tls1_2_old_cipher)
+      server_intermediate.succeed(curl_max_tls1_2.format(port="${intermediatePortStr}"))
+      server_intermediate.succeed(curl_max_tls1_2_intermediate_cipher.format(port="${intermediatePortStr}"))
+      server_intermediate.fail(curl_max_tls1_2_old_cipher.format(port="${intermediatePortStr}"))
 
       server_old.wait_for_unit("h2o.service")
-      server_old.wait_for_open_port(${portStr})
-      old_response = server_old.succeed(curl_basic)
+      server_old.wait_for_open_port(${oldPortStr})
+      old_response = server_old.succeed(curl_basic.format(port="${oldPortStr}"))
       assert "Hello, old!" in old_response
-      old_head = server_modern.succeed(curl_head)
+      old_head = server_modern.succeed(curl_head.format(port="${oldPortStr}"))
       assert "strict-transport-security" in old_head
-      server_old.succeed(curl_max_tls1_2)
-      server_old.succeed(curl_max_tls1_2_intermediate_cipher)
-      server_old.succeed(curl_max_tls1_2_old_cipher)
+      server_old.succeed(curl_max_tls1_2.format(port="${oldPortStr}"))
+      server_old.succeed(curl_max_tls1_2_intermediate_cipher.format(port="${oldPortStr}"))
+      server_old.succeed(curl_max_tls1_2_old_cipher.format(port="${oldPortStr}"))
     '';
 }

--- a/nixos/tests/web-servers/h2o/tls-recommendations.nix
+++ b/nixos/tests/web-servers/h2o/tls-recommendations.nix
@@ -78,6 +78,8 @@ in
     maintainers = with lib.maintainers; [ toastal ];
   };
 
+  # not using a `client` since it’s easiest to test with acme.test pointing at
+  # localhost for these machines
   nodes = {
     server_modern = mkH2OServer "modern";
     server_intermediate = mkH2OServer "intermediate";
@@ -99,6 +101,8 @@ in
       curl_max_tls1_2 ="curl -v --tlsv1.0 --tls-max 1.2 'https://${domain}:{port}/'"
       curl_max_tls1_2_intermediate_cipher ="curl -v --tlsv1.0 --tls-max 1.2 --ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256' 'https://${domain}:{port}/'"
       curl_max_tls1_2_old_cipher ="curl -v --tlsv1.0 --tls-max 1.2 --ciphers 'ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA256' 'https://${domain}:{port}/'"
+
+      start_all()
 
       server_modern.wait_for_unit("h2o.service")
       server_modern.wait_for_open_port(${modernPortStr})


### PR DESCRIPTION
Get ports from the node config. Use a client machine where feasible to be a more ‘real world’ test.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
