### PR TITLE
anvil-editor: 0.6 -> 0.6.3

### DIFF
--- a/pkgs/by-name/an/anvil-editor/package.nix
+++ b/pkgs/by-name/an/anvil-editor/package.nix
@@ -12,29 +12,36 @@
   vulkan-headers,
   libGL,
   xorg,
-  buildPackages,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "anvil-editor";
-  version = "0.6";
+  version = "0.6.3";
 
   # has to update vendorHash of extra package manually
   # nixpkgs-update: no auto update
   src = fetchzip {
     url = "https://anvil-editor.net/releases/anvil-src-v${finalAttrs.version}.tar.gz";
-    hash = "sha256-i0S5V3j6OPpu4z1ljDKP3WYa9L+EKwo/MBNgW2ENYk8=";
+    hash = "sha256-GPzd1oKkf160ya0sxUd72wego0BvwCerZ5SiY2q0EDE=";
   };
 
-  modRoot = "anvil/src/anvil";
+  modRoot = "anvil/editor";
 
-  vendorHash = "sha256-1oFBV7D7JgOt5yYAxVvC4vL4ccFv3JrNngZbo+5pzrk=";
+  vendorHash = "sha256-Q2iVB5pvP2/VXjdSwWVkdqrVUj/nIiC/VHyD5nP9ilE=";
 
   anvilExtras = buildGoModule {
     pname = "anvil-editor-extras";
     inherit (finalAttrs) version src meta;
-    vendorHash = "sha256-4pfk5XuwDbCWFZIF+1l+dy8NfnGNjgHmSg9y6/RnTSo=";
-    modRoot = "anvil-extras";
+    vendorHash = "sha256-q/PunSBe+gWTWyf8rjfikK56rP2PeZqpuiFG9HIVMTk=";
+    modRoot = "anvil/extras";
+    # Include dependency on anvil api
+    postPatch = ''
+      pushd anvil/extras
+      cp -r ${finalAttrs.src}/anvil/api/go/anvil ./_anvil_api
+      echo "replace github.com/jeffwilliams/anvil/api/go/anvil => ./_anvil_api" >> go.mod
+      go mod edit -require=github.com/jeffwilliams/anvil/api/go/anvil@v0.0.0
+      popd
+    '';
   };
 
   nativeBuildInputs = [
@@ -75,15 +82,7 @@ buildGoModule (finalAttrs: {
   ];
 
   postInstall = ''
-    pushd ../../img
-      # cannot add to nativeBuildInputs
-      # will be conflict with icnsutils in desktopToDarwinBundle
-      ${lib.getExe' buildPackages.libicns "icns2png"} -x anvil.icns
-      for width in 32 48 128 256; do
-        square=''${width}x''${width}
-        install -Dm644 anvil_''${square}x32.png $out/share/icons/hicolor/''${square}/apps/anvil.png
-      done
-    popd
+    install -Dm644 misc/icon/anvil-icon.svg $out/share/icons/hicolor/scalable/apps/anvil.svg
     cp ${finalAttrs.anvilExtras}/bin/* $out/bin
   '';
 
@@ -94,9 +93,5 @@ buildGoModule (finalAttrs: {
     mainProgram = "anvil";
     maintainers = with lib.maintainers; [ aleksana ];
     platforms = with lib.platforms; unix ++ windows;
-    # Doesn't build with >buildGo123Module.
-    # Multiple errors like the following:
-    # '> vendor/gioui.org/internal/vk/vulkan.go:1916:9: cannot define new methods on non-local type SurfaceCapabilities'
-    broken = true;
   };
 })


### PR DESCRIPTION
This fixes build on newer go versions

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
