### PR TITLE
modules/image/repart: fix typo in renamed option warning

### DIFF
--- a/nixos/modules/image/repart.nix
+++ b/nixos/modules/image/repart.nix
@@ -384,8 +384,8 @@ in
               you're at version 9, you cannot increment this to 10.
             ''
             ++ lib.optional (partitionConfig.stripNixStorePrefix != "_mkMergedOptionModule") ''
-              The option definition `image.repart.paritions.${fileName}.stripNixStorePrefix`
-              has changed to `image.repart.paritions.${fileName}.nixStorePrefix` and now
+              The option definition `image.repart.partitions.${fileName}.stripNixStorePrefix`
+              has changed to `image.repart.partitions.${fileName}.nixStorePrefix` and now
               accepts the path to use as prefix directly. Use `nixStorePrefix = "/"` to
               achieve the same effect as setting `stripNixStorePrefix = true`.
             ''


### PR DESCRIPTION
The repart module suggests using new module options, but has a typo in their name.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
