### PR TITLE
dmenu-wpctl: init at 0.1.0

### DIFF
--- a/pkgs/by-name/dm/dmenu-wpctl/package.nix
+++ b/pkgs/by-name/dm/dmenu-wpctl/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "dmenu-wpctl";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "iamanaws";
+    repo = "dmenu-wpctl";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-D0KtmaqTgWajustGI4QrLOj0G9GgMmMGtCShaLJu7lI=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D --target-directory=$out/bin/ ./dmenu-wpctl
+    chmod +x $out/bin/dmenu-wpctl
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Audio/Video control menu for WirePlumber";
+    longDescription = ''
+      Interactive menu interface to manage audio and video devices
+      using wpctl (WirePlumber) and dmenu-compatible programs.
+    '';
+    homepage = "https://github.com/iamanaws/dmenu-wpctl";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ iamanaws ];
+    mainProgram = "dmenu-wpctl";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
