### PR TITLE
swiftPackages.swift: fix unguarded-availability issues

### DIFF
--- a/pkgs/development/compilers/swift/compiler/default.nix
+++ b/pkgs/development/compilers/swift/compiler/default.nix
@@ -523,8 +523,10 @@ stdenv.mkDerivation {
     # Add appleSwiftCore to the search paths. Adding the whole SDK results in build failures.
     OLD_NIX_SWIFTFLAGS_COMPILE="$NIX_SWIFTFLAGS_COMPILE"
     OLD_NIX_LDFLAGS="$NIX_LDFLAGS"
+    OLD_NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE"
     export NIX_SWIFTFLAGS_COMPILE=" -I ${appleSwiftCore}/lib/swift"
     export NIX_LDFLAGS+=" -L ${appleSwiftCore}/lib/swift"
+    export NIX_CFLAGS_COMPILE+=" -Wno-error=unguarded-availability"
   ''
   + ''
 
@@ -568,6 +570,7 @@ stdenv.mkDerivation {
     # Restore search paths to remove appleSwiftCore.
     export NIX_SWIFTFLAGS_COMPILE="$OLD_NIX_SWIFTFLAGS_COMPILE"
     export NIX_LDFLAGS="$OLD_NIX_LDFLAGS"
+    export NIX_CFLAGS_COMPILE="$OLD_NIX_CFLAGS_COMPILE"
   ''
   + ''
 

--- a/pkgs/development/compilers/swift/wrapper/wrapper.sh
+++ b/pkgs/development/compilers/swift/wrapper/wrapper.sh
@@ -248,6 +248,9 @@ fi
 # TODO: If we ever need to expand functionality of this hook, it may no longer
 # be compatible with Swift. Right now, it is only used on Darwin to force
 # -target, which also happens to work with Swift.
+# As of 369cc5c66b1efdbca2f136aa0055fedca1117304 (#445119), this hook also sets
+# the -Werror=unguarded-availability flag, which Swift can't accept. We prefix
+# that flag with -Xcc in the for loop below
 if [[ -e $cc_wrapper/nix-support/add-local-cc-cflags-before.sh ]]; then
     source $cc_wrapper/nix-support/add-local-cc-cflags-before.sh
 fi
@@ -262,7 +265,7 @@ for ((i=0; i < ${#extraBefore[@]}; i++));do
         # TODO: Assumes macOS.
         extraBefore[i]="${extraBefore[i]/-apple-darwin/-apple-macosx${MACOSX_DEPLOYMENT_TARGET:-11.0}}"
         ;;
-    -march=*|-mcpu=*|-mfloat-abi=*|-mfpu=*|-mmode=*|-mthumb|-marm|-mtune=*)
+    -march=*|-mcpu=*|-mfloat-abi=*|-mfpu=*|-mmode=*|-mthumb|-marm|-mtune=*|-Werror=*)
         [[ i -gt 0 && ${extraBefore[i-1]} == -Xcc ]] && continue
         extraBefore=(
             "${extraBefore[@]:0:i}"


### PR DESCRIPTION
Fixes two issues about how Swift interacts with the `-Werror=unguarded-availability` flag that's set by default since #445119.

1. Swift itself sets a target of macOS 10.9 (via the `--target` flag). I was unable to set this to a newer version, so instead we set `-Wno-error=unguarded-availability` while building Swift itself.
2. The Swift wrapper uses a hook from cc-wrapper that used to only set `-target`, which happened to be compatible with both Clang and Swift. However, #445119 set `-Werror=unguarded-availability` in the same hook, which is not compatible with Swift. We solve this by adding that flag (in fact all flags with a `-Werror=` prefix) to the list of flags that are automatically prefixed with `-Xcc` by the Swift wrapper.

Fixes #459914.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
