### PR TITLE
qusb2snes: init at 0.7.35

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1191,6 +1191,12 @@
     githubId = 2335822;
     name = "Alexandre Esteves";
   };
+  alexland7219 = {
+    email = "alexland7219@gmail.com";
+    github = "alexland7219";
+    githubId = 58669111;
+    name = "Alexandre Ros";
+  };
   alexnabokikh = {
     email = "nabokikh@duck.com";
     github = "alexnabokikh";

--- a/pkgs/by-name/qu/qusb2snes/package.nix
+++ b/pkgs/by-name/qu/qusb2snes/package.nix
@@ -1,0 +1,54 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  qt6,
+  installShellFiles,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "qusb2snes";
+  version = "0.7.35";
+
+  src = fetchFromGitHub {
+    owner = "Skarsnik";
+    repo = "QUsb2snes";
+    tag = "v${version}";
+    fetchSubmodules = true;
+    hash = "sha256-521L4awWr4L2W12vAZUMheq4plXUXKYo4d3S6AfHgPA=";
+  };
+
+  nativeBuildInputs = [
+    qt6.qmake
+    qt6.wrapQtAppsHook
+    installShellFiles
+  ];
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtwebsockets
+    qt6.qtserialport
+  ];
+  qmakeFlags = [
+    "QUsb2snes.pro"
+    "CONFIG+=release"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    installBin QUsb2Snes
+    installManPage --name QUsb2Snes.1 QUsb2Snes.manpage.1
+    install -Dm644 ui/icons/cheer128x128.png $out/share/icons/hicolor/128x128/apps/fr.nyo.QUsb2Snes.png
+    install -Dm644 QUsb2Snes.desktop $out/share/applications/fr.nyo.QUsb2Snes.desktop
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Websocket server that provides a unified protocol for accessing SNES (or SNES emulators) software";
+    license = lib.licenses.gpl3Plus;
+    homepage = "https://skarsnik.github.io/QUsb2snes/";
+    platforms = lib.platforms.linux;
+    badPlatforms = lib.platforms.darwin;
+    mainProgram = "QUsb2Snes";
+    maintainers = with lib.maintainers; [ alexland7219 ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add [Qusb2Snes](https://skarsnik.github.io/QUsb2snes/), a reimplementation of the Usb2Snes websocket server using Qt that can upload ROM, read and write memory of the SNES console (or emulators of SNES).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
