### PR TITLE
nixos/i18n: handle C locale better

### DIFF
--- a/nixos/modules/config/i18n.nix
+++ b/nixos/modules/config/i18n.nix
@@ -7,13 +7,15 @@
 let
   sanitizeUTF8Capitalization =
     lang: (lib.replaceStrings [ "utf8" "utf-8" "UTF8" ] [ "UTF-8" "UTF-8" "UTF-8" ] lang);
-  aggregatedLocales = [
+  aggregatedLocales = lib.optionals (config.i18n.defaultLocale != "C") [
     "${config.i18n.defaultLocale}/${config.i18n.defaultCharset}"
   ]
   ++ lib.pipe config.i18n.extraLocaleSettings [
     # See description of extraLocaleSettings for why is this ignored here.
     (x: lib.removeAttrs x [ "LANGUAGE" ])
     (lib.mapAttrs (n: v: (sanitizeUTF8Capitalization v)))
+    # C locales are always installed
+    (lib.filterAttrs (n: v: v != "C"))
     (lib.mapAttrsToList (LCRole: lang: lang + "/" + (config.i18n.localeCharsets.${LCRole} or "UTF-8")))
   ]
   ++ (map sanitizeUTF8Capitalization (
@@ -111,6 +113,9 @@ in
         description = ''
           Per each {option}`i18n.extraLocaleSettings`, choose the character set
           to use for it. Essentially defaults to UTF-8 for all of them.
+
+          Note that for a locale category that uses the `C` locale, setting a
+          character set to it via this setting is ignored.
         '';
       };
 

--- a/nixos/modules/config/i18n.nix
+++ b/nixos/modules/config/i18n.nix
@@ -7,21 +7,22 @@
 let
   sanitizeUTF8Capitalization =
     lang: (lib.replaceStrings [ "utf8" "utf-8" "UTF8" ] [ "UTF-8" "UTF-8" "UTF-8" ] lang);
-  aggregatedLocales = lib.optionals (config.i18n.defaultLocale != "C") [
-    "${config.i18n.defaultLocale}/${config.i18n.defaultCharset}"
-  ]
-  ++ lib.pipe config.i18n.extraLocaleSettings [
-    # See description of extraLocaleSettings for why is this ignored here.
-    (x: lib.removeAttrs x [ "LANGUAGE" ])
-    (lib.mapAttrs (n: v: (sanitizeUTF8Capitalization v)))
-    # C locales are always installed
-    (lib.filterAttrs (n: v: v != "C"))
-    (lib.mapAttrsToList (LCRole: lang: lang + "/" + (config.i18n.localeCharsets.${LCRole} or "UTF-8")))
-  ]
-  ++ (map sanitizeUTF8Capitalization (
-    lib.optionals (builtins.isList config.i18n.extraLocales) config.i18n.extraLocales
-  ))
-  ++ (lib.optional (builtins.isString config.i18n.extraLocales) config.i18n.extraLocales);
+  aggregatedLocales =
+    lib.optionals (config.i18n.defaultLocale != "C") [
+      "${config.i18n.defaultLocale}/${config.i18n.defaultCharset}"
+    ]
+    ++ lib.pipe config.i18n.extraLocaleSettings [
+      # See description of extraLocaleSettings for why is this ignored here.
+      (x: lib.removeAttrs x [ "LANGUAGE" ])
+      (lib.mapAttrs (n: v: (sanitizeUTF8Capitalization v)))
+      # C locales are always installed
+      (lib.filterAttrs (n: v: v != "C"))
+      (lib.mapAttrsToList (LCRole: lang: lang + "/" + (config.i18n.localeCharsets.${LCRole} or "UTF-8")))
+    ]
+    ++ (map sanitizeUTF8Capitalization (
+      lib.optionals (builtins.isList config.i18n.extraLocales) config.i18n.extraLocales
+    ))
+    ++ (lib.optional (builtins.isString config.i18n.extraLocales) config.i18n.extraLocales);
 in
 {
   ###### interface

--- a/nixos/tests/i18n.nix
+++ b/nixos/tests/i18n.nix
@@ -38,6 +38,21 @@
         };
       };
     };
+    Csimple = {
+      i18n = {
+        defaultLocale = "C";
+      };
+    };
+    CnonDefault = {
+      i18n = {
+        defaultLocale = "en_US.UTF-8";
+        extraLocaleSettings = {
+          LC_COLLATE = "C";
+          LC_MESSAGES = "C";
+          LC_TIME = "C";
+        };
+      };
+    };
   };
   testScript = { nodes, ... }: "";
 }

--- a/nixos/tests/i18n.nix
+++ b/nixos/tests/i18n.nix
@@ -54,5 +54,16 @@
       };
     };
   };
-  testScript = { nodes, ... }: "";
+  testScript =
+    { nodes, ... }:
+    lib.pipe nodes [
+      builtins.attrNames
+      (map (node: ''
+        ${node}.copy_from_vm(
+            ${node}.succeed("readlink -f /etc/locale.conf").strip(),
+            "${node}"
+        )
+      ''))
+      (lib.concatStringsSep "\n")
+    ];
 }


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
