### PR TITLE
zoom-us: simplify updater script

### DIFF
--- a/pkgs/by-name/zo/zoom-us/update.sh
+++ b/pkgs/by-name/zo/zoom-us/update.sh
@@ -14,21 +14,10 @@ version_aarch64_darwin=$(jq -r .zoomArm64.version <<<"$mac_data")
 version_x86_64_darwin=$(jq -r .zoom.version <<<"$mac_data")
 version_x86_64_linux=$(jq -r .zoom.version <<<"$linux_data")
 
-echo >&2 "=== Downloading packages and computing hashes..."
-# We precalculate the hashes before calling update-source-version
-# because it attempts to calculate each architecture's package's hash
-# by running `nix-build --system <architecture> -A zoom-us.src` which
-# causes cross compiling headaches; using nix-prefetch-url with
-# hard-coded URLs is simpler.  Keep these URLs in sync with the ones
-# in package.nix where `srcs` is defined.
-hash_aarch64_darwin=$(nix --extra-experimental-features nix-command hash to-sri --type sha256 $(nix-prefetch-url --type sha256 "https://zoom.us/client/${version_aarch64_darwin}/zoomusInstallerFull.pkg?archType=arm64"))
-hash_x86_64_darwin=$(nix --extra-experimental-features nix-command hash to-sri --type sha256 $(nix-prefetch-url --type sha256 "https://zoom.us/client/${version_x86_64_darwin}/zoomusInstallerFull.pkg"))
-hash_x86_64_linux=$(nix --extra-experimental-features nix-command hash to-sri --type sha256 $(nix-prefetch-url --type sha256 "https://zoom.us/client/${version_x86_64_linux}/zoom_x86_64.pkg.tar.xz"))
-
 echo >&2 "=== Updating package.nix ..."
 # update-source-version expects to be at the root of nixpkgs
-(cd "$nixpkgs" && update-source-version zoom-us "$version_aarch64_darwin" $hash_aarch64_darwin --system=aarch64-darwin --version-key=versions.aarch64-darwin)
-(cd "$nixpkgs" && update-source-version zoom-us "$version_x86_64_darwin" $hash_x86_64_darwin --system=x86_64-darwin --version-key=versions.x86_64-darwin)
-(cd "$nixpkgs" && update-source-version zoom-us "$version_x86_64_linux" $hash_x86_64_linux --system=x86_64-linux --version-key=versions.x86_64-linux --source-key=unpacked.src)
+(cd "$nixpkgs" && update-source-version --ignore-same-version --print-changes --version-key=versions.aarch64-darwin pkgsCross.aarch64-darwin.zoom-us "$version_aarch64_darwin")
+(cd "$nixpkgs" && update-source-version --ignore-same-version --print-changes --version-key=versions.x86_64-darwin pkgsCross.x86_64-darwin.zoom-us "$version_x86_64_darwin")
+(cd "$nixpkgs" && update-source-version --ignore-same-version --print-changes --version-key=versions.x86_64-linux pkgsCross.gnu64.zoom-us "$version_x86_64_linux" --source-key=unpacked.src)
 
 echo >&2 "=== Done!"


### PR DESCRIPTION
Simplify `zoom-us.updateScript` per the suggestions by @axelkar and @magistau, see also [here](https://github.com/NixOS/nixpkgs/pull/429215#discussion_r2255114820), [here](https://github.com/NixOS/nixpkgs/pull/429215#discussion_r2256725348) and [here](https://github.com/NixOS/nixpkgs/pull/429215#discussion_r2506957507) (Thank you for that idea!).

Notifying co-maintainers: @philiptaron @ryan4yin

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

More:

- [x] `nix-shell maintainers/scripts/update.nix --argstr package zoom-us --argstr skip-prompt true` updates `zoom-us` version and hash strings to newest version (tested by artificially causing an update by changing the version numbers and hashes to an older version)

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc