### PR TITLE
haskell.packages.ghc912.extensions: fix the eval

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
@@ -72,7 +72,7 @@ with haskellLib;
   # Hand pick versions that are compatible with ghc 9.12 and base 4.21
   #
 
-  extensions = doDistribute self.extensions_0_1_0_3;
+  extensions = doDistribute self.extensions_0_1_1_0;
   ghc-exactprint = doDistribute self.ghc-exactprint_1_12_0_0;
 
   #


### PR DESCRIPTION
Without the change `haskell.packages.ghc912.extensions` eval fails as:

    $ nix build --no-link -f. haskell.packages.ghc912.extensions
    error:
       … in the left operand of the update (//) operator
         at pkgs/development/haskell-modules/lib/compose.nix:41:6:
           40|     f: drv:
           41|     (drv.override (
             |      ^
           42|       args:

       error: attribute 'extensions_0_1_0_3' missing
       at pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix:75:29:
           74|
           75|   extensions = doDistribute self.extensions_0_1_0_3;
             |                             ^
           76|   ghc-exactprint = doDistribute self.ghc-exactprint_1_12_0_0;
       Did you mean one of extensions_0_1_0_1 or extensions_0_1_1_0?


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
