### PR TITLE
ci: fix "needs: reviewer" label being removed after self review

### DIFF
--- a/ci/github-script/bot.js
+++ b/ci/github-script/bot.js
@@ -210,7 +210,7 @@ module.exports = async ({ github, context, core, dry }) => {
       }
     }
 
-    // Check for any human reviews other than GitHub actions and other GitHub apps.
+    // Check for any human reviews other than the PR author, GitHub actions and other GitHub apps.
     // Accounts could be deleted as well, so don't count them.
     const reviews = (
       await github.paginate(github.rest.pulls.listReviews, {
@@ -218,7 +218,11 @@ module.exports = async ({ github, context, core, dry }) => {
         pull_number,
       })
     ).filter(
-      (r) => r.user && !r.user.login.endsWith('[bot]') && r.user.type !== 'Bot',
+      (r) =>
+        r.user &&
+        !r.user.login.endsWith('[bot]') &&
+        r.user.type !== 'Bot' &&
+        r.user.id !== pull_request.user?.id,
     )
 
     const approvals = new Set(


### PR DESCRIPTION
My other PR https://github.com/NixOS/nixpkgs/pull/459931 has no suitable reviewers, so it got the `9.needs: reviewer` label. However, after I did a "review" by posting `nixpkgs-review` results, the label got removed, despite still needing other reviews (as mine can never be an approval).
This PR filters out the self-reviews when calculating the reviewers for a PR.

Let me know if there is a different way to fix it (I also haven't tested, not sure how I could :sweat_smile: ).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
