### PR TITLE
zensical: init at 0.0.15

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1342,6 +1342,12 @@
     githubId = 8614547;
     name = "Ali Caglayan";
   };
+  aljazerzen = {
+    email = "aljaz@erzen.si";
+    github = "aljazerzen";
+    githubId = 11072061;
+    name = "Aljaž Mur Eržen";
+  };
   alkasm = {
     email = "alexreynolds00@gmail.com";
     github = "alkasm";

--- a/pkgs/by-name/ze/zensical/package.nix
+++ b/pkgs/by-name/ze/zensical/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  fetchPypi,
+  rustPlatform,
+  python3Packages,
+  versionCheckHook,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "zensical";
+  version = "0.0.15";
+  pyproject = true;
+
+  # We fetch from PyPi, because GitHub repo does not contain all sources.
+  # The publish process also copies in assets from zensical/ui.
+  # We could combine sources, but then nix-update won't work.
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-syAMkbMDcGccULi0qkHCDlX/KBS5AD7iPJtvkjoMGb4=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit pname version src;
+    hash = "sha256-Sg4gl23aK6yPZ3Hdi+IzTGnx8wEAkSL0SrKGVdMRJ2s=";
+  };
+
+  nativeBuildInputs = with rustPlatform; [
+    maturinBuildHook
+    cargoSetupHook
+  ];
+
+  dependencies = with python3Packages; [
+    click
+    deepmerge
+    markdown
+    pygments
+    pymdown-extensions
+    pyyaml
+  ];
+
+  nativeCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  meta = {
+    description = "Static site generator for documentation";
+    longDescription = ''
+      Zensical is a modern static site generator designed to simplify
+      building and maintaining project documentation.  It's built by
+      the creators of Material for MkDocs and shares the same core
+      design principles and philosophy – batteries included, easy to
+      use, with powerful customization options.
+    '';
+    homepage = "https://zensical.org";
+    changelog = "https://github.com/zensical/zensical/releases/tag/${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ aljazerzen ];
+    mainProgram = "zensical";
+  };
+}


### PR DESCRIPTION
[Zensical][1] is a static site generator for documentation, replacing
Material for MkDocs. It was released a few weeks ago.
This PR adds a package for its CLI, written in Rust and Python.

[1]: https://github.com/zensical/zensical
  