### PR TITLE
kicad: add option to disable STEP compression.

### DIFF
--- a/pkgs/by-name/ki/kicad/libraries.nix
+++ b/pkgs/by-name/ki/kicad/libraries.nix
@@ -3,6 +3,7 @@
   stdenv,
   cmake,
   libSrc,
+  compressStep,
   stepreduce,
   parallel,
   zip,
@@ -27,9 +28,9 @@ let
 
       postInstall =
         lib.optionalString (name == "packages3d") ''
-          find $out -type f -name '*.step' | parallel 'stepreduce {} {} && zip -9 {.}.stpZ {} && rm {}'
+          find $out -type f -name '*.step' | parallel 'stepreduce {} {} ${lib.optionalString compressStep "&& zip -9 {.}.stpZ {} && rm {}"}'
         ''
-        + lib.optionalString (name == "footprints") ''
+        + lib.optionalString ((name == "footprints") && compressStep) ''
           grep -rl '\.step' $out | xargs sed -i 's/\.step/.stpZ/g'
         '';
 

--- a/pkgs/by-name/ki/kicad/package.nix
+++ b/pkgs/by-name/ki/kicad/package.nix
@@ -23,6 +23,7 @@
 
   pname ? "kicad",
   stable ? true,
+  compressStep ? true,
   testing ? false,
   withNgspice ? !stdenv.hostPlatform.isDarwin,
   libngspice,
@@ -177,7 +178,7 @@ in
 stdenv.mkDerivation rec {
 
   # Common libraries, referenced during runtime, via the wrapper.
-  passthru.libraries = callPackages ./libraries.nix { inherit libSrc; };
+  passthru.libraries = callPackages ./libraries.nix { inherit libSrc compressStep; };
   passthru.callPackage = newScope { inherit addonPath python3; };
   base = callPackage ./base.nix {
     inherit stable testing;


### PR DESCRIPTION
step file compression into stpZ breaks compatibility with non-nixos kicad installations
https://github.com/NixOS/nixpkgs/issues/450219#issuecomment-3456394475.

While disabling it alltogether would break caching, adding a package option to disable it at least gives users the ability to manually build a more compatible version of kicad.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
