### PR TITLE
use: init at 7.5.0

### DIFF
--- a/pkgs/by-name/us/use/package.nix
+++ b/pkgs/by-name/us/use/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  fetchFromGitHub,
+  gitUpdater,
+  testers,
+  use,
+  coreutils,
+  jdk,
+  makeWrapper,
+  maven,
+}:
+
+let
+  jdk' = jdk.override { enableJavaFX = true; };
+in
+maven.buildMavenPackage rec {
+  pname = "use";
+  version = "7.5.0";
+
+  src = fetchFromGitHub {
+    owner = "useocl";
+    repo = "use";
+    tag = "v${version}";
+    hash = "sha256-FftXEq5HHQ7SVmcKspg3fN37PCYKO6Xq0alAPnoeAXA=";
+  };
+
+  patches = [
+    ./remove-pom-jfx.patch
+  ];
+
+  mvnJdk = jdk';
+
+  mvnHash = "sha256-rYOmlPSkUznx1rC9XjNC8TO6da3zYeseiu0O2No8Gxs=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    gunzip -ck ./use-assembly/target/use-${version}-use-bin.tar.gz | tar -xvf-
+    mv use-${version} $out
+
+    wrapProgram $out/bin/use \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          jdk'
+          coreutils # dirname
+        ]
+      }
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    tests.version = testers.testVersion {
+      package = use;
+      command = "use -V";
+    };
+    updateScript = gitUpdater {
+      rev-prefix = "v";
+    };
+  };
+
+  meta = {
+    description = "UML-based Specification Environment";
+    homepage = "https://github.com/useocl/use";
+    license = lib.licenses.gpl2Plus;
+    mainProgram = "use";
+    maintainers = with lib.maintainers; [ OPNA2608 ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/by-name/us/use/remove-pom-jfx.patch
+++ b/pkgs/by-name/us/use/remove-pom-jfx.patch
@@ -1,0 +1,57 @@
+diff '--color=auto' -ruN a/use-gui/pom.xml b/use-gui/pom.xml
+--- a/use-gui/pom.xml	2025-11-09 18:23:14.302905490 +0100
++++ b/use-gui/pom.xml	2025-11-09 18:24:40.296371651 +0100
+@@ -22,36 +22,6 @@
+             <version>33.5.0-jre</version>
+         </dependency>
+         <dependency>
+-            <groupId>org.openjfx</groupId>
+-            <artifactId>javafx-graphics</artifactId>
+-            <version>21.0.5</version>
+-        </dependency>
+-        <dependency>
+-            <groupId>org.openjfx</groupId>
+-            <artifactId>javafx-controls</artifactId>
+-            <version>21.0.5</version>
+-        </dependency>
+-        <dependency>
+-            <groupId>org.openjfx</groupId>
+-            <artifactId>javafx-fxml</artifactId>
+-            <version>21.0.5</version>
+-        </dependency>
+-        <dependency>
+-            <groupId>org.openjfx</groupId>
+-            <artifactId>javafx-web</artifactId>
+-            <version>21.0.5</version>
+-        </dependency>
+-        <dependency>
+-            <groupId>org.openjfx</groupId>
+-            <artifactId>javafx-media</artifactId>
+-            <version>21.0.5</version>
+-        </dependency>
+-        <dependency>
+-            <groupId>org.openjfx</groupId>
+-            <artifactId>javafx-swing</artifactId>
+-            <version>21.0.5</version>
+-        </dependency>
+-        <dependency>
+             <groupId>org.controlsfx</groupId>
+             <artifactId>controlsfx</artifactId>
+             <version>11.1.1</version>
+@@ -271,14 +241,6 @@
+                     </execution>
+                 </executions>
+             </plugin>
+-            <plugin>
+-                <groupId>org.openjfx</groupId>
+-                <artifactId>javafx-maven-plugin</artifactId>
+-                <version>0.0.8</version>
+-                <configuration>
+-                    <mainClass>org.tzi.use.main.gui.Main</mainClass>
+-                </configuration>
+-            </plugin>
+         </plugins>
+     </build>
+-</project>
+\ Kein Zeilenumbruch am Dateiende.
++</project>


### PR DESCRIPTION
> USE is a system for the specification of information systems. It is based on a subset of the Unified Modeling Language (UML). A USE specification contains a textual description of a model using features found in UML class diagrams (classes, associations, etc.). Expressions written in the Object Constraint Language (OCL) are used to specify additional integrity constraints on the model. A model can be animated to validate the specification against non-formal requirements. System states (snapshots of a running system) can be created and manipulated during an animation. For each snapshot the OCL constraints are automatically checked. Information about a system state is given by graphical views. OCL expressions can be entered and evaluated to query detailed information about a system state.

This tool is being used by a prof at my uni for modelling UML stuff, and for applying OCL constraints to a UML specification.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
