### PR TITLE
sqlite: Enable tests

### DIFF
--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -128,7 +128,7 @@ stdenv.mkDerivation rec {
     mv sqlite-doc-${archiveVersion version} $doc/share/doc/sqlite
   '';
 
-  doCheck = false; # fails to link against tcl
+  doCheck = true;
 
   passthru = {
     tests = {

--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   unzip,
+  tcl,
   zlib,
   readline,
   ncurses,
@@ -32,8 +33,8 @@ stdenv.mkDerivation rec {
   # nixpkgs-update: no auto update
   # NB! Make sure to update ./tools.nix src (in the same directory).
   src = fetchurl {
-    url = "https://sqlite.org/2026/sqlite-autoconf-${archiveVersion version}.tar.gz";
-    hash = "sha256-+9ifhmsUA7tmoUMGVEAInddhAPIjgxTZInSggtTyt7s=";
+    url = "https://sqlite.org/2026/sqlite-src-${archiveVersion version}.zip";
+    hash = "sha256-hREPdi1QeUFNmd1deRe8P/fgWHbmzL0T2ElqOBfyCCk=";
   };
   docsrc = fetchurl {
     url = "https://sqlite.org/2026/sqlite-doc-${archiveVersion version}.zip";
@@ -55,6 +56,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     unzip
+    tcl
   ];
   buildInputs = [
     zlib
@@ -74,10 +76,13 @@ stdenv.mkDerivation rec {
   # on a per-output basis.
   setOutputFlags = false;
 
+  env.TCLLIBDIR = "${placeholder "out"}/lib";
+
   configureFlags = [
     "--bindir=${placeholder "bin"}/bin"
     "--includedir=${placeholder "dev"}/include"
     "--libdir=${placeholder "out"}/lib"
+    "--with-tcl=${lib.getLib tcl}/lib"
   ]
   ++ lib.optional (!interactive) "--disable-readline"
   # autosetup only looks up readline.h in predefined set of directories.


### PR DESCRIPTION
Switches the SQLite build to use the canonical source, which allows enabling tests and builds the SQLite TCL library.

See https://github.com/sqlite/sqlite/blob/051e942f5db1cbc3fce64d3a52df7428fe517de4/autoconf/README.txt#L27-L40 for more motivation

Ping @NixOS/darwin-core because it looks like sqlite is used during darwin bootstrapping, so this causes a mass rebuild there

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
