### PR TITLE
clickhouse: reduce src tarball size

### DIFF
--- a/pkgs/by-name/cl/clickhouse/generic.nix
+++ b/pkgs/by-name/cl/clickhouse/generic.nix
@@ -45,17 +45,39 @@ llvmStdenv.mkDerivation (finalAttrs: {
     name = "clickhouse-${tag}.tar.gz";
     inherit hash;
     postFetch = ''
-      # delete files that make the source too big
-      rm -rf $out/contrib/llvm-project/llvm/test
-      rm -rf $out/contrib/llvm-project/clang/test
-      rm -rf $out/contrib/croaring/benchmarks
+      # Delete files that make the source too big
+      rm -rf $out/contrib/arrow/docs/
+      rm -rf $out/contrib/arrow/testing/
+      rm -rf $out/contrib/aws/generated/protocol-tests/
+      rm -rf $out/contrib/aws/generated/smoke-tests/
+      rm -rf $out/contrib/aws/generated/tests/
+      rm -rf $out/contrib/aws/tools/
+      rm -rf $out/contrib/cld2/internal/test_shuffle_1000_48_666.utf8.gz
+      rm -rf $out/contrib/croaring/benchmarks/
+      rm -rf $out/contrib/boost/doc/
+      rm -rf $out/contrib/boost/libs/*/bench/
+      rm -rf $out/contrib/boost/libs/*/example/
+      rm -rf $out/contrib/boost/libs/*/doc/
+      rm -rf $out/contrib/boost/libs/*/test/
+      rm -rf $out/contrib/google-cloud-cpp/ci/abi-dumps/
+      rm -rf $out/contrib/icu/icu4c/source/test/
+      rm -rf $out/contrib/icu/icu4j/main/core/src/test/
+      rm -rf $out/contrib/icu/icu4j/perf-tests/
+      rm -rf $out/contrib/llvm-project/*/docs/
+      rm -rf $out/contrib/llvm-project/*/test/
+      rm -rf $out/contrib/llvm-project/*/unittests/
+      rm -rf $out/contrib/postgres/doc/
+
+      # As long as we're not running tests, remove test files
+      rm -rf $out/tests/
 
       # fix case insensitivity on macos https://github.com/NixOS/nixpkgs/issues/39308
       rm -rf $out/contrib/sysroot/linux-*
       rm -rf $out/contrib/liburing/man
 
-      # compress to not exceed the 2GB output limit
-      # try to make a deterministic tarball
+      # Compress to not exceed the 2GB output limit
+      echo "Creating deterministic source tarball..."
+
       tar -I 'gzip -n' \
         --sort=name \
         --mtime=1970-01-01 \
@@ -63,6 +85,9 @@ llvmStdenv.mkDerivation (finalAttrs: {
         --numeric-owner --mode=go=rX,u+rw,a-s \
         --transform='s@^@source/@S' \
         -cf temp  -C "$out" .
+
+      echo "Finished creating deterministic source tarball!"
+
       rm -r "$out"
       mv temp "$out"
     '';

--- a/pkgs/by-name/cl/clickhouse/lts.nix
+++ b/pkgs/by-name/cl/clickhouse/lts.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
   version = "25.8.11.66-lts";
   rev = "fa393206741c830da77b8f1bcf18c753161932c8";
-  hash = "sha256-VUdT5STQqcWevYJjtuLdTeDGZHNl3JkkDSgcckjSZbw=";
+  hash = "sha256-LBAGiYLyo535j2FYTVbcfq20d9VisGXZMPbTpONBpQU=";
   lts = true;
 }

--- a/pkgs/by-name/cl/clickhouse/package.nix
+++ b/pkgs/by-name/cl/clickhouse/package.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
   version = "25.10.1.3832-stable";
   rev = "f95c1af632a1c4fb9c69a501d05ae04a393b8f81";
-  hash = "sha256-UqdwZRJWMo2KTlZ1W3MnbXg1EhK/ifjQRciPcWiFYTk=";
+  hash = "sha256-00QqO7fVEg7vGtM/+69CEPfNKTm+P2uteoHKKVYwpoY=";
   lts = false;
 }


### PR DESCRIPTION
Found a few more directories that we don't need from `src` when building clickhouse.

This reduces the (already compressed) output size of `clickhouse.src` and `clickhouse-lts.src` from ~1.3G down to ~800M.

Maybe this could also help with the [build failure](https://hydra.nixos.org/build/312635595/nixlog/1) we're seeing on Hydra? It's hard to tell, though, due to the lack of meaningful logs.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
