### PR TITLE
yt-dlp: fix impersonation with curl-cffi

### DIFF
--- a/pkgs/by-name/yt/yt-dlp/package.nix
+++ b/pkgs/by-name/yt/yt-dlp/package.nix
@@ -98,18 +98,16 @@ python3Packages.buildPythonApplication rec {
       ''--prefix PATH : "${lib.makeBinPath packagesToBinPath}"''
     ];
 
-  # Requires network
-  doCheck = false;
-
-  postInstall = ''
+  checkPhase = ''
     # Check for "unsupported" string in yt-dlp -v output.
     output=$($out/bin/yt-dlp -v 2>&1 || true)
     if echo $output | grep -q "unsupported"; then
       echo "ERROR: Found \"unsupported\" string in yt-dlp -v output."
       exit 1
     fi
-  ''
-  + ''
+  '';
+
+  postInstall = ''
     installManPage yt-dlp.1
 
     installShellCompletion \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Impersonation with yt-dlp is broken again. The reason is that Nixpkgs uses a beta version of curl-cffi (https://github.com/NixOS/nixpkgs/pull/454616) that is not supported by yt-dlp (https://github.com/yt-dlp/yt-dlp/pull/14955).

The easiest fix seems to be to patch yt-dlp to allow the beta release, similar to this patch: https://github.com/NixOS/nixpkgs/pull/370324

This is a Nixpkgs-specific issue, a normal build would respect the `pyproject.toml` file of yt-dlp (which points to a non-beta release of curl-cffi).

As this issue is popping up regularly in Nixpkgs, I'm also proposing to add a test that checks if yt-dlp is built with an unsupported library.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [X] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
