### PR TITLE
budgie-desktop: 10.9.3-unstable-2025-09-13 -> 10.9.4

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -168,7 +168,7 @@
 
 - `meilisearch_1_11` has been removed, as it is no longer supported.
 
-- `budgie-desktop` has been updated [10.9.3](https://github.com/BuddiesOfBudgie/budgie-desktop/releases/tag/v10.9.3), this changes `XDG_CURRENT_DESKTOP` from `Budgie:GNOME` to `Budgie`.
+- `budgie-desktop` has been updated [10.9.4](https://github.com/BuddiesOfBudgie/budgie-desktop/releases/tag/v10.9.4). This changes `XDG_CURRENT_DESKTOP` from `Budgie:GNOME` to `Budgie` and contains ABI bumps for libpeas2 migration.
 
 - Greetd and its original greeters (`tuigreet`, `gtkgreet`, `qtgreet`, `regreet`, `wlgreet`) were moved from `greetd` namespace to top level (`greetd.tuigreet` -> `tuigreet`, `greetd.greetd` -> `greetd`, etc). The original attrs are available for compatibility as passthrus of `greetd`, but will emit a warning. They will be removed in future releases.
 

--- a/pkgs/by-name/bu/budgie-analogue-clock-applet/package.nix
+++ b/pkgs/by-name/bu/budgie-analogue-clock-applet/package.nix
@@ -8,6 +8,7 @@
   vala,
   budgie-desktop,
   gtk3,
+  gtk-layer-shell,
   libpeas2,
   nix-update-script,
 }:
@@ -33,14 +34,21 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     budgie-desktop
     gtk3
+    gtk-layer-shell
     libpeas2
   ];
 
   postPatch = ''
-    # https://github.com/BuddiesOfBudgie/budgie-desktop/issues/749
-    substituteInPlace meson.build \
-      --replace-fail "dependency('libpeas-1.0')" "dependency('libpeas-2')"
+    # https://github.com/samlane-ma/analogue-clock-applet/issues/7
+    substituteInPlace budgie-analogue-clock-widget/src/meson.build \
+      --replace-fail "dependency('budgie-raven-plugin-1.0')" "dependency('budgie-raven-plugin-2.0')"
   '';
+
+  mesonFlags = [
+    # The meson option actually enables libpeas2 support
+    # https://github.com/BuddiesOfBudgie/budgie-desktop/issues/749
+    "-Dfor-wayland=true"
+  ];
 
   passthru = {
     updateScript = nix-update-script { };

--- a/pkgs/by-name/bu/budgie-desktop/package.nix
+++ b/pkgs/by-name/bu/budgie-desktop/package.nix
@@ -48,14 +48,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "budgie-desktop";
-  version = "10.9.3-unstable-2025-09-13";
+  version = "10.9.4";
 
   src = fetchFromGitHub {
     owner = "BuddiesOfBudgie";
     repo = "budgie-desktop";
-    rev = "68d5136613fa1b15d39cc67ada3085590ec162ae";
+    tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-xqN06CGS4xyUwnJCsLplYzKtO/V8hDmb6UNJu/nhQHs=";
+    hash = "sha256-e1kkmzSYX8TwiY0IIZYIK/FgMbZ/8PqkUn8pk3CcXHU=";
   };
 
   outputs = [
@@ -147,8 +147,8 @@ stdenv.mkDerivation (finalAttrs: {
     teams = [ lib.teams.budgie ];
     platforms = lib.platforms.linux;
     pkgConfigModules = [
-      "budgie-1.0"
-      "budgie-raven-plugin-1.0"
+      "budgie-2.0"
+      "budgie-raven-plugin-2.0"
       "budgie-theme-1.0"
     ];
   };

--- a/pkgs/by-name/bu/budgie-media-player-applet/package.nix
+++ b/pkgs/by-name/bu/budgie-media-player-applet/package.nix
@@ -43,12 +43,18 @@ stdenv.mkDerivation (finalAttrs: {
     requests
   ];
 
+  mesonFlags = [
+    # The meson option actually enables libpeas2 support
+    # https://github.com/BuddiesOfBudgie/budgie-desktop/issues/749
+    "-Dfor-wayland=true"
+  ];
+
   postPatch = ''
     substituteInPlace meson.build --replace-fail "/usr" "$out"
 
-    # https://github.com/BuddiesOfBudgie/budgie-desktop/issues/749
-    substituteInPlace budgie-media-player-applet.plugin.in \
-      --replace-fail "Loader=@PYTHON@" "Loader=python"
+    # https://github.com/zalesyc/budgie-media-player-applet/issues/25
+    substituteInPlace src/{applet,testWin,Popover,BudgieMediaPlayer}.py \
+      --replace-fail "gi.require_version('Budgie', '1.0')" "gi.require_version('Budgie', '2.0')"
   '';
 
   postFixup = ''

--- a/pkgs/by-name/bu/budgie-systemmonitor-applet/package.nix
+++ b/pkgs/by-name/bu/budgie-systemmonitor-applet/package.nix
@@ -50,8 +50,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     # https://github.com/BuddiesOfBudgie/budgie-desktop/issues/749
+    # https://github.com/prateekmedia/budgie-systemmonitor-applet/issues/4
     substituteInPlace meson.build \
-      --replace-fail "dependency('libpeas-1.0', version: '>= 1.8.0')" "dependency('libpeas-2')"
+      --replace-fail "dependency('libpeas-1.0', version: '>= 1.8.0')" "dependency('libpeas-2')" \
+      --replace-fail "dependency('budgie-1.0', version: '>= 2')" "dependency('budgie-2.0')"
   '';
 
   passthru = {

--- a/pkgs/by-name/bu/budgie-user-indicator-redux/package.nix
+++ b/pkgs/by-name/bu/budgie-user-indicator-redux/package.nix
@@ -18,13 +18,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "budgie-user-indicator-redux";
-  version = "1.0.2";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "EbonJaeger";
     repo = "budgie-user-indicator-redux";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-X9b4H4PnrYGb/T7Sg9iXQeNDLoO1l0VCdbOCGUAgwC4=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ZvT114F0g+3zpskyb4Bn6grAXHWtMqRqb9MzfF0WLQ8=";
   };
 
   nativeBuildInputs = [
@@ -43,12 +43,6 @@ stdenv.mkDerivation (finalAttrs: {
     libpeas2
     sassc
   ];
-
-  postPatch = ''
-    # https://github.com/BuddiesOfBudgie/budgie-desktop/issues/749
-    substituteInPlace meson.build \
-      --replace-fail "dependency('libpeas-1.0', version: '>= 1.26.0')" "dependency('libpeas-2')"
-  '';
 
   passthru = {
     updateScript = nix-update-script { };


### PR DESCRIPTION
Long story short if you are not following the GNOME 49 PR:

- PyGObject switched to `girepository-2.0` (done in GNOME 49 PR).
- ... so we [need to](https://gitlab.gnome.org/GNOME/libpeas/-/issues/58) break `libpeas-1.0` ABI and switch to `girepository-2.0` (done in GNOME 49 PR).
- ... so we [need to](https://github.com/BuddiesOfBudgie/budgie-desktop/issues/749) break budgie-desktop ABI and switch to `libpeas-2` (done in GNOME 49 PR).
- ... upstream wants to bump budgie-desktop ABI version (**this PR**).

Desktop environments [have exceptions](https://github.com/NixOS/rfcs/blob/master/rfcs/0085-nixos-release-stablization.md) on breaking changes per RFC-0085 mostly because we are rushing GNOME updates in :upside_down_face: 

Ofborg can fail to build budgie's VM tests on aarch64 with kvm failing to initialize, that is unrelated to this PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

