### PR TITLE
prefetch-npm-deps: add support for `npm-shrinkwrap.json`

### DIFF
--- a/pkgs/build-support/node/fetch-npm-deps/default.nix
+++ b/pkgs/build-support/node/fetch-npm-deps/default.nix
@@ -242,12 +242,16 @@
         buildPhase = ''
           runHook preBuild
 
-          if [[ ! -e package-lock.json ]]; then
+          if [[ -f npm-shrinkwrap.json ]]; then
+            local -r srcLockfile="npm-shrinkwrap.json"
+          elif [[ -f package-lock.json ]]; then
+            local -r srcLockfile="package-lock.json"
+          else
             echo
-            echo "ERROR: The package-lock.json file does not exist!"
+            echo "ERROR: No lock file!"
             echo
-            echo "package-lock.json is required to make sure that npmDepsHash doesn't change"
-            echo "when packages are updated on npm."
+            echo "package-lock.json or npm-shrinkwrap.json is required to make sure"
+            echo "that npmDepsHash doesn't change when packages are updated on npm."
             echo
             echo "Hint: You can copy a vendored package-lock.json file via postPatch."
             echo
@@ -255,7 +259,7 @@
             exit 1
           fi
 
-          prefetch-npm-deps package-lock.json $out
+          prefetch-npm-deps $srcLockfile $out
 
           runHook postBuild
         '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Fixes: https://github.com/NixOS/nixpkgs/pull/443832#issuecomment-3508429256

Tested that I was able to reproduce the issue by setting `npmDepsHash` to an empty string in `pkgs/by-name/ar/ares-cli/package.nix` on `staging-next`; with this change I can confirm it's able to generate the correct hash.
Not sure if `staging-next` is the correct branch, it looks like it does not generate much rebuilds.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
