### PR TITLE
pygpoabuse: init at 0-unstable-2025-11-09

### DIFF
--- a/pkgs/by-name/py/pygpoabuse/package.nix
+++ b/pkgs/by-name/py/pygpoabuse/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "pygpoabuse";
+  version = "0-unstable-2025-11-09";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Hackndo";
+    repo = "pyGPOAbuse";
+    rev = "324a3c3075a7a6a5364b3cb8b3d2e0b755be9c76";
+    hash = "sha256-DNdKKxE8UACZ5oEZ2iKuNvFrmpz+RCTYI0O5pCa5jIU=";
+  };
+
+  build-system = [ python3Packages.setuptools ];
+
+  dependencies = with python3Packages; [
+    impacket
+    msldap
+  ];
+
+  postInstall = ''
+    mv $out/bin/pygpoabuse{.py,}
+  '';
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch=master" ]; };
+
+  meta = {
+    description = "Partial python implementation of SharpGPOAbuse";
+    homepage = "https://github.com/Hackndo/pyGPOAbuse";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ letgamer ];
+    mainProgram = "pygpoabuse";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This PR packages pyGPOAbuse to NixOS: https://github.com/Hackndo/pyGPOAbuse/.

pyGPOAbuse is used in Pentesting to abuse GPOs for local priviledge Escalation.

It is widely used in Active Directory Pentesting: 
https://swisskyrepo.github.io/InternalAllTheThings/active-directory/ad-adds-group-policy-objects/#abuse-gpo-with-pygpoabuse

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
