### PR TITLE
nixos/tests: fix virtualbox-image grub-install target

### DIFF
--- a/nixos/tests/virtualbox.nix
+++ b/nixos/tests/virtualbox.nix
@@ -162,7 +162,7 @@ let
           cp "${cfg.system.build.kernel}/bzImage" /mnt/linux
           cp "${cfg.system.build.initialRamdisk}/initrd" /mnt/initrd
 
-          ${pkgs.grub2}/bin/grub-install --boot-directory=/mnt /dev/vda
+          ${pkgs.grub2}/bin/grub-install --target=i386-pc --boot-directory=/mnt /dev/vda
 
           cat > /mnt/grub/grub.cfg <<GRUB
           set root=hd0,1


### PR DESCRIPTION
`nixosTests.allDrivers.virtualbox.*` was previously failing because the virtualbox-image was failing to be built. I found the reason in the logs:

```
/nix/store/n8im3z7dd0f50qk6abg0389870cr9k0z-grub-2.12/bin/grub-install: error: /nix/store/n8im3z7dd0f50qk6abg0389870cr9k0z-grub-2.12/lib/grub/i386-ieee1275/modinfo.sh doesn't exist. Please specify --target or --directory.
```

grub-install guessed a target of `i386-ieee1275` due to the VM setup, but nixpkgs only provides the `i386-pc` target. This target is applicable for BIOS (non-UEFI) bootloaders on both x86 and x86_64, so there's no need to check `use64bitGuest` (in fact, it's the only target nixpkgs seems to provide). There's no need to fix anything outside of the test environment because nixpkgs's `install-grub.pl` always explicitly passes a target to grub-install instead of letting it guess.

ZHF: #457852

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review --package nixosTests.allDrivers.virtualbox`
Commit: `45ea000a779ca80157e55cc4199a28f009b4b5a6`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 6 tests built:</summary>
  <ul>
    <li>nixosTests.allDrivers.virtualbox.headless</li>
    <li>nixosTests.allDrivers.virtualbox.host-usb-permissions</li>
    <li>nixosTests.allDrivers.virtualbox.net-hostonlyif</li>
    <li>nixosTests.allDrivers.virtualbox.simple-cli</li>
    <li>nixosTests.allDrivers.virtualbox.simple-gui</li>
    <li>nixosTests.allDrivers.virtualbox.systemd-detect-virt</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
