### PR TITLE
postgresqlPackages.pg_search: init at 0.19.5

### DIFF
--- a/pkgs/development/tools/rust/cargo-pgrx/pinned.nix
+++ b/pkgs/development/tools/rust/cargo-pgrx/pinned.nix
@@ -12,6 +12,12 @@
     cargoHash = "sha256-pnMxWWfvr1/AEp8DvG4awig8zjdHizJHoZ5RJA8CL08=";
   };
 
+  cargo-pgrx_0_15_0 = {
+    version = "0.15.0";
+    hash = "sha256-sksRfNV6l8YbdI6fzrEtanpDVV4sh14JXLqYBydHwy0=";
+    cargoHash = "sha256-c+n1bJMO9254kT4e6exVNhlIouzkkzrRIOVzR9lZeg4=";
+  };
+
   cargo-pgrx_0_16_0 = {
     version = "0.16.0";
     hash = "sha256-emNR7fXNVD9sY/Mdno7mwpH6l/7AD28cBUsFRn9je50=";

--- a/pkgs/servers/sql/postgresql/ext/pg_search.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_search.nix
@@ -1,0 +1,106 @@
+{
+  buildPgrxExtension,
+  cargo-pgrx_0_15_0,
+  fetchFromGitHub,
+  fetchurl,
+  lib,
+  nix-update-script,
+  postgresql,
+}:
+
+let
+  # corresponds to the version of pgrx* packages in the workspace Cargo.lock:
+  # https://github.com/paradedb/paradedb/blob/v0.19.5/Cargo.lock#L3228-L3230
+  cargoPgrxPkg = cargo-pgrx_0_15_0;
+
+  # https://github.com/paradedb/paradedb/blob/v0.19.5/Cargo.lock#L2588-L2616
+  linderaVersion = "0.43.3";
+  linderaWebsite = "https://lindera.dev";
+
+  # pg_search's tokenizer uses several language dictionaries used by the Lindera crate
+  dictionaries = {
+    # https://github.com/lindera/lindera/blob/v0.43.3/lindera-ko-dic/build.rs#L14
+    lindera-ko-dic = rec {
+      language = "Korean";
+      filename = "mecab-ko-dic-2.1.1-20180720.tar.gz";
+      source = fetchurl {
+        url = "${linderaWebsite}/${filename}";
+        hash = "sha256-cCztIcYWfp2a68Z0q17lSvWNREOXXylA030FZ8AgWRo=";
+      };
+    };
+
+    # https://github.com/lindera/lindera/blob/v0.43.3/lindera-cc-cedict/build.rs#L14
+    lindera-cc-cedict = rec {
+      language = "Chinese";
+      filename = "CC-CEDICT-MeCab-0.1.0-20200409.tar.gz";
+      source = fetchurl {
+        url = "${linderaWebsite}/${filename}";
+        hash = "sha256-7Tz54+yKgGR/DseD3Ana1DuMytLplPXqtv8TpB0JFsg=";
+      };
+    };
+
+    # https://github.com/lindera/lindera/blob/v0.43.3/lindera-ipadic/build.rs#L14
+    lindera-ipadic = rec {
+      language = "Japanese";
+      filename = "mecab-ipadic-2.7.0-20070801.tar.gz";
+      source = fetchurl {
+        url = "${linderaWebsite}/${filename}";
+        hash = "sha256-CZ5G6A1V58DWkGeDr/cTdI4a6Q9Gxe+W7BU7vwm/VVA";
+      };
+    };
+  };
+in
+buildPgrxExtension (finalAttrs: {
+  pname = "pg_search";
+  version = "0.19.5";
+
+  src = fetchFromGitHub {
+    owner = "paradedb";
+    repo = "paradedb";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/7AHKUUJW1wh39pUXlVEIykobE2IRMul3pWxoUCdKjA=";
+  };
+
+  cargoHash = "sha256-Yn4D8oaENExqzx1p/9OTEKsVnlJDitn1JST6rhHGPrw=";
+
+  inherit postgresql;
+
+  # Lindera dictionaries are copied to a temporary directory and the
+  # LINDERA_CACHE environment variable prevents the build.rs files in
+  # the Lindera crates from downloading their dictionary from an
+  # external URL, which doesn't work in the Nix sandbow
+  preConfigure = ''
+    export LINDERA_CACHE=$TMPDIR/lindera-cache
+    mkdir -p $LINDERA_CACHE/${linderaVersion}
+
+    ${lib.concatMapStringsSep "\n" (dict: ''
+      echo "Copying ${dict.language} dictionary to Lindera cache"
+      cp ${dict.source} $LINDERA_CACHE/${linderaVersion}/${dict.filename}
+    '') (lib.attrValues dictionaries)}
+
+    echo "Lindera cache prepared at $LINDERA_CACHE"
+  '';
+
+  cargo-pgrx = cargoPgrxPkg;
+
+  # https://github.com/paradedb/paradedb/tree/v0.19.5/pg_search
+  cargoPgrxFlags = [
+    "--package"
+    "pg_search"
+  ];
+
+  # tests don't pass on darwin and not yet tried on Linux
+  doCheck = false;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Transactional Elasticsearch alternative as a PostgreSQL extension";
+    homepage = "https://paradedb.com";
+    changelog = "https://github.com/paradedb/paradedb/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = [ lib.maintainers.lucperkins ];
+    broken = lib.versionOlder postgresql.version "14" || lib.versionAtLeast postgresql.version "18";
+    platforms = postgresql.meta.platforms;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5303,6 +5303,7 @@ with pkgs;
   inherit (callPackages ../development/tools/rust/cargo-pgrx { })
     cargo-pgrx_0_12_0_alpha_1
     cargo-pgrx_0_12_6
+    cargo-pgrx_0_15_0
     cargo-pgrx_0_16_0
     cargo-pgrx_0_16_1
     cargo-pgrx


### PR DESCRIPTION
This PR adds the [`pg_search`](https://www.paradedb.com/blog/introducing-search) Postgres extension from [ParadeDB](https://paradedb.com) to Nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
