### PR TITLE
include nixpkgs-unstable channel blockers in nixos-unstable channel blockers

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -43,12 +43,12 @@ rec {
     }
   );
 
-  nixpkgs = removeAttrs (removeMaintainers (
+  nixpkgs = removeMaintainers (
     import ../pkgs/top-level/release.nix {
       inherit supportedSystems;
       nixpkgs = nixpkgsSrc;
     }
-  )) [ "unstable" ];
+  );
 
   tested =
     let
@@ -190,6 +190,8 @@ rec {
         (onFullSupported "nixpkgs.jdk")
         (onSystems [ "x86_64-linux" ] "nixpkgs.mesa_i686") # i686 sanity check + useful
         [
+          # Include all release-critical jobs from nixpkgs-unstable channel
+          "nixpkgs.unstable"
           "nixpkgs.tarball"
           "nixpkgs.release-checks"
         ]


### PR DESCRIPTION
Previously, the `unstable` attribute was explicitly removed since 2013 (commit 5c1f8cbc70cd) to avoid potential redundancy. However, including it ensures that  packages that block nixpkgs-unstable also block nixos-unstable.
