### PR TITLE
openrsc-launcher: init at 5.29.0

### DIFF
--- a/pkgs/by-name/op/openrsc-launcher/package.nix
+++ b/pkgs/by-name/op/openrsc-launcher/package.nix
@@ -1,0 +1,48 @@
+{
+  jdk8,
+  ant,
+  makeWrapper,
+  stdenv,
+  fetchFromGitLab,
+  lib,
+}:
+stdenv.mkDerivation rec {
+  pname = "openrsc-launcher";
+  version = "5.29.0";
+  src = fetchFromGitLab {
+    owner = "openrsc";
+    repo = "openrsc";
+    tag = "ORSC-${version}";
+    hash = "sha256-e2VXV0xk0Xx2zQNtg20/PwJmwqHvbZlSUZc0wlPO0vA=";
+  };
+
+  buildInputs = [
+    jdk8
+  ];
+
+  nativeBuildInputs = [
+    ant
+    makeWrapper
+  ];
+
+  buildPhase = ''
+    cd ./PC_Launcher && ant
+    mkdir -p $out/share/pixmaps $out/share/applications
+    cp vet.rsc.OpenRSC.Launcher.svg $out/share/pixmaps
+    cp vet.rsc.OpenRSC.Launcher.desktop $out/share/applications
+    cp OpenRSC.jar $out/share
+    makeWrapper ${jdk8}/bin/java $out/bin/openrsc \
+      --prefix PATH : ${jdk8}/bin \
+      --add-flags "-jar $out/share/OpenRSC.jar --dir ~/.local/share/openrsc --no-update"
+  '';
+
+  JAVA_TOOL_OPTIONS = "-Dfile.encoding=UTF8";
+
+  meta = {
+    description = "Free, open-source launcher for various Classic (2001-2004) RSC servers";
+    homepage = "https://rsc.vet/";
+    license = lib.licenses.agpl3Only;
+    platforms = jdk8.meta.platforms;
+    mainProgram = "openrsc";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
