### PR TITLE
hyprland:  fix regression for layer-shell-qt

### DIFF
--- a/pkgs/by-name/hy/hyprland/package.nix
+++ b/pkgs/by-name/hy/hyprland/package.nix
@@ -108,6 +108,12 @@ customStdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/hyprwm/Hyprland/commit/522edc87126a48f3ce4891747b6a92a22385b1e7.patch";
       hash = "sha256-0BAlAVW5isa8gd833PjZdqO/uEpDqdTlu0iZbLP4U9s=";
     })
+
+    # NOTE: fixes regression for layer-shell-qt. should be removed with the next release.
+    (fetchpatch {
+      url = "https://github.com/hyprwm/Hyprland/commit/0bd11d5eb941b8038f0723135768d84aa5512b4a.patch";
+      hash = "sha256-yY5OsihAzm5cVLg8smGc4i/RIimUDwuZ1RUGqOlfV+Q=";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
Fixes a regression in hyprland 0.52.0 that breaks apps using layer-shell-qt. The change was merged upstream, but not sure if a patch release will happen before  25.11.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
