### PR TITLE
treewide: use externalPath

### DIFF
--- a/nixos/modules/services/backup/pgbackrest.nix
+++ b/nixos/modules/services/backup/pgbackrest.nix
@@ -83,10 +83,7 @@ let
   secretPathOption =
     with lib.types;
     lib.mkOption {
-      type = nullOr (pathWith {
-        inStore = false;
-        absolute = true;
-      });
+      type = nullOr externalPath;
       default = null;
       internal = true;
     };
@@ -142,10 +139,7 @@ in
               };
 
               options.sftp-private-key-file = lib.mkOption {
-                type = nullOr (pathWith {
-                  inStore = false;
-                  absolute = true;
-                });
+                type = nullOr externalPath;
                 default = null;
                 description = ''
                   SFTP private key file.

--- a/nixos/modules/services/databases/postgres-websockets.nix
+++ b/nixos/modules/services/databases/postgres-websockets.nix
@@ -31,12 +31,7 @@ in
     enable = lib.mkEnableOption "postgres-websockets";
 
     pgpassFile = lib.mkOption {
-      type =
-        with lib.types;
-        nullOr (pathWith {
-          inStore = false;
-          absolute = true;
-        });
+      type = with lib.types; nullOr externalPath;
       default = null;
       example = "/run/keys/db_password";
       description = ''
@@ -54,12 +49,7 @@ in
     };
 
     jwtSecretFile = lib.mkOption {
-      type =
-        with lib.types;
-        nullOr (pathWith {
-          inStore = false;
-          absolute = true;
-        });
+      type = with lib.types; nullOr externalPath;
       example = "/run/keys/jwt_secret";
       description = ''
         Secret used to sign JWT tokens used to open communications channels.

--- a/nixos/modules/services/databases/postgrest.nix
+++ b/nixos/modules/services/databases/postgrest.nix
@@ -54,12 +54,7 @@ in
     enable = lib.mkEnableOption "PostgREST";
 
     pgpassFile = lib.mkOption {
-      type =
-        with lib.types;
-        nullOr (pathWith {
-          inStore = false;
-          absolute = true;
-        });
+      type = with lib.types; nullOr externalPath;
       default = null;
       example = "/run/keys/db_password";
       description = ''
@@ -77,12 +72,7 @@ in
     };
 
     jwtSecretFile = lib.mkOption {
-      type =
-        with lib.types;
-        nullOr (pathWith {
-          inStore = false;
-          absolute = true;
-        });
+      type = with lib.types; nullOr externalPath;
       default = null;
       example = "/run/keys/jwt_secret";
       description = ''

--- a/nixos/modules/services/matrix/matrix-alertmanager.nix
+++ b/nixos/modules/services/matrix/matrix-alertmanager.nix
@@ -76,17 +76,11 @@ in
       description = "Makes the bot mention @room when posting an alert";
     };
     tokenFile = lib.mkOption {
-      type = lib.types.pathWith {
-        inStore = false;
-        absolute = true;
-      };
+      type = lib.types.externalPath;
       description = "File that contains a valid Matrix token for the Matrix user.";
     };
     secretFile = lib.mkOption {
-      type = lib.types.pathWith {
-        inStore = false;
-        absolute = true;
-      };
+      type = lib.types.externalPath;
       description = "File that contains a secret for the Alertmanager webhook.";
     };
   };

--- a/nixos/modules/services/monitoring/prometheus/exporters/storagebox.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/storagebox.nix
@@ -15,10 +15,7 @@ in
   extraOpts = {
     package = mkPackageOption pkgs "prometheus-storagebox-exporter" { };
     tokenFile = lib.mkOption {
-      type = lib.types.pathWith {
-        inStore = false;
-        absolute = true;
-      };
+      type = lib.types.externalPath;
       description = "File that contains the Hetzner API token to use.";
     };
 

--- a/nixos/modules/services/networking/cloudflare-dyndns.nix
+++ b/nixos/modules/services/networking/cloudflare-dyndns.nix
@@ -15,11 +15,7 @@ in
       package = lib.mkPackageOption pkgs "cloudflare-dyndns" { };
 
       apiTokenFile = lib.mkOption {
-        type = lib.types.pathWith {
-          absolute = true;
-          inStore = false;
-        };
-
+        type = lib.types.externalPath;
         description = ''
           The path to a file containing the CloudFlare API token.
         '';

--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -559,12 +559,7 @@ in
                                     '';
                                   };
                                   encryptionPasswordFile = mkOption {
-                                    type = types.nullOr (
-                                      types.pathWith {
-                                        inStore = false;
-                                        absolute = true;
-                                      }
-                                    );
+                                    type = types.nullOr types.externalPath;
                                     default = null;
                                     description = ''
                                       Path to encryption password. If set, the file will be read during

--- a/nixos/modules/services/security/step-ca.nix
+++ b/nixos/modules/services/security/step-ca.nix
@@ -55,12 +55,7 @@ in
         '';
       };
       intermediatePasswordFile = lib.mkOption {
-        type = lib.types.nullOr (
-          lib.types.pathWith {
-            inStore = false;
-            absolute = true;
-          }
-        );
+        type = lib.types.nullOr lib.types.externalPath;
         default = null;
         example = "/run/keys/smallstep-password";
         description = ''

--- a/nixos/modules/services/web-apps/librespeed.nix
+++ b/nixos/modules/services/web-apps/librespeed.nix
@@ -71,14 +71,7 @@ in
         The contents of the specified paths will be read at service start time and merged with the attributes provided in `settings`.
       '';
       default = { };
-      type =
-        with lib.types;
-        nullOr (
-          attrsOf (pathWith {
-            inStore = false;
-            absolute = true;
-          })
-        );
+      type = with lib.types; nullOr (attrsOf externalPath);
     };
 
     settings = lib.mkOption {

--- a/nixos/modules/services/web-apps/oncall.nix
+++ b/nixos/modules/services/web-apps/oncall.nix
@@ -78,10 +78,7 @@ in
     };
 
     secretFile = lib.mkOption {
-      type = lib.types.pathWith {
-        inStore = false;
-        absolute = true;
-      };
+      type = lib.types.externalPath;
       example = "/run/keys/oncall-dbpassword";
       description = ''
         A YAML file containing secrets such as database or user passwords.

--- a/nixos/modules/services/web-apps/photoprism.nix
+++ b/nixos/modules/services/web-apps/photoprism.nix
@@ -33,12 +33,7 @@ in
     enable = lib.mkEnableOption "Photoprism web server";
 
     passwordFile = lib.mkOption {
-      type = lib.types.nullOr (
-        lib.types.pathWith {
-          inStore = false;
-          absolute = true;
-        }
-      );
+      type = lib.types.nullOr lib.types.externalPath;
       default = null;
       description = ''
         Admin password file.
@@ -46,12 +41,7 @@ in
     };
 
     databasePasswordFile = lib.mkOption {
-      type = lib.types.nullOr (
-        lib.types.pathWith {
-          inStore = false;
-          absolute = true;
-        }
-      );
+      type = lib.types.nullOr lib.types.externalPath;
       default = null;
       description = ''
         Database password file.


### PR DESCRIPTION
apply changes from #447832

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
