### PR TITLE
logrotate: skip breaking tests

### DIFF
--- a/pkgs/by-name/lo/logrotate/package.nix
+++ b/pkgs/by-name/lo/logrotate/package.nix
@@ -33,8 +33,12 @@ stdenv.mkDerivation rec {
 
   preCheck = ''
     sed -i 's#/bin/date#${lib.getExe' coreutils "date"}#' test/*.sh
-    # Skip this test because it depends on a working root user, which we don't have in the sandbox
-    # Exiting with 77 signals that the test is skipped, and we only place it on line 2 because the shebang is on line 1
+    # Exiting with 77 signals that a test is skipped, and we only place it on line 2 because the shebang is on line 1
+    # Does not work on certain filesystems due to incorrect sparse file detection.
+    # Upstream issue: https://github.com/logrotate/logrotate/issues/682
+    sed -i '2iexit 77' test/test-0062.sh
+    sed -i '2iexit 77' test/test-0063.sh
+    # Depends on a working root user, which we don't have in the sandbox
     sed -i '2iexit 77' test/test-0110.sh
   '';
   doCheck = true;


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/460096

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
