### PR TITLE
cemu-ti: disable deploy script generation

### DIFF
--- a/pkgs/applications/science/math/cemu-ti/cmake-no-deploy.patch
+++ b/pkgs/applications/science/math/cemu-ti/cmake-no-deploy.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 68ce1294..5c2924f6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -350,7 +350,7 @@ message("Binary dir: ${CMAKE_CURRENT_BINARY_DIR}")
+
+ # TODO: linux .desktop/.xml files
+
+-if(COMMAND qt_generate_deploy_app_script)
++if(FALSE)
+     qt_generate_deploy_app_script(
+         TARGET CEmu
+         FILENAME_VARIABLE deploy_script

--- a/pkgs/applications/science/math/cemu-ti/default.nix
+++ b/pkgs/applications/science/math/cemu-ti/default.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation (finalAttrs: {
     # This is resolved upstream, but I can't apply the patch because the
     # sourceRoot isn't set to the base of the Git repo.
     ./resolve-ambiguous-constexpr.patch
+    # Disable the deploy_script generation. It's broken with Qt 6.10 and not used by this package.
+    ./cmake-no-deploy.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
Fixes the build. The deploy script generation is broken with Qt 6.10 and not used by this package. The initial error was that `FILENAME_VARIABLE` has been removed in favor of the rename `OUTPUT_SCRIPT` in Qt 6.10, but even after fixing that there's another more complicated error about dependency paths, and we don't use the deploy script anyways.

ZHF: #457852

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `528ae39cd99815631ffe21776675e3ac30b2b5b1`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>cemu-ti</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
