### PR TITLE
ath9k-htc-blobless-firmware: remove commented-out code for badPlatforms in ath9k firmware

### DIFF
--- a/pkgs/os-specific/linux/firmware/ath9k/default.nix
+++ b/pkgs/os-specific/linux/firmware/ath9k/default.nix
@@ -175,15 +175,12 @@ stdenv.mkDerivation (finalAttrs: {
     # release 1.4.0 vendors a GMP which uses an ancient version of
     # autotools that does not work on aarch64 or powerpc.
     # However, enableUnstable (unreleased upstream) works.
-    /*
-      # disabled until #195294 is merged
-      badPlatforms =
-        with lib.systems.inspect.patterns;
-        lib.optionals (!enableUnstable && lib.versionOlder finalAttrs.version "1.4.1") [
-          isAarch64
-          isPower64
-        ];
-    */
+    badPlatforms =
+      with lib.systems.inspect.patterns;
+      lib.optionals (!enableUnstable && lib.versionOlder finalAttrs.version "1.4.1") [
+        isAarch64
+        isPower64
+      ];
 
     sourceProvenance = [ lib.sourceTypes.fromSource ];
     homepage = "http://lists.infradead.org/mailman/listinfo/ath9k_htc_fw";


### PR DESCRIPTION
remove commented-out code for badPlatforms in ath9k firmware, merged upstream in 2023.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
