### PR TITLE
linuxPackages_latest.rust-out-of-tree-module: 0-unstable-2024-05-06 -> 0-unstable-2025-03-10

### DIFF
--- a/pkgs/os-specific/linux/rust-out-of-tree-module/default.nix
+++ b/pkgs/os-specific/linux/rust-out-of-tree-module/default.nix
@@ -7,14 +7,14 @@
 }:
 kernel.stdenv.mkDerivation {
   pname = "rust-out-of-tree-module";
-  version = "0-unstable-2024-05-06";
+  version = "0-unstable-2025-03-10";
 
   src = fetchFromGitHub {
     owner = "Rust-for-linux";
     repo = "rust-out-of-tree-module";
 
-    rev = "9872947486bb8f60b0d11db15d546a3d06156ec5";
-    hash = "sha256-TzCySY7uQac98dU+Nu5dC4Usm7oG0iIdZZmZgAOpni4=";
+    rev = "df508ea156314fe281cdaded07bcf89d22c3373a";
+    hash = "sha256-pPK+bvtYOKQDllsK2IzhgaNZzdawbIoK20rLU/olHow=";
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
@@ -28,7 +28,7 @@ kernel.stdenv.mkDerivation {
   passthru.updateScript = unstableGitUpdater { };
 
   meta = {
-    broken = !kernel.withRust;
+    broken = kernel.kernelOlder "6.17" || !kernel.withRust;
     description = "Basic template for an out-of-tree Linux kernel module written in Rust";
     homepage = "https://github.com/Rust-for-Linux/rust-out-of-tree-module";
     license = lib.licenses.gpl2Only;


### PR DESCRIPTION
This fixes the build failure on the latest Linux.
It still breaks on older kernels, but I think this is intended for this module.

Diff: https://github.com/Rust-for-linux/rust-out-of-tree-module/compare/9872947486bb8f60b0d11db15d546a3d06156ec5...df508ea156314fe281cdaded07bcf89d22c3373a

ZHF: #457852

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
