### PR TITLE
drbd-utils: 9.32.0 -> 9.33.0

### DIFF
--- a/pkgs/os-specific/linux/drbd/utils.nix
+++ b/pkgs/os-specific/linux/drbd/utils.nix
@@ -15,6 +15,7 @@
   systemd,
   keyutils,
   udevCheckHook,
+  gettext,
 
   # drbd-utils are compiled twice, once with forOCF = true to extract
   # its OCF definitions for use in the ocf-resource-agents derivation,
@@ -26,11 +27,11 @@
 
 stdenv.mkDerivation rec {
   pname = "drbd";
-  version = "9.32.0";
+  version = "9.33.0";
 
   src = fetchurl {
     url = "https://pkg.linbit.com/downloads/drbd/utils/${pname}-utils-${version}.tar.gz";
-    hash = "sha256-szOM7jSbXEZZ4p1P73W6tK9Put0+wOZar+cUiUNC6M0=";
+    hash = "sha256-Ij/gfQtkbpkbM7qepBRo+aZvkDVi59p2bdD8a06jPbk=";
   };
 
   nativeBuildInputs = [
@@ -40,11 +41,13 @@ stdenv.mkDerivation rec {
     asciidoctor
     keyutils
     udevCheckHook
+    gettext
   ];
 
   buildInputs = [
     perl
     perlPackages.Po4a
+    gettext
   ];
 
   configureFlags = [
@@ -98,20 +101,6 @@ stdenv.mkDerivation rec {
     patch_docbook45 documentation/v9/drbdsetup.xml.in
     patch_docbook45 documentation/v84/drbdsetup.xml
     patch_docbook45 documentation/v84/drbd.conf.xml
-    # The ja documentation is disabled because:
-    # make[1]: Entering directory '/build/drbd-utils-9.16.0/documentation/ja/v84'
-    # /nix/store/wyx2nn2pjcn50lc95c6qgsgm606rn0x2-perl5.32.1-po4a-0.62/bin/po4a-translate -f docbook -M utf-8 -L utf-8 -keep 0 -m ../../v84/drbdsetup.xml -p drbdsetup.xml.po -l drbdsetup.xml
-    # Use of uninitialized value $args[1] in sprintf at /nix/store/wyx2nn2pjcn50lc95c6qgsgm606rn0x2-perl5.32.1-po4a-0.62/lib/perl5/site_perl/Locale/Po4a/Common.pm line 134.
-    # Invalid po file drbdsetup.xml.po:
-    substituteInPlace Makefile.in \
-      --replace 'DOC_DIRS    := documentation/v9 documentation/ja/v9' \
-                'DOC_DIRS    := documentation/v9' \
-      --replace 'DOC_DIRS    += documentation/v84 documentation/ja/v84' \
-                'DOC_DIRS    += documentation/v84' \
-      --replace '$(MAKE) -C documentation/ja/v9 doc' \
-                "" \
-      --replace '$(MAKE) -C documentation/ja/v84 doc' \
-                ""
     substituteInPlace user/v9/drbdtool_common.c \
       --replace 'add_component_to_path("/lib/drbd");' \
                 'add_component_to_path("${placeholder "out"}/lib/drbd");'
@@ -139,7 +128,7 @@ stdenv.mkDerivation rec {
     ];
     longDescription = ''
       DRBD is a software-based, shared-nothing, replicated storage solution
-      mirroring the content of block devices (hard disks, partitions, logical volumes, and so on) between hosts.
+      mirroring the content of block devices (hard disks, partitions, logical volumes etc.) between hosts.
     '';
   };
 }


### PR DESCRIPTION
- userland tools updated from `9.32.0` to `9.33.0`
- gettext build inputs added to fix the `ja` docs

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
