### PR TITLE
makemkv: use fixpoint argument of `mkDerivation`

### DIFF
--- a/pkgs/by-name/ma/makemkv/package.nix
+++ b/pkgs/by-name/ma/makemkv/package.nix
@@ -16,124 +16,117 @@
   withJava ? true,
   jre_headless,
 }:
-
-let
-  version = "1.18.2";
-  # Using two URLs as the first one will break as soon as a new version is released
-  src_bin = fetchurl {
-    urls = [
-      "http://www.makemkv.com/download/makemkv-bin-${version}.tar.gz"
-      "http://www.makemkv.com/download/old/makemkv-bin-${version}.tar.gz"
-    ];
-    hash = "sha256-v8THzrwPAEl2cf/Vbmo08HcKnmr37/LwEn76FD8oY24=";
-  };
-  src_oss = fetchurl {
-    urls = [
-      "http://www.makemkv.com/download/makemkv-oss-${version}.tar.gz"
-      "http://www.makemkv.com/download/old/makemkv-oss-${version}.tar.gz"
-    ];
-    hash = "sha256-uUl/VVXCV/XTx/GLarA8dM/z6kQ36ANJ1hjRFb9fpEU=";
-  };
-in
-stdenv.mkDerivation {
-  pname = "makemkv";
-  inherit version;
-
-  srcs = [
-    src_bin
-    src_oss
-  ];
-
-  sourceRoot = "makemkv-oss-${version}";
-
-  patches = [ ./r13y.patch ];
-
-  enableParallelBuilding = true;
-
-  nativeBuildInputs = [
-    autoPatchelfHook
-    pkg-config
-    qt5.wrapQtAppsHook
-  ];
-
-  buildInputs = [
-    ffmpeg
-    openssl
-    qt5.qtbase
-    zlib
-  ];
-
-  runtimeDependencies = [ (lib.getLib curl) ];
-
-  qtWrapperArgs =
-    let
-      binPath = lib.makeBinPath [ jre_headless ];
-    in
-    lib.optionals withJava [ "--prefix PATH : ${binPath}" ];
-
-  installPhase = ''
-    runHook preInstall
-
-    install -Dm555 -t $out/bin                              out/makemkv out/mmccextr out/mmgplsrv ../makemkv-bin-${version}/bin/amd64/makemkvcon
-    install -D     -t $out/lib                              out/lib{driveio,makemkv,mmbd}.so.*
-    install -D     -t $out/share/MakeMKV                    ../makemkv-bin-${version}/src/share/*
-    install -Dm444 -t $out/share/applications               ../makemkv-oss-${version}/makemkvgui/share/makemkv.desktop
-    install -Dm444 -t $out/share/icons/hicolor/16x16/apps   ../makemkv-oss-${version}/makemkvgui/share/icons/16x16/*
-    install -Dm444 -t $out/share/icons/hicolor/32x32/apps   ../makemkv-oss-${version}/makemkvgui/share/icons/32x32/*
-    install -Dm444 -t $out/share/icons/hicolor/64x64/apps   ../makemkv-oss-${version}/makemkvgui/share/icons/64x64/*
-    install -Dm444 -t $out/share/icons/hicolor/128x128/apps ../makemkv-oss-${version}/makemkvgui/share/icons/128x128/*
-    install -Dm444 -t $out/share/icons/hicolor/256x256/apps ../makemkv-oss-${version}/makemkvgui/share/icons/256x256/*
-
-    runHook postInstall
-  '';
-
-  passthru = {
-    srcs = {
-      inherit src_bin src_oss;
-    };
-    updateScript = lib.getExe (writeShellApplication {
-      name = "update-makemkv";
-      runtimeInputs = [
-        common-updater-scripts
-        curl
-        rubyPackages.nokogiri
+stdenv.mkDerivation (
+  finalAttrs:
+  let
+    inherit (finalAttrs) version;
+    # Using two URLs as the first one will break as soon as a new version is released
+    srcs.bin = fetchurl {
+      urls = [
+        "http://www.makemkv.com/download/makemkv-bin-${version}.tar.gz"
+        "http://www.makemkv.com/download/old/makemkv-bin-${version}.tar.gz"
       ];
-      text = ''
-        get_version() {
-          # shellcheck disable=SC2016
-          curl --fail --silent 'https://forum.makemkv.com/forum/viewtopic.php?f=3&t=224' \
-            | nokogiri -e 'puts $_.css("head title").first.text.match(/\bMakeMKV (\d+\.\d+\.\d+) /)[1]'
-        }
-        oldVersion=${lib.escapeShellArg version}
-        newVersion=$(get_version)
-        if [[ $oldVersion == "$newVersion" ]]; then
-          echo "$0: New version same as old version, nothing to do." >&2
-          exit
-        fi
-        update-source-version makemkv "$newVersion" --source-key=passthru.srcs.src_bin
-        update-source-version makemkv "$newVersion" --source-key=passthru.srcs.src_oss --ignore-same-version
-      '';
-    });
-  };
+      hash = "sha256-v8THzrwPAEl2cf/Vbmo08HcKnmr37/LwEn76FD8oY24=";
+    };
+    srcs.oss = fetchurl {
+      urls = [
+        "http://www.makemkv.com/download/makemkv-oss-${version}.tar.gz"
+        "http://www.makemkv.com/download/old/makemkv-oss-${version}.tar.gz"
+      ];
+      hash = "sha256-uUl/VVXCV/XTx/GLarA8dM/z6kQ36ANJ1hjRFb9fpEU=";
+    };
+  in
+  {
+    pname = "makemkv";
+    version = "1.18.2";
 
-  meta = with lib; {
-    description = "Convert blu-ray and dvd to mkv";
-    longDescription = ''
-      makemkv is a one-click QT application that transcodes an encrypted
-      blu-ray or DVD disc into a more portable set of mkv files, preserving
-      subtitles, chapter marks, all video and audio tracks.
+    srcs = lib.attrValues finalAttrs.passthru.srcs;
+    sourceRoot = "makemkv-oss-${version}";
+    patches = [ ./r13y.patch ];
 
-      Program is time-limited -- it will stop functioning after 60 days. You
-      can always download the latest version from makemkv.com that will reset the
-      expiration date.
-    '';
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    license = [
-      licenses.unfree
-      licenses.lgpl21
+    enableParallelBuilding = true;
+    nativeBuildInputs = [
+      autoPatchelfHook
+      pkg-config
+      qt5.wrapQtAppsHook
     ];
-    homepage = "https://makemkv.com";
-    platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ jchw ];
-  };
-}
+    buildInputs = [
+      ffmpeg
+      openssl
+      qt5.qtbase
+      zlib
+    ];
+    runtimeDependencies = [ (lib.getLib curl) ];
+
+    qtWrapperArgs =
+      let
+        binPath = lib.makeBinPath [ jre_headless ];
+      in
+      lib.optionals withJava [ "--prefix PATH : ${binPath}" ];
+
+    installPhase = ''
+      runHook preInstall
+
+      install -Dm555 -t "$out"/bin                              out/{makemkv,mmccextr,mmgplsrv} \
+                                                                ../makemkv-bin-"$version"/bin/amd64/makemkvcon
+      install -D     -t "$out"/lib                              out/lib{driveio,makemkv,mmbd}.so.*
+      install -D     -t "$out"/share/MakeMKV                    ../makemkv-bin-"$version"/src/share/*
+      install -Dm444 -t "$out"/share/applications               ../makemkv-oss-"$version"/makemkvgui/share/makemkv.desktop
+      install -Dm444 -t "$out"/share/icons/hicolor/16x16/apps   ../makemkv-oss-"$version"/makemkvgui/share/icons/16x16/*
+      install -Dm444 -t "$out"/share/icons/hicolor/32x32/apps   ../makemkv-oss-"$version"/makemkvgui/share/icons/32x32/*
+      install -Dm444 -t "$out"/share/icons/hicolor/64x64/apps   ../makemkv-oss-"$version"/makemkvgui/share/icons/64x64/*
+      install -Dm444 -t "$out"/share/icons/hicolor/128x128/apps ../makemkv-oss-"$version"/makemkvgui/share/icons/128x128/*
+      install -Dm444 -t "$out"/share/icons/hicolor/256x256/apps ../makemkv-oss-"$version"/makemkvgui/share/icons/256x256/*
+
+      runHook postInstall
+    '';
+
+    passthru = {
+      inherit srcs;
+      updateScript = lib.getExe (writeShellApplication {
+        name = "update-makemkv";
+        runtimeInputs = [
+          common-updater-scripts
+          curl
+          rubyPackages.nokogiri
+        ];
+        runtimeEnv.oldVersion = version;
+        text = ''
+          get_version() {
+            # shellcheck disable=SC2016
+            curl --fail --silent 'https://forum.makemkv.com/forum/viewtopic.php?f=3&t=224' \
+              | nokogiri -e 'puts $_.css("head title").first.text.match(/\bMakeMKV (\d+\.\d+\.\d+) /)[1]'
+          }
+          newVersion=$(get_version)
+          if [ "$oldVersion" == "$newVersion" ]; then
+            echo "$0: New version same as old version, nothing to do." >&2
+            exit
+          fi
+          update-source-version makemkv "$newVersion" --source-key=passthru.srcs.bin
+          update-source-version makemkv "$newVersion" --source-key=passthru.srcs.oss --ignore-same-version
+        '';
+      });
+    };
+
+    meta = with lib; {
+      description = "Convert blu-ray and dvd to mkv";
+      longDescription = ''
+        makemkv is a one-click QT application that transcodes an encrypted
+        blu-ray or DVD disc into a more portable set of mkv files, preserving
+        subtitles, chapter marks, all video and audio tracks.
+
+        Program is time-limited -- it will stop functioning after 60 days. You
+        can always download the latest version from makemkv.com that will reset the
+        expiration date.
+      '';
+      sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+      license = [
+        licenses.unfree
+        licenses.lgpl21
+      ];
+      homepage = "https://makemkv.com";
+      platforms = [ "x86_64-linux" ];
+      maintainers = with maintainers; [ jchw ];
+    };
+  }
+)


### PR DESCRIPTION
This makes bumping the version with `overrideAttrs` easier. I also took the chance to use proper quoting in the scripts.

The formatter has made the diff much larger than the actual changes.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] (N/A) Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] (N/A) Module addition: when adding a new NixOS module.
  - [ ] (N/A) Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
