### PR TITLE
cups-brother-dcpt720dw: init at 3.5.0-1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17401,6 +17401,12 @@
     githubId = 33701036;
     name = "Milo Mc";
   };
+  mimahlavacek = {
+    email = "mima.hlavacek@gmail.com";
+    github = "mima-hlavacek";
+    githubId = 55756477;
+    name = "Míma Hlaváček";
+  };
   mimame = {
     email = "miguel.madrid.mencia@gmail.com";
     github = "mimame";

--- a/pkgs/by-name/cu/cups-brother-dcpt720dw/package.nix
+++ b/pkgs/by-name/cu/cups-brother-dcpt720dw/package.nix
@@ -1,0 +1,115 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  perl,
+  ghostscript,
+  coreutils,
+  gnugrep,
+  which,
+  file,
+  gnused,
+  dpkg,
+  makeBinaryWrapper,
+  libredirect,
+  debugLvl ? "0",
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cups-brother-dcpt720dw";
+  version = "3.5.0-1";
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf105179/dcpt720dwpdrv-${finalAttrs.version}.i386.deb";
+    hash = "sha256-ToUFGnHxd6rnLdfhdDGzhvsgFJukEAVzlm79hmkSV3E=";
+  };
+
+  strictDeps = true;
+  buildInputs = [ perl ];
+  nativeBuildInputs = [
+    dpkg
+    makeBinaryWrapper
+  ];
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    dpkg-deb -x $src $out
+
+    LPDDIR=$out/opt/brother/Printers/dcpt720dw/lpd
+    WRAPPER=$out/opt/brother/Printers/dcpt720dw/cupswrapper/brother_lpdwrapper_dcpt720dw
+
+    ln -s $LPDDIR/${stdenv.hostPlatform.linuxArch}/* $LPDDIR/
+
+    substituteInPlace $WRAPPER \
+      --replace-fail "PRINTER =~" "PRINTER = \"dcpt720dw\"; #" \
+      --replace-fail "basedir =~" "basedir = \"$out/opt/brother/Printers/dcpt720dw/\"; #" \
+      --replace-fail "lpdconf = " "lpdconf = \$lpddir.'/'.\$LPDCONFIGEXE.\$PRINTER; #" \
+      --replace-fail "\$DEBUG=0;" "\$DEBUG=${debugLvl};"
+
+    substituteInPlace $LPDDIR/filter_dcpt720dw \
+      --replace-fail "BR_PRT_PATH =~" "BR_PRT_PATH = \"$out/opt/brother/Printers/dcpt720dw/\"; #" \
+      --replace-fail "PRINTER =~" "PRINTER = \"dcpt720dw\"; #"
+
+    wrapProgram $WRAPPER \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          gnugrep
+          gnused
+        ]
+      }
+
+    wrapProgram $LPDDIR/filter_dcpt720dw \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          ghostscript
+          gnugrep
+          gnused
+          which
+          file
+        ]
+      }
+
+    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      $LPDDIR/brdcpt720dwfilter
+
+    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      $LPDDIR/brprintconf_dcpt720dw
+
+    wrapProgram $LPDDIR/brprintconf_dcpt720dw \
+      --set LD_PRELOAD "${lib.getLib libredirect}/lib/libredirect.so" \
+      --set NIX_REDIRECTS /opt=$out/opt
+
+    wrapProgram $LPDDIR/brdcpt720dwfilter \
+      --set LD_PRELOAD "${lib.getLib libredirect}/lib/libredirect.so" \
+      --set NIX_REDIRECTS /opt=$out/opt
+
+    mkdir -p "$out/lib/cups/filter" "$out/share/cups/model"
+
+    ln -s $out/opt/brother/Printers/dcpt720dw/cupswrapper/brother_lpdwrapper_dcpt720dw \
+      $out/lib/cups/filter/brother_lpdwrapper_dcpt720dw
+
+    ln -s "$out/opt/brother/Printers/dcpt720dw/cupswrapper/brother_dcpt720dw_printer_en.ppd" \
+      "$out/share/cups/model/"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Brother DCP-T720DW printer driver";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ mimahlavacek ];
+    platforms = [
+      "x86_64-linux"
+      "i686-linux"
+    ];
+    downloadPage = "https://support.brother.com/g/b/downloadtop.aspx?c=cn_ot&lang=en&prod=dcpt720dw_all";
+    homepage = "http://www.brother.com/";
+  };
+})


### PR DESCRIPTION
Adding a driver for brother DCP-T720DW I'm using to print at home. It is a straight up copy of the one for [DCP-T725DW](https://github.com/NixOS/nixpkgs/pull/330680). Currently the released deb packages differ only in the printer model, which I confirmed using `diffoscope`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
