### PR TITLE
mongoose: 3.3.5 -> 3.3.6

### DIFF
--- a/pkgs/by-name/mo/mongoose/package.nix
+++ b/pkgs/by-name/mo/mongoose/package.nix
@@ -8,11 +8,11 @@
 }:
 
 let
-  suitesparseVersion = "7.11.0";
+  suitesparseVersion = "7.12.1";
 in
 stdenv.mkDerivation {
   pname = "mongoose";
-  version = "3.3.5";
+  version = "3.3.6";
 
   outputs = [
     "bin"
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
     owner = "DrTimothyAldenDavis";
     repo = "SuiteSparse";
     tag = "v${suitesparseVersion}";
-    hash = "sha256-8CnN2P/W15GpK0nCNoRQongOrzcz5E8l9SgKksqLxd0=";
+    hash = "sha256-6EMPEH5dcNT1qtuSlzR26RhpfN7MbYJdSKcrsQ0Pzow=";
   };
 
   nativeBuildInputs = [
@@ -41,7 +41,6 @@ stdenv.mkDerivation {
   dontUseCmakeConfigure = true;
 
   cmakeFlags = [
-    "-DBLAS_LIBRARIES=${blas}"
     "-DCMAKE_BUILD_WITH_INSTALL_NAME_DIR=ON"
   ];
 


### PR DESCRIPTION
https://github.com/DrTimothyAldenDavis/SuiteSparse/commit/b8037f36bbd64dead75c9565d734ea529d901b88

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
