### PR TITLE
stalwart-mail: remove upstream systemd service

### DIFF
--- a/nixos/modules/services/mail/stalwart-mail.nix
+++ b/nixos/modules/services/mail/stalwart-mail.nix
@@ -154,8 +154,8 @@ in
     ];
 
     systemd = {
-      packages = [ cfg.package ];
       services.stalwart-mail = {
+        description = "Stalwart Mail Server";
         wantedBy = [ "multi-user.target" ];
         after = [
           "local-fs.target"
@@ -173,14 +173,20 @@ in
             '';
 
         serviceConfig = {
+          # Upstream service config
+          Type = "simple";
+          LimitNOFILE = 65536;
+          KillMode = "process";
+          KillSignal = "SIGINT";
+          Restart = "on-failure";
+          RestartSec = 5;
+          SyslogIdentifier = "stalwart-mail";
+
           ExecStart = [
             ""
             "${lib.getExe cfg.package} --config=${configFile}"
           ];
           LoadCredential = lib.mapAttrsToList (key: value: "${key}:${value}") cfg.credentials;
-
-          StandardOutput = "journal";
-          StandardError = "journal";
 
           ReadWritePaths = [
             cfg.dataDir
@@ -228,7 +234,6 @@ in
           UMask = "0077";
         };
         unitConfig.ConditionPathExists = [
-          ""
           "${configFile}"
         ];
       };


### PR DESCRIPTION
Closes #405233

I also ran into this issue, this fix has been sitting on my branch for a while since I never got around to submitting it. Better late than never I suppose. Literally just removes the upstream service file and copies its attributes to nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
