### PR TITLE
 pricehist: 1.4.7 -> 1.4.14

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18567,6 +18567,12 @@
     githubId = 6391776;
     name = "Nikita Voloboev";
   };
+  nikitawootten = {
+    email = "nixpkgs@nikita.computer";
+    github = "nikitawootten";
+    githubId = 8916363;
+    name = "Nikita Wootten";
+  };
   niklashh = {
     email = "niklas.2.halonen@aalto.fi";
     github = "xhalo32";

--- a/pkgs/by-name/pr/pricehist/package.nix
+++ b/pkgs/by-name/pr/pricehist/package.nix
@@ -6,14 +6,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "pricehist";
-  version = "1.4.7";
+  version = "1.4.14";
   format = "pyproject";
 
   src = fetchFromGitLab {
     owner = "chrisberkhout";
     repo = "pricehist";
     tag = version;
-    hash = "sha256-SBRJxNnA+nOxO6h97WZZHwhxoXeNtb5+rDayn4Hw6so=";
+    hash = "sha256-BnyoSYVjs2odnOzSpvgMF860PDkz7tPNnM0s3Fep5G0=";
   };
 
   dependencies = with python3Packages; [
@@ -33,10 +33,16 @@ python3Packages.buildPythonApplication rec {
     pytestCheckHook
   ];
 
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'lxml = "^5.1.0"' 'lxml = "^6.0.0"'
+  '';
+
   meta = {
     description = "Command-line tool for fetching and formatting historical price data, with support for multiple data sources and output formats";
     homepage = "https://gitlab.com/chrisberkhout/pricehist";
     license = lib.licenses.mit;
     mainProgram = "pricehist";
+    maintainers = with lib.maintainers; [ nikitawootten ];
   };
 }


### PR DESCRIPTION
- Fix build failure due to `lxml` version constraint in `pyproject.toml`
- Update from 1.4.7 to the latest version, 1.4.14
- Added myself as a maintainer

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
