### PR TITLE
easyeffects: 7.2.5 -> 8.0.3

### DIFF
--- a/pkgs/by-name/ea/easyeffects/package.nix
+++ b/pkgs/by-name/ea/easyeffects/package.nix
@@ -152,6 +152,7 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [
       getchoo
       aleksana
+      Gliczy
     ];
     mainProgram = "easyeffects";
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/ea/easyeffects/package.nix
+++ b/pkgs/by-name/ea/easyeffects/package.nix
@@ -1,23 +1,20 @@
 {
   lib,
   stdenv,
-  appstream-glib,
   calf,
+  cmake,
   deepfilternet,
-  desktop-file-utils,
   fetchFromGitHub,
   fftw,
   fftwFloat,
-  fmt_9,
   glib,
   gsl,
-  gtk4,
-  itstool,
+  intltool,
+  kdePackages,
   ladspaH,
-  libadwaita,
   libbs2b,
   libebur128,
-  libportal-gtk4,
+  libportal-qt6,
   libsamplerate,
   libsigcxx30,
   libsndfile,
@@ -25,61 +22,82 @@
   lsp-plugins,
   lv2,
   mda_lv2,
-  meson,
   ninja,
   nix-update-script,
   nlohmann_json,
   pipewire,
   pkg-config,
+  qt6,
   rnnoise,
   rubberband,
   soundtouch,
   speexdsp,
   onetbb,
-  wrapGAppsHook4,
+  webrtc-audio-processing,
   zam-plugins,
   zita-convolver,
 }:
 
 let
-  # Fix crashes with speexdsp effects
-  speexdsp' = speexdsp.override { withFftw3 = false; };
+  inherit (qt6)
+    qtbase
+    qtgraphs
+    qtwebengine
+    wrapQtAppsHook
+    ;
+  inherit (kdePackages)
+    appstream-qt
+    breeze-icons
+    extra-cmake-modules
+    kcolorscheme
+    kconfigwidgets
+    kiconthemes
+    kirigami
+    kirigami-addons
+    qqc2-desktop-style
+    ;
 in
 
 stdenv.mkDerivation rec {
   pname = "easyeffects";
-  version = "7.2.5";
+  version = "8.0.3";
 
   src = fetchFromGitHub {
     owner = "wwmm";
     repo = "easyeffects";
     tag = "v${version}";
-    hash = "sha256-w3Mb13LOSF8vgcdJrqbesLqyyilI5AoA19jFquE5lEw=";
+    hash = "sha256-N1VxA68IzNPZcDodoFTdQ0zpS5hCrHyLjP8Y/bqO/JA=";
   };
 
+  patches = [ ./qmlmodule-fix.patch ];
+
   nativeBuildInputs = [
-    desktop-file-utils
-    itstool
-    meson
+    cmake
+    extra-cmake-modules
+    intltool
     ninja
     pkg-config
-    wrapGAppsHook4
+    wrapQtAppsHook
   ];
 
   buildInputs = [
-    appstream-glib
+    appstream-qt
+    breeze-icons
     deepfilternet
     fftw
     fftwFloat
-    fmt_9
     glib
     gsl
-    gtk4
+    kcolorscheme
+    kconfigwidgets
+    kiconthemes
+    kirigami
+    kirigami-addons
     ladspaH
-    libadwaita
+    qqc2-desktop-style
     libbs2b
     libebur128
-    libportal-gtk4
+    libportal-qt6
     libsamplerate
     libsigcxx30
     libsndfile
@@ -87,11 +105,15 @@ stdenv.mkDerivation rec {
     lv2
     nlohmann_json
     pipewire
+    qtbase
+    qtgraphs
+    qtwebengine
     rnnoise
     rubberband
     soundtouch
-    speexdsp'
+    speexdsp
     onetbb
+    webrtc-audio-processing
     zita-convolver
   ];
 
@@ -110,7 +132,7 @@ stdenv.mkDerivation rec {
       ];
     in
     ''
-      gappsWrapperArgs+=(
+      qtWrapperArgs+=(
         --set LV2_PATH "${lib.makeSearchPath "lib/lv2" lv2Plugins}"
         --set LADSPA_PATH "${lib.makeSearchPath "lib/ladspa" ladspaPlugins}"
       )

--- a/pkgs/by-name/ea/easyeffects/qmlmodule-fix.patch
+++ b/pkgs/by-name/ea/easyeffects/qmlmodule-fix.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2736ac18b..85be09a90 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -65,7 +65,7 @@ find_package(KF${QT_MAJOR_VERSION} REQUIRED COMPONENTS
+     QQC2DesktopStyle
+ )
+ 
+-ecm_find_qmlmodule(org.kde.kirigami REQUIRED)
++ecm_find_qmlmodule(org.kde.kirigami)
+ 
+ qt_policy(SET QTP0001 NEW)


### PR DESCRIPTION
Changelog: https://github.com/wwmm/easyeffects/blob/v8.0.0/CHANGELOG.md#800
Diff: https://github.com/wwmm/easyeffects/compare/v7.2.5...v8.0.0

Upstream has dropped `gtk4` in favor of `qt6`, so this needed a few changes.

Everything I tested *seem* to work fine,  but additional testing would be nice welcomed.
One feature I didn't tested, is the newly added experiential global shortcut support.

A few things to note:
- Replaced `itstool` in favor of `intltool` as per upstream change 
- Removed `speexdsp'` to instead use the regular package without any overrides. I wasn't able to repro the crash, so it seems fine to remove? I would like to know what you think and if I should revert this change, @getchoo, as you are the one who added this fix
- Added `webrtc-audio-processing` for the new `Echo Canceller` effect
- Added myself as a maintainer
- The patch is necessary to build, otherwise it when fail with:
```
       > -- The following REQUIRED packages have not been found:
       >
       >  * org.kde.kirigami-QMLModule, QML module 'org.kde.kirigami' is a runtime dependency.
       >
       > CMake Error at /nix/store/5bn5f4ivqf4xn19khh4kcg4ngnjs6spg-cmake-4.1.2/share/cmake-4.1/Modules/FeatureSummary.cmake:499 (message):
       >   feature_summary() Error: REQUIRED package(s) are missing, aborting CMake
       >   run.
       > Call Stack (most recent call first):
       >   CMakeLists.txt:105 (feature_summary)
       >
       > 
       > -- Configuring incomplete, errors occurred!
```
It will still complain with the patch, but it does build and `easyeffects` doesn't seem to have any regression because of this. I'm not very familiar with KDE's `kirigami`, so more input on this would be welcomed.

The relevant logs after applying the patch:
```
easyeffects> -- The following RUNTIME packages have not been found:
easyeffects> 
easyeffects>  * org.kde.kirigami-QMLModule, QML module 'org.kde.kirigami' is a runtime dependency.
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
