### PR TITLE
vscoq -> 2.3.0 & add vsrocq extension 

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -3933,6 +3933,22 @@ let
 
       robocorp.robotframework-lsp = callPackage ./robocorp.robotframework-lsp { };
 
+      rocq-prover.vsrocq = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          publisher = "rocq-prover";
+          name = "vsrocq";
+          version = "2.3.2";
+          hash = "sha256-S3rKCzdGb5/UAJC6Z5GGC1Brib9PKiqQv8dRANYbp70=";
+        };
+        meta = {
+          description = "VsRocq is an extension for Visual Studio Code with support for the Rocq Prover";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=rocq-prover.vsrocq";
+          homepage = "https://github.com/rocq-prover/vsrocq";
+          license = lib.licenses.mit;
+          maintainers = [ lib.maintainers.Zimmi48 ];
+        };
+      };
+
       roman.ayu-next = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "ayu-next";

--- a/pkgs/development/coq-modules/vscoq-language-server/default.nix
+++ b/pkgs/development/coq-modules/vscoq-language-server/default.nix
@@ -16,6 +16,7 @@ let
     in
     with lib.versions;
     lib.switch coq.coq-version [
+      (case (range "8.18" "9.1") "2.3.3")
       (case (range "8.18" "9.1") "2.2.6")
       (case (range "8.18" "8.20") "2.2.1")
       (case (range "8.18" "8.19") "2.1.2")
@@ -41,6 +42,8 @@ let
     release."2.2.5".sha256 = "sha256-XyIjwem/yS7UIpQATNixgKkrMOHHs74nkAOvpU5WG1k=";
     release."2.2.6".rev = "v2.2.6";
     release."2.2.6".sha256 = "sha256-J8nRTAwN6GBEYgqlXa2kkkrHPatXsSObQg9QUQoZhgE=";
+    release."2.3.3".rev = "v2.3.3";
+    release."2.3.3".sha256 = "sha256-wgn28wqWhZS4UOLUblkgXQISgLV+XdSIIEMx9uMT/ig=";
     inherit location;
   };
   fetched = fetch (if version != null then version else defaultVersion);

--- a/pkgs/development/rocq-modules/vsrocq-language-server/default.nix
+++ b/pkgs/development/rocq-modules/vsrocq-language-server/default.nix
@@ -1,0 +1,80 @@
+{
+  metaFetch,
+  coq,
+  rocq-core,
+  lib,
+  glib,
+  adwaita-icon-theme,
+  wrapGAppsHook3,
+  version ? null,
+}:
+
+let
+  ocamlPackages = rocq-core.ocamlPackages;
+  defaultVersion =
+    let
+      case = case: out: { inherit case out; };
+    in
+    with lib.versions;
+    lib.switch rocq-core.rocq-version [
+      (case (range "8.18" "9.1") "2.3.3")
+      (case (range "8.18" "9.1") "2.3.0")
+    ] null;
+  location = {
+    domain = "github.com";
+    owner = "rocq-prover";
+    repo = "vsrocq";
+  };
+  fetch = metaFetch {
+    release."2.3.0".rev = "v2.3.0";
+    release."2.3.0".sha256 = "sha256-BZLxcCmSGFf04eUmlJXnyxmg4hTwpFaPaIik4VD444M=";
+    release."2.3.3".rev = "v2.3.3";
+    release."2.3.3".sha256 = "sha256-wgn28wqWhZS4UOLUblkgXQISgLV+XdSIIEMx9uMT/ig=";
+    inherit location;
+  };
+  fetched = fetch (if version != null then version else defaultVersion);
+in
+ocamlPackages.buildDunePackage {
+  pname = "vsrocq-language-server";
+  inherit (fetched) version;
+  src = "${fetched.src}/language-server";
+  nativeBuildInputs = [ coq ];
+  buildInputs = [
+    coq
+    glib
+    adwaita-icon-theme
+    wrapGAppsHook3
+  ]
+  ++ (with ocamlPackages; [
+    findlib
+    lablgtk3-sourceview3
+    yojson
+    zarith
+    ppx_inline_test
+    ppx_assert
+    ppx_sexp_conv
+    ppx_deriving
+    ppx_import
+    sexplib
+    ppx_yojson_conv
+    lsp
+    sel
+    ppx_optcomp
+  ]);
+  preBuild = ''
+    make dune-files
+  '';
+
+  meta =
+    with lib;
+    {
+      description = "Language server for the vsrocq vscode/codium extension";
+      homepage = "https://github.com/rocq-prover/vsrocq";
+      maintainers = with maintainers; [ cohencyril ];
+      license = licenses.mit;
+    }
+    // optionalAttrs (fetched.broken or false) {
+      rocqFilter = true;
+      broken = true;
+    };
+}

--- a/pkgs/top-level/rocq-packages.nix
+++ b/pkgs/top-level/rocq-packages.nix
@@ -40,6 +40,7 @@ let
       parseque = callPackage ../development/rocq-modules/parseque { };
       rocq-elpi = callPackage ../development/rocq-modules/rocq-elpi { };
       stdlib = callPackage ../development/rocq-modules/stdlib { };
+      vsrocq-language-server = callPackage ../development/rocq-modules/vsrocq-language-server { };
 
       filterPackages = doesFilter: if doesFilter then filterRocqPackages self else self;
     };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updating vscoq-language-server to version 2.3.0 to be compatible with the new VsRocq extension and adding this extension outright, after the deprecation of the VsCoq extension.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
