### PR TITLE
zig: fix performance issue

### DIFF
--- a/pkgs/development/compilers/zig/bintools.nix
+++ b/pkgs/development/compilers/zig/bintools.nix
@@ -4,7 +4,6 @@
   zig,
   runCommand,
   makeWrapper,
-  coreutils,
 }:
 let
   targetPrefix = lib.optionalString (
@@ -30,8 +29,7 @@ runCommand "zig-bintools-${zig.version}"
     for tool in ar objcopy ranlib ld.lld; do
       makeWrapper "$zig/bin/zig" "$out/bin/$tool" \
         --add-flags "$tool" \
-        --suffix PATH : "${lib.makeBinPath [ coreutils ]}" \
-        --run "export ZIG_GLOBAL_CACHE_DIR=\$(mktemp -d)"
+        --run "export ZIG_GLOBAL_CACHE_DIR=\$TMPDIR/zig-cache"
     done
 
     ln -s $out/bin/ld.lld $out/bin/ld

--- a/pkgs/development/compilers/zig/cc.nix
+++ b/pkgs/development/compilers/zig/cc.nix
@@ -4,7 +4,6 @@
   zig,
   stdenv,
   makeWrapper,
-  coreutils,
 }:
 let
   targetPrefix = lib.optionalString (
@@ -34,8 +33,7 @@ runCommand "zig-cc-${zig.version}"
     for tool in cc c++ ld.lld; do
       makeWrapper "$zig/bin/zig" "$out/bin/$tool" \
         --add-flags "$tool" \
-        --suffix PATH : "${lib.makeBinPath [ coreutils ]}" \
-        --run "export ZIG_GLOBAL_CACHE_DIR=\$(mktemp -d)"
+        --run "export ZIG_GLOBAL_CACHE_DIR=\$TMPDIR/zig-cache"
     done
 
     ln -s $out/bin/c++ $out/bin/clang++

--- a/pkgs/development/compilers/zig/passthru.nix
+++ b/pkgs/development/compilers/zig/passthru.nix
@@ -22,10 +22,7 @@
     nixSupport.cc-cflags = [
       "-target"
       "${stdenv.targetPlatform.system}-${stdenv.targetPlatform.parsed.abi.name}"
-    ]
-    ++ lib.optional (
-      stdenv.targetPlatform.isLinux && !(stdenv.targetPlatform.isStatic or false)
-    ) "-Wl,-dynamic-linker=${targetPackages.stdenv.cc.bintools.dynamicLinker}";
+    ];
   };
 
   stdenv = overrideCC stdenv zig.cc;


### PR DESCRIPTION
Before changes:
```console
$ nix build --impure --expr ' with (import (builtins.getFlake "github:nixos/nixpkgs/nixpkgs-unstable") {}); gdb.override { stdenv = zig_0_13.stdenv; enableDebuginfod = false; }'
gdb> buildPhase completed in 17 minutes 34 seconds
```

After changes:
```console
$ nix build --impure --expr ' with (import (builtins.getFlake "github:patryk4815/nixpkgs/fix-zig.cc3") {}); gdb.override { stdenv = zig_0_13.stdenv; enableDebuginfod = false; }'
gdb> buildPhase completed in 3 minutes 45 seconds
```

Setting `-Wl,-dynamic-linker` is not needed, `nix-support` already is setting this:
```console
$ grep -r 'dynamic-linker' $(nix eval --raw .#legacyPackages.x86_64-linux.zig.stdenv.cc)
/nix/store/cq5djqxmz7k2z8105gx7hgv1hlmyrrzj-zig-cc-wrapper-0.15.2/bin/clang:        extraBefore+=("-Wl,-dynamic-linker=$NIX_DYNAMIC_LINKER_x86_64_unknown_linux_gnu")
/nix/store/cq5djqxmz7k2z8105gx7hgv1hlmyrrzj-zig-cc-wrapper-0.15.2/bin/clang++:        extraBefore+=("-Wl,-dynamic-linker=$NIX_DYNAMIC_LINKER_x86_64_unknown_linux_gnu")

$ grep -r 'add-flags.sh' $(nix eval --raw .#legacyPackages.x86_64-linux.zig.stdenv.cc)
/nix/store/cq5djqxmz7k2z8105gx7hgv1hlmyrrzj-zig-cc-wrapper-0.15.2/bin/clang:    source /nix/store/fak9vn83x55qizfd1dag6nbgay5000kq-zig-bintools-wrapper-0.15.2/nix-support/add-flags.sh
/nix/store/cq5djqxmz7k2z8105gx7hgv1hlmyrrzj-zig-cc-wrapper-0.15.2/bin/clang:    source /nix/store/cq5djqxmz7k2z8105gx7hgv1hlmyrrzj-zig-cc-wrapper-0.15.2/nix-support/add-flags.sh
/nix/store/cq5djqxmz7k2z8105gx7hgv1hlmyrrzj-zig-cc-wrapper-0.15.2/bin/clang++:    source /nix/store/fak9vn83x55qizfd1dag6nbgay5000kq-zig-bintools-wrapper-0.15.2/nix-support/add-flags.sh
/nix/store/cq5djqxmz7k2z8105gx7hgv1hlmyrrzj-zig-cc-wrapper-0.15.2/bin/clang++:    source /nix/store/cq5djqxmz7k2z8105gx7hgv1hlmyrrzj-zig-cc-wrapper-0.15.2/nix-support/add-flags.sh
/nix/store/cq5djqxmz7k2z8105gx7hgv1hlmyrrzj-zig-cc-wrapper-0.15.2/nix-support/setup-hook:# function, and `add-flags.sh` are all communicating with each other with

$ grep -ir 'dynamic' /nix/store/fak9vn83x55qizfd1dag6nbgay5000kq-zig-bintools-wrapper-0.15.2/nix-support/add-flags.sh
    NIX_DYNAMIC_LINKER
if [ -z "$NIX_DYNAMIC_LINKER_x86_64_unknown_linux_gnu" ] && [ -e /nix/store/fak9vn83x55qizfd1dag6nbgay5000kq-zig-bintools-wrapper-0.15.2/nix-support/ld-set-dynamic-linker ]; then
    NIX_DYNAMIC_LINKER_x86_64_unknown_linux_gnu="$(< /nix/store/fak9vn83x55qizfd1dag6nbgay5000kq-zig-bintools-wrapper-0.15.2/nix-support/dynamic-linker)"

$ cat /nix/store/fak9vn83x55qizfd1dag6nbgay5000kq-zig-bintools-wrapper-0.15.2/nix-support/dynamic-linker
/nix/store/daamdpmaz2vjvna55ccrc30qw3qb8h6d-glibc-2.40-66/lib/ld-linux-x86-64.so.2
```

Still there are few more issues:
- zig.stdenv `"-target"  "${stdenv.targetPlatform.system}-${stdenv.targetPlatform.parsed.abi.name}"` is wrong for armv7l-linux and i686-linux, zig use different names.. 
- zig.hook don't support cross compilation (missing `-target` flag)
- zig.stdenv/zig.hook pickup wrong libSystem version on Darwin - it should use `darwinSdkVersion` from nixpkgs, not "random" version

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
