### PR TITLE
python3Packages.poetry-core: don't depend on virtualenv

### DIFF
--- a/pkgs/development/python-modules/poetry-core/default.nix
+++ b/pkgs/development/python-modules/poetry-core/default.nix
@@ -11,7 +11,6 @@
   setuptools,
   tomli-w,
   trove-classifiers,
-  virtualenv,
 }:
 
 buildPythonPackage rec {
@@ -26,6 +25,12 @@ buildPythonPackage rec {
     hash = "sha256-l5WTjKa+A66QfWLmrjCQq7ZrSaeuylGIRZr8jsiYq+A=";
   };
 
+  patches = [
+    # The venv fixture is only used in integration tests (through the python
+    # fixture) but we don't run those.
+    ./remove-venv-fixture.patch
+  ];
+
   nativeCheckInputs = [
     build
     gitMinimal
@@ -35,7 +40,6 @@ buildPythonPackage rec {
     setuptools
     tomli-w
     trove-classifiers
-    virtualenv
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/poetry-core/remove-venv-fixture.patch
+++ b/pkgs/development/python-modules/poetry-core/remove-venv-fixture.patch
@@ -1,0 +1,34 @@
+diff --git a/tests/conftest.py b/tests/conftest.py
+index 5ab1331..7b23117 100644
+--- a/tests/conftest.py
++++ b/tests/conftest.py
+@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING
+ from typing import Callable
+ 
+ import pytest
+-import virtualenv
+ 
+ from poetry.core.factory import Factory
+ from poetry.core.utils._compat import WINDOWS
+@@ -88,21 +87,6 @@ def temporary_directory() -> Iterator[Path]:
+         yield Path(tmp)
+ 
+ 
+-@pytest.fixture
+-def venv(temporary_directory: Path) -> Path:
+-    venv_dir = temporary_directory / ".venv"
+-    virtualenv.cli_run(
+-        [
+-            "--no-download",
+-            "--no-periodic-update",
+-            "--python",
+-            sys.executable,
+-            venv_dir.as_posix(),
+-        ]
+-    )
+-    return venv_dir
+-
+-
+ @pytest.fixture
+ def python(venv: Path) -> str:
+     return venv.joinpath("Scripts/Python.exe" if WINDOWS else "bin/python").as_posix()


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
