### PR TITLE
release-staging: add cargo (Linux only); rm unused argument

### DIFF
--- a/pkgs/top-level/release-staging.nix
+++ b/pkgs/top-level/release-staging.nix
@@ -29,9 +29,11 @@ let
 
   inherit (release-lib)
     all
+    linux
     mapTestOn
     ;
 in
 mapTestOn {
   stdenv = all;
+  cargo = linux;
 }

--- a/pkgs/top-level/release-staging.nix
+++ b/pkgs/top-level/release-staging.nix
@@ -5,12 +5,6 @@
 # early and make bisection less painful.
 
 {
-  nixpkgs ? {
-    outPath = (import ../../lib).cleanSource ../..;
-    revCount = 1234;
-    shortRev = "abcdef";
-    revision = "0000000000000000000000000000000000000000";
-  },
   # The platform doubles for which we build Nixpkgs.
   supportedSystems ? [
     "x86_64-linux"


### PR DESCRIPTION
Cargo has rustc, python3, Meson, and CMake in its build-time closure.

I make it Linux-only because our Darwin capacity on Hydra is more limited, and I suspect that those cycles are better spent elsewhere.
But if you disagree, it's easy for me to change :).

Follow-up to #352403.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- "Built" (`nix-build pkgs/top-level/release-staging.nix -A {stdenv,cargo}`) on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
