### PR TITLE
passhole, python3Packages.pykeepass-cache: init at 1.10.1 and 2.0.3 respectively

### DIFF
--- a/pkgs/by-name/pa/passhole/package.nix
+++ b/pkgs/by-name/pa/passhole/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  fetchPypi,
+  python3Packages,
+  nix-update-script,
+  fetchpatch2,
+}:
+
+let
+  inherit (python3Packages)
+    pynput
+    pykeepass
+    pykeepass-cache
+    colorama
+    pyotp
+    qrcode
+    buildPythonApplication
+    setuptools
+    ;
+in
+
+buildPythonApplication rec {
+  pname = "passhole";
+  version = "1.10.1";
+
+  patches = [
+    # Until version v1.10.2 or later is released, passhole's dependencies
+    # include "future", an vestigial Python2 compatibility layer.
+    # The inclusion of this dependency breaks the build on newer versions
+    # of Python, so we remove it here.
+    #
+    # Once this patch is included in an upstream release, it can be safely
+    # removed from here.
+    (fetchpatch2 {
+      name = "remove-future-dependency.patch";
+      url = "https://github.com/Evidlo/passhole/commit/a6d688af8cdfec0d33fddf6c18a72aeea154d207.patch?full_index=1";
+      sha256 = "AF2dGFlkaIgvLjtE6Wnp20G7e3EVPouZC9HYQyuZKhE=";
+    })
+  ];
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "5x8RA5H0DxAAI0deLXhUSy+q5vGixCWHU4d9FYXRcdE=";
+  };
+  propagatedBuildInputs = [
+    pynput
+    pykeepass
+    pykeepass-cache
+    colorama
+    pyotp
+    qrcode
+  ];
+
+  pythonImportsCheck = [ "passhole" ];
+  pyproject = true;
+  build-system = [ setuptools ];
+
+  passthru.updateScript = nix-update-script { };
+  meta = with lib; {
+    homepage = "https://github.com/Evidlo/passhole";
+    description = "CLI KeePass client with dmenu support";
+    license = licenses.gpl3Only;
+    maintainers = [ lib.maintainers.alch-emi ];
+    platforms = lib.platforms.linux;
+    mainProgram = "passhole"; # Also available as the "ph" alias
+    changelog = "https://github.com/Evidlo/passhole/blob/master/CHANGELOG.rst";
+  };
+}

--- a/pkgs/by-name/pa/passhole/package.nix
+++ b/pkgs/by-name/pa/passhole/package.nix
@@ -4,6 +4,7 @@
   python3Packages,
   nix-update-script,
   fetchpatch2,
+  callPackage,
 }:
 
 let
@@ -53,6 +54,8 @@ buildPythonApplication rec {
   pythonImportsCheck = [ "passhole" ];
   pyproject = true;
   build-system = [ setuptools ];
+
+  passthru.tests.basicFunctionality = callPackage ./test.nix { };
 
   passthru.updateScript = nix-update-script { };
   meta = with lib; {

--- a/pkgs/by-name/pa/passhole/remove-future-dependency.patch
+++ b/pkgs/by-name/pa/passhole/remove-future-dependency.patch
@@ -1,0 +1,12 @@
+diff --git a/setup.py b/setup.py
+index 943e319..b90edec 100644
+--- a/setup.py
++++ b/setup.py
+@@ -24,7 +24,6 @@ setup(
+         "pykeepass>=4.0.3",
+         "pykeepass_cache",
+         "colorama",
+-        "future",
+         "pyotp",
+         "qrcode",
+     ],

--- a/pkgs/by-name/pa/passhole/test.nix
+++ b/pkgs/by-name/pa/passhole/test.nix
@@ -1,0 +1,27 @@
+{ runCommand, passhole }:
+
+runCommand "passhole-basic-test"
+  {
+    nativeBuildInputs = [ passhole ];
+
+    expectedList = "mypass\n";
+    expectedPassword = "pword";
+    expectedUsername = "uname";
+  }
+  ''
+    mkdir $out/
+
+    # Setup the database with a single password
+    passhole --config ./config.ini init --database ./db.kdbx --keyfile ./keyfile.txt --name test-database
+    echo -e 'uname\npword\npword\nhttps://example.com\n\n' | passhole --config ./config.ini --no-password add mypass
+
+    # Test the database
+    passhole --config ./config.ini list > $out/list.txt
+    passhole --config ./config.ini show mypass --field password > $out/password.txt
+    passhole --config ./config.ini show mypass --field username > $out/username.txt
+
+    # Check that the output was correct
+    cmp $out/list.txt <(echo -n "$expectedList")
+    cmp $out/password.txt <(echo -n "$expectedPassword")
+    cmp $out/username.txt <(echo -n "$expectedUsername")
+  ''

--- a/pkgs/development/python-modules/pykeepass-cache/default.nix
+++ b/pkgs/development/python-modules/pykeepass-cache/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildPythonPackage,
+  pykeepass,
+  rpyc,
+  python-daemon,
+  setuptools,
+  fetchPypi,
+  nix-update-script,
+}:
+
+buildPythonPackage rec {
+  pname = "pykeepass-cache";
+  version = "2.0.3";
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-fzb+qC8dACPr+V31DV50ElHzIePdXMX6TtepTY6fYeg=";
+  };
+
+  propagatedBuildInputs = [
+    pykeepass
+    rpyc
+    python-daemon
+  ];
+  pythonImportsCheck = [ "pykeepass_cache" ];
+  pyproject = true;
+  build-system = [ setuptools ];
+
+  passthru.updateScript = nix-update-script { };
+  meta = {
+    homepage = "https://github.com/libkeepass/pykeepass_cache";
+    description = "Drop-in replacement for PyKeePass, providing access to KeePass databases with daemonized caching";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.alch-emi ];
+    platforms = lib.platforms.linux;
+    # Note: An official changelog is not published by the package authors
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13411,6 +13411,8 @@ self: super: with self; {
 
   pykeepass = callPackage ../development/python-modules/pykeepass { };
 
+  pykeepass-cache = callPackage ../development/python-modules/pykeepass-cache { };
+
   pykerberos = callPackage ../development/python-modules/pykerberos { krb5-c = pkgs.krb5; };
 
   pykeyatome = callPackage ../development/python-modules/pykeyatome { };


### PR DESCRIPTION
[`passhole`](https://github.com/Evidlo/passhole) is a pass-inspired command-line interface for the open-source password management database format used by KeePassXC.  It served as the inspiration for [`keepmenu`](https://github.com/firecat53/keepmenu/) (currently in Nix) and is, in my opinion, the most ergonomic CLI interface to Keepass databases.

[`pykeepass-cache`](https://github.com/libkeepass/pykeepass_cache) is a dependency of passhole which wraps an `pykeepass` (already in nix) and runs in the background as a daemon, thus providing the ability for `passhole` leave the database unlocked for a brief period of time after execution completes, meaning the user won't need to re-enter their password on successive runs.

Notes:  I needed to include a patch for `passhole` which hasn't been included in a release yet.  The patch has been accepted upstream, but is still pending a release, and may be for some time.  I wasn't sure what nixpkg's preference is about packaging a `-unstable-` version versus including a patch, but I went with the later.  I'm happy to change my approach if need be!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
