### PR TITLE
tor: add PortForwarding settings

### DIFF
--- a/nixos/modules/services/security/tor.nix
+++ b/nixos/modules/services/security/tor.nix
@@ -205,6 +205,16 @@ let
     type = with lib.types; listOf str;
     default = [ ];
   };
+  optionPortForwarding = lib.mkOption {
+    type = lib.types.bool;
+    default = false;
+    description = "Attempt UPnP and NAT-PMP forwarding for the DirPort and ORPort.";
+  };
+  optionPortForwardingHelper = lib.mkOption {
+    type = lib.types.str;
+    default = "tor-fw-helper";
+    description = "If PortForwarding is set, allows to overwrite the used helper.";
+  };
   optionORPort =
     optionName:
     lib.mkOption {
@@ -1063,6 +1073,8 @@ in
           options.PerConnBWBurst = optionBandwidth "PerConnBWBurst";
           options.PerConnBWRate = optionBandwidth "PerConnBWRate";
           options.PidFile = optionPath "PidFile";
+          options.PortForwarding = optionBool "PortForwarding";
+          options.PortForwardingHelper = optionString "PortForwardingHelper";
           options.ProtocolWarnings = optionBool "ProtocolWarnings";
           options.PublishHidServDescriptors = optionBool "PublishHidServDescriptors";
           options.PublishServerDescriptor = lib.mkOption {
@@ -1264,6 +1276,8 @@ in
         # by some hosting providers...
         DirPort = lib.mkForce [ ];
         ORPort = lib.mkForce [ ];
+        PortForwarding = lib.mkForce false;
+        PortForwardingHelper = lib.mkForce "tor-fw-helper";
         PublishServerDescriptor = lib.mkForce false;
       })
       (lib.mkIf (!cfg.client.enable) {


### PR DESCRIPTION
Add two torrc settings for UPnP and NAT-PMP forwarding.

```
PortForwarding 0|1
PortForwardingHelper filename|pathname
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
