### PR TITLE
resholve: 0.10.6 -> 0.10.7

### DIFF
--- a/pkgs/development/misc/resholve/resholve-utils.nix
+++ b/pkgs/development/misc/resholve/resholve-utils.nix
@@ -200,9 +200,6 @@ rec {
             )
           ))
         }
-      ''
-      + lib.optionalString (partialSolution.interpreter != "none") ''
-        ${partialSolution.interpreter} -n $out
       '';
     };
   writeScriptBin =
@@ -220,9 +217,6 @@ rec {
             }
           )
         )}
-      ''
-      + lib.optionalString (partialSolution.interpreter != "none") ''
-        ${partialSolution.interpreter} -n $out/bin/${name}
       '';
     };
   mkDerivation =
@@ -232,6 +226,7 @@ rec {
       version,
       passthru ? { },
       solutions,
+      postResholve ? "",
       ...
     }@attrs:
     let
@@ -285,6 +280,8 @@ rec {
         # supports default python.logging levels
         # LOGLEVEL="INFO";
         preFixup = phraseSolutions solutions unresholved;
+
+        postFixup = postResholve;
 
         # don't break the metadata...
         meta = unresholved.meta;

--- a/pkgs/development/misc/resholve/source.nix
+++ b/pkgs/development/misc/resholve/source.nix
@@ -4,11 +4,11 @@
 }:
 
 rec {
-  version = "0.10.6";
+  version = "0.10.7";
   rSrc = fetchFromGitHub {
     owner = "abathur";
     repo = "resholve";
     rev = "v${version}";
-    hash = "sha256-iJEkfW60QO4nFp+ib2+DeDRsZviYFhWRQoBw1VAhzJY=";
+    hash = "sha256-aUhxaxniGcmFAawUTXa5QrWUSpw5NUoJO5y4INk5mQU=";
   };
 }

--- a/pkgs/development/misc/resholve/test.nix
+++ b/pkgs/development/misc/resholve/test.nix
@@ -25,6 +25,7 @@
   rlwrap,
   gnutar,
   bc,
+  systemd,
   # override testing
   esh,
   getconf,
@@ -49,7 +50,6 @@
   nix-direnv,
   pdf2odt,
   pdfmm,
-  rancid,
   s0ix-selftest-tool,
   unix-privesc-check,
   wgnord,
@@ -77,6 +77,9 @@ let
     gnutar
     bc
     msmtp
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    systemd
   ];
 in
 rec {
@@ -158,6 +161,9 @@ rec {
         inputs = [ ];
       };
     };
+    postResholve = ''
+      echo "not a load-bearing test, just prove we exist"
+    '';
   };
   # demonstrate that we could use resholve in larger build
   module3 = stdenv.mkDerivation {
@@ -219,6 +225,8 @@ rec {
     INTERP = "${bash}/bin/bash";
 
     checkPhase = ''
+      echo removing parse tests matching no${stdenv.buildPlatform.uname.system}
+      rm tests/parse_*no${stdenv.buildPlatform.uname.system}.sh || true # ok if none exist
       patchShebangs .
       mkdir empty_lore
       touch empty_lore/{execers,wrappers}
@@ -338,7 +346,6 @@ rec {
 // lib.optionalAttrs stdenv.hostPlatform.isLinux {
   inherit arch-install-scripts;
   inherit dgoss;
-  inherit rancid;
   inherit unix-privesc-check;
   inherit wgnord;
   inherit wsl-vpnkit;


### PR DESCRIPTION
https://github.com/abathur/resholve/blob/master/CHANGELOG.md#v0107-nov-9-2025

Non-source changes:
- drops `bash -n` style syntax checking for writeScript(Bin) to avoid breaking cross builds
- add postResholve hook (supersedes unmerged pr #439997)
- track testing changes in resholve


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
