### PR TITLE
php: Enable ACL support for FPM

### DIFF
--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -13,6 +13,7 @@ let
       makeBinaryWrapper,
       symlinkJoin,
       writeText,
+      acl,
       autoconf,
       automake,
       bison,
@@ -248,6 +249,7 @@ let
 
             # Enable sapis
             ++ lib.optionals pearSupport [ libxml2.dev ]
+            ++ lib.optionals (fpmSupport && stdenv.hostPlatform.isLinux) [ acl ]
 
             # Misc deps
             ++ lib.optional apxs2Support apacheHttpd
@@ -268,7 +270,10 @@ let
             # Enable sapis
             ++ lib.optional (!cgiSupport) "--disable-cgi"
             ++ lib.optional (!cliSupport) "--disable-cli"
-            ++ lib.optional fpmSupport "--enable-fpm"
+            ++ lib.optionals fpmSupport [
+              "--enable-fpm"
+              (lib.withFeature stdenv.hostPlatform.isLinux "fpm-acl")
+            ]
             ++ lib.optionals pearSupport [
               "--with-pear"
               "--enable-xml"


### PR DESCRIPTION
This will allow authorizing extra processes like Prometheus exporter without having to run it as `listen.user` (or adding it `listen.group` and changing `listen.mode` to `0660`).

It is disabled by default:

https://www.php.net/manual/en/install.fpm.install.php

but it has been available since PHP 5.6:

https://github.com/php/php-src/commit/744ada7d9ddb7c0f37c494bf0e7636cb1ed6cb34

And Debian enables it too:

https://salsa.debian.org/php-team/php/-/commit/153055e5e35b4e8fce0fc452d2052e5457242abd


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
