### PR TITLE
libblockdev: 3.3.0 -> 3.4.0

### DIFF
--- a/pkgs/by-name/li/libblockdev/package.nix
+++ b/pkgs/by-name/li/libblockdev/package.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "storaged-project";
     repo = "libblockdev";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-KvcGvMsASgEKTerhh/lSPjQoXYDMBvbaPSdc6f5p7wc=";
   };
 
@@ -60,6 +60,8 @@ stdenv.mkDerivation (finalAttrs: {
   configureFlags = [
     "--with-python_prefix=${placeholder "python"}"
   ];
+
+  strictDeps = true;
 
   nativeBuildInputs = [
     autoconf-archive
@@ -103,7 +105,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    changelog = "https://github.com/storaged-project/libblockdev/raw/${finalAttrs.src.rev}/NEWS.rst";
+    changelog = "https://github.com/storaged-project/libblockdev/raw/${finalAttrs.src.tag}/NEWS.rst";
     description = "Library for manipulating block devices";
     homepage = "http://storaged.org/libblockdev/";
     license = with lib.licenses; [

--- a/pkgs/by-name/li/libblockdev/package.nix
+++ b/pkgs/by-name/li/libblockdev/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   autoreconfHook,
   pkg-config,
   gtk-doc,
@@ -36,22 +35,14 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "libblockdev";
-  version = "3.3.0";
+  version = "3.4.0";
 
   src = fetchFromGitHub {
     owner = "storaged-project";
     repo = "libblockdev";
     rev = finalAttrs.version;
-    hash = "sha256-Q7610i+2PQi+Oza3c2SwPneljrb+1cuFA4K4DQTpt8A=";
+    hash = "sha256-KvcGvMsASgEKTerhh/lSPjQoXYDMBvbaPSdc6f5p7wc=";
   };
-
-  patches = [
-    # CVE-2025-6019: https://www.openwall.com/lists/oss-security/2025/06/17/5
-    (fetchpatch {
-      url = "https://github.com/storaged-project/libblockdev/commit/4e35eb93e4d2672686789b9705623cc4f9f85d02.patch";
-      hash = "sha256-3pQxvbFX6jmT5LCaePoVfvPTNPoTPPhT0GcLaGkVVso=";
-    })
-  ];
 
   outputs = [
     "out"


### PR DESCRIPTION
Resolves #438482

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
