### PR TITLE
aroccPackages.latest-unwrapped: 0-unstable-2025-03-05 -> 0-unstable-2025-11-09

### DIFF
--- a/pkgs/development/compilers/arocc/default.nix
+++ b/pkgs/development/compilers/arocc/default.nix
@@ -2,18 +2,18 @@
   lib,
   fetchFromGitHub,
   callPackage,
-  zig_0_14,
+  zig,
 }:
 let
   versions = [
     {
-      zig = zig_0_14;
-      version = "0-unstable-2025-03-05";
+      inherit zig;
+      version = "0-unstable-2025-11-09";
       src = fetchFromGitHub {
         owner = "Vexu";
         repo = "arocc";
-        rev = "8c6bab43ba351fc045a1d262d8a8da4a11215e37";
-        hash = "sha256-J5Cj9UMwAMwH2JGby13FIKl5Qbj4N4XpSSY7zL21aoY=";
+        rev = "3fb778c201718bd82bf1f08cd46ea133c4697b76";
+        hash = "sha256-Hac+rhf7wB3KTs2OIfdcGVq2+H/81yXMl3cq//LUeRk=";
       };
     }
   ];


### PR DESCRIPTION
Resolves #437304

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
