### PR TITLE
nixosOptionsDoc: remove documentType arg

### DIFF
--- a/doc/doc-support/options-doc.nix
+++ b/doc/doc-support/options-doc.nix
@@ -23,6 +23,5 @@ let
 in
 nixosOptionsDoc {
   inherit (modules) options;
-  documentType = "none";
   transformOptions = opt: opt // { declarations = map transformDeclaration opt.declarations; };
 }

--- a/nixos/doc/manual/default.nix
+++ b/nixos/doc/manual/default.nix
@@ -89,7 +89,6 @@ let
               decl
           ) opt.declarations;
         };
-      documentType = "none";
       variablelistId = "test-options-list";
       optionIdPrefix = "test-opt-";
     };

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -219,6 +219,8 @@
 
 - `miniflux` no longer uses the hstore PostgreSQL extension. Having the extension would prevent Miniflux from starting. In case you are managing your `miniflux` PostgreSQL database externally, disable the extension with `DROP EXTENSION IF EXISTS hstore;`.
 
+- `nixosOptionsDoc` argument `documentType` has been deprecated. It was a no-op and added no additional behavior.
+
 - `netbox-manage` script created by the `netbox` module no longer uses `sudo -u netbox` internally. It can be run as root and will change it's user to `netbox` using `runuser`.
 
 - NixOS display manager modules now strictly use tty1, where many of them previously used tty7. Options to configure display managers' VT have been dropped. A configuration with a display manager enabled will not start `getty@tty1.service`, even if the system is forced to boot into `multi-user.target` instead of `graphical.target`.

--- a/nixos/lib/make-options-doc/default.nix
+++ b/nixos/lib/make-options-doc/default.nix
@@ -91,9 +91,8 @@
   lib,
   options,
   transformOptions ? lib.id, # function for additional transformations of the options
-  documentType ? "appendix",
-  # TODO deprecate "appendix" in favor of "none"
-  #      and/or rename function to moduleOptionDoc for clean slate
+  documentType ? null,
+  # TODO  rename function to moduleOptionDoc for clean slate
 
   # If you include more than one option list into a document, you need to
   # provide different ids.
@@ -108,9 +107,10 @@
   # instead of printing warnings for eg options with missing descriptions (which may be lost
   # by nix build unless -L is given), emit errors instead and fail the build
   warningsAreErrors ? true,
-}:
+}@args:
 
-let
+lib.warnIf (args ? documentType)
+(let
   rawOpts = lib.optionAttrSetToDocList options;
   transformedOpts = map transformOptions rawOpts;
   filteredOpts = lib.filter (opt: opt.visible && !opt.internal) transformedOpts;
@@ -246,4 +246,4 @@ rec {
           echo "file json $dst/options.json" >> $out/nix-support/hydra-build-products
           echo "file json-br $dst/options.json.br" >> $out/nix-support/hydra-build-products
       '';
-}
+})

--- a/pkgs/by-name/tr/treefmt/options-doc.nix
+++ b/pkgs/by-name/tr/treefmt/options-doc.nix
@@ -25,7 +25,6 @@ let
     };
 in
 nixosOptionsDoc {
-  documentType = "none";
   options = removeAttrs configuration.options [ "_module" ];
   transformOptions = opt: opt // { declarations = map transformDeclaration opt.declarations; };
 }


### PR DESCRIPTION
Removed the `documentType` arguent from `nixosOptionsDoc` and all relevant places. I believe this was left over with no functionality as the old code which consumed `documentType` no longer exists. So I think it is best to remove this in the near future.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
