### PR TITLE
ocamlPackages.facile: unbreak

### DIFF
--- a/pkgs/development/ocaml-modules/facile/default.nix
+++ b/pkgs/development/ocaml-modules/facile/default.nix
@@ -1,30 +1,34 @@
 {
   lib,
   fetchurl,
+  fetchpatch,
   buildDunePackage,
-  ocaml,
+  stdlib-shims,
+
 }:
 
-lib.throwIf (lib.versionAtLeast ocaml.version "5.0") "facile is not available for OCaml ≥ 5.0"
+buildDunePackage (finalAttrs: {
+  pname = "facile";
+  version = "1.1.4";
 
-  buildDunePackage
-  rec {
-    pname = "facile";
-    version = "1.1.4";
+  src = fetchurl {
+    url = "https://github.com/Emmanuel-PLF/facile/releases/download/${finalAttrs.version}/facile-${finalAttrs.version}.tbz";
+    sha256 = "0jqrwmn6fr2vj2rrbllwxq4cmxykv7zh0y4vnngx29f5084a04jp";
+  };
 
-    src = fetchurl {
-      url = "https://github.com/Emmanuel-PLF/facile/releases/download/${version}/facile-${version}.tbz";
-      sha256 = "0jqrwmn6fr2vj2rrbllwxq4cmxykv7zh0y4vnngx29f5084a04jp";
-    };
+  patches = fetchpatch {
+    url = "https://patch-diff.githubusercontent.com/raw/Emmanuel-PLF/facile/pull/4.patch";
+    excludes = [ "Makefile" ];
+    hash = "sha256-syZO3lzuHxE2Y4yUaS+XgAQUFtLrENy2MwyWzPygfdg=";
+  };
 
-    doCheck = true;
+  propagatedBuildInputs = [ stdlib-shims ];
 
-    duneVersion = if lib.versionAtLeast ocaml.version "4.12" then "2" else "1";
-    postPatch = lib.optionalString (duneVersion != "1") "dune upgrade";
+  doCheck = true;
 
-    meta = {
-      homepage = "http://opti.recherche.enac.fr/facile/";
-      license = lib.licenses.lgpl21Plus;
-      description = "Functional Constraint Library";
-    };
-  }
+  meta = {
+    homepage = "http://opti.recherche.enac.fr/facile/";
+    license = lib.licenses.lgpl21Plus;
+    description = "Functional Constraint Library";
+  };
+})


### PR DESCRIPTION
Just apply a patch that has been contributed upstream.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
