### PR TITLE
hyprland: 0.52.0 -> 0.52.1

### DIFF
--- a/pkgs/by-name/hy/hyprland/info.json
+++ b/pkgs/by-name/hy/hyprland/info.json
@@ -1,7 +1,7 @@
 {
-  "branch": "main",
-  "commit_hash": "f56ec180d3a03a5aa978391249ff8f40f949fb73",
-  "commit_message": "version: bump to 0.52.0",
-  "date": "2025-11-07",
-  "tag": "v0.52.0"
+  "branch": "v0.52.1-b",
+  "commit_hash": "967c3c7404d4fa00234e29c70df3e263386d2597",
+  "commit_message": "version: bump to 0.52.1",
+  "date": "2025-11-09",
+  "tag": "v0.52.1"
 }

--- a/pkgs/by-name/hy/hyprland/package.nix
+++ b/pkgs/by-name/hy/hyprland/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   stdenvAdapters,
   fetchFromGitHub,
-  fetchpatch,
   pkg-config,
   makeWrapper,
   cmake,
@@ -92,29 +91,15 @@ assert assertMsg (
 
 customStdenv.mkDerivation (finalAttrs: {
   pname = "hyprland" + optionalString debug "-debug";
-  version = "0.52.0";
+  version = "0.52.1";
 
   src = fetchFromGitHub {
     owner = "hyprwm";
     repo = "hyprland";
     fetchSubmodules = true;
     tag = "v${finalAttrs.version}";
-    hash = "sha256-5jYD01l95U/HTfZMAccAvhSnrWgHIRWEjLi9R4wPIVI=";
+    hash = "sha256-Lr8kwriXtUxjYsi1sGRMIR2LZilgrxYQA1TTmbpSJ+g=";
   };
-
-  patches = [
-    # NOTE: this is required to make plugins compile. should be removed with the next release.
-    (fetchpatch {
-      url = "https://github.com/hyprwm/Hyprland/commit/522edc87126a48f3ce4891747b6a92a22385b1e7.patch";
-      hash = "sha256-0BAlAVW5isa8gd833PjZdqO/uEpDqdTlu0iZbLP4U9s=";
-    })
-
-    # NOTE: fixes regression for layer-shell-qt. should be removed with the next release.
-    (fetchpatch {
-      url = "https://github.com/hyprwm/Hyprland/commit/0bd11d5eb941b8038f0723135768d84aa5512b4a.patch";
-      hash = "sha256-yY5OsihAzm5cVLg8smGc4i/RIimUDwuZ1RUGqOlfV+Q=";
-    })
-  ];
 
   postPatch = ''
     # Fix hardcoded paths to /usr installation


### PR DESCRIPTION
[Some fixes backported](https://github.com/hyprwm/Hyprland/releases/tag/v0.52.1)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
