### PR TITLE
SDL_compat: revert breaking upstream change

### DIFF
--- a/pkgs/by-name/sd/SDL_compat/package.nix
+++ b/pkgs/by-name/sd/SDL_compat/package.nix
@@ -4,6 +4,7 @@
   cmake,
   darwin,
   fetchFromGitHub,
+  fetchpatch2,
   libGLU,
   libiconv,
   libX11,
@@ -84,10 +85,18 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s $out/lib/pkgconfig/sdl12_compat.pc $out/lib/pkgconfig/sdl.pc
   '';
 
-  # The setup hook scans paths of buildInputs to find SDL related packages and
-  # adds their include and library paths to environment variables. The sdl-config
-  # is patched to use these variables to produce correct flags for compiler.
-  patches = [ ./find-headers.patch ];
+  patches = [
+    # The setup hook scans paths of buildInputs to find SDL related packages and
+    # adds their include and library paths to environment variables. The sdl-config
+    # is patched to use these variables to produce correct flags for compiler.
+    ./find-headers.patch
+
+    # https://github.com/libsdl-org/sdl12-compat/issues/382
+    (fetchpatch2 {
+      url = "https://github.com/libsdl-org/sdl12-compat/commit/bef8f7412dd44edc4f7e14dc35d3b20399e25496.patch?full_index=1";
+      hash = "sha256-5kJawjmA8C3uH3OIXHmqQjnIRtoTJtXmm3iLxG3e1qc=";
+    })
+  ];
   setupHook = ./setup-hook.sh;
 
   passthru.tests = {


### PR DESCRIPTION
Fixes several of the build failures that were caused by <https://github.com/NixOS/nixpkgs/pull/457112>, e.g.:

* https://hydra.nixos.org/build/311791969
* https://hydra.nixos.org/build/311791578
* https://hydra.nixos.org/build/311802072

ZHF: #457852
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
