### PR TITLE
nmapautomator: init at 0-unstable-2021-04-10

### DIFF
--- a/pkgs/by-name/nm/nmapautomator/package.nix
+++ b/pkgs/by-name/nm/nmapautomator/package.nix
@@ -1,0 +1,105 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  dirb,
+  metasploit,
+  nix-update-script,
+  withFullDeps ? false,
+
+  # required dependencies
+  nmap,
+  coreutils,
+  gawk,
+  gnugrep,
+  gnused,
+  findutils,
+
+  # optional dependencies
+  smtp-user-enum,
+  dnsrecon,
+  bind,
+  sslscan,
+  nikto,
+  ffuf,
+  joomscan,
+  smbmap,
+  enum4linux,
+  wpscan,
+  samba,
+  openldap,
+  net-snmp,
+  snmpcheck,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "nmapautomator";
+  version = "0-unstable-2021-04-10";
+
+  src = fetchFromGitHub {
+    owner = "21y4d";
+    repo = "nmapAutomator";
+    rev = "c5e15de8429c78aa5923010145dfac0996aba9e1";
+    hash = "sha256-HwBvhFvGVY5q0C62XjNalQUaX7y24B1Vt8UqAIHp8/g=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  runtimeDeps = [
+    nmap
+    coreutils
+    gawk
+    gnugrep
+    gnused
+    findutils
+  ]
+  ++ lib.optionals withFullDeps [
+    smtp-user-enum
+    dnsrecon
+    bind.dnsutils
+    bind.host
+    sslscan
+    nikto
+    ffuf
+    joomscan
+    smbmap
+    enum4linux
+    wpscan
+    samba
+    openldap
+    net-snmp
+    snmpcheck
+  ];
+  # TODO: Package and add odat and droopescan
+
+  postPatch = ''
+    substituteInPlace nmapAutomator.sh \
+      --replace-fail '/usr/share/nmap/' '${nmap}/share/nmap/' \
+      --replace-fail '/usr/share/wordlists/dirb/' '${dirb}/share/dirb/wordlists/' \
+      --replace-fail '/usr/share/wordlists/metasploit/' '${metasploit.src}/data/wordlists/'
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm 555 nmapAutomator.sh $out/bin/nmapAutomator
+    wrapProgram $out/bin/nmapAutomator \
+      --prefix PATH : ${lib.makeBinPath finalAttrs.runtimeDeps}
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch=master" ]; };
+
+  meta = {
+    description = "Nmap script to automate the process of enumeration & recon";
+    homepage = "https://github.com/21y4d/nmapAutomator";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ letgamer ];
+    mainProgram = "nmapAutomator";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This PR add the nmapAutomator Package: https://github.com/21y4d/nmapAutomator

This script automates the usage of nmap and is often used in Pentesting.

All of the additional Recon can be enabled by setting:
```nix
(pkgs.nmapautomator.override { withFullDeps = true; })
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
