### PR TITLE
cryptpad: 2025.6.0 -> 2025.9.0

### DIFF
--- a/pkgs/by-name/cr/cryptpad/0001-install-onlyoffice.sh-fix-check-for-new-install_vers.patch
+++ b/pkgs/by-name/cr/cryptpad/0001-install-onlyoffice.sh-fix-check-for-new-install_vers.patch
@@ -1,0 +1,50 @@
+From 711aa33dbc75c68ce2184d7c9ed522c0b0358cc6 Mon Sep 17 00:00:00 2001
+From: Dominique Martinet <asmadeus@codewreck.org>
+Date: Sat, 8 Nov 2025 07:09:39 +0900
+Subject: [PATCH] install-onlyoffice.sh: fix --check for new install_version
+ function
+
+---
+ install-onlyoffice.sh | 20 +++++++++++++++-----
+ 1 file changed, 15 insertions(+), 5 deletions(-)
+
+diff --git a/install-onlyoffice.sh b/install-onlyoffice.sh
+index 757be5437a74..c26d98d73b48 100755
+--- a/install-onlyoffice.sh
++++ b/install-onlyoffice.sh
+@@ -271,17 +271,27 @@ install_old_version() {
+ }
+ 
+ install_version() {
+-    ensure_command_available curl
+-    ensure_command_available sha512sum
+-    ensure_command_available unzip
+-
+     local DIR=$1
+     local VERSION=$2
+     local HASH=$3
+     local FULL_DIR=$OO_DIR/$DIR
+     local LAST_DIR=$(pwd)
+ 
+-    if [ ! -e "$FULL_DIR"/.version ] || [ "$(cat "$FULL_DIR"/.version)" != "$VERSION" ]; then
++    local ACTUAL_VERSION="not installed"
++    if [ -e "$FULL_DIR"/.version ]; then
++        ACTUAL_VERSION="$(cat "$FULL_DIR"/.version)"
++    fi
++
++    if [ "$ACTUAL_VERSION" != "$VERSION" ]; then
++        if [ ${CHECK+x} ]; then
++            echo "Wrong version in $FULL_DIR. Expected: $VERSION. Found: $ACTUAL_VERSION"
++            exit 1
++        fi
++
++        ensure_command_available sha512sum
++        ensure_command_available curl
++        ensure_command_available unzip
++
+         rm -rf "$FULL_DIR"
+         mkdir -p "$FULL_DIR"
+ 
+-- 
+2.51.1
+

--- a/pkgs/by-name/cr/cryptpad/package.nix
+++ b/pkgs/by-name/cr/cryptpad/package.nix
@@ -14,7 +14,7 @@
 }:
 
 let
-  version = "2025.6.0";
+  version = "2025.9.0";
   # nix version of install-onlyoffice.sh
   # a later version could rebuild from sdkjs/web-apps as per
   # https://github.com/cryptpad/onlyoffice-builds/blob/main/build.sh
@@ -102,8 +102,8 @@ let
     }
     {
       subdir = "v8";
-      version = "v8.3.3.23+4";
-      hash = "sha256-DeK84fa7Jc1L1+vF8LBKLXM5oWS0SV2qBnAWG3Xzu4U=";
+      version = "v8.3.3.23+5";
+      hash = "sha256-+53jzvmGltD1yjXAimLl8zL1V4YDc1qF1PUFSeyiUm8=";
     }
   ];
 
@@ -127,10 +127,10 @@ buildNpmPackage {
     owner = "cryptpad";
     repo = "cryptpad";
     tag = version;
-    hash = "sha256-R8Oonrnb1tqvl1zTkWv5Xv/f8bFtUljD6X/re72IvsU=";
+    hash = "sha256-veLtKjrk1CZe2u3MkozsPK98hyhdsWbQGUxh8oWjLXg=";
   };
 
-  npmDepsHash = "sha256-4Zr+8ANZJ9XX2umY/SY7BrEHPheVelFSeZipgOaW6bI==";
+  npmDepsHash = "sha256-d/2JKGdC/tgDOo4Qr/0g83lh5gW6Varr0vkZUZe+WTA=";
 
   nativeBuildInputs = [
     makeBinaryWrapper

--- a/pkgs/by-name/cr/cryptpad/package.nix
+++ b/pkgs/by-name/cr/cryptpad/package.nix
@@ -146,7 +146,11 @@ buildNpmPackage {
     owner = "cryptpad";
     repo = "cryptpad";
     tag = version;
-    hash = "sha256-veLtKjrk1CZe2u3MkozsPK98hyhdsWbQGUxh8oWjLXg=";
+    hash = "sha256-C5vj8vgSzR81NJhCSlY9sEoSAQs3ckeoCrChrSTTIso=";
+    # case-insensitive file results in different hash on darwin, delete to avoid collision
+    postFetch = ''
+      find $out -iname "funding.json" -delete
+    '';
   };
 
   npmDepsHash = "sha256-d/2JKGdC/tgDOo4Qr/0g83lh5gW6Varr0vkZUZe+WTA=";

--- a/pkgs/by-name/cr/cryptpad/package.nix
+++ b/pkgs/by-name/cr/cryptpad/package.nix
@@ -143,6 +143,9 @@ buildNpmPackage {
     # fix httpSafePort setting
     # https://github.com/cryptpad/cryptpad/pull/1571
     ./0001-env.js-fix-httpSafePort-handling.patch
+    # fix install-onlyyofice.sh check
+    # https://github.com/cryptpad/cryptpad/pull/2097
+    ./0001-install-onlyoffice.sh-fix-check-for-new-install_vers.patch
   ];
 
   # cryptpad build tries to write in cache dir
@@ -179,9 +182,11 @@ buildNpmPackage {
     # verify that we've installed the correct versions of the various
     # OnlyOffice components.
 
-    # TODO: Patch the new install method to only verify versions;
-    # patchShebangs --build $out_cryptpad/install-onlyoffice.sh
-    # $out_cryptpad/install-onlyoffice.sh --accept-license --check --rdfind
+    patchShebangs --build $out_cryptpad/install-onlyoffice.sh
+    mkdir -p $out_cryptpad/onlyoffice-conf
+    # Need to set this to verify older versions - next commit will optimize
+    echo oldest_needed_version=v1 > $out_cryptpad/onlyoffice-conf/onlyoffice.properties
+    $out_cryptpad/install-onlyoffice.sh --accept-license --check --rdfind
 
     # cryptpad assumes it runs in the source directory and also outputs
     # its state files there, which is not exactly great for us.


### PR DESCRIPTION
## Things done

- update cryptpad to 2025.9.0
- fix the install-onlyoffice.sh --check ( https://github.com/cryptpad/cryptpad/pull/2097  -- saves some space with hardlinks as well as ensures we're not shooting ourself in the foot with an half update)
- only install onlyoffice v7 and v8 (saves more space, we don't need older versions as they never were used in nixpkgs)

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
