### PR TITLE
nixos/services.nginx.sso: use 'LoadCredential'

### DIFF
--- a/nixos/modules/services/security/nginx-sso.nix
+++ b/nixos/modules/services/security/nginx-sso.nix
@@ -75,16 +75,8 @@ in
         '';
         LoadCredential = secretsReplacement.credentials;
         Restart = "always";
-        User = "nginx-sso";
-        Group = "nginx-sso";
+        DynamicUser = true;
       };
     };
-
-    users.users.nginx-sso = {
-      isSystemUser = true;
-      group = "nginx-sso";
-    };
-
-    users.groups.nginx-sso = { };
   };
 }

--- a/nixos/modules/services/security/nginx-sso.nix
+++ b/nixos/modules/services/security/nginx-sso.nix
@@ -9,6 +9,9 @@ let
   cfg = config.services.nginx.sso;
   format = pkgs.formats.yaml { };
   configPath = "/var/lib/nginx-sso/config.yaml";
+  secretsReplacement = utils.genJqSecretsReplacement {
+    loadCredential = true;
+  } cfg.configuration configPath;
 in
 {
   options.services.nginx.sso = {
@@ -47,7 +50,7 @@ in
         Options containing secret data should be set to an attribute set
         with the singleton attribute `_secret` - a string value set to the path
         to the file containing the secret value which should be used in the
-        configuration. This file must be readable by `nginx-sso`.
+        configuration.
       '';
     };
   };
@@ -63,13 +66,14 @@ in
         ExecStartPre = pkgs.writeShellScript "merge-nginx-sso-config" ''
           rm -f '${configPath}'
           # Relies on YAML being a superset of JSON
-          ${utils.genJqSecretsReplacementSnippet cfg.configuration configPath}
+          ${secretsReplacement.script}
         '';
         ExecStart = ''
           ${lib.getExe cfg.package} \
             --config ${configPath} \
             --frontend-dir ${lib.getBin cfg.package}/share/frontend
         '';
+        LoadCredential = secretsReplacement.credentials;
         Restart = "always";
         User = "nginx-sso";
         Group = "nginx-sso";


### PR DESCRIPTION
This removes the need for secret files to be readable by `nginx-sso` => the service can go back to being `DynamicUser=true`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
