### PR TITLE
linger-users: default to null, be explicit about null = imperative

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -385,7 +385,7 @@ and [release notes for v18](https://goteleport.com/docs/changelog/#1800-070325).
   - In all other cases, you'll need to set this option to `true` yourself.
   - `boot.isNspawnContainer` being `true` implies [](#opt-boot.isContainer) being `true`.
 
-- `users.users.*.linger` now defaults to `null` rather than `false`, meaning NixOS will not attempt to enable or disable lingering for that user account.  In practice, this is unlikely to make a difference for most people, as new users are created without lingering configured, but it means users who use `loginctl` commands to manage lingering imperatively will not have their changes overridden by default.  There is a new, related option, `users.manageLingering`, which can be used to prevent NixOS attempting to manage lingering entirely.
+- `users.users.*.linger` now defaults to `null` rather than `false`, meaning NixOS will not attempt to enable or disable lingering for that user account, instead allowing for imperative control over lingering using the `loginctl` commands. In practice, this is unlikely to make a difference for most people, as new users are created without lingering configured. There is a new, related option, `users.manageLingering`, which can be used to prevent NixOS attempting to manage lingering entirely.
 
 - Due to [deprecation of gnome-session X11 support](https://blogs.gnome.org/alatiera/2025/06/08/the-x11-session-removal/), `services.desktopManager.pantheon` now defaults to pantheon-wayland session. The X11 session has been removed, see [this issue](https://github.com/elementary/session-settings/issues/91) for details.
 

--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -130,10 +130,6 @@ let
   '';
 
   userOpts =
-    let
-      # Pass state version through despite config being overwritten in the inner module
-      inherit (config.system) stateVersion;
-    in
     { name, config, ... }:
     {
 
@@ -463,8 +459,7 @@ let
         linger = mkOption {
           type = types.nullOr types.bool;
           example = true;
-          default = if versionOlder stateVersion "26.11" then false else null;
-          defaultText = literalExpression "if lib.versionOlder config.system.stateVersion \"25.11\" then false else null";
+          default = null;
           description = ''
             Whether to enable or disable lingering for this user.  Without
             lingering, user units will not be started until the user logs in,
@@ -472,8 +467,8 @@ let
             `logind.conf`.
 
             By default, NixOS will not manage lingering, new users will default
-            to not lingering, and you can change the linger setting using
-            `loginctl enable-linger` or `loginctl disable-linger`.  Setting
+            to not lingering, and lingering can be configured imperatively using
+            `loginctl enable-linger` or `loginctl disable-linger`. Setting
             this option to `true` or `false` is the declarative equivalent of
             running `loginctl enable-linger` or `loginctl disable-linger`
             respectively.


### PR DESCRIPTION
Addresses https://github.com/NixOS/nixpkgs/pull/363209#pullrequestreview-3441998922

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
