### PR TITLE
playwright: 1.54.0 -> 1.56.1

### DIFF
--- a/pkgs/by-name/pl/playwright-mcp/package.nix
+++ b/pkgs/by-name/pl/playwright-mcp/package.nix
@@ -5,19 +5,18 @@
   playwright-driver,
   playwright-test,
 }:
-
 buildNpmPackage rec {
   pname = "playwright-mcp";
-  version = "0.0.34";
+  version = "0.0.35";
 
   src = fetchFromGitHub {
     owner = "Microsoft";
     repo = "playwright-mcp";
     tag = "v${version}";
-    hash = "sha256-SGSzX41D9nOTsGiU16tRFXgarWgePRsNWIcEnNGH0lQ=";
+    hash = "sha256-bF/F4dP2ri09AlQLItQwQxDAQybY2fXft4ccxSKijt8=";
   };
 
-  npmDepsHash = "sha256-+6HmuR1Z5cJkoZq/vsFq6wNsYpZeDS42wwmh3hEgJhM=";
+  npmDepsHash = "sha256-xSQCs6rJlUrdS8c580mo1/VjpcDxwHor0pdstB9VQEo=";
 
   postInstall = ''
     rm -r $out/lib/node_modules/@playwright/mcp/node_modules/playwright
@@ -26,7 +25,9 @@ buildNpmPackage rec {
     ln -s ${playwright-test}/lib/node_modules/playwright-core $out/lib/node_modules/@playwright/mcp/node_modules/playwright-core
 
     wrapProgram $out/bin/mcp-server-playwright \
-      --set PLAYWRIGHT_BROWSERS_PATH ${playwright-driver.browsers}
+      --set PLAYWRIGHT_BROWSERS_PATH ${playwright-driver.browsers} \
+      --set-default PLAYWRIGHT_MCP_BROWSER chromium \
+      --run 'if [ -z "$PLAYWRIGHT_MCP_USER_DATA_DIR" ]; then PLAYWRIGHT_MCP_USER_DATA_DIR="$(mktemp -d -t mcp-pw-XXXXXX)"; export PLAYWRIGHT_MCP_USER_DATA_DIR; trap "rm -rf \"$PLAYWRIGHT_MCP_USER_DATA_DIR\"" EXIT; fi'
   '';
 
   passthru = {

--- a/pkgs/by-name/pl/playwright-mcp/package.nix
+++ b/pkgs/by-name/pl/playwright-mcp/package.nix
@@ -7,16 +7,16 @@
 }:
 buildNpmPackage rec {
   pname = "playwright-mcp";
-  version = "0.0.35";
+  version = "0.0.41";
 
   src = fetchFromGitHub {
     owner = "Microsoft";
     repo = "playwright-mcp";
     tag = "v${version}";
-    hash = "sha256-bF/F4dP2ri09AlQLItQwQxDAQybY2fXft4ccxSKijt8=";
+    hash = "sha256-OoTAYd1/hedR0k/3b83YOPaOviLWv1Y3pffNoeSf2g4=";
   };
 
-  npmDepsHash = "sha256-xSQCs6rJlUrdS8c580mo1/VjpcDxwHor0pdstB9VQEo=";
+  npmDepsHash = "sha256-xgOPlCnlRXJZAZRM4xZ7SYSA5lsPglSewXxY19TbD/A=";
 
   postInstall = ''
     rm -r $out/lib/node_modules/@playwright/mcp/node_modules/playwright
@@ -29,6 +29,8 @@ buildNpmPackage rec {
       --set-default PLAYWRIGHT_MCP_BROWSER chromium \
       --run 'if [ -z "$PLAYWRIGHT_MCP_USER_DATA_DIR" ]; then PLAYWRIGHT_MCP_USER_DATA_DIR="$(mktemp -d -t mcp-pw-XXXXXX)"; export PLAYWRIGHT_MCP_USER_DATA_DIR; trap "rm -rf \"$PLAYWRIGHT_MCP_USER_DATA_DIR\"" EXIT; fi'
   '';
+
+  dontNpmBuild = true;
 
   passthru = {
     # Package and playwright driver versions are tightly coupled.

--- a/pkgs/development/python-modules/playwright/default.nix
+++ b/pkgs/development/python-modules/playwright/default.nix
@@ -22,7 +22,7 @@ in
 buildPythonPackage rec {
   pname = "playwright";
   # run ./pkgs/development/python-modules/playwright/update.sh to update
-  version = "1.55.0";
+  version = "1.56.0";
   pyproject = true;
   disabled = pythonOlder "3.9";
 
@@ -30,7 +30,7 @@ buildPythonPackage rec {
     owner = "microsoft";
     repo = "playwright-python";
     tag = "v${version}";
-    hash = "sha256-/q+Z4qKkAZpjPcp+WTNs03Ky/Zl5i2wOaogYTvpObec=";
+    hash = "sha256-46+UxHimmmyQMTe+G2ootSbVX9pAzdfdyTO2qrWd9l8=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/playwright/default.nix
+++ b/pkgs/development/python-modules/playwright/default.nix
@@ -22,7 +22,7 @@ in
 buildPythonPackage rec {
   pname = "playwright";
   # run ./pkgs/development/python-modules/playwright/update.sh to update
-  version = "1.54.0";
+  version = "1.55.0";
   pyproject = true;
   disabled = pythonOlder "3.9";
 
@@ -30,7 +30,7 @@ buildPythonPackage rec {
     owner = "microsoft";
     repo = "playwright-python";
     tag = "v${version}";
-    hash = "sha256-xyuofDL0hWL8Gn4sYNLKte8q/4bMo+3aSbYaf5iWiBk=";
+    hash = "sha256-/q+Z4qKkAZpjPcp+WTNs03Ky/Zl5i2wOaogYTvpObec=";
   };
 
   patches = [

--- a/pkgs/development/web/playwright/browsers.json
+++ b/pkgs/development/web/playwright/browsers.json
@@ -2,19 +2,19 @@
   "comment": "This file is kept up to date via update.sh",
   "browsers": {
     "chromium": {
-      "revision": "1181",
-      "browserVersion": "139.0.7258.5"
+      "revision": "1187",
+      "browserVersion": "140.0.7339.16"
     },
     "chromium-headless-shell": {
-      "revision": "1181",
-      "browserVersion": "139.0.7258.5"
+      "revision": "1187",
+      "browserVersion": "140.0.7339.16"
     },
     "firefox": {
-      "revision": "1489",
-      "browserVersion": "140.0.2"
+      "revision": "1490",
+      "browserVersion": "141.0"
     },
     "webkit": {
-      "revision": "2191",
+      "revision": "2203",
       "revisionOverrides": {
         "debian11-x64": "2105",
         "debian11-arm64": "2105",

--- a/pkgs/development/web/playwright/browsers.json
+++ b/pkgs/development/web/playwright/browsers.json
@@ -2,19 +2,19 @@
   "comment": "This file is kept up to date via update.sh",
   "browsers": {
     "chromium": {
-      "revision": "1187",
-      "browserVersion": "140.0.7339.16"
+      "revision": "1194",
+      "browserVersion": "141.0.7390.37"
     },
     "chromium-headless-shell": {
-      "revision": "1187",
-      "browserVersion": "140.0.7339.16"
+      "revision": "1194",
+      "browserVersion": "141.0.7390.37"
     },
     "firefox": {
-      "revision": "1490",
-      "browserVersion": "141.0"
+      "revision": "1495",
+      "browserVersion": "142.0.1"
     },
     "webkit": {
-      "revision": "2203",
+      "revision": "2215",
       "revisionOverrides": {
         "debian11-x64": "2105",
         "debian11-arm64": "2105",

--- a/pkgs/development/web/playwright/chromium-headless-shell.nix
+++ b/pkgs/development/web/playwright/chromium-headless-shell.nix
@@ -30,8 +30,8 @@ let
       stripRoot = false;
       hash =
         {
-          x86_64-linux = "sha256-R4hBsfb6iS1xVNVDWQKCQUBYWVMwfdxLqqsR/gZiGiQ=";
-          aarch64-linux = "sha256-4QRCSqzvhnHUsSLWpaCUREq9pqW83Km6txqvjtFiN7E=";
+          x86_64-linux = "sha256-khYVM0jocno97lV8mRH71WHzopIjnq3eX/PD1kQuZnE=";
+          aarch64-linux = "sha256-1G0UAIFmBcij0EXq1VVxvku5iQmGGWvQxdBT+zRW0ZM=";
         }
         .${system} or throwSystem;
     };
@@ -66,8 +66,8 @@ let
     stripRoot = false;
     hash =
       {
-        x86_64-darwin = "sha256-hs2SAoSL484IUs2u+BOz6lvlGPCPsQF2N2v+lnTI1v8=";
-        aarch64-darwin = "sha256-WL70Nt9J5zrwlJ5p5dBVT5TIocdtvOZrlAN0JEkii/g=";
+        x86_64-darwin = "sha256-R4XdK3wD3eoNREydU34MkrvCkI2VqSxIiM7Zhf5EvjM=";
+        aarch64-darwin = "sha256-8CyMLQdtWhMUxwd6UWQ7vGtyi69mCxEA6WwXk2S82qA=";
       }
       .${system} or throwSystem;
   };

--- a/pkgs/development/web/playwright/chromium-headless-shell.nix
+++ b/pkgs/development/web/playwright/chromium-headless-shell.nix
@@ -30,8 +30,8 @@ let
       stripRoot = false;
       hash =
         {
-          x86_64-linux = "sha256-AYh2urKZdjXCELimYaFihWp0FbDLf4uRrKLJZVxug5M=";
-          aarch64-linux = "sha256-diBiy0z51BxGK0PcfQOf1aryUcZesKu/UHBSZUjqwMk=";
+          x86_64-linux = "sha256-R4hBsfb6iS1xVNVDWQKCQUBYWVMwfdxLqqsR/gZiGiQ=";
+          aarch64-linux = "sha256-4QRCSqzvhnHUsSLWpaCUREq9pqW83Km6txqvjtFiN7E=";
         }
         .${system} or throwSystem;
     };
@@ -66,8 +66,8 @@ let
     stripRoot = false;
     hash =
       {
-        x86_64-darwin = "sha256-vIJuDjkasUYlMW0aCOyztyrlh5kvcwNR9GBaoa/yh/M=";
-        aarch64-darwin = "sha256-6Q6nz0H2749srdMF/puk/gnG1gQBEnWe9cQO3owL2OU=";
+        x86_64-darwin = "sha256-hs2SAoSL484IUs2u+BOz6lvlGPCPsQF2N2v+lnTI1v8=";
+        aarch64-darwin = "sha256-WL70Nt9J5zrwlJ5p5dBVT5TIocdtvOZrlAN0JEkii/g=";
       }
       .${system} or throwSystem;
   };

--- a/pkgs/development/web/playwright/chromium.nix
+++ b/pkgs/development/web/playwright/chromium.nix
@@ -41,8 +41,8 @@ let
       url = "https://playwright.azureedge.net/builds/chromium/${revision}/chromium-${suffix}.zip";
       hash =
         {
-          x86_64-linux = "sha256-8J7K4PE9BMuCnptHE+Nl7ED30cLdMDKqjGKY82I3OqQ=";
-          aarch64-linux = "sha256-8PZf2PYtBmFXEHhFLzNP/fkUXKQAviXCo8fy36Nb4OA=";
+          x86_64-linux = "sha256-uf8FUMgUUyM1xw5eUuMUgUg9GIW8bDcNZz0mIfnoTLM=";
+          aarch64-linux = "sha256-j+j6w99EmfehV+qyqbLFK2H5HpB2qakq93GgdTMPibU=";
         }
         .${system} or throwSystem;
     };
@@ -109,8 +109,8 @@ let
     stripRoot = false;
     hash =
       {
-        x86_64-darwin = "sha256-Dj4Pf86gdXLKB/T9Qty+0w3N8Im0SRHlKCQgdt5/Mdc=";
-        aarch64-darwin = "sha256-lyJV3WJq6XmDgehsMwc/fW9Ieylz1mrQIXbKS4KHLiI=";
+        x86_64-darwin = "sha256-dsyw6fT/jfx2RC2wEFMgIkIpVYu+6TXaDpFLNHX5als=";
+        aarch64-darwin = "sha256-G7PlHJPlDQXQzO5MGuCuGQUxV9VqKY4yQebuoltVq6U=";
       }
       .${system} or throwSystem;
   };

--- a/pkgs/development/web/playwright/chromium.nix
+++ b/pkgs/development/web/playwright/chromium.nix
@@ -41,8 +41,8 @@ let
       url = "https://playwright.azureedge.net/builds/chromium/${revision}/chromium-${suffix}.zip";
       hash =
         {
-          x86_64-linux = "sha256-R7nMCVpUqgRwtB0syhfIK81maiTVWr8lYBLp4bR8VBg=";
-          aarch64-linux = "sha256-4fc4X7QwBigktmEeseuqIyEeV70Dy3eO/femXrftMd0=";
+          x86_64-linux = "sha256-8J7K4PE9BMuCnptHE+Nl7ED30cLdMDKqjGKY82I3OqQ=";
+          aarch64-linux = "sha256-8PZf2PYtBmFXEHhFLzNP/fkUXKQAviXCo8fy36Nb4OA=";
         }
         .${system} or throwSystem;
     };
@@ -109,8 +109,8 @@ let
     stripRoot = false;
     hash =
       {
-        x86_64-darwin = "sha256-0u1AStbUTX+qgUmg2DvL59B4b265WywDaBV+MdSuaNE=";
-        aarch64-darwin = "sha256-4pg4wmNTF8mw+APmdpvYlFxb9zc6OUh11oW5gCRKETY=";
+        x86_64-darwin = "sha256-Dj4Pf86gdXLKB/T9Qty+0w3N8Im0SRHlKCQgdt5/Mdc=";
+        aarch64-darwin = "sha256-lyJV3WJq6XmDgehsMwc/fW9Ieylz1mrQIXbKS4KHLiI=";
       }
       .${system} or throwSystem;
   };

--- a/pkgs/development/web/playwright/driver.nix
+++ b/pkgs/development/web/playwright/driver.nix
@@ -27,13 +27,13 @@ let
     }
     .${system} or throwSystem;
 
-  version = "1.55.0";
+  version = "1.56.1";
 
   src = fetchFromGitHub {
     owner = "Microsoft";
     repo = "playwright";
     rev = "v${version}";
-    hash = "sha256-J1Uys2TG9Ve++oMyEWpXgboEo0E7c5DjE8gqQwVPt+k=";
+    hash = "sha256-39s1fb2tZZWWpZrs4/MAw4TdHkzEWj8YVoK39sj2UPE=";
   };
 
   babel-bundle = buildNpmPackage {
@@ -92,7 +92,7 @@ let
     inherit version src;
 
     sourceRoot = "${src.name}"; # update.sh depends on sourceRoot presence
-    npmDepsHash = "sha256-HfNal3ksP6d/i06xKq0LwytV6PIeHcwshh+TmuQeSaw=";
+    npmDepsHash = "sha256-AOjiI6Db+WL4iTaY9XWH4tntBHM8SFP7/7S8RJZitlI=";
 
     nativeBuildInputs = [
       cacert

--- a/pkgs/development/web/playwright/driver.nix
+++ b/pkgs/development/web/playwright/driver.nix
@@ -27,20 +27,20 @@ let
     }
     .${system} or throwSystem;
 
-  version = "1.54.1";
+  version = "1.55.0";
 
   src = fetchFromGitHub {
     owner = "Microsoft";
     repo = "playwright";
     rev = "v${version}";
-    hash = "sha256-xwyREgelHLkpbUXOZTppKK7L6dE4jx0d/lbDWSKGzTY=";
+    hash = "sha256-J1Uys2TG9Ve++oMyEWpXgboEo0E7c5DjE8gqQwVPt+k=";
   };
 
   babel-bundle = buildNpmPackage {
     pname = "babel-bundle";
     inherit version src;
     sourceRoot = "${src.name}/packages/playwright/bundles/babel";
-    npmDepsHash = "sha256-sdl+rMCmuOmY1f7oSfGuAAFCiPCFzqkQtFCncL4o5LQ=";
+    npmDepsHash = "sha256-ByCy4go8PM0ksDg+2DcJPyoKG7Z0uIqKM647ZQwYwAE=";
     dontNpmBuild = true;
     installPhase = ''
       cp -r . "$out"
@@ -92,7 +92,7 @@ let
     inherit version src;
 
     sourceRoot = "${src.name}"; # update.sh depends on sourceRoot presence
-    npmDepsHash = "sha256-4bsX8Q8V3CBpIsyqMYTzfERQQPY5zlPf7CoqR6UkUHU=";
+    npmDepsHash = "sha256-HfNal3ksP6d/i06xKq0LwytV6PIeHcwshh+TmuQeSaw=";
 
     nativeBuildInputs = [
       cacert

--- a/pkgs/development/web/playwright/firefox.nix
+++ b/pkgs/development/web/playwright/firefox.nix
@@ -17,8 +17,8 @@ let
       }.zip";
       hash =
         {
-          x86_64-linux = "sha256-hGlG7Snw/YVgXDHWXK24Ci87JxpENEfhpve7fu+ol1E=";
-          aarch64-linux = "sha256-R5wl+oln2gFse+31NFfLaIsGQOOVrCRj8drOE9qmiwY=";
+          x86_64-linux = "sha256-qdAlGPnpiOfa49zJZsbLvNtEqh4xnaPDH3TvX5fA+PA=";
+          aarch64-linux = "sha256-6880Y68m5uvD+e/ZLqJqoTQNPcmK8CUKgaR2wBdBxsw=";
         }
         .${system} or throwSystem;
     };
@@ -41,8 +41,8 @@ let
     stripRoot = false;
     hash =
       {
-        x86_64-darwin = "sha256-qov3gZspe95py/tHcKzGVvzvmcKWsOtGNMj76QPhFbE=";
-        aarch64-darwin = "sha256-8mfFZuNuOo04ZNwqrm2JQJoSkJC6ChdwPDgIDKse34s=";
+        x86_64-darwin = "sha256-3NEDS0Uw2k0W2hUuIIU4pO/xCnPEc5iowP88M5NNAuA=";
+        aarch64-darwin = "sha256-XXJf0nBdLQjHdes5ZAA4zhKK+E9caqD42CFqCQ92EKM=";
       }
       .${system} or throwSystem;
   };

--- a/pkgs/development/web/playwright/firefox.nix
+++ b/pkgs/development/web/playwright/firefox.nix
@@ -17,8 +17,8 @@ let
       }.zip";
       hash =
         {
-          x86_64-linux = "sha256-j7gOuXMyftNQencgfpk8Y4ED2LuT7TAa30IPyzmir48=";
-          aarch64-linux = "sha256-deIUGKBrp56TsDr61cbNbRRSRcVpSoa6pdmMk4oB/Eg=";
+          x86_64-linux = "sha256-hGlG7Snw/YVgXDHWXK24Ci87JxpENEfhpve7fu+ol1E=";
+          aarch64-linux = "sha256-R5wl+oln2gFse+31NFfLaIsGQOOVrCRj8drOE9qmiwY=";
         }
         .${system} or throwSystem;
     };
@@ -41,8 +41,8 @@ let
     stripRoot = false;
     hash =
       {
-        x86_64-darwin = "sha256-ljgFoyqCg9kma2cDFodNjbkAeEylIzVdWkS1vU/9Rbg=";
-        aarch64-darwin = "sha256-W2J5APPWEkmoDgBEox6/ygg2xyWpOHZESXFG0tZbj1M=";
+        x86_64-darwin = "sha256-qov3gZspe95py/tHcKzGVvzvmcKWsOtGNMj76QPhFbE=";
+        aarch64-darwin = "sha256-8mfFZuNuOo04ZNwqrm2JQJoSkJC6ChdwPDgIDKse34s=";
       }
       .${system} or throwSystem;
   };

--- a/pkgs/development/web/playwright/webkit.nix
+++ b/pkgs/development/web/playwright/webkit.nix
@@ -137,8 +137,8 @@ let
       stripRoot = false;
       hash =
         {
-          x86_64-linux = "sha256-FndRfpPsBh+x15MIL2ybhxG1QskpvHLmIa7RhSw6GBQ=";
-          aarch64-linux = "sha256-frZLMVhMrokww1teSBb7VCM9vkCX6n3js0Pa1G51254=";
+          x86_64-linux = "sha256-giXoY2uPjwLzc6sbADI+g/qLgE/O+FJbQok7xNNrsaQ=";
+          aarch64-linux = "sha256-TJIY7ZC3ez9F0iEH655JKEBNY36nj0SjYdt0E4oXySs=";
         }
         .${system} or throwSystem;
     };
@@ -218,8 +218,8 @@ let
     stripRoot = false;
     hash =
       {
-        x86_64-darwin = "sha256-4uvJFUEQ63mER+jjVOwYVgSfWRegujuuOXO7Sm6bGzU=";
-        aarch64-darwin = "sha256-+8LzvP2pNrb04S3N/JId4YimH9bfxAeLzpqYeKO5hb0=";
+        x86_64-darwin = "sha256-V/5dbXwtgITteYrSwL9qj3V0VChyG+rHTGLsYEpQRJw=";
+        aarch64-darwin = "sha256-1DaDFVn6RyyFevx2oUai5ZtWMRE5WiDEZfpOY1A+/oU=";
       }
       .${system} or throwSystem;
   };

--- a/pkgs/development/web/playwright/webkit.nix
+++ b/pkgs/development/web/playwright/webkit.nix
@@ -137,8 +137,8 @@ let
       stripRoot = false;
       hash =
         {
-          x86_64-linux = "sha256-OSVHFGdcQrzmhLPdXF61tKmip/6/D+uaQgSBBQiOIZI=";
-          aarch64-linux = "sha256-b8XwVMCwSbujyqgkJKIPAVNX83Qmmsthprr2x9XSb10=";
+          x86_64-linux = "sha256-FndRfpPsBh+x15MIL2ybhxG1QskpvHLmIa7RhSw6GBQ=";
+          aarch64-linux = "sha256-frZLMVhMrokww1teSBb7VCM9vkCX6n3js0Pa1G51254=";
         }
         .${system} or throwSystem;
     };
@@ -218,8 +218,8 @@ let
     stripRoot = false;
     hash =
       {
-        x86_64-darwin = "sha256-shjhozJS2VbBjpjJVlM9hwBzGWwgva1qhfEUhY8t9Bk=";
-        aarch64-darwin = "sha256-ZRl86L/OOTNPWfZDl6JQfuXL41kI/Wir99/JIbf7T7M=";
+        x86_64-darwin = "sha256-4uvJFUEQ63mER+jjVOwYVgSfWRegujuuOXO7Sm6bGzU=";
+        aarch64-darwin = "sha256-+8LzvP2pNrb04S3N/JId4YimH9bfxAeLzpqYeKO5hb0=";
       }
       .${system} or throwSystem;
   };


### PR DESCRIPTION
- Upgraded playwright python and node packages to 1.56.1.
- Upgraded playwright-mcp to 0.0.41 and disabled the npm build command
- Fixed playwright-mcp so it runs without having to specify `--browser` and `--user-data-dir`

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
