### PR TITLE
vcv-rack: update apple-sdk to 14 to fix eval

### DIFF
--- a/pkgs/by-name/vc/vcv-rack/package.nix
+++ b/pkgs/by-name/vc/vcv-rack/package.nix
@@ -1,6 +1,6 @@
 {
   alsa-lib,
-  apple-sdk_13,
+  apple-sdk_14,
   cmake,
   copyDesktopItems,
   curl,
@@ -123,7 +123,7 @@ let
       libjack2
       libpulseaudio
     ]
-    ++ lib.optional stdenv.hostPlatform.isDarwin [ apple-sdk_13 ];
+    ++ lib.optional stdenv.hostPlatform.isDarwin [ apple-sdk_14 ];
 
     cmakeFlags = [
       (lib.cmakeBool "RTAUDIO_API_ALSA" stdenv.hostPlatform.isLinux)
@@ -277,7 +277,7 @@ stdenv.mkDerivation (finalAttrs: {
     libpulseaudio
     zenity
   ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [ apple-sdk_13 ];
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ apple-sdk_14 ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

see https://github.com/NixOS/nixpkgs/pull/332358#issuecomment-3510587755. #332358 broke eval on staging-next, as `apple-sdk_13` was dropped in https://github.com/NixOS/nixpkgs/commit/0f6b88a896e6b2c1ebadd528f75e75d631db227.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
