### PR TITLE
secretive: init at 3.0.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23846,6 +23846,12 @@
     github = "shelvacu";
     githubId = 1731537;
   };
+  shgew = {
+    name = "Hleb Shauchenka";
+    email = "me@marleb.org";
+    github = "shgew";
+    githubId = 5584672;
+  };
   shhht = {
     name = "shhht";
     email = "stp.tjeerd@gmail.com";

--- a/pkgs/by-name/se/secretive/package.nix
+++ b/pkgs/by-name/se/secretive/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "secretive";
+  version = "3.0.4";
+
+  src = fetchzip {
+    url = "https://github.com/maxgoedjen/secretive/releases/download/v${finalAttrs.version}/Secretive.zip";
+    hash = "sha256-dZqcYnEHaeUN92lYIlGcv3qXPEIKY5z1LLJiSyeY2BM=";
+    stripRoot = false;
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Applications"
+    cp -R Secretive.app "$out/Applications/"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Store SSH keys in the Secure Enclave";
+    homepage = "https://github.com/maxgoedjen/secretive";
+    changelog = "https://github.com/maxgoedjen/secretive/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ shgew ];
+    platforms = lib.platforms.darwin;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
Secretive is a macOS application that stores SSH keys in the Secure Enclave, preventing them from being exported by design. It supports Touch ID or Apple Watch authentication for key access and provides activity notifications when keys are used.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc