### PR TITLE
treewide: remove iedame

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10840,12 +10840,6 @@
     githubId = 1550265;
     name = "Dominic Steinitz";
   };
-  iedame = {
-    email = "git@ieda.me";
-    github = "iedame";
-    githubId = 60272;
-    name = "Rafael Ieda";
-  };
   if-loop69420 = {
     github = "if-loop69420";
     githubId = 81078181;

--- a/pkgs/applications/graphics/xournalpp/default.nix
+++ b/pkgs/applications/graphics/xournalpp/default.nix
@@ -84,10 +84,7 @@ stdenv.mkDerivation rec {
     homepage = "https://xournalpp.github.io/";
     changelog = "https://github.com/xournalpp/xournalpp/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [
-      sikmir
-      iedame
-    ];
+    maintainers = with lib.maintainers; [ sikmir ];
     platforms = lib.platforms.unix;
     mainProgram = "xournalpp";
   };

--- a/pkgs/applications/misc/lutris/default.nix
+++ b/pkgs/applications/misc/lutris/default.nix
@@ -155,10 +155,7 @@ buildPythonApplication rec {
     homepage = "https://lutris.net";
     description = "Open Source gaming platform for GNU/Linux";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [
-      rapiteanu
-      iedame
-    ];
+    maintainers = with maintainers; [ rapiteanu ];
     platforms = platforms.linux;
     mainProgram = "lutris";
   };

--- a/pkgs/applications/science/electronics/librepcb/default.nix
+++ b/pkgs/applications/science/electronics/librepcb/default.nix
@@ -63,7 +63,6 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [
       luz
       thoughtpolice
-      iedame
     ];
     license = licenses.gpl3Plus;
     platforms = platforms.linux;

--- a/pkgs/applications/science/misc/vite/default.nix
+++ b/pkgs/applications/science/misc/vite/default.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     homepage = "http://vite.gforge.inria.fr/";
     license = lib.licenses.cecill20;
-    maintainers = with lib.maintainers; [ iedame ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/_1/_1password-cli/package.nix
+++ b/pkgs/by-name/_1/_1password-cli/package.nix
@@ -93,7 +93,6 @@ stdenv.mkDerivation {
     maintainers = with lib.maintainers; [
       joelburget
       khaneliman
-      iedame
     ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;

--- a/pkgs/by-name/_1/_1password-gui/package.nix
+++ b/pkgs/by-name/_1/_1password-gui/package.nix
@@ -35,7 +35,6 @@ let
       timstott
       sebtm
       bdd
-      iedame
     ];
     platforms = [
       "x86_64-linux"

--- a/pkgs/by-name/ad/adwsteamgtk/package.nix
+++ b/pkgs/by-name/ad/adwsteamgtk/package.nix
@@ -46,10 +46,7 @@ python3Packages.buildPythonApplication rec {
     description = "Simple Gtk wrapper for Adwaita-for-Steam";
     homepage = "https://github.com/Foldex/AdwSteamGtk";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [
-      reedrw
-      iedame
-    ];
+    maintainers = with lib.maintainers; [ reedrw ];
     mainProgram = "adwaita-steam-gtk";
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/al/alure/package.nix
+++ b/pkgs/by-name/al/alure/package.nix
@@ -28,6 +28,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/kcat/alure";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ iedame ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/ap/appcleaner/package.nix
+++ b/pkgs/by-name/ap/appcleaner/package.nix
@@ -30,10 +30,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://freemacsoft.net/appcleaner";
     license = lib.licenses.unfree;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    maintainers = with lib.maintainers; [
-      emilytrau
-      iedame
-    ];
+    maintainers = with lib.maintainers; [ emilytrau ];
     platforms = lib.platforms.darwin;
   };
 })

--- a/pkgs/by-name/ar/aranym/package.nix
+++ b/pkgs/by-name/ar/aranym/package.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = with lib.licenses; [ gpl2Plus ];
     mainProgram = "aranym";
-    maintainers = with lib.maintainers; [ iedame ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
     # never successfully built on Hydra for darwin or aarch64 linux
     broken = stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isAarch64;

--- a/pkgs/by-name/ar/arduino-ide/package.nix
+++ b/pkgs/by-name/ar/arduino-ide/package.nix
@@ -32,10 +32,7 @@ appimageTools.wrapType2 {
     changelog = "https://github.com/arduino/arduino-ide/releases/tag/${version}";
     license = lib.licenses.agpl3Only;
     mainProgram = "arduino-ide";
-    maintainers = with lib.maintainers; [
-      clerie
-      iedame
-    ];
+    maintainers = with lib.maintainers; [ clerie ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/by-name/ba/backrest/package.nix
+++ b/pkgs/by-name/ba/backrest/package.nix
@@ -119,7 +119,7 @@ buildGoModule {
     homepage = "https://github.com/garethgeorge/backrest";
     changelog = "https://github.com/garethgeorge/backrest/releases/tag/v${version}";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ iedame ];
+    maintainers = [ ];
     mainProgram = "backrest";
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/bb/bbedit/package.nix
+++ b/pkgs/by-name/bb/bbedit/package.nix
@@ -34,7 +34,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "Powerful and full-featured professional HTML and text editor for macOS";
     homepage = "https://www.barebones.com/products/bbedit/";
     license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [ iedame ];
+    maintainers = [ ];
     platforms = lib.platforms.darwin;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };

--- a/pkgs/by-name/bl/bloodspilot-client/package.nix
+++ b/pkgs/by-name/bl/bloodspilot-client/package.nix
@@ -41,10 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "bloodspilot-client-sdl";
     homepage = "http://bloodspilot.sf.net/";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [
-      raskin
-      iedame
-    ];
+    maintainers = with lib.maintainers; [ raskin ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/bl/bloodspilot-server/package.nix
+++ b/pkgs/by-name/bl/bloodspilot-server/package.nix
@@ -28,10 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "xpilots";
     homepage = "http://bloodspilot.sf.net/";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [
-      raskin
-      iedame
-    ];
+    maintainers = with lib.maintainers; [ raskin ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/bo/bolt-launcher/package.nix
+++ b/pkgs/by-name/bo/bolt-launcher/package.nix
@@ -155,7 +155,6 @@ buildFHSEnv {
     maintainers = with lib.maintainers; [
       nezia
       jaspersurmont
-      iedame
     ];
     platforms = lib.platforms.linux;
     mainProgram = "${bolt.name}";

--- a/pkgs/by-name/bo/borgbackup/package.nix
+++ b/pkgs/by-name/bo/borgbackup/package.nix
@@ -153,7 +153,6 @@ python.pkgs.buildPythonApplication rec {
     maintainers = with maintainers; [
       dotlambda
       globin
-      iedame
     ];
   };
 }

--- a/pkgs/by-name/cu/cutechess/package.nix
+++ b/pkgs/by-name/cu/cutechess/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "GUI, CLI, and library for playing chess";
     homepage = "https://cutechess.com/";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ iedame ];
+    maintainers = [ ];
     platforms = with lib.platforms; (linux ++ windows);
     mainProgram = "cutechess";
   };

--- a/pkgs/by-name/cu/cutemaze/package.nix
+++ b/pkgs/by-name/cu/cutemaze/package.nix
@@ -49,10 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "cutemaze";
     homepage = "https://gottcode.org/cutemaze/";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [
-      dotlambda
-      iedame
-    ];
+    maintainers = with lib.maintainers; [ dotlambda ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/cy/cyberduck/package.nix
+++ b/pkgs/by-name/cy/cyberduck/package.nix
@@ -53,7 +53,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       emilytrau
       DimitarNestorov
-      iedame
     ];
     platforms = lib.platforms.darwin;
     mainProgram = "cyberduck";

--- a/pkgs/by-name/en/ente-auth/package.nix
+++ b/pkgs/by-name/en/ente-auth/package.nix
@@ -114,7 +114,6 @@ flutter332.buildFlutterApplication rec {
       schnow265
       zi3m5f
       gepbird
-      iedame
     ];
     mainProgram = "enteauth";
     platforms = [

--- a/pkgs/by-name/en/ente-cli/package.nix
+++ b/pkgs/by-name/en/ente-cli/package.nix
@@ -86,10 +86,7 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/ente-io/ente/tree/main/cli#readme";
     changelog = "https://github.com/ente-io/ente/releases/tag/cli-v${finalAttrs.version}";
     license = lib.licenses.agpl3Only;
-    maintainers = with lib.maintainers; [
-      zi3m5f
-      iedame
-    ];
+    maintainers = with lib.maintainers; [ zi3m5f ];
     mainProgram = "ente";
   };
 })

--- a/pkgs/by-name/en/ente-desktop/package.nix
+++ b/pkgs/by-name/en/ente-desktop/package.nix
@@ -142,7 +142,6 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       pinpox
       yuka
-      iedame
     ];
     platforms = lib.platforms.all;
     broken = stdenv.hostPlatform.isDarwin;

--- a/pkgs/by-name/en/ente-web/package.nix
+++ b/pkgs/by-name/en/ente-web/package.nix
@@ -85,7 +85,6 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       pinpox
       oddlama
-      iedame
     ];
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/fa/fallout-ce/package.nix
+++ b/pkgs/by-name/fa/fallout-ce/package.nix
@@ -94,10 +94,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://github.com/alexbatalov/fallout1-ce";
     license = lib.licenses.sustainableUse;
-    maintainers = with lib.maintainers; [
-      hughobrien
-      iedame
-    ];
+    maintainers = with lib.maintainers; [ hughobrien ];
     platforms = lib.platforms.linux;
     mainProgram = "fallout-ce";
   };

--- a/pkgs/by-name/fa/fallout2-ce/package.nix
+++ b/pkgs/by-name/fa/fallout2-ce/package.nix
@@ -98,10 +98,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://github.com/alexbatalov/fallout2-ce";
     license = lib.licenses.sustainableUse;
-    maintainers = with lib.maintainers; [
-      hughobrien
-      iedame
-    ];
+    maintainers = with lib.maintainers; [ hughobrien ];
     platforms = lib.platforms.linux;
     mainProgram = "fallout2-ce";
   };

--- a/pkgs/by-name/ff/fflogs/package.nix
+++ b/pkgs/by-name/ff/fflogs/package.nix
@@ -32,10 +32,7 @@ appimageTools.wrapType2 {
     license = licenses.unfree; # no license listed
     mainProgram = "fflogs";
     platforms = platforms.linux;
-    maintainers = with maintainers; [
-      keysmashes
-      iedame
-    ];
+    maintainers = with maintainers; [ keysmashes ];
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
   };
 }

--- a/pkgs/by-name/fi/filezilla/package.nix
+++ b/pkgs/by-name/fi/filezilla/package.nix
@@ -70,9 +70,6 @@ stdenv.mkDerivation {
     '';
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [
-      pSub
-      iedame
-    ];
+    maintainers = with maintainers; [ pSub ];
   };
 }

--- a/pkgs/by-name/fl/flightgear/package.nix
+++ b/pkgs/by-name/fl/flightgear/package.nix
@@ -106,10 +106,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Flight simulator";
-    maintainers = with lib.maintainers; [
-      raskin
-      iedame
-    ];
+    maintainers = with lib.maintainers; [ raskin ];
     platforms = lib.platforms.linux;
     hydraPlatforms = [ ]; # disabled from hydra because it's so big
     license = lib.licenses.gpl2Plus;

--- a/pkgs/by-name/fr/freedink/package.nix
+++ b/pkgs/by-name/fr/freedink/package.nix
@@ -119,7 +119,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://gnu.org/software/freedink/"; # Formerly http://www.freedink.org
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ iedame ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
     mainProgram = "freedink";
   };

--- a/pkgs/by-name/fr/freeorion/package.nix
+++ b/pkgs/by-name/fr/freeorion/package.nix
@@ -89,6 +89,6 @@ stdenv.mkDerivation (finalAttrs: {
       cc-by-sa-30
     ];
     platforms = platforms.linux;
-    maintainers = with lib.maintainers; [ iedame ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/fr/fritzing/package.nix
+++ b/pkgs/by-name/fr/fritzing/package.nix
@@ -132,7 +132,6 @@ stdenv.mkDerivation {
     maintainers = with lib.maintainers; [
       robberer
       muscaln
-      iedame
     ];
     platforms = lib.platforms.unix;
     mainProgram = "Fritzing";

--- a/pkgs/by-name/ga/garden-of-coloured-lights/package.nix
+++ b/pkgs/by-name/ga/garden-of-coloured-lights/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Old-school vertical shoot-em-up / bullet hell";
     mainProgram = "garden";
     homepage = "https://sourceforge.net/projects/garden/";
-    maintainers = with lib.maintainers; [ iedame ];
+    maintainers = [ ];
     license = lib.licenses.gpl3;
   };
 })

--- a/pkgs/by-name/ge/geogebra/package.nix
+++ b/pkgs/by-name/ge/geogebra/package.nix
@@ -48,7 +48,6 @@ let
     maintainers = with maintainers; [
       sikmir
       soupglasses
-      iedame
     ];
     license = with licenses; [
       gpl3

--- a/pkgs/by-name/ge/geogebra6/package.nix
+++ b/pkgs/by-name/ge/geogebra6/package.nix
@@ -25,7 +25,6 @@ let
     maintainers = with maintainers; [
       voidless
       sikmir
-      iedame
     ];
     license = licenses.geogebra;
     sourceProvenance = with sourceTypes; [

--- a/pkgs/by-name/ge/getdp/package.nix
+++ b/pkgs/by-name/ge/getdp/package.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation {
     '';
     homepage = "http://getdp.info/";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ iedame ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/gh/ghostscript/package.nix
+++ b/pkgs/by-name/gh/ghostscript/package.nix
@@ -247,10 +247,7 @@ stdenv.mkDerivation rec {
     '';
     license = lib.licenses.agpl3Plus;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [
-      tobim
-      iedame
-    ];
+    maintainers = with lib.maintainers; [ tobim ];
     mainProgram = "gs";
   };
 }

--- a/pkgs/by-name/gm/gmsh/package.nix
+++ b/pkgs/by-name/gm/gmsh/package.nix
@@ -113,6 +113,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://gmsh.info/";
     changelog = "https://gitlab.onelab.info/gmsh/gmsh/-/releases/gmsh_${lib.concatStringsSep "_" (lib.versions.splitVersion finalAttrs.version)}#changelog";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ iedame ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/go/gogdl/package.nix
+++ b/pkgs/by-name/go/gogdl/package.nix
@@ -32,7 +32,7 @@ python3Packages.buildPythonApplication rec {
     mainProgram = "gogdl";
     homepage = "https://github.com/Heroic-Games-Launcher/heroic-gogdl";
     license = with licenses; [ gpl3 ];
-    maintainers = with maintainers; [ iedame ];
+    maintainers = [ ];
   };
 
   # Upstream no longer create git tags when bumping the version, so we have to

--- a/pkgs/by-name/he/heroic-unwrapped/epic-integration.nix
+++ b/pkgs/by-name/he/heroic-unwrapped/epic-integration.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/Etaash-mathamsetty/heroic-epic-integration";
     changelog = "https://github.com/Etaash-mathamsetty/heroic-epic-integration/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ iedame ];
+    maintainers = [ ];
   };
 
   passthru.updateScript = gitUpdater { };

--- a/pkgs/by-name/he/heroic-unwrapped/legendary.nix
+++ b/pkgs/by-name/he/heroic-unwrapped/legendary.nix
@@ -37,7 +37,7 @@ python3Packages.buildPythonApplication {
     '';
     homepage = "https://github.com/Heroic-Games-Launcher/legendary";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ iedame ];
+    maintainers = [ ];
     mainProgram = "legendary";
   };
 

--- a/pkgs/by-name/he/heroic-unwrapped/package.nix
+++ b/pkgs/by-name/he/heroic-unwrapped/package.nix
@@ -124,7 +124,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher";
     changelog = "https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ iedame ];
+    maintainers = [ ];
     # Heroic may work on nix-darwin, but it needs a dedicated maintainer for the platform.
     # It may also work on other Linux targets, but all the game stores only
     # support x86 Linux, so it would require extra hacking to run games via QEMU

--- a/pkgs/by-name/is/istat-menus/package.nix
+++ b/pkgs/by-name/is/istat-menus/package.nix
@@ -48,10 +48,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "Set of nine separate and highly configurable menu items that let you know exactly what's going on inside your Mac";
     homepage = "https://bjango.com/mac/istatmenus/";
     license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [
-      FlameFlag
-      iedame
-    ];
+    maintainers = with lib.maintainers; [ FlameFlag ];
     platforms = lib.platforms.darwin;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };

--- a/pkgs/by-name/it/itsycal/package.nix
+++ b/pkgs/by-name/it/itsycal/package.nix
@@ -31,10 +31,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "Tiny menu bar calendar";
     homepage = "https://www.mowglii.com/itsycal/";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [
-      FlameFlag
-      iedame
-    ];
+    maintainers = with lib.maintainers; [ FlameFlag ];
     platforms = lib.platforms.darwin;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };

--- a/pkgs/by-name/ke/keka/package.nix
+++ b/pkgs/by-name/ke/keka/package.nix
@@ -31,10 +31,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://www.keka.io";
     license = lib.licenses.unfree;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    maintainers = with lib.maintainers; [
-      emilytrau
-      iedame
-    ];
+    maintainers = with lib.maintainers; [ emilytrau ];
     platforms = lib.platforms.darwin;
   };
 })

--- a/pkgs/by-name/li/libfilezilla/package.nix
+++ b/pkgs/by-name/li/libfilezilla/package.nix
@@ -42,10 +42,7 @@ stdenv.mkDerivation {
     homepage = "https://lib.filezilla-project.org/";
     description = "Modern C++ library, offering some basic functionality to build high-performing, platform-independent programs";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [
-      pSub
-      iedame
-    ];
+    maintainers = with maintainers; [ pSub ];
     platforms = lib.platforms.unix;
     broken = stdenv.hostPlatform.isDarwin;
   };

--- a/pkgs/by-name/li/lincity-ng/package.nix
+++ b/pkgs/by-name/li/lincity-ng/package.nix
@@ -77,10 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "City building game";
     mainProgram = "lincity-ng";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [
-      raskin
-      iedame
-    ];
+    maintainers = with lib.maintainers; [ raskin ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/li/lincity/package.nix
+++ b/pkgs/by-name/li/lincity/package.nix
@@ -80,6 +80,6 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "xlincity";
     license = lib.licenses.gpl2Plus;
     homepage = "https://sourceforge.net/projects/lincity";
-    maintainers = with lib.maintainers; [ iedame ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/lu/ludusavi/package.nix
+++ b/pkgs/by-name/lu/ludusavi/package.nix
@@ -125,7 +125,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     maintainers = with lib.maintainers; [
       pasqui23
       megheaiulian
-      iedame
     ];
     mainProgram = "ludusavi";
   };

--- a/pkgs/by-name/lu/lugaru/package.nix
+++ b/pkgs/by-name/lu/lugaru/package.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation rec {
     description = "Third person ninja rabbit fighting game";
     mainProgram = "lugaru";
     homepage = "https://osslugaru.gitlab.io";
-    maintainers = with lib.maintainers; [ iedame ];
+    maintainers = [ ];
     platforms = platforms.linux;
     license = licenses.gpl2Plus;
   };

--- a/pkgs/by-name/me/megasync/package.nix
+++ b/pkgs/by-name/me/megasync/package.nix
@@ -152,7 +152,7 @@ stdenv.mkDerivation (finalAttrs: {
       "i686-linux"
       "x86_64-linux"
     ];
-    maintainers = with lib.maintainers; [ iedame ];
+    maintainers = [ ];
     mainProgram = "megasync";
   };
 })

--- a/pkgs/by-name/mi/microsoft-edge/package.nix
+++ b/pkgs/by-name/mi/microsoft-edge/package.nix
@@ -274,7 +274,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       leleuvilela
       bricklou
       jonhermansen
-      iedame
     ];
     platforms = [ "x86_64-linux" ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];

--- a/pkgs/by-name/mo/mountain-duck/package.nix
+++ b/pkgs/by-name/mo/mountain-duck/package.nix
@@ -30,10 +30,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://mountainduck.io";
     license = licenses.unfree;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    maintainers = with maintainers; [
-      emilytrau
-      iedame
-    ];
+    maintainers = with maintainers; [ emilytrau ];
     platforms = platforms.darwin;
   };
 })

--- a/pkgs/by-name/mt/mtpaint/package.nix
+++ b/pkgs/by-name/mt/mtpaint/package.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation {
     homepage = "https://mtpaint.sourceforge.net/";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ iedame ];
+    maintainers = [ ];
     mainProgram = "mtpaint";
   };
 }

--- a/pkgs/by-name/mu/museum/package.nix
+++ b/pkgs/by-name/mu/museum/package.nix
@@ -61,7 +61,6 @@ buildGoModule (finalAttrs: {
     maintainers = with lib.maintainers; [
       pinpox
       oddlama
-      iedame
     ];
     mainProgram = "museum";
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/ne/nethack/package.nix
+++ b/pkgs/by-name/ne/nethack/package.nix
@@ -236,7 +236,7 @@ stdenvUsed.mkDerivation (finalAttrs: {
     homepage = "http://nethack.org/";
     license = lib.licenses.ngpl;
     platforms = if x11Mode then lib.platforms.linux else lib.platforms.unix;
-    maintainers = with lib.maintainers; [ iedame ];
+    maintainers = [ ];
     mainProgram = "nethack";
     broken = if qtMode then stdenv.hostPlatform.isDarwin else false;
   };

--- a/pkgs/by-name/nv/nvd/package.nix
+++ b/pkgs/by-name/nv/nvd/package.nix
@@ -37,10 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://khumba.net/projects/nvd";
     license = lib.licenses.asl20;
     mainProgram = "nvd";
-    maintainers = with lib.maintainers; [
-      khumba
-      iedame
-    ];
+    maintainers = with lib.maintainers; [ khumba ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/op/openlierox/package.nix
+++ b/pkgs/by-name/op/openlierox/package.nix
@@ -82,10 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "http://openlierox.net";
     license = lib.licenses.lgpl2Plus;
     mainProgram = "openlierox";
-    maintainers = with lib.maintainers; [
-      tomasajt
-      iedame
-    ];
+    maintainers = with lib.maintainers; [ tomasajt ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/op/opensurge/package.nix
+++ b/pkgs/by-name/op/opensurge/package.nix
@@ -64,6 +64,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/alemart/opensurge/blob/v${finalAttrs.version}/CHANGES.md";
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ iedame ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/pg/pgbackrest/package.nix
+++ b/pkgs/by-name/pg/pgbackrest/package.nix
@@ -58,9 +58,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/pgbackrest/pgbackrest/releases/tag/release%2F${finalAttrs.version}";
     license = lib.licenses.mit;
     mainProgram = "pgbackrest";
-    maintainers = with lib.maintainers; [
-      zaninime
-      iedame
-    ];
+    maintainers = with lib.maintainers; [ zaninime ];
   };
 })

--- a/pkgs/by-name/po/podman-tui/package.nix
+++ b/pkgs/by-name/po/podman-tui/package.nix
@@ -55,7 +55,7 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/containers/podman-tui";
     description = "Podman Terminal UI";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ iedame ];
+    maintainers = [ ];
     mainProgram = "podman-tui";
   };
 })

--- a/pkgs/by-name/po/pomodoro-gtk/package.nix
+++ b/pkgs/by-name/po/pomodoro-gtk/package.nix
@@ -58,10 +58,7 @@ stdenv.mkDerivation {
     homepage = "https://gitlab.com/idevecore/pomodoro";
     license = lib.licenses.gpl3Plus;
     mainProgram = "pomodoro";
-    maintainers = with lib.maintainers; [
-      aleksana
-      iedame
-    ];
+    maintainers = with lib.maintainers; [ aleksana ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/pr/pro-office-calculator/package.nix
+++ b/pkgs/by-name/pr/pro-office-calculator/package.nix
@@ -32,10 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Completely normal office calculator";
     mainProgram = "procalc";
     homepage = "https://proofficecalculator.com/";
-    maintainers = with lib.maintainers; [
-      pmiddend
-      iedame
-    ];
+    maintainers = with lib.maintainers; [ pmiddend ];
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl3Only;
   };

--- a/pkgs/by-name/ra/rare/package.nix
+++ b/pkgs/by-name/ra/rare/package.nix
@@ -56,7 +56,7 @@ python3Packages.buildPythonApplication rec {
   meta = {
     description = "GUI for Legendary, an Epic Games Launcher open source alternative";
     homepage = "https://github.com/RareDevs/Rare";
-    maintainers = with lib.maintainers; [ iedame ];
+    maintainers = [ ];
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.linux;
     mainProgram = "rare";

--- a/pkgs/by-name/ri/ringracers/package.nix
+++ b/pkgs/by-name/ri/ringracers/package.nix
@@ -114,10 +114,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://kartkrew.org";
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [
-      donovanglover
-      iedame
-    ];
+    maintainers = with lib.maintainers; [ donovanglover ];
     mainProgram = "ringracers";
   };
 })

--- a/pkgs/by-name/ro/robodoc/package.nix
+++ b/pkgs/by-name/ro/robodoc/package.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
       Java -- basically any program in which you can use remarks/comments.
     '';
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ iedame ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
     mainProgram = "robodoc";
   };

--- a/pkgs/by-name/ru/runescape/package.nix
+++ b/pkgs/by-name/ru/runescape/package.nix
@@ -99,10 +99,7 @@ let
       homepage = "https://www.runescape.com/";
       sourceProvenance = with sourceTypes; [ binaryNativeCode ];
       license = licenses.unfree;
-      maintainers = with maintainers; [
-        grburst
-        iedame
-      ];
+      maintainers = with maintainers; [ grburst ];
       platforms = [ "x86_64-linux" ];
     };
   };
@@ -152,10 +149,7 @@ buildFHSEnv {
     description = "RuneScape Game Client (NXT) - Launcher for RuneScape 3";
     homepage = "https://www.runescape.com/";
     license = licenses.unfree;
-    maintainers = with maintainers; [
-      grburst
-      iedame
-    ];
+    maintainers = with maintainers; [ grburst ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/by-name/sc/scanmem/package.nix
+++ b/pkgs/by-name/sc/scanmem/package.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     homepage = "https://github.com/scanmem/scanmem";
     description = "Memory scanner for finding and poking addresses in executing processes";
-    maintainers = with lib.maintainers; [ iedame ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl3Plus;
   };

--- a/pkgs/by-name/sg/sgt-puzzles/package.nix
+++ b/pkgs/by-name/sg/sgt-puzzles/package.nix
@@ -94,7 +94,6 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       raskin
       tomfitzhenry
-      iedame
     ];
     platforms = lib.platforms.linux;
     homepage = "https://www.chiark.greenend.org.uk/~sgtatham/puzzles/";

--- a/pkgs/by-name/si/simulide/package.nix
+++ b/pkgs/by-name/si/simulide/package.nix
@@ -172,7 +172,6 @@ stdenv.mkDerivation {
     maintainers = with lib.maintainers; [
       carloscraveiro
       tomasajt
-      iedame
     ];
     platforms = [
       "x86_64-linux"

--- a/pkgs/by-name/sl/sloth-app/package.nix
+++ b/pkgs/by-name/sl/sloth-app/package.nix
@@ -37,10 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://sveinbjorn.org/sloth";
     license = lib.licenses.bsd3;
     mainProgram = "Sloth";
-    maintainers = with lib.maintainers; [
-      emilytrau
-      iedame
-    ];
+    maintainers = with lib.maintainers; [ emilytrau ];
     platforms = lib.platforms.darwin;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };

--- a/pkgs/by-name/sp/spotify/darwin.nix
+++ b/pkgs/by-name/sp/spotify/darwin.nix
@@ -48,7 +48,6 @@ stdenv.mkDerivation {
     maintainers = with lib.maintainers; [
       matteopacini
       Enzime
-      iedame
     ];
   };
 }

--- a/pkgs/by-name/st/stats/package.nix
+++ b/pkgs/by-name/st/stats/package.nix
@@ -37,7 +37,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       FlameFlag
       emilytrau
-      iedame
     ];
     platforms = lib.platforms.darwin;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];

--- a/pkgs/by-name/ty/typioca/package.nix
+++ b/pkgs/by-name/ty/typioca/package.nix
@@ -36,7 +36,7 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/bloznelis/typioca";
     changelog = "https://github.com/bloznelis/typioca/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ iedame ];
+    maintainers = [ ];
     mainProgram = "typioca";
   };
 })

--- a/pkgs/by-name/un/unciv/package.nix
+++ b/pkgs/by-name/un/unciv/package.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation rec {
     description = "Open-source Android/Desktop remake of Civ V";
     mainProgram = "unciv";
     homepage = "https://github.com/yairm210/Unciv";
-    maintainers = with lib.maintainers; [ iedame ];
+    maintainers = [ ];
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.mpl20;
     platforms = platforms.all;

--- a/pkgs/by-name/vo/vorta/package.nix
+++ b/pkgs/by-name/vo/vorta/package.nix
@@ -100,10 +100,7 @@ python3Packages.buildPythonApplication rec {
     description = "Desktop Backup Client for Borg";
     homepage = "https://vorta.borgbase.com/";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [
-      ma27
-      iedame
-    ];
+    maintainers = with lib.maintainers; [ ma27 ];
     platforms = lib.platforms.linux;
     mainProgram = "vorta";
   };

--- a/pkgs/by-name/we/wesnoth/package.nix
+++ b/pkgs/by-name/we/wesnoth/package.nix
@@ -158,10 +158,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.wesnoth.org/";
     changelog = "https://github.com/wesnoth/wesnoth/blob/${finalAttrs.version}/changelog.md";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [
-      niklaskorz
-      iedame
-    ];
+    maintainers = with lib.maintainers; [ niklaskorz ];
     platforms = lib.platforms.unix;
     mainProgram = "wesnoth${suffix}";
   };

--- a/pkgs/by-name/xp/xpilot-ng/package.nix
+++ b/pkgs/by-name/xp/xpilot-ng/package.nix
@@ -44,10 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Multiplayer X11 space combat game";
     homepage = "http://xpilot.sf.net/";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [
-      raskin
-      iedame
-    ];
+    maintainers = with lib.maintainers; [ raskin ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/development/python-modules/img2pdf/default.nix
+++ b/pkgs/development/python-modules/img2pdf/default.nix
@@ -103,7 +103,6 @@ buildPythonPackage rec {
     maintainers = with lib.maintainers; [
       veprbl
       dotlambda
-      iedame
     ];
   };
 }


### PR DESCRIPTION
- Remove iedame from maintainers and all packages.

So long, and thanks for all the fish. 

Please consider adopting one of the orphaned packages if you have the bandwidth to do so.
```
rg "iedame"
maintainers/maintainer-list.nix
10843:  iedame = {
10845:    github = "iedame";

maintainers/github-teams.json
223:      "iedame": 60272,

pkgs/applications/science/electronics/librepcb/default.nix
66:      iedame

pkgs/applications/science/misc/vite/default.nix
63:    maintainers = with lib.maintainers; [ iedame ];

pkgs/applications/misc/lutris/default.nix
160:      iedame

pkgs/applications/graphics/xournalpp/default.nix
89:      iedame

pkgs/by-name/mi/microsoft-edge/package.nix
277:      iedame

pkgs/by-name/sp/spotify/darwin.nix
51:      iedame

pkgs/by-name/si/simulide/package.nix
175:      iedame

pkgs/by-name/ba/backrest/package.nix
122:    maintainers = with lib.maintainers; [ iedame ];

pkgs/by-name/ke/keka/package.nix
36:      iedame

pkgs/by-name/un/unciv/package.nix
76:    maintainers = with lib.maintainers; [ iedame ];

pkgs/by-name/bl/bloodspilot-server/package.nix
33:      iedame

pkgs/by-name/bl/bloodspilot-client/package.nix
46:      iedame

pkgs/by-name/sg/sgt-puzzles/package.nix
97:      iedame

pkgs/by-name/sl/sloth-app/package.nix
42:      iedame

pkgs/by-name/ge/geogebra6/package.nix
28:      iedame

pkgs/by-name/ge/getdp/package.nix
54:    maintainers = with lib.maintainers; [ iedame ];

pkgs/by-name/ge/geogebra/package.nix
51:      iedame

pkgs/development/python-modules/img2pdf/default.nix
106:      iedame

pkgs/by-name/al/alure/package.nix
31:    maintainers = with lib.maintainers; [ iedame ];

pkgs/by-name/ad/adwsteamgtk/package.nix
51:      iedame

pkgs/by-name/fr/freedink/package.nix
122:    maintainers = with lib.maintainers; [ iedame ];

pkgs/by-name/pg/pgbackrest/package.nix
63:      iedame

pkgs/by-name/fr/freeorion/package.nix
92:    maintainers = with lib.maintainers; [ iedame ];

pkgs/by-name/fr/fritzing/package.nix
135:      iedame

pkgs/by-name/sc/scanmem/package.nix
61:    maintainers = with lib.maintainers; [ iedame ];

pkgs/by-name/ra/rare/package.nix
59:    maintainers = with lib.maintainers; [ iedame ];

pkgs/by-name/we/wesnoth/package.nix
163:      iedame

pkgs/by-name/gh/ghostscript/package.nix
252:      iedame

pkgs/by-name/po/podman-tui/package.nix
58:    maintainers = with lib.maintainers; [ iedame ];

pkgs/by-name/po/pomodoro-gtk/package.nix
63:      iedame

pkgs/by-name/vo/vorta/package.nix
105:      iedame

pkgs/by-name/go/gogdl/package.nix
35:    maintainers = with maintainers; [ iedame ];

pkgs/by-name/_1/_1password-cli/package.nix
96:      iedame

pkgs/by-name/_1/_1password-gui/package.nix
38:      iedame

pkgs/by-name/ar/aranym/package.nix
57:    maintainers = with lib.maintainers; [ iedame ];

pkgs/by-name/mt/mtpaint/package.nix
69:    maintainers = with lib.maintainers; [ iedame ];

pkgs/by-name/ar/arduino-ide/package.nix
37:      iedame

pkgs/by-name/gm/gmsh/package.nix
116:    maintainers = with lib.maintainers; [ iedame ];

pkgs/by-name/st/stats/package.nix
40:      iedame

pkgs/by-name/bb/bbedit/package.nix
37:    maintainers = with lib.maintainers; [ iedame ];

pkgs/by-name/xp/xpilot-ng/package.nix
49:      iedame

pkgs/by-name/mu/museum/package.nix
64:      iedame

pkgs/by-name/en/ente-desktop/package.nix
145:      iedame

pkgs/by-name/en/ente-cli/package.nix
91:      iedame

pkgs/by-name/en/ente-auth/package.nix
117:      iedame

pkgs/by-name/en/ente-web/package.nix
88:      iedame

pkgs/by-name/cu/cutemaze/package.nix
54:      iedame

pkgs/by-name/cu/cutechess/package.nix
41:    maintainers = with lib.maintainers; [ iedame ];

pkgs/by-name/fa/fallout-ce/package.nix
99:      iedame

pkgs/by-name/fa/fallout2-ce/package.nix
103:      iedame

pkgs/by-name/ty/typioca/package.nix
39:    maintainers = with lib.maintainers; [ iedame ];

pkgs/by-name/ff/fflogs/package.nix
37:      iedame

pkgs/by-name/li/lincity/package.nix
83:    maintainers = with lib.maintainers; [ iedame ];

pkgs/by-name/me/megasync/package.nix
155:    maintainers = with lib.maintainers; [ iedame ];

pkgs/by-name/bo/borgbackup/package.nix
156:      iedame

pkgs/by-name/bo/bolt-launcher/package.nix
158:      iedame

pkgs/by-name/ro/robodoc/package.nix
60:    maintainers = with lib.maintainers; [ iedame ];

pkgs/by-name/ne/nethack/package.nix
239:    maintainers = with lib.maintainers; [ iedame ];

pkgs/by-name/lu/lugaru/package.nix
69:    maintainers = with lib.maintainers; [ iedame ];

pkgs/by-name/lu/ludusavi/package.nix
128:      iedame

pkgs/by-name/fi/filezilla/package.nix
75:      iedame

pkgs/by-name/op/opensurge/package.nix
67:    maintainers = with lib.maintainers; [ iedame ];

pkgs/by-name/op/openlierox/package.nix
87:      iedame

pkgs/by-name/is/istat-menus/package.nix
53:      iedame

pkgs/by-name/ri/ringracers/package.nix
119:      iedame

pkgs/by-name/li/libfilezilla/package.nix
47:      iedame

pkgs/by-name/ap/appcleaner/package.nix
35:      iedame

pkgs/by-name/li/lincity-ng/package.nix
82:      iedame

pkgs/by-name/mo/mountain-duck/package.nix
35:      iedame

pkgs/by-name/ga/garden-of-coloured-lights/package.nix
44:    maintainers = with lib.maintainers; [ iedame ];

pkgs/by-name/he/heroic-unwrapped/legendary.nix
40:    maintainers = with maintainers; [ iedame ];

pkgs/by-name/he/heroic-unwrapped/package.nix
127:    maintainers = with lib.maintainers; [ iedame ];

pkgs/by-name/he/heroic-unwrapped/epic-integration.nix
45:    maintainers = with lib.maintainers; [ iedame ];

pkgs/by-name/ru/runescape/package.nix
104:        iedame
157:      iedame

pkgs/by-name/cy/cyberduck/package.nix
56:      iedame

pkgs/by-name/nv/nvd/package.nix
42:      iedame

pkgs/by-name/it/itsycal/package.nix
36:      iedame

pkgs/by-name/pr/pro-office-calculator/package.nix
37:      iedame

pkgs/by-name/fl/flightgear/package.nix
111:      iedame
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
