### PR TITLE
workflows: harden against cachix token extraction

### DIFF
--- a/.github/actions/install-nix/action.yml
+++ b/.github/actions/install-nix/action.yml
@@ -4,7 +4,7 @@ description: 'Install and configure Nix and setup Cachix.'
 
 inputs:
   cachix-name:
-    description: "Name of the cache on cachix to use. Defaults to nixpkgs-ci. Can be set in forks to allow pushing."
+    description: "Name of the cache on cachix to use. Defaults to nixpkgs-gha. Can be set in forks to allow pushing."
     required: true
   cachix-token:
     description: "Cachix Auth Token to allow pushing."
@@ -25,8 +25,8 @@ runs:
 
     - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
       with:
-        # The nixpkgs-ci cache should not be trusted or used outside of Nixpkgs and its forks' CI.
-        name: ${{ inputs.cachix-name || 'nixpkgs-ci' }}
-        extraPullNames: nixpkgs-ci
+        # The nixpkgs-gha cache should not be trusted or used outside of Nixpkgs and its forks' CI.
+        name: ${{ inputs.cachix-name || 'nixpkgs-gha' }}
+        extraPullNames: nixpkgs-gha
         authToken: ${{ inputs.cachix-token }}
         pushFilter: '(-source$|-nixpkgs-tarball-|-single-chunk)'

--- a/.github/actions/install-nix/action.yml
+++ b/.github/actions/install-nix/action.yml
@@ -15,8 +15,13 @@ runs:
   steps:
     - uses: cachix/install-nix-action@456688f15bc354bef6d396e4a35f4f89d40bf2b7 # v31
       with:
-        # Sandbox is disabled on MacOS by default.
-        extra_nix_config: sandbox = true
+        extra_nix_config: |
+          # Filesets access the local path via fetchGit.
+          allowed-uris = git+file://${{ github.workspace }} https://github.com
+          nix-path = workspace=${{ github.workspace }} store=/nix/store
+          restrict-eval = true
+          # Sandbox is disabled on MacOS by default.
+          sandbox = true
 
     - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
       with:

--- a/.github/actions/install-nix/action.yml
+++ b/.github/actions/install-nix/action.yml
@@ -1,0 +1,27 @@
+name: Install Nix
+
+description: 'Install and configure Nix and setup Cachix.'
+
+inputs:
+  cachix-name:
+    description: "Name of the cache on cachix to use. Defaults to nixpkgs-ci. Can be set in forks to allow pushing."
+    required: true
+  cachix-token:
+    description: "Cachix Auth Token to allow pushing."
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: cachix/install-nix-action@456688f15bc354bef6d396e4a35f4f89d40bf2b7 # v31
+      with:
+        # Sandbox is disabled on MacOS by default.
+        extra_nix_config: sandbox = true
+
+    - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
+      with:
+        # The nixpkgs-ci cache should not be trusted or used outside of Nixpkgs and its forks' CI.
+        name: ${{ inputs.cachix-name || 'nixpkgs-ci' }}
+        extraPullNames: nixpkgs-ci
+        authToken: ${{ inputs.cachix-token }}
+        pushFilter: '(-source$|-nixpkgs-tarball-|-single-chunk)'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ on:
         required: true
         type: string
     secrets:
-      CACHIX_AUTH_TOKEN:
+      CACHIX_AUTH_TOKEN_GHA:
         required: true
 
 permissions: {}
@@ -65,7 +65,7 @@ jobs:
         uses: ./.github/actions/install-nix
         with:
           cachix-name: ${{ vars.CACHIX_NAME }}
-          cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN_GHA }}
 
       - run: nix-env --option restrict-eval false --install -f nixpkgs/trusted-pinned -A nix-build-uncached
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,23 +51,17 @@ jobs:
         with:
           persist-credentials: false
           sparse-checkout: .github/actions
+
       - name: Checkout the merge commit
         uses: ./.github/actions/checkout
         with:
           merged-as-untrusted-at: ${{ inputs.mergedSha }}
 
-      - uses: cachix/install-nix-action@456688f15bc354bef6d396e4a35f4f89d40bf2b7 # v31
+      - name: Install Nix
+        uses: ./.github/actions/install-nix
         with:
-          # Sandbox is disabled on MacOS by default.
-          extra_nix_config: sandbox = true
-
-      - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
-        with:
-          # The nixpkgs-ci cache should not be trusted or used outside of Nixpkgs and its forks' CI.
-          name: ${{ vars.CACHIX_NAME || 'nixpkgs-ci' }}
-          extraPullNames: nixpkgs-ci
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          pushFilter: '(-source$|-nixpkgs-tarball-)'
+          cachix-name: ${{ vars.CACHIX_NAME }}
+          cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - run: nix-env --install -f nixpkgs/untrusted-pinned -A nix-build-uncached
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ on:
       mergedSha:
         required: true
         type: string
+      targetSha:
+        required: true
+        type: string
     secrets:
       CACHIX_AUTH_TOKEN:
         required: true
@@ -56,6 +59,7 @@ jobs:
         uses: ./.github/actions/checkout
         with:
           merged-as-untrusted-at: ${{ inputs.mergedSha }}
+          target-as-trusted-at: ${{ inputs.targetSha }}
 
       - name: Install Nix
         uses: ./.github/actions/install-nix
@@ -63,7 +67,7 @@ jobs:
           cachix-name: ${{ vars.CACHIX_NAME }}
           cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
-      - run: nix-env --install -f nixpkgs/untrusted-pinned -A nix-build-uncached
+      - run: nix-env --install -f nixpkgs/trusted-pinned -A nix-build-uncached
 
       - name: Build shell
         if: contains(matrix.builds, 'shell')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
           cachix-name: ${{ vars.CACHIX_NAME }}
           cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
-      - run: nix-env --install -f nixpkgs/trusted-pinned -A nix-build-uncached
+      - run: nix-env --option restrict-eval false --install -f nixpkgs/trusted-pinned -A nix-build-uncached
 
       - name: Build shell
         if: contains(matrix.builds, 'shell')

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -76,21 +76,18 @@ jobs:
         with:
           persist-credentials: false
           sparse-checkout: .github/actions
+
       - name: Checkout merge and target commits
         uses: ./.github/actions/checkout
         with:
           merged-as-untrusted-at: ${{ inputs.mergedSha }}
           target-as-trusted-at: ${{ inputs.targetSha }}
 
-      - uses: cachix/install-nix-action@456688f15bc354bef6d396e4a35f4f89d40bf2b7 # v31
-
-      - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
+      - name: Install Nix
+        uses: ./.github/actions/install-nix
         with:
-          # The nixpkgs-ci cache should not be trusted or used outside of Nixpkgs and its forks' CI.
-          name: ${{ vars.CACHIX_NAME || 'nixpkgs-ci' }}
-          extraPullNames: nixpkgs-ci
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          pushFilter: -source$
+          cachix-name: ${{ vars.CACHIX_NAME }}
+          cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Build codeowners validator
         run: nix-build nixpkgs/trusted/ci --arg nixpkgs ./nixpkgs/trusted-pinned -A codeownersValidator

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,7 +16,7 @@ on:
         required: true
         type: string
     secrets:
-      CACHIX_AUTH_TOKEN:
+      CACHIX_AUTH_TOKEN_GHA:
         required: true
 
 permissions: {}
@@ -87,7 +87,7 @@ jobs:
         uses: ./.github/actions/install-nix
         with:
           cachix-name: ${{ vars.CACHIX_NAME }}
-          cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN_GHA }}
 
       - name: Build codeowners validator
         run: nix-build nixpkgs/trusted/ci --arg nixpkgs ./nixpkgs/trusted-pinned -A codeownersValidator

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -19,7 +19,7 @@ on:
         default: false
         type: boolean
     secrets:
-      CACHIX_AUTH_TOKEN:
+      CACHIX_AUTH_TOKEN_GHA:
         required: true
 
 permissions: {}
@@ -56,7 +56,7 @@ jobs:
         uses: ./.github/actions/install-nix
         with:
           cachix-name: ${{ vars.CACHIX_NAME }}
-          cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN_GHA }}
 
       - name: Load supported versions
         id: versions
@@ -106,7 +106,7 @@ jobs:
         uses: ./.github/actions/install-nix
         with:
           cachix-name: ${{ vars.CACHIX_NAME }}
-          cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN_GHA }}
 
       - name: Evaluate the ${{ matrix.system }} output paths at the merge commit
         env:
@@ -190,7 +190,7 @@ jobs:
         uses: ./.github/actions/install-nix
         with:
           cachix-name: ${{ vars.CACHIX_NAME }}
-          cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN_GHA }}
 
       - name: Combine all output paths and eval stats
         run: |
@@ -357,7 +357,7 @@ jobs:
         uses: ./.github/actions/install-nix
         with:
           cachix-name: ${{ vars.CACHIX_NAME }}
-          cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN_GHA }}
 
       - name: Run misc eval tasks in parallel
         run: |

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -40,6 +40,7 @@ jobs:
           persist-credentials: false
           path: trusted
           sparse-checkout: |
+            .github/actions
             ci/supportedVersions.nix
 
       - name: Check out the PR at the test merge commit
@@ -52,7 +53,10 @@ jobs:
             ci/pinned.json
 
       - name: Install Nix
-        uses: cachix/install-nix-action@456688f15bc354bef6d396e4a35f4f89d40bf2b7 # v31
+        uses: ./.github/actions/install-nix
+        with:
+          cachix-name: ${{ vars.CACHIX_NAME }}
+          cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Load supported versions
         id: versions
@@ -91,6 +95,7 @@ jobs:
         with:
           persist-credentials: false
           sparse-checkout: .github/actions
+
       - name: Check out the PR at merged and target commits
         uses: ./.github/actions/checkout
         with:
@@ -98,15 +103,10 @@ jobs:
           target-as-trusted-at: ${{ inputs.targetSha }}
 
       - name: Install Nix
-        uses: cachix/install-nix-action@456688f15bc354bef6d396e4a35f4f89d40bf2b7 # v31
-
-      - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
+        uses: ./.github/actions/install-nix
         with:
-          # The nixpkgs-ci cache should not be trusted or used outside of Nixpkgs and its forks' CI.
-          name: ${{ vars.CACHIX_NAME || 'nixpkgs-ci' }}
-          extraPullNames: nixpkgs-ci
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          pushFilter: '(-source|-single-chunk)$'
+          cachix-name: ${{ vars.CACHIX_NAME }}
+          cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Evaluate the ${{ matrix.system }} output paths at the merge commit
         env:
@@ -172,6 +172,7 @@ jobs:
         with:
           persist-credentials: false
           sparse-checkout: .github/actions
+
       - name: Check out the PR at the target commit
         uses: ./.github/actions/checkout
         with:
@@ -186,7 +187,10 @@ jobs:
           merge-multiple: true
 
       - name: Install Nix
-        uses: cachix/install-nix-action@456688f15bc354bef6d396e4a35f4f89d40bf2b7 # v31
+        uses: ./.github/actions/install-nix
+        with:
+          cachix-name: ${{ vars.CACHIX_NAME }}
+          cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Combine all output paths and eval stats
         run: |
@@ -343,13 +347,17 @@ jobs:
         with:
           persist-credentials: false
           sparse-checkout: .github/actions
+
       - name: Checkout the merge commit
         uses: ./.github/actions/checkout
         with:
           merged-as-untrusted-at: ${{ inputs.mergedSha }}
 
       - name: Install Nix
-        uses: cachix/install-nix-action@456688f15bc354bef6d396e4a35f4f89d40bf2b7 # v31
+        uses: ./.github/actions/install-nix
+        with:
+          cachix-name: ${{ vars.CACHIX_NAME }}
+          cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Run misc eval tasks in parallel
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ on:
         required: true
         type: string
     secrets:
-      CACHIX_AUTH_TOKEN:
+      CACHIX_AUTH_TOKEN_GHA:
         required: true
 
 permissions: {}
@@ -38,7 +38,7 @@ jobs:
         uses: ./.github/actions/install-nix
         with:
           cachix-name: ${{ vars.CACHIX_NAME }}
-          cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN_GHA }}
 
       # TODO: Figure out how to best enable caching for the treefmt job. Cachix doesn't work well,
       # because the cache is invalidated on every commit - treefmt checks every file.
@@ -78,7 +78,7 @@ jobs:
         uses: ./.github/actions/install-nix
         with:
           cachix-name: ${{ vars.CACHIX_NAME }}
-          cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN_GHA }}
 
       - name: Parse all nix files
         run: |
@@ -104,7 +104,7 @@ jobs:
         uses: ./.github/actions/install-nix
         with:
           cachix-name: ${{ vars.CACHIX_NAME }}
-          cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN_GHA }}
 
       - name: Running nixpkgs-vet
         env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,15 +28,20 @@ jobs:
         with:
           persist-credentials: false
           sparse-checkout: .github/actions
+
       - name: Checkout the merge commit
         uses: ./.github/actions/checkout
         with:
           merged-as-untrusted-at: ${{ inputs.mergedSha }}
 
-      - uses: cachix/install-nix-action@456688f15bc354bef6d396e4a35f4f89d40bf2b7 # v31
+      - name: Install Nix
+        uses: ./.github/actions/install-nix
+        with:
+          cachix-name: ${{ vars.CACHIX_NAME }}
+          cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
-      # TODO: Figure out how to best enable caching for the treefmt job. Cachix won't work well,
-      # because the cache would be invalidated on every commit - treefmt checks every file.
+      # TODO: Figure out how to best enable caching for the treefmt job. Cachix doesn't work well,
+      # because the cache is invalidated on every commit - treefmt checks every file.
       # Maybe we can cache treefmt's eval-cache somehow.
 
       - name: Check that files are formatted
@@ -63,20 +68,17 @@ jobs:
         with:
           persist-credentials: false
           sparse-checkout: .github/actions
+
       - name: Checkout the merge commit
         uses: ./.github/actions/checkout
         with:
           merged-as-untrusted-at: ${{ inputs.mergedSha }}
 
-      - uses: cachix/install-nix-action@456688f15bc354bef6d396e4a35f4f89d40bf2b7 # v31
-
-      - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
+      - name: Install Nix
+        uses: ./.github/actions/install-nix
         with:
-          # The nixpkgs-ci cache should not be trusted or used outside of Nixpkgs and its forks' CI.
-          name: ${{ vars.CACHIX_NAME || 'nixpkgs-ci' }}
-          extraPullNames: nixpkgs-ci
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          pushFilter: -source$
+          cachix-name: ${{ vars.CACHIX_NAME }}
+          cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Parse all nix files
         run: |
@@ -91,21 +93,18 @@ jobs:
         with:
           persist-credentials: false
           sparse-checkout: .github/actions
+
       - name: Checkout merge and target commits
         uses: ./.github/actions/checkout
         with:
           merged-as-untrusted-at: ${{ inputs.mergedSha }}
           target-as-trusted-at: ${{ inputs.targetSha }}
 
-      - uses: cachix/install-nix-action@456688f15bc354bef6d396e4a35f4f89d40bf2b7 # v31
-
-      - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
+      - name: Install Nix
+        uses: ./.github/actions/install-nix
         with:
-          # The nixpkgs-ci cache should not be trusted or used outside of Nixpkgs and its forks' CI.
-          name: ${{ vars.CACHIX_NAME || 'nixpkgs-ci' }}
-          extraPullNames: nixpkgs-ci
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          pushFilter: -source$
+          cachix-name: ${{ vars.CACHIX_NAME }}
+          cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Running nixpkgs-vet
         env:

--- a/.github/workflows/merge-group.yml
+++ b/.github/workflows/merge-group.yml
@@ -14,7 +14,7 @@ on:
         required: true
         type: string
     secrets:
-      CACHIX_AUTH_TOKEN:
+      CACHIX_AUTH_TOKEN_GHA:
         required: true
 
 permissions: {}
@@ -40,7 +40,7 @@ jobs:
     name: Lint
     uses: ./.github/workflows/lint.yml
     secrets:
-      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      CACHIX_AUTH_TOKEN_GHA: ${{ secrets.CACHIX_AUTH_TOKEN_GHA }}
     with:
       mergedSha: ${{ inputs.mergedSha || github.event.merge_group.head_sha }}
       targetSha: ${{ inputs.targetSha || github.event.merge_group.base_sha }}
@@ -55,7 +55,7 @@ jobs:
       # compare
       statuses: write
     secrets:
-      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      CACHIX_AUTH_TOKEN_GHA: ${{ secrets.CACHIX_AUTH_TOKEN_GHA }}
     with:
       artifact-prefix: ${{ inputs.artifact-prefix }}
       mergedSha: ${{ inputs.mergedSha || github.event.merge_group.head_sha }}

--- a/.github/workflows/pull-request-target.yml
+++ b/.github/workflows/pull-request-target.yml
@@ -119,6 +119,7 @@ jobs:
       artifact-prefix: ${{ inputs.artifact-prefix }}
       baseBranch: ${{ needs.prepare.outputs.baseBranch }}
       mergedSha: ${{ needs.prepare.outputs.mergedSha }}
+      targetSha: ${{ needs.prepare.outputs.targetSha }}
 
   # This job's only purpose is to create the target for the "Required Status Checks" branch ruleset.
   # It "needs" all the jobs that should block merging a PR.

--- a/.github/workflows/pull-request-target.yml
+++ b/.github/workflows/pull-request-target.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
     secrets:
-      CACHIX_AUTH_TOKEN:
+      CACHIX_AUTH_TOKEN_GHA:
         required: true
       NIXPKGS_CI_APP_PRIVATE_KEY:
         required: true
@@ -64,7 +64,7 @@ jobs:
       # cherry-picks
       pull-requests: write
     secrets:
-      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      CACHIX_AUTH_TOKEN_GHA: ${{ secrets.CACHIX_AUTH_TOKEN_GHA }}
     with:
       baseBranch: ${{ needs.prepare.outputs.baseBranch }}
       headBranch: ${{ needs.prepare.outputs.headBranch }}
@@ -76,7 +76,7 @@ jobs:
     needs: [prepare]
     uses: ./.github/workflows/lint.yml
     secrets:
-      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      CACHIX_AUTH_TOKEN_GHA: ${{ secrets.CACHIX_AUTH_TOKEN_GHA }}
     with:
       mergedSha: ${{ needs.prepare.outputs.mergedSha }}
       targetSha: ${{ needs.prepare.outputs.targetSha }}
@@ -89,7 +89,7 @@ jobs:
       # compare
       statuses: write
     secrets:
-      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      CACHIX_AUTH_TOKEN_GHA: ${{ secrets.CACHIX_AUTH_TOKEN_GHA }}
     with:
       artifact-prefix: ${{ inputs.artifact-prefix }}
       mergedSha: ${{ needs.prepare.outputs.mergedSha }}
@@ -114,7 +114,7 @@ jobs:
     needs: [prepare]
     uses: ./.github/workflows/build.yml
     secrets:
-      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      CACHIX_AUTH_TOKEN_GHA: ${{ secrets.CACHIX_AUTH_TOKEN_GHA }}
     with:
       artifact-prefix: ${{ inputs.artifact-prefix }}
       baseBranch: ${{ needs.prepare.outputs.baseBranch }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
     permissions:
       statuses: write
     secrets:
-      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      CACHIX_AUTH_TOKEN_GHA: ${{ secrets.CACHIX_AUTH_TOKEN_GHA }}
     with:
       artifact-prefix: mg-
       mergedSha: ${{ needs.prepare.outputs.mergedSha }}
@@ -101,7 +101,7 @@ jobs:
       pull-requests: write
       statuses: write
     secrets:
-      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      CACHIX_AUTH_TOKEN_GHA: ${{ secrets.CACHIX_AUTH_TOKEN_GHA }}
       NIXPKGS_CI_APP_PRIVATE_KEY: ${{ secrets.NIXPKGS_CI_APP_PRIVATE_KEY }}
     with:
       artifact-prefix: pr-


### PR DESCRIPTION
A recent security report triggered another analysis of how secure our secrets in CI currently are, and where we execute untrusted code. One thing that I previously neglected is the ability to extract secrets while *evaluating untrusted nix code*. To consistently prevent that, we'll need to set `restrict-eval = true`. This PR does that and adds some refactoring to make sure this is re-used everywhere.

Together with this PR, we are rotating the cachix auth token and are also clearing the cache. The simplest way to do that is to just create a new cachix cache, which also has the benefit of moving away from an individually-owned-cache to an org-owned cache. For that purpose, I created a "nixpkgs-ci" org on cachix and will invite the @NixOS/nixpkgs-ci members to it. This way the team has control in case secrets need to be rotated in the future or similar.

With opening this PR, I removed the old `CACHIX_AUTH_TOKEN` secret. This means that all CI will temporarily run without cache, until this PR is merged. That's fine, because it should not break things in principle - just make them slower a bit.

## Things done

- [x] Tested in my fork.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
