### PR TITLE
pdi: fix cmake 4 compatibility

### DIFF
--- a/pkgs/by-name/pd/pdi/package.nix
+++ b/pkgs/by-name/pd/pdi/package.nix
@@ -41,12 +41,22 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-bbhsMbTVvG19vtkZyOiCRH168kCFk2ahSFc7davfXzo=";
   };
 
-  # Current hdf5 version in nixpkgs is 1.14.4.3 which is 4 numbers long and doesn't match the 3 number regex. :')
-  # Patch it to make it match a 4 number-long version.
-  postPatch = ''
-    substituteInPlace plugins/decl_hdf5/cmake/FindHDF5.cmake \
-      --replace-fail '"H5_VERSION[ \t]+\"([0-9]+\\.[0-9]+\\.[0-9]+)' '"H5_VERSION[ \t]+\"([0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+)*)'
-  '';
+  postPatch =
+    # Current hdf5 version in nixpkgs is 1.14.4.3 which is 4 numbers long and doesn't match the 3 number regex. :')
+    # Patch it to make it match a 4 number-long version.
+    ''
+      substituteInPlace plugins/decl_hdf5/cmake/FindHDF5.cmake \
+        --replace-fail '"H5_VERSION[ \t]+\"([0-9]+\\.[0-9]+\\.[0-9]+)' '"H5_VERSION[ \t]+\"([0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+)*)'
+    ''
+    # CMake 4 dropped support of versions lower than 3.5,
+    # versions lower than 3.10 are deprecated.
+    # "https://github.com/NixOS/nixpkgs/issues/445447"
+    + ''
+      substituteInPlace vendor/zpp-1.0.16/zpp/cmake/Zpp.cmake \
+        --replace-fail \
+          "cmake_minimum_required(VERSION 3.0)" \
+          "cmake_minimum_required(VERSION 3.10)"
+    '';
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
## Things done

Tracking: https://github.com/NixOS/nixpkgs/issues/445447

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
