### PR TITLE
flake.nix: avoid aliased usage of targetPlatform

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -113,7 +113,7 @@
             (
               self.legacyPackages.${system}.stdenv.hostPlatform.isLinux
               # Exclude power64 due to "libressl is not available on the requested hostPlatform" with hostPlatform being power64
-              && !self.legacyPackages.${system}.targetPlatform.isPower64
+              && !self.legacyPackages.${system}.stdenv.targetPlatform.isPower64
               # Exclude armv6l-linux because "cannot bootstrap GHC on this platform ('armv6l-linux' with libc 'defaultLibc')"
               && system != "armv6l-linux"
               # Exclude riscv64-linux because "cannot bootstrap GHC on this platform ('riscv64-linux' with libc 'defaultLibc')"


### PR DESCRIPTION
This unbreaks `nix flake show`, when running with `abort-on-warn` set to `true`.

```shellsession
$ nix --option abort-on-warn true --experimental-features 'nix-command flakes' flake show github:NixOS/nixpkgs
github:NixOS/nixpkgs/1dcdb7dcba947f9607911f3394b19c8f61d716cb?narHash=sha256-IKULzG2wmOaF0BQz2ADZfkAlnlLNFegZAMFCZcrVoGg%3D
├───checks
evaluation warning: 'targetPlatform' has been renamed to/replaced by 'stdenv.targetPlatform'
error:
       … in the right operand of the update (//) operator
         at «github:NixOS/nixpkgs/1dcdb7dcba947f9607911f3394b19c8f61d716cb»/flake.nix:112:11:
          111|         //
          112|           lib.optionalAttrs
             |           ^
          113|             (

       … while evaluating a branch condition
         at «github:NixOS/nixpkgs/1dcdb7dcba947f9607911f3394b19c8f61d716cb»/lib/attrsets.nix:1478:29:
         1477|   */
         1478|   optionalAttrs = cond: as: if cond then as else { };
             |                             ^
         1479|

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: aborting to reveal stack trace of warning, as abort-on-warn is set

$ nix --option abort-on-warn true --experimental-features 'nix-command flakes' flake show github:NixOS/nixpkgs/981b5f7eb145f710dc57458bbac382f190ce1a54
github:NixOS/nixpkgs/981b5f7eb145f710dc57458bbac382f190ce1a54?narHash=sha256-c3kSb5hMVPCho1lWXR5XgsP3EIW4bdyBMKMh1Hnhb4Y%3D
├───checks
│   ├───aarch64-darwin
│   │   └───tarball omitted (use '--all-systems' to show)
│   ├───aarch64-linux
│   │   ├───nixosSystemAcceptsLib omitted (use '--all-systems' to show)
│   │   └───tarball omitted (use '--all-systems' to show)
│   ├───armv6l-linux
│   │   └───tarball omitted (use '--all-systems' to show)
│   ├───armv7l-linux
│   │   ├───nixosSystemAcceptsLib omitted (use '--all-systems' to show)
│   │   └───tarball omitted (use '--all-systems' to show)
│   ├───i686-linux
│   │   ├───nixosSystemAcceptsLib omitted (use '--all-systems' to show)
│   │   └───tarball omitted (use '--all-systems' to show)
│   ├───powerpc64le-linux
│   │   └───tarball omitted (use '--all-systems' to show)
│   ├───riscv64-linux
│   │   └───tarball omitted (use '--all-systems' to show)
│   ├───x86_64-darwin
│   │   └───tarball omitted (use '--all-systems' to show)
│   └───x86_64-linux
│       ├───nixosSystemAcceptsLib: derivation 'nixos-system-nixos-25.11.20251110.981b5f7'
│       └───tarball: derivation 'nixpkgs-tarball-25.11pre20251110.981b5f7'
├───devShells
│   ├───aarch64-darwin
│   │   └───default omitted (use '--all-systems' to show)
│   ├───aarch64-linux
│   │   └───default omitted (use '--all-systems' to show)
│   ├───armv7l-linux
│   │   └───default omitted (use '--all-systems' to show)
│   ├───i686-linux
│   │   └───default omitted (use '--all-systems' to show)
│   ├───powerpc64le-linux
│   │   └───default omitted (use '--all-systems' to show)
│   ├───x86_64-darwin
│   │   └───default omitted (use '--all-systems' to show)
│   └───x86_64-linux
│       └───default: development environment 'nix-shell'
├───formatter
│   ├───aarch64-darwin omitted (use '--all-systems' to show)
│   ├───aarch64-linux omitted (use '--all-systems' to show)
│   ├───armv7l-linux omitted (use '--all-systems' to show)
│   ├───i686-linux omitted (use '--all-systems' to show)
│   ├───powerpc64le-linux omitted (use '--all-systems' to show)
│   ├───x86_64-darwin omitted (use '--all-systems' to show)
│   └───x86_64-linux: package 'treefmt'
├───htmlDocs: unknown
├───legacyPackages
│   ├───aarch64-darwin omitted (use '--legacy' to show)
│   ├───aarch64-linux omitted (use '--legacy' to show)
│   ├───armv6l-linux omitted (use '--legacy' to show)
│   ├───armv7l-linux omitted (use '--legacy' to show)
│   ├───i686-linux omitted (use '--legacy' to show)
│   ├───powerpc64le-linux omitted (use '--legacy' to show)
│   ├───riscv64-linux omitted (use '--legacy' to show)
│   ├───x86_64-darwin omitted (use '--legacy' to show)
│   ├───x86_64-freebsd omitted (use '--legacy' to show)
│   └───x86_64-linux omitted (use '--legacy' to show)
├───lib: unknown
└───nixosModules
    ├───notDetected: NixOS module
    └───readOnlyPkgs: NixOS module

$
```

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
