### PR TITLE
kdePackages.plasma-keyboard: init at 0.1.0

### DIFF
--- a/pkgs/kde/default.nix
+++ b/pkgs/kde/default.nix
@@ -86,6 +86,7 @@ let
         oxygen-icons = self.callPackage ./misc/oxygen-icons { };
         phonon = self.callPackage ./misc/phonon { };
         phonon-vlc = self.callPackage ./misc/phonon-vlc { };
+        plasma-keyboard = self.callPackage ./misc/plasma-keyboard { };
         plasma-wayland-protocols = self.callPackage ./misc/plasma-wayland-protocols { };
         polkit-qt-1 = self.callPackage ./misc/polkit-qt-1 { };
         pulseaudio-qt = self.callPackage ./misc/pulseaudio-qt { };

--- a/pkgs/kde/generated/licenses.json
+++ b/pkgs/kde/generated/licenses.json
@@ -2716,6 +2716,20 @@
     "LicenseRef-KFQF-Accepted-GPL",
     "LicenseRef-Qt-Commercial"
   ],
+  "plasma-keyboard": [
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC0-1.0",
+    "FSFAP",
+    "GPL-2.0-only",
+    "GPL-2.0-or-later",
+    "GPL-3.0-only",
+    "GPL-3.0-or-later",
+    "LGPL-2.1-only",
+    "LGPL-3.0-only",
+    "LicenseRef-KDE-Accepted-GPL",
+    "LicenseRef-KDE-Accepted-LGPL"
+  ],
   "plasma-mobile": [
     "Apache-2.0",
     "BSD-2-Clause",

--- a/pkgs/kde/misc/plasma-keyboard/default.nix
+++ b/pkgs/kde/misc/plasma-keyboard/default.nix
@@ -1,0 +1,33 @@
+{
+  mkKdeDerivation,
+  fetchFromGitLab,
+  qtvirtualkeyboard,
+  pkg-config,
+  wayland-protocols,
+}:
+mkKdeDerivation rec {
+  pname = "plasma-keyboard";
+  version = "0.1.0";
+
+  src = fetchFromGitLab {
+    domain = "invent.kde.org";
+    owner = "plasma";
+    repo = "plasma-keyboard";
+    tag = "v${version}";
+    hash = "sha256-Bka/tmSZIaQ6ZgWx5lCXKM8tlBUgKUy2Amv2TepdO7s=";
+  };
+
+  extraNativeBuildInputs = [
+    pkg-config
+  ];
+
+  extraBuildInputs = [
+    qtvirtualkeyboard
+    wayland-protocols
+  ];
+
+  qtWrapperArgs = [
+    # FIXME: fix this upstream? This should probably be XDG_DATA_DIRS
+    "--set QT_VIRTUALKEYBOARD_HUNSPELL_DATA_PATH /run/current-system/sw/share/hunspell/"
+  ];
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
