### PR TITLE
teleport_18: 18.3.1 -> 18.3.2; teleport_17: 17.7.8 -> 17.7.9

### DIFF
--- a/pkgs/by-name/te/teleport_17/package.nix
+++ b/pkgs/by-name/te/teleport_17/package.nix
@@ -7,11 +7,11 @@
 }:
 
 buildTeleport {
-  version = "17.7.8";
-  hash = "sha256-z520UT17nFLBwyVLjdfx9aTbkMv1fljsN88G6WRPvZE=";
-  vendorHash = "sha256-mtOCLAcVIxaEhGzdsVWxnKQ4FRTXZ5vVAF+NVMdFItk=";
+  version = "17.7.9";
+  hash = "sha256-qS0QWSbhyhBEJTEcJGEbomhsH4hkcLYJlvsaQeBIH7A=";
+  vendorHash = "sha256-ZxJPzqvSGjc4AS5CPuSKCLWVvqcpqlMUUMtSqWn37o0=";
   cargoHash = "sha256-qz8gkooQTuBlPWC4lHtvBQpKkd+nEZ0Hl7AVg9JkPqs=";
-  pnpmHash = "sha256-zTl7hSVPEdnFXx76QpApdY/qDKVNA3yrhaprSYp7YQo=";
+  pnpmHash = "sha256-+240TF1+wHw2HIt4GrhnknL3yxLqQbO+atNUkf/vh6Q=";
 
   wasm-bindgen-cli = wasm-bindgen-cli_0_2_95;
   inherit buildGoModule withRdpClient extPatches;

--- a/pkgs/by-name/te/teleport_18/package.nix
+++ b/pkgs/by-name/te/teleport_18/package.nix
@@ -7,9 +7,9 @@
 }:
 
 buildTeleport {
-  version = "18.3.1";
-  hash = "sha256-HM0pu+3O7zoClH15YC0naxxmKJC9ngamnvraTosRqG0=";
-  vendorHash = "sha256-HyS0KKW7lyn3NzedxM4+UxFV9OnxgtFDMW5jkj3ir/8=";
+  version = "18.3.2";
+  hash = "sha256-BeYn/uq81t9aL3xfxc7TJlNhvqJ2MDzN2Cue2XeG7g8=";
+  vendorHash = "sha256-FSG/54vVFVWiJmlUYqS+3l2EoqxM9tUH91/Nap1p8nk=";
   pnpmHash = "sha256-6sThtwACNEdV0fleaQf3iMmFxPsd0AshYeYZUatFMcg=";
   cargoHash = "sha256-ia4We4IfIkqz82aFMVvXdzjDXw0w+OJSPVdutfau6PA=";
 


### PR DESCRIPTION
Includes a dependency update to fix https://github.com/advisories/GHSA-pwhc-rpq9-4c8w.

Changelog: https://github.com/gravitational/teleport/releases/tag/v18.3.2
Diff: https://github.com/gravitational/teleport/compare/v18.3.1...v18.3.2

Changelog: https://github.com/gravitational/teleport/releases/tag/v17.7.9
Diff: https://github.com/gravitational/teleport/compare/v17.7.8...v17.7.9


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
