### PR TITLE
treewide: remove in-tree usages of nixpkgs.config.allowUnfree

### DIFF
--- a/nixos/tests/breitbandmessung.nix
+++ b/nixos/tests/breitbandmessung.nix
@@ -23,9 +23,6 @@
 
       environment.systemPackages = with pkgs; [ breitbandmessung ];
       environment.variables.XAUTHORITY = "/home/alice/.Xauthority";
-
-      # breitbandmessung is unfree
-      nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [ "breitbandmessung" ];
     };
 
   enableOCR = true;

--- a/nixos/tests/brscan5.nix
+++ b/nixos/tests/brscan5.nix
@@ -7,7 +7,6 @@
   node.pkgsReadOnly = false;
 
   nodes.machine = {
-    nixpkgs.config.allowUnfree = true;
     hardware.sane = {
       enable = true;
       brscan5 = {

--- a/nixos/tests/consul.nix
+++ b/nixos/tests/consul.nix
@@ -57,8 +57,6 @@ let
       ];
       networking.firewall = firewallSettings;
 
-      nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [ "consul" ];
-
       services.consul = {
         enable = true;
         inherit webUi;
@@ -86,8 +84,6 @@ let
         }
       ];
       networking.firewall = firewallSettings;
-
-      nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [ "consul" ];
 
       services.consul =
         assert builtins.elem thisConsensusServerHost allConsensusServerHosts;

--- a/nixos/tests/deconz.nix
+++ b/nixos/tests/deconz.nix
@@ -12,7 +12,6 @@ in
   node.pkgsReadOnly = false;
 
   nodes.machine = {
-    nixpkgs.config.allowUnfree = true;
     services.deconz = {
       enable = true;
       inherit httpPort;

--- a/nixos/tests/minecraft-server.nix
+++ b/nixos/tests/minecraft-server.nix
@@ -15,8 +15,6 @@ in
     {
       environment.systemPackages = [ pkgs.mcrcon ];
 
-      nixpkgs.config.allowUnfree = true;
-
       services.minecraft-server = {
         declarative = true;
         enable = true;

--- a/nixos/tests/n8n.nix
+++ b/nixos/tests/n8n.nix
@@ -15,12 +15,6 @@ in
   nodes.machine =
     { ... }:
     {
-      nixpkgs.config.allowUnfreePredicate =
-        pkg:
-        builtins.elem (lib.getName pkg) [
-          "n8n"
-        ];
-
       services.n8n = {
         enable = true;
         environment.WEBHOOK_URL = webhookUrl;

--- a/nixos/tests/outline.nix
+++ b/nixos/tests/outline.nix
@@ -8,7 +8,6 @@
 
   nodes.outline = {
     virtualisation.memorySize = 2 * 1024;
-    nixpkgs.config.allowUnfree = true;
     services.outline = {
       enable = true;
       forceHttps = false;

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -1502,9 +1502,6 @@ let
       metricProvider = {
         services.sabnzbd.enable = true;
 
-        # unrar is required for sabnzbd
-        nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (pkgs.lib.getName pkg) [ "unrar" ];
-
         # extract the generated api key before starting
         systemd.services.sabnzbd-apikey = {
           requires = [ "sabnzbd.service" ];

--- a/nixos/tests/quake3.nix
+++ b/nixos/tests/quake3.nix
@@ -7,18 +7,6 @@ let
     });
   };
 
-  # Only allow the demo data to be used (only if it's unfreeRedistributable).
-  unfreePredicate =
-    pkg:
-    let
-      allowPackageNames = [
-        "quake3-demodata"
-        "quake3-pointrelease"
-      ];
-      allowLicenses = [ lib.licenses.unfreeRedistributable ];
-    in
-    lib.elem pkg.pname allowPackageNames && lib.elem (pkg.meta.license or null) allowLicenses;
-
   client =
     { pkgs, ... }:
     {
@@ -26,7 +14,6 @@ let
       hardware.graphics.enable = true;
       environment.systemPackages = [ pkgs.quake3demo ];
       nixpkgs.config.packageOverrides = overrides;
-      nixpkgs.config.allowUnfreePredicate = unfreePredicate;
     };
 in
 {
@@ -49,7 +36,6 @@ in
             + "+map q3dm7 +addbot grunt +addbot daemia 2> /tmp/log";
         };
         nixpkgs.config.packageOverrides = overrides;
-        nixpkgs.config.allowUnfreePredicate = unfreePredicate;
         networking.firewall.allowedUDPPorts = [ 27960 ];
       };
 

--- a/nixos/tests/sabnzbd.nix
+++ b/nixos/tests/sabnzbd.nix
@@ -11,9 +11,6 @@
       services.sabnzbd = {
         enable = true;
       };
-
-      # unrar is unfree
-      nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [ "unrar" ];
     };
 
   testScript = ''

--- a/nixos/tests/unifi.nix
+++ b/nixos/tests/unifi.nix
@@ -11,8 +11,6 @@
   node.pkgsReadOnly = false;
 
   nodes.machine = {
-    nixpkgs.config.allowUnfree = true;
-
     services.unifi.enable = true;
   };
 

--- a/nixos/tests/virtualbox.nix
+++ b/nixos/tests/virtualbox.nix
@@ -426,8 +426,6 @@ let
             enable = true;
           }
           // vboxHostConfig;
-
-          nixpkgs.config.allowUnfree = config.virtualisation.virtualbox.host.enableExtensionPack;
         };
 
       testScript = ''

--- a/nixos/tests/vscode-remote-ssh.nix
+++ b/nixos/tests/vscode-remote-ssh.nix
@@ -1,22 +1,6 @@
 import ./make-test-python.nix (
-  { lib, ... }@args:
+  { lib, pkgs, ... }@args:
   let
-    pkgs = args.pkgs.extend (
-      self: super: {
-        stdenv = super.stdenv.override {
-          config = super.config // {
-            allowUnfreePredicate =
-              pkg:
-              builtins.elem (lib.getName pkg) [
-                "vscode"
-                "vscode-with-extensions"
-                "vscode-extension-ms-vscode-remote-remote-ssh"
-              ];
-          };
-        };
-      }
-    );
-
     inherit (import ./ssh-keys.nix pkgs) snakeOilPrivateKey snakeOilPublicKey;
 
     inherit (pkgs.vscode.passthru) rev vscodeServer;


### PR DESCRIPTION
In multiple NixOS tests, `nixpkgs.config.allowUnfree` or `nixpkgs.config.allowUnfreePredicate` was set. This leads to Hydra building and redistributing packages with a unfree license. This is a quite huge legal problem. This changes removes these use cases.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
