### PR TITLE
python3Packages.aiortc: init at 1.14.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9418,6 +9418,15 @@
     githubId = 10353047;
     name = "Tobias Happ";
   };
+  gesperon = {
+    email = "gesperon@mac.com";
+    github = "gesperon";
+    githubId = 117491118;
+    name = "Gabor Esperon";
+    keys = [
+      { fingerprint = "8102 3AF7 84FC 4DA7 B9D7  ECFF A0AF 4AD2 D44C C6FE"; }
+    ];
+  };
   getchoo = {
     name = "Seth Flynn";
     email = "getchoo@tuta.io";

--- a/pkgs/development/python-modules/aioice/default.nix
+++ b/pkgs/development/python-modules/aioice/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  setuptools,
+  dnspython,
+  ifaddr,
+  fetchFromGitHub,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "aioice";
+  version = "0.10.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "aiortc";
+    repo = "aioice";
+    tag = version;
+    hash = "sha256-KFYPzGPm+d1QrFAW9OhTDxroV/MnFusmfy5qcYCfDiM=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    dnspython
+    ifaddr
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+  disabledTestPaths = [
+    # Network tests failing
+    "tests/test_ice.py"
+    "tests/test_mdns.py"
+    "tests/test_turn.py"
+    "tests/test_ice_trickle.py"
+  ];
+  doCheck = true;
+  pythonImportsCheck = [
+    "aioice"
+  ];
+
+  meta = {
+    description = "Asyncio-based Interactive Connectivity Establishment (RFC 5245)";
+    homepage = "https://github.com/aiortc/aioice";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ gesperon ];
+  };
+}

--- a/pkgs/development/python-modules/aiortc/default.nix
+++ b/pkgs/development/python-modules/aiortc/default.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  buildPythonPackage,
+  setuptools,
+  aioice,
+  av,
+  cffi,
+  cryptography,
+  google-crc32c,
+  pyee,
+  pylibsrtp,
+  pyopenssl,
+  libopus,
+  libvpx,
+  ifaddr,
+  dnspython,
+  fetchFromGitHub,
+  pytestCheckHook,
+  numpy,
+}:
+
+buildPythonPackage rec {
+  pname = "aiortc";
+  version = "1.14.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "aiortc";
+    repo = "aiortc";
+    tag = version;
+    hash = "sha256-ZgxSaiKkJrA5XvUT1zq8kwqB8mOvn46vLWXHyJSsHbM=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    aioice
+    av
+    cffi
+    cryptography
+    google-crc32c
+    pyee
+    pylibsrtp
+    pyopenssl
+    libopus
+    libvpx
+    ifaddr
+    dnspython
+  ];
+
+  nativeCheckInputs = [
+    numpy
+    pytestCheckHook
+  ];
+  disabledTestPaths = [
+    "tests/test_ortc.py" # hangs on: aiortc.rtcicetransport:rtcicetransport.py:365 RTCIceTransport(controlled) - new -> checking
+    "tests/test_rtcicetransport.py" # hangs on: aiortc.rtcicetransport:rtcicetransport.py:365 RTCIceTransport(controlled) - new -> checking
+    "tests/test_rtcpeerconnection.py" # fails
+    "tests/test_contrib_signaling.py" # fails on darwin
+  ];
+  doCheck = true;
+  pythonImportsCheck = [
+    "aiortc"
+  ];
+
+  meta = {
+    description = "WebRTC and ORTC implementation for Python using asyncio";
+    homepage = "https://github.com/aiortc/aiortc";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ gesperon ];
+  };
+}

--- a/pkgs/development/python-modules/pylibsrtp/default.nix
+++ b/pkgs/development/python-modules/pylibsrtp/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  cffi,
+  srtp,
+  openssl,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "pylibsrtp";
+  version = "1.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "aiortc";
+    repo = "pylibsrtp";
+    tag = version;
+    hash = "sha256-Q8EyGAJKkq14sqSEMWLB8arKvj/wuALK/XwOZ27F1nQ=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    cffi
+    srtp
+    openssl
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+  doCheck = true;
+  pythonImportsCheck = [
+    "pylibsrtp"
+  ];
+
+  meta = {
+    description = "Python bindings for libsrtp";
+    homepage = "https://github.com/aiortc/pylibsrtp";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ gesperon ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13594,6 +13594,8 @@ self: super: with self; {
 
   pylibrespot-java = callPackage ../development/python-modules/pylibrespot-java { };
 
+  pylibsrtp = callPackage ../development/python-modules/pylibsrtp { };
+
   pylink-square = callPackage ../development/python-modules/pylink-square { };
 
   pylint = callPackage ../development/python-modules/pylint { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -348,6 +348,8 @@ self: super: with self; {
 
   aiohwenergy = callPackage ../development/python-modules/aiohwenergy { };
 
+  aioice = callPackage ../development/python-modules/aioice { };
+
   aioimaplib = callPackage ../development/python-modules/aioimaplib { };
 
   aioimmich = callPackage ../development/python-modules/aioimmich { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -460,6 +460,8 @@ self: super: with self; {
 
   aiorpcx = callPackage ../development/python-modules/aiorpcx { };
 
+  aiortc = callPackage ../development/python-modules/aiortc { };
+
   aiortm = callPackage ../development/python-modules/aiortm { };
 
   aiortsp = callPackage ../development/python-modules/aiortsp { };


### PR DESCRIPTION
python3Packages.aiortc: 1.14.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
