### PR TITLE
python3Packages.keeper_secrets_manager_core: init at 17.0.0

### DIFF
--- a/pkgs/development/python-modules/keeper-secrets-manager-core/default.nix
+++ b/pkgs/development/python-modules/keeper-secrets-manager-core/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  setuptools,
+  cffi,
+  cryptography,
+  importlib-metadata,
+  requests,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "keeper-secrets-manager-core";
+  version = "17.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Keeper-Security";
+    repo = "secrets-manager";
+    rev = "release/sdk/python/core/v${version}";
+    hash = "sha256-kYEZOI3ucpLHjWHjvCit/NOJyBjzQ6PEtvAk3Z+NDlg=";
+  };
+
+  sourceRoot = "${src.name}/sdk/python/core";
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    cffi
+    cryptography
+    importlib-metadata
+    requests
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  doCheck = true;
+  pythonImportsCheck = [
+    "keeper_secrets_manager_core"
+  ];
+
+  meta = {
+    description = "Keeper Secrets Manager Python SDK";
+    homepage = "https://github.com/Keeper-Security/secrets-manager/tree/master/sdk/python/core";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ gesperon ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8195,6 +8195,10 @@ self: super: with self; {
 
   keepalive = callPackage ../development/python-modules/keepalive { };
 
+  keeper-secrets-manager-core =
+    callPackage ../development/python-modules/keeper-secrets-manager-core
+      { };
+
   keepkey = callPackage ../development/python-modules/keepkey { };
 
   keepkey-agent = callPackage ../development/python-modules/keepkey-agent { };


### PR DESCRIPTION
python3Packages.keeper_secrets_manager_core: 17.0.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
