### PR TITLE
python3Packages.keeper-pam-webrtc-rs: init at 1.1.6

### DIFF
--- a/pkgs/development/python-modules/keeper-pam-webrtc-rs/default.nix
+++ b/pkgs/development/python-modules/keeper-pam-webrtc-rs/default.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  rustPlatform,
+  pytest,
+  pytest-asyncio,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "keeper-pam-webrtc-rs";
+  version = "1.1.7";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = builtins.replaceStrings [ "-" ] [ "_" ] pname;
+    inherit version;
+    hash = "sha256-6RnqIZx+p7a+4Dv549n4BBVJANzFfBGmDk07/Fi+ssU=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit pname version src;
+    hash = "sha256-sdkkWJjrVDtstMnjX2VpcU46S8bHiK6eSh16dslpBUE=";
+  };
+
+  nativeBuildInputs = with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
+  ];
+
+  patchPhase = ''
+    # If missing README.md: Failed to read readme specified in pyproject.toml, which should be at /build/keeper_pam_webrtc_rs-1.1.6/README.md
+    touch README.md
+  '';
+
+  nativeCheckInputs = [
+    pytest
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # tests require internet access
+    "tests/test_cleanup.py::TestCleanupIntegration::test_integration_pattern_old_style"
+    "tests/test_close_operations.py::TestCloseOperations::test_close_connection_after_peer_connection"
+    "tests/test_ice_restart_and_keepalive.py::TestICERestartAndKeepalive::test_connection_stats_api"
+    "tests/test_ice_restart_and_keepalive.py::TestICERestartAndKeepalive::test_keepalive_functionality_monitoring"
+    "tests/test_ice_restart_and_keepalive.py::TestICERestartAndKeepalive::test_manual_ice_restart_api"
+    "tests/test_metrics_system.py::TestMetricsSystem::test_metrics_integration_with_basic_functionality"
+    "tests/test_performance.py::TestWebRTCPerformance::test_data_channel_load"
+    "tests/test_performance.py::TestWebRTCPerformance::test_e2e_echo_flow"
+    "tests/test_performance.py::TestWebRTCFragmentation::test_data_channel_fragmentation"
+  ];
+
+  preCheck = ''
+    # Or fails with: ModuleNotFoundError: No module named 'test_utils'
+    cd tests
+  '';
+
+  doCheck = true;
+  pythonImportsCheck = [ "keeper_pam_webrtc_rs" ];
+
+  meta = {
+    description = "A secure, stable, and high-performance Tube API for Python, providing WebRTC-based secure tunneling with enterprise-grade security and reliability optimizations.";
+    homepage = "https://pypi.org/project/keeper-pam-webrtc-rs";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ gesperon ];
+  };
+}

--- a/pkgs/development/python-modules/keeper-secrets-manager-core/default.nix
+++ b/pkgs/development/python-modules/keeper-secrets-manager-core/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  setuptools,
+  cffi,
+  cryptography,
+  importlib-metadata,
+  requests,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "keeper-secrets-manager-core";
+  version = "17.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Keeper-Security";
+    repo = "secrets-manager";
+    rev = "release/sdk/python/core/v${version}";
+    hash = "sha256-kYEZOI3ucpLHjWHjvCit/NOJyBjzQ6PEtvAk3Z+NDlg=";
+  };
+
+  sourceRoot = "${src.name}/sdk/python/core";
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    cffi
+    cryptography
+    importlib-metadata
+    requests
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  doCheck = true;
+  pythonImportsCheck = [
+    "keeper_secrets_manager_core"
+  ];
+
+  meta = {
+    description = "Keeper Secrets Manager Python SDK";
+    homepage = "https://github.com/Keeper-Security/secrets-manager/tree/master/sdk/python/core";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ gesperon ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8195,6 +8195,10 @@ self: super: with self; {
 
   keepalive = callPackage ../development/python-modules/keepalive { };
 
+  keeper-secrets-manager-core =
+    callPackage ../development/python-modules/keeper-secrets-manager-core
+      { };
+
   keepkey = callPackage ../development/python-modules/keepkey { };
 
   keepkey-agent = callPackage ../development/python-modules/keepkey-agent { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8195,6 +8195,8 @@ self: super: with self; {
 
   keepalive = callPackage ../development/python-modules/keepalive { };
 
+  keeper-pam-webrtc-rs = callPackage ../development/python-modules/keeper-pam-webrtc-rs { };
+
   keeper-secrets-manager-core =
     callPackage ../development/python-modules/keeper-secrets-manager-core
       { };


### PR DESCRIPTION
python3Packages.keeper_pam_webrtc_rs: 1.1.6

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
