### PR TITLE
python3Packages.unrar2-cffi: init at 0.4.1

### DIFF
--- a/pkgs/development/python-modules/unrar2-cffi/default.nix
+++ b/pkgs/development/python-modules/unrar2-cffi/default.nix
@@ -1,0 +1,62 @@
+{
+  buildPythonPackage,
+  cffi,
+  fetchPypi,
+  lib,
+  nix-update-script,
+  pytestCheckHook,
+  pythonOlder,
+  setuptools,
+}:
+buildPythonPackage rec {
+  pname = "unrar2-cffi";
+  version = "0.4.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "unrar2_cffi";
+    hash = "sha256-P+MXSmoMiIkk42MEYoJq9Okd1JTVwEPLCjGGXrnpyDM=";
+  };
+
+  build-system = [
+    cffi
+    setuptools
+  ];
+
+  dependencies = [
+    cffi
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    rm -r unrar
+  '';
+
+  pythonImportsCheck = [
+    "unrar.cffi"
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Read RAR file from python -- cffi edition";
+    homepage = "https://github.com/noaione/unrar2-cffi";
+    changelog = "https://github.com/noaione/unrar2-cffi/releases/tag/v${version}";
+    license = with lib; [
+      licenses.asl20
+      licenses.unfreeRedistributable # for including unrar
+    ];
+    maintainers = [
+      lib.maintainers.jwillikers
+      lib.maintainers.JollyDevelopment
+    ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20066,6 +20066,8 @@ self: super: with self; {
 
   unpaddedbase64 = callPackage ../development/python-modules/unpaddedbase64 { };
 
+  unrar2-cffi = callPackage ../development/python-modules/unrar2-cffi { };
+
   unrardll = callPackage ../development/python-modules/unrardll { };
 
   unrpa = callPackage ../development/python-modules/unrpa { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This adds the [unrar2-cffi](https://github.com/noaione/unrar2-cffi) python module. Its needed by https://github.com/NixOS/nixpkgs/pull/361155 but that one has not moved in ages so I figured i'd split it off to its own PR so we can drop it from that one and maybe make it easier for both to get in.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
