### PR TITLE
nut: configure the user and group nut should be built with

### DIFF
--- a/pkgs/by-name/nu/nut/package.nix
+++ b/pkgs/by-name/nu/nut/package.nix
@@ -106,6 +106,8 @@ stdenv.mkDerivation rec {
     "--with-systemdshutdowndir=$(out)/lib/systemd/system-shutdown"
     "--with-systemdtmpfilesdir=$(out)/lib/tmpfiles.d"
     "--with-udev-dir=$(out)/etc/udev"
+    "--with-user=nutmon"
+    "--with-group=nutmon"
   ]
   ++ (lib.lists.optionals withApcModbus [
     "--with-modbus+usb"


### PR DESCRIPTION
The udev rules which are generated during build are defaulting to the `nobody` user which does not exist and should not be used (ref: [#55370](https://github.com/NixOS/nixpkgs/issues/55370))

This results in a lot of noise in journald as whenever udev detects a device change and the rules from NUT is checked, the following is output for each line containing the `GROUP="nobody"` entry.
The rules file as of 2025-11-10 contains 129 rules (meaning 129 entries logged to journald).
```
nov. 10 14:44:10 workstation systemd-udevd[2348179]: /etc/udev/rules.d/62-nut-usbups.rules:198 Group 'nobody' is not a system group, ignoring.
```

This is fixed by setting the `--with-user` and `--with-group` flags in configureFlags.


This was also raised upstream [networkupstools/nut#3173](https://github.com/networkupstools/nut/issues/3173) and was informed that the `nobody` user will stay as is but they will consider adding a warning. The user and group should be set by the builder (end user / distribution).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
