### PR TITLE
arjun: 2.2.7 -> 2.2.7-unstable-2025-02-20

### DIFF
--- a/pkgs/by-name/ar/arjun/package.nix
+++ b/pkgs/by-name/ar/arjun/package.nix
@@ -6,14 +6,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "arjun";
-  version = "2.2.7";
+  version = "2.2.7-unstable-2025-02-20";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "s0md3v";
     repo = "Arjun";
-    tag = version;
-    hash = "sha256-XEfCQEvRCvmNQ8yOlaR0nd7knhK1fQIrXEfQgrdVDrs=";
+    rev = "d1fb995cb1e064d4e171d83f19f6af79b0a3c5ce";
+    hash = "sha256-z6YGCwypp69+98KSC1YUzJETfwb3V4Qp1sV5V3N9zMI=";
   };
 
   build-system = with python3.pkgs; [ setuptools ];
@@ -32,7 +32,7 @@ python3.pkgs.buildPythonApplication rec {
   meta = {
     description = "HTTP parameter discovery suite";
     homepage = "https://github.com/s0md3v/Arjun";
-    changelog = "https://github.com/s0md3v/Arjun/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/s0md3v/Arjun/blob/${src.rev}/CHANGELOG.md";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ octodi ];
     mainProgram = "arjun";


### PR DESCRIPTION
[This commit](https://github.com/s0md3v/Arjun/commit/6f87dccd17ce47ace280564cd8fde0773635065a) fixes a major issue that makes the program unusable for me. No release has been made since this fix.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
