### PR TITLE
Add peakrdl utilities

### DIFF
--- a/pkgs/development/python-modules/peakrdl-cheader/default.nix
+++ b/pkgs/development/python-modules/peakrdl-cheader/default.nix
@@ -1,0 +1,45 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  gitUpdater,
+  jinja2,
+  lib,
+  peakrdl,
+  setuptools,
+  setuptools-scm,
+  systemrdl-compiler,
+}:
+
+buildPythonPackage rec {
+  pname = "peakrdl-cheader";
+  version = "1.0.0";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "SystemRDL";
+    repo = "PeakRDL-cheader";
+    tag = "v${version}";
+    hash = "sha256-1LxKGCea5ClKmrArl+CM6ZRpiTh2ThbYSe9TYYHjRlY=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    jinja2
+    peakrdl
+    systemrdl-compiler
+  ];
+
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
+
+  meta = {
+    description = "C Header generator for a SystemRDL definition";
+    homepage = "https://peakrdl-cheader.readthedocs.io/";
+    license = lib.licenses.lgpl3;
+    maintainers = [ lib.maintainers.jmbaur ];
+  };
+}

--- a/pkgs/development/python-modules/peakrdl-ipxact/default.nix
+++ b/pkgs/development/python-modules/peakrdl-ipxact/default.nix
@@ -1,0 +1,43 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  gitUpdater,
+  lib,
+  peakrdl,
+  setuptools,
+  setuptools-scm,
+  systemrdl-compiler,
+}:
+
+buildPythonPackage rec {
+  pname = "peakrdl-ipxact";
+  version = "3.5.0";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "SystemRDL";
+    repo = "PeakRDL-ipxact";
+    tag = "v${version}";
+    hash = "sha256-GFHgIyK82dt+/t0XbDdk61q0DXUOabxtjlhZhgacUVA=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    peakrdl
+    systemrdl-compiler
+  ];
+
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
+
+  meta = {
+    description = "Import and export IP-XACT XML register models";
+    homepage = "http://peakrdl-ipxact.readthedocs.io/";
+    license = lib.licenses.lgpl3;
+    maintainers = [ lib.maintainers.jmbaur ];
+  };
+}

--- a/pkgs/development/python-modules/peakrdl-markdown/default.nix
+++ b/pkgs/development/python-modules/peakrdl-markdown/default.nix
@@ -1,0 +1,39 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  gitUpdater,
+  lib,
+  peakrdl,
+  py-markdown-table,
+  poetry-core,
+}:
+
+buildPythonPackage rec {
+  pname = "peakrdl-markdown";
+  version = "1.0.3";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "SystemRDL";
+    repo = "PeakRDL-markdown";
+    tag = "v${version}";
+    hash = "sha256-Dt8FxnvvXY9nVhFehIcfSC9mFbbEzEuaVnBMu032dug=";
+  };
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    peakrdl
+    py-markdown-table
+  ];
+
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
+
+  meta = {
+    description = "Export Markdown description from the systemrdl-compiler register model";
+    homepage = "https://peakrdl-markdown.readthedocs.io/";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.jmbaur ];
+  };
+}

--- a/pkgs/development/python-modules/peakrdl-regblock/default.nix
+++ b/pkgs/development/python-modules/peakrdl-regblock/default.nix
@@ -1,0 +1,45 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  gitUpdater,
+  jinja2,
+  lib,
+  peakrdl,
+  setuptools,
+  setuptools-scm,
+  systemrdl-compiler,
+}:
+
+buildPythonPackage rec {
+  pname = "peakrdl-regblock";
+  version = "1.2.0";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "SystemRDL";
+    repo = "PeakRDL-regblock";
+    tag = "v${version}";
+    hash = "sha256-hVHqdmXsxOoqpo84KPaK+74VPVsl61QyB5b7lFlmA0o=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    jinja2
+    peakrdl
+    systemrdl-compiler
+  ];
+
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
+
+  meta = {
+    description = "Generate SystemVerilog RTL that implements a register block from compiled SystemRDL input";
+    homepage = "http://peakrdl-regblock.readthedocs.io/";
+    license = lib.licenses.lgpl3;
+    maintainers = [ lib.maintainers.jmbaur ];
+  };
+}

--- a/pkgs/development/python-modules/peakrdl-rust/default.nix
+++ b/pkgs/development/python-modules/peakrdl-rust/default.nix
@@ -1,0 +1,40 @@
+{
+  buildPythonPackage,
+  case-converter,
+  fetchFromGitHub,
+  jinja2,
+  lib,
+  peakrdl,
+  systemrdl-compiler,
+  uv-build,
+}:
+
+buildPythonPackage rec {
+  pname = "peakrdl-rust";
+  version = "0.4.0";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "darsor";
+    repo = "PeakRDL-rust";
+    tag = "v${version}";
+    hash = "sha256-MD0iMdNFvu/V/yWnivJ9cbE0/d77bsoCVScpMMGMG/I=";
+  };
+
+  build-system = [ uv-build ];
+
+  dependencies = [
+    case-converter
+    jinja2
+    peakrdl
+    systemrdl-compiler
+  ];
+
+  meta = {
+    description = "Generate a Rust crate from SystemRDL for accessing control/status registers";
+    homepage = "https://peakrdl-rust.readthedocs.io/";
+    license = lib.licenses.lgpl21Only;
+    maintainers = [ lib.maintainers.jmbaur ];
+  };
+}

--- a/pkgs/development/python-modules/peakrdl/default.nix
+++ b/pkgs/development/python-modules/peakrdl/default.nix
@@ -1,0 +1,45 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  gitUpdater,
+  lib,
+  setuptools,
+  setuptools-scm,
+  systemrdl-compiler,
+  typing-extensions,
+}:
+
+buildPythonPackage rec {
+  pname = "peakrdl";
+  version = "1.5.0";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "SystemRDL";
+    repo = "PeakRDL";
+    tag = "v${version}";
+    hash = "sha256-SqLhOzx0gUVG8k4ikNbx8p1vO/ZqTQ/KAtidRWM2SZI=";
+  };
+  sourceRoot = "${src.name}/peakrdl-cli";
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    systemrdl-compiler
+    typing-extensions
+  ];
+
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
+
+  meta = {
+    description = "Control and status register code generator toolchain";
+    homepage = "https://peakrdl.readthedocs.io/";
+    license = lib.licenses.lgpl3;
+    maintainers = [ lib.maintainers.jmbaur ];
+    mainProgram = "peakrdl";
+  };
+}

--- a/pkgs/development/python-modules/py-markdown-table/default.nix
+++ b/pkgs/development/python-modules/py-markdown-table/default.nix
@@ -1,0 +1,29 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  poetry-core,
+}:
+
+buildPythonPackage rec {
+  pname = "py-markdown-table";
+  version = "1.3.0";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "hvalev";
+    repo = "py-markdown-table";
+    tag = "v${version}";
+    hash = "sha256-BZDyBDW6Ok9WUb5FEAevVqkYM1S12pvkUCGbZ0XxxV4=";
+  };
+
+  build-system = [ poetry-core ];
+
+  meta = {
+    description = "Tiny python library with zero dependencies which generates formatted multiline tables in markdown";
+    homepage = "https://github.com/hvalev/py-markdown-table";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jmbaur ];
+  };
+}

--- a/pkgs/development/python-modules/systemrdl-compiler/default.nix
+++ b/pkgs/development/python-modules/systemrdl-compiler/default.nix
@@ -1,0 +1,45 @@
+{
+  antlr4-python3-runtime,
+  buildPythonPackage,
+  colorama,
+  fetchFromGitHub,
+  gitUpdater,
+  lib,
+  markdown,
+  setuptools,
+  setuptools-scm,
+}:
+
+buildPythonPackage rec {
+  pname = "systemrdl-compiler";
+  version = "1.32.1";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "SystemRDL";
+    repo = "systemrdl-compiler";
+    tag = "v${version}";
+    hash = "sha256-BTONBzNE9GfBeallS6P4E1ukPs2EzFa31/SpxEjXmKw=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    antlr4-python3-runtime
+    colorama
+    markdown
+  ];
+
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
+
+  meta = {
+    description = "SystemRDL 2.0 language compiler front-end";
+    homepage = "https://systemrdl-compiler.readthedocs.io/en/stable/";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jmbaur ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11876,6 +11876,8 @@ self: super: with self; {
 
   peakrdl-ipxact = callPackage ../development/python-modules/peakrdl-ipxact { };
 
+  peakrdl-markdown = callPackage ../development/python-modules/peakrdl-markdown { };
+
   peakrdl-regblock = callPackage ../development/python-modules/peakrdl-regblock { };
 
   peakrdl-rust = callPackage ../development/python-modules/peakrdl-rust { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11872,6 +11872,8 @@ self: super: with self; {
 
   peakrdl = callPackage ../development/python-modules/peakrdl { };
 
+  peakrdl-regblock = callPackage ../development/python-modules/peakrdl-regblock { };
+
   peakutils = callPackage ../development/python-modules/peakutils { };
 
   peaqevcore = callPackage ../development/python-modules/peaqevcore { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11878,6 +11878,8 @@ self: super: with self; {
 
   peakrdl-regblock = callPackage ../development/python-modules/peakrdl-regblock { };
 
+  peakrdl-rust = callPackage ../development/python-modules/peakrdl-rust { };
+
   peakutils = callPackage ../development/python-modules/peakutils { };
 
   peaqevcore = callPackage ../development/python-modules/peaqevcore { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12732,6 +12732,8 @@ self: super: with self; {
 
   py-madvr2 = callPackage ../development/python-modules/py-madvr2 { };
 
+  py-markdown-table = callPackage ../development/python-modules/py-markdown-table { };
+
   py-melissa-climate = callPackage ../development/python-modules/py-melissa-climate { };
 
   py-multiaddr = callPackage ../development/python-modules/py-multiaddr { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11872,6 +11872,8 @@ self: super: with self; {
 
   peakrdl = callPackage ../development/python-modules/peakrdl { };
 
+  peakrdl-ipxact = callPackage ../development/python-modules/peakrdl-ipxact { };
+
   peakrdl-regblock = callPackage ../development/python-modules/peakrdl-regblock { };
 
   peakutils = callPackage ../development/python-modules/peakutils { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11872,6 +11872,8 @@ self: super: with self; {
 
   peakrdl = callPackage ../development/python-modules/peakrdl { };
 
+  peakrdl-cheader = callPackage ../development/python-modules/peakrdl-cheader { };
+
   peakrdl-ipxact = callPackage ../development/python-modules/peakrdl-ipxact { };
 
   peakrdl-regblock = callPackage ../development/python-modules/peakrdl-regblock { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11870,6 +11870,8 @@ self: super: with self; {
 
   peacasso = callPackage ../development/python-modules/peacasso { };
 
+  peakrdl = callPackage ../development/python-modules/peakrdl { };
+
   peakutils = callPackage ../development/python-modules/peakutils { };
 
   peaqevcore = callPackage ../development/python-modules/peaqevcore { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18341,6 +18341,8 @@ self: super: with self; {
 
   systemdunitparser = callPackage ../development/python-modules/systemdunitparser { };
 
+  systemrdl-compiler = callPackage ../development/python-modules/systemrdl-compiler { };
+
   sysv-ipc = callPackage ../development/python-modules/sysv-ipc { };
 
   t61codec = callPackage ../development/python-modules/t61codec { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This adds a few different peakrdl utilities for working with systemrdl definitions. Usage looks like the following:

```nix
python3.withPackages (
  p: with p; [
    peakrdl
    # add optional plugins
    peakrdl-cheader
    peakrdl-ipxact
    peakrdl-regblock
    peakrdl-rust
  ]
)
```

```console
$ ./result/bin/peakrdl --help
usage: peakrdl [-h] [--version] [--plugins] [-f FILE] [--peakrdl-cfg CFG] <subcommand> ...

PeakRDL is a control & status register model automation toolchain.

For help about a specific subcommand, try:
    peakrdl <command> --help

For more documentation, visit https://peakrdl.readthedocs.io

options:
  -h, --help         show this help message and exit
  --version          show program's version number and exit
  --plugins          Report the PeakRDL plugins, their versions, then exit
  -f FILE            Specify a file containing more command line arguments
  --peakrdl-cfg CFG  Specify a PeakRDL configuration TOML file

subcommands:
    dump             print register model contents to stdout
    globals          list all globally accessible types that can be elaborated as top
    preprocess       Preprocess SystemRDL and write the result to a file
    c-header         Generate a C header definition of an address space
    ip-xact          Export the register model to IP-XACT
    regblock         Generate a SystemVerilog control/status register (CSR) block
    rust             Generate a Rust crate for accessing SystemRDL registers
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
