### PR TITLE
mathics3: init at 9.0.0

### DIFF
--- a/pkgs/by-name/ma/mathics3/package.nix
+++ b/pkgs/by-name/ma/mathics3/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  python3Packages,
+  fetchPypi,
+  fetchpatch2,
+  versionCheckHook,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "mathics3";
+  version = "9.0.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-i0nBVrAS3YrJ67CJYyCKfeNlHNHrBI7GCk4fm+WG5wM=";
+  };
+
+  build-system = with python3Packages; [
+    cython
+    mathics-scanner
+    packaging
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    mathics-scanner
+    mpmath
+    numpy
+    palettable
+    pillow
+    pint
+    pympler
+    python-dateutil
+    requests
+    scipy
+    setuptools
+    stopit
+    sympy
+  ];
+
+  optional-dependencies = with python3Packages; {
+    cython = [ cython ];
+
+    dev = [
+      pexpect
+      pytest
+    ];
+
+    full = [
+      ipywidgets
+      llvmlite
+      lxml
+      psutil
+      pyocr
+      scikit-image
+      unidecode
+      wordcloud
+    ];
+  };
+
+  pythonImportsCheck = [ "mathics" ];
+
+  patches = [
+    # Remove mathics3 > 9.0.0
+    (fetchpatch2 {
+      url = "https://github.com/Mathics3/mathics-core/commit/dce5300c96beb97f72c41f4171af19788781a5cb.patch";
+      hash = "sha256-OTgYLZ7je1w91rjE9MAEI3S3z3CgaLFELFts8SNn2/w=";
+    })
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  meta = {
+    description = "General-purpose computer algebra system (CAS)";
+    longDescription = ''
+      Mathics3 is a free general-purpose computer algebra system
+      featuring Mathematica®-compatible syntax and functions.
+    '';
+    homepage = "https://mathics.org";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "mathics";
+  };
+}

--- a/pkgs/development/python-modules/mathics-scanner/default.nix
+++ b/pkgs/development/python-modules/mathics-scanner/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  fetchPypi,
+  buildPythonPackage,
+  click,
+  pyyaml,
+  setuptools,
+  chardet,
+  pytest,
+  ujson,
+}:
+
+buildPythonPackage rec {
+  pname = "mathics-scanner";
+  version = "2.0.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "mathics_scanner";
+    inherit version;
+    hash = "sha256-BCSuCRgxNkCvUqe7rckYJMoYaesa0ODdh8eEwUEybZo=";
+  };
+
+  build-system = [
+    click
+    pyyaml
+    setuptools
+  ];
+
+  dependencies = [
+    chardet
+    click
+    pyyaml
+  ];
+
+  optional-dependencies = {
+    dev = [ pytest ];
+    full = [ ujson ];
+  };
+
+  pythonImportsCheck = [ "mathics_scanner" ];
+
+  meta = {
+    description = "Character Tables and Tokenizer for Mathics and the Wolfram Language";
+    homepage = "https://mathics.org";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "mathics-scanner";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9190,6 +9190,8 @@ self: super: with self; {
 
   materialyoucolor = callPackage ../development/python-modules/materialyoucolor { };
 
+  mathics-scanner = callPackage ../development/python-modules/mathics-scanner { };
+
   mathutils = callPackage ../development/python-modules/mathutils { };
 
   matplotlib = callPackage ../development/python-modules/matplotlib {


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
