### PR TITLE
tonelib-gfx: 4.8.7 -> 4.9.0

### DIFF
--- a/pkgs/by-name/to/tonelib-gfx/package.nix
+++ b/pkgs/by-name/to/tonelib-gfx/package.nix
@@ -8,6 +8,7 @@
   freetype,
   libglvnd,
   curl,
+  fontconfig,
   libxcursor,
   libxinerama,
   libxrandr,
@@ -17,21 +18,21 @@
 
 stdenv.mkDerivation rec {
   pname = "tonelib-gfx";
-  version = "4.8.7";
+  version = "4.9.0";
 
   # It's hard to find out when a release happens and what version that release is,
   #  without visiting the site directly.
   #
   # The following command can retrieve the latest released version.
   # curl --silent https://tonelib.net/downloads.html | \
-  #     grep -P 'ToneLib GFX</h3' -A3 | \
+  #     grep -P '>ToneLib GFX<' -A3 | \
   #     sed -nE 's/^.*Version: ([0-9.]+).*/\1/p'
   #
   # The following command gives us the URL for the latest release without intermediate redirects.
   # curl --head 'https://www.tonelib.net/download.php?id=gfx&os=lnx'
   src = fetchurl {
-    url = "https://tonelib.vip/download/24-10-24/ToneLib-GFX-amd64.deb";
-    hash = "sha256-2ao6tTRbPMpE2Y/7/gwQN3G5Z6Uu+SQel9o1ejwD9v4=";
+    url = "https://tonelib.vip/download/25-11-10/ToneLib-GFX-amd64.deb";
+    hash = "sha256-WL9kV50R5AGG57I5IkNz7EKd4NPlf0iO+QiE8k+E26Q=";
   };
 
   nativeBuildInputs = [
@@ -49,6 +50,7 @@ stdenv.mkDerivation rec {
 
   runtimeDependencies = map lib.getLib [
     curl
+    fontconfig
     libxcursor
     libxinerama
     libxrandr


### PR DESCRIPTION
Bump version to `4.9.0`

Build now requires `libfontconfig`

Also correcting the curl command in the comment example for retrieving the latest version information.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
