### PR TITLE
treewide: use pname and version

### DIFF
--- a/pkgs/applications/misc/redshift/default.nix
+++ b/pkgs/applications/misc/redshift/default.nix
@@ -174,7 +174,6 @@ rec {
     };
 
     meta = redshift.meta // {
-      name = "${pname}-${version}";
       longDescription = "Gammastep" + lib.removePrefix "Redshift" redshift.meta.longDescription;
       homepage = "https://gitlab.com/chinstrap/gammastep";
       mainProgram = "gammastep";

--- a/pkgs/by-name/ca/cables/package.nix
+++ b/pkgs/by-name/ca/cables/package.nix
@@ -8,7 +8,6 @@
 let
   pname = "cables";
   version = "0.8.0";
-  name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://github.com/cables-gl/cables_electron/releases/download/v${version}/cables-${version}-linux-x64.AppImage";
@@ -18,7 +17,7 @@ let
   appimageContents = appimageTools.extract {
     inherit pname version src;
     postExtract = ''
-      substituteInPlace $out/${pname}-${version}.desktop --replace 'Exec=AppRun' 'Exec=cables'
+      substituteInPlace $out/cables-${version}.desktop --replace 'Exec=AppRun' 'Exec=cables'
     '';
   };
 
@@ -27,8 +26,8 @@ appimageTools.wrapType2 {
   inherit pname version src;
 
   extraInstallCommands = ''
-    install -m 444 -D ${appimageContents}/${name}.desktop $out/share/applications/cables.desktop
-    install -m 444 -D ${appimageContents}/${name}.png $out/share/icons/hicolor/512x512/apps/cables.png
+    install -m 444 -D ${appimageContents}/cables-${version}.desktop $out/share/applications/cables.desktop
+    install -m 444 -D ${appimageContents}/cables-${version}.png $out/share/icons/hicolor/512x512/apps/cables.png
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/ca/capacities/package.nix
+++ b/pkgs/by-name/ca/capacities/package.nix
@@ -8,7 +8,6 @@
 let
   pname = "capacities";
   version = "1.52.6";
-  name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://web.archive.org/web/20250519011655/https://capacities-desktop-app.fra1.cdn.digitaloceanspaces.com/capacities-${version}.AppImage";

--- a/pkgs/by-name/cl/clutter-gtk/package.nix
+++ b/pkgs/by-name/cl/clutter-gtk/package.nix
@@ -12,15 +12,14 @@
 }:
 
 let
-  pname = "clutter-gtk";
   version = "1.8.4";
 in
-
 stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
+  pname = "clutter-gtk";
+  inherit version;
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${name}.tar.xz";
+    url = "mirror://gnome/sources/clutter-gtk/${lib.versions.majorMinor version}/clutter-gtk-${version}.tar.xz";
     sha256 = "01ibniy4ich0fgpam53q252idm7f4fn5xg5qvizcfww90gn9652j";
   };
 

--- a/pkgs/by-name/cl/clutter/package.nix
+++ b/pkgs/by-name/cl/clutter/package.nix
@@ -25,14 +25,14 @@
 }:
 
 let
-  pname = "clutter";
   version = "1.26.4";
 in
-stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
+stdenv.mkDerivation {
+  pname = "clutter";
+  inherit version;
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${name}.tar.xz";
+    url = "mirror://gnome/sources/clutter/${lib.versions.majorMinor version}/clutter-${version}.tar.xz";
     sha256 = "1rn4cd1an6a9dfda884aqpcwcgq8dgydpqvb19nmagw4b70zlj4b";
   };
 
@@ -85,7 +85,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = gnome.updateScript {
-      packageName = pname;
+      packageName = "clutter";
       versionPolicy = "odd-unstable";
     };
   };

--- a/pkgs/by-name/ed/edukai/package.nix
+++ b/pkgs/by-name/ed/edukai/package.nix
@@ -9,7 +9,6 @@ stdenvNoCC.mkDerivation rec {
   version = "5.0";
 
   src = fetchzip {
-    name = "${pname}-${version}";
     url = "https://language.moe.gov.tw/001/Upload/Files/site_content/M0001/edukai-${version}.zip";
     sha256 = "sha256-3+w9n6GJQg9+HfHYukC7tlm4GVs8vEOO23hrLw6qjTY=";
   };

--- a/pkgs/by-name/ed/eduli/package.nix
+++ b/pkgs/by-name/ed/eduli/package.nix
@@ -4,12 +4,11 @@
   fetchzip,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation {
   pname = "eduli";
   version = "3.0";
 
   src = fetchzip {
-    name = "${pname}-${version}";
     url = "https://language.moe.gov.tw/001/Upload/Files/site_content/M0001/MoeLI-3.0.zip";
     hash = "sha256-bDQtLugYPWwJJNusBLEJrgIVufocRK4NIR0CCGaTkyw=";
   };

--- a/pkgs/by-name/fi/fira/package.nix
+++ b/pkgs/by-name/fi/fira/package.nix
@@ -5,10 +5,9 @@
   fira-sans,
 }:
 
-symlinkJoin rec {
+symlinkJoin {
   pname = "fira";
   inherit (fira-sans) version;
-  name = "${pname}-${version}";
 
   paths = [
     fira-mono

--- a/pkgs/by-name/ho/hol/package.nix
+++ b/pkgs/by-name/ho/hol/package.nix
@@ -26,7 +26,7 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "${pname}-${version}";
+  inherit pname version;
 
   src = fetchurl {
     url = "mirror://sourceforge/hol/hol/${longVersion}/${holsubdir}.tar.gz";

--- a/pkgs/by-name/jn/jnr-posix/package.nix
+++ b/pkgs/by-name/jn/jnr-posix/package.nix
@@ -18,8 +18,8 @@ let
   };
 
   deps = stdenv.mkDerivation {
-    name = "${pname}-${version}-deps";
-    inherit src;
+    pname = "deps-${pname}";
+    inherit src version;
 
     nativeBuildInputs = [
       jdk

--- a/pkgs/by-name/me/meslo-lg/package.nix
+++ b/pkgs/by-name/me/meslo-lg/package.nix
@@ -4,23 +4,22 @@
   fetchurl,
   unzip,
 }:
-
-stdenv.mkDerivation rec {
-  version = "1.2.1";
-
+let
   pname = "meslo-lg";
+  version = "1.2.1";
 
   meslo-lg = fetchurl {
     url = "https://raw.githubusercontent.com/andreberg/Meslo-Font/09a431d546d211130352c28eb0466e5d7d5aeaf0/dist/v${version}/Meslo%20LG%20v${version}.zip";
-    name = "${pname}-${version}";
     sha256 = "1l08mxlzaz3i5bamnfr49s2k4k23vdm64b8nz2ha33ysimkbgg6h";
   };
 
   meslo-lg-dz = fetchurl {
     url = "https://raw.githubusercontent.com/andreberg/Meslo-Font/09a431d546d211130352c28eb0466e5d7d5aeaf0/dist/v${version}/Meslo%20LG%20DZ%20v${version}.zip";
-    name = "${pname}-${version}-dz";
     sha256 = "0lnbkrvcpgz9chnvix79j6fiz36wj6n46brb7b1746182rl1l875";
   };
+in
+stdenv.mkDerivation {
+  inherit pname version;
 
   nativeBuildInputs = [ unzip ];
 

--- a/pkgs/by-name/mo/monosat/package.nix
+++ b/pkgs/by-name/mo/monosat/package.nix
@@ -45,8 +45,12 @@ let
   '';
 
   core = stdenv.mkDerivation {
-    name = "${pname}-${version}";
-    inherit src patches;
+    inherit
+      pname
+      version
+      src
+      patches
+      ;
     postPatch = commonPostPatch + ''
       substituteInPlace CMakeLists.txt \
         --replace-fail "cmake_minimum_required(VERSION 3.02)" "cmake_minimum_required(VERSION 3.10)"

--- a/pkgs/by-name/ms/msr/package.nix
+++ b/pkgs/by-name/ms/msr/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   version = "20060208";
 
   src = fetchzip {
-    name = "${pname}-${version}";
+    inherit pname version;
     url = "http://www.etallen.com/msr/${pname}-${version}.src.tar.gz";
     hash = "sha256-e01qYWbOALkXp5NpexuVodMxA3EBySejJ6ZBpZjyT+E=";
   };

--- a/pkgs/by-name/na/nailgun/package.nix
+++ b/pkgs/by-name/na/nailgun/package.nix
@@ -69,7 +69,6 @@ symlinkJoin rec {
   pname = "nailgun";
   inherit client server version;
 
-  name = "${pname}-${version}";
   paths = [
     client
     server

--- a/pkgs/by-name/ni/niff/package.nix
+++ b/pkgs/by-name/ni/niff/package.nix
@@ -6,11 +6,11 @@
 }:
 
 let
-  pname = "niff";
   version = "0.1";
 in
 stdenv.mkDerivation {
-  name = "${pname}-${version}";
+  pname = "niff";
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "FRidh";

--- a/pkgs/by-name/pu/pulseaudio-ctl/package.nix
+++ b/pkgs/by-name/pu/pulseaudio-ctl/package.nix
@@ -21,11 +21,10 @@ let
     pulseaudio
   ];
   pname = "pulseaudio-ctl";
-
-in
-stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
   version = "1.70";
+in
+stdenv.mkDerivation {
+  inherit pname version;
 
   src = fetchFromGitHub {
     owner = "graysky2";

--- a/pkgs/by-name/qu/quivira/package.nix
+++ b/pkgs/by-name/qu/quivira/package.nix
@@ -4,7 +4,7 @@ let
   version = "4.1";
 in
 fetchurl {
-  name = "${pname}-${version}";
+  inherit pname version;
   url = "http://www.quivira-font.com/files/Quivira.otf";
 
   # Download the source file to a temporary directory so that $out can be a

--- a/pkgs/by-name/ra/ratman/package.nix
+++ b/pkgs/by-name/ra/ratman/package.nix
@@ -46,7 +46,8 @@ rustPlatform.buildRustPackage rec {
     sourceRoot = "${src.name}/ratman/dashboard";
 
     npmDeps = fetchNpmDeps {
-      name = "${pname}-${version}-npm-deps";
+      pname = "npm-deps-${pname}";
+      inherit version;
       src = "${src}/ratman/dashboard";
       hash = "sha256-47L4V/Vf8DK3q63MYw3x22+rzIN3UPD0N/REmXh5h3w=";
     };

--- a/pkgs/by-name/sc/scummvm/games.nix
+++ b/pkgs/by-name/sc/scummvm/games.nix
@@ -61,7 +61,7 @@ let
     in
     stdenv.mkDerivation (
       {
-        name = "${pname}-${version}";
+        inherit pname version;
 
         nativeBuildInputs = [ unzip ];
 

--- a/pkgs/by-name/sw/sway/package.nix
+++ b/pkgs/by-name/sw/sway/package.nix
@@ -46,10 +46,9 @@ let
     fi
   '';
 in
-symlinkJoin rec {
+symlinkJoin {
   pname = replaceStrings [ "-unwrapped" ] [ "" ] sway.pname;
   inherit (sway) version;
-  name = "${pname}-${version}";
 
   paths = (optional withBaseWrapper baseWrapper) ++ [ sway ];
 

--- a/pkgs/by-name/ta/talkfilters/package.nix
+++ b/pkgs/by-name/ta/talkfilters/package.nix
@@ -10,7 +10,7 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "${pname}-${version}";
+  inherit pname version;
 
   src = fetchurl {
     url = "http://www.hyperrealm.com/${pname}/${pname}-${version}.tar.gz";

--- a/pkgs/by-name/va/vagrant/package.nix
+++ b/pkgs/by-name/va/vagrant/package.nix
@@ -27,7 +27,6 @@ let
   ruby = ruby_3_4;
 
   deps = bundlerEnv rec {
-    name = "${pname}-${version}";
     pname = "vagrant";
     inherit version;
 

--- a/pkgs/development/compilers/corretto/mk-corretto.nix
+++ b/pkgs/development/compilers/corretto/mk-corretto.nix
@@ -28,7 +28,6 @@ in
 jdk.overrideAttrs (
   finalAttrs: oldAttrs: {
     inherit pname version src;
-    name = "${pname}-${version}";
 
     nativeBuildInputs = oldAttrs.nativeBuildInputs ++ [
       jdk

--- a/pkgs/development/compilers/mozart/default.nix
+++ b/pkgs/development/compilers/mozart/default.nix
@@ -16,23 +16,22 @@
 
 let
   stdenv = llvmPackages.stdenv;
-
-in
-stdenv.mkDerivation rec {
   pname = "mozart2";
   version = "2.0.1";
-  name = "${pname}-${version}";
-
-  src = fetchurl {
-    url = "https://github.com/mozart/mozart2/releases/download/v${version}/${name}-Source.zip";
-    sha256 = "1mad9z5yzzix87cdb05lmif3960vngh180s2mb66cj5gwh5h9dll";
-  };
 
   # This is a workaround to avoid using sbt.
   # I guess it is acceptable to fetch the bootstrapping compiler in binary form.
   bootcompiler = fetchurl {
     url = "https://github.com/layus/mozart2/releases/download/v2.0.0-beta.1/bootcompiler.jar";
     sha256 = "1hgh1a8hgzgr6781as4c4rc52m2wbazdlw3646s57c719g5xphjz";
+  };
+in
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchurl {
+    url = "https://github.com/mozart/mozart2/releases/download/v${version}/${pname}-${version}-Source.zip";
+    sha256 = "1mad9z5yzzix87cdb05lmif3960vngh180s2mb66cj5gwh5h9dll";
   };
 
   patches = [

--- a/pkgs/development/python-modules/fast-query-parsers/default.nix
+++ b/pkgs/development/python-modules/fast-query-parsers/default.nix
@@ -22,8 +22,7 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-kp5bCmHYMS/e8eM6HrRw0JlVaxwPscFGDLQ0PX4ZIC4=";
   };
 

--- a/pkgs/development/python-modules/hypothesis/default.nix
+++ b/pkgs/development/python-modules/hypothesis/default.nix
@@ -147,8 +147,8 @@ buildPythonPackage rec {
       # Forge look and feel of multi-output derivation as best as we can.
       #
       # Using 'outputs = [ "doc" ];' breaks a lot of assumptions.
-      name = "${pname}-${version}-doc";
-      inherit src pname version;
+      pname = "${pname}-doc";
+      inherit src version;
 
       postInstallSphinx = ''
         mv $out/share/doc/* $out/share/doc/python$pythonVersion-$pname-$version

--- a/pkgs/development/python-modules/jinja2/default.nix
+++ b/pkgs/development/python-modules/jinja2/default.nix
@@ -58,8 +58,8 @@ buildPythonPackage rec {
     # Forge look and feel of multi-output derivation as best as we can.
     #
     # Using 'outputs = [ "doc" ];' breaks a lot of assumptions.
-    name = "${pname}-${version}-doc";
-    inherit src pname version;
+    pname = "${pname}-doc";
+    inherit src version;
 
     patches = [
       # Fix import of "sphinxcontrib-log-cabinet"

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -211,7 +211,8 @@ let
   ]);
 
   rules_cc_darwin_patched = stdenv.mkDerivation {
-    name = "rules_cc-${pname}-${version}";
+    pname = "rules_cc-${pname}";
+    inherit version;
 
     src = _bazel-build.deps;
 
@@ -245,7 +246,8 @@ let
     '';
   };
   llvm-raw_darwin_patched = stdenv.mkDerivation {
-    name = "llvm-raw-${pname}-${version}";
+    pname = "llvm-raw-${pname}";
+    inherit version;
 
     src = _bazel-build.deps;
 
@@ -285,7 +287,7 @@ let
       _bazel-build;
 
   _bazel-build = buildBazelPackage.override { inherit stdenv; } {
-    name = "${pname}-${version}";
+    inherit pname version;
     #bazel = bazel_5;
     bazel = bazel;
 

--- a/pkgs/development/python-modules/vl-convert-python/default.nix
+++ b/pkgs/development/python-modules/vl-convert-python/default.nix
@@ -24,8 +24,7 @@ buildPythonPackage rec {
   patches = [ ./libffi-sys-system-feature.patch ];
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-oPUpX7aMZBSsVujcXkIBNL8pk2JJ0RyBCwoVsuARkkQ=";
   };
 

--- a/pkgs/development/tools/ocaml/cppo/default.nix
+++ b/pkgs/development/tools/ocaml/cppo/default.nix
@@ -49,8 +49,7 @@ else
   in
 
   stdenv.mkDerivation {
-
-    name = "${pname}-${version}";
+    inherit pname version;
 
     src = fetchFromGitHub {
       owner = "mjambon";

--- a/pkgs/os-specific/bsd/netbsd/pkgs/libc.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/libc.nix
@@ -13,8 +13,7 @@
   version,
 }:
 
-symlinkJoin rec {
-  name = "${pname}-${version}";
+symlinkJoin {
   pname = "libc-netbsd";
   inherit version;
 

--- a/pkgs/os-specific/bsd/openbsd/pkgs/libc.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/libc.nix
@@ -13,8 +13,7 @@
   version,
 }:
 
-symlinkJoin rec {
-  name = "${pname}-${version}";
+symlinkJoin {
   pname = "libc-openbsd";
   inherit version;
 

--- a/pkgs/os-specific/linux/acpi-call/default.nix
+++ b/pkgs/os-specific/linux/acpi-call/default.nix
@@ -5,11 +5,13 @@
   kernel,
   kernelModuleMakeFlags,
 }:
-
-stdenv.mkDerivation rec {
+let
   pname = "acpi-call";
   version = "1.2.2";
-  name = "${pname}-${version}-${kernel.version}";
+in
+stdenv.mkDerivation {
+  inherit pname;
+  version = "${version}-${kernel.version}";
 
   src = fetchFromGitHub {
     owner = "nix-community";

--- a/pkgs/tools/misc/html-proofer/default.nix
+++ b/pkgs/tools/misc/html-proofer/default.nix
@@ -6,7 +6,6 @@
 }:
 
 bundlerEnv rec {
-  name = "${pname}-${version}";
   pname = "html-proofer";
   version = (import ./gemset.nix).html-proofer.version;
 


### PR DESCRIPTION
part of #103997

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
