### PR TITLE
opensupaplex: modernize, darwin support

### DIFF
--- a/pkgs/by-name/op/opensupaplex/darwin.patch
+++ b/pkgs/by-name/op/opensupaplex/darwin.patch
@@ -1,0 +1,16 @@
+diff --git a/src/sdl_common/audio.c b/src/sdl_common/audio.c
+index 797c678..ebb9eda 100644
+--- a/src/sdl_common/audio.c
++++ b/src/sdl_common/audio.c
+@@ -25,11 +25,7 @@
+ 
+ #if HAVE_SDL2
+ #include <SDL2/SDL.h>
+-#if TARGET_OS_MAC
+-#include <SDL2_mixer/SDL_mixer.h>
+-#else
+ #include <SDL2/SDL_mixer.h>
+-#endif
+ #elif HAVE_SDL
+ #include <SDL/SDL.h>
+ #include <SDL/SDL_mixer.h>

--- a/pkgs/by-name/op/opensupaplex/package.nix
+++ b/pkgs/by-name/op/opensupaplex/package.nix
@@ -18,15 +18,15 @@ let
     sha256 = "sha256-nKeSBUGjSulbEP7xxc6smsfCRjyc/xsLykH0o3Rq5wo=";
   };
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "opensupaplex";
   version = "7.1.2";
 
   src = fetchFromGitHub {
     owner = "sergiou87";
     repo = "open-supaplex";
-    rev = "v${version}";
-    sha256 = "sha256-hP8dJlLXE5J/oxPhRkrrBl1Y5e9MYbJKi8OApFM3+GU=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-hP8dJlLXE5J/oxPhRkrrBl1Y5e9MYbJKi8OApFM3+GU=";
   };
 
   nativeBuildInputs = [
@@ -66,18 +66,17 @@ stdenv.mkDerivation rec {
   passthru.tests.version = testers.testVersion {
     package = opensupaplex;
     command = "opensupaplex --help";
-    version = "v${version}";
+    version = "v${finalAttrs.version}";
   };
 
   desktopItems = [
     (makeDesktopItem {
       name = "opensupaplex";
-      exec = meta.mainProgram;
+      exec = finalAttrs.meta.mainProgram;
       icon = "open-supaplex";
       desktopName = "OpenSupaplex";
-      comment = meta.description;
+      comment = finalAttrs.meta.description;
       categories = [
-        "Application"
         "Game"
       ];
     })
@@ -86,10 +85,10 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Decompilation of Supaplex in C and SDL";
     homepage = "https://github.com/sergiou87/open-supaplex";
-    changelog = "https://github.com/sergiou87/open-supaplex/blob/master/changelog/v${version}.txt";
+    changelog = "https://github.com/sergiou87/open-supaplex/blob/master/changelog/v${finalAttrs.version}.txt";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ matteopacini ];
     platforms = lib.platforms.linux; # Many more are supported upstream, but only linux is tested.
     mainProgram = "opensupaplex";
   };
-}
+})

--- a/pkgs/by-name/op/opensupaplex/package.nix
+++ b/pkgs/by-name/op/opensupaplex/package.nix
@@ -9,6 +9,7 @@
   opensupaplex,
   SDL2,
   SDL2_mixer,
+  desktopToDarwinBundle,
 }:
 
 let
@@ -29,10 +30,19 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-hP8dJlLXE5J/oxPhRkrrBl1Y5e9MYbJKi8OApFM3+GU=";
   };
 
+  patches = [
+    ./reproducible-build.patch
+    ./darwin.patch
+  ];
+
   nativeBuildInputs = [
     SDL2 # For "sdl2-config"
     copyDesktopItems
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    desktopToDarwinBundle
   ];
+
   buildInputs = [ SDL2_mixer ];
 
   enableParallelBuilding = true;
@@ -82,13 +92,16 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
+  # Strip only the main binary, not the data files which would corrupt them.
+  stripExclude = [ "lib/opensupaplex/*" ];
+
   meta = {
     description = "Decompilation of Supaplex in C and SDL";
     homepage = "https://github.com/sergiou87/open-supaplex";
     changelog = "https://github.com/sergiou87/open-supaplex/blob/master/changelog/v${finalAttrs.version}.txt";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ matteopacini ];
-    platforms = lib.platforms.linux; # Many more are supported upstream, but only linux is tested.
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
     mainProgram = "opensupaplex";
   };
 })

--- a/pkgs/by-name/op/opensupaplex/reproducible-build.patch
+++ b/pkgs/by-name/op/opensupaplex/reproducible-build.patch
@@ -1,0 +1,17 @@
+diff --git a/linux/Makefile b/linux/Makefile
+index 6041a89..588341c 100644
+--- a/linux/Makefile
++++ b/linux/Makefile
+@@ -5,6 +5,12 @@ LDFLAGS += -lSDL2_mixer -lvorbis -logg `sdl2-config --libs` -lm
+ 
+ CFLAGS += `sdl2-config --cflags` -DHAVE_SDL2
+ 
++UNAME_S := $(shell uname -s)
++ifeq ($(UNAME_S),Darwin)
++# Darwin-specific reproducible build flags
++LDFLAGS += -Wl,-no_uuid
++endif
++
+ opensupaplex: $(obj)
+ 	$(CC) -o $@ $^ $(LDFLAGS)
+ 


### PR DESCRIPTION

<img width="1392" height="940" alt="Screenshot 2025-11-10 at 23 47 33" src="https://github.com/user-attachments/assets/6f4f4309-3faa-4633-b29a-46e2c08aa7f5" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
