### PR TITLE
meshcentral: cleanup

### DIFF
--- a/pkgs/tools/admin/meshcentral/default.nix
+++ b/pkgs/tools/admin/meshcentral/default.nix
@@ -1,55 +1,63 @@
 {
   lib,
   fetchzip,
+  stdenv,
   fetchYarnDeps,
-  yarn2nix-moretea,
   nodejs_20,
   dos2unix,
+  yarnConfigHook,
+  yarnInstallHook,
 }:
 
-yarn2nix-moretea.mkYarnPackage {
+stdenv.mkDerivation (finalAttrs: {
+  pname = "meshcentral";
   version = "1.1.54";
 
   src = fetchzip {
     url = "https://registry.npmjs.org/meshcentral/-/meshcentral-1.1.54.tgz";
-    sha256 = "0p33bcf8n981mlkvds28y78cc7lsxpdlxcdbdqgk2ch6h04vyzcr";
+    hash = "sha256-mX2/CYAGMjEfbquxTtvtmh7G0PFI6LYnrQElixxbY1w=";
   };
+
+  # Tarball has CRLF line endings. This makes patching difficult, so let's convert them.
+  prePatch = ''
+    find . -name '*.js' -exec dos2unix {} +
+  '';
 
   patches = [
     ./fix-js-include-paths.patch
   ];
 
-  packageJSON = ./package.json;
-  yarnLock = ./yarn.lock;
+  postPatch = ''
+    cp ${./yarn.lock} ./yarn.lock
+    chmod u+w ./yarn.lock
+  '';
 
   offlineCache = fetchYarnDeps {
+    inherit (finalAttrs) postPatch;
     yarnLock = ./yarn.lock;
     hash = "sha256-t5lSKw6PX+mrQxYiglUsyWtqo0SGe3yYGFLA+bvCEPU=";
   };
 
-  # Tarball has CRLF line endings. This makes patching difficult, so let's convert them.
-  nativeBuildInputs = [ dos2unix ];
-  prePatch = ''
-    find . -name '*.js' -exec dos2unix {} +
-    ln -snf meshcentral.js bin/meshcentral
-  '';
+  nativeBuildInputs = [
+    dos2unix
+    yarnConfigHook
+    yarnInstallHook
+    nodejs_20
+  ];
 
   preFixup = ''
     mkdir -p $out/bin
-    chmod a+x $out/libexec/meshcentral/deps/meshcentral/meshcentral.js
-    sed -i '1i#!${nodejs_20}/bin/node' $out/libexec/meshcentral/deps/meshcentral/meshcentral.js
-    ln -s $out/libexec/meshcentral/deps/meshcentral/meshcentral.js $out/bin/meshcentral
+    chmod a+x $out/lib/node_modules/meshcentral/meshcentral.js
+    patchShebangs $out/lib/node_modules/meshcentral/meshcentral.js
   '';
-
-  publishBinsFor = [ ];
 
   passthru.updateScript = ./update.sh;
 
-  meta = with lib; {
+  meta = {
     description = "Computer management web app";
     homepage = "https://meshcentral.com/";
-    maintainers = with maintainers; [ ma27 ];
-    license = licenses.asl20;
+    maintainers = with lib.maintainers; [ ma27 ];
+    license = lib.licenses.asl20;
     mainProgram = "meshcentral";
   };
-}
+})

--- a/pkgs/tools/admin/meshcentral/update.sh
+++ b/pkgs/tools/admin/meshcentral/update.sh
@@ -38,7 +38,6 @@ awk <meshcentral.js "
 # yarn.lock/yarn.nix
 yarn install --ignore-scripts
 
-cp package.json "$expr_dir"
 cp yarn.lock "$expr_dir/yarn.lock"
 
 cd "$expr_dir/../../../.."


### PR DESCRIPTION
Removes usage of mkYarnPackage, the package.json file, and updates the updateScript to account for this.

Also just some simple modernization to go along with it.

Part of #324246


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
