### PR TITLE
timeshift: add man output

### DIFF
--- a/pkgs/applications/backup/timeshift/unwrapped.nix
+++ b/pkgs/applications/backup/timeshift/unwrapped.nix
@@ -19,6 +19,10 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "timeshift";
   version = "25.07.7";
+  outputs = [
+    "out"
+    "man"
+  ];
 
   src = fetchFromGitHub {
     owner = "linuxmint";

--- a/pkgs/applications/backup/timeshift/wrapper.nix
+++ b/pkgs/applications/backup/timeshift/wrapper.nix
@@ -10,7 +10,7 @@
 
 timeshift-unwrapped: runtimeDeps:
 stdenvNoCC.mkDerivation {
-  inherit (timeshift-unwrapped) pname version;
+  inherit (timeshift-unwrapped) pname version outputs;
 
   dontUnpack = true;
 
@@ -21,8 +21,12 @@ stdenvNoCC.mkDerivation {
 
   installPhase = ''
     runHook preInstall
-    mkdir -p "$out"
-    lndir "${timeshift-unwrapped}" "$out"
+  ''
+  + lib.concatMapStrings (outputName: ''
+    mkdir -p "''$${outputName}"
+    lndir -silent "${timeshift-unwrapped.${outputName}}" "''$${outputName}"
+  '') timeshift-unwrapped.outputs
+  + ''
     runHook postInstall
   '';
 


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
