### PR TITLE
luaPackages.lua-resty-dns: init at 0.23

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23284,6 +23284,12 @@
     githubId = 5104601;
     name = "schnusch";
   };
+  schra = {
+    email = "andre.schroeder@andresco.de";
+    github = "schra";
+    githubId = 23171985;
+    name = "André Schröder";
+  };
   schrobingus = {
     email = "brent.monning.jr@gmail.com";
     name = "Brent Monning";

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -202,6 +202,30 @@ rec {
     }
   ) { };
 
+  lua-resty-dns = callPackage (
+    { fetchFromGitHub }:
+    buildLuaPackage rec {
+      pname = "lua-resty-dns";
+      version = "0.23";
+
+      src = fetchFromGitHub {
+        owner = "openresty";
+        repo = "lua-resty-dns";
+        rev = "v${version}";
+        sha256 = "sha256-VQOVMja74kjPjhtqIAVy8S5cxdkNwTL6bmXTr/RUE/A=";
+      };
+
+      propagatedBuildInputs = [ lua-resty-lrucache ];
+
+      meta = with lib; {
+        description = "DNS resolver for the nginx lua module";
+        homepage = "https://github.com/openresty/lua-resty-dns";
+        license = licenses.bsd3;
+        maintainers = with maintainers; [ schra ];
+      };
+    }
+  ) { };
+
   luv = callPackage ../development/lua-modules/luv { };
   libluv = callPackage ../development/lua-modules/luv/lib.nix { };
 


### PR DESCRIPTION
Tested it on my server and it works.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
