### PR TITLE
ubpm: 0.10.0 -> 0.13.0-unstable-2025-10-18, migrate to pkgs/by-name, migrate from `Qt5` to `Qt6`

### DIFF
--- a/pkgs/by-name/ub/ubpm/package.nix
+++ b/pkgs/by-name/ub/ubpm/package.nix
@@ -2,21 +2,22 @@
   stdenv,
   lib,
   fetchFromGitea,
-  libsForQt5,
+  qt6,
   udev,
   pkg-config,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ubpm";
-  version = "1.13.0";
+  version = "1.13.0-unstable-2025-10-18";
+  baseVersion = lib.head (lib.splitString "-" finalAttrs.version);
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "LazyT";
     repo = "ubpm";
-    rev = finalAttrs.version;
-    hash = "sha256-lS9SVWTk7Obr3g9YsqJcEL+4dxzTQ+Z98C3lFEsn3Tw=";
+    rev = "748ce8504185ae96dbdbd1cff5352d1eef2c046d";
+    hash = "sha256-WSweHj4+qgjqEsn0TNtmbVXjFJD84EWkdqK44/CsqgQ=";
     fetchSubmodules = true;
   };
 
@@ -27,26 +28,27 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   nativeBuildInputs = [
-    libsForQt5.qmake
-    libsForQt5.qttools
-    libsForQt5.wrapQtAppsHook
+    qt6.qmake
+    qt6.qttools
+    qt6.wrapQtAppsHook
     pkg-config
   ];
 
   # *.so plugins are being wrapped automatically which breaks them
   dontWrapQtApps = true;
-
+  
   buildInputs = [
-    libsForQt5.qtbase
-    libsForQt5.qtserialport
-    libsForQt5.qtconnectivity
-    libsForQt5.qtcharts
+    qt6.qtbase
+    qt6.qtserialport
+    qt6.qtconnectivity
+    qt6.qtcharts
+    qt6.qtsvg
     udev
   ];
 
   meta = {
     homepage = "https://codeberg.org/LazyT/ubpm";
-    changelog = "https://codeberg.org/LazyT/ubpm/releases/tag/${finalAttrs.version}";
+    changelog = "https://codeberg.org/LazyT/ubpm/releases/tag/${finalAttrs.baseVersion}";
     description = "Universal Blood Pressure Manager";
     mainProgram = "ubpm";
     license = lib.licenses.gpl3Only;

--- a/pkgs/by-name/ub/ubpm/package.nix
+++ b/pkgs/by-name/ub/ubpm/package.nix
@@ -23,6 +23,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/sources";
 
+  qmakeFlags = [
+    "DEFINES+=DISTRIBUTION"
+    "DEFINES+=UPDATE_HIDE"
+    "DEFINES+=UPDATE_DISABLE"
+  ];
+
   postFixup = ''
     wrapQtApp $out/bin/ubpm
   '';
@@ -36,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # *.so plugins are being wrapped automatically which breaks them
   dontWrapQtApps = true;
-  
+
   buildInputs = [
     qt6.qtbase
     qt6.qtserialport

--- a/pkgs/by-name/ub/ubpm/package.nix
+++ b/pkgs/by-name/ub/ubpm/package.nix
@@ -20,9 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
     fetchSubmodules = true;
   };
 
-  preConfigure = ''
-    cd ./sources/
-  '';
+  sourceRoot = "${finalAttrs.src.name}/sources";
 
   postFixup = ''
     wrapQtApp $out/bin/ubpm
@@ -48,6 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://codeberg.org/LazyT/ubpm";
+    changelog = "https://codeberg.org/LazyT/ubpm/releases/tag/${finalAttrs.version}";
     description = "Universal Blood Pressure Manager";
     mainProgram = "ubpm";
     license = lib.licenses.gpl3Only;

--- a/pkgs/by-name/ub/ubpm/package.nix
+++ b/pkgs/by-name/ub/ubpm/package.nix
@@ -2,13 +2,7 @@
   stdenv,
   lib,
   fetchFromGitea,
-  qmake,
-  qttools,
-  qtbase,
-  qtserialport,
-  qtconnectivity,
-  qtcharts,
-  wrapQtAppsHook,
+  libsForQt5,
   fetchpatch,
 }:
 
@@ -41,19 +35,19 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   nativeBuildInputs = [
-    qmake
-    qttools
-    wrapQtAppsHook
+    libsForQt5.qmake
+    libsForQt5.qttools
+    libsForQt5.wrapQtAppsHook
   ];
 
   # *.so plugins are being wrapped automatically which breaks them
   dontWrapQtApps = true;
 
   buildInputs = [
-    qtbase
-    qtserialport
-    qtconnectivity
-    qtcharts
+    libsForQt5.qtbase
+    libsForQt5.qtserialport
+    libsForQt5.qtconnectivity
+    libsForQt5.qtcharts
   ];
 
   meta = {

--- a/pkgs/by-name/ub/ubpm/package.nix
+++ b/pkgs/by-name/ub/ubpm/package.nix
@@ -3,28 +3,22 @@
   lib,
   fetchFromGitea,
   libsForQt5,
-  fetchpatch,
+  udev,
+  pkg-config,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ubpm";
-  version = "1.10.0";
+  version = "1.13.0";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "LazyT";
     repo = "ubpm";
     rev = finalAttrs.version;
-    hash = "sha256-BUUn1WyLT7nm4I+2SpO1ZtIf8isGDy8Za15SiO7sXL8=";
+    hash = "sha256-lS9SVWTk7Obr3g9YsqJcEL+4dxzTQ+Z98C3lFEsn3Tw=";
+    fetchSubmodules = true;
   };
-
-  patches = [
-    # fixes qmake for nix
-    (fetchpatch {
-      url = "https://codeberg.org/LazyT/ubpm/commit/f18841d6473cab9aa2a9d4c02392b8e103245ef6.diff";
-      hash = "sha256-lgXWu8PUUCt66btj6hVgOFXz3U1BJM3ataSo1MpHkfU=";
-    })
-  ];
 
   preConfigure = ''
     cd ./sources/
@@ -38,6 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
     libsForQt5.qmake
     libsForQt5.qttools
     libsForQt5.wrapQtAppsHook
+    pkg-config
   ];
 
   # *.so plugins are being wrapped automatically which breaks them
@@ -48,6 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     libsForQt5.qtserialport
     libsForQt5.qtconnectivity
     libsForQt5.qtcharts
+    udev
   ];
 
   meta = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4008,8 +4008,6 @@ with pkgs;
     python3Packages.callPackage ../applications/misc/twitch-chat-downloader
       { };
 
-  ubpm = libsForQt5.callPackage ../applications/misc/ubpm { };
-
   uftraceFull = uftrace.override {
     withLuaJIT = true;
     withPython = true;


### PR DESCRIPTION
### Updates to `ubpm`

[Release notes for 0.13.0](https://codeberg.org/LazyT/ubpm/releases/tag/1.13.0)
[Diff from 0.10.0 to 0.13.0](https://codeberg.org/LazyT/ubpm/compare/1.10.0...1.13.0)

This PR introduces several improvements to the `ubpm` package:

- **Location migration:** Migrated the package from `pkgs/applications/misc/ubpm` to `pkgs/by-name/ub/ubpm`.
- **Version update:** Upgraded from 0.10.0 to 0.13.0-unstable-2025-10-18. The unstable commit is tracked because the main branch includes important fixes for `Qt 6.10`.
- **Qt upgrade:** Migrated from `Qt 5` to `Qt 6`.
- **Modernisation:** Added `meta.changelog` and applied other minor improvements to align with current packaging standards.
- **Build flags:** Enabled the following `qmakeFlags`: `DISTRIBUTION`, `UPDATE_HIDE`, and `UPDATE_DISABLE`. These flags help upstream distributors like `nixpkgs` indicate that the package is externally maintained and prevent the software from attempting self-updates.

Closes: https://github.com/NixOS/nixpkgs/issues/395961
Supersedes: https://github.com/NixOS/nixpkgs/pull/395973

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
