### PR TITLE
stremio-service: init at 0.1.15

### DIFF
--- a/pkgs/by-name/st/stremio-service/package.nix
+++ b/pkgs/by-name/st/stremio-service/package.nix
@@ -1,0 +1,168 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  fetchFromGitHub,
+  rustPlatform,
+
+  pkg-config,
+  makeBinaryWrapper,
+  desktop-file-utils,
+  librsvg,
+
+  openssl,
+  glib,
+  gtk3,
+
+  libayatana-appindicator,
+  jellyfin-ffmpeg, # stremio docs: "We use a specific version of ffmpeg-jellyfin"
+  nodejs,
+}:
+let
+  # if updating this package, make sure this matches
+  # the version specified in Cargo.toml's package.metadata.server
+  server = fetchurl rec {
+    pname = "stremio-server";
+    version = "4.20.16";
+    url = "https://dl.strem.io/server/v${version}/desktop/server.js";
+    hash = "sha256-iOiH8Fh2Xw49vGNoKedoergHWcOS65pk30V8j5/Ibig=";
+    meta.license = lib.licenses.unfree;
+  };
+  os = if stdenv.hostPlatform.isDarwin then "macos" else stdenv.hostPlatform.parsed.kernel.name;
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "stremio-service";
+  version = "0.1.15";
+
+  src = fetchFromGitHub {
+    owner = "Stremio";
+    repo = "stremio-service";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-PMrIei1LqhkZjUKBQJB+UuiCkTNcTjdWhbuRUtrY5wQ=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    makeBinaryWrapper
+    desktop-file-utils
+    librsvg
+  ];
+  buildInputs = [
+    openssl
+    gtk3.dev
+    glib
+  ];
+
+  cargoHash = "sha256-KaHVjC+Q7/5WSCWuXaopKhRypfo5Z/nt9Vmq6oHlEIw=";
+  buildFeatures = [
+    "offline-build"
+    "bundled"
+  ];
+
+  postPatch = ''
+    # fix desktop file path
+    substituteInPlace ./src/constants.rs \
+      --replace-fail "/usr/share/applications" "${placeholder "out"}/share/applications";
+  '';
+
+  preBuild = ''
+    # run pre-build checks
+    # check for server.js version mismatch
+    server_version=$(sed -n '/package.metadata.server/,$p' Cargo.toml | grep -m 1 'version =' | awk -F'"' '{print $2}');
+    if [ "$server_version" != "v${server.version}" ]; then
+      echo "Server version mismatch: expected $server_version, got v${server.version}"
+      exit 1
+    fi
+
+    # replace binary nodejs/ffmpeg with symlinks to the system versions
+    rm -rf ./resources/bin/${os}/{ffmpeg,ffprobe,stremio-runtime}
+    ln -s ${jellyfin-ffmpeg}/bin/ffmpeg ./resources/bin/${os}/ffmpeg
+    ln -s ${jellyfin-ffmpeg}/bin/ffprobe ./resources/bin/${os}/ffprobe
+    ln -s ${nodejs}/bin/node ./resources/bin/${os}/stremio-runtime
+
+    # create server.js symlink and server_version.txt
+    ln -s ${server} ./resources/bin/${os}/server.js
+    echo "v${server.version}" > ./resources/bin/${os}/server_version.txt
+  '';
+
+  dontCargoInstall = true;
+  installPhase =
+    let
+      cargoTarget = stdenv.hostPlatform.rust.cargoShortTarget;
+    in
+    ''
+      runHook preInstall
+
+      # install desktop/icon files
+      mkdir -p $out/share/{applications,metainfo}
+      install -Dm 644 \
+        ./resources/com.stremio.service.desktop \
+        $out/share/applications/com.stremio.service.desktop;
+      install -Dm 644 \
+        ./resources/com.stremio.service.metainfo.xml \
+        $out/share/metainfo/com.stremio.service.metainfo.xml;
+      install -Dm 644 \
+        ./resources/com.stremio.service.svg \
+        $out/share/icons/hicolor/scalable/apps/com.stremio.service.svg;
+
+      # render non-scalable icons
+      for size in 16 32 64 128 256; do
+        mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
+        rsvg-convert \
+          -w $size -h $size \
+          ./resources/com.stremio.service.svg \
+          -o $out/share/icons/hicolor/"$size"x"$size"/apps/com.stremio.service.png
+      done
+
+      # patch desktop file
+      desktop-file-edit \
+        --set-key="Exec" --set-value="stremio-service" \
+        --set-key="TryExec" --set-value="stremio-service" \
+        $out/share/applications/com.stremio.service.desktop
+
+      # install data directory (/share/stremio-service)
+      mkdir -p $out/{bin,share/stremio-service}
+      cp -r ./resources/bin/${os}/* $out/share/stremio-service
+      install -Dm 755 \
+        ./target/${cargoTarget}/release/stremio-service \
+        $out/share/stremio-service/stremio-service;
+      install -Dm 644 ./LICENSE.md $out/share/stremio-service/LICENSE.md;
+
+      # create /bin wrapper
+      makeBinaryWrapper \
+        $out/share/stremio-service/stremio-service \
+        $out/bin/stremio-service \
+        --add-flags "--skip-updater" \
+        --set NODE_ENV production \
+        --prefix LD_LIBRARY_PATH : "${
+          lib.makeLibraryPath [
+            libayatana-appindicator
+          ]
+        }";
+
+      runHook postInstall
+    '';
+
+  checkFlags = [
+    # failing
+    "--skip=copyright"
+  ];
+
+  passthru = {
+    inherit server;
+  };
+
+  meta = {
+    mainProgram = "stremio-service";
+    description = "Modern media center that gives you the freedom to watch everything you want (Service only)";
+    homepage = "https://www.stremio.com/";
+    license = with lib.licenses; [
+      gpl2Only
+      unfree # server.js is unfree
+    ];
+    maintainers = with lib.maintainers; [
+      griffi-gh
+    ];
+    platforms = with lib.platforms; linux ++ darwin;
+  };
+})


### PR DESCRIPTION
Based on the good work of 
https://github.com/NixOS/nixpkgs/pull/418703

I just updated (and will continue to update) versions, as he does not have time to work on the PR

Stremio Service: Required to use the Web and iOS Stremio apps and can be used by third-party apps to share cache between multiple devices.
Provides a transcoding/streaming server and a torrent client for Stremio apps without a full desktop Qt UI.

closes https://github.com/NixOS/nixpkgs/issues/238550

Closes https://github.com/NixOS/nixpkgs/pull/244595

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
