### PR TITLE
python3Packages.cx-freeze: 8.3.0 -> 8.5.0

### DIFF
--- a/pkgs/development/python-modules/cx-freeze/default.nix
+++ b/pkgs/development/python-modules/cx-freeze/default.nix
@@ -9,6 +9,7 @@
 
   # dependencies
   filelock,
+  freeze-core,
   packaging,
   tomli,
 
@@ -19,23 +20,30 @@
   dmgbuild,
 
   # tests
-  ensureNewerSourcesForZipFilesHook,
+  backports-zstd,
+  numpy,
+  pillow,
   pytest-mock,
   pytestCheckHook,
+  pytz,
+  scikit-image,
+  scikit-learn,
+  scipy,
+  tzdata,
   versionCheckHook,
   writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
   pname = "cx-freeze";
-  version = "8.3.0";
+  version = "8.5.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "marcelotduarte";
     repo = "cx_Freeze";
     tag = version;
-    hash = "sha256-PhUzHSn9IqUcb11D0kRT8zhmZ/KusTBDpAempiDN4Rc=";
+    hash = "sha256-wGsI1Z5bcpmxnJLvgorzWxosh5+xtDZsK1YWvt7tggc=";
   };
 
   patches = [
@@ -46,7 +54,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail "setuptools>=77.0.3,<=80.4.0" "setuptools>=77.0.3"
+      --replace-fail "setuptools>=78.1.1,<81" "setuptools>=78.1.1"
   '';
 
   build-system = [
@@ -60,8 +68,9 @@ buildPythonPackage rec {
   pythonRemoveDeps = [ "patchelf" ];
 
   dependencies = [
-    distutils
+    #distutils
     filelock
+    freeze-core
     packaging
     setuptools
   ]
@@ -84,21 +93,34 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
+    numpy
+    pillow
     pytest-mock
     pytestCheckHook
+    pytz
+    scikit-image
+    scikit-learn
+    scipy
+    tzdata
     writableTmpDirAsHomeHook
     versionCheckHook
+  ]
+  ++ lib.optionals (pythonOlder "3.14") [
+    backports-zstd
   ];
-  versionCheckProgram = "${placeholder "out"}/bin/cxfreeze";
-  versionCheckProgramArg = "--version";
 
   preCheck = ''
     rm -rf cx_Freeze
   '';
 
+  disabledTestPaths = [
+    "samples"
+  ];
+
   disabledTests = [
     # Require internet access
     "test_bdist_appimage_download_appimagetool"
+    "test_bdist_appimage_download_runtime"
     "test_bdist_appimage_target_name"
     "test_bdist_appimage_target_name_and_version"
     "test_bdist_appimage_target_name_and_version_none"

--- a/pkgs/development/python-modules/cx-freeze/fix-tests-relative-path.patch
+++ b/pkgs/development/python-modules/cx-freeze/fix-tests-relative-path.patch
@@ -1,15 +1,16 @@
 diff --git a/tests/conftest.py b/tests/conftest.py
-index 04400a17..1facf55d 100644
+index de76c5f3..841b83b7 100644
 --- a/tests/conftest.py
 +++ b/tests/conftest.py
-@@ -46,9 +46,7 @@ class TempPackage:
-         # environment
+@@ -80,9 +80,9 @@ class TempPackage:
+         self.python: Path = sysexe
          self.system_path: Path = Path(os.getcwd())
-         self.system_prefix: Path = Path(sys.prefix)
--        self.relative_site = Path(pytest.__file__).parent.parent.relative_to(
--            self.system_prefix
--        )
-+        self.relative_site = Path(pytest.__file__).resolve().parent.parent
+         self.system_prefix: Path = prefix
+-        self.relative_bin: str = sysexe.parent.relative_to(prefix).as_posix()
++        self.relative_bin: str = sysexe.resolve().parent
+         self.relative_site: str = (
+-            Path(pytest.__file__).parent.parent.relative_to(prefix).as_posix()
++            Path(pytest.__file__).resolve().parent.parent
+         )
  
          # make a temporary directory and set it as current
-         name = request.node.name

--- a/pkgs/development/python-modules/freeze-core/default.nix
+++ b/pkgs/development/python-modules/freeze-core/default.nix
@@ -1,0 +1,50 @@
+{
+  buildPythonPackage,
+  distutils,
+  fetchFromGitHub,
+  filelock,
+  lib,
+  pytestCheckHook,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "freeze-core";
+  version = "0.4.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "marcelotduarte";
+    repo = "freeze-core";
+    tag = version;
+    hash = "sha256-9uw47EwMl/I6/A76w0xrfexv9D0uKskow8zUmcdnnfE=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "setuptools>=78.1.1,<=80.9.0" "setuptools>=78.1.1"
+  '';
+
+  build-system = [
+    distutils
+    setuptools
+  ];
+
+  dependencies = [
+    filelock
+  ];
+
+  pythonImportsCheck = [ "freeze_core" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = {
+    changelog = "https://github.com/marcelotduarte/freeze-core/releases/tag/${src.tag}";
+    description = "Core dependency for cx_Freeze";
+    homepage = "https://github.com/marcelotduarte/freeze-core";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.dotlambda ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5689,6 +5689,8 @@ self: super: with self; {
 
   freetype-py = callPackage ../development/python-modules/freetype-py { };
 
+  freeze-core = callPackage ../development/python-modules/freeze-core { };
+
   freezegun = callPackage ../development/python-modules/freezegun { };
 
   frelatage = callPackage ../development/python-modules/frelatage { };


### PR DESCRIPTION
Diff: https://github.com/marcelotduarte/cx_Freeze/compare/8.3.0...8.5.0

Changelog:
https://github.com/marcelotduarte/cx_Freeze/releases/tag/8.4.0
https://github.com/marcelotduarte/cx_Freeze/releases/tag/8.4.1
https://github.com/marcelotduarte/cx_Freeze/releases/tag/8.5.0

fixes https://github.com/NixOS/nixpkgs/issues/459800
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
