### PR TITLE
bibata-cursors-translucent: fix build

### DIFF
--- a/pkgs/data/icons/bibata-cursors/0001-fix-broken-symlinks.patch
+++ b/pkgs/data/icons/bibata-cursors/0001-fix-broken-symlinks.patch
@@ -1,0 +1,80 @@
+diff --git a/Bibata_Ghost/cursors/diamond_cross b/Bibata_Ghost/cursors/diamond_cross
+deleted file mode 120000
+index f406d83..0000000
+--- a/Bibata_Ghost/cursors/diamond_cross
++++ /dev/null
+@@ -1 +0,0 @@
+-diamond_cross
+\ No newline at end of file
+diff --git a/Bibata_Ghost/cursors/draft_large b/Bibata_Ghost/cursors/draft_large
+index 1ab4059..490f177 120000
+--- a/Bibata_Ghost/cursors/draft_large
++++ b/Bibata_Ghost/cursors/draft_large
+@@ -1 +1 @@
+-daft
+\ No newline at end of file
++draft
+\ No newline at end of file
+diff --git a/Bibata_Ghost/cursors/ew-resize b/Bibata_Ghost/cursors/ew-resize
+index c5694de..572e2ca 120000
+--- a/Bibata_Ghost/cursors/ew-resize
++++ b/Bibata_Ghost/cursors/ew-resize
+@@ -1 +1 @@
+-side_hor
+\ No newline at end of file
++size-hor
+\ No newline at end of file
+diff --git a/Bibata_Spirit/cursors/diamond_cross b/Bibata_Spirit/cursors/diamond_cross
+deleted file mode 120000
+index f406d83..0000000
+--- a/Bibata_Spirit/cursors/diamond_cross
++++ /dev/null
+@@ -1 +0,0 @@
+-diamond_cross
+\ No newline at end of file
+diff --git a/Bibata_Spirit/cursors/draft_large b/Bibata_Spirit/cursors/draft_large
+index 1ab4059..490f177 120000
+--- a/Bibata_Spirit/cursors/draft_large
++++ b/Bibata_Spirit/cursors/draft_large
+@@ -1 +1 @@
+-daft
+\ No newline at end of file
++draft
+\ No newline at end of file
+diff --git a/Bibata_Spirit/cursors/ew-resize b/Bibata_Spirit/cursors/ew-resize
+index c5694de..572e2ca 120000
+--- a/Bibata_Spirit/cursors/ew-resize
++++ b/Bibata_Spirit/cursors/ew-resize
+@@ -1 +1 @@
+-side_hor
+\ No newline at end of file
++size-hor
+\ No newline at end of file
+diff --git a/Bibata_Tinted/cursors/diamond_cross b/Bibata_Tinted/cursors/diamond_cross
+deleted file mode 120000
+index f406d83..0000000
+--- a/Bibata_Tinted/cursors/diamond_cross
++++ /dev/null
+@@ -1 +0,0 @@
+-diamond_cross
+\ No newline at end of file
+diff --git a/Bibata_Tinted/cursors/draft_large b/Bibata_Tinted/cursors/draft_large
+index 1ab4059..490f177 120000
+--- a/Bibata_Tinted/cursors/draft_large
++++ b/Bibata_Tinted/cursors/draft_large
+@@ -1 +1 @@
+-daft
+\ No newline at end of file
++draft
+\ No newline at end of file
+diff --git a/Bibata_Tinted/cursors/ew-resize b/Bibata_Tinted/cursors/ew-resize
+index c5694de..572e2ca 120000
+--- a/Bibata_Tinted/cursors/ew-resize
++++ b/Bibata_Tinted/cursors/ew-resize
+@@ -1 +1 @@
+-side_hor
+\ No newline at end of file
++size-hor
+\ No newline at end of file
+-- 
+2.50.1

--- a/pkgs/data/icons/bibata-cursors/translucent.nix
+++ b/pkgs/data/icons/bibata-cursors/translucent.nix
@@ -15,6 +15,10 @@ stdenvNoCC.mkDerivation rec {
     sha256 = "sha256-RroynJfdFpu+Wl9iw9NrAc9wNZsSxWI+heJXUTwEe7s=";
   };
 
+  patches = [
+    ./0001-fix-broken-symlinks.patch
+  ];
+
   installPhase = ''
     install -dm 0755 $out/share/icons
     cp -pr Bibata_* $out/share/icons/


### PR DESCRIPTION
### Fix Broken Build for `bibata-cursors-translucent`

- The build is broken due to dangling and reflexive symlinks.

- A PR is open upstream to fix this (https://github.com/silica-dev/Bibata_Cursor_Translucent/pull/11), but it has not been merged yet. Therefore, the patch has been vendored in this PR.

**Tracking:** https://github.com/NixOS/nixpkgs/issues/457852

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
