### PR TITLE
wild: make wrapped default, add wild-unwrapped

### DIFF
--- a/pkgs/by-name/wi/wild-unwrapped/adapterTest.nix
+++ b/pkgs/by-name/wi/wild-unwrapped/adapterTest.nix
@@ -7,7 +7,7 @@
   runCommandCC,
   makeBinaryWrapper,
   gcc,
-  wild,
+  wild-unwrapped,
   binutils-unwrapped-all-targets,
   clang,
   lld,
@@ -91,7 +91,7 @@ let
     '';
 in
 {
-  testWild = wild.overrideAttrs {
+  testWild = wild-unwrapped.overrideAttrs {
     pname = "wild-tests";
     doCheck = true;
     doInstallCheck = false;

--- a/pkgs/by-name/wi/wild-unwrapped/package.nix
+++ b/pkgs/by-name/wi/wild-unwrapped/package.nix
@@ -9,7 +9,7 @@
   nix-update-script,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
-  pname = "wild";
+  pname = "wild-unwrapped";
   version = "0.7.0";
 
   src = fetchFromGitHub {
@@ -42,7 +42,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   passthru = {
     updateScript = nix-update-script { };
 
-    tests = callPackage ./adapterTest.nix { wild = finalAttrs.finalPackage; };
+    tests = callPackage ./adapterTest.nix { wild-unwrapped = finalAttrs.finalPackage; };
   };
 
   meta = {

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -345,7 +345,7 @@ rec {
         cc = prev.cc.override {
           bintools = prev.cc.bintools.override {
             extraBuildCommands = ''
-              ln -fs ${pkgs.buildPackages.wild-wrapped}/bin/* "$out/bin"
+              ln -fs ${pkgs.buildPackages.wild}/bin/* "$out/bin"
             '';
           };
         };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6805,17 +6805,17 @@ with pkgs;
 
   vcpkg-tool-unwrapped = vcpkg-tool.override { doWrap = false; };
 
-  wild-wrapped =
+  wild =
     let
       ldWrapper = ../build-support/bintools-wrapper/ld-wrapper.sh;
     in
     wrapBintoolsWith {
-      bintools = wild;
+      bintools = wild-unwrapped;
       extraBuildCommands = ''
-        wrap wild ${ldWrapper} ${lib.getExe buildPackages.wild}
-        wrap ld.wild ${ldWrapper} ${lib.getExe buildPackages.wild}
-        wrap ${stdenv.cc.bintools.targetPrefix}ld.wild ${ldWrapper} ${lib.getExe buildPackages.wild}
-        wrap ${stdenv.cc.bintools.targetPrefix}ld ${ldWrapper} ${lib.getExe buildPackages.wild}
+        wrap wild ${ldWrapper} ${lib.getExe buildPackages.wild-unwrapped}
+        wrap ld.wild ${ldWrapper} ${lib.getExe buildPackages.wild-unwrapped}
+        wrap ${stdenv.cc.bintools.targetPrefix}ld.wild ${ldWrapper} ${lib.getExe buildPackages.wild-unwrapped}
+        wrap ${stdenv.cc.bintools.targetPrefix}ld ${ldWrapper} ${lib.getExe buildPackages.wild-unwrapped}
       '';
     };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
