### PR TITLE
immich: use finalAttrs.src for all immich derivations

### DIFF
--- a/nixos/modules/services/web-apps/immich.nix
+++ b/nixos/modules/services/web-apps/immich.nix
@@ -446,7 +446,7 @@ in
       wantedBy = [ "multi-user.target" ];
       inherit (cfg.machine-learning) environment;
       serviceConfig = commonServiceConfig // {
-        ExecStart = lib.getExe (cfg.package.machine-learning.override { immich = cfg.package; });
+        ExecStart = lib.getExe cfg.package.machine-learning;
         Slice = "system-immich.slice";
         CacheDirectory = "immich";
         User = cfg.user;


### PR DESCRIPTION
Using finalAttrs makes it much easier to override the source of immich. Without this change it required manually fetching the `npmDeps` and also overriding them in the immich package. Then, you would have to override the `web` derivation and somehow patch immich's `installPhase` to include the updated `web`, either by copying the `installPhase` over from nixpkgs, or by using string replacement to change the previous `installPhase`. Now you end up with a package where `passthru.{src, web, machine-learning}` still point to the wrong source, unless you manually override them as well.

With this change all you need to do is change the `src` using `overrideAttrs`, and potentially override the `npmDepsHash` if the dependencies have changed.

This PR also overrides `passthru.machine-learning` to override immich with the `finalPackage`. I think if you override immich
```nix
immich = pkgs.immich.override # ...
```
you would expect `immich.web` and `immich.machine-learning` to reflect those changes. If you didn't want the overridden version you would probably use `pkgs.immich-machine-learning` instead of `immich.machine-learning`.
The nixos module for immich previously included this override already. I removed it there as the package itself now includes it.

This is theoretically a breaking change but I doubt that anyone relied on overriding immich and then using the overridden package's `passthru` to access the original source so I don't think it merits an entry in the release notes.

**Commit description**
```
Using finalAttrs.src for all derivations makes it
possible to override the source using overrideAttrs
without having to reimplement part of the logic
within the immich package.
Using finalAttrs.web in the installPhase additionally
makes it possible to override only the web derivation.
Overriding immich in passthru.machine-learning makes
sure that the exposed immich-machine-learning also
uses the updated src.
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - Not applicable. With this change immich and immich.{src,web,machine-learning} all evaluate to the same derivation as before.
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
