### PR TITLE
soundtracker: 1.0.5 -> 1.0.5.1, fix build, clean up

### DIFF
--- a/pkgs/by-name/so/soundtracker/package.nix
+++ b/pkgs/by-name/so/soundtracker/package.nix
@@ -16,7 +16,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "soundtracker";
-  version = "1.0.5";
+  version = "1.0.5.1";
 
   src = fetchzip {
     # Past releases get moved to the "old releases" directory.
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Nonetheless, only the name of the file seems to affect which file is
     # downloaded, so this path should be fine both for old and current releases.
     url = "mirror://sourceforge/soundtracker/soundtracker-${finalAttrs.version}.tar.xz";
-    hash = "sha256-g96Z1SdFGMq7WFI6x+UtmAHPZF0C+tHUOjNhmK2ld8I=";
+    hash = "sha256-pvBCPPu8jBq9CFbSlKewEI+3t092zmtq+pbNLeJWU/8=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/so/soundtracker/package.nix
+++ b/pkgs/by-name/so/soundtracker/package.nix
@@ -13,6 +13,7 @@
   libxml2,
   libsndfile,
   libpulseaudio,
+  glib,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -56,14 +57,21 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
+  strictDeps = true;
+
   nativeBuildInputs = [
     pkg-config
     autoreconfHook
+    SDL # AM_PATH_SDL
+    glib # glib-genmarshal
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    alsa-lib # AM_PATH_ALSA
   ];
 
   buildInputs = [
     gtk2
-    SDL
+    SDL # found by AM_PATH_SDL
     jack2
     audiofile
     goocanvas

--- a/pkgs/by-name/so/soundtracker/package.nix
+++ b/pkgs/by-name/so/soundtracker/package.nix
@@ -83,7 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
     libpulseaudio # found by PKG_CHECK_MODULES
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Music tracking tool similar in design to the DOS program FastTracker and the Amiga legend ProTracker";
     longDescription = ''
       SoundTracker is a pattern-oriented music editor (similar to the DOS
@@ -94,9 +94,9 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "http://www.soundtracker.org/";
     downloadPage = "https://sourceforge.net/projects/soundtracker/files/";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ fgaz ];
-    platforms = platforms.all;
-    hydraPlatforms = platforms.linux; # sdl-config times out on darwin
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ fgaz ];
+    platforms = lib.platforms.all;
+    hydraPlatforms = lib.platforms.linux; # sdl-config times out on darwin
   };
 })

--- a/pkgs/by-name/so/soundtracker/package.nix
+++ b/pkgs/by-name/so/soundtracker/package.nix
@@ -12,6 +12,7 @@
   goocanvas, # graphical envelope editing
   libxml2,
   libsndfile,
+  libpulseaudio,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -69,7 +70,10 @@ stdenv.mkDerivation (finalAttrs: {
     libxml2 # found by PKG_CHECK_MODULES
     libsndfile
   ]
-  ++ lib.optional stdenv.hostPlatform.isLinux alsa-lib;
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    alsa-lib # found by AM_PATH_ALSA
+    libpulseaudio # found by PKG_CHECK_MODULES
+  ];
 
   meta = with lib; {
     description = "Music tracking tool similar in design to the DOS program FastTracker and the Amiga legend ProTracker";

--- a/pkgs/by-name/so/soundtracker/package.nix
+++ b/pkgs/by-name/so/soundtracker/package.nix
@@ -27,7 +27,13 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-g96Z1SdFGMq7WFI6x+UtmAHPZF0C+tHUOjNhmK2ld8I=";
   };
 
-  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+  postPatch = ''
+    substituteInPlace configure.ac \
+      --replace-fail 'AM_PATH_XML2(2.6.0, [], AC_MSG_ERROR(Fatal error: Need libxml2 >= 2.6.0))' \
+          'PKG_CHECK_MODULES([XML], [libxml-2.0 >= 2.6.0])' \
+      --replace-fail 'XML_CPPFLAGS' 'XML_CFLAGS' \
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
     # Darwin binutils don't support D option for ar
     # ALSA macros are missing on Darwin, causing error
     substituteInPlace configure.ac \
@@ -60,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
     jack2
     audiofile
     goocanvas
-    libxml2
+    libxml2 # found by PKG_CHECK_MODULES
     libsndfile
   ]
   ++ lib.optional stdenv.hostPlatform.isLinux alsa-lib;


### PR DESCRIPTION
Part of https://github.com/NixOS/nixpkgs/issues/457852
Found in https://github.com/NixOS/nixpkgs/pull/460292#issuecomment-3510754116

- patched libxml2 configure logic
- updated to 1.0.5.1
- added pulse support
- added `strictDeps`
- removed `with lib`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
