### PR TITLE
obs-studio-plugins.obs-vertical-canvas: 1.4.10 -> 1.6.1

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/obs-vertical-canvas.diff
+++ b/pkgs/applications/video/obs-studio/plugins/obs-vertical-canvas.diff
@@ -1,17 +1,13 @@
-diff --color -urpN obs-vertical-canvas.bak/file-updater.c obs-vertical-canvas/file-updater.c
---- obs-vertical-canvas.bak/file-updater.c	2025-07-18 18:32:13.239718611 -0400
-+++ obs-vertical-canvas/file-updater.c	2025-07-18 18:32:30.732020377 -0400
-@@ -67,10 +67,10 @@ static bool do_http_request(struct updat
- 	curl_easy_setopt(info->curl, CURLOPT_ERRORBUFFER, info->error);
- 	curl_easy_setopt(info->curl, CURLOPT_WRITEFUNCTION, http_write);
- 	curl_easy_setopt(info->curl, CURLOPT_WRITEDATA, info);
--	curl_easy_setopt(info->curl, CURLOPT_FAILONERROR, true);
--	curl_easy_setopt(info->curl, CURLOPT_NOSIGNAL, 1);
-+	curl_easy_setopt(info->curl, CURLOPT_FAILONERROR, 1L);
-+	curl_easy_setopt(info->curl, CURLOPT_NOSIGNAL, 1L);
- 	curl_easy_setopt(info->curl, CURLOPT_ACCEPT_ENCODING, "");
--	curl_easy_setopt(info->curl, CURLOPT_SSL_OPTIONS, CURLSSLOPT_REVOKE_BEST_EFFORT);
-+	curl_easy_setopt(info->curl, CURLOPT_SSL_OPTIONS, (long)CURLSSLOPT_REVOKE_BEST_EFFORT);
- 
- 	code = curl_easy_perform(info->curl);
- 	if (code != CURLE_OK) {
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 10ef443..5db6d37 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -28,7 +28,7 @@ endif()
+ find_package(Qt6 COMPONENTS Widgets Core)
+ if(BUILD_OUT_OF_TREE)
+   if(OS_LINUX OR OS_FREEBSD OR OS_OPENBSD)
+-    find_package(Qt6 REQUIRED Gui)
++    find_package(Qt6 REQUIRED GuiPrivate)
+   endif()
+ endif()
+ target_link_libraries(${PROJECT_NAME} PRIVATE Qt::Core Qt::Widgets)

--- a/pkgs/applications/video/obs-studio/plugins/obs-vertical-canvas.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-vertical-canvas.nix
@@ -10,16 +10,16 @@
 
 stdenv.mkDerivation rec {
   pname = "obs-vertical-canvas";
-  version = "1.4.10";
+  version = "1.6.1";
 
   src = fetchFromGitHub {
     owner = "Aitum";
     repo = "obs-vertical-canvas";
     rev = version;
-    sha256 = "sha256-0XfJ8q8n2ANO0oDtLZhZjRunZ5S1EouQ6Ak/pxEQYOQ=";
+    sha256 = "sha256-tvoNdv0HkGch8FZCiK7S4BR7iWOqLvTj0blFxyyUjQE=";
   };
 
-  # Remove after https://github.com/Aitum/obs-vertical-canvas/pull/25 is released :)
+  # Remove after https://github.com/Aitum/obs-vertical-canvas/pull/26 is released :)
   patches = [ ./obs-vertical-canvas.diff ];
 
   nativeBuildInputs = [ cmake ];
@@ -45,7 +45,10 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Plugin for OBS Studio to add vertical canvas";
     homepage = "https://github.com/Aitum/obs-vertical-canvas";
-    maintainers = with lib.maintainers; [ flexiondotorg ];
+    maintainers = with lib.maintainers; [
+      flexiondotorg
+      jonhermansen
+    ];
     license = lib.licenses.gpl2Plus;
     inherit (obs-studio.meta) platforms;
   };


### PR DESCRIPTION
The plugin required slight patching for Qt 6.10, which is the current version in nixpkgs.

I raised https://github.com/Aitum/obs-vertical-canvas/pull/26 for the fix upstream but the change isn't backwards compatible, might need some further refinement before getting merged.

I saw someone asking about this on [Reddit](https://www.reddit.com/r/NixOS/comments/1n6l0k5/comment/nnwazqh/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button) so I figured I'd help out.

The build is currently broken on [Hydra](https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.obs-studio-plugins.obs-vertical-canvas.x86_64-linux) anyways, due to the Qt upgrade

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `5d4ed1bca4d216beac7773cefed294dc51865ff6`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>obs-studio-plugins.obs-vertical-canvas</li>
  </ul>
</details>