### PR TITLE
obs-studio-plugins.obs-color-monitor: 0.9.3 -> 0.9.5

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/obs-color-monitor.diff
+++ b/pkgs/applications/video/obs-studio/plugins/obs-color-monitor.diff
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 10c4046..4c27389 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -29,7 +29,7 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
+ 	find_package(obs-frontend-api REQUIRED)
+ 	include(cmake/ObsPluginHelpers.cmake)
+ 	add_library(OBS::frontend-api ALIAS OBS::obs-frontend-api)
+-	find_qt(VERSION ${QT_VERSION} COMPONENTS Widgets Core COMPONENTS_LINUX Gui)
++	find_qt(VERSION ${QT_VERSION} COMPONENTS Widgets Core COMPONENTS_LINUX GuiPrivate)
+ endif()
+ 
+ configure_file(

--- a/pkgs/applications/video/obs-studio/plugins/obs-color-monitor.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-color-monitor.nix
@@ -9,14 +9,17 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "obs-color-monitor";
-  version = "0.9.3";
+  version = "0.9.5";
 
   src = fetchFromGitHub {
     owner = "norihiro";
     repo = "obs-color-monitor";
     tag = finalAttrs.version;
-    hash = "sha256-TwsEIOgQjj1wza7i8nne63oBM3FB6GmMjCq8/PuiWHs=";
+    hash = "sha256-1QB9iV5We1LQ/pj7KEHThUL6RTlO/qXPM5Op8O0RzUQ=";
   };
+
+  # Remove after https://github.com/norihiro/obs-color/monitor/pull/124 is released
+  patches = [ ./obs-color-monitor.diff ];
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [
@@ -38,6 +41,9 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/norihiro/obs-color-monitor";
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ hlad ];
+    maintainers = with lib.maintainers; [
+      hlad
+      jonhermansen
+    ];
   };
 })


### PR DESCRIPTION
The plugin required slight patching for Qt 6.10, which is the current version in nixpkgs.

I raised https://github.com/norihiro/obs-color-monitor/pull/124 for the fix upstream but the change isn't backwards compatible, might need further refinement before getting merged.

The build is currently broken on [Hydra](https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.obs-studio-plugins.obs-color-monitor.x86_64-linux) due to the Qt upgrade

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

---

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `5febdb24780ffe7ba3a46f1d670a1053bc8f1366`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>obs-studio-plugins.obs-color-monitor</li>
  </ul>
</details>