### PR TITLE
pasfmt: init at 0.7.0

### DIFF
--- a/pkgs/by-name/pa/pasfmt/package.nix
+++ b/pkgs/by-name/pa/pasfmt/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "pasfmt";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "integrated-application-development";
+    repo = "pasfmt";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-f8aXZdgiZJS/iIKgqisx97g/IRL5skstsb788QFffV4=";
+  };
+
+  cargoHash = "sha256-hSPFgf2G7JBFbnejuBwCdmt2xnLosu+OPO51UVt1QtA=";
+
+  meta = {
+    description = "Delphi/Pascal code formatter";
+    homepage = "https://github.com/integrated-application-development/pasfmt";
+    changelog = "https://github.com/integrated-application-development/pasfmt/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.lgpl3;
+    maintainers = with lib.maintainers; [ daru-san ];
+    mainProgram = "pasfmt";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds the package pasfmt, a pascal code formatter.

Homepage: <https://github.com/integrated-application-development/pasfmt>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
