### PR TITLE
element-web-unwrapped: override jitsi-meet known vulnerabilities

### DIFF
--- a/pkgs/by-name/el/element-web-unwrapped/package.nix
+++ b/pkgs/by-name/el/element-web-unwrapped/package.nix
@@ -15,6 +15,12 @@ let
   noPhoningHome = {
     disable_guests = true; # disable automatic guest account registration at matrix.org
   };
+  # Do not inherit jitsi-meet's knownVulnerabilities (libolm).
+  # https://github.com/NixOS/nixpkgs/pull/335753
+  # https://github.com/NixOS/nixpkgs/pull/334638
+  jitsi-meet-override = jitsi-meet.overrideAttrs (previousAttrs: {
+    meta = removeAttrs previousAttrs.meta [ "knownVulnerabilities" ];
+  });
 in
 stdenv.mkDerivation (
   finalAttrs:
@@ -55,7 +61,7 @@ stdenv.mkDerivation (
       runHook preInstall
 
       cp -R webapp $out
-      cp ${jitsi-meet}/libs/external_api.min.js $out/jitsi_external_api.min.js
+      cp ${jitsi-meet-override}/libs/external_api.min.js $out/jitsi_external_api.min.js
       echo "${finalAttrs.version}" > "$out/version"
       jq -s '.[0] * $conf' "config.sample.json" --argjson "conf" '${builtins.toJSON noPhoningHome}' > "$out/config.json"
 


### PR DESCRIPTION
Continue to avoid inheriting `jitsi-meet`'s `knownVulnerabilities`.

Note that we used `jitsi-meet` in `element-web` like this since https://github.com/NixOS/nixpkgs/pull/335753, but f05f1abb5e0c2d3216011992a2ec0c72eefc95f2 changed how we use the dependency in `element-web-unwrapped`.

References:
- https://github.com/NixOS/nixpkgs/pull/334638

Closes: https://github.com/NixOS/nixpkgs/pull/460401

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
