### PR TITLE
postgresql_{13,14,15,16,17,18}: minor version updates

### DIFF
--- a/pkgs/servers/sql/postgresql/13.nix
+++ b/pkgs/servers/sql/postgresql/13.nix
@@ -1,7 +1,9 @@
 import ./generic.nix {
-  version = "13.22";
-  rev = "refs/tags/REL_13_22";
-  hash = "sha256-6zHA+WU1FroUbGJcTAeEbPKBVQY7SKpT5+Kxe9ZhtoM=";
+  version = "13.23";
+  # TODO: Move back to tag, when they appear upstream:
+  # rev = "refs/tags/REL_13_23";
+  rev = "89df812eb890814b105d871185935b580478e660";
+  hash = "sha256-GSIHFSt2wzaI3HkA3yX/gZZF+LKwODHYislagdhQjmE=";
   muslPatches = {
     disable-test-collate-icu-utf8 = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql13/disable-test-collate.icu.utf8.patch?id=69faa146ec9fff3b981511068f17f9e629d4688b";

--- a/pkgs/servers/sql/postgresql/14.nix
+++ b/pkgs/servers/sql/postgresql/14.nix
@@ -1,7 +1,9 @@
 import ./generic.nix {
-  version = "14.19";
-  rev = "refs/tags/REL_14_19";
-  hash = "sha256-z8MEeLae4W4YqGBNcPtKnUENxnixugnv5Q6r+LW4uu8=";
+  version = "14.20";
+  # TODO: Move back to tag, when they appear upstream:
+  # rev = "refs/tags/REL_14_20";
+  rev = "9ad034be354da9af1cea76836a9e576c110d1ff3";
+  hash = "sha256-5wWuS78yn1p+ZjlUy5jCf1mLq78D3iI7mWPBVTd1Ufk=";
   muslPatches = {
     disable-test-collate-icu-utf8 = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql14/disable-test-collate.icu.utf8.patch?id=56999e6d0265ceff5c5239f85fdd33e146f06cb7";

--- a/pkgs/servers/sql/postgresql/15.nix
+++ b/pkgs/servers/sql/postgresql/15.nix
@@ -1,7 +1,9 @@
 import ./generic.nix {
-  version = "15.14";
-  rev = "refs/tags/REL_15_14";
-  hash = "sha256-KzN0gsEY6wFLqNYMxbTj2NH+4IWO0pplWP4XO/fqRLM=";
+  version = "15.15";
+  # TODO: Move back to tag, when they appear upstream:
+  # rev = "refs/tags/REL_15_15";
+  rev = "32f38816779420502d4a311835d5fe939e9548a0";
+  hash = "sha256-veGKXAvK+dNofBuSXsmCsPdXDJOC04+QV3HEr0XaE68=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql15/dont-use-locale-a-on-musl.patch?id=f424e934e6d076c4ae065ce45e734aa283eecb9c";

--- a/pkgs/servers/sql/postgresql/16.nix
+++ b/pkgs/servers/sql/postgresql/16.nix
@@ -1,7 +1,9 @@
 import ./generic.nix {
-  version = "16.10";
-  rev = "refs/tags/REL_16_10";
-  hash = "sha256-1zG8+G/lNA1xm0hxLVEilIaI+25d4gfpqA2aCb4+taY=";
+  version = "16.11";
+  # TODO: Move back to tag, when they appear upstream:
+  # rev = "refs/tags/REL_16_11";
+  rev = "d61dd817be70749d14e982a369e97fdda9d5cba6";
+  hash = "sha256-hxv+N+OWqiXmFmsB+SSYGKQLBbHtNMnneHFvOtUz8z4=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql16/dont-use-locale-a-on-musl.patch?id=08a24be262339fd093e641860680944c3590238e";

--- a/pkgs/servers/sql/postgresql/17.nix
+++ b/pkgs/servers/sql/postgresql/17.nix
@@ -1,7 +1,9 @@
 import ./generic.nix {
-  version = "17.6";
-  rev = "refs/tags/REL_17_6";
-  hash = "sha256-/7C+bjmiJ0/CvoAc8vzTC50vP7OsrM6o0w+lmmHvKvU=";
+  version = "17.7";
+  # TODO: Move back to tag, when they appear upstream:
+  # rev = "refs/tags/REL_17_7";
+  rev = "fbb530a3dff569222bea7098ad4de3d8bde97740";
+  hash = "sha256-W+505LAeiO5ln7wBhxZLv/p3GxiJp8MFfCGVDyvHREg=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql17/dont-use-locale-a-on-musl.patch?id=d69ead2c87230118ae7f72cef7d761e761e1f37e";

--- a/pkgs/servers/sql/postgresql/18.nix
+++ b/pkgs/servers/sql/postgresql/18.nix
@@ -1,7 +1,9 @@
 import ./generic.nix {
-  version = "18.0";
-  rev = "refs/tags/REL_18_0";
-  hash = "sha256-xA6gbJe4tIV9bYRFrdI4Rfy20ZwTkvyyjt7ZxvCFEec=";
+  version = "18.1";
+  # TODO: Move back to tag, when they appear upstream:
+  # rev = "refs/tags/REL_18_1";
+  rev = "4b324845ba5d24682b9b3708a769f00d160afbd7";
+  hash = "sha256-cZA2hWtr5RwsUrRWkvl/yvUzFPSfdtpyAKGXfrVUr0g=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql17/dont-use-locale-a-on-musl.patch?id=d69ead2c87230118ae7f72cef7d761e761e1f37e";

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -426,12 +426,6 @@ let
       ]
       ++ lib.optionals (stdenv'.hostPlatform.isDarwin && olderThan "16") [
         ./patches/export-dynamic-darwin-15-.patch
-      ]
-      ++ lib.optionals (atLeast "18") [
-        (fetchpatch2 {
-          url = "https://github.com/postgres/postgres/commit/a48d1ef58652229521ba4b5070e19f857608b22e.patch";
-          hash = "sha256-3FKQS1Vpu+p6z6c1GWs6GlrLl2Bgm9paEU/z81LrEus=";
-        })
       ];
 
       installTargets = [ "install-world" ];

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -163,11 +163,12 @@ let
 
       dlSuffix = if olderThan "16" then ".so" else stdenv.hostPlatform.extensions.sharedLibrary;
 
-      # Pin LLVM 20 until upstream has resolved:
+      # Pin LLVM 20 until upstream has fully resolved:
       # https://www.postgresql.org/message-id/flat/d25e6e4a-d1b4-84d3-2f8a-6c45b975f53d%40applied-asynchrony.com
+      # Currently still a problem on aarch64.
       # TODO: Remove with next minor releases
       llvmPackages = lib.warnIf (
-        version == "17.7"
+        version == "17.8"
       ) "PostgreSQL: Is the pin for LLVM 20 still needed?" llvmPackages_20;
 
       stdenv' =
@@ -426,7 +427,7 @@ let
       ++ lib.optionals (stdenv'.hostPlatform.isDarwin && olderThan "16") [
         ./patches/export-dynamic-darwin-15-.patch
       ]
-      ++ lib.optionals (atLeast "17") [
+      ++ lib.optionals (atLeast "18") [
         (fetchpatch2 {
           url = "https://github.com/postgres/postgres/commit/a48d1ef58652229521ba4b5070e19f857608b22e.patch";
           hash = "sha256-3FKQS1Vpu+p6z6c1GWs6GlrLl2Bgm9paEU/z81LrEus=";


### PR DESCRIPTION
PostgreSQL minor version updates which will be officially released on Thursday. The releases are already stamped, so the commit hashes won't move anymore - the tags will appear on Thursday.

Release Notes are not rendered, yet, but available here: https://github.com/postgres/postgres/blob/4b324845ba5d24682b9b3708a769f00d160afbd7/doc/src/sgml/release-18.sgml

Fixes:
- [CVE-2025-12817](https://github.com/postgres/postgres/commit/00eb646ea43410e5df77fed96f4a981e66811796)
- [CVE-2025-12818](https://github.com/postgres/postgres/commit/7eb8fcad860e9a0548191dab7a87a5bead5f8e91)

`libpq` will be updated in a separate PR towards `staging-next`: #460645

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
