### PR TITLE
libpq: 18.0 -> 18.1

### DIFF
--- a/pkgs/servers/sql/postgresql/libpq.nix
+++ b/pkgs/servers/sql/postgresql/libpq.nix
@@ -40,14 +40,16 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libpq";
-  version = "18.0";
+  version = "18.1";
 
   src = fetchFromGitHub {
     owner = "postgres";
     repo = "postgres";
     # rev, not tag, on purpose: see generic.nix.
-    rev = "refs/tags/REL_18_0";
-    hash = "sha256-xA6gbJe4tIV9bYRFrdI4Rfy20ZwTkvyyjt7ZxvCFEec=";
+    # TODO: Move back to tag, when they appear upstream:
+    # rev = "refs/tags/REL_18_1";
+    rev = "4b324845ba5d24682b9b3708a769f00d160afbd7";
+    hash = "sha256-cZA2hWtr5RwsUrRWkvl/yvUzFPSfdtpyAKGXfrVUr0g=";
   };
 
   __structuredAttrs = true;


### PR DESCRIPTION
Release Notes:
https://github.com/postgres/postgres/blob/4b324845ba5d24682b9b3708a769f00d160afbd7/doc/src/sgml/release-18.sgml

Fixes:
[CVE-2025-12818](https://github.com/postgres/postgres/commit/00eb646ea43410e5df77fed96f4a981e66811796)

PostgreSQL server packages updated in #460644.

## Things done

- Built on platform:
  - [x] x86_64-linux (regular + pkgsStatic)
  - [x] aarch64-linux (regular + pkgsStatic)
  - [x] x86_64-darwin
  - [x] aarch64-darwin (regular + pkgsStatic)
  - [x] x86_64-freebsd (cross)
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
