### PR TITLE
mission-center: 1.0.2 -> 1.1.0

### DIFF
--- a/pkgs/by-name/mi/mission-center/package.nix
+++ b/pkgs/by-name/mi/mission-center/package.nix
@@ -4,7 +4,9 @@
   fetchFromGitHub,
   fetchFromGitLab,
   rustPlatform,
+  systemdMinimal,
   symlinkJoin,
+
   # nativeBuildInputs
   blueprint-compiler,
   cargo,
@@ -17,6 +19,7 @@
   python3,
   rustc,
   wrapGAppsHook4,
+
   # buildInputs
   appstream-glib,
   cairo,
@@ -35,11 +38,14 @@
   sqlite,
   udev,
   wayland,
+
+  # tests
+  versionCheckHook,
+
   # magpie wrapper
   addDriverRunpath,
   libGL,
   vulkan-loader,
-  versionCheckHook,
 }:
 
 # UPDATE PROCESS:
@@ -59,20 +65,20 @@ let
   nvtop = fetchFromGitHub {
     owner = "Syllo";
     repo = "nvtop";
-    rev = "73291884d926445e499d6b9b71cb7a9bdbc7c393";
-    hash = "sha256-8iChT55L2NSnHg8tLIry0rgi/4966MffShE0ib+2ywc=";
+    rev = "339ee0b10a64ec51f43d27357b0068a40f16e9e4";
+    hash = "sha256-QxGP6lHbjS7GAQGWUnxFdrYgxBVhtuk5CzS2EUVFjOs=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "mission-center";
-  version = "1.0.2";
+  version = "1.1.0";
 
   src = fetchFromGitLab {
     owner = "mission-center-devs";
     repo = "mission-center";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-TvrYwuJR03mvPc8oXBx6GClOLc+r5kblaOj0uaLwbwE=";
+    hash = "sha256-KETaCjKTxEvh3tgLzJw5PLJHAQivqXhGYcluvFhGGd8=";
   };
 
   postPatch =
@@ -106,6 +112,11 @@ stdenv.mkDerivation (finalAttrs: {
     # Patch the shebang of this python script called at build time
     + ''
       patchShebangs $SRC_MAGPIE_DIR/platform-linux/hwdb/generate_hwdb.py
+    ''
+    # Inject the absolute path to the udevadm binary in magpie's source code
+    + ''
+      substituteInPlace subprojects/magpie/platform-linux/src/memory.rs \
+        --replace-fail "udevadm" "${lib.getExe' systemdMinimal "udevadm"}"
     '';
 
   cargoDeps = symlinkJoin {
@@ -113,13 +124,13 @@ stdenv.mkDerivation (finalAttrs: {
     paths = [
       (rustPlatform.fetchCargoVendor {
         inherit (finalAttrs) pname version src;
-        hash = "sha256-1Bcxp0EuHbJrLQIb2STLNIL2BM2eOgL8ftx4g1o/JY4=";
+        hash = "sha256-XS+/gpCMIqDgFR6AjuT2q+p+85GklUuRhKWzaBfQjZg=";
       })
       (rustPlatform.fetchCargoVendor {
         pname = "${finalAttrs.pname}-magpie";
         inherit (finalAttrs) version src;
         sourceRoot = "${finalAttrs.src.name}/subprojects/magpie";
-        hash = "sha256-ouY9zSQ7csAqPzQrbWGtCTB9ECVBKOUX78K5SiqTTxg=";
+        hash = "sha256-9YZ2dgIaq0AtS8QsIC/0cJlELIy/UbOvulgZFL/qRRs=";
       })
     ];
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://gitlab.com/mission-center-devs/mission-center/-/compare/v1.0.2...v1.1.0?from_project_id=44426042
Changelog: https://gitlab.com/mission-center-devs/mission-center/-/wikis/Release-Notes/v1.1.0

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
