### PR TITLE
nvidia-k8s-device-plugin init at 0.18.0

### DIFF
--- a/pkgs/by-name/nv/nvidia-k8s-device-plugin/package.nix
+++ b/pkgs/by-name/nv/nvidia-k8s-device-plugin/package.nix
@@ -1,0 +1,57 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+  nvidiaPackages ? null,
+}:
+
+buildGoModule rec {
+  pname = "nvidia-k8s-device-plugin";
+  version = "0.18.0";
+  # version = "0.14.3";
+
+  src = fetchFromGitHub {
+    owner = "NVIDIA";
+    repo = "k8s-device-plugin";
+    rev = "v${version}";
+    sha256 = "sha256-caZCbEvOQ1jHJua15qVMLrAVUOAxSou7mgvavDIeSNE=";
+    # sha256 = "sha256-rN4SIX77EiXEe2LVoGYOIe4RkyPgo4TLtKuG8tC7NQk=";
+  };
+
+  vendorHash = null;
+
+  buildInputs = lib.optional (nvidiaPackages != null) (with nvidiaPackages; [ production ]);
+
+  ldflags = [
+    "-s"
+    "-w"
+  ]
+  ++ lib.optional (nvidiaPackages != null) [
+    # lazy because unresolved nvmlDeviceCcuSetStreamState, which isn't used
+    # anyway, but I can't figure out to link it properly for the loader to find
+    # early
+    "-extldflags '-Wl,-z,lazy -lnvidia-ml -lcuda'"
+  ];
+
+  subPackages = [ "cmd/nvidia-device-plugin" ];
+
+  # Make it possible to build on machines without nivida hw
+  makeFlags = lib.optional (nvidiaPackages != null) [
+    "LDFLAGS=-L${nvidiaPackages.production}/lib"
+    "CFLAGS=-I${nvidiaPackages.production}/include"
+  ];
+
+  # # github.com/cilium/ebpf/internal/unix
+  # vendor/github.com/cilium/ebpf/internal/unix/types_linux.go:40:36: undefined: linux.BPF_F_KPROBE_MULTI_RETURN
+  # FAIL    github.com/NVIDIA/k8s-device-plugin/tests/e2e [build failed]
+  doCheck = false;
+
+  meta = with lib; {
+    description = "NVIDIA device plugin for Kubernetes";
+    homepage = "https://github.com/NVIDIA/k8s-device-plugin";
+    license = licenses.unfree; # Nividia stuff
+    maintainers = [ ];
+    mainProgram = "nvidia-device-plugin";
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
