### PR TITLE
ghostscript-fonts: init at 1.0.0-91edd6

### DIFF
--- a/pkgs/by-name/gh/ghostscript-fonts/package.nix
+++ b/pkgs/by-name/gh/ghostscript-fonts/package.nix
@@ -1,0 +1,43 @@
+{
+  stdenvNoCC,
+  fetchgit,
+  lib,
+}:
+
+stdenvNoCC.mkDerivation rec {
+  name = "ghostscript-fonts";
+  version = "1.0.0-${"src.rev:0:7"}";
+  src = fetchgit {
+    url = "git://git.ghostscript.com/urw-core35-fonts.git";
+    rev = "91edd6ece36e84a1c6d63a1cf63a1a6d84bd443a";
+    hash = "sha256-T4Pcp1sv+WVl9UVdyVm6kSangEFuWarJ8xJ0CC3GyT8=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 ${src}/*.ttf -t $out/share/fonts/truetype
+    install -Dm644 ${src}/*.otf -t $out/share/fonts/opentype
+    install -Dm644 ${src}/*.{afm,t1} -t $out/share/fonts/type1
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Ghostscript fonts";
+    longDescription = ''
+      This package provides the Ghostscript fonts, which are a set of free
+      alternatives to the standard 35 PostScript fonts defined by Adobe. These
+      fonts are widely used in desktop publishing, graphic design, and printing
+      applications.
+      This package includes TrueType, OpenType, and
+      Type 1 font formats for the follwoing fonts: C059, D050000L, NimbusSansNarrow,
+      NumbusMonoPS, NumbusRoman, NumbusSans, P052, StandardSymbolsPS, URWBookman,
+      URWGothic, and Z003.
+    '';
+    homepage = "https://ghostscript.com";
+    license = lib.licenses.agpl3Plus;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ vaavaav ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR introduces a new package, `ghostscript-fonts`, providing the URW Core 35 Ghostscript fonts. Unlike existing Ghostscript-related packages in Nixpkgs, this derivation only installs the fonts themselves, without including Ghostscript or other utilities.

The package fetches the fonts directly from the official Ghostscript URW Core35 repository and installs the available TrueType, OpenType, and Type 1 font variants.

It might be useful to split this into three separate packages according to the font formats:

- `ghostscript-fonts-ttf`
- `ghostscript-fonts-otf`
- `ghostscript-fonts-type1`

This would allow more granular control over dependencies.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
