### PR TITLE
jaero: init at 1.0.4.14-unstable-2023-11-21

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19258,6 +19258,12 @@
     githubId = 810877;
     name = "Tom Doggett";
   };
+  noderyos = {
+    email = "vincent.bsod@gmail.com";
+    github = "Noderyos";
+    githubId = 56077132;
+    name = "Noderyos";
+  };
   noiioiu = {
     github = "noiioiu";
     githubId = 151288161;

--- a/pkgs/by-name/ja/jaero/package.nix
+++ b/pkgs/by-name/ja/jaero/package.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  libsForQt5,
+  libacars,
+  libcorrect,
+  libvorbis,
+  zeromq,
+  qmqtt,
+  makeWrapper,
+}:
+
+let
+  jfft-src = fetchFromGitHub {
+    owner = "jontio";
+    repo = "JFFT";
+    rev = "4b74486e58e1d266f1cc3c570f3d073d40c353d6";
+    hash = "sha256-GDagnbbYT6Xn8IQ7YH7giBiNqSYYkyyTqInlvT5TZZA=";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "jaero";
+  version = "1.0.4.14-unstable-2023-11-21";
+
+  src = fetchFromGitHub {
+    owner = "jontio";
+    repo = "JAERO";
+    rev = "1d4e515921244aec1d85a03f5f38b4e7818fdbe6";
+    hash = "sha256-/miAV87IyeOid4srLL25Ec+3Up47Aox2TsI3E3UQanw=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/JAERO";
+
+  preConfigure = ''
+    substituteInPlace JAERO.pro \
+      --replace-fail "QT       += multimedia core network gui svg sql qmqtt" \
+                     "QT       += multimedia core network gui svg sql" \
+      --replace-fail "JFFT_PATH = ../../JFFT/" "JFFT_PATH = ${jfft-src}" \
+      --replace-fail "INSTALL_PATH = /opt/jaero" "INSTALL_PATH = ${placeholder "out"}" \
+      --replace-fail "/usr" "${placeholder "out"}"
+      cat >> JAERO.pro <<"EOF"
+        LIBS += -L${qmqtt}/lib -lqmqtt
+      EOF
+  '';
+
+  buildInputs = [
+    qmqtt
+    libacars
+    libcorrect
+    libvorbis
+    zeromq
+  ]
+  ++ (with libsForQt5; [
+    qtbase
+    qcustomplot
+    qtmultimedia
+    qtsvg
+  ]);
+
+  nativeBuildInputs = with libsForQt5; [
+    qmake
+    wrapQtAppsHook
+    makeWrapper
+  ];
+
+  postInstall = ''
+    mkdir -p $out/bin
+    mv $out/JAERO $out/bin/JAERO
+  '';
+
+  meta = {
+    description = "SatCom ACARS demodulator and decoder for the Aero standard";
+    homepage = "https://github.com/jontio/JAERO";
+    platforms = lib.platforms.linux;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ noderyos ];
+  };
+})

--- a/pkgs/by-name/li/libcorrect/package.nix
+++ b/pkgs/by-name/li/libcorrect/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libcorrect";
+  version = "0-unstable-2018-10-10";
+
+  src = fetchFromGitHub {
+    owner = "quiet";
+    repo = "libcorrect";
+    rev = "f5a28c74fba7a99736fe49d3a5243eca29517ae9";
+    hash = "sha256-78OgoQFVcBWAqOSfYnygzryxfGwbdWbudl3MUDqaiWE=";
+  };
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "cmake_minimum_required(VERSION 2.8)" "cmake_minimum_required(VERSION 3.10)"
+  '';
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "C library for Convolutional codes and Reed-Solomon";
+    homepage = "https://github.com/quiet/libcorrect";
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ noderyos ];
+  };
+})


### PR DESCRIPTION
Packaged JAERO, a software to demodulate and decode Aero signals.

See https://github.com/jontio/JAERO

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
