### PR TITLE
python3Packages.spectral-cube: 0.6.6-unstable-2025-06-11 -> 0.6.7

### DIFF
--- a/pkgs/development/python-modules/spectral-cube/default.nix
+++ b/pkgs/development/python-modules/spectral-cube/default.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
 
   # build-system
+  setuptools,
   setuptools-scm,
 
   # dependencies
@@ -25,22 +26,20 @@
 
 buildPythonPackage rec {
   pname = "spectral-cube";
-  version = "0.6.6-unstable-2025-06-11";
+  version = "0.6.7";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "radio-astro-tools";
     repo = "spectral-cube";
-    # tag = "v${version}";
-    # Unreleased PR with several build and test fixes: https://github.com/radio-astro-tools/spectral-cube/pull/951
-    rev = "f95ba1ca1823758d340ce0bfd3181ae3bc041b93";
-    hash = "sha256-LUWdxA7gfZI2MDpKuk+DiEJtXyWeS8co+3tZt97Uh3w=";
+    tag = "v${version}";
+    hash = "sha256-l5r7oeWr/JrmGOmUo4po2VlGldh8y7E3ufd+Gw1/JmM=";
   };
 
-  # remove after update to 0.6.7
-  env.SETUPTOOLS_SCM_PRETEND_VERSION = "0.6.6";
-
-  build-system = [ setuptools-scm ];
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
 
   dependencies = [
     astropy


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/radio-astro-tools/spectral-cube/compare/f95ba1ca1823758d340ce0bfd3181ae3bc041b93...f95ba1ca1823758d340ce0bfd3181ae3bc041b93
Changelog: https://github.com/radio-astro-tools/spectral-cube/releases/tag/v0.6.7

cc @smaret

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc