### PR TITLE
spire: build tpmdevid nodeattestor plugin and oidc-discovery-provider

### DIFF
--- a/pkgs/by-name/sp/spire/package.nix
+++ b/pkgs/by-name/sp/spire/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  openssl,
 }:
 
 buildGoModule (finalAttrs: {
@@ -21,7 +22,11 @@ buildGoModule (finalAttrs: {
     sha256 = "sha256-iZMeD5ZwWKjY9mfuXgEgh+QLotmv28T8xBgpKoQTgxw=";
   };
 
-  vendorHash = "sha256-tho3Qm9uHiiSNFmBZGZFgxhAKD4HKWsIUmiqkWlToQk=";
+  # Needed for github.co/google/go-tpm-tools/simulator  which contains non-go files that `go mod vendor` strips
+  proxyVendor = true;
+  vendorHash = "sha256-nslLp/NjzsN1hSMMga67T6tMGLiqBNYQMt4Kjtwyvoc=";
+
+  buildInputs = [ openssl ];
 
   ldflags = [
     "-s"
@@ -32,12 +37,6 @@ buildGoModule (finalAttrs: {
   subPackages = [
     "cmd/spire-agent"
     "cmd/spire-server"
-  ];
-
-  excludedPackages = [
-    # ensure these files aren't evaluated, see preCheck
-    "test/tmpsimulator"
-    "pkg/agent/plugin/nodeattestor/tpmdevid"
   ];
 
   __darwinAllowLocalNetworking = true;
@@ -53,10 +52,6 @@ buildGoModule (finalAttrs: {
     [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
   preCheck = ''
-    # remove test files which reference github.com/google/go-tpm-tools/simulator
-    # since it requires cgo and some missing header files
-    rm -rf test/tpmsimulator pkg/server/plugin/nodeattestor/tpmdevid/devid_test.go
-
     # unset to run all tests
     unset subPackages
   '';

--- a/pkgs/by-name/sp/spire/package.nix
+++ b/pkgs/by-name/sp/spire/package.nix
@@ -95,6 +95,7 @@ buildGoModule (finalAttrs: {
       fkautz
       jk
       mjm
+      arianvp
     ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
