### PR TITLE
python3Packages.vllm: enhance CLI UX

### DIFF
--- a/pkgs/development/python-modules/flashinfer/default.nix
+++ b/pkgs/development/python-modules/flashinfer/default.nix
@@ -9,6 +9,7 @@
   config,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch2,
 
   # build-system
   setuptools,
@@ -22,7 +23,7 @@
   click,
   einops,
   numpy,
-  pynvml,
+  nvidia-ml-py,
   tabulate,
   torch,
   tqdm,
@@ -40,6 +41,15 @@ buildPythonPackage rec {
     fetchSubmodules = true;
     hash = "sha256-e9PfLfU0DdoLKlXiHylCbGd125c7Iw9y4NDIOAP0xHs=";
   };
+
+  patches = [
+    # TODO: remove patch with update to v0.5.2+
+    # Switch pynvml to nvidia-ml-py
+    (fetchpatch2 {
+      url = "https://github.com/flashinfer-ai/flashinfer/commit/a42f99255d68d1a54b689bd4985339c6b44963a6.patch?full_index=1";
+      hash = "sha256-3XJFcdQeZ/c5fwiQvd95z4p9BzTn8pjle21WzeBxUgk=";
+    })
+  ];
 
   build-system = [ setuptools ];
 
@@ -86,7 +96,7 @@ buildPythonPackage rec {
     click
     einops
     numpy
-    pynvml
+    nvidia-ml-py
     tabulate
     torch
     tqdm
@@ -104,6 +114,9 @@ buildPythonPackage rec {
       scenarios.
     '';
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ breakds ];
+    maintainers = with lib.maintainers; [
+      breakds
+      daniel-fahey
+    ];
   };
 }

--- a/pkgs/development/python-modules/vllm/default.nix
+++ b/pkgs/development/python-modules/vllm/default.nix
@@ -34,7 +34,7 @@
   uvicorn,
   pydantic,
   aioprometheus,
-  pynvml,
+  nvidia-ml-py,
   openai,
   pyzmq,
   tiktoken,
@@ -314,6 +314,13 @@ buildPythonPackage rec {
   ];
 
   postPatch = ''
+    # Remove vendored pynvml entirely
+    rm vllm/third_party/pynvml.py
+    substituteInPlace tests/utils.py \
+      --replace-fail "from vllm.third_party.pynvml import" "from pynvml import"
+    substituteInPlace vllm/utils/__init__.py \
+      --replace-fail "import vllm.third_party.pynvml" "import pynvml"
+
     # pythonRelaxDeps does not cover build-system
     substituteInPlace pyproject.toml \
       --replace-fail "torch ==" "torch >=" \
@@ -442,7 +449,7 @@ buildPythonPackage rec {
   ]
   ++ lib.optionals cudaSupport [
     cupy
-    pynvml
+    nvidia-ml-py
     flashinfer
   ];
 


### PR DESCRIPTION
Replaces the unofficial and deprecated `pynvml` library with the official `nvidia-ml-py` in vLLM (maintainers: @happysalada, @CertainLach) and Flashinfer (one of its dependencies, maintainer: @breakds).

Using `nvidia-ml-py` with its [patch for Nix](https://github.com/NixOS/nixpkgs/blob/b6a8526db03f735b89dd5ff348f53f752e7ddc8e/pkgs/development/python-modules/nvidia-ml-py/0001-locate-libnvidia-ml.so.1-on-NixOS.patch) means
1. Not needing to set `LD_LIBRARY_PATH=/run/opengl-driver/lib` before using `vllm` commands to avoid runtime errors with CUDA
2. Avoiding the `FutureWarning`

Both can be [a pain point for new users](https://github.com/NixOS/nixpkgs/issues/450190).

At the time of writing:
```
git ls-remote https://github.com/NixOS/nixpkgs nixos-unstable
```
b6a8526db03f735b89dd5ff348f53f752e7ddc8e	refs/heads/nixos-unstable

Before 1:
```bash
nix-shell --pure \
--arg config '{ allowUnfree = true; cudaSupport = true; }' \
--include nixpkgs=https://github.com/NixOS/nixpkgs/archive/nixos-unstable.tar.gz \
--packages python313Packages.vllm \
--run "vllm --version"
```
```console
/nix/store/sk16mwyavzpsl6w1szhg8jp7nvk1rbvd-python3.13-torch-2.9.0/lib/python3.13/site-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
INFO 11-11 16:33:14 [__init__.py:220] No platform detected, vLLM is running on UnspecifiedPlatform
Traceback (most recent call last):
  File "/nix/store/6kzx3v1aa164dv26bx75wpnvr2ifb5v3-python3.13-vllm-0.11.0/bin/.vllm-wrapped", line 9, in <module>
    sys.exit(main())
             ~~~~^^
  File "/nix/store/6kzx3v1aa164dv26bx75wpnvr2ifb5v3-python3.13-vllm-0.11.0/lib/python3.13/site-packages/vllm/entrypoints/cli/main.py", line 46, in main
    cmd.subparser_init(subparsers).set_defaults(
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/nix/store/6kzx3v1aa164dv26bx75wpnvr2ifb5v3-python3.13-vllm-0.11.0/lib/python3.13/site-packages/vllm/entrypoints/cli/serve.py", line 70, in subparser_init
    serve_parser = make_arg_parser(serve_parser)
  File "/nix/store/6kzx3v1aa164dv26bx75wpnvr2ifb5v3-python3.13-vllm-0.11.0/lib/python3.13/site-packages/vllm/entrypoints/openai/cli_args.py", line 263, in make_arg_parser
    parser = AsyncEngineArgs.add_cli_args(parser)
  File "/nix/store/6kzx3v1aa164dv26bx75wpnvr2ifb5v3-python3.13-vllm-0.11.0/lib/python3.13/site-packages/vllm/engine/arg_utils.py", line 1714, in add_cli_args
    parser = EngineArgs.add_cli_args(parser)
  File "/nix/store/6kzx3v1aa164dv26bx75wpnvr2ifb5v3-python3.13-vllm-0.11.0/lib/python3.13/site-packages/vllm/engine/arg_utils.py", line 919, in add_cli_args
    vllm_kwargs = get_kwargs(VllmConfig)
  File "/nix/store/6kzx3v1aa164dv26bx75wpnvr2ifb5v3-python3.13-vllm-0.11.0/lib/python3.13/site-packages/vllm/engine/arg_utils.py", line 281, in get_kwargs
    return copy.deepcopy(_compute_kwargs(cls))
                         ~~~~~~~~~~~~~~~^^^^^
  File "/nix/store/6kzx3v1aa164dv26bx75wpnvr2ifb5v3-python3.13-vllm-0.11.0/lib/python3.13/site-packages/vllm/engine/arg_utils.py", line 182, in _compute_kwargs
    default = field.default_factory()
  File "/nix/store/4d9559v70h3nqh53gmymdb6aggkgjr7g-python3.13-pydantic-2.11.7/lib/python3.13/site-packages/pydantic/_internal/_dataclasses.py", line 123, in __init__
    s.__pydantic_validator__.validate_python(ArgsKwargs(args, kwargs), self_instance=s)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/6kzx3v1aa164dv26bx75wpnvr2ifb5v3-python3.13-vllm-0.11.0/lib/python3.13/site-packages/vllm/config/device.py", line 58, in __post_init__
    raise RuntimeError(
    ...<2 lines>...
        "to turn on verbose logging to help debug the issue.")
RuntimeError: Failed to infer device type, please set the environment variable `VLLM_LOGGING_LEVEL=DEBUG` to turn on verbose logging to help debug the issue.
```
Before 2:
```bash
nix-shell --pure \
--arg config '{ allowUnfree = true; cudaSupport = true; }' \
--include nixpkgs=https://github.com/NixOS/nixpkgs/archive/nixos-unstable.tar.gz \
--packages python313Packages.vllm \
--run "LD_LIBRARY_PATH=/run/opengl-driver/lib vllm --version"
```
```console
/nix/store/sk16mwyavzpsl6w1szhg8jp7nvk1rbvd-python3.13-torch-2.9.0/lib/python3.13/site-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
INFO 11-11 16:44:36 [__init__.py:216] Automatically detected platform cuda.
0.11.0
```

After:
```bash
nix-shell --pure \
--arg config '{ allowUnfree = true; cudaSupport = true; }' \
--include nixpkgs=https://github.com/daniel-fahey/nixpkgs/archive/fix/python3Packages.vllm.tar.gz \
--packages python313Packages.vllm \
--run "vllm --version"
```
```console
INFO 11-11 16:32:36 [__init__.py:216] Automatically detected platform cuda.
0.11.0
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
