### PR TITLE
workflows: run build & check in the merge queue; never push to cachix in PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,10 @@ on:
         required: true
         type: string
     secrets:
+      # Should only be provided in the merge queue, not in pull requests,
+      # where we're evaluating untrusted code.
       CACHIX_AUTH_TOKEN:
-        required: true
+        required: false
 
 permissions: {}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ on:
     secrets:
       # Should only be provided in the merge queue, not in pull requests,
       # where we're evaluating untrusted code.
-      CACHIX_AUTH_TOKEN:
+      CACHIX_AUTH_TOKEN_GHA:
         required: false
 
 permissions: {}
@@ -69,10 +69,10 @@ jobs:
 
       - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
         with:
-          # The nixpkgs-ci cache should not be trusted or used outside of Nixpkgs and its forks' CI.
-          name: ${{ vars.CACHIX_NAME || 'nixpkgs-ci' }}
-          extraPullNames: nixpkgs-ci
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          # The nixpkgs-gha cache should not be trusted or used outside of Nixpkgs and its forks' CI.
+          name: ${{ vars.CACHIX_NAME || 'nixpkgs-gha' }}
+          extraPullNames: nixpkgs-gha
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN_GHA }}
           pushFilter: '(-source$|-nixpkgs-tarball-)'
 
       - run: nix-env --install -f nixpkgs/trusted-pinned -A nix-build-uncached

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ on:
       mergedSha:
         required: true
         type: string
+      targetSha:
+        required: true
+        type: string
     secrets:
       CACHIX_AUTH_TOKEN:
         required: true
@@ -55,6 +58,7 @@ jobs:
         uses: ./.github/actions/checkout
         with:
           merged-as-untrusted-at: ${{ inputs.mergedSha }}
+          target-as-trusted-at: ${{ inputs.targetSha }}
 
       - uses: cachix/install-nix-action@456688f15bc354bef6d396e4a35f4f89d40bf2b7 # v31
         with:
@@ -69,7 +73,7 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           pushFilter: '(-source$|-nixpkgs-tarball-)'
 
-      - run: nix-env --install -f nixpkgs/untrusted-pinned -A nix-build-uncached
+      - run: nix-env --install -f nixpkgs/trusted-pinned -A nix-build-uncached
 
       - name: Build shell
         if: contains(matrix.builds, 'shell')

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,7 @@ on:
     secrets:
       # Should only be provided in the merge queue, not in pull requests,
       # where we're evaluating untrusted code.
-      CACHIX_AUTH_TOKEN:
+      CACHIX_AUTH_TOKEN_GHA:
         required: false
 
 permissions: {}
@@ -89,10 +89,10 @@ jobs:
 
       - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
         with:
-          # The nixpkgs-ci cache should not be trusted or used outside of Nixpkgs and its forks' CI.
-          name: ${{ vars.CACHIX_NAME || 'nixpkgs-ci' }}
-          extraPullNames: nixpkgs-ci
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          # The nixpkgs-gha cache should not be trusted or used outside of Nixpkgs and its forks' CI.
+          name: ${{ vars.CACHIX_NAME || 'nixpkgs-gha' }}
+          extraPullNames: nixpkgs-gha
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN_GHA }}
           pushFilter: -source$
 
       - name: Build codeowners validator

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,8 +16,10 @@ on:
         required: true
         type: string
     secrets:
+      # Should only be provided in the merge queue, not in pull requests,
+      # where we're evaluating untrusted code.
       CACHIX_AUTH_TOKEN:
-        required: true
+        required: false
 
 permissions: {}
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,10 +4,10 @@ on:
   workflow_call:
     inputs:
       baseBranch:
-        required: true
+        required: false
         type: string
       headBranch:
-        required: true
+        required: false
         type: string
       mergedSha:
         required: true
@@ -27,6 +27,7 @@ defaults:
 
 jobs:
   commits:
+    if: inputs.baseBranch && inputs.headBranch
     permissions:
       pull-requests: write
     runs-on: ubuntu-24.04-arm

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -19,8 +19,10 @@ on:
         default: false
         type: boolean
     secrets:
+      # Should only be provided in the merge queue, not in pull requests,
+      # where we're evaluating untrusted code.
       CACHIX_AUTH_TOKEN:
-        required: true
+        required: false
 
 permissions: {}
 

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -21,7 +21,7 @@ on:
     secrets:
       # Should only be provided in the merge queue, not in pull requests,
       # where we're evaluating untrusted code.
-      CACHIX_AUTH_TOKEN:
+      CACHIX_AUTH_TOKEN_GHA:
         required: false
 
 permissions: {}
@@ -104,10 +104,10 @@ jobs:
 
       - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
         with:
-          # The nixpkgs-ci cache should not be trusted or used outside of Nixpkgs and its forks' CI.
-          name: ${{ vars.CACHIX_NAME || 'nixpkgs-ci' }}
-          extraPullNames: nixpkgs-ci
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          # The nixpkgs-gha cache should not be trusted or used outside of Nixpkgs and its forks' CI.
+          name: ${{ vars.CACHIX_NAME || 'nixpkgs-gha' }}
+          extraPullNames: nixpkgs-gha
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN_GHA }}
           pushFilter: '(-source|-single-chunk)$'
 
       - name: Evaluate the ${{ matrix.system }} output paths at the merge commit

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,8 +10,10 @@ on:
         required: true
         type: string
     secrets:
+      # Should only be provided in the merge queue, not in pull requests,
+      # where we're evaluating untrusted code.
       CACHIX_AUTH_TOKEN:
-        required: true
+        required: false
 
 permissions: {}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ on:
     secrets:
       # Should only be provided in the merge queue, not in pull requests,
       # where we're evaluating untrusted code.
-      CACHIX_AUTH_TOKEN:
+      CACHIX_AUTH_TOKEN_GHA:
         required: false
 
 permissions: {}
@@ -74,10 +74,10 @@ jobs:
 
       - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
         with:
-          # The nixpkgs-ci cache should not be trusted or used outside of Nixpkgs and its forks' CI.
-          name: ${{ vars.CACHIX_NAME || 'nixpkgs-ci' }}
-          extraPullNames: nixpkgs-ci
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          # The nixpkgs-gha cache should not be trusted or used outside of Nixpkgs and its forks' CI.
+          name: ${{ vars.CACHIX_NAME || 'nixpkgs-gha' }}
+          extraPullNames: nixpkgs-gha
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN_GHA }}
           pushFilter: -source$
 
       - name: Parse all nix files
@@ -103,10 +103,10 @@ jobs:
 
       - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
         with:
-          # The nixpkgs-ci cache should not be trusted or used outside of Nixpkgs and its forks' CI.
-          name: ${{ vars.CACHIX_NAME || 'nixpkgs-ci' }}
-          extraPullNames: nixpkgs-ci
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          # The nixpkgs-gha cache should not be trusted or used outside of Nixpkgs and its forks' CI.
+          name: ${{ vars.CACHIX_NAME || 'nixpkgs-gha' }}
+          extraPullNames: nixpkgs-gha
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN_GHA }}
           pushFilter: -source$
 
       - name: Running nixpkgs-vet

--- a/.github/workflows/merge-group.yml
+++ b/.github/workflows/merge-group.yml
@@ -13,9 +13,6 @@ on:
       targetSha:
         required: true
         type: string
-    secrets:
-      CACHIX_AUTH_TOKEN:
-        required: true
 
 permissions: {}
 

--- a/.github/workflows/merge-group.yml
+++ b/.github/workflows/merge-group.yml
@@ -23,7 +23,9 @@ jobs:
   prepare:
     runs-on: ubuntu-24.04-arm
     outputs:
-      systems: ${{ steps.systems.outputs.systems }}
+      mergedSha: ${{ steps.prepare.outputs.mergedSha }}
+      targetSha: ${{ steps.prepare.outputs.targetSha }}
+      systems: ${{ steps.prepare.outputs.systems }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -31,19 +33,28 @@ jobs:
           sparse-checkout: |
             ci/supportedSystems.json
 
-      - name: Load supported systems
-        id: systems
-        run: |
-          echo "systems=$(jq -c <ci/supportedSystems.json)" >> "$GITHUB_OUTPUT"
+      - id: prepare
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          MERGED_SHA: ${{ inputs.mergedSha }}
+          TARGET_SHA: ${{ inputs.targetSha }}
+        with:
+          script: |
+            core.setOutput('mergedSha', context.payload.merge_group?.head_sha ?? process.env.MERGED_SHA)
+            core.info(`mergedSha: ${context.payload.merge_group?.head_sha ?? process.env.MERGED_SHA}`)
+            core.setOutput('targetSha', context.payload.merge_group?.base_sha ?? process.env.TARGET_SHA)
+            core.info(`targetSha: ${context.payload.merge_group?.base_sha ?? process.env.TARGET_SHA}`)
+            core.setOutput('systems', require('./ci/supportedSystems.json'))
 
   lint:
     name: Lint
+    needs: [prepare]
     uses: ./.github/workflows/lint.yml
     secrets:
       CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
     with:
-      mergedSha: ${{ inputs.mergedSha || github.event.merge_group.head_sha }}
-      targetSha: ${{ inputs.targetSha || github.event.merge_group.base_sha }}
+      mergedSha: ${{ needs.prepare.outputs.mergedSha }}
+      targetSha: ${{ needs.prepare.outputs.targetSha }}
 
   eval:
     name: Eval
@@ -58,8 +69,8 @@ jobs:
       CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
     with:
       artifact-prefix: ${{ inputs.artifact-prefix }}
-      mergedSha: ${{ inputs.mergedSha || github.event.merge_group.head_sha }}
-      targetSha: ${{ inputs.targetSha || github.event.merge_group.base_sha }}
+      mergedSha: ${{ needs.prepare.outputs.mergedSha }}
+      targetSha: ${{ needs.prepare.outputs.targetSha }}
       systems: ${{ needs.prepare.outputs.systems }}
 
   # This job's only purpose is to create the target for the "Required Status Checks" branch ruleset.

--- a/.github/workflows/merge-group.yml
+++ b/.github/workflows/merge-group.yml
@@ -56,6 +56,19 @@ jobs:
             core.info(`targetSha: ${context.payload.merge_group?.base_sha ?? process.env.TARGET_SHA}`)
             core.setOutput('systems', require('./ci/supportedSystems.json'))
 
+  check:
+    name: Check
+    needs: [prepare]
+    uses: ./.github/workflows/check.yml
+    permissions:
+      # cherry-picks; formality right now, but unused
+      pull-requests: write
+    secrets:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+    with:
+      mergedSha: ${{ needs.prepare.outputs.mergedSha }}
+      targetSha: ${{ needs.prepare.outputs.targetSha }}
+
   lint:
     name: Lint
     needs: [prepare]

--- a/.github/workflows/merge-group.yml
+++ b/.github/workflows/merge-group.yml
@@ -23,6 +23,7 @@ jobs:
   prepare:
     runs-on: ubuntu-24.04-arm
     outputs:
+      baseBranch: ${{ steps.prepare.outputs.base }}
       mergedSha: ${{ steps.prepare.outputs.mergedSha }}
       targetSha: ${{ steps.prepare.outputs.targetSha }}
       systems: ${{ steps.prepare.outputs.systems }}
@@ -40,6 +41,15 @@ jobs:
           TARGET_SHA: ${{ inputs.targetSha }}
         with:
           script: |
+            const { classify } = require('./ci/supportedBranches.js')
+            const baseBranch = (
+              context.payload.merge_group?.base_ref ??
+              context.payload.pull_request.base.ref
+            ).replace(/^refs\/heads\//, '')
+            const baseClassification = classify(baseBranch)
+            core.setOutput('base', baseClassification)
+            core.info('base classification:', baseClassification)
+
             core.setOutput('mergedSha', context.payload.merge_group?.head_sha ?? process.env.MERGED_SHA)
             core.info(`mergedSha: ${context.payload.merge_group?.head_sha ?? process.env.MERGED_SHA}`)
             core.setOutput('targetSha', context.payload.merge_group?.base_sha ?? process.env.TARGET_SHA)
@@ -72,6 +82,18 @@ jobs:
       mergedSha: ${{ needs.prepare.outputs.mergedSha }}
       targetSha: ${{ needs.prepare.outputs.targetSha }}
       systems: ${{ needs.prepare.outputs.systems }}
+
+  build:
+    name: Build
+    needs: [prepare]
+    uses: ./.github/workflows/build.yml
+    secrets:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+    with:
+      artifact-prefix: ${{ inputs.artifact-prefix }}
+      baseBranch: ${{ needs.prepare.outputs.baseBranch }}
+      mergedSha: ${{ needs.prepare.outputs.mergedSha }}
+      targetSha: ${{ needs.prepare.outputs.targetSha }}
 
   # This job's only purpose is to create the target for the "Required Status Checks" branch ruleset.
   # It "needs" all the jobs that should block the Merge Queue.

--- a/.github/workflows/merge-group.yml
+++ b/.github/workflows/merge-group.yml
@@ -61,7 +61,7 @@ jobs:
       # cherry-picks; formality right now, but unused
       pull-requests: write
     secrets:
-      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      CACHIX_AUTH_TOKEN_GHA: ${{ secrets.CACHIX_AUTH_TOKEN_GHA }}
     with:
       mergedSha: ${{ needs.prepare.outputs.mergedSha }}
       targetSha: ${{ needs.prepare.outputs.targetSha }}
@@ -71,7 +71,7 @@ jobs:
     needs: [prepare]
     uses: ./.github/workflows/lint.yml
     secrets:
-      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      CACHIX_AUTH_TOKEN_GHA: ${{ secrets.CACHIX_AUTH_TOKEN_GHA }}
     with:
       mergedSha: ${{ needs.prepare.outputs.mergedSha }}
       targetSha: ${{ needs.prepare.outputs.targetSha }}
@@ -86,7 +86,7 @@ jobs:
       # compare
       statuses: write
     secrets:
-      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      CACHIX_AUTH_TOKEN_GHA: ${{ secrets.CACHIX_AUTH_TOKEN_GHA }}
     with:
       artifact-prefix: ${{ inputs.artifact-prefix }}
       mergedSha: ${{ needs.prepare.outputs.mergedSha }}
@@ -98,7 +98,7 @@ jobs:
     needs: [prepare]
     uses: ./.github/workflows/build.yml
     secrets:
-      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      CACHIX_AUTH_TOKEN_GHA: ${{ secrets.CACHIX_AUTH_TOKEN_GHA }}
     with:
       artifact-prefix: ${{ inputs.artifact-prefix }}
       baseBranch: ${{ needs.prepare.outputs.baseBranch }}

--- a/.github/workflows/pull-request-target.yml
+++ b/.github/workflows/pull-request-target.yml
@@ -119,6 +119,7 @@ jobs:
       artifact-prefix: ${{ inputs.artifact-prefix }}
       baseBranch: ${{ needs.prepare.outputs.baseBranch }}
       mergedSha: ${{ needs.prepare.outputs.mergedSha }}
+      targetSha: ${{ needs.prepare.outputs.targetSha }}
 
   # This job's only purpose is to create the target for the "Required Status Checks" branch ruleset.
   # It "needs" all the jobs that should block merging a PR.

--- a/.github/workflows/pull-request-target.yml
+++ b/.github/workflows/pull-request-target.yml
@@ -8,8 +8,6 @@ on:
         required: true
         type: string
     secrets:
-      CACHIX_AUTH_TOKEN:
-        required: true
       NIXPKGS_CI_APP_PRIVATE_KEY:
         required: true
 
@@ -63,8 +61,6 @@ jobs:
     permissions:
       # cherry-picks
       pull-requests: write
-    secrets:
-      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
     with:
       baseBranch: ${{ needs.prepare.outputs.baseBranch }}
       headBranch: ${{ needs.prepare.outputs.headBranch }}
@@ -75,8 +71,6 @@ jobs:
     name: Lint
     needs: [prepare]
     uses: ./.github/workflows/lint.yml
-    secrets:
-      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
     with:
       mergedSha: ${{ needs.prepare.outputs.mergedSha }}
       targetSha: ${{ needs.prepare.outputs.targetSha }}
@@ -88,8 +82,6 @@ jobs:
     permissions:
       # compare
       statuses: write
-    secrets:
-      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
     with:
       artifact-prefix: ${{ inputs.artifact-prefix }}
       mergedSha: ${{ needs.prepare.outputs.mergedSha }}
@@ -113,8 +105,6 @@ jobs:
     name: Build
     needs: [prepare]
     uses: ./.github/workflows/build.yml
-    secrets:
-      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
     with:
       artifact-prefix: ${{ inputs.artifact-prefix }}
       baseBranch: ${{ needs.prepare.outputs.baseBranch }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,6 +82,7 @@ jobs:
     uses: ./.github/workflows/merge-group.yml
     # Those are actually only used on the merge_group event, but will throw an error if not set.
     permissions:
+      pull-requests: write
       statuses: write
     secrets:
       CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,8 +84,6 @@ jobs:
     permissions:
       pull-requests: write
       statuses: write
-    secrets:
-      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
     with:
       artifact-prefix: mg-
       mergedSha: ${{ needs.prepare.outputs.mergedSha }}
@@ -102,7 +100,6 @@ jobs:
       pull-requests: write
       statuses: write
     secrets:
-      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
       NIXPKGS_CI_APP_PRIVATE_KEY: ${{ secrets.NIXPKGS_CI_APP_PRIVATE_KEY }}
     with:
       artifact-prefix: pr-


### PR DESCRIPTION
This is an alternative approach to #460358. If we don't provide the cachix auth token to untrusted code - problem solved.

Needs a few commits of preparation, but doing these things in the Merge Queue would have happened eventually anyway.

TLDR: cachix is available as read-only in PRs and as read-write in the Merge Queue.

## Things done

- [x] Tested this: Test workflow results LGTM.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
