### PR TITLE
python3Packages.firedrake: 2025.10.1 -> 2025.10.2

### DIFF
--- a/pkgs/development/python-modules/firedrake-fiat/default.nix
+++ b/pkgs/development/python-modules/firedrake-fiat/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "firedrake-fiat";
-  version = "2025.10.0";
+  version = "2025.10.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "firedrakeproject";
     repo = "fiat";
     tag = version;
-    hash = "sha256-kyQe4VFzcK1idMt/NNND2cytGUryyhh5+ZP292zxT7c=";
+    hash = "sha256-x1/gf/QVez6GxPUafxdhxqyT0MkL6w2Qz6VAxRNufdc=";
   };
 
   postPatch =

--- a/pkgs/development/python-modules/firedrake/default.nix
+++ b/pkgs/development/python-modules/firedrake/default.nix
@@ -4,9 +4,7 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch2,
   python,
-  pax-utils,
 
   # build-system
   setuptools,
@@ -61,22 +59,15 @@ let
 in
 buildPythonPackage rec {
   pname = "firedrake";
-  version = "2025.10.1";
+  version = "2025.10.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "firedrakeproject";
     repo = "firedrake";
     tag = version;
-    hash = "sha256-paZNs6T9v7TNSdc8YJTjNcQvGrPg/Sy9K27/aUxNu5w=";
+    hash = "sha256-A0dr9A1fm74IzpYiVxzdo4jtELYH7JBeRMOD9uYJODQ=";
   };
-
-  patches = [
-    (fetchpatch2 {
-      url = "https://github.com/firedrakeproject/firedrake/pull/4632/commits/717ae8a62e19e0cc91419c12ca14170d252b2bb9.patch?full_index=1";
-      hash = "sha256-XHIcXmfh/brlQkrM4FTRvTrOovLvBN5mBrqZpZewTnc=";
-    })
-  ];
 
   # relax build-dependency petsc4py
   postPatch = ''
@@ -111,6 +102,7 @@ buildPythonPackage rec {
     fenics-ufl
     firedrake-fiat
     firedrakePackages.h5py
+    immutabledict
     libsupermesh
     loopy
     petsc4py
@@ -126,11 +118,11 @@ buildPythonPackage rec {
     rtree
     scipy
     sympy
+    # vtk optional required by IO module, we can make it a hard dependency in nixpkgs,
+    # see https://github.com/firedrakeproject/firedrake/pull/4713
     vtk
     # required by script spydump
     matplotlib
-    # required by pyop2
-    immutabledict
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     islpy


### PR DESCRIPTION
changelog:
https://github.com/firedrakeproject/fiat/releases/tag/2025.10.1
https://github.com/firedrakeproject/firedrake/releases/tag/2025.10.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
