### PR TITLE
gitea: 1.25.0 -> 1.25.1

### DIFF
--- a/pkgs/by-name/gi/gitea/package.nix
+++ b/pkgs/by-name/gi/gitea/package.nix
@@ -45,13 +45,13 @@ let
 in
 buildGoModule rec {
   pname = "gitea";
-  version = "1.25.0";
+  version = "1.25.1";
 
   src = fetchFromGitHub {
     owner = "go-gitea";
     repo = "gitea";
     tag = "v${gitea.version}";
-    hash = "sha256-uBBL62Q/aigsCo0S0hwNooKljTn+OfcqoJxan6Ac0rM=";
+    hash = "sha256-JTkpjUXCz+0Y8EY7JlDT4tLbCjDYElZ4uG1oLmij8Iw=";
   };
 
   proxyVendor = true;


### PR DESCRIPTION
needs to target staging because of go 1.25.3

```
> Running phase: unpackPhase
> unpacking source archive /nix/store/l0fwmpxl3wxv86524lv7y475306j4p9d-source
> source root is source
> Running phase: patchPhase
> applying patch /nix/store/z61a6xfx9pmxcqf63yfycbxp2z5gv5y0-static-root-path.patch
> patching file modules/setting/server.go
> Hunk #1 succeeded at 348 (offset -3 lines).
> Running phase: updateAutotoolsGnuConfigScriptsPhase
> Running phase: configurePhase
> Running phase: buildPhase
> go: go.mod requires go >= 1.25.3 (running go 1.25.2; GOTOOLCHAIN=local)
For full logs, run:
 nix log /nix/store/dm6qfcsi0v837nh6h4md60z08g6x0acp-gitea-1.25.1-go-modules.drv
error: Cannot build '/nix/store/dm6qfcsi0v837nh6h4md60z08g6x0acp-gitea-1.25.1-go-modules.drv'.
Reason: builder failed with exit code 1.
Output paths:
 /nix/store/r266q38myqigcp2vvv2lpzzmfsrkh7rz-gitea-1.25.1-go-modules
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
