### PR TITLE
efibooteditor: 1.5.3 -> 1.5.4

### DIFF
--- a/pkgs/by-name/ef/efibooteditor/package.nix
+++ b/pkgs/by-name/ef/efibooteditor/package.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "efibooteditor";
-  version = "1.5.3";
+  version = "1.5.4";
 
   src = fetchFromGitHub {
     owner = "Neverous";
     repo = "efibooteditor";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-xD40ZzkpwerDYC8nzGVqEHLV0KWbxcc0ApquQjrPJTc=";
+    hash = "sha256-tufB90EhO/jdCnQfeuibcJu5C7RfCjIxBYp+8uR0Zv0=";
   };
 
   buildInputs = [ zlib ] ++ lib.optional stdenv.hostPlatform.isLinux efivar;

--- a/pkgs/by-name/ef/efibooteditor/package.nix
+++ b/pkgs/by-name/ef/efibooteditor/package.nix
@@ -39,12 +39,25 @@ stdenv.mkDerivation (finalAttrs: {
         'sh -c "pkexec env DISPLAY=$DISPLAY XAUTHORITY=$XAUTHORITY efibooteditor"'
   '';
 
-  env.BUILD_VERSION = "v${finalAttrs.version}";
+  env = {
+    LANG = "C.UTF8";
+    BUILD_VERSION = "v${finalAttrs.version}";
+  };
+
   cmakeBuildType = "MinSizeRel";
   cmakeFlags = [ "-DQT_VERSION_MAJOR=6" ];
 
   postInstall = ''
     install -Dm644 $src/LICENSE.txt $out/share/licenses/efibooteditor/LICENSE
+  '';
+
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+
+    ctest --output-on-failure
+
+    runHook postCheck
   '';
 
   meta = {


### PR DESCRIPTION
Replaces https://github.com/NixOS/nixpkgs/pull/460528

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
