### PR TITLE
nixos/release: set a default location for configuration argument for better diagnostics

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -28,6 +28,8 @@ with import ../pkgs/top-level/release-lib.nix { inherit supportedSystems; };
 
 let
 
+  configuration' = lib.setDefaultModuleLocation "<argument to nixos/release.nix>" configuration;
+
   version = fileContents ../.version;
   versionSuffix =
     (if stableBranch then "." else "pre") + "${toString nixpkgs.revCount}.${nixpkgs.shortRev}";
@@ -84,7 +86,7 @@ let
     };
 
   makeModules = module: rest: [
-    configuration
+    configuration'
     versionModule
     module
     rest
@@ -335,7 +337,7 @@ rec {
       (import lib/eval-config.nix {
         inherit system;
         modules = [
-          configuration
+          configuration'
           versionModule
           ./maintainers/scripts/ec2/amazon-image.nix
         ];
@@ -352,7 +354,7 @@ rec {
       (import lib/eval-config.nix {
         inherit system;
         modules = [
-          configuration
+          configuration'
           versionModule
           ./maintainers/scripts/ec2/amazon-image-zfs.nix
         ];
@@ -376,7 +378,7 @@ rec {
           (import lib/eval-config.nix {
             inherit system;
             modules = [
-              configuration
+              configuration'
               versionModule
               ./maintainers/scripts/incus/incus-container-image.nix
             ];
@@ -400,7 +402,7 @@ rec {
           (import lib/eval-config.nix {
             inherit system;
             modules = [
-              configuration
+              configuration'
               versionModule
               ./maintainers/scripts/incus/incus-container-image.nix
             ];
@@ -424,7 +426,7 @@ rec {
           (import lib/eval-config.nix {
             inherit system;
             modules = [
-              configuration
+              configuration'
               versionModule
               ./maintainers/scripts/incus/incus-virtual-machine-image.nix
             ];
@@ -448,7 +450,7 @@ rec {
           (import lib/eval-config.nix {
             inherit system;
             modules = [
-              configuration
+              configuration'
               versionModule
               ./maintainers/scripts/incus/incus-virtual-machine-image.nix
             ];


### PR DESCRIPTION
Before this change, if the module passed into release.nix was inline, any diagnostics would report that release.nix itself was the source of the warnings, which is subpar UX at best.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
