### PR TITLE
 notion-appimage: init at version 4.23.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11828,6 +11828,13 @@
     name = "Jeffrey C. Ollie";
     keys = [ { fingerprint = "A8CF 5B72 ABC3 9A17 3FEA  620E 6F86 035A 6D97 044E"; } ];
   };
+  jcorbalan = {
+    email = "jcorbalan@mailbox.org";
+    github = "jcorbalanm";
+    githubId = 187110985;
+    name = "Julio Corbalán Moreno";
+    keys = [ { fingerprint = "EA6C 6CFC F9DF 839E 954D  899B CED6 C3ED 3A50 85E7"; } ];
+  };
   jcouyang = {
     email = "oyanglulu@gmail.com";
     github = "jcouyang";

--- a/pkgs/by-name/no/notion-appimage/package.nix
+++ b/pkgs/by-name/no/notion-appimage/package.nix
@@ -1,0 +1,33 @@
+{
+  appimageTools,
+  fetchurl,
+  lib,
+  nix-update-script,
+}:
+let
+  pname = "notion-appimage";
+  version = "4.23.0";
+
+  src = fetchurl {
+    url = "https://github.com/jcorbalanm/notion-appimage/releases/download/${version}/Notion-${version}-x86_64.AppImage";
+    hash = "sha256-IMijh723HBrkGgrfVwzaDp/aPx3qTpG1WJI55ZSashs=";
+  };
+
+  passthru.updateScript = nix-update-script { };
+
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+  meta = {
+    mainProgram = "notion-appimage";
+    description = "App to write, plan, collaborate, and get organised (AppImage version)";
+    homepage = "https://www.notion.so/";
+    downloadPage = "https://github.com/jcorbalanm/notion-appimage/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ jcorbalan ];
+    platforms = [
+      "x86_64-linux"
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
Created a new package that wraps a Notion AppImage found here: https://github.com/jcorbalanm/notion-appimage. Set myself as maintainer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
