### PR TITLE
multiviewer-for-f1: 2.1.0 -> 2.3.0

### DIFF
--- a/pkgs/by-name/mu/multiviewer-for-f1/package.nix
+++ b/pkgs/by-name/mu/multiviewer-for-f1/package.nix
@@ -25,15 +25,15 @@
   writeScript,
 }:
 let
-  id = "289869947";
+  id = "305607196";
 in
 stdenvNoCC.mkDerivation rec {
   pname = "multiviewer-for-f1";
-  version = "2.1.0";
+  version = "2.3.0";
 
   src = fetchurl {
     url = "https://releases.multiviewer.dev/download/${id}/multiviewer_${version}_amd64.deb";
-    sha256 = "sha256-H+tt2FiT1UxkWBxpuyOIUjRMOMl7kN/SFH/WqoRdVUU=";
+    sha256 = "sha256-Uc4db2o4XBV9eRNugxS6pA9Z5YhjY5QnEkwOICXmUwc=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Updated to latest version

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.