### PR TITLE
python312Packages.monosat: 1.8.0 -> 1.8.0-unstable-2025-03-21

### DIFF
--- a/pkgs/by-name/mo/monosat/package.nix
+++ b/pkgs/by-name/mo/monosat/package.nix
@@ -16,25 +16,17 @@
 let
   boolToCmake = x: if x then "ON" else "OFF";
 
-  rev = "1.8.0";
-  sha256 = "0q3a8x3iih25xkp2bm842sm2hxlb8hxlls4qmvj7vzwrh4lvsl7b";
+  rev = "fa810d432ae24b6abd5612725c3bf7c0871c07d2";
+  sha256 = "sha256-zf8cL/vGTvns6o8ZgwI9N9bNb67yq633kj32W5DQuV4=";
 
   pname = "monosat";
-  version = rev;
+  version = "1.8.0-unstable-2025-03-21";
 
   src = fetchFromGitHub {
     owner = "sambayless";
     repo = "monosat";
     inherit rev sha256;
   };
-
-  patches = [
-    # Python 3.8 compatibility
-    (fetchpatch {
-      url = "https://github.com/sambayless/monosat/commit/a5079711d0df0451f9840f3a41248e56dbb03967.patch";
-      sha256 = "1p2y0jw8hb9c90nbffhn86k1dxd6f6hk5v70dfmpzka3y6g1ksal";
-    })
-  ];
 
   # source behind __linux__ check assumes system is also x86 and
   # tries to disable x86/x87-specific extended precision mode
@@ -46,7 +38,7 @@ let
 
   core = stdenv.mkDerivation {
     name = "${pname}-${version}";
-    inherit src patches;
+    inherit src;
     postPatch = commonPostPatch + ''
       substituteInPlace CMakeLists.txt \
         --replace-fail "cmake_minimum_required(VERSION 3.02)" "cmake_minimum_required(VERSION 3.10)"
@@ -96,7 +88,6 @@ let
         pname
         version
         src
-        patches
         ;
 
       propagatedBuildInputs = [


### PR DESCRIPTION
fails on hydra currently. by updating we can fix it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
