### PR TITLE
nixos/nebula: enable reloadable configuration

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -446,6 +446,8 @@ and [release notes for v18](https://goteleport.com/docs/changelog/#1800-070325).
 
 - `linux_libre` & `linux_latest_libre` have been removed due to a lack of maintenance.
 
+- `services.nebula.networks.<name>` will now store configuration files in `/etc/nebula/<name>.yml` and supports config reloading.
+
 - `services.pds` has been renamed to `services.bluesky-pds`.
 
 - `services.xserver.desktopManager.deepin` and associated packages have been removed due to being unmaintained. See issue [#422090](https://github.com/NixOS/nixpkgs/issues/422090) for more details.

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1011,7 +1011,7 @@ in
     defaults.services.ncps.cache.dataPath = "/path/to/ncps";
   };
   ndppd = runTest ./ndppd.nix;
-  nebula = runTest ./nebula.nix;
+  nebula.connectivity = runTest ./nebula/connectivity.nix;
   neo4j = runTest ./neo4j.nix;
   netbird = runTest ./netbird.nix;
   netbox-upgrade = runTest ./web-apps/netbox-upgrade.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1012,6 +1012,7 @@ in
   };
   ndppd = runTest ./ndppd.nix;
   nebula.connectivity = runTest ./nebula/connectivity.nix;
+  nebula.reload = runTest ./nebula/reload.nix;
   neo4j = runTest ./neo4j.nix;
   netbird = runTest ./netbird.nix;
   netbox-upgrade = runTest ./web-apps/netbox-upgrade.nix;

--- a/nixos/tests/nebula/connectivity.nix
+++ b/nixos/tests/nebula/connectivity.nix
@@ -2,7 +2,7 @@
 let
 
   # We'll need to be able to trade cert files between nodes via scp.
-  inherit (import ./ssh-keys.nix pkgs)
+  inherit (import ../ssh-keys.nix pkgs)
     snakeOilPrivateKey
     snakeOilPublicKey
     ;

--- a/nixos/tests/nebula/reload.nix
+++ b/nixos/tests/nebula/reload.nix
@@ -1,0 +1,92 @@
+{ pkgs, lib, ... }:
+let
+
+  inherit (import ../ssh-keys.nix pkgs)
+    snakeOilPrivateKey
+    snakeOilPublicKey
+    ;
+
+in
+{
+  name = "nebula";
+
+  nodes = {
+    lighthouse =
+      {
+        pkgs,
+        lib,
+        config,
+        ...
+      }:
+      {
+        environment.systemPackages = [ pkgs.nebula ];
+        environment.etc."nebula-key" = {
+          user = "nebula-smoke";
+          group = "nebula-smoke";
+          source = snakeOilPrivateKey;
+          mode = "0600";
+        };
+
+        services.nebula.networks.smoke = {
+          # Note that these paths won't exist when the machine is first booted.
+          ca = "/etc/nebula/ca.crt";
+          cert = "/etc/nebula/lighthouse.crt";
+          key = "/etc/nebula/lighthouse.key";
+          isLighthouse = true;
+          listen = {
+            host = "0.0.0.0";
+            port = 4242;
+          };
+          enableReload = true;
+          settings.sshd = {
+            enabled = true;
+            listen = "127.0.0.1:2222";
+            host_key = "/etc/nebula-key";
+          };
+        };
+
+        # We will test that nebula is reloaded by switching specialisations.
+        specialisation.sshd-off.configuration = {
+          services.nebula.networks.smoke.settings.sshd.enabled = lib.mkForce false;
+        };
+        specialisation.sshd-on.configuration = {
+          services.nebula.networks.smoke.settings.sshd.enabled = lib.mkForce true;
+        };
+      };
+  };
+
+  testScript =
+    { nodes, ... }:
+    let
+      sshd-on = "${nodes.lighthouse.system.build.toplevel}/specialisation/sshd-on";
+      sshd-off = "${nodes.lighthouse.system.build.toplevel}/specialisation/sshd-off";
+    in
+    ''
+      # Create the certificate and sign the lighthouse's keys.
+      lighthouse.succeed(
+          "mkdir -p /etc/nebula",
+          'nebula-cert ca -duration $((10*365*24*60))m -name "Smoke Test" -out-crt /etc/nebula/ca.crt -out-key /etc/nebula/ca.key',
+          'nebula-cert sign -duration $((365*24*60))m -ca-crt /etc/nebula/ca.crt -ca-key /etc/nebula/ca.key -name "lighthouse" -groups "lighthouse" -ip "10.0.100.1/24" -out-crt /etc/nebula/lighthouse.crt -out-key /etc/nebula/lighthouse.key',
+          'chown -R nebula-smoke:nebula-smoke /etc/nebula'
+      )
+
+      # Restart nebula to pick up the keys.
+      lighthouse.systemctl("restart nebula@smoke.service")
+      lighthouse.succeed("ping -c5 10.0.100.1")
+
+      # Verify that nebula's ssh interface is up.
+      lighthouse.succeed("${pkgs.nmap}/bin/nmap 127.0.0.1 | grep 2222/tcp")
+
+      # Switch configuration, verify nebula was reloaded and not restarted.
+      lighthouse.succeed("${sshd-off}/bin/switch-to-configuration test 2>&1 | grep 'nebula' | grep 'reload'")
+
+      # Verify that nebula's ssh interface is no longer up.
+      lighthouse.fail("${pkgs.nmap}/bin/nmap 127.0.0.1 | grep 2222/tcp")
+
+      # Switch configuration, verify reload again.
+      lighthouse.succeed("${sshd-on}/bin/switch-to-configuration test 2>&1 | grep 'nebula' | grep 'reload'")
+
+      # Verify that ssh is back.
+      lighthouse.succeed("${pkgs.nmap}/bin/nmap 127.0.0.1 | grep 2222/tcp")
+    '';
+}

--- a/pkgs/by-name/ne/nebula/package.nix
+++ b/pkgs/by-name/ne/nebula/package.nix
@@ -26,7 +26,10 @@ buildGoModule rec {
   ldflags = [ "-X main.Build=${version}" ];
 
   passthru.tests = {
-    inherit (nixosTests.nebula) connectivity;
+    inherit (nixosTests.nebula)
+      connectivity
+      reload
+      ;
   };
 
   meta = {

--- a/pkgs/by-name/ne/nebula/package.nix
+++ b/pkgs/by-name/ne/nebula/package.nix
@@ -26,7 +26,7 @@ buildGoModule rec {
   ldflags = [ "-X main.Build=${version}" ];
 
   passthru.tests = {
-    inherit (nixosTests) nebula;
+    inherit (nixosTests.nebula) connectivity;
   };
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Optional support for reloading instead of restarting. This works by moving the config into `/etc/nebula/${netName}.yml` via `reloadTriggers`.

Succeeds https://github.com/NixOS/nixpkgs/pull/444668. @bzadm reported several weeks of personal usage with no issues, and a new nixos test verifies that a reload occurs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
