### PR TITLE
stirling-pdf: 1.3.2 -> 1.5.0

### DIFF
--- a/pkgs/by-name/st/stirling-pdf/deps.json
+++ b/pkgs/by-name/st/stirling-pdf/deps.json
@@ -88,23 +88,23 @@
    "module": "sha256-IFNqlfL+sr9DBRKMaq7Lb9idxFeYqchfJgK4qAnXUNs=",
    "pom": "sha256-Q1z/VXiZht7arXF/aPuo1UgklHhWLc2EsirU1lZvRAs="
   },
-  "com/diffplug/spotless#com.diffplug.spotless.gradle.plugin/7.2.1": {
-   "pom": "sha256-r0KlKH8JY2fsdKz6zNzXhSIUanQ4EoxTfnABcFEykHw="
+  "com/diffplug/spotless#com.diffplug.spotless.gradle.plugin/8.0.0": {
+   "pom": "sha256-P/Oh7RadAeWWadmHM4wl8jDaB9YpUlOPDdT5R3YokDY="
   },
-  "com/diffplug/spotless#spotless-lib-extra/3.3.1": {
-   "jar": "sha256-ZMEhkjb+Vivaqao7qJUxw/q4HqIypP/9RkRN9jmb+Vo=",
-   "module": "sha256-Go/Yhes5xVNeS8+5a9Pheq2utfOR2Q9W/OicT2qrz4Q=",
-   "pom": "sha256-OiP6xrSairRgMHCzZ9pidzGVi1BuxQUNsxxIBbRG7UY="
+  "com/diffplug/spotless#spotless-lib-extra/4.0.0": {
+   "jar": "sha256-eU/w7Rnmc9WDQiAay+mWa7V8opNptlkapAfpH3EIc2c=",
+   "module": "sha256-dqvsZm0K6Bu7X0LZSYmo9NBgzIv4HAWXyzycbJ8weA0=",
+   "pom": "sha256-mFOj57ehlVHOyeTfguC9ODVt9gOmFcOjOZCEYD8ZPTQ="
   },
-  "com/diffplug/spotless#spotless-lib/3.3.1": {
-   "jar": "sha256-fHSqPYXl8FY/Bq8FgIzvYq+ON4eG8n3KQM/oF/QCJns=",
-   "module": "sha256-pNqsenu42CaoB85idydMpGGUWqKXh9dx5TkkFlk+J0E=",
-   "pom": "sha256-LoohCSNFX+hQEun6ep9ItdLEr5OUUa6wtoGZCSS9xao="
+  "com/diffplug/spotless#spotless-lib/4.0.0": {
+   "jar": "sha256-N40MNuxkPDeA+rUo52uvANqE/ZRKp1epM/Z3rCg9M84=",
+   "module": "sha256-92+01yygh52jJV5JO6u5d9b/zZjBRnpQ68oDHCqhBls=",
+   "pom": "sha256-+cBI1/AcYo5IvXJAaj3WVp2p1ic1wgv1Tf8/XwxdqAI="
   },
-  "com/diffplug/spotless#spotless-plugin-gradle/7.2.1": {
-   "jar": "sha256-/1vZveHyG0htD4epai6Q+tHYiXGgS+9pQdlMqlLiev0=",
-   "module": "sha256-Gwij+KJQJMTVC8NwY4s5Ge15vYrXRnHBh3/A4NPCEtE=",
-   "pom": "sha256-BNp7IbLy2Xao44DgkOO92gLSzyaC4h8SM97fgUamX+E="
+  "com/diffplug/spotless#spotless-plugin-gradle/8.0.0": {
+   "jar": "sha256-SBsYKnFP49cVsGv7aNYcwSv5legJIsSSu+BJVp7ImSg=",
+   "module": "sha256-r/+o5mZMvgJa0XGjawqR2EoPmR66Ppyw8QBMOn5cDJk=",
+   "pom": "sha256-1bqWuk97BrrT2ObX/uAcy+vrA7tvvzoq509UApXddYU="
   },
   "com/fasterxml#oss-parent/69": {
    "pom": "sha256-OFbVhKqhyOM86UxnJE9x9vcFOKJZ/+jngXYbn6qth18="
@@ -218,8 +218,11 @@
    "pom": "sha256-2TFXvSlStMSp4Q2RXijyl8KiGSEQVLQ77N64IHJidns="
   },
   "commons-codec#commons-codec/1.17.1": {
-   "jar": "sha256-+fbLED8t3DyZqdgK2irnvwaFER/Wv/zLcgM9HaTm/yM=",
    "pom": "sha256-f6DbTYFQ2vkylYuK6onuJKu00Y4jFqXeU1J4/BMVEqA="
+  },
+  "commons-codec#commons-codec/1.18.0": {
+   "jar": "sha256-ugBfMEzvkqPe3iSjitWsm4r8zw2PdYOdbBM4Y0z39uQ=",
+   "pom": "sha256-dLkW2ksDhMYZ5t1MGN7+iqQ4f3lSBSU8+0u7L0WM3c4="
   },
   "commons-io#commons-io/2.16.1": {
    "jar": "sha256-9B97qs1xaJZEes6XWGIfYsHGsKkdiazuSI2ib8R3yE8=",
@@ -333,6 +336,9 @@
   "org/apache/commons#commons-parent/73": {
    "pom": "sha256-TtRFYLB/hEhHnf0eg6Qiuk6D5gs25RsocaxQKm1cG+o="
   },
+  "org/apache/commons#commons-parent/79": {
+   "pom": "sha256-Yo3zAUis08SRz8trc8euS1mJ5VJqsTovQo3qXUrRDXo="
+  },
   "org/apache/httpcomponents#httpcomponents-parent/13": {
    "pom": "sha256-5Ch4ZwNYVsc3QgNo3VhuXlfnAgmBNYQM89c+nINj17M="
   },
@@ -372,16 +378,16 @@
    "jar": "sha256-rdWRXmrPxqtYNuH9il4hxkiFNqjB8h84bus78oC3Atc=",
    "pom": "sha256-KJEtE5+e7RQcOUNx++W6b//5HnjxycuDSPlEok0gTtI="
   },
-  "org/eclipse/jgit#org.eclipse.jgit-parent/6.10.1.202505221210-r": {
-   "pom": "sha256-qosjJzQVcamIZ/iB7cYgVHtAmOlR87a72c9wxH4pUMw="
+  "org/eclipse/jgit#org.eclipse.jgit-parent/7.3.0.202506031305-r": {
+   "pom": "sha256-EuCm1BYOBfIGFJVPhMPmemiCdBhQJTysHHTj+5nXmjQ="
   },
-  "org/eclipse/jgit#org.eclipse.jgit/6.10.1.202505221210-r": {
-   "jar": "sha256-jwE1ykXQDE2o57oultROGt5FK/J515yk61SSHo8nlSw=",
-   "pom": "sha256-zVAKQncnlazpys4jPeQGGUMRdJR+MNLCRUVGJgA1ztw="
+  "org/eclipse/jgit#org.eclipse.jgit/7.3.0.202506031305-r": {
+   "jar": "sha256-xMTho+sa/p3Gqck7HIkG6qq5panNtcld5MyA7/TKDcE=",
+   "pom": "sha256-vWj77cwn8P6jA6dOS4JFmyRaL8IR0DZDrda/XpxYVyg="
   },
-  "org/eclipse/platform#org.eclipse.osgi/3.23.100": {
-   "jar": "sha256-kWT0D9C0JMryHKZRgYbSr4JpHyqN5FL4p9KQuVUoCiE=",
-   "pom": "sha256-gph5O0PkohKzeJ6c/dpZEqEGTCkPTgr4pUrLSNB5TuQ="
+  "org/eclipse/platform#org.eclipse.osgi/3.23.200": {
+   "jar": "sha256-jZQFjq0/RlGQAWaSSmd8O+tumW8HL6vzhf/dcFELxJM=",
+   "pom": "sha256-py2jWv3kgc2hDp2UsxpUwbkKe2hQqt5MmtnpVtdIWtA="
   },
   "org/gradle/toolchains#foojay-resolver/1.0.0": {
    "jar": "sha256-eLhqR9/fdpfJvRXaeJg/2A2nJH1uAvwQa98H4DiLYKg=",
@@ -534,33 +540,33 @@
   "org/springdoc/openapi-gradle-plugin#org.springdoc.openapi-gradle-plugin.gradle.plugin/1.9.0": {
    "pom": "sha256-tl5WbBE1MB1a3ZBIt2+eSkYygpKKJ27CMFDL64QIWd0="
   },
-  "org/springframework#spring-core/6.2.10": {
-   "jar": "sha256-KBItbkpI64tqDk4IelXpbkb7TV59XSx03IBRQB2BAdo=",
-   "module": "sha256-MmC8Tf0xYWQt2mU62/Em9cHvm874d73jQvgnLuKLzcA=",
-   "pom": "sha256-4v/tn6SWogTfN+OZtOyHMek0EddkDeLRJMufPK80eTM="
+  "org/springframework#spring-core/6.2.11": {
+   "jar": "sha256-od5v8tiMBUQkaDYLifiBt3/3o5O4zVsdV1h1ay4kf4o=",
+   "module": "sha256-GeuETmap4UhDGB+BSyNfaQsgGoEuGyxleiHAfkpP6+M=",
+   "pom": "sha256-/WrFgJ6d9jy0KXDViNyiKUPzRFfbusSi/pDh9axiVJQ="
   },
-  "org/springframework#spring-jcl/6.2.10": {
-   "jar": "sha256-cVhuCM3GLaosbwbcYGocwDHjJHeYaiFsJy0aFycLKt4=",
-   "module": "sha256-Njez/NAN6jtZWccyipfmYOgh6Q8uS5kmV3QWFiC+e1Q=",
-   "pom": "sha256-wO64UdvnE6rsQbMAVNAECv5GLY/OyWSL8wqPJJ6VLMc="
+  "org/springframework#spring-jcl/6.2.11": {
+   "jar": "sha256-pdkpI7ZYY3xixIHcROqwKa/BuBaxDY0P2l7WNxXzz4U=",
+   "module": "sha256-HkXgaDrLoCn50ftWGqWlTqdAzHqAMMt6WDeOs6C92RQ=",
+   "pom": "sha256-zgEwE3kvwGe6DSZsqA1M01YzSIMgNHWWEzniYk432LA="
   },
-  "org/springframework/boot#org.springframework.boot.gradle.plugin/3.5.5": {
-   "pom": "sha256-siIS+HdJdKxJAPdmCHy3ka1WG2UgSy8oESSz5cwsk/c="
+  "org/springframework/boot#org.springframework.boot.gradle.plugin/3.5.6": {
+   "pom": "sha256-vMD9hA5J80z2ci7gU9ydLTkJ0AhGr1U7LJ3h59wdMNI="
   },
-  "org/springframework/boot#spring-boot-buildpack-platform/3.5.5": {
-   "jar": "sha256-FnqJxfvqUYrhgc8opcqhGSb/tWX5M1pqfHyeAsTdnNw=",
-   "module": "sha256-kNZmXGGKhQ2CAgdeWuUNcCNfY/79FSkiikQMcZIDPoY=",
-   "pom": "sha256-zHjruodVnZDtpuP9Ql+vBdXpLdu+dWxoYAfu+Y5gdG4="
+  "org/springframework/boot#spring-boot-buildpack-platform/3.5.6": {
+   "jar": "sha256-kK0VQw0dsgB3Csy97yDERvZbbxCljRnE9MEY0Q7iyLI=",
+   "module": "sha256-n4TD8AfZqk/Jv5til/AcvlIZQxoBpa/8i9hzQ4BBW8M=",
+   "pom": "sha256-hVLg2Wcfe5D6bqsr30Zt2xrYyu06b6Ki2LREqpkRmRg="
   },
-  "org/springframework/boot#spring-boot-gradle-plugin/3.5.5": {
-   "jar": "sha256-SByclAa1HlOmdVfJlKDQWVqnDCJHGEXQPCpjIQPHtIE=",
-   "module": "sha256-xtChfOm0iN0kTBLC1A2dC4JwLrBnh6EAe90xfscZhAg=",
-   "pom": "sha256-9SKtYYcWjI9H9ObNisuel8jkdNE/PPb0MS/PdMTed8g="
+  "org/springframework/boot#spring-boot-gradle-plugin/3.5.6": {
+   "jar": "sha256-dNOtlSVxtaiR3/nXr/ayMkosA2SPymejmCCcpK249y4=",
+   "module": "sha256-O3wuZKJr6Usn8v3Tk7PB25LbnHgV4zudF4cgo1TD4Fw=",
+   "pom": "sha256-memWbdVNsTWsu29GTlCIwHZCFhZQdqz2mSddkVQ9qF4="
   },
-  "org/springframework/boot#spring-boot-loader-tools/3.5.5": {
-   "jar": "sha256-SebVQqdDUQdHf9w8/owDBPm0qbC261KO1X0pghM1hLY=",
-   "module": "sha256-Zd6KuwbHDwF/9PNkXh3uX8Ym3ANKfz9MGuKzs9BQADY=",
-   "pom": "sha256-xelv0vi9C0PyAmuG7hwubrE5d0ZQpJGTGHlTPGYsi6o="
+  "org/springframework/boot#spring-boot-loader-tools/3.5.6": {
+   "jar": "sha256-TYJP++QjZ2TN6l/nqpFKipt9K1eHJ8xRbmokY7gUE30=",
+   "module": "sha256-Q5i8H7Y45UYhd1bAIoPiLe3CigrILPS4wbgynD6MVzE=",
+   "pom": "sha256-FRQIxEDvH0/7aj29kqrEOMCPN/4k4HhZh8nOn5gAaG0="
   },
   "org/tomlj#tomlj/1.0.0": {
    "jar": "sha256-Mml8dWeykhxHNnioILE/xkcAqoe7FFdu60jQ7VhHz9Q=",
@@ -580,12 +586,23 @@
    "jar": "sha256-PhUz0DIfiBXu9GdQruARG0FVT5pGRMPE0tQEdEsJ9g8=",
    "pom": "sha256-1VfNKrI95KR+zocGQhYqn5Rzn80LHDE+J4MlFO4gODM="
   },
+  "ch/qos/logback#logback-classic/1.5.19": {
+   "jar": "sha256-CHLBoqFMKf/PwOQiJ7gPfpn7F6VFYnBJmsbK0NBDbxw=",
+   "pom": "sha256-oKXyFTNAIPDHpx1Lc82Gua/FTpn/im3f9yM244ugx9s="
+  },
   "ch/qos/logback#logback-core/1.5.18": {
    "jar": "sha256-hROee1e0ZPjl42Mm3YExdki+0ZnMxPmM1CWF+NdXECc=",
    "pom": "sha256-x3JHKX1dm7ngTpLUyC51xujqviRUNokvkRQzW4t5DIM="
   },
+  "ch/qos/logback#logback-core/1.5.19": {
+   "jar": "sha256-nKcv4x4y+tJE7JM5VwRS4pYx9nt7mnKny+zXPJTcPzw=",
+   "pom": "sha256-Ff+xACOXxj5lne52QsBjTGZ/GCHf6T7HYf3LIDA0ndI="
+  },
   "ch/qos/logback#logback-parent/1.5.18": {
    "pom": "sha256-U8PiGxI7vTijAbQNDYFAlOrUehAj0h1hPMdI1w57nGk="
+  },
+  "ch/qos/logback#logback-parent/1.5.19": {
+   "pom": "sha256-IWEzrZSgx3+i5Ho7ewr13T66RJClBX6dfMb4zHM8VTY="
   },
   "com/adobe/xmp#xmpcore/6.1.11": {
    "jar": "sha256-j3AzxXm5n6DZ1t3LlEiHW15LV3w1AAInjORpl9Z4tzc=",
@@ -737,6 +754,11 @@
    "jar": "sha256-B/tuOjBAEiuEbF5SUgAzF1wyUeLsiDDfgvh8sh84i7E=",
    "pom": "sha256-jQd0KBAHliclrx93swfN6BbP1+4loQxTI3nW41ZMvh4="
   },
+  "com/github/junrar#junrar/7.5.5": {
+   "jar": "sha256-4BuUlofipbTGgBHBcCql0syObEWGVqwskWWLac67G7M=",
+   "module": "sha256-MN6tDcEK8MzjOqrkn/l21sIvsbOImoZdOoXjfHKbogo=",
+   "pom": "sha256-eLkOtUPiaTa9zzpOq5cAazwdVk2b+9660FyMbAj4GYY="
+  },
   "com/github/stephenc/jcip#jcip-annotations/1.0-1": {
    "jar": "sha256-T8z/g4Kq/FiZYsTtsmL2qlleNPHhHmEFfRxqluj8cyM=",
    "pom": "sha256-aMKlqm6PNFdDCT5StbngGQuk1aUhXApZtNfTNkcgjLs="
@@ -745,25 +767,26 @@
    "jar": "sha256-dmrSoHg/JoeWLIrXTO7MOKKLn3Ki0IXuQ4t4E+ko0Mc=",
    "pom": "sha256-GYidvfGyVLJgGl7mRbgUepdGRIgil2hMeYr+XWPXjf4="
   },
-  "com/google/code/gson#gson-parent/2.13.1": {
-   "pom": "sha256-+IEKzlDd/j/ag9ESbeZdmdXSUVoUo2uIvrG5mkdpeDY="
+  "com/google/code/gson#gson-parent/2.13.2": {
+   "pom": "sha256-g6tSip1Q/XauuK1vcns+6ct2ZYYlV3TtFsqMTHbZ2s0="
   },
-  "com/google/code/gson#gson/2.13.1": {
-   "jar": "sha256-lIVZQtSZLxEpRtPeHDNOcJI3uBJtgTC/B4B8AYpKISA=",
-   "pom": "sha256-wPZXItdcDljNGDWzBGBG9ga12mmZBBYfjba3j+ubQBo="
-  },
-  "com/google/errorprone#error_prone_annotations/2.38.0": {
-   "pom": "sha256-MAe++K/zro6hLYHD/qy08Vl5ss9cPjj8kYmpjeoUEWc="
+  "com/google/code/gson#gson/2.13.2": {
+   "jar": "sha256-3QzhtVo+0ggMtw+cZVhQzahsIGhiMQAJ3LXlyVJlpeA=",
+   "pom": "sha256-OqBqp8D5rwkpYaQtCVeOQyS+FGNIoO5u1HhX98Jne3Y="
   },
   "com/google/errorprone#error_prone_annotations/2.40.0": {
    "jar": "sha256-v6d+SSJum9KsesG8SjxwQwB48ubNMMjgYV1sJdiugY0=",
    "pom": "sha256-GI+AyOrAS0CvdrRdA90dCjk5IOP6DEglL05u8YcojK4="
   },
-  "com/google/errorprone#error_prone_parent/2.38.0": {
-   "pom": "sha256-5iRYpqPmMIG8fFezwPrJ8E92zjL2BlMttp/is9R7k0w="
+  "com/google/errorprone#error_prone_annotations/2.41.0": {
+   "jar": "sha256-pW54K1tQgRrCBAc6NVoh2RWiEH/OE+xxEzGtA29mD8w=",
+   "pom": "sha256-oVHfHi4LSGGNiwahgHSKKbOrs5sbI5b2och5pydIjG4="
   },
   "com/google/errorprone#error_prone_parent/2.40.0": {
    "pom": "sha256-HGt0MRxgFPj9aMjdHl9h3bVEz/LHQ8JyTbf4LXLd5Is="
+  },
+  "com/google/errorprone#error_prone_parent/2.41.0": {
+   "pom": "sha256-xTg4jXYKXByY3PBvbtPP5fEaZRgn21y9LtgojHlcrUI="
   },
   "com/google/guava#failureaccess/1.0.1": {
    "jar": "sha256-oXHuTHNN0tqDfksWvp30Zhr6typBra8x64Tf2vk2yiY=",
@@ -830,9 +853,9 @@
    "jar": "sha256-6MHFlOJCW9vqLYYN5Vxptp/F1ZRURSRJoPCRPCpbijE=",
    "pom": "sha256-gksNfeeCer/GpH5u+UsP+qE4/vOK8IxWon9dOhUiEZ4="
   },
-  "com/nimbusds#nimbus-jose-jwt/9.37.3": {
-   "jar": "sha256-Eq5KOiYAldeuuirep645bouVcNuLe0CeCagkwhnMBEQ=",
-   "pom": "sha256-r8Y7aJ2IFDm5XzQ7Hcp1A5HtrGO4c5K+TZDRnJTMr74="
+  "com/nimbusds#nimbus-jose-jwt/9.37.4": {
+   "jar": "sha256-j89Kl4u+51SOje5uBSi8hbD/qEwPhRfJTdKeWQ5FlEk=",
+   "pom": "sha256-OXFJdcGHn9JO/A09JM1fDm8nuUFKEA+qTUuLTmvoWPM="
   },
   "com/nimbusds#oauth2-oidc-sdk/9.43.6": {
    "jar": "sha256-/ulOrlxDiOHef7qE462iuS0Xu7soxjDUJYpvBhXB8wM=",
@@ -1055,9 +1078,9 @@
    "jar": "sha256-MTOHjRCPDhlk19Qn83mnQz4bcaRfnzwfq37QrAMB07A=",
    "pom": "sha256-wwO7cco5tSiAann47wLaSpTxklt11Bh3ojRNsbwiWpI="
   },
-  "com/zaxxer#HikariCP/6.3.2": {
-   "jar": "sha256-bTwbjcFX9qhSWTXLOjxW+LIzSm1cOUVSpQUzyjuSNr8=",
-   "pom": "sha256-5jQKhf34SuSHkzOYy9bIv2WPEhlETWtyscgAWMlXLMY="
+  "com/zaxxer#HikariCP/6.3.3": {
+   "jar": "sha256-cJ83jAV1YoCTnOUPwbHxpTu44YmdwbJJ8h8ScDZAtIs=",
+   "pom": "sha256-JE7+AJ71MAutMI3kGMspCD3ieMELroFsWdqqKBmB/OU="
   },
   "commons-beanutils#commons-beanutils/1.11.0": {
    "jar": "sha256-nkS6aOyaPyEob6Kou7ADtzXA9pEBu0MUS3n0+KqnRwk=",
@@ -1125,31 +1148,40 @@
   "io/micrometer#micrometer-bom/1.15.3": {
    "pom": "sha256-nKOxjc3L4T5dZjipTfI7WenVWUflND/gA6sXRtSB7t4="
   },
-  "io/micrometer#micrometer-commons/1.15.3": {
-   "jar": "sha256-DcZ8oVXudkcMDDZhLoA8gfiXsq+Aih9ANTZY1ENPeRQ=",
-   "pom": "sha256-ZxGT7XYuJMLGmNe1q2Qu9V6Oqvw+j5nWvZhNqdRwRVk="
+  "io/micrometer#micrometer-bom/1.15.4": {
+   "pom": "sha256-ABXmHVoKghYxOXm5vgsduiajk+VAqVnsl0qMisYCvxs="
   },
-  "io/micrometer#micrometer-core/1.15.3": {
-   "jar": "sha256-x4BXQEEqBTzX3KO/Gs091MV2XjJk5Mm2jjc/nf+4eoo=",
-   "pom": "sha256-CR3m2ToDXDI6YJB7H8CcpL/yCTTmgv1mNJHtEmgciDs="
+  "io/micrometer#micrometer-commons/1.15.4": {
+   "jar": "sha256-2ZcSc5V9fNaViHy8aAdyt1hEv88/pwFxiRcWg3mLkYE=",
+   "pom": "sha256-gjxzp3dhh+mUt8YRvmWQiyZlmkEnpdmJg3Ij/1+kMSo="
   },
-  "io/micrometer#micrometer-jakarta9/1.15.3": {
-   "jar": "sha256-T3/dTVRtlSJpxN0IKMwxp6m0lAjCQMyLVfD7LKwJf3k=",
-   "pom": "sha256-bBljpLWOeT4N2RBvKoF01RejCCxYymlmNVPM9SnyqD0="
+  "io/micrometer#micrometer-core/1.15.4": {
+   "jar": "sha256-MXi4oMCxIKwfSsjgztl+XHOXpqObXiny39ba9mJjgsw=",
+   "pom": "sha256-Ysmyrm4zxjBD1m8+inzfsmvyyIoC5a0Nol/nxCE5zTM="
   },
-  "io/micrometer#micrometer-observation/1.15.3": {
-   "jar": "sha256-UsywVu8m+ofdcabtq7+9ArSkggts03NEcg4U+dtu4M4=",
-   "pom": "sha256-gjMo+yvu5PQkM3PaObtswTV1o5SEAVxDWgZ5mHNDykM="
+  "io/micrometer#micrometer-jakarta9/1.15.4": {
+   "jar": "sha256-yaP7sjB7F53QKJx15qDo4lFQ6HCZDkHASHDH99CjqOk=",
+   "pom": "sha256-ZgGHs7x5vCdLPA6n09KCf8Ng9XWXFLuBAc+3RIi8DlM="
   },
-  "io/micrometer#micrometer-registry-prometheus/1.15.3": {
-   "jar": "sha256-Ze84eO/x2zprnLbjGwQsXSoiatn8wETIB6c/yov8NmI=",
-   "pom": "sha256-4G+8OIkOoBLqUzSMIM7i5hsMMbHn5Zu5uz5YeH4TVKg="
+  "io/micrometer#micrometer-observation/1.15.4": {
+   "jar": "sha256-SWk6I5rwIZOE/UH2z15IY54JfF2g9ihDPh+be/MSDRs=",
+   "pom": "sha256-F4+w2wAAmBJRu9nwxt+8/vgEN7wvV2mAA7qc3COz4BU="
+  },
+  "io/micrometer#micrometer-registry-prometheus/1.15.4": {
+   "jar": "sha256-ByUckbe6BCdzlByyGAGf2uhmiw1y0WQIDm2zPeCmiAA=",
+   "pom": "sha256-X228LsSoLcjxw9JcVA0UhFB4FsNainoYUHGQdzhuPK0="
   },
   "io/micrometer#micrometer-tracing-bom/1.5.3": {
    "pom": "sha256-6O2PDqLXvn4l8jhc2qDIOxQjF2wajS+CPt1IDiDavcc="
   },
+  "io/micrometer#micrometer-tracing-bom/1.5.4": {
+   "pom": "sha256-PuwU2f6z4X5tobvmJyTymxoXcbtq3O6FwG8KW6fXGQo="
+  },
   "io/netty#netty-bom/4.1.124.Final": {
    "pom": "sha256-JjYm03b6G+14HpVMgeDbM9+quHZZ07WhMnoSfL8qYac="
+  },
+  "io/netty#netty-bom/4.1.127.Final": {
+   "pom": "sha256-7Pd2NMh0A9eIJSvf7mY0f5qHPid0dgLWxUqEVnmkm9g="
   },
   "io/netty#netty-bom/4.2.0.Final": {
    "pom": "sha256-+q0GIXkS4qfLmTtFIAp5y9JRyXsEMzuLm5njcK8Vfbk="
@@ -1177,6 +1209,10 @@
   "io/projectreactor#reactor-bom/2024.0.0": {
    "module": "sha256-q9+I0toctizFQ+OgBJvN0/40JvOfqIH6/38OEifY1S8=",
    "pom": "sha256-sPfCTHH0Hlqqku03Pm1SI6HTXuKRMDgNhehmSnhPpRY="
+  },
+  "io/projectreactor#reactor-bom/2024.0.10": {
+   "module": "sha256-eijJZTfVcQ67mgCZsw0NulwpaQf8o1RSo/wessNqBZc=",
+   "pom": "sha256-fuypyG++Ds4ei7yf51U+uCEdwKSd30qE3wak4hxy9lQ="
   },
   "io/projectreactor#reactor-bom/2024.0.9": {
    "module": "sha256-wLZbyjpHhdixpuFh8NsJKhPJIslCX8EKKJCPYcPSv/I=",
@@ -1244,16 +1280,31 @@
    "jar": "sha256-jdd1/Sflazsmub71rSqyJahy6XgEe+d9yA/g/mCaZBk=",
    "pom": "sha256-cyZE7PPYjQWlP9NZuM+J4CCAHJ5LV0o6tzTVtlVIyFo="
   },
+  "io/swagger/core/v3#swagger-annotations-jakarta/2.2.38": {
+   "jar": "sha256-zxWqSrfox0fXs9l5ZgpJMg6lbA3Ii3Ah5IzJCcE7mXs=",
+   "pom": "sha256-ud+S6yEEgJjPORpPgvJ4MVcTZNUpqIGvlm4/40ztRFk="
+  },
   "io/swagger/core/v3#swagger-core-jakarta/2.2.36": {
    "jar": "sha256-SwVjPS3HDjmy8HWj8bGrIiDF4OiOjrrRJO8J++Oj7ZU=",
    "pom": "sha256-2HOfvfoHBi+pTTWKXdQRAmleTznSTM1X+eai1IMpqYw="
+  },
+  "io/swagger/core/v3#swagger-core-jakarta/2.2.38": {
+   "jar": "sha256-6ZyE9YTQiL8fMu7pgYxANUKey2Y/4axJ/JZ+5SFWTD4=",
+   "pom": "sha256-E3VXkjZIWZ3oOYUD94U6Tcqkx29xHxJSTHJ6BBWVHpI="
   },
   "io/swagger/core/v3#swagger-models-jakarta/2.2.36": {
    "jar": "sha256-vPmtxshskIKuxXOYe57QniJUOSpchOW0ly3Vf1ymaZc=",
    "pom": "sha256-LwKuEM6/PQ3j6q+ws66zAROs4Q8lTeGHHyhUgPw8Lko="
   },
+  "io/swagger/core/v3#swagger-models-jakarta/2.2.38": {
+   "jar": "sha256-dZ8Hpd5UayYmZDxiTg8TEEAvoAd4LhUbT1oyBaSkMl4=",
+   "pom": "sha256-kGlH9lU52LBepRPJYsPIMi9A6ugBwjPGWKUV+xbliOg="
+  },
   "io/swagger/core/v3#swagger-project-jakarta/2.2.36": {
    "pom": "sha256-BdmEubWsZiK4YkFR0NHznA1e4M3c3hBK/kfBdVlbOec="
+  },
+  "io/swagger/core/v3#swagger-project-jakarta/2.2.38": {
+   "pom": "sha256-LKHDFdg66t8KLTkrs41ZH69BkT5WLm5+zaDZrKnJHfc="
   },
   "io/zipkin/brave#brave-bom/6.1.0": {
    "pom": "sha256-iUcmZppvAAqtW1/P97rsP42c9wAag9D0gFSxLxbhbpM="
@@ -1261,9 +1312,9 @@
   "io/zipkin/reporter2#zipkin-reporter-bom/3.5.1": {
    "pom": "sha256-j5/3aCMobH1es/BhsFO+pf2CnSVc3dqEm4MfQRZqfZA="
   },
-  "jakarta/activation#jakarta.activation-api/2.1.3": {
-   "jar": "sha256-AbF21xihaSY+eCkGkfxHmXcYa8xrMzSHMlCE1lhvRic=",
-   "pom": "sha256-slSZQMF7aGWjT2E1t3Iu2Mv+9tC2wNs3LDDwNGvIzVg="
+  "jakarta/activation#jakarta.activation-api/2.1.4": {
+   "jar": "sha256-ydtSEAzmyKrJXMOQdflXINLlYbEfgFG4HBIa1O/9cAQ=",
+   "pom": "sha256-dXeXDcCfETGkpCdp4Xce0GLwjSL0DaMEH/PhbVsv3qg="
   },
   "jakarta/annotation#jakarta.annotation-api/2.1.1": {
    "jar": "sha256-X2X9r0JO7itV4diCupuzdr6T+wmze4CL5uIuiFHJCf4=",
@@ -1288,13 +1339,13 @@
    "jar": "sha256-73h9P3E/xv9PAs1LDb7Qj5PYrzQAyQy7Q/tLXAWDcQs=",
    "pom": "sha256-0RTaY7IJPwvZwqllegFs5w/ro3YFCAalxZldiRPffV8="
   },
-  "jakarta/mail#jakarta.mail-api/2.1.3": {
-   "jar": "sha256-gFG1jXX5gvmluWOzdlQm6CSypkhl7wrxcgXkVbmNsFw=",
-   "pom": "sha256-/r52PsEKgXMh7LFdqGyx+8mVx+NS4cET8P01fku1eYA="
-  },
   "jakarta/mail#jakarta.mail-api/2.1.4": {
    "jar": "sha256-/La3QNkiLRewejIzrGLJriAOImMGG8YU8KgF6AzoVf0=",
    "pom": "sha256-7DEC3AKrkrICGbnJ6qmQl4rud7Q1Gt+OYcd2jQVxWEY="
+  },
+  "jakarta/mail#jakarta.mail-api/2.1.5": {
+   "jar": "sha256-qkk3U6y3qMRbqPTJzxIwp04gI3BW3Vtci8hsWD6M+g4=",
+   "pom": "sha256-8DvLWbt34aAJnIkGPZ0JprtNUNVpl6TV7hv1jjhk70M="
   },
   "jakarta/persistence#jakarta.persistence-api/3.1.0": {
    "jar": "sha256-R1OJRG01xvRsVlcot1bcUIwoRkTqJpBkTg2OfjOdQv0=",
@@ -1453,9 +1504,9 @@
    "jar": "sha256-bucx31yOWil2ocoCO2uzIOqNNTn75kyKHVy3ZRJ8M7Q=",
    "pom": "sha256-NRxuSUDpObHzMN9H9g8Tujg9uB7gCBga9UHzoqbSpWw="
   },
-  "org/apache/commons#commons-lang3/3.18.0": {
-   "jar": "sha256-Tu6ujSDAeKu2SwFewVit04OsWBVxzdxFxo8MmuAjByA=",
-   "pom": "sha256-qiVLNztvbUa8ncqGMxsHKoq4brJeqZIf1Dlhg5LpihY="
+  "org/apache/commons#commons-lang3/3.19.0": {
+   "jar": "sha256-MnM6tLyQtFtj63JnfYhpYQA/1O0RPgexAo+Yd8sqxzU=",
+   "pom": "sha256-10Y5Bqswgf9CzzUx63k7JA+wyj8cJv1Y/IT7IwMqcrc="
   },
   "org/apache/commons#commons-parent/39": {
    "pom": "sha256-h80n4aAqXD622FBZzphpa7G0TCuLZQ8FZ8ht9g+mHac="
@@ -1486,6 +1537,9 @@
   },
   "org/apache/commons#commons-parent/85": {
    "pom": "sha256-0Yn/LAAn6Wu2XTHm8iftKvlmFps2rx6XPdW6CJJtx7U="
+  },
+  "org/apache/commons#commons-parent/88": {
+   "pom": "sha256-i/cmFQ0dakO6CqkgYOVSkzyvKHOqGTlS2dSWRw+p+9g="
   },
   "org/apache/commons#commons-text/1.10.0": {
    "jar": "sha256-dwzZA/p7YE0ffve6F/hBCGZylLK0eL6O0a87/7SuABg=",
@@ -1578,15 +1632,15 @@
    "jar": "sha256-VRPnQX7cHrcYitxN4DEukxVr18ptbB5gctPgAG3v/yM=",
    "pom": "sha256-Ez/s/gIYho799ZY03YaS9/Ke5uLeQynWdwDJF6OE7kA="
   },
-  "org/apache/tomcat/embed#tomcat-embed-core/10.1.44": {
-   "pom": "sha256-34z2k8TkeP9iUoXi5wCpz/pNSp37YnS+eTjxaNdLkrI="
+  "org/apache/tomcat/embed#tomcat-embed-core/10.1.46": {
+   "pom": "sha256-TZWq8O6Un51Sj9kAw55Jvin4q3BCJx45RAARrBtrUy8="
   },
-  "org/apache/tomcat/embed#tomcat-embed-el/10.1.44": {
-   "jar": "sha256-jwKTDUktNbbrmH88iixjKF7uc5QTEx+0iGaN6MYqSYY=",
-   "pom": "sha256-f8mVKleDMcgxy2p9gqvSHOUhhFqnhM6oD/jTfsfJgZo="
+  "org/apache/tomcat/embed#tomcat-embed-el/10.1.46": {
+   "jar": "sha256-XGkkfQmE61+EdWwGfCJXXY9K//ByE+HYErxTVNG0gXM=",
+   "pom": "sha256-G/a7aCORuIOVFQqQmVz9KzW9Zt/SDF1+8g83OD8UNbk="
   },
-  "org/apache/tomcat/embed#tomcat-embed-websocket/10.1.44": {
-   "pom": "sha256-ZwPWaYpatbvk0xDKOngKROz/jIFzo7ZRkVIGa+Xc/oY="
+  "org/apache/tomcat/embed#tomcat-embed-websocket/10.1.46": {
+   "pom": "sha256-pYfr0CRP5HfaxJ0o+vw5q8YyBGCKSKBYwk0QA9AH/Uc="
   },
   "org/apache/velocity#velocity-engine-core/2.3": {
    "jar": "sha256-sIbO6P2Bg+JAtK/PVP447DPdjrDaQUY25b96pNmFZik=",
@@ -1646,13 +1700,13 @@
    "jar": "sha256-VqBUyxcNQfsfi6CylWiAYli3/+/cXpi3fvltR0Dz1rw=",
    "pom": "sha256-KFuL5ZWHD2HXXniBsPtO3C0ao30KecT8j/Lczx2caf0="
   },
-  "org/bouncycastle#bcpkix-jdk18on/1.81": {
-   "jar": "sha256-s4xgSHHzaQEJo8AJgtkUVjQSXeM2WoF7oW65DYjiQsk=",
-   "pom": "sha256-gmKXCFw2VHLz1Fyx4sxzyl04h4vIQQjwVFl6+/WQPuI="
+  "org/bouncycastle#bcpkix-jdk18on/1.82": {
+   "jar": "sha256-vccj4gg0gyrGrxNstbX/BeQ7cdT6FRzGUQ2SEu4IbmM=",
+   "pom": "sha256-9ZxFA6pO73U+GBOvaX5XtEbzNZMCXlUOuudLDz3+kK8="
   },
-  "org/bouncycastle#bcprov-jdk18on/1.81": {
-   "jar": "sha256-JJ85ZBKwwM5n8lyBl9p1eyQbi+PsQZk4bABwSiRXRZs=",
-   "pom": "sha256-IDmQEivg/dNL8S0LeIwGVRYThqjoWLpD8G43CcLMdMw="
+  "org/bouncycastle#bcprov-jdk18on/1.82": {
+   "jar": "sha256-FM3i/fqoiQSAqOW2es7vDJD5ZoLB4jwTO6/cngsyVc4=",
+   "pom": "sha256-IIFtWAs+mNGQCnGsqBnsns7HimpKN+ejwMbCeTkDlD8="
   },
   "org/bouncycastle#bcutil-jdk15on/1.69": {
    "pom": "sha256-p2e8fzQtGTKJfso8i6zHAEygOAv6dSnyOpc0VJZcffw="
@@ -1661,16 +1715,9 @@
    "jar": "sha256-RTd/22VgqXHupyX1B9kf1rj70Hl9Yb/Ibyy2U8WBhqQ=",
    "pom": "sha256-VwEEzKwN+inkb7ZAL35qchcCwlXe9DvjAcassYwl520="
   },
-  "org/bouncycastle#bcutil-jdk18on/1.81": {
-   "jar": "sha256-MaX+OnukLjRXuDkw8P+NZ5+1t26q3ytR9XQMkqOUv1I=",
-   "pom": "sha256-ZUPundbFVOb9vvw5zHT0JY9FLRCyU6XWzXhUi/lJLdQ="
-  },
-  "org/bouncycastle/bcutil-jdk18on/maven-metadata": {
-   "xml": {
-    "groupId": "org.bouncycastle",
-    "lastUpdated": "20250917070135",
-    "release": "1.82"
-   }
+  "org/bouncycastle#bcutil-jdk18on/1.82": {
+   "jar": "sha256-RCBpGVitHAuidabW2KYxetvb3JJ3BVtqcqqJyIzajH0=",
+   "pom": "sha256-pel6j6ALh5IPPwsFA7ri1GGx4mEsVviGirV554QqHEI="
   },
   "org/checkerframework#checker-qual/3.12.0": {
    "jar": "sha256-/xB4WsKjV+xd6cKTy5gqLLtgXAMJ6kzBy5ubxtvn88s=",
@@ -1682,16 +1729,21 @@
    "module": "sha256-dv9CWNsfoaC8bOeur0coPfEGD9Q3oJvm7zxcMmnqWtM=",
    "pom": "sha256-i+QBdkYoXZFCx/sibPuARFwXfcfBNjsj2UH6bJuwXc8="
   },
-  "org/commonmark#commonmark-ext-gfm-tables/0.25.1": {
-   "jar": "sha256-t6ofBMSsWzI65mbklDv2pEfcOJC+zuc5Chbb6mWDAJc=",
-   "pom": "sha256-uNEo5y+5FbyUIQAh6T0uegiXQPw1z7pPENCh7d7leiM="
+  "org/checkerframework#checker-qual/3.49.5": {
+   "jar": "sha256-UIyDxiw0T29+4o9HuIqHl9YRbQQ7/RygV2yCjdHfKIA=",
+   "module": "sha256-+zeot4Ic/rPYxSoh7WCqZwPgx0MnW5SWbvLNh6Jnibo=",
+   "pom": "sha256-V+9aHvxp0UcORdDRIwiAtt718X3MVVl+xD43REwUkmI="
   },
-  "org/commonmark#commonmark-parent/0.25.1": {
-   "pom": "sha256-u+e7KSkTa6DWzNID7lp4iHWwdGaBbXqrCu/pgOPUztI="
+  "org/commonmark#commonmark-ext-gfm-tables/0.27.0": {
+   "jar": "sha256-xp0al9H9ycIvnE2QOv9CzC4DeuuhHbpEzHzH8MGR+hw=",
+   "pom": "sha256-PXTgI6DbfE2yIhnx6aqcsXPxp+D5ep1FzQ343UK5QIg="
   },
-  "org/commonmark#commonmark/0.25.1": {
-   "jar": "sha256-uGLjqL5979lhFQLH9jyUFwGMo5VgjCFqE+LeI9N9Uu4=",
-   "pom": "sha256-IuBPuRoy5ZYN/9bskJjUrb8Z4GsWec1RxuWaIUqwf/U="
+  "org/commonmark#commonmark-parent/0.27.0": {
+   "pom": "sha256-jsEfhXLBhcxLwC2tZUNXdZiAiRaLRgiYSF3lWUWxD+o="
+  },
+  "org/commonmark#commonmark/0.27.0": {
+   "jar": "sha256-eloaboSOcp/X+FMJ8553evlJhIqRTlWcrrf2S6725j4=",
+   "pom": "sha256-uf3+/4RdbdusKOMSJkuMLsYCplb9J+UvcRETR4toVDo="
   },
   "org/cryptacular#cryptacular/1.2.5": {
    "jar": "sha256-xgDRrmG1sP8TkeAOtvs5AgHkYSw6ry3BuUBQyHhIQL4=",
@@ -1699,6 +1751,9 @@
   },
   "org/eclipse/angus#all/2.0.4": {
    "pom": "sha256-/M1yMQnFQB6VNOZYBCnxNj/1yEa0sWkThqbx9zdcoQw="
+  },
+  "org/eclipse/angus#all/2.0.5": {
+   "pom": "sha256-Yk3ST3oU8IDdCEbK5mINoRb+JUv+snBK0uDxldqNbag="
   },
   "org/eclipse/angus#angus-activation-project/2.0.2": {
    "pom": "sha256-r5GIoQy4qk61/+bTkfHuIVnx6kp/2JDuaYYj5vN52PY="
@@ -1710,6 +1765,10 @@
   "org/eclipse/angus#angus-mail/2.0.4": {
    "jar": "sha256-hzAYZVhLrZFwZis+7vA1Cqr+pFIkg+OOVK6H3D3z6Vg=",
    "pom": "sha256-hQ9aU/bgvIyFxRwmuDzkvVGEsbmC3zTRMfYIRO2T6zg="
+  },
+  "org/eclipse/angus#angus-mail/2.0.5": {
+   "jar": "sha256-tNjDDTX0Vd72x6Bf5ZWh5i6iuAysPv7B6cz0EYsjFoo=",
+   "pom": "sha256-svt2qeqAezVbj/pjTehK3vrC8nnPYNWMtZxqbBFMVa8="
   },
   "org/eclipse/angus#jakarta.mail/2.0.4": {
    "jar": "sha256-CO0mFHVJG7thXsuFJ6jorm99UHtuuhhwYaXGMMU7ARQ=",
@@ -1727,133 +1786,139 @@
   "org/eclipse/ee4j#project/1.0.9": {
    "pom": "sha256-glN5k0oc8pJJ80ny0Yra95p7LLLb4jFRiXTh7nCUHBc="
   },
-  "org/eclipse/jetty#jetty-alpn-client/12.0.25": {
-   "jar": "sha256-E4sHDJVuULXhL50+IuDmTcBfwxSl8kG1P6R932gqFrk=",
-   "pom": "sha256-zPlcYg0Uc/xPiLlhMC7GSvHjjQa75RMS84B5AZ3abBw="
+  "org/eclipse/jetty#jetty-alpn-client/12.0.27": {
+   "jar": "sha256-m8kgTbyi+f6n2AY3AfDveG73/6X0HAtlfplfTFYCDsw=",
+   "pom": "sha256-BCz5blLrc3NuiaES/gvGIV9Jx+i1cACRhiXMejt7YMI="
   },
-  "org/eclipse/jetty#jetty-alpn/12.0.25": {
-   "pom": "sha256-gjDzAW5BSgw898levq9IhcYEYlNbRx5Jyc4o6crXteM="
+  "org/eclipse/jetty#jetty-alpn/12.0.27": {
+   "pom": "sha256-iH1O4l5lOFZvZH9XXFuTGvbyBa6pKr63cCYHMIJOEJU="
   },
   "org/eclipse/jetty#jetty-bom/12.0.25": {
    "pom": "sha256-9qh6HNgykiWtLLlspl8xsavzbGXNlDV/FiNvIHyhL8M="
   },
-  "org/eclipse/jetty#jetty-client/12.0.25": {
-   "jar": "sha256-TGFD50QoEl2IGSTSHdFh90dWGA77kW30aeaUDYDe2bo=",
-   "pom": "sha256-aRzeTTCKr6STdQ59TxmoGsoWULwnY4gsipiBcserCQQ="
+  "org/eclipse/jetty#jetty-bom/12.0.27": {
+   "pom": "sha256-3YVZ0zTh40PUUND8ZrWCBB4m/kxLe/w9wx2JjRM8Yds="
   },
-  "org/eclipse/jetty#jetty-core/12.0.25": {
-   "pom": "sha256-vLdH49pPegTwZBp+zntIG2+TvucWutn2X4gLpqTdWmw="
+  "org/eclipse/jetty#jetty-client/12.0.27": {
+   "jar": "sha256-+K29ogKTzrQ+DdhI69ktiY3faIDKAGBgihMm+IugkJs=",
+   "pom": "sha256-i7CobH8TE1oqJCvy6ddke84sB2OeHp7Ux+2r3spC2xU="
   },
-  "org/eclipse/jetty#jetty-ee/12.0.25": {
-   "jar": "sha256-P8Ls3i8T/ndr8gsOWdVwmOoTAdirTmiXuX/olg7HKI4=",
-   "pom": "sha256-13sKAJDHTzh+9+ur81dwlMqNuIlk+VN6pSMGP8E7bWY="
+  "org/eclipse/jetty#jetty-core/12.0.27": {
+   "pom": "sha256-kh1pcRZgFiMi4r3ol91Ix9zl/BqGW35WyH03eWHQ1G0="
   },
-  "org/eclipse/jetty#jetty-http/12.0.25": {
-   "jar": "sha256-2bFwQRSYWRBczgxk9hPBBanbqCn9OZRnfmaYE0peCLs=",
-   "pom": "sha256-omSKww3NtLodDVzY3QoLolxBRvgiWh93hgcpzXbHs1E="
+  "org/eclipse/jetty#jetty-ee/12.0.27": {
+   "jar": "sha256-nakZaspV1kXrw73/nAliG2+I0sJ2MD4xyC3B/kRfFUE=",
+   "pom": "sha256-uu7lQYGMBcj0nRBpf8ijLPrWzWtF4MeeexMJibNuK2E="
   },
-  "org/eclipse/jetty#jetty-io/12.0.25": {
-   "jar": "sha256-hSX54g7cPQjfxF1nOQgfKd+ffmRC4kZ7d/eOuo5CgUM=",
-   "pom": "sha256-0/Uxy0jpBcvEnDEsTl4yVjwug0GlId/Jw2tthVz7IOk="
+  "org/eclipse/jetty#jetty-http/12.0.27": {
+   "jar": "sha256-mN8TVO966j6zY+acKnJX5VG3h3ovBsHmIY3t7EI16WI=",
+   "pom": "sha256-K+NCFCM5a3r46SASE2FtHy/YBksummqmNv2Y3xgjzW0="
   },
-  "org/eclipse/jetty#jetty-plus/12.0.25": {
-   "jar": "sha256-y52Z645ekm200W9w4AxI9Em9aMNmIxHJQxlN+OeLOME=",
-   "pom": "sha256-eBgZIEGaCx6Hn1d4We5GjXy2lYUvdaZgXneMAztKkqg="
+  "org/eclipse/jetty#jetty-io/12.0.27": {
+   "jar": "sha256-EDYktEr4/dKC+Z1UsJ5sj8FND0GJdE8JsWF5YSUyFS4=",
+   "pom": "sha256-1HsTok/v011wrTojqiSpU3zfryVTETqGwyatV13MR1E="
   },
-  "org/eclipse/jetty#jetty-project/12.0.25": {
-   "pom": "sha256-cBLMFruT8cVXWFc0bgdsjozg0Y3fL1Aaf5ACYGPqHys="
+  "org/eclipse/jetty#jetty-plus/12.0.27": {
+   "jar": "sha256-+VQQ2+8QEkQ2WIivd58fwlOO7eynvmCCCucB0FRjpk4=",
+   "pom": "sha256-Gc2IbI9zH5HRKu3djwSjIuacwn6XDqMRlPcGNKFxSdQ="
   },
-  "org/eclipse/jetty#jetty-security/12.0.25": {
-   "jar": "sha256-VAXcWLXn22dYya7gFdnFNPedRXd76zXNCqAh9KiLe5o=",
-   "pom": "sha256-4xxznIuKaO2HA1+jsLYYHzqvOAP5hwx5JD6lDFlL/p4="
+  "org/eclipse/jetty#jetty-project/12.0.27": {
+   "pom": "sha256-YmI2pyvnlQPAv+QvLCzK70EPROb9IvLraE5T/mCw+es="
   },
-  "org/eclipse/jetty#jetty-server/12.0.25": {
-   "jar": "sha256-6SOg7Dj7OK/o1XFWfL4BcP0ZvO80Fv5Yq/Xg/D9B4tA=",
-   "pom": "sha256-lX3fyUtulF3DnsvF1wfZD2Ie/C6Dl9PLhj3ocr5wyc0="
+  "org/eclipse/jetty#jetty-security/12.0.27": {
+   "jar": "sha256-Uifsg4566FcymN8QompsO7JBebdEjIR0sfhxDteGX4E=",
+   "pom": "sha256-VJDf1Zx7QzY8qvKoUTxcFZJIcN8ojq1hTMJizBA/Ee4="
   },
-  "org/eclipse/jetty#jetty-session/12.0.25": {
-   "jar": "sha256-Z3GTf8xpFDvQQI2JmU/FmSfjVKaGkUsS0XbxeSHuD8A=",
-   "pom": "sha256-SgnVWqDlK3lqTe48AmzFr6kQ5dlZM12suos+3OtDkig="
+  "org/eclipse/jetty#jetty-server/12.0.27": {
+   "jar": "sha256-BUAM5aiEh9g2aXnbRATibY46oL8BJpdkT+5plytf5MA=",
+   "pom": "sha256-ZDjC8oix6FEgq0qPkxK82bp7cj1S0Ro/LOx34qFn74I="
   },
-  "org/eclipse/jetty#jetty-util/12.0.25": {
-   "jar": "sha256-JnPzwLStzxxa+i6zxU/UMZt+dMr4PTA7AwZn9bAzdq4=",
-   "pom": "sha256-/NJHm6vfrx6QGiCwxFeow9z1lFHS905nWG/sz8DbMEM="
+  "org/eclipse/jetty#jetty-session/12.0.27": {
+   "jar": "sha256-htOIuhhc8u8H+eHvWwywvm/5m84kIyoIJYIqG3n0N0w=",
+   "pom": "sha256-wGZmMD096a7SU15oz7XB4+wQpS1OZhFrqa9bRwGz+Nk="
   },
-  "org/eclipse/jetty#jetty-xml/12.0.25": {
-   "jar": "sha256-AUGtD1gLpEhffgi79zcCkrYrSoADwjlbwwCa6YTCyTg=",
-   "pom": "sha256-9zBeYlvVedmzLFD9lnH+IG96anBoJsVo2sWOlsvcV0Q="
+  "org/eclipse/jetty#jetty-util/12.0.27": {
+   "jar": "sha256-bjw8cPWGysdlbmyBKyhUo/T1YpxKm9eGYJ8hXd+cSC4=",
+   "pom": "sha256-7Afayh10ZgC2Scm98+SOfBmabTKwVUhAPTQg1VcV/Bk="
   },
-  "org/eclipse/jetty/ee10#jetty-ee10-annotations/12.0.25": {
-   "jar": "sha256-0wByRxiIy9N7FVdRkLnd7KAhn7VqR7oLNTzNQQkWSuE=",
-   "pom": "sha256-ZOVPJOt2TayHHvyKPoJ6B13HTBjzobIF14THgD24uDM="
+  "org/eclipse/jetty#jetty-xml/12.0.27": {
+   "jar": "sha256-xzoLmlbq1AWumnJAk0ZGXf0ZTLxMRaMIg3rgfj159lw=",
+   "pom": "sha256-VH7l18obxWpCvJZQ7uTxcatGBj2Kd48saVDu6owG66s="
+  },
+  "org/eclipse/jetty/ee10#jetty-ee10-annotations/12.0.27": {
+   "jar": "sha256-mtNENHzNCkGU8+QGVn7d1lNfOjWvMGWXODj0YPuPhIQ=",
+   "pom": "sha256-RgSL3Zx+aLlgq6OgZZGFDCfmWDjvo3wNZE2KwMMcrzY="
   },
   "org/eclipse/jetty/ee10#jetty-ee10-bom/12.0.25": {
    "pom": "sha256-na76ox1J2KzxmzUsnpXQcmPHJj6AD2pKvrGqZE4w+Gg="
   },
-  "org/eclipse/jetty/ee10#jetty-ee10-plus/12.0.25": {
-   "jar": "sha256-q0cJT+VRINdEx5Q7bs3zArYXxI2RoXWq/ehe4gf2h5g=",
-   "pom": "sha256-SKZ25Tpa6GgKJAQTF3mywzz1R4BZORmu9D9/ZH1kqgI="
+  "org/eclipse/jetty/ee10#jetty-ee10-bom/12.0.27": {
+   "pom": "sha256-xhgO2bv8Kpanlm94db5S95g5WdQeXeh8iuqGsFy3DG4="
   },
-  "org/eclipse/jetty/ee10#jetty-ee10-servlet/12.0.25": {
-   "jar": "sha256-GYVtF59aPdNC0WvsMmSeWMQm4SRrVWfMkZGm32SVY3U=",
-   "pom": "sha256-wNGcbPQaNtJQTT4rGwEg0OHKH5gpw78cl2CH0MRWx14="
+  "org/eclipse/jetty/ee10#jetty-ee10-plus/12.0.27": {
+   "jar": "sha256-QKNoATMLgo5uCoq4T7SGOyInxj9S3gQGxtS0Rbm4zuc=",
+   "pom": "sha256-PU50s0HSA6GZ44uc/slyR0Dr7Hz/QXuHfAbouKMMCZU="
   },
-  "org/eclipse/jetty/ee10#jetty-ee10-servlets/12.0.25": {
-   "jar": "sha256-902Yhk+t41nVueVtieZjfke22uCVT2v4wKqti3nE2oM=",
-   "pom": "sha256-Xzw/FllRXsy3w/SduvqMJf9xfqgnFAPfzYdfM/xTglM="
+  "org/eclipse/jetty/ee10#jetty-ee10-servlet/12.0.27": {
+   "jar": "sha256-hl8OB7T02PhiY0NiVBaUf1OFgR8cuV7Qzo/Auwit3Pw=",
+   "pom": "sha256-UwIBO5EHnhQko7JVM2gq+7oEzijYgqijpXaRwkGWdvw="
   },
-  "org/eclipse/jetty/ee10#jetty-ee10-webapp/12.0.25": {
-   "jar": "sha256-Mr5AYD/TgjFhbvA0Q7zn55TLSd2rb49Ht5MXngttfDk=",
-   "pom": "sha256-5z1osr+bldTJS7T1NC4xfhXZeA41iTVYa0yzKViIhms="
+  "org/eclipse/jetty/ee10#jetty-ee10-servlets/12.0.27": {
+   "jar": "sha256-UVz3xAsoAtFS8wU0Tx9IThtDUsJmHTulIol7Jg3NPfE=",
+   "pom": "sha256-5ZzttN4/1UWwuig+2Kb2IrDep86XkhULLHVgq9opVrA="
   },
-  "org/eclipse/jetty/ee10#jetty-ee10/12.0.25": {
-   "pom": "sha256-vSQdg2u75+/YVjJ3gAorOcPm7q2Sgyte9zIl3rxuJys="
+  "org/eclipse/jetty/ee10#jetty-ee10-webapp/12.0.27": {
+   "jar": "sha256-aktQbqIGIaRpsUCaY2QO0ioHoKFDvlzsn5KdB6GEQ8c=",
+   "pom": "sha256-J8J15u5TbeYO3K5Nw1c4e4aq28+o95AIC3ob9qUJd4Q="
   },
-  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jakarta-client/12.0.25": {
-   "jar": "sha256-HjAariEgeRyBHWk7CXlaaNMjI/xsGWZCd/VC+gvsq0w=",
-   "pom": "sha256-zDzxWUggMerkUpKdsBR8ft1NU92xri/YjYIBhHDSXOA="
+  "org/eclipse/jetty/ee10#jetty-ee10/12.0.27": {
+   "pom": "sha256-d+1Hu/dEwT/z8UU0VtcuXCsRrZWs6gKSo5P1ZiDSqH8="
   },
-  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jakarta-common/12.0.25": {
-   "jar": "sha256-rNuiJr4gJQl0QSOgweET/tSE7pmYKGKFNmjrSEsbW+8=",
-   "pom": "sha256-o3odtZGgxbT+2ymStwCzdr1Ch9xcqa3XM7DBSq/sZhs="
+  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jakarta-client/12.0.27": {
+   "jar": "sha256-X8VWbuu8+CfB0I0wDWlxzO4nxKDJego4C3Aw3F/QSno=",
+   "pom": "sha256-HI7/omYr3Dzxih3XBZMMcUbFr4NhvFwDvhL1qlnuJEk="
   },
-  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jakarta-server/12.0.25": {
-   "jar": "sha256-LY89adEKEIt+s9XbAYfxjuvVc3aaMN3R+3qGl8fAID8=",
-   "pom": "sha256-3zprfN21xppje2LcTUyDRCkz4Xi0Nf8cIGLODX50UWw="
+  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jakarta-common/12.0.27": {
+   "jar": "sha256-y8CmI5EspFGho9nR/zasAqsdksClF+vhjtMts1fmUQE=",
+   "pom": "sha256-PRYi+64NL+IV+I0DfTcLnY/Fx0EFd6aduK8CbOak7Qs="
   },
-  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jetty-server/12.0.25": {
-   "jar": "sha256-zGT7GeCcLx9AEPnLZGYjSQX+KLKY90zy2h1GQ1JNqY8=",
-   "pom": "sha256-SicF8wkGjJPjJHKsvgK9rg5/JWJ2lceF0enli5CGJ1w="
+  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jakarta-server/12.0.27": {
+   "jar": "sha256-QwzPhLxOUCOePHWFDLnabzkHh+IroKnn5dKA2s49YDo=",
+   "pom": "sha256-mx8RYAfAWX33ASB7jChA+YSzferY3imPHNCFtoh+YRI="
   },
-  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-servlet/12.0.25": {
-   "jar": "sha256-0LyoE4DFykWm/e+6rWsx05ixitbFsV82TZ9ezYPGs18=",
-   "pom": "sha256-Mg905Jt94uoPt/OZYA0uDP5p2zpUYaZ2v/yNqwqSfLk="
+  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jetty-server/12.0.27": {
+   "jar": "sha256-iKZaVAqcHI2FNv3kVZazY5ErbkMbBlCD2s0yf25useU=",
+   "pom": "sha256-DbhkDZereyoYZUxeCCBl+oitcZFDfWaDNfqtF22n7sQ="
   },
-  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket/12.0.25": {
-   "pom": "sha256-iyQPp2yoVGxQPvP0c0OGGSEDAeka5KsVKuD9mk6WkIY="
+  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-servlet/12.0.27": {
+   "jar": "sha256-9ODjrSyXx/Z3vQ9u6/CWjCq2XrbwU3C6wDsfxAOkvjM=",
+   "pom": "sha256-Nute7QkUbVFW9XSUpl/aTmoHXCqcg/QFk7Xdm+nJX2U="
   },
-  "org/eclipse/jetty/websocket#jetty-websocket-core-client/12.0.25": {
-   "jar": "sha256-yOjuqTHJQjGS4+rAuUfWRf2aCO+0K8bZcNZEZa8K1j4=",
-   "pom": "sha256-NV7U5qKXyvqa7DxdmhEy83eZn6/1/Q5DkTkAwE7ACV4="
+  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket/12.0.27": {
+   "pom": "sha256-Ew2+haSSaBbozA4uk1ugMzLorODfxQNGdUWeJaFXcVU="
   },
-  "org/eclipse/jetty/websocket#jetty-websocket-core-common/12.0.25": {
-   "jar": "sha256-DeP7T8+apU3Kx2yG0rWJc64R/7jn837l+Ibh+nht64g=",
-   "pom": "sha256-rOYFDyybj8dxzuN/6yfWFA6pHOSMPiM7Xp6LJn6yf3E="
+  "org/eclipse/jetty/websocket#jetty-websocket-core-client/12.0.27": {
+   "jar": "sha256-MoIj03dxgWsIC3r0EwRqV8HeGTxjKQZ+hvccT265Zxw=",
+   "pom": "sha256-o02XNsDx9Ez9RGB4Nyghn24WfUMt5nOj0LVRT8di0Sk="
   },
-  "org/eclipse/jetty/websocket#jetty-websocket-core-server/12.0.25": {
-   "jar": "sha256-2uAlBSOMoa9ujhLG4wT3Kz+hmgfzSGIjHC3+ZHyCkts=",
-   "pom": "sha256-iA1lo8oblSZCRrZiHj17m5GAsr3qeGsTlP3utWSmV0k="
+  "org/eclipse/jetty/websocket#jetty-websocket-core-common/12.0.27": {
+   "jar": "sha256-5uD8dWgiB25d29601cGZDN8Rf1RCutTIFKFDD7vuk0c=",
+   "pom": "sha256-QhH9SGZmd2GpHRVjGO3BANcOYIzv4xdVQA//9E2QNDk="
   },
-  "org/eclipse/jetty/websocket#jetty-websocket-jetty-api/12.0.25": {
-   "jar": "sha256-VggCl1ELUa7lfAaGjYvt4Q5LFjtbLrwgaieHr/lfjAQ=",
-   "pom": "sha256-X19EI+XUaKA6vQmzF1NpX2fHH1KxvPztCuSz9Jzcae4="
+  "org/eclipse/jetty/websocket#jetty-websocket-core-server/12.0.27": {
+   "jar": "sha256-8cjQfvnE+sf31eNVQZgZGvo+fv9yjDWmAvQTTWCvybo=",
+   "pom": "sha256-OJGLMHzOWmrkD1uW73Btzb9roNm3B4BFys2PZkK389A="
   },
-  "org/eclipse/jetty/websocket#jetty-websocket-jetty-common/12.0.25": {
-   "jar": "sha256-TNXW55FTyjyA8iBTnkcCVwR/TZBeDdf5SF884R/iLkk=",
-   "pom": "sha256-lE5J6VdtM+Erym6lKP3Ktfairwzcp3vdHfYW8wcdhBg="
+  "org/eclipse/jetty/websocket#jetty-websocket-jetty-api/12.0.27": {
+   "jar": "sha256-IIMr9Hqhd8lacspkoCDFZYPB4BKYYGhu14G2bNYDDxE=",
+   "pom": "sha256-Tl1ohVPofBetCEUY89drO/bQyboUZWwqc44x26zBE0E="
   },
-  "org/eclipse/jetty/websocket#jetty-websocket/12.0.25": {
-   "pom": "sha256-C0oXxdF01WIxlSraz+jeRxSULNCR5BylF78D3NmGTNA="
+  "org/eclipse/jetty/websocket#jetty-websocket-jetty-common/12.0.27": {
+   "jar": "sha256-fA9CN1TYbZ+iEwPPcrgnn+QvI8oYz+E2QXq4cwsu5pQ=",
+   "pom": "sha256-7Zc99K1Etv2oSNWqfPqNqEvkX/LzZA4//96lgmgNZt4="
+  },
+  "org/eclipse/jetty/websocket#jetty-websocket/12.0.27": {
+   "pom": "sha256-HZYZbUK1N/fklMn3xFqJxz2Es733XszhZ8L6knkMSzc="
   },
   "org/glassfish/jaxb#jaxb-bom/4.0.5": {
    "pom": "sha256-7JfsQtk308iVGXl+RCRvgN4IUIGax6euZ1xEl7cHXDk="
@@ -1892,9 +1957,9 @@
    "module": "sha256-sapyAvw/Z9IgZpA9Ph63BS7hD0cyKhy5JfovRJ8lruM=",
    "pom": "sha256-ZvbmB7MHQOORmJglpa4HamyHepm3jrBUqBRmUKr/cus="
   },
-  "org/hibernate/orm#hibernate-core/6.6.26.Final": {
-   "jar": "sha256-t1rg3Y29Bw9uh/tt0U5Aw2dNBL81mID3xvgko389EFc=",
-   "pom": "sha256-Dva4GxJXb84kgRM+srnAAGzwjYOmgR2PSDIph+eApG4="
+  "org/hibernate/orm#hibernate-core/6.6.29.Final": {
+   "jar": "sha256-p2kzTtG0d6/H88HsTzaNHc2fZTWrJyqFYAN+TxY6Ch8=",
+   "pom": "sha256-fSXGZtnwtzawAfZHd790nEUROnB3dL7W+QOmcHU1qKY="
   },
   "org/hibernate/search#hibernate-search-bom/7.2.4.Final": {
    "pom": "sha256-FeQ040Zi1w3XLUNQwSGZTHISigSVOyfFOU91y0lV1II="
@@ -1909,11 +1974,17 @@
   "org/infinispan#infinispan-bom/15.2.5.Final": {
    "pom": "sha256-pYWE4Uusd4EG4YI0XIZlGsRbLRqQFxTRwaztgc7crKA="
   },
+  "org/infinispan#infinispan-bom/15.2.6.Final": {
+   "pom": "sha256-u5OCufYvaxwsp5SsAO/N9r9Jgimo1jJg/li5dezIuG4="
+  },
   "org/infinispan#infinispan-build-configuration-parent/15.2.4.Final": {
    "pom": "sha256-6ev57jNm+l4N4HD7x4iMjHvukRbdPZ7niUgfXTL3lFM="
   },
   "org/infinispan#infinispan-build-configuration-parent/15.2.5.Final": {
    "pom": "sha256-qCfDuEIoLhZAiXFWulWmDwrDOz+Z0FkNLFpCx64Tn88="
+  },
+  "org/infinispan#infinispan-build-configuration-parent/15.2.6.Final": {
+   "pom": "sha256-Om9mkHTwu24ztx17FOLxh3jFB0X2QNcCfQOA1smMSQs="
   },
   "org/jacoco#org.jacoco.agent/0.8.13": {
    "jar": "sha256-nbPJ1ddPqHCyYbZKMIJBLhvW4i6fqY9HN7G/+K+cxk0=",
@@ -2012,6 +2083,10 @@
   "org/junit#junit-bom/5.13.3": {
    "module": "sha256-XchNdO+YHQI8Y56wy8Sx+e+JEDQofOGxAe/7vA8VNLQ=",
    "pom": "sha256-47k+m7iHGWnPEcDo/xD1B4QdsYhcoQV44pCEb2YP1o4="
+  },
+  "org/junit#junit-bom/5.13.4": {
+   "module": "sha256-6Vkoj94bGwUNm8CC/HhniRKNpdKFMJFGj8pQQQS99AA=",
+   "pom": "sha256-16CKmbJQLwu2jNTh+YTwv2kySqogi9D3M2bAP8NUikI="
   },
   "org/junit#junit-bom/5.9.0": {
    "module": "sha256-oFTq9QFrWLvN6GZgREp8DdPiyvhNKhrV/Ey1JZecGbk=",
@@ -2148,9 +2223,16 @@
    "jar": "sha256-FXlj1grmbWB+CUZujAzfgIfpyyDQFZiZ/8qWvKJShGA=",
    "pom": "sha256-qCA7TCFN12Zi0VIdwZaeUYszcJ8IL9nNgTjP9MNpQMw="
   },
-  "org/projectlombok#lombok/1.18.38": {
-   "jar": "sha256-Hh5CfDb/Y8RP0w7yktnnc+oxVEYKtiZdP+1+b1vFD7k=",
-   "pom": "sha256-gWXuhymafa8GmnyYG3u4YENCE7mvyqurC0abO6v0jm0="
+  "org/postgresql#postgresql/42.7.8": {
+   "jar": "sha256-KjKp3LxC1npQrToN5e/RAsjSvkZyAEXyy9ZonxYKt8c=",
+   "pom": "sha256-gSWAq7t1dry37do8TLITXVleqFcIOstggFeYNRhUr5M="
+  },
+  "org/projectlombok#lombok/1.18.40": {
+   "pom": "sha256-1nxojbairP4dHNGr2cCKgSec4IFnu6k5gG+CqijxcF8="
+  },
+  "org/projectlombok#lombok/1.18.42": {
+   "jar": "sha256-NIik6ZlMJllrqs7r7ljK02pQ472uxb5ytYNNPDtWAwY=",
+   "pom": "sha256-ptIdhmGC3OpTRZNsTCOjLrTjfHO7au+oYH7hERU0Bf0="
   },
   "org/seleniumhq/selenium#selenium-bom/4.31.0": {
    "pom": "sha256-j6Ed533w4ozCMO4s/T+Hd1vI5CXBKsA6PYdaG+8l9rg="
@@ -2183,55 +2265,55 @@
   "org/sonatype/oss#oss-parent/9": {
    "pom": "sha256-+0AmX5glSCEv+C42LllzKyGH7G8NgBgohcFO8fmCgno="
   },
-  "org/springdoc#springdoc-openapi-starter-common/2.8.12": {
-   "jar": "sha256-E6zC1Y/khjaMYCGRF0lb24fjmTluesmqKzjKPCSxwnc=",
-   "pom": "sha256-zfVs+KltVzGlKZRCCFGoiHkAOf5SVexQmV7vDBzFH3g="
+  "org/springdoc#springdoc-openapi-starter-common/2.8.13": {
+   "jar": "sha256-M+rkcgDh5P9UlAgxPLNbYKdt8DCMXMks8nThVtLOows=",
+   "pom": "sha256-4tBQX/F71sRvj7zc7winrRJxSxRwdT0g4YDdqGPvKk4="
   },
-  "org/springdoc#springdoc-openapi-starter-webmvc-api/2.8.12": {
-   "jar": "sha256-BAycronB4rrXyojNLTqk/5b93WewBXxnduuMrEUT6Z0=",
-   "pom": "sha256-dYfjLA+XauYyxVC5S3Cv5VrFNRk/L8lYWfvsbqZ3ooI="
+  "org/springdoc#springdoc-openapi-starter-webmvc-api/2.8.13": {
+   "jar": "sha256-7QnH/ntKaODgQI+JsVf2B+EOk3SBUGfePQRnWrzh5Lk=",
+   "pom": "sha256-5RyogtLOFbPU7FlLyerioJP6wr0F6v3eJqpgZgx6UeY="
   },
-  "org/springdoc#springdoc-openapi-starter-webmvc-ui/2.8.12": {
-   "jar": "sha256-c2UxY8TeNGWadJCrAshijUKVPs6brNKBBnSuyTIzFEw=",
-   "pom": "sha256-wL83mV3vrjSEZwfT5++k2h+UPwoFL6V566UytizT6mU="
+  "org/springdoc#springdoc-openapi-starter-webmvc-ui/2.8.13": {
+   "jar": "sha256-o2IMpGTNmoBZqO/w4Cy76pB3bLocrFGNBSSiz9qSdds=",
+   "pom": "sha256-syIsNO8DnmqmHUYGiqerptbuctAHlhy+7QNxiW0VItw="
   },
-  "org/springdoc#springdoc-openapi/2.8.12": {
-   "pom": "sha256-PQpRDx7fdLjcPTdGrlvoFpANnonSUZku6xsi6hWC2yU="
+  "org/springdoc#springdoc-openapi/2.8.13": {
+   "pom": "sha256-LFzzMrdkBASfv5V1i6b5P55onbtoCujHXRjh5qhQq1g="
   },
-  "org/springframework#spring-aop/6.2.10": {
-   "jar": "sha256-nd6ixdrL6Bl1SMPTITVaDtc1jdZOuxkWN+Wdgn3xBII=",
-   "module": "sha256-o8v7RxeVW56XJgewqiyYo/5EzpZ2tbVvDYhKlM6E17o=",
-   "pom": "sha256-LMoNeWG+dn77NGE08mpRn8kzWbLSH+4qibpjaq3auhE="
+  "org/springframework#spring-aop/6.2.11": {
+   "jar": "sha256-kebNQgzWAaNNxB/DM2TP531Atige5HKgty1DeR8God0=",
+   "module": "sha256-sMHNV5DNZ8dbf8aMGF3OfRVkAKwID82AK9X4MV/VkvU=",
+   "pom": "sha256-82mKE9Vu1+yEg9+X0VqeFQkJlqxGMErQym7RDe0jJXo="
   },
-  "org/springframework#spring-aspects/6.2.10": {
-   "jar": "sha256-fdH151B3l89jvI/bH3BnIV286jUVs7yMIqpT4vZK6lM=",
-   "module": "sha256-gghCNUBdAGRQesgJZgZSwLe7FAMZk5O+OS1KEAgekaI=",
-   "pom": "sha256-fPpzJhmSPhWvlg7zruU7RiZty+kpuC1Keht7dCpfWgw="
+  "org/springframework#spring-aspects/6.2.11": {
+   "jar": "sha256-FfrOVwy7oYcDI0pC9j69nkwFvLg4nE+rdUxK7bfkjJI=",
+   "module": "sha256-KgmjKkHzsLctDBFgRACE5WV0bIRVZ/Aajh8Njq05SFQ=",
+   "pom": "sha256-2+AdZU3o2oPbg+NkEUU7EJ4gGi63GuNJq97rpzGzsls="
   },
-  "org/springframework#spring-beans/6.2.10": {
-   "jar": "sha256-14YCemk2h9hMa6nuGy9kD0wGi9nBBGmQ5nbGg8MJIPw=",
-   "module": "sha256-QsH0yP62uUQ2SYr7luEbAFSc4lsubb59rZXrrwP4EGA=",
-   "pom": "sha256-l3nGeQDqaRIopW2jqxCeINeLVlBOPgXOy9KyCZ2pmRQ="
+  "org/springframework#spring-beans/6.2.11": {
+   "jar": "sha256-+bpd7e6UlHsR2TAgn/GhK76eKLG09zxbrrovs/4y0I4=",
+   "module": "sha256-k+zH/L7zVq16cFX2DBDSZjgmqMXpyR+tgACC0ARgI9g=",
+   "pom": "sha256-k+RAp2lj2vbtaL4i+67oojhCKdi+X9x6vpRjno0Ykuw="
   },
-  "org/springframework#spring-context-support/6.2.10": {
-   "jar": "sha256-mcIn+VDrM2kC0XGrVCkAzWu6pSD0T4MuH09cduqhCXw=",
-   "module": "sha256-Kgw2qf4YGZXbP6J0nV/oO1cgAwMZbR2RoKtQQnWsm0k=",
-   "pom": "sha256-nKSBz/v8UxjqJbdtDW6bCZb2wInsI+MvDpfmze31+C8="
+  "org/springframework#spring-context-support/6.2.11": {
+   "jar": "sha256-GjOYhZAcRroSgH5zZmTXpQNfmxsvx9HvHeavIUfcU2o=",
+   "module": "sha256-apZD0bc/vQoIUULt2IYojVSodc0Oy6i7Uefm1+PtOMQ=",
+   "pom": "sha256-xgOfMwfze+RiOZyeAcPmTFaZ/CCc29jRJfeXhl1SZKE="
   },
-  "org/springframework#spring-context/6.2.10": {
-   "jar": "sha256-tG4v8ncIovhdrf2lzxxByezVKzJlsnIhHOCFUWwCivk=",
-   "module": "sha256-N942GEcvmm9zbmarTD4Quy3WwsLfbTEk9s18ID8JFTs=",
-   "pom": "sha256-Y1dsxaQ8WcBXtwZ0cntb5AsQ+bsqED8QUF0SOooZPwI="
+  "org/springframework#spring-context/6.2.11": {
+   "jar": "sha256-oscy/OiyTq18r0ohoVcWe86ZEEhjiAXPEnel7WpWgFc=",
+   "module": "sha256-GDjlNeVSQHG/oY7xsX/AiN2PQQZo9KNsJz1hdiuR6WU=",
+   "pom": "sha256-dkKRXfH6vssCUrnmY74mKsWjfZ4KTDBaozJZBDV49Cw="
   },
-  "org/springframework#spring-core/6.2.10": {
-   "jar": "sha256-KBItbkpI64tqDk4IelXpbkb7TV59XSx03IBRQB2BAdo=",
-   "module": "sha256-MmC8Tf0xYWQt2mU62/Em9cHvm874d73jQvgnLuKLzcA=",
-   "pom": "sha256-4v/tn6SWogTfN+OZtOyHMek0EddkDeLRJMufPK80eTM="
+  "org/springframework#spring-core/6.2.11": {
+   "jar": "sha256-od5v8tiMBUQkaDYLifiBt3/3o5O4zVsdV1h1ay4kf4o=",
+   "module": "sha256-GeuETmap4UhDGB+BSyNfaQsgGoEuGyxleiHAfkpP6+M=",
+   "pom": "sha256-/WrFgJ6d9jy0KXDViNyiKUPzRFfbusSi/pDh9axiVJQ="
   },
-  "org/springframework#spring-expression/6.2.10": {
-   "jar": "sha256-T7B8WSSc+zQSCKJ8NxiGwRC1XNoskz5ZRO1+Auq/GCg=",
-   "module": "sha256-jHR210n0nuzoQ2rmtShdZAUT2jDPCjtIL4PRbcA3JBo=",
-   "pom": "sha256-eVRpFH6iA7In/jodmCEzNpbHr4b3TZ2VR5o1vk6AsMA="
+  "org/springframework#spring-expression/6.2.11": {
+   "jar": "sha256-D9h1OxrYYQGaseHO27qCwTVLqwMT8MhQl5nt0/yYu7M=",
+   "module": "sha256-aO5i7ynJA9t3vIw4YwrItFGqVuDGKN0XW6echx1kCqg=",
+   "pom": "sha256-sJ5mW2AlDiI11OwnMVKkWoYzhDnMkgk5/JbQdORdoIQ="
   },
   "org/springframework#spring-framework-bom/5.3.25": {
    "module": "sha256-bPPIDzsrxVO0LptyC/9x/bBxUmy4kMVwkz2deAd2JQ4=",
@@ -2253,172 +2335,186 @@
    "module": "sha256-c1FObtnw4rZ83ukm8QT93yc0vPtI5eZEPo1qwbs3UFc=",
    "pom": "sha256-NUCFKBQ8D99ynzuC00PuBaAReU3+E4oMrer86pOsh08="
   },
-  "org/springframework#spring-jcl/6.2.10": {
-   "jar": "sha256-cVhuCM3GLaosbwbcYGocwDHjJHeYaiFsJy0aFycLKt4=",
-   "module": "sha256-Njez/NAN6jtZWccyipfmYOgh6Q8uS5kmV3QWFiC+e1Q=",
-   "pom": "sha256-wO64UdvnE6rsQbMAVNAECv5GLY/OyWSL8wqPJJ6VLMc="
+  "org/springframework#spring-framework-bom/6.2.11": {
+   "module": "sha256-CpCQd40hWMhxGLTb2XElGZADlmC9W9tl3cZxABZsy2g=",
+   "pom": "sha256-08QBQ/EqLgPvLUscIjYsQoEg4WLsK7pqzTuuITx2yAk="
   },
-  "org/springframework#spring-jdbc/6.2.10": {
-   "jar": "sha256-QhgRs4+fMCQ8ZyCQnv0RDO7BHBPFIyM/oSJueonYQR0=",
-   "module": "sha256-RYpxSF6ZghqRQpERdIYeHSmxy13da0lDC4LAqeFZY3s=",
-   "pom": "sha256-UPn+aql6YloJq/mCV1jRdPOeP9BZGJIHyq4pOqHJETQ="
+  "org/springframework#spring-jcl/6.2.11": {
+   "jar": "sha256-pdkpI7ZYY3xixIHcROqwKa/BuBaxDY0P2l7WNxXzz4U=",
+   "module": "sha256-HkXgaDrLoCn50ftWGqWlTqdAzHqAMMt6WDeOs6C92RQ=",
+   "pom": "sha256-zgEwE3kvwGe6DSZsqA1M01YzSIMgNHWWEzniYk432LA="
   },
-  "org/springframework#spring-orm/6.2.10": {
-   "jar": "sha256-99gSZZNIgl2NgjXfXZdPeO4YsifiH1E8DbG9ZKwNRHA=",
-   "module": "sha256-SC34rjFHYOfzpe7hs/e833m1D98S0QzFB3weB2oxN5o=",
-   "pom": "sha256-DDwdgJ3XUTazYyVn065N2s5kyEgQ35rhMOSBzH/IpxM="
+  "org/springframework#spring-jdbc/6.2.11": {
+   "jar": "sha256-AeY+C7YIWbpkJ5mY/RYZtK2PrQ8SfMhCccdlLgDuapg=",
+   "module": "sha256-IYAbYsOsu/82HhLrAE2OXLoyvd54Nla5NsyrFynMz5s=",
+   "pom": "sha256-XtIBWkoTqza3i4hGBLheuWny2SxTYWg9bRJInaqaXs4="
   },
-  "org/springframework#spring-test/6.2.10": {
-   "jar": "sha256-tJQ5Syk2uVxm1ywoXL5rYTwgQVH+lNybuZRCPslHLJM=",
-   "module": "sha256-Zz4cV8urN85SxSFb9obxM3EcMa59UnkRJZpd1Gg4zsk=",
-   "pom": "sha256-hdygmXQXXW/16BNWoEWCnPQcEEZnuPkoobITWOn/UEc="
+  "org/springframework#spring-orm/6.2.11": {
+   "jar": "sha256-48hl+V9Wh1gk2sB4IPmgWJ71ZQmEP9yWWFgmCX3R9lQ=",
+   "module": "sha256-0ys0CFYCz/Y8RcR6T6aoLwqpncA5Duw719dOHZBdXnI=",
+   "pom": "sha256-jOJ/RS3t5f589PFTZb1tkqIaqRb3rdn8Kt+f6LEHqaw="
   },
-  "org/springframework#spring-tx/6.2.10": {
-   "jar": "sha256-Y3qEddK+d0O7/ePP/DiKkBMwHtqnCKvX7aRy5hhV994=",
-   "module": "sha256-ryqit3lLbpSV0Lm+BLNdbpBwjcic8h6JXLXQAL2hlIc=",
-   "pom": "sha256-3e92u0SprwdUO1SHW0SS4fPsVWpnLMc85EXajtIQMIA="
+  "org/springframework#spring-test/6.2.11": {
+   "jar": "sha256-p1b92xbFhHVxHlYkW987MSlbLK3sV58t7O/2Vzd5B/g=",
+   "module": "sha256-PTt9t2JoSRU/idT7ucxohpC3XbvJ2HHpGnRpAMEph6k=",
+   "pom": "sha256-kRhaG/dP2qBVPg2DlM2CS3eL2SsQVJWSPlpydGX8YWE="
   },
-  "org/springframework#spring-web/6.2.10": {
-   "jar": "sha256-ebaMUlJ3Xi+2fpReqPY9SHLcDXs8o17CV23Ij3vbiV4=",
-   "module": "sha256-HITCzYo+Rp3Gkj3DhK+8DWOV9zvnzmUpth8VFpHL+Ns=",
-   "pom": "sha256-9iyDUxaQpjPzbsdLW1Y9EsUoQGdgv0a2qYhIxZ053mU="
+  "org/springframework#spring-tx/6.2.11": {
+   "jar": "sha256-3X6zUUpRyR5WWkyh57Fw91E7TaVtb3ghrITLMtxPuxY=",
+   "module": "sha256-76P8C+orwx4AVhS+NDJv/D0zy4bjqvDQdcXXSSXJnmg=",
+   "pom": "sha256-ctNvbwZVTvkv0nk6jgLUagQfu0/3YwCG5qBhn28h21I="
   },
-  "org/springframework#spring-webmvc/6.2.10": {
-   "jar": "sha256-zdK9teU5bVJxVZwSDC24EWL0IPz/8rCQB7kWi4Y1F10=",
-   "module": "sha256-okumzTllmEQ1iN6jlRRCCgcbP1doO4+CLNjqeakBnhE=",
-   "pom": "sha256-kS/0o0Vs8fKgR8HRtqs88hJC1KTQvH3n1YYN2AFwnCs="
+  "org/springframework#spring-web/6.2.11": {
+   "jar": "sha256-uKcACsaN6lnyCBSL9AoeAs8/H2wSDp62aW19RvV9ftA=",
+   "module": "sha256-TIYqFLUpD1n9v+3ryLHoMkJFkX4KV6Za+u8MzFW7+48=",
+   "pom": "sha256-uYvPX2zkJ2NQtFugsDwXnWTOw6x8AfvK1p4GU4SWUJE="
+  },
+  "org/springframework#spring-webmvc/6.2.11": {
+   "jar": "sha256-wZSZcLJwKAn7hbr6Hjs8bmio5pJI53zXfN4nP7JNsTk=",
+   "module": "sha256-SylSXGD/yiMIlqwdd2BynrWxnTHBX13572KjyJbotFI=",
+   "pom": "sha256-UabjLkcF4K/tpzTu7rxANXomJ6B2cr1nLda+U+au9As="
   },
   "org/springframework/amqp#spring-amqp-bom/3.2.6": {
    "module": "sha256-xGWJNtXHpd3wIdfoIkUwP4P4Fwze5QLrVIfwpb5VW8A=",
    "pom": "sha256-d/uyfjFp2vGY15bSQkMEOVdyCmc7/HUmUGUvTouvhVM="
   },
+  "org/springframework/amqp#spring-amqp-bom/3.2.7": {
+   "module": "sha256-MBkJUPEkJH+2PqI3V3O6SSMxO85Imm4Hcyr+tpfFedg=",
+   "pom": "sha256-lAKzfWI60XEwwn0GCUx4MEr40Y3OeVxz3N8GHkO2O10="
+  },
   "org/springframework/batch#spring-batch-bom/5.2.2": {
    "pom": "sha256-SJs2UNjohLCPgk5pY7T9M/GIrgTewdAIIP4Ap939nsE="
   },
-  "org/springframework/boot#spring-boot-actuator-autoconfigure/3.5.5": {
-   "jar": "sha256-2xb2cu3Ow+iQwtIXUTzobLy3YnYgRGAFBkO8kVYCp9E=",
-   "module": "sha256-qxwwCHbhpM5OZJnltC3T6gLnu89LOueCl78AcQNCSPU=",
-   "pom": "sha256-puMYxv3Cdlxa0wUwYo4pHft+t3zuzGi43Na3ntmrb2k="
+  "org/springframework/batch#spring-batch-bom/5.2.3": {
+   "pom": "sha256-6VnooxK1etQJlfX8nPc75fQLg/kN+fBTj+GLvQie1Yw="
   },
-  "org/springframework/boot#spring-boot-actuator/3.5.5": {
-   "jar": "sha256-WcLEpOc73mvdwl3jgLh0K+TEMC8ov8EsVHelOTIvgKk=",
-   "module": "sha256-MebnpOoYKONP8w4ksYuWLWptxEpvqMNRpnWn1JWD/NM=",
-   "pom": "sha256-SmxjEOXUj5qMChPUgOBzgpHLlm1pla6Dc+dWNEnASsc="
+  "org/springframework/boot#spring-boot-actuator-autoconfigure/3.5.6": {
+   "jar": "sha256-8H/k8Q4MyollNyRaE6xFB5IQLOA3M80ZUJoKzBDiDfk=",
+   "module": "sha256-dg53jEzvuhRnyWdthAo/PZWukHh6WjSk6TGk2CzoFXI=",
+   "pom": "sha256-eIFBSnXIkARJiHmszY+c5TQY1B1cDt4PB1o+WJeKrUM="
   },
-  "org/springframework/boot#spring-boot-autoconfigure/3.5.5": {
-   "jar": "sha256-sSmF5icAFGlzdAIXqOAQUjsqCIeZkJCbQ72CS9gQeU0=",
-   "module": "sha256-on6VgQf4efSoe335JJMXxjlW2KazI9FUSBTjrQYkCHg=",
-   "pom": "sha256-1ZXHhIrLxf1tt96e9EWwYkhEtPd133bXE6o0qHzMRYk="
+  "org/springframework/boot#spring-boot-actuator/3.5.6": {
+   "jar": "sha256-sGFD02WjN99RcxGf6NaUJKdGe1rUImA0t+btOisRwVg=",
+   "module": "sha256-8DqhH7E2OiZY/H7K7KpIMHI12ulfguxXaBLDJW+wptc=",
+   "pom": "sha256-BzqDRyGVw2uafpIQJjEEKN76dKJ8YHrGPuhjRZD3SQg="
+  },
+  "org/springframework/boot#spring-boot-autoconfigure/3.5.6": {
+   "jar": "sha256-H4KEzvr/swGNgD5MnPBl6qiNw+CamqKr6o6HaYGxvno=",
+   "module": "sha256-z6nw4MZ/p3+1fbv3IHqlktfK5WLTXXzufXPNbAZ1le0=",
+   "pom": "sha256-BeUbT7Ytvjc9GjKvi5O+fdReaSEXaX9bhsgyTBedKr0="
   },
   "org/springframework/boot#spring-boot-dependencies/3.5.5": {
    "pom": "sha256-JW/xEsc3m2TpHI3usCT1DICSEuXCGTSK7ERkffOGxZo="
   },
-  "org/springframework/boot#spring-boot-devtools/3.5.5": {
-   "jar": "sha256-/AbLdC4nFf1KGACUqSt/gNolkr+aqV7ARlSFeJDIc+I=",
-   "module": "sha256-NipceeJGSwsKg5LJo9UGKTR5+W79QFJTbr7my3zjdg4=",
-   "pom": "sha256-IpBOsoLA3jscb88ibn5tFVRS5bQOsUTnkQTPeBiFHhg="
+  "org/springframework/boot#spring-boot-dependencies/3.5.6": {
+   "pom": "sha256-v3qNPijKN1rdC0gQBAXW08VEcd4Cds58TwDE6v8hoPc="
   },
-  "org/springframework/boot#spring-boot-starter-actuator/3.5.5": {
-   "jar": "sha256-Wf0K/8PKz56hruP3T/7AJO0N0U2Uq5IqYoM2mIOFjDo=",
-   "module": "sha256-eJQmNzhY/dDd6vhOCnnxprSPD7Zy1y2EHsKZ3wvQ7Eg=",
-   "pom": "sha256-kVrb1G6hmmgaR1pdXu5gFLH6yiwdEK0uqYnVHpqdoRY="
+  "org/springframework/boot#spring-boot-devtools/3.5.6": {
+   "jar": "sha256-62XlpR2nEQ8739cI+26jbYR8Nje2nBrHApjhrKh3l/8=",
+   "module": "sha256-OFv1k4HC99tB6DLdzBKP3gHUByy3XhkoX5Kof453HRw=",
+   "pom": "sha256-Pz1lutZExgY5dlms93J9dDTtLpAhTOq3XnrT2f1r/eU="
   },
-  "org/springframework/boot#spring-boot-starter-aop/3.5.5": {
-   "jar": "sha256-BvUBJzpHQsIs/NLfY8GJPeX017YbiemioC+09i4aNa4=",
-   "module": "sha256-kFtfNJZQlvIzRXbJj7KPhmvBN2T6hVzmxZqBiQGssTc=",
-   "pom": "sha256-XXcumls+nov+qkhMehvQAOpfS89EP68/0TwhVe99Tnw="
+  "org/springframework/boot#spring-boot-starter-actuator/3.5.6": {
+   "jar": "sha256-tiu0Sex4RaKCvNCBqUE14CF38iUuK9M9vkbguX0Ee9k=",
+   "module": "sha256-iDk56qJvP/atjA9U2IeBrLFb4bUGinhvjZpu44JW9+Y=",
+   "pom": "sha256-xx3z9h8cvqdtLwXsLEIhH0RSax6mhAAUVmPgPPUEGEI="
   },
-  "org/springframework/boot#spring-boot-starter-cache/3.5.5": {
-   "jar": "sha256-x/AT6TtN364Frr0Z/F2K6U5xMkNYvmpkdUA5S32CB7I=",
-   "module": "sha256-z9cLZsMwPifLiJ7GQcwBclVfm872We4mYm0vq1SeRPE=",
-   "pom": "sha256-O/m7nwVJ6ADSlhWXKPIUvlWvgN2jyS11FzSOSMJmAjw="
+  "org/springframework/boot#spring-boot-starter-aop/3.5.6": {
+   "jar": "sha256-aNMDHc4g9viBWwJ/pdp4a7Dll40Qkrvv7IZG7FEDckU=",
+   "module": "sha256-baLXhweqg6Lwm8g7FpuIConDcxAiecuugJhusTdsuV0=",
+   "pom": "sha256-sysnQ3p0FQnNpmPr9AoZA6QMbToBClMvcY1QV7k7wsg="
   },
-  "org/springframework/boot#spring-boot-starter-data-jpa/3.5.5": {
-   "jar": "sha256-sWIjExRATaUdbZ37j15yadLAAyc/03fsIxx22aNuMYo=",
-   "module": "sha256-NQeKZT4EpcDoNGhafUuvzJaS1nT5aMQCaZYxI8/m624=",
-   "pom": "sha256-cEc8BK/3SqEBF6JXwt4nGKBI6ern5vfyRSJeQIzPtME="
+  "org/springframework/boot#spring-boot-starter-cache/3.5.6": {
+   "jar": "sha256-6Wc/lIU+N8g+nsB9zawy26cbmWFFCyvM4Rn+mnthB/c=",
+   "module": "sha256-Gs7Dwvj9GFUzLu9xEsM4dfh88yfDzQt3/isyk7gGXnY=",
+   "pom": "sha256-H6aXxoPd5V9HE7sVijKgZkX6Bk7kDjpwkSnBu+kCux0="
   },
-  "org/springframework/boot#spring-boot-starter-jdbc/3.5.5": {
-   "jar": "sha256-NBwM+LDI93Ed7db9y4TIOsVKx6p+Q0DovDPdHa2fb14=",
-   "module": "sha256-4SFunOGykJ89Z1XMuk3HLe9roA+FXIne9XjAqoXRFx4=",
-   "pom": "sha256-dlMu2chO04Yd6MdrkBXeVc6lfSeRA4uijPYfaoVEGYQ="
+  "org/springframework/boot#spring-boot-starter-data-jpa/3.5.6": {
+   "jar": "sha256-lPj8vs//XnmuFMHou7MCjgCYn/dms8Uo1sVSPxPidwE=",
+   "module": "sha256-I8eRrBlXbIhSOQ4pzFQ7xP1caOQFjRbqLxQF0HflrnA=",
+   "pom": "sha256-9Cdp6+j2cGkytMmPOmubqsRjB/qyQLMETa3B+3SFAuQ="
   },
-  "org/springframework/boot#spring-boot-starter-jetty/3.5.5": {
-   "jar": "sha256-WEZoCFe3VEvgCeN5hiMhU9UDHUzYrVhPjUzabRK540E=",
-   "module": "sha256-XCMGSVi+5EyRrV0HgXcjQvgVLglURFwunH2pfe96w9w=",
-   "pom": "sha256-cqei4laiJFsDk0qPQ9TRqWf5QBhWT3woYBfs7YR/LLE="
+  "org/springframework/boot#spring-boot-starter-jdbc/3.5.6": {
+   "jar": "sha256-6J4RbKgXrRsqO0LOUaef2gs3t0YohBYYUJhmiyx7pOs=",
+   "module": "sha256-bspwsxxRhtqUwbJ6O14QFo0Bwmdnzi1+LQ5AMTE294c=",
+   "pom": "sha256-nuQ4jNgYSKbdcWzimyfXqrubE1ssaMgSBAKrR8W4/GU="
   },
-  "org/springframework/boot#spring-boot-starter-json/3.5.5": {
-   "jar": "sha256-O2qKFSUULVgot2hUK9l1UCMWunp69iIvaFAHDYwdXpM=",
-   "module": "sha256-QMj8rVJfJl9SCkwFF0rSevqPqq6kIYHiZF58OgF3UJk=",
-   "pom": "sha256-8acNOjpZkf/YjCTt/sFw6XZZOx+2EVPnm6QnvsnefB4="
+  "org/springframework/boot#spring-boot-starter-jetty/3.5.6": {
+   "jar": "sha256-VnLzLjtap5SlEw7n2z6338S36w3Pq8IyrsII3Tu8zww=",
+   "module": "sha256-j2832wbP3qey3rE+x7k8Nj+9F5MsCFJ2fbCwNjQNUDs=",
+   "pom": "sha256-Da0531Ms/nZ2qbwZIGnNcK4dtokq1jstsvEmINb5JaQ="
   },
-  "org/springframework/boot#spring-boot-starter-logging/3.5.5": {
-   "jar": "sha256-mc2f7/8l40aKoyBjxYvfnjz1T1j4a0GXjFqbRIS8TdE=",
-   "module": "sha256-TKO9mFXkVIE2LFXJT5rT5tvK0pznYQKU9jXMR6dEMG8=",
-   "pom": "sha256-v9VjGYVrARtAfdhHxZ1JwZ9SccVJ8OOrvMZJSmNx848="
+  "org/springframework/boot#spring-boot-starter-json/3.5.6": {
+   "jar": "sha256-AYCH41NMWoFMgKJ9hVdoPtk2qVk5/ko+GActSl76zyg=",
+   "module": "sha256-FLN/fLYCc6WjRFTlrznhbTG6hCqfQsEeWNs6M410gcU=",
+   "pom": "sha256-AJTi+2GaDc7FeGRq17pA8ox2l/gspp2cH6MWI3va598="
   },
-  "org/springframework/boot#spring-boot-starter-mail/3.5.5": {
-   "jar": "sha256-fDAc8TOUM9dSNMmVSe73s7Tq6CmVc7T7JjelBxlNq5c=",
-   "module": "sha256-KhAYlmPtlvw3JeLKiOydDFDCXeUq3TggCSEJ71p5Gw4=",
-   "pom": "sha256-gwaTKc+xQoGGkqUZHVilDyb+u5leU2edhyz+sSlmgp4="
+  "org/springframework/boot#spring-boot-starter-logging/3.5.6": {
+   "jar": "sha256-5okt7zUuVq5hInS3aM8p665xgQQzVgsSwhd6qqg2IIA=",
+   "module": "sha256-AVaBcXFkfdD98MjRlpKl8HkmElRFXH+M4n4B0rhHlsE=",
+   "pom": "sha256-9RSDFirdtqEE0f3WKGI1qV54g9jNOT2OHZKr8O+3ly0="
   },
-  "org/springframework/boot#spring-boot-starter-oauth2-client/3.5.5": {
-   "jar": "sha256-/ENbZn1+agUNnvRGrKe842hSVPPl0VZ+tZuQY9j/SkY=",
-   "module": "sha256-Hg8ncpGlHD1WRRFWquHmpeRob2WzfQlDOB9gQg60JGQ=",
-   "pom": "sha256-2ghFR7+WR4ogVUsBBEgUsdeM08zxzxNnESxVeCD1Pkw="
+  "org/springframework/boot#spring-boot-starter-mail/3.5.6": {
+   "jar": "sha256-51FycCnoLK4hHYnjMdUk83MPgC1vgO1d70StjEVycwE=",
+   "module": "sha256-ixcdg+whNvv0+IwdYf0SbIv48DdkT2h4cYPS/3yUlrc=",
+   "pom": "sha256-z6gjg7XxtORsG7htUK4ZrYkTzqxSirskoA9PB/chHNY="
+  },
+  "org/springframework/boot#spring-boot-starter-oauth2-client/3.5.6": {
+   "jar": "sha256-+Pzuvhq1YhAg/ss0Qz1dpbD0pHyyWh/RGPoydLr8zC0=",
+   "module": "sha256-nsHS+zhRD8ZCcioAaZ7iXB0N3hNOHVio+7iK5TcER6I=",
+   "pom": "sha256-VakA8WMs7q/h5ZgSvc/fDv2RJmmK63olufw9kdYSO0c="
   },
   "org/springframework/boot#spring-boot-starter-parent/3.5.5": {
    "pom": "sha256-BPkIZ96YOw5Nf+wFxAHTQabhYOEXtgnmTC58qJEQ9Qc="
   },
-  "org/springframework/boot#spring-boot-starter-security/3.5.5": {
-   "jar": "sha256-pX2Ux4BL6e834KHy6Nv72I9RZlivDBuRgCe2ZzC9eY8=",
-   "module": "sha256-Q5nXjXtS2Wb4P6D44laGbOJUhOLL1BhEMgELWQHddCk=",
-   "pom": "sha256-/upOWRk3qcTpO5ovuWWO26m/wHjQ8nIXQbNT44UXslc="
+  "org/springframework/boot#spring-boot-starter-security/3.5.6": {
+   "jar": "sha256-EF7vzf5FgwMTkd3CgWbl0JDlb89hJdtYU35ECo34moM=",
+   "module": "sha256-sB2lvRSXgrZDtrYLJ7vgrLbAR1NMNp5qTCiz/aBiFn4=",
+   "pom": "sha256-rzg/J050slJCsR9o3KbVOnHUOqs4dplfjVy84p/8XMQ="
   },
-  "org/springframework/boot#spring-boot-starter-test/3.5.5": {
-   "jar": "sha256-WE07yrN3IcL/gO70IOEVntr0Ek3CWx5p2JVG45aZByo=",
-   "module": "sha256-T4wGj5pvomkMS7MivIMqRdrrBkIYhBasgcD2lc5bvmI=",
-   "pom": "sha256-rAGrzXXoECrObZoPjm9EaIlpxwet3ELz/ckR9YUW/7o="
+  "org/springframework/boot#spring-boot-starter-test/3.5.6": {
+   "jar": "sha256-w5rNH2TB5klRHZaFT2xZVWLA3Sr0qhIZA/SWgneS1d4=",
+   "module": "sha256-ounEDJp+NivBQ2DRiz+qEiBwN2X3pT7j2g9Lq/DEXPs=",
+   "pom": "sha256-IvoLlLamqEOa/Baw2GMIR9PIBYheEFAGwbCKKzIJrfw="
   },
-  "org/springframework/boot#spring-boot-starter-thymeleaf/3.5.5": {
-   "jar": "sha256-d+e2M6t4Yjdbe7RPkw9tvTWiT0go0D+I0wi5eoWckYc=",
-   "module": "sha256-xUveW+wSBmBlVSxVkQViNTlh7lAScbpSpIqL4hS6Lpw=",
-   "pom": "sha256-IztrcQHkwQPyPV1J2vCXeH4OVhjfMEbv/v05SLh1kww="
+  "org/springframework/boot#spring-boot-starter-thymeleaf/3.5.6": {
+   "jar": "sha256-ZlBTFak5IiEEGDY04tgJZjQ12mhkMZRhhl5L9r69h8c=",
+   "module": "sha256-oW5jSyI+8C9uXom+enIbMHZHKxAbrJERwdxHNzMXe5c=",
+   "pom": "sha256-sWCeF/Vy2ra95gt7VEdX5y1+Ymw022gnPUr0GTTwjcg="
   },
-  "org/springframework/boot#spring-boot-starter-tomcat/3.5.5": {
-   "module": "sha256-2+V1WHMJn9f3V4SENlXWqgpCiBctiABMogumjIqsz1I=",
-   "pom": "sha256-7XFgHmhc15VkcuBMiyWW9LOvild2KaBNpo+SaujATLg="
+  "org/springframework/boot#spring-boot-starter-tomcat/3.5.6": {
+   "module": "sha256-5aFqwTsj1U7bQllBY0Kuhb/YRMPot6OkYjv35bDeHkQ=",
+   "pom": "sha256-vyyKpcoYnApfHjaJhSag4p0y+pmoO2PXJoQkb7pNbUs="
   },
-  "org/springframework/boot#spring-boot-starter-validation/3.5.5": {
-   "jar": "sha256-goiSZE404vyIsEo/AlSb2NE7MlVPMVixM9N80C2Fo24=",
-   "module": "sha256-tC8kiSBFW6hmze4Aw6Ar0dPnG9if6dw7wubfh1lJjrE=",
-   "pom": "sha256-H7ZVqOaaxB5Rz+SMB5OpxV7P47sEeGpqET07RbY80tw="
+  "org/springframework/boot#spring-boot-starter-validation/3.5.6": {
+   "jar": "sha256-DRfOG0LSoqPPaf1oyFVCSWk6fLttbpY7qaE62upnED4=",
+   "module": "sha256-y7PZCFpNpARUSnEYS4u9QCExbW4ikkSVhj21JsnwMYQ=",
+   "pom": "sha256-E7CKduKyprB9O3rdyoocbkrFpoJgCx9Ba1MKm5Qf2t0="
   },
-  "org/springframework/boot#spring-boot-starter-web/3.5.5": {
-   "jar": "sha256-Yjrp/k0L4P4a6f0TUQtI/9MexHAipbffpUYZqbQyXvo=",
-   "module": "sha256-cXvh7Wcz4VKYBN1eptw1t6a8+VNO4VVWyoEh4VNZfh0=",
-   "pom": "sha256-b8pD9BVZnJtGyXCF/xiuzDF2m/xc2Bm7iWOWJKHk0fU="
+  "org/springframework/boot#spring-boot-starter-web/3.5.6": {
+   "jar": "sha256-OHMLzYhXUoJM2sIMvtjm5D/y+YJ8OimZvvScgjaOz4w=",
+   "module": "sha256-3ABtorxARa/eVgoN+aR67kUf+fYeBrb6Vn8VKNTwaKQ=",
+   "pom": "sha256-FMvZ0FSB5bix9Rs5UIHcNE64gzZu2QzMjFU2E9yzepM="
   },
-  "org/springframework/boot#spring-boot-starter/3.5.5": {
-   "jar": "sha256-PtZK3lADkeaRfnssnonf3uwL6kDbKeJiRrPncUj7ef4=",
-   "module": "sha256-3VZ9BYYEb7c1Sqg6Ds+SW+3EpLuEc72YWYJrnpfhFuE=",
-   "pom": "sha256-FXr1F7mZSCccv8z0aN7rma8nIza3/IwhnkUIBRVdarQ="
+  "org/springframework/boot#spring-boot-starter/3.5.6": {
+   "jar": "sha256-dIWsRnlffiyHJSsoXfoLk2Sisy8koKog667iqIsDsps=",
+   "module": "sha256-eJn0vMZMJI7BYYPhfmywS2reon3XZhS8ZY0gtDChzOA=",
+   "pom": "sha256-XxSN5dxXEaYokb9GARfyBt9TwLSIRiL0GRf399mULpk="
   },
-  "org/springframework/boot#spring-boot-test-autoconfigure/3.5.5": {
-   "jar": "sha256-UPKm+aoXwRxbPunaAIjGf6rcT9jhIzalpkluXhOulWo=",
-   "module": "sha256-Dhm2QRwUjE+Zo8jGFsCT+bekMBj/3MReOW4QXXO7nxE=",
-   "pom": "sha256-xGX287Ss0KxTgbxOvJqy7iFv/XjZ9wumEcDXat2/TLY="
+  "org/springframework/boot#spring-boot-test-autoconfigure/3.5.6": {
+   "jar": "sha256-bgfu6TZW3i1ZJEBszH9XoCQw7/nE49VLD547tBiKowY=",
+   "module": "sha256-c5Y/tA10kDDe9xi20rK+emLMXA1zNsqOicGMYgwZSds=",
+   "pom": "sha256-ZTOgbQU7tTcxqhZ/Tui+HqQZ8vx/8H+WCV4l0Dzw84Q="
   },
-  "org/springframework/boot#spring-boot-test/3.5.5": {
-   "jar": "sha256-Z3LY4xFlhl1x/eT4sIqoSDMmiDnMkC+ZPzfsFZYnfUc=",
-   "module": "sha256-RnR6JR4HiW2SyX72GVyGxfdjkJl/MFRWfFOV7sjAbos=",
-   "pom": "sha256-6g/Km3tBiSp0KV3wJSpSrjvQVGOl5yb1gYNjqMLGt1w="
+  "org/springframework/boot#spring-boot-test/3.5.6": {
+   "jar": "sha256-SU4N8LnMr6NbI/5lB+oD74bAIbuujy/Ffj7b+xaVObk=",
+   "module": "sha256-4TXPeAUTk/FlT50A9HPJKcufGG7eJ6cnJxg8HGpxHBc=",
+   "pom": "sha256-jhlXTbOoRIZ20yffem4AuMm/40gyYSn3jHq8DqRK9Vc="
   },
-  "org/springframework/boot#spring-boot/3.5.5": {
-   "jar": "sha256-ttV3sZcchKK5NBa28BTk0B36xy3NYrl9XcHIMisw6+c=",
-   "module": "sha256-NsEY353WZFwDbyk4LeLQ92JxB0P1TJYhSjLzu8izvAo=",
-   "pom": "sha256-J1b6Y3l46biZWCicq0cjOUQXiIVJFdFgSlePVZ9PyOI="
+  "org/springframework/boot#spring-boot/3.5.6": {
+   "jar": "sha256-Tmb28xUuFIwCiXfDOrEska44FwG12dmVGIKoTwX/X+o=",
+   "module": "sha256-qVVhgjMpzEFgCen9OtK1ukLi8Wl0i7VNGAwlIgHgrfY=",
+   "pom": "sha256-hsSwoSpIrUO2LRfSe+2LPE0nPnSYkA0yknScnHiu2+E="
   },
   "org/springframework/cloud#spring-cloud-dependencies-parent/4.2.1": {
    "pom": "sha256-ktuXOlcqL1nZIAYhy4EPPShvPfaG4nGCHzgAQgApjk0="
@@ -2429,26 +2525,37 @@
   "org/springframework/data#spring-data-bom/2025.0.3": {
    "pom": "sha256-I88YZ5nTos9fIe7ie1DPv2G0rvCYI8HLjIIb60Ua4jk="
   },
-  "org/springframework/data#spring-data-commons/3.5.3": {
-   "jar": "sha256-7c+XRV7DlvUnqlBwQyeeuPhb920gwhFFjo+7fFFMqaA=",
-   "pom": "sha256-Yu1gKcpDXo2QlYbAKOahZheT7f4AG9GqQIi4vDKnuOg="
+  "org/springframework/data#spring-data-bom/2025.0.4": {
+   "pom": "sha256-vczu6HlJK2ybLXg0nZaQu5KPZJ3s4yd1oo825IdStCI="
   },
-  "org/springframework/data#spring-data-jpa-parent/3.5.3": {
-   "pom": "sha256-e1W5kill86coeFfCUEnmbCV9y/sf9eXwaE1nzuVPAgY="
+  "org/springframework/data#spring-data-commons/3.5.4": {
+   "jar": "sha256-Aylf4uPGCTHUYVMTa02ACNnS4L2MegWN2/vF6Wd5ygw=",
+   "pom": "sha256-7b1H5OznwdTRD8whDG4+6SzJoj9KAnlCzuMAWxNayIo="
   },
-  "org/springframework/data#spring-data-jpa/3.5.3": {
-   "jar": "sha256-UcZ4fWlnUQkU7V5zVlzNbEvsg7TnGOLmnoanlbKN7T0=",
-   "pom": "sha256-zagmZP9OXyRpNL0axlrlpz6skreshUxjml/F+dxQuUQ="
+  "org/springframework/data#spring-data-jpa-parent/3.5.4": {
+   "pom": "sha256-LFcraizO2Bb+g00MeM0fbbpC+H83B6DopxzW8lrGoQw="
   },
-  "org/springframework/data/build#spring-data-build/3.5.3": {
-   "pom": "sha256-OVw0dj17wt6p3v1cd/CZI8UXI5lt/xENYyvk+SeoToQ="
+  "org/springframework/data#spring-data-jpa/3.5.4": {
+   "jar": "sha256-rLQXmfVABDJ1xgcTtyRF6b9bSlj68s5XFsqdyZPVsuM=",
+   "pom": "sha256-bQSBjGTYXhg8GWEoq+NFFCwzk/g0Wphg0pVlVBphEw8="
   },
-  "org/springframework/data/build#spring-data-parent/3.5.3": {
-   "pom": "sha256-klFZfAkjK1TJEhDeVNOg59K9p/r9h61RqhqaS+RmyC8="
+  "org/springframework/data/build#spring-data-build/3.5.4": {
+   "pom": "sha256-kCN98A3WjA5vF2U0TgSF8WCvVcaMbAekQ1jzThDoXtI="
+  },
+  "org/springframework/data/build#spring-data-parent/3.5.4": {
+   "pom": "sha256-vchbnVtM8COxWX989sM8b8/vGH8HDVZUtYPoJCxNaPc="
   },
   "org/springframework/integration#spring-integration-bom/6.5.1": {
    "module": "sha256-XnyXPE08Y1fe4/EGXsw0NcH3jtpwHjb9KWElACxY3tk=",
    "pom": "sha256-t1WmIh+KFElhjMs6Bhf/N0GDsHbpt+vjv08CX/rA590="
+  },
+  "org/springframework/integration#spring-integration-bom/6.5.2": {
+   "module": "sha256-l2ugH964/eRpQNNUfOAbmZmqyC6rGmieWtGGZCD2Tus=",
+   "pom": "sha256-pWBG3DwvVaIBxxTer0ie6cS5ZBA8QDRlQO55IPkODwM="
+  },
+  "org/springframework/pulsar#spring-pulsar-bom/1.2.10": {
+   "module": "sha256-8U2Si4IVcjg4ukvz/JGesr9Yi57BExL6o7Sm8d66N4w=",
+   "pom": "sha256-nc2t1zV686B4XaNDWE3aKcyE5tVbCZSBNBEIniI58pM="
   },
   "org/springframework/pulsar#spring-pulsar-bom/1.2.9": {
    "module": "sha256-mhxkfqHgQx4PsCAH6eeIRQDu4BYULLV9wr4yAm77vNo=",
@@ -2465,45 +2572,49 @@
    "module": "sha256-CZe8Clr1QovAY0cC5oByRQmlG98dSWNvMXdHeUHkLbQ=",
    "pom": "sha256-YA1yx9qOb3aR5AmxJ4Z6FlEOe0iQFF2EnGrVIgKLTd4="
   },
-  "org/springframework/security#spring-security-config/6.5.3": {
-   "jar": "sha256-3v3W4pOLYYOzJ4JRqlCmivsRMRZg7ysB3kQse99vXtM=",
-   "module": "sha256-M3AOB5OeO9W5unhDaVNXwVCef0Q/1GDyamilV2veV9k=",
-   "pom": "sha256-uCOUwRuDIhlm540PW1u3anjT+T2sGW4IgJPnafSNloA="
+  "org/springframework/security#spring-security-bom/6.5.5": {
+   "module": "sha256-ZrAeM78faQSU5+fzPFfBCdqS2rlpCRRzbZuTaKiQIPM=",
+   "pom": "sha256-yncaXa0TnNEl9aUdJhQyyhlXNsMLId6yyZqMG28vJSc="
   },
-  "org/springframework/security#spring-security-core/6.5.3": {
-   "jar": "sha256-7r03/zcCifUayEsIIpdjnJBb3fRZMbQJCYAiAd2tvjI=",
-   "module": "sha256-+wtz9+XduJU/RRn1VCOxv3Ty6AynA2/SjkMoORECG0U=",
-   "pom": "sha256-o/8WjtjUrdzx0MfQCTWwtvv0fyT5IyGRYnIFFVAXDwM="
+  "org/springframework/security#spring-security-config/6.5.5": {
+   "jar": "sha256-2ISIfE0RBmJOlyTbGZ2KvfTDuUZ4NZ1dbqwS9psNrqI=",
+   "module": "sha256-mxKSOK182QqfrRycQrNRpjV8NsQDDCGV3Nq3f9kPfRU=",
+   "pom": "sha256-Gtg6dFq6bNFf2WdvqKSZIpS5qAxnyY1+1bJAev317bU="
   },
-  "org/springframework/security#spring-security-crypto/6.5.3": {
-   "jar": "sha256-Y1rL4V6pII+AT4JOifgDwXD4SGegifiTJuOBFh8uEdA=",
-   "module": "sha256-EmGk61HoCzmM68z4pD5lXAfMarcfFQh/AA5VlerxKqo=",
-   "pom": "sha256-5Ng8QJCx5xLE3cTPrtJgb/pBDBaGtil8JhAwBUxYcew="
+  "org/springframework/security#spring-security-core/6.5.5": {
+   "jar": "sha256-IuAkdfswTlL6DxGF0SeF/Xqi/pB6pgsNd7J/nEVdop4=",
+   "module": "sha256-pJy08kpjNgYG5vB14CoTYNJkF41WpuyhP5smfWvNYaY=",
+   "pom": "sha256-8fREZPYT3BMmgh8ohRppFQ4PzQXezznL2yYWgW4GzPY="
   },
-  "org/springframework/security#spring-security-oauth2-client/6.5.3": {
-   "jar": "sha256-jGQ53kmj/j84t9D7kp17T0XpzBSDIekYNXxZyyanB0E=",
-   "module": "sha256-1bLgcL5Hw5EcoIFO+DptwZUEaMXAc9QhkoLFHQ5VqR4=",
-   "pom": "sha256-C6V3kI+80225VcpLItMH18UjNpU1Byn4THThfiiJ/IY="
+  "org/springframework/security#spring-security-crypto/6.5.5": {
+   "jar": "sha256-yWklD/zry/oYWG7CFh5PEG1M0RJfEamy6Bn5birv8cE=",
+   "module": "sha256-tZY+3eOZqKXQhdGjYPLIPV5X+pdl69LUMagwmf2NqN4=",
+   "pom": "sha256-XDsVbrjPHYL1ykVdLD2iNYwBTMH8cLMsoK1llxdFpt8="
   },
-  "org/springframework/security#spring-security-oauth2-core/6.5.3": {
-   "jar": "sha256-6d8zQ1Mh+U2ayZN2NVXRfIoVAbw/xW3XihGDyzlEKt0=",
-   "module": "sha256-IFzSXt9GmrWtoep79i5sOccDv3zU2DGPEbd0L767pAg=",
-   "pom": "sha256-Qvv56vHHANhcLGkqvG2M2cGVVUDJB9gBod9FUYE9P7U="
+  "org/springframework/security#spring-security-oauth2-client/6.5.5": {
+   "jar": "sha256-28Z8PZSyr7orO2TrrnvOo12FBBZc8jSRtvR5lOD6pbw=",
+   "module": "sha256-RuVVLRpZZ8NQVXsUT0rmQ3r4pEd7bRUqDT9dDtL1Ono=",
+   "pom": "sha256-rclANDP1cRYMf6yvPSyya0oT/LSEH3IvESox0Qs7haY="
   },
-  "org/springframework/security#spring-security-oauth2-jose/6.5.3": {
-   "jar": "sha256-DVUSDDY3JoMbiEwYyqWq+pj32dZ1XYDIbKsURGuD60Q=",
-   "module": "sha256-Pe8mFJfzl3I5kUk2jTTc2kQW+cNVCbyJd16bMleyAzQ=",
-   "pom": "sha256-PYPSazmG/tiqIatMlCqBZ2ej+QbopghSgRUvZDsvoDk="
+  "org/springframework/security#spring-security-oauth2-core/6.5.5": {
+   "jar": "sha256-aTcXGKFbwlkay8FZo0znqxgTYcS8YeDM4xuBBNCkGyY=",
+   "module": "sha256-C8XB0/j397N5xGIgDmBc52P15e8m0fUrdwEp0nda9CI=",
+   "pom": "sha256-lYlEfcU0LV/7qgLHfp+BybRQX3fmHyqlO42X6mtSmWg="
   },
-  "org/springframework/security#spring-security-saml2-service-provider/6.5.3": {
-   "jar": "sha256-/+qRxS0PCn7wdix4AXLF+2/VJJ75P1HM3N4zHUiGNJA=",
-   "module": "sha256-RPUKQCUZKE6cBvINs3+VbLCQBPXdxNOSE1Tw8zb+6Og=",
-   "pom": "sha256-Bvr/JRxthlyQjVCcWcnUi0wcaBJYJ9cjMsLCBvamnFo="
+  "org/springframework/security#spring-security-oauth2-jose/6.5.5": {
+   "jar": "sha256-qljGubLe/Lr7/v8j4knsgucl36gfyGOFrZ2B/uPgsIA=",
+   "module": "sha256-1FhvMsPRxId5CCLMnVM1zctFY2v4F595qhmtqo7MmV8=",
+   "pom": "sha256-zu0p9cJ9SbDSktx7mMSA26XkYnWjLJhzRPZe3zEhtTU="
   },
-  "org/springframework/security#spring-security-web/6.5.3": {
-   "jar": "sha256-zKIdkWlkqU3BKp1Up48ajgs9i2ESTFUBrZYca8f/Udg=",
-   "module": "sha256-Hnx4R1a7DPGBUdSx8htnNN7Pwfpla0M0FtiRPuN2gGI=",
-   "pom": "sha256-+fbyi3oxQLrz8+pRBAMzOYtxJqKaapEz9YLABSeeIPI="
+  "org/springframework/security#spring-security-saml2-service-provider/6.5.5": {
+   "jar": "sha256-XX3T0hTX5LRk0l9HV38PgAyo1GDYczsspRI0BQXp4SY=",
+   "module": "sha256-FTVrDsFnWfyFpntrFgMhywwnTuyyZe2uQ3JSL0i9SDU=",
+   "pom": "sha256-8FgTEQuzbdIFxGP8fF3A8g4bLlnfIMYMDo17ra9nSlw="
+  },
+  "org/springframework/security#spring-security-web/6.5.5": {
+   "jar": "sha256-urfPCSH6uni5LEj/0/dMiN4b67ZY5KznDctQ8VoofYw=",
+   "module": "sha256-MlW1yWviAqBL9MfT/1FLIYmUE2eAO56TvNwwy7+lqdQ=",
+   "pom": "sha256-gtCT+rEs4ld7GBuOj+p1NBw8AYp5SY10d+YYqazje/I="
   },
   "org/springframework/session#spring-session-bom/3.5.2": {
    "module": "sha256-1CEGGhka+Ep0ns15LKgc0nV2ttH6jLM/ROp1j9tMaXE=",
@@ -2549,20 +2660,20 @@
    "jar": "sha256-WXz4fVsaTzhbnRzsl0t7SDq7PuhfxbP4tir45L7JXCw=",
    "pom": "sha256-AgOVYrsyfVQcDwUHZ+kYmPo4l0eSZojMITvRG8dRJ9E="
   },
-  "org/webjars#swagger-ui/5.28.0": {
-   "jar": "sha256-6VEYmw9g5DfExnCYThYfL7R2zXhFRunUdrzazEnS1bE=",
-   "pom": "sha256-EgZGZvt7IyKHdeCgpGcBX5afBSuiFHAdygpENt1omLA="
+  "org/webjars#swagger-ui/5.28.1": {
+   "jar": "sha256-NDF/1XdBPKPEF72pEek2/lfbCmhcJqL5hxZoIJ4RF2c=",
+   "pom": "sha256-qE9omcLf7mC5tp6P0qFaPc5FYB2OxWjCqoM2Y098W2k="
   },
   "org/webjars#webjars-locator-lite/1.1.0": {
    "jar": "sha256-/Tbi0U/AgPeNFOHsaCDzskaY+IoGLMH1ksnrWbE5P80=",
    "pom": "sha256-yG/RQXp8lvK5zV6/hzHiqWNInSbJoSKeeBEStNAHElc="
   },
-  "org/xmlunit#xmlunit-core/2.10.3": {
-   "jar": "sha256-VhGwyK51I3e1+WJEur2nQJf7g/C6OPQnqgsYNNCLAoY=",
-   "pom": "sha256-4lEOU/QoeYpiz/S5bUm4+YceuwAkFZLCoM7z7x8FPFA="
+  "org/xmlunit#xmlunit-core/2.10.4": {
+   "jar": "sha256-II4M7oKu3ZGDk35LmuRLg4hBefckpwa+9XlUd6z8ypE=",
+   "pom": "sha256-QMVRcQPPFS8IejttyqpTDs5h8D1/KUSR/4gtk2utBl8="
   },
-  "org/xmlunit#xmlunit-parent/2.10.3": {
-   "pom": "sha256-ZsNDvIPhYEEVRpeEKqqCaBIcYTeoYySPDE5zaBS6dA8="
+  "org/xmlunit#xmlunit-parent/2.10.4": {
+   "pom": "sha256-g9gzkrJTxbwHpRKgjYt5RiPn1MW7u6DE25H0zjeAkeI="
   },
   "org/yaml#snakeyaml/2.4": {
    "jar": "sha256-73ea9dKand6MxwzgNB9cb3c14j7f+Whc6qnTU1m3u38=",

--- a/pkgs/by-name/st/stirling-pdf/package.nix
+++ b/pkgs/by-name/st/stirling-pdf/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch2,
   gradle_8,
   makeWrapper,
   jre,
@@ -13,24 +12,18 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "stirling-pdf";
-  version = "1.3.2";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "Stirling-Tools";
     repo = "Stirling-PDF";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-H1nYRUIUVRUGGK+Vonr2v7oM6SfhYEsFk+JJp/4DI4M=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-IgzBWIYK3ps0WxBMkJK/vEyvgpEv3NurbNhaTwz25Bc=";
   };
 
   patches = [
     # remove timestamp from the header of a generated .properties file
     ./remove-props-file-timestamp.patch
-    # Apply fix for building on macOS. Remove when updating the package next time.
-    (fetchpatch2 {
-      name = "normalize-path-in-ApplicationPropertiesLogicTest.patch";
-      url = "https://github.com/Stirling-Tools/Stirling-PDF/commit/93fb62047a6ab85db63305c23dde5e5118e1ae2e.patch";
-      hash = "sha256-kQNYyRtJ0smuhaoII31k87b7QRBJosK6xlFiQUwobsg=";
-    })
   ];
 
   mitmCache = gradle.fetchDeps {


### PR DESCRIPTION
- `1.4.0` Release Notes: https://github.com/Stirling-Tools/Stirling-PDF/releases/tag/v1.4.0
- `1.5.0` Release Notes: https://github.com/Stirling-Tools/Stirling-PDF/releases/tag/v1.5.0
- Diff: https://github.com/Stirling-Tools/Stirling-PDF/compare/v1.3.2...v1.5.0


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
