### PR TITLE
micromamba: simplify as a wrapper over mamba-cpp

### DIFF
--- a/pkgs/by-name/mi/micromamba/package.nix
+++ b/pkgs/by-name/mi/micromamba/package.nix
@@ -1,80 +1,25 @@
 {
   lib,
   stdenv,
-  fetchFromGitHub,
-  fetchpatch,
-  bzip2,
-  cli11,
-  cmake,
-  curl,
-  ghc_filesystem,
-  libarchive,
-  libsolv,
-  yaml-cpp,
-  nlohmann_json,
-  python3,
-  reproc,
-  spdlog,
-  tl-expected,
+  mamba-cpp,
 }:
 
-let
-  libsolv' = libsolv.overrideAttrs (oldAttrs: {
-    cmakeFlags = oldAttrs.cmakeFlags ++ [
-      "-DENABLE_CONDA=true"
-    ];
-
-    patches = [
-      # Apply the same patch as in the "official" boa-forge build:
-      # https://github.com/mamba-org/boa-forge/tree/master/libsolv
-      (fetchpatch {
-        url = "https://raw.githubusercontent.com/mamba-org/boa-forge/20530f80e2e15012078d058803b6e2c75ed54224/libsolv/conda_variant_priorization.patch";
-        sha256 = "1iic0yx7h8s662hi2jqx68w5kpyrab4fr017vxd4wyxb6wyk35dd";
-      })
-    ];
-  });
-in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "micromamba";
-  version = "1.5.8";
+  version = mamba-cpp.version;
 
-  src = fetchFromGitHub {
-    owner = "mamba-org";
-    repo = "mamba";
-    rev = "micromamba-" + version;
-    hash = "sha256-sxZDlMFoMLq2EAzwBVO++xvU1C30JoIoZXEX/sqkXS0=";
-  };
+  dontUnpack = true;
+  dontBuild = true;
+  dontConfigure = true;
 
-  nativeBuildInputs = [ cmake ];
+  installPhase = ''
+    mkdir -p $out/bin
+    ln -s ${mamba-cpp}/bin/mamba $out/bin/micromamba
+  '';
 
-  buildInputs = [
-    bzip2
-    cli11
-    nlohmann_json
-    curl
-    libarchive
-    yaml-cpp
-    libsolv'
-    reproc
-    spdlog
-    ghc_filesystem
-    python3
-    tl-expected
-  ];
-
-  cmakeFlags = [
-    "-DBUILD_LIBMAMBA=ON"
-    "-DBUILD_SHARED=ON"
-    "-DBUILD_MICROMAMBA=ON"
-    # "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
-  ];
-
-  meta = with lib; {
-    description = "Reimplementation of the conda package manager";
-    homepage = "https://github.com/mamba-org/mamba";
-    license = licenses.bsd3;
-    platforms = platforms.all;
-    maintainers = with maintainers; [ mausch ];
+  meta = mamba-cpp.meta // {
+    maintainers = with lib.maintainers; [ mausch ];
     mainProgram = "micromamba";
   };
+
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Simplifies the package by expressing it as a wrapper over `mamba-cpp`.
This was discussed in https://github.com/NixOS/nixpkgs/pull/382599 but that one never got merged.
This also addresses #456288

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
