### PR TITLE
tlsrpt-reporter: reduce noisy default logging

### DIFF
--- a/pkgs/by-name/tl/tlsrpt-reporter/logging.patch
+++ b/pkgs/by-name/tl/tlsrpt-reporter/logging.patch
@@ -1,0 +1,27 @@
+From 32dd88d622379087ed97d9f2c07bc0155b5a9d29 Mon Sep 17 00:00:00 2001
+From: Martin Weinelt <hexa@darmstadt.ccc.de>
+Date: Sun, 27 Jul 2025 17:18:06 +0200
+Subject: [PATCH] Reduce loglevel for sleep cycle messages in loop
+
+Logging this information every 5 minutes on INFO is not super actionable
+and should be considered an implementation detail.
+---
+ tlsrpt_reporter/tlsrpt.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tlsrpt_reporter/tlsrpt.py b/tlsrpt_reporter/tlsrpt.py
+index b724596..5377ba2 100644
+--- a/tlsrpt_reporter/tlsrpt.py
++++ b/tlsrpt_reporter/tlsrpt.py
+@@ -1437,9 +1437,9 @@ def run_loop(self):
+             dt = self.wakeuptime - tlsrpt_utc_time_now()
+             seconds_to_sleep = dt.total_seconds()
+             if seconds_to_sleep >= 0:
+-                logger.info("Sleeping for %d seconds", seconds_to_sleep)
++                logger.debug("Sleeping for %d seconds", seconds_to_sleep)
+             else:
+-                logger.info("Skipping sleeping for negative %d seconds", seconds_to_sleep)
++                logger.debug("Skipping sleeping for negative %d seconds", seconds_to_sleep)
+             for key, _ in sel.select(timeout=seconds_to_sleep):
+                 if key.fileobj == interrupt_read:
+                     signumb = interrupt_read.recv(1)

--- a/pkgs/by-name/tl/tlsrpt-reporter/package.nix
+++ b/pkgs/by-name/tl/tlsrpt-reporter/package.nix
@@ -32,6 +32,8 @@ python3.pkgs.buildPythonApplication rec {
       url = "https://github.com/sys4/tlsrpt-reporter/commit/32d00c13508dd7f9695b77e253e88c88dc838fbd.patch";
       hash = "sha256-RUNF86RkTu6DLv6/7eaY//fFB8kGzmZxQ70kdNpLxj8=";
     })
+    # https://github.com/sys4/tlsrpt-reporter/pull/48
+    ./logging.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
This makes the logs more actionable, by focusing on what it tlsrpt-reporter does and not what it doesn't.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
