### PR TITLE
luaPackages.telescope-nvim: fix rockspec

### DIFF
--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -1181,6 +1181,14 @@ in
     '';
   });
 
+  telescope-nvim = prev.telescope-nvim.overrideAttrs {
+    # NOTE: Until luarocks rockspec is updated with changes from upstream repo
+    postConfigure = ''
+      substituteInPlace ''${rockspecFilename} \
+        --replace-fail "'autoload'," ""
+    '';
+  };
+
   # aliases
   cjson = prev.lua-cjson;
 }


### PR DESCRIPTION
Follow up to https://github.com/NixOS/nixpkgs/pull/459608
Closes https://github.com/NixOS/nixpkgs/pull/460812
Was changed in repo, but has not been changed in luarocks rockspec we fetch.

https://github.com/nvim-telescope/telescope.nvim/commit/7fb51c8255e8cf689fde6779ca581ab71e76dddd


```bash
> structuredAttrs is enabled
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/v0a14cg6wb0npnlbjzyagq5x1ih52gb8-source
       > source root is source
       > Running phase: patchPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > Running phase: buildPhase
       > Running phase: installPhase
       >
       >
       > telescope.nvim scm-1 depends on lua 5.1 (5.1-1 provided by VM: success)
       > telescope.nvim scm-1 depends on plenary.nvim (scm-1 installed: success)
       >
       > Error: Directory 'autoload' not found
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
