### PR TITLE
zx:  8.5.4 -> 8.8.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8207,6 +8207,12 @@
       }
     ];
   };
+  f64u = {
+    email = "me@fadyadal.dev";
+    github = "f64u";
+    githubId = 24705058;
+    name = "Fady Adal";
+  };
   fab = {
     email = "mail@fabian-affolter.ch";
     matrix = "@fabaff:matrix.org";

--- a/pkgs/by-name/zx/zx/package.nix
+++ b/pkgs/by-name/zx/zx/package.nix
@@ -1,46 +1,27 @@
 {
   lib,
   buildNpmPackage,
-  buildGoModule,
   fetchFromGitHub,
-  esbuild,
   versionCheckHook,
   nix-update-script,
 }:
 
-let
-  esbuild' = esbuild.override {
-    buildGoModule =
-      args:
-      buildGoModule (
-        args
-        // rec {
-          version = "0.25.3";
-          src = fetchFromGitHub {
-            owner = "evanw";
-            repo = "esbuild";
-            tag = "v${version}";
-            hash = "sha256-YYwvz6TCLAtVHsmXLGC+L/CQVAy5qSFU6JS1o5O5Zkg=";
-          };
-          vendorHash = "sha256-+BfxCyg0KkDQpHt/wycy/8CTG6YBA/VJvJFhhzUnSiQ=";
-        }
-      );
-  };
-in
 buildNpmPackage (finalAttrs: {
   pname = "zx";
-  version = "8.5.4";
+  version = "8.8.5";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "zx";
     tag = finalAttrs.version;
-    hash = "sha256-328I8SgBIeTCNFH3Ahm9Zb1OCxwGuhWE/iWmDHElbsA=";
+    hash = "sha256-TB4TDGvrMqJgLGm2E3wGLg/uJv3YmbAuxTuZGerj7vM=";
   };
 
-  npmDepsHash = "sha256-R0pCoITmLQBj0T1iIXXN4clpEKDn9wkG5Ke0AedgnlQ=";
+  npmDepsHash = "sha256-yr4oPr4tTFfl+uUc2RJnVkmzSVHrw2adzWuZ+R2bQaU=";
 
-  env.ESBUILD_BINARY_PATH = lib.getExe esbuild';
+  npmFlags = [ "--legacy-peer-deps" ];
+
+  dontNpmBuild = true;
 
   doInstallCheck = true;
 
@@ -53,7 +34,10 @@ buildNpmPackage (finalAttrs: {
     homepage = "https://github.com/google/zx";
     changelog = "https://github.com/google/zx/releases/tag/${finalAttrs.version}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ jlbribeiro ];
+    maintainers = with lib.maintainers; [
+      jlbribeiro
+      f64u
+    ];
     mainProgram = "zx";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Changelog: zx 8.5.4 → 8.8.5

### 8.5.5 — PVC Wizard
- `ProcessPromise` and `ProcessOutput` `lines()` getters now accept a custom delimiter
- Improved handling of `.nothrow()` option in async iteration
- YAML dependency updated to v2.8.0

### 8.6.0 — Valve Vanguard
- Enabled `thenable` params processing for `$` literals
- Supports Promise resolution within template expressions
- Internal refactorings focusing on optimization
- Dependency version bumping and byte shrinking

### 8.6.1 — Drain Hero
- Use `process.env.SHELL` as default shell if defined
- Accepts numeric strings as arguments to `parseDuration()`
- Docker base image updated to Node 24-Alpine

### 8.6.2 — Flow Unstoppable
- Fixed `$.prefix` and `$.postfix` value settings via environment variables

### 8.7.0 — Solder Savior
- Fixed flaky bugs in `kill()` and `ps()` methods
- Prevention of reused PID issues
- Improved Windows process parsing

### 8.7.1 — Pipe Whisperer
- Addressed `ps()` corner cases
- Improved `$.kill` mechanics on Windows

### 8.7.2 — Copper Crafter
- `nothrow` option handling at init stage
- `killSignal` value handling improvements
- Introduced `Fail` class
- Exposed `$` as a type

### 8.8.0 — Pressure Tested
- Added `unpipe()` method
- Many-to-one piping support
- Piping from rejected processes
- Added `versions` static map for component visibility

### 8.8.1 — Turbo Flush
- Applied flags filtration for CLI-driven dependency installation
- Added `kill()` event logging
- Set `SIGTERM` as `kill()` fallback signal
- Allowed `stdio()` argument to be an array
- Version checking for zx@lite package
- Updated dependencies (chalk, fs-extra, yaml)

### 8.8.2 — Leaking Valve ⚠️
- **Security fix:** Fixed potential command injection vulnerability in `kill()` method for Windows (affected versions 8.7.1-8.8.1)

### 8.8.3 — Sealing Gasket 🔒
- **Security improvements:** Prevent injections via `Proxy` input or custom `toString()` manipulations

### 8.8.4 — Flange Coupling
- Updated internals so `ps` API and related methods like `ProcessPromise.kill()` work on Windows without `wmic`
- Preparing for Windows 11 25H2 where `wmic` will be unavailable

### 8.8.5 — Temporary Reservoir
- Fixed issues where zx would flush external `node_modules` when linking
- Upgraded to `globby@15.0.0`

---

**Summary:** This update spans 10 releases over ~5 months, including important security fixes (8.8.2, 8.8.3), Windows compatibility improvements, and enhanced piping/process management capabilities.



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
