### PR TITLE
tbe: migrate to pkgs/by-name and modernize derivation

### DIFF
--- a/pkgs/by-name/tb/tbe/package.nix
+++ b/pkgs/by-name/tb/tbe/package.nix
@@ -1,23 +1,20 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
   cmake,
-  qttools,
-  wrapQtAppsHook,
-  qtbase,
-  qtsvg,
+  libsForQt5,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tbe";
   version = "0.9.3.1";
 
   src = fetchFromGitHub {
     owner = "kaa-ching";
     repo = "tbe";
-    tag = "v${version}";
-    sha256 = "1ag2cp346f9bz9qy6za6q54id44d2ypvkyhvnjha14qzzapwaysj";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-UnvFr/ofk6CgtBv6ua8XjZAWScFGfeNx+is5Q8Zl4qk=";
   };
 
   postPatch = ''
@@ -34,10 +31,13 @@ mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
+  ]
+  ++ (with libsForQt5; [
     qttools
     wrapQtAppsHook
-  ];
-  buildInputs = [
+  ]);
+
+  buildInputs = with libsForQt5; [
     qtbase
     qtsvg
   ];
@@ -50,12 +50,12 @@ mkDerivation rec {
     cp -r ../usr/share $out/
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Physics-based game vaguely similar to Incredible Machine";
     mainProgram = "tbe";
     homepage = "http://the-butterfly-effect.org/";
-    maintainers = [ maintainers.raskin ];
-    platforms = platforms.linux;
-    license = licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ raskin ];
+    platforms = lib.platforms.linux;
+    license = lib.licenses.gpl2Only;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13195,8 +13195,6 @@ with pkgs;
     lua = lua5_2;
   };
 
-  tbe = libsForQt5.callPackage ../games/the-butterfly-effect { };
-
   teeworlds-server = teeworlds.override { buildClient = false; };
 
   tengine = callPackage ../servers/http/tengine {


### PR DESCRIPTION
- Moved package from pkgs/games/the-butterfly-effect/default.nix to pkgs/by-name/tb/tbe/package.nix
- Switched from mkDerivation rec to stdenv.mkDerivation with finalAttrs
- Updated fetchFromGitHub to use `hash` instead of `sha256`
- Consolidated Qt dependencies under libsForQt5
- Adjusted meta attributes to use lib.* directly
- Removed old entry from all-packages.nix


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
