### PR TITLE
tor: 0.4.8.19 -> 0.4.8.20

### DIFF
--- a/pkgs/by-name/to/tor/package.nix
+++ b/pkgs/by-name/to/tor/package.nix
@@ -46,11 +46,11 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tor";
-  version = "0.4.8.19";
+  version = "0.4.8.20";
 
   src = fetchurl {
     url = "https://dist.torproject.org/tor-${finalAttrs.version}.tar.gz";
-    hash = "sha256-PLZJodM7pqZfEJ0iRTTpOq8KbehKWxy0sFS/oGu3T1o=";
+    hash = "sha256-G7IjKM3R7pSGR7/O1XHvp4wS/FBkGHtB1SVAhbUoL6c=";
   };
 
   outputs = [


### PR DESCRIPTION
Release announcement: https://forum.torproject.org/t/stable-release-0-4-8-20/20781
Release notes: https://gitlab.torproject.org/tpo/core/tor/-/raw/release-0.4.8/ReleaseNotes

I've run both a tor client and relay with this change, and everything appears to work fine.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---
## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 18 packages built:</summary>
  <ul>
    <li>bisq2</li>
    <li>briar-desktop</li>
    <li>carburetor</li>
    <li>cwtch-ui</li>
    <li>cwtch-ui.debug</li>
    <li>cwtch-ui.pubcache</li>
    <li>feather</li>
    <li>onionshare</li>
    <li>onionshare-gui</li>
    <li>onionshare-gui.dist</li>
    <li>onionshare.dist</li>
    <li>sparrow</li>
    <li>tor</li>
    <li>tor.geoip</li>
    <li>tractor</li>
    <li>tractor.dist</li>
    <li>trezor-suite</li>
    <li>wahay</li>
  </ul>
</details>

---
### `aarch64-linux`
<details>
  <summary>:white_check_mark: 14 packages built:</summary>
  <ul>
    <li>bisq2</li>
    <li>carburetor</li>
    <li>feather</li>
    <li>onionshare</li>
    <li>onionshare-gui</li>
    <li>onionshare-gui.dist</li>
    <li>onionshare.dist</li>
    <li>sparrow</li>
    <li>tor</li>
    <li>tor.geoip</li>
    <li>tractor</li>
    <li>tractor.dist</li>
    <li>trezor-suite</li>
    <li>wahay</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
