### PR TITLE
qbootctl: init at 0.2.2

### DIFF
--- a/pkgs/by-name/qb/qbootctl/package.nix
+++ b/pkgs/by-name/qb/qbootctl/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  fetchFromGitHub,
+  linuxHeaders,
+  meson,
+  ninja,
+  nix-update-script,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "qbootctl";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "linux-msm";
+    repo = "qbootctl";
+    tag = finalAttrs.version;
+    hash = "sha256-lpDCU9RJ4pK/qX4dEFfOCEdsF7l4Z/J8wzWMD4orFQY=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    linuxHeaders
+  ];
+
+  CFLAGS = [ "-I${linuxHeaders}/include" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://github.com/linux-msm/qbootctl";
+    description = "Qualcomm bootctl HAL for Linux";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ numinit ];
+    platforms = lib.platforms.linux;
+    mainProgram = "qbootctl";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Allows A/B slot control on Qualcomm devices.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
