### PR TITLE
spec-kit: init at 0.0.86

### DIFF
--- a/pkgs/by-name/sp/spec-kit/package.nix
+++ b/pkgs/by-name/sp/spec-kit/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "spec-kit";
+  version = "0.0.86";
+
+  src = fetchFromGitHub {
+    owner = "github";
+    repo = "spec-kit";
+    tag = "v${version}";
+    hash = "sha256-zgiJN7rzD5x/xpL6CMvxITy+/YTu1TKk26UhhQ/s5V8=";
+  };
+
+  pyproject = true;
+
+  build-system = with python3Packages; [
+    hatchling
+  ];
+
+  dependencies =
+    with python3Packages;
+    [
+      typer
+      rich
+      httpx
+      platformdirs
+      readchar
+      truststore
+    ]
+    ++ httpx.optional-dependencies.socks;
+
+  pythonImportsCheck = [
+    "specify_cli"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Bootstrap your projects for Spec-Driven Development (SDD)";
+    homepage = "https://github.com/github/spec-kit";
+    changelog = "https://github.com/github/spec-kit/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ luochen1990 ];
+    mainProgram = "specify";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
