### PR TITLE
tzpfms: init at 0.4.1

### DIFF
--- a/pkgs/by-name/tz/tzpfms/package.nix
+++ b/pkgs/by-name/tz/tzpfms/package.nix
@@ -53,6 +53,8 @@ stdenv.mkDerivation (finalPackage: {
       --replace-fail "-flto" "" \
       --replace-fail "out/" "$out/" \
       --replace-fail "ln -f" "ln -sf"
+    substituteInPlace src/bin/zfs-tpm-list.cpp \
+      --replace-fail "none     = -1," "none     = (char)-1,"
   '';
 
   dontInstall = true;

--- a/pkgs/by-name/tz/tzpfms/package.nix
+++ b/pkgs/by-name/tz/tzpfms/package.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  fetchFromSourcehut,
+  libtirpc,
+  libuuid,
+  mandoc,
+  nix-update-script,
+  openssl,
+  pkgconf,
+  shellcheck,
+  stdenv,
+  tpm2-tss,
+  trousers,
+  zfs,
+  zlib,
+}:
+
+stdenv.mkDerivation (finalPackage: {
+  pname = "tzpfms";
+  version = "0.4.1";
+
+  src = fetchFromSourcehut {
+    owner = "~nabijaczleweli";
+    repo = "tzpfms";
+    rev = "v${finalPackage.version}";
+    hash = "sha256-DHmJpfURyFPeOWxIkfwn4f0n2WeDYErevC1gY2oM3Vg=";
+  };
+
+  env = {
+    TZPFMS_VERSION = ''"${finalPackage.version}"'';
+    TZPFMS_DATE = "January 1, 1980";
+  };
+
+  nativeBuildInputs = [
+    mandoc
+    pkgconf
+    shellcheck
+  ];
+
+  buildInputs = [
+    libtirpc
+    libuuid
+    openssl
+    tpm2-tss
+    trousers
+    zfs
+    zlib
+  ];
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail "-flto=full" "" \
+      --replace-fail "-flto" "" \
+      --replace-fail "out/" "$out/" \
+      --replace-fail "ln -f" "ln -sf"
+  '';
+
+  dontInstall = true;
+
+  preFixup = ''
+    rm -rf $out/{build,systemd,initramfs-tools,dracut}
+    mkdir -p $out/bin
+    mv -v $out/zfs-* $out/bin
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://git.sr.ht/~nabijaczleweli/tzpfms";
+    description = "TPM-based encryption keys for ZFS datasets.";
+    longDescription = ''
+      Essentially BitLocker, but for ZFS – a random raw key is generated
+      and sealed to the TPM (both 2 and 1.x supported) with an additional
+      optional password in front of it, tying the dataset to the platform
+      and an additional optional secret (or to the possession of the back-up).
+    '';
+    maintainers = with lib.maintainers; [ numinit ];
+    license = with lib.licenses; [
+      mit
+      bsd0
+    ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Utility to unlock ZFS datasets with a key sealed in a TPM.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
