### PR TITLE
nixos/fish: fix indentation of generated files

### DIFF
--- a/nixos/modules/programs/fish.nix
+++ b/nixos/modules/programs/fish.nix
@@ -27,6 +27,14 @@ let
 
   envInteractiveShellInit = pkgs.writeText "interactiveShellInit" cfge.interactiveShellInit;
 
+  indentFishFile =
+    name: text:
+    pkgs.runCommand name {
+      nativeBuildInputs = [ cfg.package ];
+      inherit text;
+      passAsFile = [ "text" ];
+    } "fish_indent < $textPath > $out";
+
   sourceEnv =
     file:
     if cfg.useBabelfish then
@@ -182,16 +190,16 @@ in
       })
 
       {
-        etc."fish/nixos-env-preinit.fish".text =
+        etc."fish/nixos-env-preinit.fish".source =
           if cfg.useBabelfish then
-            ''
+            indentFishFile "nixos-env-preinit.fish" ''
               # source the NixOS environment config
               if [ -z "$__NIXOS_SET_ENVIRONMENT_DONE" ]
                 source /etc/fish/setEnvironment.fish
               end
             ''
           else
-            ''
+            indentFishFile "nixos-env-preinit.fish" ''
               # This happens before $__fish_datadir/config.fish sets fish_function_path, so it is currently
               # unset. We set it and then completely erase it, leaving its configuration to $__fish_datadir/config.fish
               set fish_function_path ${pkgs.fishPlugins.foreign-env}/share/fish/vendor_functions.d $__fish_datadir/functions
@@ -207,7 +215,7 @@ in
       }
 
       {
-        etc."fish/config.fish".text = ''
+        etc."fish/config.fish".source = indentFishFile "config.fish" ''
           # /etc/fish/config.fish: DO NOT EDIT -- this file has been generated automatically.
 
           # if we haven't sourced the general config, do it

--- a/nixos/modules/programs/fish.nix
+++ b/nixos/modules/programs/fish.nix
@@ -6,7 +6,6 @@
 }:
 
 let
-
   cfge = config.environment;
 
   cfg = config.programs.fish;
@@ -54,13 +53,9 @@ let
     } "babelfish < ${path} > $out;";
 
 in
-
 {
-
   options = {
-
     programs.fish = {
-
       enable = lib.mkOption {
         default = false;
         description = ''
@@ -161,13 +156,10 @@ in
         '';
         type = lib.types.lines;
       };
-
     };
-
   };
 
   config = lib.mkIf cfg.enable {
-
     programs.fish.shellAliases = lib.mapAttrs (name: lib.mkDefault) cfge.shellAliases;
 
     # Required for man completions

--- a/nixos/tests/fish.nix
+++ b/nixos/tests/fish.nix
@@ -24,5 +24,7 @@
       machine.succeed(
           "fish -ic 'echo $fish_complete_path' | grep -q '/share/fish/completions /etc/fish/generated_completions /root/.cache/fish/generated_completions$'"
       )
+      machine.wait_for_file("/etc/fish/config.fish")
+      config = machine.succeed("fish_indent -c /etc/fish/config.fish")
     '';
 }


### PR DESCRIPTION
Recently swapped to the NixOS fish module from the home-manager one, and noticed that the generated config files were ending up with some really messed up indentation. Short snippet to show what I mean, including lots of trailing whitespace:
```fish
# /etc/fish/config.fish: DO NOT EDIT -- this file has been generated automatically.

# if we haven't sourced the general config, do it
if not set -q __fish_nixos_general_config_sourced
  source /etc/fish/shellInit.fish

  

  # and leave a note so we don't source this config section again from
  # this very shell (children will source the general config anew)
  set -g __fish_nixos_general_config_sourced 1
end

# if we haven't sourced the login config, do it
status is-login; and not set -q __fish_nixos_login_config_sourced
and begin
  source /etc/fish/loginShellInit.fish

  

  # and leave a note so we don't source this config section again from
  # this very shell (children will source the general config anew)
  set -g __fish_nixos_login_config_sourced 1
end
```

This PR has the files now go through `fish_indent`, which leads to a much saner output. We take a similar approach to the [hm implementation](https://github.com/nix-community/home-manager/blob/3b955f5f0a942f9f60cdc9cacb7844335d0f21c3/modules/programs/fish.nix#L254), but remove the $home logic, as I don't see the point of it. Also added a test to guarantee that the files are formatted properly.

(Note: I added a small formatting commit to get rid of some newlines that nixfmt didn't touch. I can drop it if people want, I just thought I might as well include it)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
