### PR TITLE
odmpy: init at 0.8.1, python3.pkgs.iso639-lang: init at 2.6.3

### DIFF
--- a/pkgs/by-name/od/odmpy/delete_impure_tests.patch
+++ b/pkgs/by-name/od/odmpy/delete_impure_tests.patch
@@ -1,0 +1,14 @@
+diff --git a/tests/__init__.py b/tests/__init__.py
+index 20e8af4..502ff6a 100644
+--- a/tests/__init__.py
++++ b/tests/__init__.py
+@@ -2,9 +2,7 @@
+
+ # flake8: noqa
+ from .odmpy_tests import OdmpyTests
+-from .libby_tests import LibbyClientTests
+ from .utils_tests import UtilsTests
+ from .odmpy_libby_tests import OdmpyLibbyTests
+ from .odmpy_dl_tests import OdmpyDlTests
+ from .odmpy_shared_tests import ProcessingSharedTests
+-from .overdrive_tests import OverDriveClientTests

--- a/pkgs/by-name/od/odmpy/package.nix
+++ b/pkgs/by-name/od/odmpy/package.nix
@@ -1,0 +1,85 @@
+{
+  ffmpeg,
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  writableTmpDirAsHomeHook,
+}:
+
+let
+  version = "0.8.1";
+in
+python3Packages.buildPythonApplication {
+  pname = "odmpy";
+  inherit version;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ping";
+    repo = "odmpy";
+    tag = version;
+    hash = "sha256-RWaB/W8ilAKRr0ZSISisCG8Mdgw5LXRCLOl5o1RsmbA=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+    wheel
+  ];
+
+  postPatch = ''
+    substituteInPlace odmpy/processing/shared.py \
+      --replace-fail '"ffmpeg",' '"${lib.getExe ffmpeg}",'
+
+    substituteInPlace tests/odmpy_dl_tests.py \
+      --replace-fail '"ffprobe",' '"${lib.getExe' ffmpeg "ffprobe"}",'
+  '';
+
+  dependencies = with python3Packages; [
+    beautifulsoup4
+    eyed3
+    iso639-lang
+    lxml
+    mutagen
+    requests
+    termcolor
+    tqdm
+    typing-extensions
+  ];
+
+  nativeCheckInputs =
+    (with python3Packages; [
+      coverage
+      responses
+      ebooklib
+    ])
+    ++ [
+      writableTmpDirAsHomeHook
+    ];
+
+  pythonImportsCheck = [
+    "odmpy"
+  ];
+
+  patches = [
+    # These tests (perhaps unintentionally?) access the network.
+    ./delete_impure_tests.patch
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    # Strangely, this script does not have a #! nor is executable:
+    # https://github.com/ping/odmpy/blob/0.8.0/.github/workflows/lint-test.yml#L85
+    bash ./run_tests.sh
+
+    runHook postCheck
+  '';
+
+  meta = {
+    description = "Simple command line manager for OverDrive/Libby loans. Download your library loans from the command line";
+    homepage = "https://github.com/ping/odmpy";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ jfly ];
+    mainProgram = "odmpy";
+  };
+}

--- a/pkgs/development/python-modules/iso639-lang/default.nix
+++ b/pkgs/development/python-modules/iso639-lang/default.nix
@@ -1,0 +1,42 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  lib,
+  setuptools,
+  pytestCheckHook,
+}:
+
+let
+  version = "2.6.3";
+in
+buildPythonPackage {
+  pname = "iso639-lang";
+  inherit version;
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "iso639_lang";
+    inherit version;
+    hash = "sha256-B43bfNAYLcwENnaRrMgCLd9xWLbLCfCPeYr4I/qGQmU=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "iso639"
+    "iso639.data"
+  ];
+
+  meta = {
+    description = "Fast, comprehensive, ISO 639 library";
+    homepage = "https://pypi.org/project/iso639-lang/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jfly ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7360,6 +7360,8 @@ self: super: with self; {
 
   iso4217 = callPackage ../development/python-modules/iso4217 { };
 
+  iso639-lang = callPackage ../development/python-modules/iso639-lang { };
+
   iso8601 = callPackage ../development/python-modules/iso8601 { };
 
   isodate = callPackage ../development/python-modules/isodate { };


### PR DESCRIPTION
Adding `odmpy`, which depends on `iso639-lang`, which we did not have packaged yet.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
