### PR TITLE
piko: init at 0.10.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7646,6 +7646,12 @@
     name = "Daniel Ebbert";
     keys = [ { fingerprint = "E765 FCA3 D9BF 7FDB 856E  AD73 47BC 1559 27CB B9C7"; } ];
   };
+  echoz = {
+    email = "chris@echoz.io";
+    github = "echozio";
+    githubId = 7262891;
+    name = "Echoz";
+  };
   ecklf = {
     email = "ecklf@icloud.com";
     github = "ecklf";

--- a/pkgs/by-name/pi/piko/package.nix
+++ b/pkgs/by-name/pi/piko/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule rec {
+  pname = "piko";
+  version = "0.10.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "andydunstall";
+    repo = "piko";
+    tag = "v${version}";
+    hash = "sha256-fOdPtPeUKHw0e//PrvqvwhjGpYB4C7x0tGJckVRBEkQ=";
+  };
+
+  vendorHash = "sha256-fDhG1YeuoAw+wkrPRUONW0Sb/aPzwFDMmLadOefxVsw=";
+
+  ldflags = [
+    "-X github.com/andydunstall/piko/pkg/build.Version=${version}"
+  ];
+
+  meta = {
+    description = "Open-source alternative to Ngrok, designed to serve production traffic and be simple to host (particularly on Kubernetes)";
+    homepage = "https://github.com/andydunstall/piko";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ echoz ];
+    mainProgram = "piko";
+  };
+}


### PR DESCRIPTION
Adds Piko, an open source alternative to ngrok. Client and server are part of the same binary.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
