### PR TITLE
team/nim: init

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -512,3 +512,9 @@ pkgs/by-name/te/teleport*     @arianvp @justinas @sigma @tomberek @freezeboy @te
 
 # Warp-terminal
 pkgs/by-name/wa/warp-terminal/  @emilytrau @imadnyc @FlameFlag @johnrtitor
+
+# Nim
+/doc/languages-frameworks/nim.section.md  @NixOS/nim
+/pkgs/build-support/build-nim-package.nix @NixOS/nim
+/pkgs/build-support/build-nim-sbom.nix    @NixOS/nim
+/pkgs/top-level/nim-overrides.nix         @NixOS/nim

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -706,6 +706,11 @@ with lib.maintainers;
     shortName = "NGI";
   };
 
+  nim = {
+    github = "nim";
+    enableFeatureFreezePing = true;
+  };
+
   # same as https://github.com/orgs/NixOS/teams/nix-team
   nix = {
     members = [

--- a/pkgs/by-name/ni/nim-unwrapped-2_2/package.nix
+++ b/pkgs/by-name/ni/nim-unwrapped-2_2/package.nix
@@ -176,9 +176,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://nim-lang.org/";
     license = licenses.mit;
     mainProgram = "nim";
-    maintainers = with maintainers; [
-      eveeifyeve
-    ];
+    teams = [ lib.teams.nim ];
   };
 
 })

--- a/pkgs/by-name/ni/nimble/package.nix
+++ b/pkgs/by-name/ni/nimble/package.nix
@@ -42,7 +42,7 @@ buildNimPackage (
       changelog = "https://github.com/nim-lang/nimble/releases/tag/v${final.version}";
       license = lib.licenses.bsd3;
       mainProgram = "nimble";
-      maintainers = [ lib.maintainers.daylinmorgan ];
+      teams = [ lib.teams.nim ];
     };
   }
 )


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Created a nim team for managing language and language tools such as nimble and `buildNimPackage`.
We need a github team as well so we can do code owner: 
```
# nim
/doc/languages-frameworks/nim.section.md  @NixOS/nim-lang
/pkgs/build-support/build-nim-package.nix @NixOS/nim-lang
/pkgs/build-support/build-nim-sbom.nix    @NixOS/nim-lang
/pkgs/top-level/nim-overrides.nix         @NixOS/nim-lang
```

Links: #460877 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

CC @NixOS/nixpkgs-core 

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
