### PR TITLE
pam: allow override to enable debug mode

### DIFF
--- a/pkgs/by-name/li/linux-pam/package.nix
+++ b/pkgs/by-name/li/linux-pam/package.nix
@@ -28,6 +28,7 @@
     lib.meta.availableOn stdenv.hostPlatform audit
     # cross-compilation only works from platforms with linux headers
     && lib.meta.availableOn stdenv.buildPlatform linuxHeaders,
+  debugMode ? false, # warning: slower execution due to debug makes VM tests fail!
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -96,7 +97,6 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonEnable "audit" withAudit)
     (lib.mesonEnable "pam_lastlog" (!stdenv.hostPlatform.isMusl)) # TODO: switch to pam_lastlog2, pam_lastlog is deprecated and broken on musl
     (lib.mesonEnable "pam_unix" true)
-    # (lib.mesonBool "pam-debug" true) # warning: slower execution due to debug makes VM tests fail!
     (lib.mesonOption "sysconfdir" "etc") # relative to meson prefix, which is $out
     (lib.mesonEnable "elogind" false)
     (lib.mesonEnable "econf" false)
@@ -104,7 +104,9 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonEnable "nis" false)
     (lib.mesonBool "xtests" false)
     (lib.mesonBool "examples" false)
-  ];
+  ]
+  # warning: slower execution due to debug makes VM tests fail!
+  ++ lib.optional debugMode (lib.mesonBool "pam-debug" true);
 
   postInstall = ''
     moveToOutput sbin/pam_namespace_helper $scripts


### PR DESCRIPTION
Can be applied using the following snippet:

```nix
security.pam.package = pkgs.pam.override { debugMode = true; };
```

Makes testing pam things less painful, though i guess one could already just `overrideAttrs` to add the flag.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
