### PR TITLE
python3Packages.orjson: fix build for riscv64

### DIFF
--- a/pkgs/development/python-modules/orjson/cross-arch-compat.patch
+++ b/pkgs/development/python-modules/orjson/cross-arch-compat.patch
@@ -1,0 +1,44 @@
+From 8a6c16fd79e78aaaf1223090e673bdbe11451abc Mon Sep 17 00:00:00 2001
+From: DavHau <hsngrmpf+github@gmail.com>
+Date: Wed, 22 Oct 2025 10:40:03 +0700
+Subject: [PATCH] Fix cross-compilation by checking target arch in build.rs
+
+Previously, build.rs used #[cfg(target_arch)] attributes which check
+the host architecture where the build script runs, not the target
+being compiled for. This caused AVX-512 features to be incorrectly
+enabled when cross-compiling from x86_64 to other architectures like
+riscv64, leading to compilation errors.
+
+Now uses CARGO_CFG_TARGET_ARCH environment variable to correctly
+detect the target architecture during cross-compilation.
+---
+ build.rs | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/build.rs b/build.rs
+index 42788623..28e006a9 100644
+--- a/build.rs
++++ b/build.rs
+@@ -38,8 +38,11 @@ fn main() {
+     #[allow(unused_variables)]
+     let is_64_bit_python = matches!(python_config.pointer_width, Some(64));
+
+-    #[cfg(all(target_arch = "x86_64", not(target_os = "macos")))]
+-    if version_check::is_min_version("1.89.0").unwrap_or(false) && is_64_bit_python {
++    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
++    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
++
++    if target_arch == "x86_64" && target_os != "macos"
++        && version_check::is_min_version("1.89.0").unwrap_or(false) && is_64_bit_python {
+         println!("cargo:rustc-cfg=feature=\"avx512\"");
+     }
+
+@@ -51,8 +54,7 @@ fn main() {
+         println!("cargo:rustc-cfg=feature=\"optimize\"");
+     }
+
+-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+-    if is_64_bit_python {
++    if (target_arch == "x86_64" || target_arch == "aarch64") && is_64_bit_python {
+         println!("cargo:rustc-cfg=feature=\"inline_int\"");
+     }

--- a/pkgs/development/python-modules/orjson/default.nix
+++ b/pkgs/development/python-modules/orjson/default.nix
@@ -42,6 +42,11 @@ buildPythonPackage rec {
     hash = "sha256-oTrmDYmUHXMKxgxzBIStw7nnWXcyH9ir0ohnbX4bdjU=";
   };
 
+  patches = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    # fix architecture checks in build.rs to fix build for riscv
+    ./cross-arch-compat.patch
+  ];
+
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
     hash = "sha256-y6FmK1RR1DAswVoTlnl19CmoYXAco1dY7lpV/KTypzE=";


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
replaces https://github.com/NixOS/nixpkgs/pull/454437, not triggering a mass rebuild anymore
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
