### PR TITLE
frawk: fix build

### DIFF
--- a/pkgs/by-name/fr/frawk/fix-some-compiler-warnings-errors.patch
+++ b/pkgs/by-name/fr/frawk/fix-some-compiler-warnings-errors.patch
@@ -1,0 +1,55 @@
+From ad649637b9a1c8ac1fdae72bdc3ccd12f04b5800 Mon Sep 17 00:00:00 2001
+From: Gert Hulselmans <gert.hulselmans@kuleuven.be>
+Date: Fri, 29 Aug 2025 23:49:53 +0200
+Subject: [PATCH] Fix some compiler warnings/errors.
+
+  - error: implicit autoref creates a reference to the dereference of a raw pointer
+  - unsafe precondition(s) violated: slice::get_unchecked_mut requires that the index is within the slice
+---
+ src/interp.rs                 | 2 +-
+ src/runtime/splitter/batch.rs | 4 ++--
+ src/runtime/str_impl.rs       | 3 ++-
+ 3 files changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/src/interp.rs b/src/interp.rs
+index 587afbab83c3440e0364ee33dd89afd6a1b9e1d2..7b88ce32e9eedab648cc3eae8f6f98721d2cc976 100644
+--- a/src/interp.rs
++++ b/src/interp.rs
+@@ -653,7 +653,7 @@ impl<'a, LR: LineReader> Interp<'a, LR> {
+             cur = loop {
+                 debug_assert!(cur < unsafe { (*instrs).len() });
+                 use Variable::*;
+-                match unsafe { (*instrs).get_unchecked(cur) } {
++                match unsafe { (&(*instrs)).get_unchecked(cur) } {
+                     StoreConstStr(sr, s) => {
+                         let sr = *sr;
+                         *self.get_mut(sr) = s.clone_str()
+diff --git a/src/runtime/splitter/batch.rs b/src/runtime/splitter/batch.rs
+index cc8d05e44b49c6a0a0e930c527e35bd6773ba120..1d4c53dcb4ceca6bc6739ce5c226777b6f6a1e34 100644
+--- a/src/runtime/splitter/batch.rs
++++ b/src/runtime/splitter/batch.rs
+@@ -1128,8 +1128,8 @@ mod generic {
+         let len = buf.len();
+         let len_minus_64 = len.saturating_sub(V::INPUT_SIZE);
+         let mut ix = 0;
+-        let field_base_ptr: *mut u64 = field_offsets.fields.get_unchecked_mut(0);
+-        let newline_base_ptr: *mut u64 = newline_offsets.fields.get_unchecked_mut(0);
++        let field_base_ptr: *mut u64 = field_offsets.fields.as_mut_ptr();
++        let newline_base_ptr: *mut u64 = newline_offsets.fields.as_mut_ptr();
+         let mut field_base = 0;
+         let mut newline_base = 0;
+ 
+diff --git a/src/runtime/str_impl.rs b/src/runtime/str_impl.rs
+index e34176f86b7d0c4ba77f2107d3ebe571f207fbbd..4f8fbca5ac56b94765efdb3e03edfb0e82370e05 100644
+--- a/src/runtime/str_impl.rs
++++ b/src/runtime/str_impl.rs
+@@ -727,7 +727,8 @@ impl<'a> Str<'a> {
+         );
+         let new_len = to - from;
+         if new_len <= MAX_INLINE_SIZE {
+-            return Str::from_rep(Inline::from_unchecked(&(*self.get_bytes())[from..to]).into());
++            let bytes: &[u8] = &*self.get_bytes();
++            return Str::from_rep(Inline::from_unchecked(&bytes[from..to]).into());
+         }
+         let tag = self.rep().get_tag();
+         let u32_max = u32::max_value() as usize;

--- a/pkgs/by-name/fr/frawk/package.nix
+++ b/pkgs/by-name/fr/frawk/package.nix
@@ -26,6 +26,11 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-VraFR3Mp4mPh+39hw88R0q1p5iNkcQzvhRVNPwSxzU0=";
 
+  patches = [
+    # This patch comes from https://github.com/ezrosent/frawk/pull/120, which was squash-merged.
+    ./fix-some-compiler-warnings-errors.patch
+  ];
+
   buildInputs = [
     libxml2
     ncurses


### PR DESCRIPTION
Upstream squash-merged the original [PR](https://github.com/ezrosent/frawk/pull/120).

We cannot use the resulting commit directly because it includes Cargo.toml changes. Additionally, using the `fetchpatch` `includes/excludes` inputs is not possible, as the merged commit modifies the same file at multiple locations.

I avoided using direct GitHub URLs in this PR to follow the [policy](https://github.com/NixOS/nixpkgs/blob/b950bd29f73327c58318f890e76ce127c44bbdca/pkgs/README.md?plain=1#L650-L652) against unmerged commits.

Consequently, I prefer vendoring a patch file over using a [direct GitHub URL](https://github.com/ezrosent/frawk/commit/ad649637b9a1c8ac1fdae72bdc3ccd12f04b5800.patch?full_index=1).
I also considered updating this package to the unstable version. However, The [crate](https://crates.io/crates/frawk/versions) isn't updated, and the Cargo.lock in the GitHub repository is also not updated.

After this change

```console
> ./result/bin/frawk -F',' 'NR>1 { SUM+=$2 } END { print SUM }' <<EOF
Item,Quantity
Carrot,2
"The Deluge: The Great War, America and the Remaking of the Global Order, 1916-1931",3
Banana,4
EOF
6

> ./result/bin/frawk -i csv 'NR>1 { SUM+=$2 } END { print SUM }' <<EOF
Item,Quantity
Carrot,2
"The Deluge: The Great War, America and the Remaking of the Global Order, 1916-1931",3
Banana,4
EOF
9
```

ZHF: #457852

```console
> hydra-check frawk
Build Status for nixpkgs.frawk.x86_64-linux on jobset nixos/trunk-combined
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.frawk.x86_64-linux
✖ (Failed)  frawk-0.4.8  2025-11-11  https://hydra.nixos.org/build/310376569
✖ (Failed)  frawk-0.4.8  2025-10-10  https://hydra.nixos.org/build/308816103
✖ (Failed)  frawk-0.4.8  2025-09-11  https://hydra.nixos.org/build/306894085
✖ (Failed)  frawk-0.4.8  2025-08-25  https://hydra.nixos.org/build/305573367
✔           frawk-0.4.8  2025-07-26  https://hydra.nixos.org/build/303352284
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
