### PR TITLE
arti: 1.6.0 -> 1.7.0, enable `full` feature

### DIFF
--- a/pkgs/by-name/ar/arti/package.nix
+++ b/pkgs/by-name/ar/arti/package.nix
@@ -39,9 +39,25 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "arti"
   ];
 
+  # `full` includes all stable and non-conflicting feature flags. the primary
+  # downsides are increased binary size and memory usage for building, but
+  # those are acceptable for nixpkgs
+  buildFeatures = [ "full" ];
+
+  # several tests under `full` require access to internal types, which are
+  # currently marked as experimental for public usage.
+  checkFeatures = [
+    "full"
+    "experimental-api"
+  ];
+
   checkFlags = [
     # problematic test that hangs the build
     "--skip=reload_cfg::test::watch_single_file"
+
+    # some of the cli tests attempt to validate that the filesystem and build
+    # is securely configured, which is somewhat broken by the nix build sandbox
+    "--skip=cli_tests"
   ];
 
   nativeInstallCheckInputs = [

--- a/pkgs/by-name/ar/arti/package.nix
+++ b/pkgs/by-name/ar/arti/package.nix
@@ -12,7 +12,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "arti";
-  version = "1.6.0";
+  version = "1.7.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.torproject.org";
@@ -20,10 +20,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "core";
     repo = "arti";
     tag = "arti-v${finalAttrs.version}";
-    hash = "sha256-uBt4A9ORjJccnmzHxwoVHguvox7jOKqdrc6JdrvSrzk=";
+    hash = "sha256-4Vx5ATVdE8AoMWjDKKkwGOFVOwI0Qhyfr8MiAo+7MNw=";
   };
 
-  cargoHash = "sha256-XkdkCCHY+xLc1haFvqpwNsPgs6rh4AAGxMofrIwFFk0=";
+  cargoHash = "sha256-x1Pws9XbvwZqxJTJmPHQd6qbNLgkHxCK3YIZbRylk2M=";
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ pkg-config ];
 
@@ -41,7 +41,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   checkFlags = [
     # problematic test that hangs the build
-    "--skip=reload_cfg::test::watch_multiple"
+    "--skip=reload_cfg::test::watch_single_file"
   ];
 
   nativeInstallCheckInputs = [


### PR DESCRIPTION
Release post: https://blog.torproject.org/arti_1_7_0_released/
Full changelog: https://gitlab.torproject.org/tpo/core/arti/-/blob/arti-v1.7.0/CHANGELOG.md

This also enables the `full` feature flag. This flag includes all stable and non-conflicting arti feature flags. Upstream notes that the primary downsides are increased memory usage during build and an increased binary size (13,227 KB vs. 16,851 KB for x86_64-linux), both of which *I think* are acceptable for nixpkgs. Some tests enabled by this feature flag do fail due to security checks that are incompatible with the nixpkgs build sandbox, so those do need to be disabled (which I've done here).

This latter change may be controversial, and I can revert it if desired.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
