### PR TITLE
Add ctrl-os team to team list

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16743,6 +16743,12 @@
     github = "merrkry";
     githubId = 124278440;
   };
+  messemar = {
+    email = "martin.messer@cyberus-technology.de";
+    name = "messemar";
+    github = "messemar";
+    githubId = 22659757;
+  };
   metalmatze = {
     email = "matthias.loibl@polarsignals.com";
     name = "Matthias Loibl";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -226,6 +226,18 @@ with lib.maintainers;
     shortName = "Cosmopolitan";
   };
 
+  ctrl-os = {
+    # Existing members may approve additions.
+    members = [
+      blitz
+      messemar
+      flyfloh
+    ];
+
+    scope = "Team of Cyberus Technology employees that maintain packages relevant to CTRL-OS";
+    shortName = "CTRL-OS";
+  };
+
   cuda = {
     github = "cuda-maintainers";
   };
@@ -234,7 +246,6 @@ with lib.maintainers;
     # Verify additions by approval of an already existing member of the team.
     members = [
       xanderio
-      blitz
       snu
       e1mo
     ];

--- a/pkgs/by-name/cy/cyclonedx-cli/package.nix
+++ b/pkgs/by-name/cy/cyclonedx-cli/package.nix
@@ -34,7 +34,7 @@ buildDotnetModule rec {
     homepage = "https://github.com/CycloneDX/cyclonedx-cli";
     changelog = "https://github.com/CycloneDX/cyclonedx-cli/releases/tag/v${version}";
     maintainers = with lib.maintainers; [ thillux ];
-    teams = [ lib.teams.cyberus ];
+    teams = [ lib.teams.ctrl-os ];
     license = lib.licenses.asl20;
     platforms = with lib.platforms; (linux ++ darwin);
     mainProgram = "cyclonedx";

--- a/pkgs/by-name/cy/cyclonedx-python/package.nix
+++ b/pkgs/by-name/cy/cyclonedx-python/package.nix
@@ -37,7 +37,7 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://github.com/CycloneDX/cyclonedx-python";
     changelog = "https://github.com/CycloneDX/cyclonedx-python/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
-    teams = [ lib.teams.cyberus ];
+    teams = [ lib.teams.ctrl-os ];
     mainProgram = "cyclonedx-py";
   };
 }


### PR DESCRIPTION
This adds the `ctrl-os` team. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
