### PR TITLE
vicinae: add update script, 0.16.2 -> 0.16.5

### DIFF
--- a/pkgs/by-name/vi/vicinae/package.nix
+++ b/pkgs/by-name/vi/vicinae/package.nix
@@ -20,13 +20,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "vicinae";
-  version = "0.16.2";
+  version = "0.16.5";
 
   src = fetchFromGitHub {
     owner = "vicinaehq";
     repo = "vicinae";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-CNL45FJG8JAtFFbc8V8Hhf+RwZuWXFwz/v5E1yAi1bQ=";
+    hash = "sha256-smhbchRZmp7DwRLGA3QoI12kQuMVaxiNkhzfC+n19+4=";
   };
 
   apiDeps = fetchNpmDeps {

--- a/pkgs/by-name/vi/vicinae/package.nix
+++ b/pkgs/by-name/vi/vicinae/package.nix
@@ -90,6 +90,8 @@ stdenv.mkDerivation (finalAttrs: {
     }"
   ];
 
+  passthru.updateScript = ./update.sh;
+
   meta = {
     description = "A focused launcher for your desktop — native, fast, extensible";
     homepage = "https://github.com/vicinaehq/vicinae";

--- a/pkgs/by-name/vi/vicinae/update.sh
+++ b/pkgs/by-name/vi/vicinae/update.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p coreutils curl common-updater-scripts jq prefetch-npm-deps
+# shellcheck shell=bash
+
+set -euo pipefail
+
+version=$(curl -s "https://api.github.com/repos/vicinaehq/vicinae/releases/latest" | jq -r ".tag_name" | tr -d v)
+
+if [[ "$UPDATE_NIX_OLD_VERSION" == "$version" ]]; then
+  echo "Already up to date!"
+  exit 0
+fi
+
+pushd "$(mktemp -d)"
+curl -s "https://raw.githubusercontent.com/vicinaehq/vicinae/v${version}/typescript/api/package-lock.json" -o api-package-lock.json
+curl -s "https://raw.githubusercontent.com/vicinaehq/vicinae/v${version}/typescript/extension-manager/package-lock.json" -o extension-manager-package-lock.json
+newApiDepsHash=$(prefetch-npm-deps api-package-lock.json)
+newExtensionManagerDepsHash=$(prefetch-npm-deps extension-manager-package-lock.json)
+popd
+
+PACKAGE_ROOT=$(dirname "${BASH_SOURCE[0]}")
+NIXPKGS_ROOT=$(realpath "$PACKAGE_ROOT"/../../../..)
+
+oldApiDepsHash=$(nix-instantiate --eval --strict --expr \
+  "(import \"$NIXPKGS_ROOT\" {}).vicinae.apiDeps.hash" | tr -d '"')
+oldExtensionManagerDepsHash=$(nix-instantiate --eval --strict --expr \
+  "(import \"$NIXPKGS_ROOT\" {}).vicinae.extensionManagerDeps.hash" | tr -d '"')
+
+update-source-version vicinae "$version"
+sed -i "s@$oldApiDepsHash@$newApiDepsHash@g" "$PACKAGE_ROOT"/package.nix
+sed -i "s@$oldExtensionManagerDepsHash@$newExtensionManagerDepsHash@g" "$PACKAGE_ROOT"/package.nix


### PR DESCRIPTION
Add an update script which makes it easy to handle updating both the `src` and the two separate `fetchNpmDeps` hashes that vicinae uses.

Incorporate a collection of mostly minor fixes. Release notes:
 - https://github.com/vicinaehq/vicinae/releases/tag/v0.16.3
 - https://github.com/vicinaehq/vicinae/releases/tag/v0.16.4
 - https://github.com/vicinaehq/vicinae/releases/tag/v0.16.5

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
