### PR TITLE
python3Packages.pytorch-tokenizers: init at 1.0.1

### DIFF
--- a/pkgs/development/python-modules/pytorch-tokenizers/default.nix
+++ b/pkgs/development/python-modules/pytorch-tokenizers/default.nix
@@ -1,0 +1,94 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  replaceVars,
+
+  # build-system
+  cmake,
+  pybind11,
+  setuptools,
+
+  # dependencies
+  sentencepiece,
+  tiktoken,
+  tokenizers,
+
+  # tests
+  pytestCheckHook,
+  transformers,
+}:
+
+let
+  # https://github.com/meta-pytorch/tokenizers/blob/v1.0.1/CMakeLists.txt#L174-L175
+  pybind11-src = fetchFromGitHub {
+    owner = "pybind";
+    repo = "pybind11";
+    tag = "v2.13.6";
+    hash = "sha256-SNLdtrOjaC3lGHN9MAqTf51U9EzNKQLyTMNPe0GcdrU=";
+  };
+in
+buildPythonPackage rec {
+  pname = "pytorch-tokenizers";
+  version = "1.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "meta-pytorch";
+    repo = "tokenizers";
+    tag = "v${version}";
+    fetchSubmodules = true;
+    hash = "sha256-1BGazimbauNBN/VfLiuhk21VEhbP07GEpPc+GAfKTQY=";
+  };
+
+  patches = [
+    (replaceVars ./dont-fetch-pybind11.patch {
+      pybind11 = pybind11-src;
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail '"pip>=23",' "" \
+      --replace-fail '"pytest",' ""
+  '';
+
+  build-system = [
+    cmake
+    pybind11
+    setuptools
+  ];
+  dontUseCmakeConfigure = true;
+
+  dependencies = [
+    sentencepiece
+    tiktoken
+    tokenizers
+  ];
+
+  pythonImportsCheck = [
+    "pytorch_tokenizers"
+    "pytorch_tokenizers.pytorch_tokenizers_cpp"
+  ];
+
+  preCheck = ''
+    rm -rf pytorch_tokenizers
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    transformers
+  ];
+
+  disabledTestPaths = [
+    # Require downloading models from huggingface
+    "test/test_hf_tokenizer.py"
+  ];
+
+  meta = {
+    description = "C++ implementations for various tokenizers (sentencepiece, tiktoken, etc.)";
+    homepage = "https://github.com/meta-pytorch/tokenizers";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/development/python-modules/pytorch-tokenizers/dont-fetch-pybind11.patch
+++ b/pkgs/development/python-modules/pytorch-tokenizers/dont-fetch-pybind11.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 97f0fe6..8c78f85 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -171,8 +171,7 @@ if(TOKENIZERS_BUILD_PYTHON)
+   include(FetchContent)
+   FetchContent_Declare(
+     pybind11
+-    GIT_REPOSITORY https://github.com/pybind/pybind11.git
+-    GIT_TAG v2.13.6
++    URL @pybind11@
+   )
+   FetchContent_MakeAvailable(pybind11)
+ 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15434,6 +15434,8 @@ self: super: with self; {
 
   pytorch-tabnet = callPackage ../development/python-modules/pytorch-tabnet { };
 
+  pytorch-tokenizers = callPackage ../development/python-modules/pytorch-tokenizers { };
+
   pytorch3d = callPackage ../development/python-modules/pytorch3d { };
 
   pytorchviz = callPackage ../development/python-modules/pytorchviz { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add [pytorch-tokenizers](https://github.com/meta-pytorch/tokenizers), C++ implementations for various tokenizers (sentencepiece, tiktoken etc).

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
