### PR TITLE
python3Packages.torchtune: init at 0.6.1

### DIFF
--- a/pkgs/development/python-modules/pytest-integration/default.nix
+++ b/pkgs/development/python-modules/pytest-integration/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-integration";
+  version = "0.2.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "jbwdevries";
+    repo = "pytest-integration";
+    tag = "v${version}";
+    hash = "sha256-Ziy+GEfljYDccx3mm63p7rhDUQVDXLbk7DxUW3npjiE=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  pythonImportsCheck = [ "pytest_integration" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  # Tests need to discover the mock `package` module located under `example/`
+  preCheck = ''
+    pushd example
+  '';
+
+  postCheck = ''
+    popd
+  '';
+
+  meta = {
+    description = "Organizing test by unit test, quick integration or slow integration";
+    homepage = "https://github.com/jbwdevries/pytest-integration";
+    changelog = "https://github.com/jbwdevries/pytest-integration/blob/${src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/development/python-modules/torchtune/default.nix
+++ b/pkgs/development/python-modules/torchtune/default.nix
@@ -1,0 +1,123 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  blobfile,
+  datasets,
+  huggingface-hub,
+  kagglehub,
+  numpy,
+  omegaconf,
+  pillow,
+  psutil,
+  safetensors,
+  sentencepiece,
+  tiktoken,
+  tokenizers,
+  torch,
+  torchdata,
+  tqdm,
+  torchao,
+  torchvision,
+
+  # tests
+  comet-ml,
+  mlflow,
+  pytest-integration,
+  pytest-mock,
+  pytestCheckHook,
+  writableTmpDirAsHomeHook,
+}:
+
+buildPythonPackage rec {
+  pname = "torchtune";
+  version = "0.6.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "meta-pytorch";
+    repo = "torchtune";
+    tag = "v${version}";
+    hash = "sha256-evhQBpZiUXriL0PAYkEzGypH21iRs37Ix6Nl5YAyeQ0=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    blobfile
+    datasets
+    huggingface-hub
+    kagglehub
+    numpy
+    omegaconf
+    pillow
+    psutil
+    safetensors
+    sentencepiece
+    tiktoken
+    tokenizers
+    torch
+    torchdata
+    tqdm
+
+    # Not explicitly listed as requirements, but effectively imported at runtime
+    torchao
+    torchvision
+  ]
+  ++ huggingface-hub.optional-dependencies.hf_transfer;
+
+  pythonImportsCheck = [ "torchtune" ];
+
+  nativeCheckInputs = [
+    comet-ml
+    mlflow
+    pytest-integration
+    pytest-mock
+    pytestCheckHook
+    writableTmpDirAsHomeHook
+  ];
+
+  disabledTests = [
+    # AssertionError (tensors are not equal)
+    "test_stop_tokens"
+    "test_stop_tokens_batched"
+    "test_stop_tokens_batched_uneven_stopping"
+    "test_stop_tokens_batched_uneven_stopping_left_padded"
+
+    # RuntimeError: not allowed to set torch.backends.cudnn flags after disable_global_flags;
+    # please use flags() context manager instead
+    "test_deterministic_false"
+    "test_deterministic_true"
+
+    # TypeError: exceptions must be derived from Warning, not <class 'NoneType'>
+    "test_deprecated"
+
+    # Flaky
+    # AssertionError: actual: -83.3048095703125, expected: -83.15229797363281
+    "test_forward"
+    "test_forward_kv_cache"
+    "test_forward_with_2d_pos_ids"
+    "test_forward_with_curr_pos"
+    "test_forward_with_packed_pos"
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+    # Fatal Python error: Segmentation fault
+    "test_forward_gqa"
+  ];
+
+  meta = {
+    description = "PyTorch native post-training library";
+    homepage = "https://github.com/meta-pytorch/torchtune";
+    changelog = "https://github.com/meta-pytorch/torchtune/releases/tag/${src.tag}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18849,6 +18849,8 @@ self: super: with self; {
 
   torchtnt = callPackage ../development/python-modules/torchtnt { };
 
+  torchtune = callPackage ../development/python-modules/torchtune { };
+
   torchvision = callPackage ../development/python-modules/torchvision { };
 
   torchvision-bin = callPackage ../development/python-modules/torchvision/bin.nix { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14737,6 +14737,8 @@ self: super: with self; {
 
   pytest-instafail = callPackage ../development/python-modules/pytest-instafail { };
 
+  pytest-integration = callPackage ../development/python-modules/pytest-integration { };
+
   pytest-isort = callPackage ../development/python-modules/pytest-isort { };
 
   pytest-json-report = callPackage ../development/python-modules/pytest-json-report { };


### PR DESCRIPTION
## Things done

Add [torchtune](https://github.com/meta-pytorch/torchtune), a Pytorch native post-training library.

- **python3Packages.pytest-integration: init at 0.2.3**
- **python3Packages.torchtune: init at 0.6.1**

Depends on:
- https://github.com/NixOS/nixpkgs/pull/460928
- https://github.com/NixOS/nixpkgs/pull/460931

---

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
