### PR TITLE
prow: 0-unstable-2024-08-27 -> 0-unstable-2025-11-09

### DIFF
--- a/pkgs/by-name/pr/prow/package.nix
+++ b/pkgs/by-name/pr/prow/package.nix
@@ -2,7 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  git,
+  gitMinimal,
   nix-update-script,
 }:
 
@@ -63,7 +63,7 @@ buildGoModule rec {
     "cmd/webhook-server"
   ];
 
-  nativeCheckInputs = [ git ];
+  nativeCheckInputs = [ gitMinimal ];
 
   passthru = {
     updateScript = nix-update-script {

--- a/pkgs/by-name/pr/prow/package.nix
+++ b/pkgs/by-name/pr/prow/package.nix
@@ -3,6 +3,7 @@
   buildGoModule,
   fetchFromGitHub,
   git,
+  nix-update-script,
 }:
 
 buildGoModule rec {
@@ -63,6 +64,12 @@ buildGoModule rec {
   ];
 
   nativeCheckInputs = [ git ];
+
+  passthru = {
+    updateScript = nix-update-script {
+      extraArgs = [ "--version=branch" ];
+    };
+  };
 
   meta = {
     description = "Kubernetes based CI/CD system developed to serve the Kubernetes community";

--- a/pkgs/by-name/pr/prow/package.nix
+++ b/pkgs/by-name/pr/prow/package.nix
@@ -8,18 +8,18 @@
 
 buildGoModule rec {
   pname = "prow";
-  version = "0-unstable-2024-08-27";
-  rev = "195f38540f39dd3ec95ca2d7086487ec19922e61";
+  version = "0-unstable-2025-11-09";
+  rev = "98a0c9d48d175803e1c616b856f39362011abef3";
 
   src = fetchFromGitHub {
     inherit rev;
 
     owner = "kubernetes-sigs";
     repo = "prow";
-    hash = "sha256-/OhlJdxPa4rTuT7XIklx8vxprbENfasJYwiJxD4CeXY=";
+    hash = "sha256-ypSIWTktqTzi/BIx2IqMhpwjPxz06YNCfryzY5PwdTs=";
   };
 
-  vendorHash = "sha256-bJ0P/rHp+0zB/Dtp3F3n4AN3xF/A5qoq3lCQVBK+L4w=";
+  vendorHash = "sha256-J/DQbAWKHQdE+V/uRuo6rAwGGpEq4OeV1NUpB27xJTg=";
 
   # doCheck = false;
 

--- a/pkgs/by-name/pr/prow/package.nix
+++ b/pkgs/by-name/pr/prow/package.nix
@@ -65,6 +65,10 @@ buildGoModule rec {
 
   nativeCheckInputs = [ gitMinimal ];
 
+  # Workaround for: panic: httptest: failed to listen on a port: listen tcp6 [::1]:0: bind: operation not permitted
+  # ref: https://github.com/NixOS/nix/pull/1646
+  __darwinAllowLocalNetworking = true;
+
   passthru = {
     updateScript = nix-update-script {
       extraArgs = [ "--version=branch" ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Diff: https://github.com/kubernetes-sigs/prow/compare/195f38540f39dd3ec95ca2d7086487ec19922e61...98a0c9d48d175803e1c616b856f39362011abef3

There are no changes in the subdirectory names directly in `cmd/`.

https://github.com/kubernetes-sigs/prow/tree/195f38540f39dd3ec95ca2d7086487ec19922e61/cmd
https://github.com/kubernetes-sigs/prow/tree/98a0c9d48d175803e1c616b856f39362011abef3/cmd

```bash
diff \
 <(curl -s "https://api.github.com/repos/kubernetes-sigs/prow/contents/cmd?ref=195f38540f39dd3ec95ca2d7086487ec19922e61" | jq -r '.[] | select(.type=="dir") | .name' | sort) \
 <(curl -s "https://api.github.com/repos/kubernetes-sigs/prow/contents/cmd?ref=98a0c9d48d175803e1c616b856f39362011abef3" | jq -r '.[] | select(.type=="dir") | .name' | sort)
```

I kept `cmd/external-plugins` in this PR.

```
no Go files in /nix/var/nix/builds/nix-12248-1596523997/source/cmd/external-plugins
```

ZHF: #457852

```console
> hydra-check prow
Build Status for nixpkgs.prow.x86_64-linux on jobset nixos/trunk-combined
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.prow.x86_64-linux
✖ (Failed)  prow-0-unstable-2024-08-27  2025-11-11  https://hydra.nixos.org/build/310439333
✖ (Failed)  prow-0-unstable-2024-08-27  2025-10-10  https://hydra.nixos.org/build/308878226
✖ (Failed)  prow-0-unstable-2024-08-27  2025-09-11  https://hydra.nixos.org/build/306957875
✔           prow-0-unstable-2024-08-27  2025-08-25  https://hydra.nixos.org/build/305639236
✔           prow-0-unstable-2024-08-27  2025-07-27  https://hydra.nixos.org/build/303415062
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc: @kalbasit

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
