### PR TITLE
chromium,chromedriver: 142.0.7444.134 -> 142.0.7444.162

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,10 +1,10 @@
 {
   "chromium": {
-    "version": "142.0.7444.134",
+    "version": "142.0.7444.162",
     "chromedriver": {
-      "version": "142.0.7444.135",
-      "hash_darwin": "sha256-i34SR1pfHcAA4N4ppIioa7r33PnvY0OYA8/+U1bQFs8=",
-      "hash_darwin_aarch64": "sha256-dsbjEDkZ0AVghazgF5w9O3aUWZNSy8R9WiHn9m/Sa9g="
+      "version": "142.0.7444.162",
+      "hash_darwin": "sha256-5IjkO18e8WiruQjTPZ4WXybbbDOwcSEbI+AnDEwNR3I=",
+      "hash_darwin_aarch64": "sha256-xDsFiFdeDmZyceDRhe6Kl5KndDgVzkwFtvB4qdzUt0E="
     },
     "deps": {
       "depot_tools": {
@@ -21,8 +21,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "b6965f826881a60c51151cfc0a0175966a0a4e81",
-        "hash": "sha256-NTBQrGihsT7kuY/Mac5s4oH1xEn3CFEAR6eOEvZwmYs=",
+        "rev": "c076baf266c3ed5efb225de664cfa7b183668ad6",
+        "hash": "sha256-HdVZl4Zvspgm/9wy+WtDc1UiSM1VrszfwpITQchYoSc=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -92,8 +92,8 @@
       },
       "src/third_party/angle": {
         "url": "https://chromium.googlesource.com/angle/angle.git",
-        "rev": "e5b338502c7c65bd38d4695bc557938ca4cc3aa7",
-        "hash": "sha256-FWPyOxpsXvFtOD6OJ950NQUBcpVIeYvjuAKaqnER6A0="
+        "rev": "7b27cb13556246035dfc7b308702b1b20710df47",
+        "hash": "sha256-PM7msE9678QFyr7qp47Bc0vTntsSCeB/cirg9ME6TZk="
       },
       "src/third_party/angle/third_party/glmark2/src": {
         "url": "https://chromium.googlesource.com/external/github.com/glmark2/glmark2",
@@ -807,8 +807,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "4427aa4a9c14d3d542866c0ed2ae8a8554cfd68d",
-        "hash": "sha256-SL9YaplMFA1Ez11bIzAfl/F5qQob/PvCP1uknP1LiLs="
+        "rev": "9210361d0a26fa4afefad8c5e60c85e59c5e2c8e",
+        "hash": "sha256-otYRT8scmJ9boG2PKXRacL0C5FFwOVctKK/Dh7WG0tU="
       }
     }
   },


### PR DESCRIPTION
https://chromereleases.googleblog.com/2025/11/stable-channel-update-for-desktop_11.html

This update includes 1 security fix.

CVEs:
CVE-2025-13042

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
