### PR TITLE
nwchem: use system versions of libxc and scalapack

### DIFF
--- a/pkgs/applications/science/chemistry/nwchem/default.nix
+++ b/pkgs/applications/science/chemistry/nwchem/default.nix
@@ -13,6 +13,7 @@
   blas,
   lapack,
   scalapack,
+  libxc,
   python3,
   tcsh,
   automake,
@@ -36,12 +37,6 @@ let
   dftd3Src = fetchurl {
     url = "https://www.chemie.uni-bonn.de/grimme/software/dft-d3/dftd3.tgz";
     hash = "sha256-2Xz5dY9hqoH9hUJUSPv0pujOB8EukjZzmDGjrzKID1k=";
-  };
-
-  versionLibxc = "6.1.0";
-  libxcSrc = fetchurl {
-    url = "https://gitlab.com/libxc/libxc/-/archive/${versionLibxc}/libxc-${versionLibxc}.tar.gz";
-    hash = "sha256-9ZN0X6R+v7ndxGeqr9wvoSdfDXJQxpLOl2E4mpDdjq8=";
   };
 
   plumedSrc = fetchFromGitHub {
@@ -83,6 +78,7 @@ stdenv.mkDerivation rec {
     blas
     lapack
     scalapack
+    libxc
     python3
   ];
   propagatedBuildInputs = [ mpi ];
@@ -99,7 +95,6 @@ stdenv.mkDerivation rec {
 
     # Provide tarball in expected location
     ln -s ${dftd3Src} source/src/nwpw/nwpwlib/nwpwxc/dftd3.tgz
-    ln -s ${libxcSrc} source/src/libext/libxc/libxc-${versionLibxc}.tar.gz
   '';
 
   postPatch = ''
@@ -144,6 +139,10 @@ stdenv.mkDerivation rec {
     export USE_SCALAPACK="y"
     export SCALAPACK="-L${scalapack}/lib -lscalapack"
     export SCALAPACK_SIZE="4"
+
+    export LIBXC_INCLUDE="${lib.getDev libxc}/include"
+    export LIBXC_MODDIR="${lib.getDev libxc}/include"
+    export LIBXC_LIB="${lib.getLib libxc}/lib"
 
     # extra TCE related options
     export MRCC_METHODS="y"

--- a/pkgs/applications/science/chemistry/nwchem/default.nix
+++ b/pkgs/applications/science/chemistry/nwchem/default.nix
@@ -12,6 +12,7 @@
   mpi,
   blas,
   lapack,
+  scalapack,
   python3,
   tcsh,
   automake,
@@ -81,6 +82,7 @@ stdenv.mkDerivation rec {
     openssh
     blas
     lapack
+    scalapack
     python3
   ];
   propagatedBuildInputs = [ mpi ];
@@ -139,6 +141,9 @@ stdenv.mkDerivation rec {
     export BLASOPT="-L${blas}/lib -lblas"
     export LAPACK_LIB="-L${lapack}/lib -llapack"
     export BLAS_SIZE=${if blas.isILP64 then "8" else "4"}
+    export USE_SCALAPACK="y"
+    export SCALAPACK="-L${scalapack}/lib -lscalapack"
+    export SCALAPACK_SIZE="4"
 
     # extra TCE related options
     export MRCC_METHODS="y"


### PR DESCRIPTION
This enables the usage of nixpkgs' versions of Scalapack and LibXC in NWChem, enabling clean overrides, and in case of ScaLapack also hopefully improving performance (the previous version did not use scalapack at all).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
