### PR TITLE
nixos: Shuffle definitions and deprecate system.extraSystemBuilderCmds

### DIFF
--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -53,8 +53,6 @@ let
       ${config.boot.bootspec.writer}
       ${optionalString config.boot.bootspec.enableValidation ''${config.boot.bootspec.validator} "$out/${config.boot.bootspec.filename}"''}
     ''}
-
-    ${config.system.extraSystemBuilderCmds}
   '';
 
   # Putting it all together.  This builds a store path containing
@@ -129,6 +127,7 @@ in
       [ "system" "replaceRuntimeDependencies" ]
       [ "system" "replaceDependencies" "replacements" ]
     )
+    (mkRenamedOptionModule [ "system" "extraSystemBuilderCmds" ] [ "system" "systemBuilderCommands" ])
   ];
 
   options = {
@@ -210,15 +209,6 @@ in
       description = ''
         POSIX Extended Regular Expressions that match store paths that
         should not appear in the system closure, with the exception of {option}`system.extraDependencies`, which is not checked.
-      '';
-    };
-
-    system.extraSystemBuilderCmds = mkOption {
-      type = types.lines;
-      internal = true;
-      default = "";
-      description = ''
-        This code will be added to the builder creating the system store path.
       '';
     };
 
@@ -343,7 +333,7 @@ in
       }
     ];
 
-    system.extraSystemBuilderCmds =
+    system.systemBuilderCommands =
       optionalString config.system.copySystemConfiguration ''
         ln -s '${import ../../../lib/from-env.nix "NIXOS_CONFIG" <nixos-config>}' \
           "$out/configuration.nix"

--- a/nixos/tests/switch-test.nix
+++ b/nixos/tests/switch-test.nix
@@ -64,7 +64,7 @@ in
         boot.loader.grub.enable = false;
 
         specialisation = rec {
-          brokenInitInterface.configuration.config.system.extraSystemBuilderCmds = ''
+          brokenInitInterface.configuration.config.system.systemBuilderCommands = ''
             echo "systemd 0" > $out/init-interface-version
           '';
 


### PR DESCRIPTION
Shuffle:
The definitions are now combined into a single option. Since they have no interdependencies, that's ok, but you may notice this trivial change by a changed hash, and analyzing with nix-diff.

Deprecation:
Use the option `system.systemBuilderCommands` instead.

Context:
- https://github.com/NixOS/nixpkgs/pull/199595#pullrequestreview-3453333360

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
