### PR TITLE
cuda-samples: Add driver runpath to samples

### DIFF
--- a/pkgs/development/cuda-modules/packages/cuda-samples.nix
+++ b/pkgs/development/cuda-modules/packages/cuda-samples.nix
@@ -1,4 +1,5 @@
 {
+  autoAddDriverRunpath,
   backendStdenv,
   _cuda,
   cmake,
@@ -176,6 +177,7 @@ backendStdenv.mkDerivation (finalAttrs: {
     '';
 
   nativeBuildInputs = [
+    autoAddDriverRunpath
     cmake
     cuda_nvcc
   ];


### PR DESCRIPTION
Some CUDA samples dlopen the userspace drivers instead of going through libcuda (as part of being a sample/demo). Ensure these samples run by patchelf'ing in the driver runpath.

## Things done

- Built on platform:
  - [x] x86_64-linux (cudaPackages_12.cuda-samples ; cudaPackages_13.cuda-samples)
  - [x] aarch64-linux (cudaPackages_12.cuda-samples ; cudaPackages_13.cuda-samples)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
