### PR TITLE
cuda-modules: cudatoolkit: Add cuda_crt to symlinkJoin

### DIFF
--- a/pkgs/development/cuda-modules/packages/cudatoolkit.nix
+++ b/pkgs/development/cuda-modules/packages/cudatoolkit.nix
@@ -2,8 +2,10 @@
   lib,
   symlinkJoin,
   backendStdenv,
+  cudaAtLeast,
   cudaMajorMinorVersion,
   cuda_cccl ? null,
+  cuda_crt ? null,
   cuda_cudart ? null,
   cuda_cuobjdump ? null,
   cuda_cupti ? null,
@@ -53,6 +55,9 @@ let
     libcusolver
     libcusparse
     libnpp
+  ]
+  ++ lib.optionals (cudaAtLeast "13") [
+    cuda_crt
   ];
 
   # This assumes we put `cudatoolkit` in `buildInputs` instead of `nativeBuildInputs`:


### PR DESCRIPTION
cuda_crt was previously bundled in cuda_cudart but has moved into its own redistributable starting with CUDA 13. Add it into the cudatoolkit so packages depending on the symlinkJoin can still build.

## Things done

- Built on platform:
  - [x] x86_64-linux (cudaPackages_12.cudatoolkit ; cudaPackages_13.cudatoolkit)
  - [x] aarch64-linux (cudaPackages_12.cudatoolkit ; cudaPackages_13.cudatoolkit)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
