### PR TITLE
rslint: fix build

### DIFF
--- a/pkgs/by-name/rs/rslint/fix-rustc-1.89-compatibility.patch
+++ b/pkgs/by-name/rs/rslint/fix-rustc-1.89-compatibility.patch
@@ -1,0 +1,22 @@
+From 1ceaa3a78d591599a5fe30f702bdb3dae1004f70 Mon Sep 17 00:00:00 2001
+From: Daeho Ro <40587651+daeho-ro@users.noreply.github.com>
+Date: Sun, 14 Sep 2025 15:47:53 +0900
+Subject: [PATCH] fix: rust 1.89 compatibility
+
+---
+ crates/rslint_rowan/src/arc.rs | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/crates/rslint_rowan/src/arc.rs b/crates/rslint_rowan/src/arc.rs
+index 0977f4422e85384872183d999603be4d563a4a55..9d2e00c5844412bf0d097f5b219f877e67cab7e0 100644
+--- a/crates/rslint_rowan/src/arc.rs
++++ b/crates/rslint_rowan/src/arc.rs
+@@ -575,7 +575,7 @@ impl<H, T> Arc<HeaderSlice<H, [T]>> {
+             // we'll just leak the uninitialized memory.
+             ptr::write(&mut ((*ptr).count), atomic::AtomicUsize::new(1));
+             ptr::write(&mut ((*ptr).data.header), header);
+-            if let Some(current) = (*ptr).data.slice.get_mut(0) {
++            if let Some(current) = (&mut (*ptr).data.slice).get_mut(0) {
+                 let mut current: *mut T = current;
+                 for _ in 0..num_items {
+                     ptr::write(

--- a/pkgs/by-name/rs/rslint/package.nix
+++ b/pkgs/by-name/rs/rslint/package.nix
@@ -24,6 +24,11 @@ rustPlatform.buildRustPackage rec {
     "rslint_lsp"
   ];
 
+  patches = [
+    # This patch comes from https://github.com/rslint/rslint/pull/165, which was unmerged.
+    ./fix-rustc-1.89-compatibility.patch
+  ];
+
   meta = with lib; {
     description = "Fast, customizable, and easy to use JavaScript and TypeScript linter";
     homepage = "https://rslint.org";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Upstream PR: https://github.com/rslint/rslint/pull/165

ZHF: #457852

```console
> hydra-check rslint
Build Status for nixpkgs.rslint.x86_64-linux on jobset nixos/trunk-combined
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.rslint.x86_64-linux
✖ (Failed)  rslint-0.3.2  2025-11-11  https://hydra.nixos.org/build/310481165
✖ (Failed)  rslint-0.3.2  2025-10-10  https://hydra.nixos.org/build/308920022
✖ (Failed)  rslint-0.3.2  2025-09-11  https://hydra.nixos.org/build/306999440
✖ (Failed)  rslint-0.3.2  2025-08-25  https://hydra.nixos.org/build/305680515
✔           rslint-0.3.2  2025-07-28  https://hydra.nixos.org/build/303455771
✔           rslint-0.3.2  2025-07-14  https://hydra.nixos.org/build/302482960
```

After this change

```console
> ./result/bin/rslint explain no-cond-assign | tail
//          6 is always truthy, therefore the if statement always runs even if we dont want it to.

} else {}
//^^^^ it makes this else unreachable

foo // 6


Docs: https://rslint.org/rules/errors/no-cond-assign.html
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
