### PR TITLE
podman: 5.6.2 -> 5.7.0

### DIFF
--- a/pkgs/by-name/po/podman/hardcode-paths.patch
+++ b/pkgs/by-name/po/podman/hardcode-paths.patch
@@ -1,8 +1,8 @@
-diff --git a/vendor/github.com/containers/common/pkg/config/default.go b/vendor/github.com/containers/common/pkg/config/default.go
-index 02ff128..d3254ba 100644
---- a/vendor/github.com/containers/common/pkg/config/default.go
-+++ b/vendor/github.com/containers/common/pkg/config/default.go
-@@ -378,75 +378,34 @@ func defaultEngineConfig() (*EngineConfig, error) {
+diff --git a/vendor/go.podman.io/common/pkg/config/default.go b/vendor/go.podman.io/common/pkg/config/default.go
+index 3bf0bc1..05496ae 100644
+--- a/vendor/go.podman.io/common/pkg/config/default.go
++++ b/vendor/go.podman.io/common/pkg/config/default.go
+@@ -389,75 +389,34 @@ func defaultEngineConfig() (*EngineConfig, error) {
  	c.Retry = 3
  	c.OCIRuntimes = map[string][]string{
  		"crun": {
@@ -87,11 +87,11 @@ index 02ff128..d3254ba 100644
 +			"@bin_path@/bin/ocijail",
  		},
  	}
- 	c.PlatformToOCIRuntime = map[string]string{
-@@ -457,26 +416,12 @@ func defaultEngineConfig() (*EngineConfig, error) {
+ 	c.OCIRuntimesFlags = map[string][]string{}
+@@ -469,26 +428,12 @@ func defaultEngineConfig() (*EngineConfig, error) {
  	// Needs to be called after populating c.OCIRuntimes.
  	c.OCIRuntime = c.findRuntime()
- 
+
 -	c.ConmonEnvVars.Set([]string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"})
 +	c.ConmonEnvVars.Set([]string{})
  	c.ConmonPath.Set([]string{

--- a/pkgs/by-name/po/podman/package.nix
+++ b/pkgs/by-name/po/podman/package.nix
@@ -76,13 +76,13 @@ let
 in
 buildGoModule rec {
   pname = "podman";
-  version = "5.6.2";
+  version = "5.7.0";
 
   src = fetchFromGitHub {
     owner = "containers";
     repo = "podman";
     rev = "v${version}";
-    hash = "sha256-VVPwnzcGOm3UDHtoLbP1I+9NIluMU/wHuerM+ePiKhg=";
+    hash = "sha256-SHIWfY8eKdimwpLfB1NtpF1DBh6qaR5KCDTU4vWAMFw=";
   };
 
   patches = [

--- a/pkgs/by-name/po/podman/rm-podman-mac-helper-msg.patch
+++ b/pkgs/by-name/po/podman/rm-podman-mac-helper-msg.patch
@@ -1,14 +1,14 @@
 diff --git a/pkg/machine/machine_common.go b/pkg/machine/machine_common.go
-index d2ba418..5098cdc 100644
+index 44773f2..eba7b46 100644
 --- a/pkg/machine/machine_common.go
 +++ b/pkg/machine/machine_common.go
-@@ -34,13 +34,8 @@ func GetDevNullFiles() (*os.File, *os.File, error) {
+@@ -31,13 +31,8 @@ func GetDevNullFiles() (*os.File, *os.File, error) {
  // WaitAPIAndPrintInfo prints info about the machine and does a ping test on the
  // API socket
- func WaitAPIAndPrintInfo(forwardState APIForwardingState, name, helper, forwardSock string, noInfo, rootful bool) {
+ func WaitAPIAndPrintInfo(forwardState APIForwardingState, name, helper, forwardSock string, noInfo, _ bool) {
 -	suffix := ""
  	var fmtString string
- 
+
 -	if name != define.DefaultMachineName {
 -		suffix = " " + name
 -	}
@@ -16,8 +16,8 @@ index d2ba418..5098cdc 100644
  	if forwardState == NoForwarding {
  		return
  	}
-@@ -62,14 +57,6 @@ address can't be used by podman. `
- 
+@@ -59,14 +54,6 @@ address can't be used by podman. `
+
  				if len(helper) < 1 {
  					fmt.Print(fmtString)
 -				} else {


### PR DESCRIPTION
Updates podman to version 5.7.0.

Patches were updated to reflect the updated code.
Since the `containers/common` library was moved to the `containers/containers-libs` monorepo, the patched files in the `hardcode-paths.patch` patch were updated to reflect their new location.

Changelog: https://github.com/containers/podman/releases/tag/v5.7.0

Finally, I went through the changelog to see if any further changes needed to be done, but I didn't find any. I would appreciate it if a package maintainer could double-check this. Thank you!

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
