### PR TITLE
bulletty: 0.1.9 -> 0.2.0

### DIFF
--- a/pkgs/by-name/bu/bulletty/package.nix
+++ b/pkgs/by-name/bu/bulletty/package.nix
@@ -1,38 +1,50 @@
 {
   lib,
-  pkgs,
-  fetchFromGitHub,
   rustPlatform,
-  nix-update-script,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
   versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "bulletty";
-  version = "0.1.9";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "CrociDB";
     repo = "bulletty";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-fNMUdZ5WoDUVShiKl4pitkcOlHYTKXUVfiAHVqpdWmo=";
+    hash = "sha256-HX5J00Y7nkBwLIOEoc9jRtv9xObeWrWpHhYBQUOUVKA=";
   };
 
-  cargoHash = "sha256-ZdJtFPEjPDQSUEtdPv3uIH44wa6mGPzm/KRp5VTOb1Y=";
-
-  # perl is required for bulletty package build for openssl
-  nativeBuildInputs = with pkgs; [
-    perl
+  patches = [
+    # Add patch that disables rustfmt to prevent compile time crashes
+    ./remove-rustfmt-exec.patch
   ];
 
-  doInstallCheck = true;
+  cargoHash = "sha256-WIEbZIWdIGWiwi6918MVFu++aZ2oWJTF4AUSTpKRZvQ=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ];
+
+  env.OPENSSL_NO_VENDOR = true;
+
   nativeInstallCheckInputs = [ versionCheckHook ];
+
+  doInstallCheck = true;
+  versionCheckProgramArg = "--version";
+
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "bulletty is a feed reader for the terminal";
-    homepage = "https://bulletty.croci.dev/";
+    description = "Terminal UI RSS/ATOM feed reader";
+    homepage = "https://bulletty.croci.dev";
+    changelog = "https://github.com/CrociDB/bulletty/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.FKouhai ];
+    mainProgram = "bulletty";
   };
 })

--- a/pkgs/by-name/bu/bulletty/remove-rustfmt-exec.patch
+++ b/pkgs/by-name/bu/bulletty/remove-rustfmt-exec.patch
@@ -1,0 +1,14 @@
+diff --git a/build.rs b/build.rs
+index cb8d19a..f6dc5dc 100644
+--- a/build.rs
++++ b/build.rs
+@@ -103,9 +103,4 @@ fn embed_themes() {
+         writeln!(out, "    m").unwrap();
+         writeln!(out, "}}").unwrap();
+     }
+-
+-    std::process::Command::new("rustfmt")
+-        .arg(out_path)
+-        .status()
+-        .expect("Failed to run rustfmt");
+ }


### PR DESCRIPTION
- Update to [0.2.0](https://github.com/CrociDB/bulletty/releases/tag/v0.2.0) ([diff](https://github.com/CrociDB/bulletty/compare/v0.1.9...v0.2.0) | [changelog](https://github.com/CrociDB/bulletty/releases/tag/v0.2.0))
- Remove `perl` and use `openssl` from nixpkgs
- Reorder phases
- Add `changelog` and `mainProgram`

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
