### PR TITLE
python3Packages.pycrdt-store: init at 0.1.3b1; python3Packages.pycrdt-websockets: 0.15.5 -> 0.16.0

### DIFF
--- a/pkgs/development/python-modules/jupyter-collaboration-ui/default.nix
+++ b/pkgs/development/python-modules/jupyter-collaboration-ui/default.nix
@@ -9,13 +9,13 @@
 
 buildPythonPackage rec {
   pname = "jupyter-collaboration-ui";
-  version = "2.1.1";
+  version = "2.1.2";
   pyproject = true;
 
   src = fetchPypi {
     pname = "jupyter_collaboration_ui";
     inherit version;
-    hash = "sha256-eqPssYhFQMOi3MdPwCoGrYIMK8BN6HafQG2Gq6Ftn60=";
+    hash = "sha256-Eajdc0AI47AtxLUW4xwxCZw3G/1aiKCa8Mnh7bYq00s=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/jupyter-collaboration/default.nix
+++ b/pkgs/development/python-modules/jupyter-collaboration/default.nix
@@ -23,14 +23,14 @@
 
 buildPythonPackage rec {
   pname = "jupyter-collaboration";
-  version = "4.1.0";
+  version = "4.1.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jupyterlab";
     repo = "jupyter-collaboration";
     tag = "v${version}";
-    hash = "sha256-PnfUWtOXdXYG5qfzAW5kATSQr2sWKDBNiINA8/G4ZX4=";
+    hash = "sha256-/NFx76jqByPhzFKYFIcVctJv9+WQeuoUQaqNt+tUs8o=";
   };
 
   sourceRoot = "${src.name}/projects/jupyter-collaboration";
@@ -63,6 +63,11 @@ buildPythonPackage rec {
   preCheck = ''
     appendToVar enabledTestPaths "$src/tests"
   '';
+
+  disabledTests = [
+    # Failed: Timeout (>300.0s) from pytest-timeout
+    "test_document_ttl_from_settings"
+  ];
 
   __darwinAllowLocalNetworking = true;
 

--- a/pkgs/development/python-modules/jupyter-docprovider/default.nix
+++ b/pkgs/development/python-modules/jupyter-docprovider/default.nix
@@ -9,13 +9,13 @@
 
 buildPythonPackage rec {
   pname = "jupyter-docprovider";
-  version = "2.1.1";
+  version = "2.1.2";
   pyproject = true;
 
   src = fetchPypi {
     pname = "jupyter_docprovider";
     inherit version;
-    hash = "sha256-cwPzUoU0d9ipbj3mEADzCpt97n98AjfVUsrupPRER3k=";
+    hash = "sha256-lHnCmOeqpEl/JSrMwet9s5gXjdDty7N+/VWKh7Zh44w=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/jupyter-server-ydoc/default.nix
+++ b/pkgs/development/python-modules/jupyter-server-ydoc/default.nix
@@ -15,13 +15,13 @@
 
 buildPythonPackage rec {
   pname = "jupyter-server-ydoc";
-  version = "2.1.0";
+  version = "2.1.2";
   pyproject = true;
 
   src = fetchPypi {
     pname = "jupyter_server_ydoc";
     inherit version;
-    hash = "sha256-tSa+aEqmIev9lywYpUynxhPGfy0FHPUteiaqCS9zWkY=";
+    hash = "sha256-rQOkjRB4HU8KB/M9VifIlPqkChpKPA2KjaJ8sUHIi4c=";
   };
 
   build-system = [ hatchling ];

--- a/pkgs/development/python-modules/pycrdt-store/default.nix
+++ b/pkgs/development/python-modules/pycrdt-store/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  anyio,
+  pycrdt,
+  sqlite-anyio,
+
+  # tests
+  pytestCheckHook,
+  trio,
+}:
+
+buildPythonPackage rec {
+  pname = "pycrdt-store";
+  version = "0.1.3b1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "y-crdt";
+    repo = "pycrdt-store";
+    tag = version;
+    hash = "sha256-UMLR30PqtPUlD6z7VTPl7ZkSSw4HkmO5bUa/lSeFFoE=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    anyio
+    pycrdt
+    sqlite-anyio
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    trio
+  ];
+
+  pythonImportsCheck = [ "pycrdt.store" ];
+
+  meta = {
+    description = "Persistent storage for pycrdt";
+    homepage = "https://github.com/y-crdt/pycrdt-store";
+    changelog = "https://github.com/y-crdt/pycrdt-store/blob/${src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sarahec ];
+  };
+}

--- a/pkgs/development/python-modules/pycrdt-websocket/default.nix
+++ b/pkgs/development/python-modules/pycrdt-websocket/default.nix
@@ -9,6 +9,7 @@
   # dependencies
   anyio,
   pycrdt,
+  pycrdt-store,
   sqlite-anyio,
 
   # optional-dependencies
@@ -26,14 +27,14 @@
 
 buildPythonPackage rec {
   pname = "pycrdt-websocket";
-  version = "0.15.5";
+  version = "0.16.0";
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "jupyter-server";
+    owner = "y-crdt";
     repo = "pycrdt-websocket";
-    tag = "v${version}";
-    hash = "sha256-piNd85X5YsTAOC9frYQRDyb/DPfzZicIPJ+bEVzgOsU=";
+    tag = version;
+    hash = "sha256-Qux8IxJR1nGbdpGz7RZBKJjYN0qfwfEpd2UDlduOna0=";
   };
 
   build-system = [ hatchling ];
@@ -41,6 +42,7 @@ buildPythonPackage rec {
   dependencies = [
     anyio
     pycrdt
+    pycrdt-store
     sqlite-anyio
   ];
 
@@ -48,7 +50,7 @@ buildPythonPackage rec {
     django = [ channels ];
   };
 
-  pythonImportsCheck = [ "pycrdt_websocket" ];
+  pythonImportsCheck = [ "pycrdt.websocket" ];
 
   nativeCheckInputs = [
     httpx-ws
@@ -77,7 +79,7 @@ buildPythonPackage rec {
   meta = {
     description = "WebSocket Connector for pycrdt";
     homepage = "https://github.com/jupyter-server/pycrdt-websocket";
-    changelog = "https://github.com/jupyter-server/pycrdt-websocket/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/jupyter-server/pycrdt-websocket/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     teams = [ lib.teams.jupyter ];
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12921,6 +12921,8 @@ self: super: with self; {
 
   pycrdt = callPackage ../development/python-modules/pycrdt { };
 
+  pycrdt-store = callPackage ../development/python-modules/pycrdt-store { };
+
   pycrdt-websocket = callPackage ../development/python-modules/pycrdt-websocket { };
 
   pycritty = callPackage ../development/python-modules/pycritty { };


### PR DESCRIPTION
Add `python3Packages.pycrdt-store` and update `python3Packages.pycrdt-websockets` to 0.16.0. (Latter was blocked by needing `pycrdt-store`).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
