### PR TITLE
python3Packages.{langchain,langgraph}-*: updates and build fixes

### DIFF
--- a/pkgs/development/python-modules/langchain-classic/default.nix
+++ b/pkgs/development/python-modules/langchain-classic/default.nix
@@ -1,0 +1,114 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  langchain-core,
+  langchain-text-splitters,
+  langsmith,
+  pydantic,
+  pyyaml,
+  requests,
+  sqlalchemy,
+
+  # tests
+  blockbuster,
+  cffi,
+  freezegun,
+  langchain-openai,
+  langchain-tests,
+  lark,
+  numpy,
+  packaging,
+  pandas,
+  pytest-asyncio,
+  pytest-dotenv,
+  pytest-mock,
+  pytest-socket,
+  pytest-xdist,
+  pytestCheckHook,
+  requests-mock,
+  responses,
+  syrupy,
+  toml,
+}:
+
+buildPythonPackage rec {
+  pname = "langchain-classic";
+  version = "1.0.0-unstable-2025-11-11";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "langchain-ai";
+    repo = "langchain";
+    # no tagged releases avaialble
+    rev = "3dfea96ec1d2dac4e506d287860ee943c183c9f1";
+    hash = "sha256-U3UllSSa4tFz+nXAP6aNoYceU/xCPbwKSP2F2et+qgQ=";
+  };
+
+  sourceRoot = "${src.name}/libs/langchain";
+
+  build-system = [ hatchling ];
+
+  pythonRelaxDeps = [
+    # Each component release requests the exact latest core.
+    "langchain-core"
+  ];
+
+  dependencies = [
+    langchain-core
+    langchain-text-splitters
+    langsmith
+    pydantic
+    pyyaml
+    requests
+    sqlalchemy
+  ];
+
+  nativeCheckInputs = [
+    blockbuster
+    cffi
+    freezegun
+    langchain-core
+    langchain-openai
+    langchain-tests
+    langchain-text-splitters
+    lark
+    numpy
+    packaging
+    pandas
+    pytest-asyncio
+    pytest-dotenv
+    pytest-mock
+    pytest-socket
+    pytest-xdist
+    pytestCheckHook
+    requests-mock
+    responses
+    syrupy
+    toml
+  ];
+
+  enabledTestPaths = [
+    # integration_tests require network access, database access and require `OPENAI_API_KEY`, etc.
+    "tests/unit_tests"
+  ];
+
+  disabledTests = [
+    # Network access (web.example.com)
+    "test_socket_disabled"
+  ];
+
+  pythonImportsCheck = [ "langchain_classic" ];
+
+  meta = {
+    description = "Classic (0.x) compatibility layer for LangChain";
+    homepage = "https://github.com/langchain-ai/langchain/tree/master/libs/langchain";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sarahec ];
+  };
+}

--- a/pkgs/development/python-modules/langchain-community/default.nix
+++ b/pkgs/development/python-modules/langchain-community/default.nix
@@ -10,7 +10,7 @@
   aiohttp,
   dataclasses-json,
   httpx-sse,
-  langchain,
+  langchain-classic,
   langchain-core,
   langsmith,
   numpy,
@@ -42,39 +42,30 @@
 
 buildPythonPackage rec {
   pname = "langchain-community";
-  version = "0.3.27";
+  version = "0.4.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain-community";
     tag = "libs/community/v${version}";
-    hash = "sha256-rGU8AYe7993+zMAtHLkNiK+wA+UtZnGkUQsOPMtUQ8w=";
+    hash = "sha256-N92YDmej2shQQlktr0veFOKyGFWemFj0hdJIYu1rYSc=";
   };
 
   sourceRoot = "${src.name}/libs/community";
 
   build-system = [ pdm-backend ];
 
+  # Only needed for mixed python 3.12/3.13 builds
   pythonRelaxDeps = [
-    # Each component release requests the exact latest langchain and -core.
-    # That prevents us from updating individual components.
-    "langchain"
-    "langchain-core"
     "numpy"
-    "pydantic-settings"
-    "tenacity"
-  ];
-
-  pythonRemoveDeps = [
-    "bs4"
   ];
 
   dependencies = [
     aiohttp
     dataclasses-json
     httpx-sse
-    langchain
+    langchain-classic
     langchain-core
     langsmith
     numpy

--- a/pkgs/development/python-modules/langchain-core/default.nix
+++ b/pkgs/development/python-modules/langchain-core/default.nix
@@ -36,24 +36,19 @@
 
 buildPythonPackage rec {
   pname = "langchain-core";
-  version = "1.0.0";
+  version = "1.0.7";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-core==${version}";
-    hash = "sha256-/V2xwpVIR7AWkN85D51LYokMrTrnJlIkGr0q1ztVh8A=";
+    hash = "sha256-esMMA9z8z9Q909buPGZP1jujEWzdXT+Mxlwvjz0XqKk=";
   };
 
   sourceRoot = "${src.name}/libs/core";
 
   build-system = [ hatchling ];
-
-  pythonRelaxDeps = [
-    "packaging"
-    "tenacity"
-  ];
 
   dependencies = [
     jsonpatch
@@ -74,7 +69,6 @@ buildPythonPackage rec {
     blockbuster
     freezegun
     grandalf
-    httpx
     langchain-tests
     numpy
     pytest-asyncio

--- a/pkgs/development/python-modules/langchain-experimental/default.nix
+++ b/pkgs/development/python-modules/langchain-experimental/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
 
   # build-system
-  poetry-core,
+  pdm-backend,
 
   # dependencies
   langchain-core,
@@ -20,14 +20,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-experimental";
-  version = "0.3.4";
+  version = "0.4.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain-experimental";
     tag = "libs/experimental/v${version}";
-    hash = "sha256-KgGfJfxHOfpwVVo/OcbOjiO5pbxoDE1MiyKqUwsqfIg=";
+    hash = "sha256-A5qCTOCmKt/a1DTKVOC/WwuLCqOYI5pGhAGo/Y4C/FY=";
   };
 
   sourceRoot = "${src.name}/libs/experimental";
@@ -38,7 +38,7 @@ buildPythonPackage rec {
   ];
 
   build-system = [
-    poetry-core
+    pdm-backend
   ];
 
   pythonRelaxDeps = [
@@ -68,7 +68,7 @@ buildPythonPackage rec {
 
   meta = {
     changelog = "https://github.com/langchain-ai/langchain-experimental/releases/tag/${src.tag}";
-    description = "Package add experimental features on LangChain";
+    description = "Experimental features for LangChain";
     homepage = "https://github.com/langchain-ai/langchain-experimental/tree/main/libs/experimental";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ mrdev023 ];

--- a/pkgs/development/python-modules/langchain-experimental/default.nix
+++ b/pkgs/development/python-modules/langchain-experimental/default.nix
@@ -71,6 +71,9 @@ buildPythonPackage rec {
     description = "Experimental features for LangChain";
     homepage = "https://github.com/langchain-ai/langchain-experimental/tree/main/libs/experimental";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ mrdev023 ];
+    maintainers = with lib.maintainers; [
+      mrdev023
+      sarahec
+    ];
   };
 }

--- a/pkgs/development/python-modules/langchain-groq/default.nix
+++ b/pkgs/development/python-modules/langchain-groq/default.nix
@@ -20,14 +20,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-groq";
-  version = "1.0.0";
+  version = "1.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-groq==${version}";
-    hash = "sha256-OuZEdpPp0mKSejd43RW3bXzCzp3E4Pce7flsSr5JleY=";
+    hash = "sha256-08dEZI+sI33i4FGSAVvE3i5KIRccdslw0PXqXlMLldE=";
   };
 
   sourceRoot = "${src.name}/libs/partners/groq";

--- a/pkgs/development/python-modules/langchain-mistralai/default.nix
+++ b/pkgs/development/python-modules/langchain-mistralai/default.nix
@@ -24,14 +24,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-mistralai";
-  version = "1.0.0";
+  version = "1.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-mistralai==${version}";
-    hash = "sha256-khpZY6kttbgacnY1EKCyIPBR2ZiZHC3OA+0NpIBXg9s=";
+    hash = "sha256-o9xIIcqsuTgWMeluk3EMY3hbB3wGjhYYfzbHizpNTo8=";
   };
 
   sourceRoot = "${src.name}/libs/partners/mistralai";
@@ -46,12 +46,6 @@ buildPythonPackage rec {
     pydantic
   ];
 
-  pythonRelaxDeps = [
-    # Each component release requests the exact latest core.
-    # That prevents us from updating individual components.
-    "langchain-core"
-  ];
-
   nativeCheckInputs = [
     langchain-tests
     pytest-asyncio
@@ -59,6 +53,11 @@ buildPythonPackage rec {
   ];
 
   enabledTestPaths = [ "tests/unit_tests" ];
+
+  disabledTests = [
+    # Comparison error due to message formatting differences
+    "test__convert_dict_to_message_tool_call"
+  ];
 
   pythonImportsCheck = [ "langchain_mistralai" ];
 
@@ -71,7 +70,7 @@ buildPythonPackage rec {
   };
 
   meta = {
-    changelog = "https://github.com/langchain-ai/langchain-mistralai/releases/tag/${src.tag}";
+    changelog = "https://github.com/langchain-ai/langchain/releases/tag/${src.tag}";
     description = "Build LangChain applications with mistralai";
     homepage = "https://github.com/langchain-ai/langchain/tree/master/libs/partners/mistralai";
     license = lib.licenses.mit;

--- a/pkgs/development/python-modules/langchain-mongodb/default.nix
+++ b/pkgs/development/python-modules/langchain-mongodb/default.nix
@@ -30,12 +30,12 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
-    repo = "langchain";
-    tag = "langchain-mongodb==${version}";
+    repo = "langchain-mongodb";
+    tag = "libs/langchain-mongodb/v${version}";
     hash = "sha256-Jd9toXkS9dGtSIrJQ/5W+swV1z2BJOJKBtkyGzj3oSc=";
   };
 
-  sourceRoot = "${src.name}/libs/partners/mongodb";
+  sourceRoot = "${src.name}/libs/langchain-mongodb";
 
   build-system = [ poetry-core ];
 
@@ -70,14 +70,14 @@ buildPythonPackage rec {
     # python updater script sets the wrong tag
     skipBulkUpdate = true;
     updateScript = gitUpdater {
-      rev-prefix = "langchain-mongodb==";
+      rev-prefix = "libs/langchain-mongodb/v";
     };
   };
 
   meta = {
-    changelog = "https://github.com/langchain-ai/langchain/releases/tag/${src.tag}";
+    changelog = "https://github.com/langchain-ai/langchain-mongodb/releases/tag/${src.tag}";
     description = "Integration package connecting MongoDB and LangChain";
-    homepage = "https://github.com/langchain-ai/langchain/tree/master/libs/partners/mongodb";
+    homepage = "https://github.com/langchain-ai/langchain-mongodb";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       natsukium

--- a/pkgs/development/python-modules/langchain-mongodb/default.nix
+++ b/pkgs/development/python-modules/langchain-mongodb/default.nix
@@ -4,16 +4,24 @@
   fetchFromGitHub,
 
   # build-system
-  poetry-core,
+  hatchling,
 
   # dependencies
+  langchain,
+  langchain-classic,
   langchain-core,
+  langchain-text-splitters,
+  lark,
   numpy,
   pymongo,
 
   freezegun,
   httpx,
-  langchain,
+  langchain-community,
+  langchain-ollama,
+  langchain-openai,
+  langchain-tests,
+  mongomock,
   pytest-asyncio,
   pytestCheckHook,
   pytest-mock,
@@ -25,19 +33,19 @@
 
 buildPythonPackage rec {
   pname = "langchain-mongodb";
-  version = "0.2.0";
+  version = "0.8.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain-mongodb";
     tag = "libs/langchain-mongodb/v${version}";
-    hash = "sha256-Jd9toXkS9dGtSIrJQ/5W+swV1z2BJOJKBtkyGzj3oSc=";
+    hash = "sha256-TpEiTQe4nZEhb7yWdm73oKaHGr58Ej3cNeD1sP5pAxA=";
   };
 
   sourceRoot = "${src.name}/libs/langchain-mongodb";
 
-  build-system = [ poetry-core ];
+  build-system = [ hatchling ];
 
   pythonRelaxDeps = [
     # Each component release requests the exact latest core.
@@ -47,7 +55,10 @@ buildPythonPackage rec {
   ];
 
   dependencies = [
+    langchain
+    langchain-classic
     langchain-core
+    langchain-text-splitters
     numpy
     pymongo
   ];
@@ -55,7 +66,12 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     freezegun
     httpx
-    langchain
+    langchain-community
+    langchain-ollama
+    langchain-openai
+    langchain-tests
+    lark
+    mongomock
     pytest-asyncio
     pytestCheckHook
     pytest-mock
@@ -63,6 +79,11 @@ buildPythonPackage rec {
   ];
 
   enabledTestPaths = [ "tests/unit_tests" ];
+
+  disabledTestPaths = [
+    # Expects a MongoDB cluster and are very slow
+    "tests/unit_tests/test_index.py"
+  ];
 
   pythonImportsCheck = [ "langchain_mongodb" ];
 

--- a/pkgs/development/python-modules/langchain-openai/default.nix
+++ b/pkgs/development/python-modules/langchain-openai/default.nix
@@ -33,25 +33,19 @@
 
 buildPythonPackage rec {
   pname = "langchain-openai";
-  version = "1.0.1";
+  version = "1.0.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-openai==${version}";
-    hash = "sha256-lKZZw9kMV3oM7fNpVvofZJfOcyoUdqByWQmBV5MTFZo=";
+    hash = "sha256-6xJEzwJlKGJg6LBQdKIt1E0dkSJcnocUOXq+NzUVEEc=";
   };
 
   sourceRoot = "${src.name}/libs/partners/openai";
 
   build-system = [ hatchling ];
-
-  pythonRelaxDeps = [
-    # Each component release requests the exact latest core.
-    # That prevents us from updating individual components.
-    "langchain-core"
-  ];
 
   dependencies = [
     langchain-core
@@ -85,11 +79,7 @@ buildPythonPackage rec {
     "test_embed_documents_with_custom_chunk_size"
     "test_get_num_tokens_from_messages"
     "test_get_token_ids"
-    "test_init_o1"
-
-    # TypeError: exceptions must be derived from Warning, not <class 'NoneType'>
-    # https://github.com/langchain-ai/langchain/issues/33705
-    "test_init_minimal_reasoning_effort"
+    "test_embeddings_respects_token_limit"
   ];
 
   pythonImportsCheck = [ "langchain_openai" ];

--- a/pkgs/development/python-modules/langgraph-checkpoint-mongodb/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint-mongodb/default.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  langgraph-checkpoint,
+  langchain-mongodb,
+  pymongo,
+}:
+
+buildPythonPackage rec {
+  pname = "langgraph-checkpoint-mongodb";
+  version = "0.3.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "langchain-ai";
+    repo = "langchain-mongodb";
+    tag = "libs/langgraph-checkpoint-mongodb/v${version}";
+    hash = "sha256-pfgqJ7QPtAxV86HEEaRBMAOCKC8y/iTlZmPzu1szE/o=";
+  };
+
+  sourceRoot = "${src.name}/libs/langgraph-checkpoint-mongodb";
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    langgraph-checkpoint
+    langchain-mongodb
+    pymongo
+  ];
+
+  enabledTestPaths = [ "tests/unit_tests" ];
+
+  # Connection refused (to localhost:27017) for all tests
+  doCheck = false;
+
+  # no pythonImportsCheck as this package does not provide any direct imports
+  pythonImportsCheck = [ "langgraph.checkpoint.mongodb" ];
+
+  meta = {
+    description = "Integrations between MongoDB, Atlas, LangChain, and LangGraph";
+    homepage = "https://github.com/langchain-ai/langchain-mongodb/tree/main/libs/langgraph-checkpoint-mongodb";
+    changelog = "https://github.com/langchain-ai/langchain-mongodb/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sarahec ];
+  };
+}

--- a/pkgs/development/python-modules/langgraph-store-mongodb/default.nix
+++ b/pkgs/development/python-modules/langgraph-store-mongodb/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  langgraph-checkpoint,
+  langchain-mongodb,
+}:
+
+buildPythonPackage rec {
+  pname = "langgraph-store-mongodb";
+  version = "0.1.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "langchain-ai";
+    repo = "langchain-mongodb";
+    tag = "libs/langgraph-store-mongodb/v${version}";
+    hash = "sha256-/dafQK6iy85rMt7FMVb3ssaIop9JjjrwajaHAfBUp7g=";
+  };
+
+  sourceRoot = "${src.name}/libs/langgraph-store-mongodb";
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    langgraph-checkpoint
+    langchain-mongodb
+  ];
+
+  # Connection Refused (to mongodb://localhost:27017)
+  # Note that `langchain-mongodb` runs the same tests with mocks.
+  doCheck = false;
+
+  pythonImportsCheck = [ "langgraph.store.mongodb" ];
+
+  meta = {
+    description = "Integrations between MongoDB, Atlas, LangChain, and LangGraph";
+    homepage = "https://github.com/langchain-ai/langchain-mongodb/tree/main/libs/langgraph-store-mongodb";
+    changelog = "https://github.com/langchain-ai/langchain-mongodb/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sarahec ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8079,6 +8079,8 @@ self: super: with self; {
 
   langchain-chroma = callPackage ../development/python-modules/langchain-chroma { };
 
+  langchain-classic = callPackage ../development/python-modules/langchain-classic { };
+
   langchain-community = callPackage ../development/python-modules/langchain-community { };
 
   langchain-core = callPackage ../development/python-modules/langchain-core { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8139,6 +8139,8 @@ self: super: with self; {
 
   langgraph-sdk = callPackage ../development/python-modules/langgraph-sdk { };
 
+  langgraph-store-mongodb = callPackage ../development/python-modules/langgraph-store-mongodb { };
+
   langid = callPackage ../development/python-modules/langid { };
 
   langsmith = callPackage ../development/python-modules/langsmith { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8123,6 +8123,10 @@ self: super: with self; {
 
   langgraph-checkpoint = callPackage ../development/python-modules/langgraph-checkpoint { };
 
+  langgraph-checkpoint-mongodb =
+    callPackage ../development/python-modules/langgraph-checkpoint-mongodb
+      { };
+
   langgraph-checkpoint-postgres =
     callPackage ../development/python-modules/langgraph-checkpoint-postgres
       { };


### PR DESCRIPTION
Hydra: [313983934](https://hydra.nixos.org/build/313983934) on langchain-community, the rest are mostly `nixpkgs-review` cleanups.

1. `python3Packages.langchain-classic: init at 1.0.0` , adopts [CHANGELOG]()
2. `python3Packages.langchain-core: 1.0.0 -> 1.0.7` to support `langchain-community` [CHANGELOG](https://github.com/langchain-ai/langchain/releases/tag/langchain-core%3D%3D1.0.7) [DIFF](https://github.com/langchain-ai/langchain/compare/langchain-core%3D%3D1.0.0...langchain-core%3D%3D1.0.7)
3. `python3Packages.langchain-openai: 1.0.1 -> 1.0.3` that fixes a broken test [CHANGELOG](https://github.com/langchain-ai/langchain/releases/tag/langchain-openai%3D%3D1.0.3) [DIFF](https://github.com/langchain-ai/langchain/compare/langchain-openai%3D%3D1.0.1...langchain-openai%3D%3D1.0.3)
4. `python3Packages.langchain-community: 0.3.27 -> 0.4.1` and fixes test collection errors [CHANGELOG](https://github.com/langchain-ai/langchain-community/releases/tag/libs%2Fcommunity%2Fv0.4.1) [DIFF](https://github.com/langchain-ai/langchain-community/compare/libs/community/v0.3.27...libs/community/v0.4.1)
5. `python3Packages.langchain-experimental: 0.3.4 -> 0.4.0`, adopts [CHANGELOG](https://github.com/langchain-ai/langchain-experimental/releases/tag/libs%2Fexperimental%2Fv0.4.0) [DIFF](https://github.com/langchain-ai/langchain-experimental/compare/libs/experimental/v0.3.4...libs/experimental/v0.4.0)
6. `python3Packages.langchain-mongodb: 0.2.0 -> 0.8.0` [CHANGELOG]() [DIFF]()
7. `python3Packages.langgraph-store-mongodb: init at 1.0.1` [CHANGELOG](https://github.com/langchain-ai/langchain-mongodb/releases/tag/libs%2Flanggraph-store-mongodb%2Fv0.1.1)
8. `python3Packages.langchain-groq: 1.0.0 -> 1.0.1` that fixes a broken test [CHANGELOG](https://github.com/langchain-ai/langchain/releases/tag/langchain-groq%3D%3D1.0.1) [DIFF](https://github.com/langchain-ai/langchain/compare/langchain-groq%3D%3D1.0.0...langchain-groq%3D%3D1.0.1)
9. `python3Packages.langgraph-mistralai: 1.0.0 -> 1.0.1` due to broken tests [CHANGELOG](https://github.com/langchain-ai/langchain/releases/tag/langchain-mistralai%3D%3D1.0.1) [DIFF](https://github.com/langchain-ai/langchain/compare/langchain-mistralai%3D%3D1.0.0...langchain-mistralai%3D%3D1.0.1)
10. `python3Packages.langgraph-checkpoint-mongodb: init at 0.3.0`, adopt [CHANGELOG](https://github.com/langchain-ai/langchain-mongodb/releases/tag/libs%2Flanggraph-checkpoint-mongodb%2Fv0.3.0)

Fixes #461605 
Supersedes #460914
ZHF: #457852

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin **requires working pyarrow**
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
