### PR TITLE
mock: init at 1.4.14

### DIFF
--- a/pkgs/by-name/mo/mock/package.nix
+++ b/pkgs/by-name/mo/mock/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  pkgsBuildBuild,
+  installShellFiles,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "mock";
+  version = "1.4.14";
+
+  src = fetchFromGitHub {
+    owner = "dhuan";
+    repo = "mock";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-BkIDvN1161BzL/DIbp8X2FfkQr6RcXBxq5472PLOXuc=";
+  };
+
+  vendorHash = "sha256-9L7wTSBgM8MBMBxEJvwZrfqzWM9KeCOj8TZ+lGRwbNU=";
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  # https://github.com/dhuan/mock/blob/master/scripts/create_assets.sh
+  postPatch = ''
+    substituteInPlace internal/cmd/version.go \
+      --replace-fail '__VERSION__' '${finalAttrs.version}' \
+      --replace-fail '__GOOS__' "${pkgsBuildBuild.go.GOOS}" \
+      --replace-fail '__GOARCH__' "${pkgsBuildBuild.go.GOARCH}"
+
+    substituteInPlace internal/mock/response.go \
+      --replace-fail '__MOCK_VERSION__' '${finalAttrs.version}'
+
+    # substituteInPlace tests/e2e/utils/utils.go \
+    #   --replace-fail 'BinaryPath: fmt.Sprintf("%s/bin/mock", pwd())' 'BinaryPath: "${placeholder "out"}/bin/${finalAttrs.meta.mainProgram}"'
+  '';
+
+  checkFlags = [
+    # tries to exec /build/source/tests/e2e/../../bin/mock
+    "-skip=^Test_(E2E|Middlewares).+"
+  ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd ${finalAttrs.meta.mainProgram} \
+      --bash <($out/bin/${finalAttrs.meta.mainProgram} completion bash) \
+      --fish <($out/bin/${finalAttrs.meta.mainProgram} completion fish) \
+      --zsh <($out/bin/${finalAttrs.meta.mainProgram} completion zsh)
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgramArg = "version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "CLI tool to do API mocking with scriptable responses";
+    homepage = "https://github.com/dhuan/mock";
+    changelog = "https://github.com/dhuan/mock/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kpbaks ];
+    mainProgram = "mock";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Init package [mock](https://dhuan.github.io/mock/latest/index.html?ref=console.dev). 

**NOTE** I have tried to substitute the path to the produced binary in `tests/e2e/utils/utils.go` such that tests matching `^Test_(E2E|Middlewares).+` can be run, but I am not able to figure out how to refer to the build directory in the `patch` phase before the build.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
