### PR TITLE
grpc-health-probe: Add versionCheckHook

### DIFF
--- a/pkgs/by-name/gr/grpc-health-probe/package.nix
+++ b/pkgs/by-name/gr/grpc-health-probe/package.nix
@@ -2,6 +2,7 @@
   buildGoModule,
   lib,
   fetchFromGitHub,
+  versionCheckHook,
 }:
 
 buildGoModule rec {
@@ -25,6 +26,11 @@ buildGoModule rec {
   ];
 
   vendorHash = "sha256-9NDSkfHUa6xfLByjtuDMir2UM5flaKhD6jZDa71D+0w=";
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "command-line tool to perform health-checks for gRPC applications";

--- a/pkgs/by-name/gr/grpc-health-probe/package.nix
+++ b/pkgs/by-name/gr/grpc-health-probe/package.nix
@@ -5,14 +5,14 @@
   versionCheckHook,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "grpc-health-probe";
   version = "0.4.42";
 
   src = fetchFromGitHub {
     owner = "grpc-ecosystem";
     repo = "grpc-health-probe";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-/7Xxti2QOClWRo6EwHRb369+x/NeT6LHhDDyIJSHv00=";
   };
 
@@ -22,7 +22,7 @@ buildGoModule rec {
 
   ldflags = [
     "-w"
-    "-X main.versionTag=${version}"
+    "-X main.versionTag=${finalAttrs.version}"
   ];
 
   vendorHash = "sha256-9NDSkfHUa6xfLByjtuDMir2UM5flaKhD6jZDa71D+0w=";
@@ -35,9 +35,9 @@ buildGoModule rec {
   meta = with lib; {
     description = "command-line tool to perform health-checks for gRPC applications";
     homepage = "https://github.com/grpc-ecosystem/grpc-health-probe";
-    changelog = "https://github.com/grpc-ecosystem/grpc-health-probe/releases/tag/v${version}";
+    changelog = "https://github.com/grpc-ecosystem/grpc-health-probe/releases/tag/v${finalAttrs.version}";
     license = licenses.asl20;
     maintainers = with maintainers; [ jpds ];
     mainProgram = "grpc-health-probe";
   };
-}
+})

--- a/pkgs/by-name/gr/grpc-health-probe/package.nix
+++ b/pkgs/by-name/gr/grpc-health-probe/package.nix
@@ -15,6 +15,15 @@ buildGoModule rec {
     hash = "sha256-/7Xxti2QOClWRo6EwHRb369+x/NeT6LHhDDyIJSHv00=";
   };
 
+  tags = [
+    "netgo"
+  ];
+
+  ldflags = [
+    "-w"
+    "-X main.versionTag=${version}"
+  ];
+
   vendorHash = "sha256-9NDSkfHUa6xfLByjtuDMir2UM5flaKhD6jZDa71D+0w=";
 
   meta = with lib; {

--- a/pkgs/by-name/gr/grpc-health-probe/package.nix
+++ b/pkgs/by-name/gr/grpc-health-probe/package.nix
@@ -35,6 +35,7 @@ buildGoModule rec {
   meta = with lib; {
     description = "command-line tool to perform health-checks for gRPC applications";
     homepage = "https://github.com/grpc-ecosystem/grpc-health-probe";
+    changelog = "https://github.com/grpc-ecosystem/grpc-health-probe/releases/tag/v${version}";
     license = licenses.asl20;
     maintainers = with maintainers; [ jpds ];
     mainProgram = "grpc-health-probe";


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
