### PR TITLE
tkey-ssh-agent: Add versionCheckHook

### DIFF
--- a/pkgs/by-name/tk/tkey-ssh-agent/package.nix
+++ b/pkgs/by-name/tk/tkey-ssh-agent/package.nix
@@ -24,6 +24,11 @@ buildGoModule rec {
     "cmd/tkey-ssh-agent"
   ];
 
+  ldflags = [
+    "-w"
+    "-X main.version=${version}"
+  ];
+
   passthru = {
     updateScript = gitUpdater { rev-prefix = "v"; };
     tests = {

--- a/pkgs/by-name/tk/tkey-ssh-agent/package.nix
+++ b/pkgs/by-name/tk/tkey-ssh-agent/package.nix
@@ -3,8 +3,6 @@
   fetchFromGitHub,
   buildGoModule,
   gitUpdater,
-  testers,
-  tkey-ssh-agent,
   versionCheckHook,
 }:
 
@@ -32,11 +30,6 @@ buildGoModule (finalAttrs: {
 
   passthru = {
     updateScript = gitUpdater { rev-prefix = "v"; };
-    tests = {
-      tkey-ssh-agent-version = testers.testVersion {
-        package = tkey-ssh-agent;
-      };
-    };
   };
 
   nativeInstallCheckInputs = [

--- a/pkgs/by-name/tk/tkey-ssh-agent/package.nix
+++ b/pkgs/by-name/tk/tkey-ssh-agent/package.nix
@@ -5,6 +5,7 @@
   gitUpdater,
   testers,
   tkey-ssh-agent,
+  versionCheckHook,
 }:
 
 buildGoModule rec {
@@ -37,6 +38,11 @@ buildGoModule rec {
       };
     };
   };
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "SSH Agent for TKey, the flexible open hardware/software USB security key";

--- a/pkgs/by-name/tk/tkey-ssh-agent/package.nix
+++ b/pkgs/by-name/tk/tkey-ssh-agent/package.nix
@@ -8,14 +8,14 @@
   versionCheckHook,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "tkey-ssh-agent";
   version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "tillitis";
     repo = "tkey-ssh-agent";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-Uf3VJJfZn4UYX1q79JdaOfrore+L/Mic3whzpP32JV0=";
   };
 
@@ -27,7 +27,7 @@ buildGoModule rec {
 
   ldflags = [
     "-w"
-    "-X main.version=${version}"
+    "-X main.version=${finalAttrs.version}"
   ];
 
   passthru = {
@@ -47,10 +47,10 @@ buildGoModule rec {
   meta = with lib; {
     description = "SSH Agent for TKey, the flexible open hardware/software USB security key";
     homepage = "https://tillitis.se/app/tkey-ssh-agent/";
-    changelog = "https://github.com/tillitis/tkey-ssh-agent/releases/tag/v${version}";
+    changelog = "https://github.com/tillitis/tkey-ssh-agent/releases/tag/v${finalAttrs.version}";
     license = licenses.gpl2;
     maintainers = with maintainers; [ bbigras ];
     mainProgram = "tkey-ssh-agent";
     platforms = platforms.all;
   };
-}
+})

--- a/pkgs/by-name/tk/tkey-ssh-agent/package.nix
+++ b/pkgs/by-name/tk/tkey-ssh-agent/package.nix
@@ -47,6 +47,7 @@ buildGoModule rec {
   meta = with lib; {
     description = "SSH Agent for TKey, the flexible open hardware/software USB security key";
     homepage = "https://tillitis.se/app/tkey-ssh-agent/";
+    changelog = "https://github.com/tillitis/tkey-ssh-agent/releases/tag/v${version}";
     license = licenses.gpl2;
     maintainers = with maintainers; [ bbigras ];
     mainProgram = "tkey-ssh-agent";


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
