### PR TITLE
mold: prepare to switch default from unwrapped to wrapped

### DIFF
--- a/pkgs/by-name/ev/evcxr/package.nix
+++ b/pkgs/by-name/ev/evcxr/package.nix
@@ -9,7 +9,7 @@
   libiconv,
   cargo,
   gcc,
-  mold,
+  mold-wrapped,
   rustc,
   nix-update-script,
 
@@ -75,7 +75,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
                 gcc
                 rustc
               ]
-              ++ lib.optional withMold mold
+              ++ lib.optional withMold mold-wrapped
             )
           } \
           --set-default RUST_SRC_PATH "$RUST_SRC_PATH"

--- a/pkgs/by-name/gf/gfold/package.nix
+++ b/pkgs/by-name/gf/gfold/package.nix
@@ -4,7 +4,7 @@
   lib,
   rustPlatform,
   testers,
-  mold,
+  mold-wrapped,
   nix-update-script,
 }:
 
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-pbIE8QXY8lYsDGdmGVsOPesVTaHRjDBSd7ihQhN2XrI=";
 
-  nativeBuildInputs = [ mold ];
+  nativeBuildInputs = [ mold-wrapped ];
 
   passthru = {
     updateScript = nix-update-script { };

--- a/pkgs/by-name/hy/hyperspeedcube/package.nix
+++ b/pkgs/by-name/hy/hyperspeedcube/package.nix
@@ -21,7 +21,7 @@
   libxkbcommon,
   libXrandr,
   makeWrapper,
-  mold,
+  mold-wrapped,
   pango,
   pkg-config,
   python3,
@@ -73,7 +73,7 @@ rustPlatform.buildRustPackage rec {
     glib
     gtk3
     harfbuzz
-    mold
+    mold-wrapped
     pango
     shaderc
     zlib

--- a/pkgs/by-name/mo/mold-unwrapped/package.nix
+++ b/pkgs/by-name/mo/mold-unwrapped/package.nix
@@ -15,7 +15,7 @@
   clangStdenv,
   gccStdenv,
   hello,
-  mold,
+  mold-unwrapped,
   mold-wrapped,
   runCommandCC,
   testers,
@@ -25,7 +25,7 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  pname = "mold";
+  pname = "mold-unwrapped";
   version = "2.40.4";
 
   src = fetchFromGitHub {
@@ -93,7 +93,7 @@ stdenv.mkDerivation (finalAttrs: {
           '';
       in
       {
-        version = testers.testVersion { package = mold; };
+        version = testers.testVersion { package = mold-unwrapped; };
       }
       // lib.optionalAttrs stdenv.hostPlatform.isLinux {
         adapter-gcc = helloTest "adapter-gcc" (

--- a/pkgs/by-name/un/universal-android-debloater/package.nix
+++ b/pkgs/by-name/un/universal-android-debloater/package.nix
@@ -9,7 +9,7 @@
   libglvnd,
   libxkbcommon,
   makeWrapper,
-  mold,
+  mold-wrapped,
   nix-update-script,
   pkg-config,
   rustPlatform,
@@ -39,7 +39,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeBuildInputs = [
     makeWrapper
-    mold
+    mold-wrapped
     pkg-config
   ];
 

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -310,9 +310,9 @@ rec {
       let
         bintools = stdenv.cc.bintools.override {
           extraBuildCommands = ''
-            wrap ld.mold ${../build-support/bintools-wrapper/ld-wrapper.sh} ${pkgs.buildPackages.mold}/bin/ld.mold
-            wrap ${stdenv.cc.bintools.targetPrefix}ld.mold ${../build-support/bintools-wrapper/ld-wrapper.sh} ${pkgs.buildPackages.mold}/bin/ld.mold
-            wrap ${stdenv.cc.bintools.targetPrefix}ld ${../build-support/bintools-wrapper/ld-wrapper.sh} ${pkgs.buildPackages.mold}/bin/ld.mold
+            wrap ld.mold ${../build-support/bintools-wrapper/ld-wrapper.sh} ${pkgs.buildPackages.mold-unwrapped}/bin/ld.mold
+            wrap ${stdenv.cc.bintools.targetPrefix}ld.mold ${../build-support/bintools-wrapper/ld-wrapper.sh} ${pkgs.buildPackages.mold-unwrapped}/bin/ld.mold
+            wrap ${stdenv.cc.bintools.targetPrefix}ld ${../build-support/bintools-wrapper/ld-wrapper.sh} ${pkgs.buildPackages.mold-unwrapped}/bin/ld.mold
           '';
         };
       in

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1044,6 +1044,7 @@ mapAliases {
   mmsd = throw "'mmsd' has been removed due to being unmaintained upstream. Consider using 'mmsd-tng' instead"; # Added 2025-06-07
   mmutils = throw "'mmutils' has been removed due to being unmaintained upstream"; # Added 2025-08-29
   moar = warnAlias "`moar` has been renamed to `moor` by upstream in v2.0.0. See https://github.com/walles/moor/pull/305 for more." pkgs.moor; # Added 2025-09-02
+  mold = warnAlias "'mold' package will switch from being unwrapped to being wrapped; use explicit 'mold-wrapped' or 'mold-unwrapped' in the interim" pkgs.mold-unwrapped; # Added 2025-11-12
   mongodb-6_0 = throw "mongodb-6_0 has been removed, it's end of life since July 2025"; # Added 2025-07-23
   monitor = pantheon.elementary-monitor; # Added 2025-10-10
   mono4 = mono6; # Added 2025-08-25

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6544,10 +6544,10 @@ with pkgs;
   mkdocs = with python3Packages; toPythonApplication mkdocs;
 
   mold-wrapped = wrapBintoolsWith {
-    bintools = mold;
+    bintools = mold-unwrapped;
     extraBuildCommands = ''
-      wrap ${targetPackages.stdenv.cc.bintools.targetPrefix}ld.mold ${../build-support/bintools-wrapper/ld-wrapper.sh} ${mold}/bin/ld.mold
-      wrap ${targetPackages.stdenv.cc.bintools.targetPrefix}mold ${../build-support/bintools-wrapper/ld-wrapper.sh} ${mold}/bin/mold
+      wrap ${targetPackages.stdenv.cc.bintools.targetPrefix}ld.mold ${../build-support/bintools-wrapper/ld-wrapper.sh} ${mold-unwrapped}/bin/ld.mold
+      wrap ${targetPackages.stdenv.cc.bintools.targetPrefix}mold ${../build-support/bintools-wrapper/ld-wrapper.sh} ${mold-unwrapped}/bin/mold
     '';
   };
 


### PR DESCRIPTION
Unfortunately `mold` linker has been unwrapped by default in nixpkgs for a while now, and at some point `mold-wrapped` was added to address it. This is opposite to what is typically done, so would be great to revert it.

There are two approaches that I can see:

* #461063 phase it out
* #461050 just switch, as the wrapped version probably works better for most downstream consumers anyway

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
