### PR TITLE
[Backport release-25.05] python3Packages.pyroaring: 1.0.0 -> 1.0.3

### DIFF
--- a/pkgs/development/python-modules/pyroaring/default.nix
+++ b/pkgs/development/python-modules/pyroaring/default.nix
@@ -10,20 +10,15 @@
 
 buildPythonPackage rec {
   pname = "pyroaring";
-  version = "1.0.2";
+  version = "1.0.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Ezibenroc";
     repo = "PyRoaringBitMap";
     tag = version;
-    hash = "sha256-g+xpQ2DuVn8b0DiIOY69QOH6iwOYHG4bltX1zbDemdI=";
+    hash = "sha256-of4BuTHtIIwdpWUm0d9CByWc8YiaxXNQ1oDXUZYWRjU=";
   };
-
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace-fail "cython>=3.0.2,<3.1.0" "cython"
-  '';
 
   build-system = [
     cython

--- a/pkgs/development/python-modules/pyroaring/default.nix
+++ b/pkgs/development/python-modules/pyroaring/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "pyroaring";
-  version = "1.0.0";
+  version = "1.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Ezibenroc";
     repo = "PyRoaringBitMap";
     tag = version;
-    hash = "sha256-pnANvqyQ5DpG4NWSgWkAkXvSNLO67nfa97nEz3fYf1Y=";
+    hash = "sha256-Zs/MO1R4iBHDfTRVizMl6KyEWI6k2iDX7jAkBZs7kZE=";
   };
 
   build-system = [
@@ -35,7 +35,7 @@ buildPythonPackage rec {
   meta = {
     description = "Python library for handling efficiently sorted integer sets";
     homepage = "https://github.com/Ezibenroc/PyRoaringBitMap";
-    changelog = "https://github.com/Ezibenroc/PyRoaringBitMap/releases/tag/${version}";
+    changelog = "https://github.com/Ezibenroc/PyRoaringBitMap/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ drupol ];
   };

--- a/pkgs/development/python-modules/pyroaring/default.nix
+++ b/pkgs/development/python-modules/pyroaring/default.nix
@@ -20,6 +20,11 @@ buildPythonPackage rec {
     hash = "sha256-g+xpQ2DuVn8b0DiIOY69QOH6iwOYHG4bltX1zbDemdI=";
   };
 
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail "cython>=3.0.2,<3.1.0" "cython"
+  '';
+
   build-system = [
     cython
     setuptools

--- a/pkgs/development/python-modules/pyroaring/default.nix
+++ b/pkgs/development/python-modules/pyroaring/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "pyroaring";
-  version = "1.0.1";
+  version = "1.0.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Ezibenroc";
     repo = "PyRoaringBitMap";
     tag = version;
-    hash = "sha256-Zs/MO1R4iBHDfTRVizMl6KyEWI6k2iDX7jAkBZs7kZE=";
+    hash = "sha256-g+xpQ2DuVn8b0DiIOY69QOH6iwOYHG4bltX1zbDemdI=";
   };
 
   build-system = [


### PR DESCRIPTION
Manual backport of #408388, #423077, #450330.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
