### PR TITLE
gnomeExtensions: Update for GNOME 49

### DIFF
--- a/pkgs/desktops/gnome/extensions/collisions.json
+++ b/pkgs/desktops/gnome/extensions/collisions.json
@@ -1,4 +1,8 @@
 {
+  "activitywatch-status": [
+    "activitywatch-status@cweiske.de",
+    "aw-status@brayo.dev"
+  ],
   "applications-menu": [
     "Applications_Menu@rmy.pobox.com",
     "apps-menu@gnome-shell-extensions.gcampax.github.com"
@@ -12,13 +16,13 @@
     "eur-usd-gshell@vezza.github.com",
     "usd-mxn-gshell@kinduff.github.com"
   ],
-  "fullscreen-to-empty-workspace": [
-    "fullscreen-to-empty-workspace2@corgijan.dev",
-    "fullscreen-to-empty-workspace@aiono.dev"
-  ],
   "fuzzy-clock": [
     "FuzzyClock@fire-man-x",
     "FuzzyClock@johngoetz"
+  ],
+  "lock-keys": [
+    "lockkeys@febueldo.test",
+    "lockkeys@vaina.lt"
   ],
   "mouse-follows-focus": [
     "mouse-follows-focus@crisidev.org",
@@ -32,12 +36,9 @@
     "PersianCalendar@oxygenws.com",
     "persian-calendar@iamrezamousavi.gmail.com"
   ],
-  "power-profile-indicator": [
-    "power-profile-indicator@laux.wtf",
-    "power-profile@fthx"
-  ],
   "system-monitor": [
     "System_Monitor@bghome.gmail.com",
+    "system-monitor@axet.github.com",
     "system-monitor@gnome-shell-extensions.gcampax.github.com"
   ]
 }

--- a/pkgs/desktops/gnome/extensions/default.nix
+++ b/pkgs/desktops/gnome/extensions/default.nix
@@ -76,9 +76,10 @@ rec {
   gnome46Extensions = mapUuidNames (produceExtensionsList "46");
   gnome47Extensions = mapUuidNames (produceExtensionsList "47");
   gnome48Extensions = mapUuidNames (produceExtensionsList "48");
+  gnome49Extensions = mapUuidNames (produceExtensionsList "49");
 
   # Keep the last three versions in here
-  gnomeExtensions = lib.trivial.pipe (gnome46Extensions // gnome47Extensions // gnome48Extensions) [
+  gnomeExtensions = lib.trivial.pipe (gnome47Extensions // gnome48Extensions // gnome49Extensions) [
     # Apply some custom patches for automatically packaged extensions
     (callPackage ./extensionOverrides.nix { })
     # Add all manually packaged extensions

--- a/pkgs/desktops/gnome/extensions/extensionOverrides.nix
+++ b/pkgs/desktops/gnome/extensions/extensionOverrides.nix
@@ -123,16 +123,6 @@ lib.trivial.pipe super [
     ];
   }))
 
-  (patchExtension "gnome-shell-screenshot@ttll.de" (old: {
-    # Requires gjs
-    # https://github.com/NixOS/nixpkgs/issues/136112
-    postPatch = ''
-      for file in *.js; do
-        substituteInPlace $file --replace "gjs" "${gjs}/bin/gjs"
-      done
-    '';
-  }))
-
   (patchExtension "gtk4-ding@smedius.gitlab.com" (old: {
     nativeBuildInputs = [ wrapGAppsHook3 ];
     patches = [

--- a/pkgs/desktops/gnome/extensions/update-extensions.py
+++ b/pkgs/desktops/gnome/extensions/update-extensions.py
@@ -32,10 +32,11 @@ supported_versions = {
     "46": "46",
     "47": "47",
     "48": "48",
+    "49": "49",
 }
 
 # shell versions that we want to put into the gnomeExtensions attr set
-versions_to_merge = ["46", "47", "48"]
+versions_to_merge = ["47", "48", "49"]
 
 # Some type alias to increase readability of complex compound types
 PackageName = str


### PR DESCRIPTION
I added GNOME 49 to `default.nix` and `update-extensions.py`, and ran `update-extensions.py` to update `extensions.json` and `collisions.json`.

- #440720

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
