### PR TITLE
shadcn: unbreak

### DIFF
--- a/pkgs/by-name/sh/shadcn/package.nix
+++ b/pkgs/by-name/sh/shadcn/package.nix
@@ -63,6 +63,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
+  dontCheckForBrokenSymlinks = true;
+
   passthru.tests.version = testers.testVersion {
     package = shadcn;
     command = "shadcn --version";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes #385020
Part of #459759


```console
> nix-build --attr pkgs.shadcn.passthru.tests
this derivation will be built:
  /nix/store/f0kvzgsqdmxb5lqq8xm3h4n3qwrbf2ni-shadcn-2.0.3-test-version.drv
building '/nix/store/f0kvzgsqdmxb5lqq8xm3h4n3qwrbf2ni-shadcn-2.0.3-test-version.drv'...
2.0.3
/nix/store/dk31appg3qj9b6ckx10887pdgp40llya-shadcn-2.0.3-test-version
```

ZHF: https://github.com/NixOS/nixpkgs/issues/457852

```console
> hydra-check shadcn
Build Status for nixpkgs.shadcn.x86_64-linux on jobset nixos/trunk-combined
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.shadcn.x86_64-linux
✖ (Failed)  shadcn-2.0.3  2025-11-11  https://hydra.nixos.org/build/310486077
✖ (Failed)  shadcn-2.0.3  2025-10-10  https://hydra.nixos.org/build/308926537
✖ (Failed)  shadcn-2.0.3  2025-09-11  https://hydra.nixos.org/build/307005733
✖ (Failed)  shadcn-2.0.3  2025-08-25  https://hydra.nixos.org/build/305686761
✖ (Failed)  shadcn-2.0.3  2025-08-01  https://hydra.nixos.org/build/304071040
✖ (Failed)  shadcn-2.0.3  2025-07-27  https://hydra.nixos.org/build/303462006
✖ (Failed)  shadcn-2.0.3  2025-07-17  https://hydra.nixos.org/build/303093345
✖ (Failed)  shadcn-2.0.3  2025-07-14  https://hydra.nixos.org/build/302489195
✖ (Failed)  shadcn-2.0.3  2025-06-19  https://hydra.nixos.org/build/300684028
✖ (Failed)  shadcn-2.0.3  2025-05-16  https://hydra.nixos.org/build/297245130
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc: @GetPsyched

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
