### PR TITLE
venator: init at 1.0.4

### DIFF
--- a/pkgs/by-name/ve/venator/package.nix
+++ b/pkgs/by-name/ve/venator/package.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchNpmDeps,
+  cargo-tauri,
+  glib-networking,
+  nodejs,
+  npmHooks,
+  openssl,
+  pkg-config,
+  webkitgtk_4_1,
+  wrapGAppsHook4,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "venator";
+  version = "1.0.4";
+
+  src = fetchFromGitHub {
+    owner = "kmdreko";
+    repo = "venator";
+    tag = "v1.0.4";
+    hash = "sha256-qjSB/XAxB/VbO4m9Gg/XP9332WaSm/d/ejSTrHRchHg=";
+  };
+
+  cargoRoot = "venator-app";
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+
+  cargoHash = "sha256-OLtWDJuK9fXbpjUfidLP2nKdD49cWmqWI92bhV29054=";
+
+  # Nasty honestly.
+  postPatch = ''
+    cp ${finalAttrs.src}/venator-app/package.json .
+    cp ${finalAttrs.src}/venator-app/package-lock.json .
+    cp ${finalAttrs.src}/Cargo.lock venator-app/
+  '';
+
+  # Assuming our app's frontend uses `npm` as a package manager
+  npmDeps = fetchNpmDeps {
+    name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
+    inherit (finalAttrs) src;
+    sourceRoot = "${finalAttrs.src.name}/venator-app";
+    hash = "sha256-DnpqX+B0s2d5GwftPh2rpBvUuZpzG+i4+jdgcaB7fIg=";
+  };
+
+  cargoBuildFlags = [
+    "--package"
+    "venator-app"
+  ];
+
+  cargoTestFlags = [
+    "--package"
+    "venator-app"
+  ];
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    nodejs
+    npmHooks.npmConfigHook
+    pkg-config
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ wrapGAppsHook4 ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    glib-networking
+    openssl
+    webkitgtk_4_1
+  ];
+
+  meta = {
+    description = "OpenTelemetry trace viewer GUI";
+    homepage = "https://github.com/kmdreko/venator";
+    license = lib.licenses.mit;
+    maintainers = [
+      lib.maintainers._9999years
+    ];
+    mainProgram = "venator";
+  };
+})


### PR DESCRIPTION
Adds [Venator](https://github.com/kmdreko/venator), an OpenTelemetry log viewer GUI.

I don't have a Linux machine, so help verifying the Linux dependencies would be appreciated.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
