### PR TITLE
WIP: nixosTests.esphome: Add esphome device compile tests, rename nixosTests.esphome -> nixosTests.esphome-dashboard

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -522,6 +522,7 @@ in
   };
   ergo = runTest ./ergo.nix;
   ergochat = runTest ./ergochat.nix;
+  esphome = runTest ./esphome.nix;
   esphome-dashboard = runTest ./esphome-dashboard.nix;
   etc = pkgs.callPackage ../modules/system/etc/test.nix { inherit evalMinimalConfig; };
   etcd = import ./etcd/default.nix { inherit pkgs runTest; };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -522,7 +522,7 @@ in
   };
   ergo = runTest ./ergo.nix;
   ergochat = runTest ./ergochat.nix;
-  esphome = runTest ./esphome.nix;
+  esphome-dashboard = runTest ./esphome-dashboard.nix;
   etc = pkgs.callPackage ../modules/system/etc/test.nix { inherit evalMinimalConfig; };
   etcd = import ./etcd/default.nix { inherit pkgs runTest; };
   etebase-server = runTest ./etebase-server.nix;

--- a/nixos/tests/esphome-dashboard.nix
+++ b/nixos/tests/esphome-dashboard.nix
@@ -5,7 +5,7 @@ let
   unixSocket = "/run/esphome/esphome.sock";
 in
 {
-  name = "esphome";
+  name = "esphome-dashboard";
   meta.maintainers = with lib.maintainers; [ oddlama ];
 
   nodes = {

--- a/nixos/tests/esphome.nix
+++ b/nixos/tests/esphome.nix
@@ -1,0 +1,78 @@
+{ pkgs, lib, ... }:
+
+{
+  name = "esphome";
+  meta.maintainers = with lib.maintainers; [
+    thanegill
+    oddlama
+  ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    let
+
+      mkEsphomeConfig =
+        name: attrs:
+        pkgs.writers.writeYAML "${name}.yaml" (
+          {
+            esphome.name = name;
+            wifi.ssid = "test-ssid";
+          }
+          // attrs
+        );
+
+      esp8266 = mkEsphomeConfig "test-esp8266" {
+        esp8266.board = "esp01_1m";
+      };
+
+      esp32Arduino = mkEsphomeConfig "test-esp32-arduino" {
+        esp32 = {
+          variant = "esp32";
+          framework.type = "arduino";
+        };
+      };
+
+      esp32Esp-idf = mkEsphomeConfig "test-esp32-esp-idf" {
+        esp32 = {
+          variant = "esp32";
+          framework.type = "esp-idf";
+        };
+      };
+    in
+    {
+
+      virtualisation = {
+        cores = 4;
+        memorySize = 4096;
+        # Need larger disk for platformio downloads
+        diskSize = 8192;
+      };
+
+      environment.systemPackages = [
+        pkgs.esphome
+      ];
+
+      systemd.tmpfiles.rules = [
+        "C+ /root/${esp8266.name} - - - - ${esp8266}"
+        "C+ /root/${esp32Arduino.name} - - - - ${esp32Arduino}"
+        "C+ /root/${esp32Esp-idf.name} - - - - ${esp32Esp-idf}"
+      ];
+    };
+
+  testScript = ''
+    machine.systemctl("start network-online.target")
+    machine.wait_for_unit("network-online.target")
+
+    machine.succeed("esphome -v config /root/test-esp8266.yaml >&2")
+    machine.succeed("esphome -v compile /root/test-esp8266.yaml >&2")
+
+
+    machine.succeed("rm -rf /root/.esphome /root/.platformio")
+    machine.succeed("esphome -v config /root/test-esp32-arduino.yaml >&2")
+    machine.succeed("esphome -v compile /root/test-esp32-arduino.yaml >&2")
+
+    machine.succeed("rm -rf /root/.esphome /root/.platformio")
+    machine.succeed("esphome -v config /root/test-esp32-esp-idf.yaml >&2")
+    machine.succeed("esphome -v compile /root/test-esp32-esp-idf.yaml >&2")
+  '';
+}

--- a/pkgs/by-name/es/esphome/package.nix
+++ b/pkgs/by-name/es/esphome/package.nix
@@ -179,7 +179,10 @@ python.pkgs.buildPythonApplication rec {
   passthru = {
     dashboard = python.pkgs.esphome-dashboard;
     updateScript = callPackage ./update.nix { };
-    tests = { inherit (nixosTests) esphome-dashboard; };
+    tests = {
+      inherit (nixosTests) esphome;
+      inherit (nixosTests) esphome-dashboard;
+    };
   };
 
   meta = {

--- a/pkgs/by-name/es/esphome/package.nix
+++ b/pkgs/by-name/es/esphome/package.nix
@@ -179,7 +179,7 @@ python.pkgs.buildPythonApplication rec {
   passthru = {
     dashboard = python.pkgs.esphome-dashboard;
     updateScript = callPackage ./update.nix { };
-    tests = { inherit (nixosTests) esphome; };
+    tests = { inherit (nixosTests) esphome-dashboard; };
   };
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
## Things done

Continuation of work in #451760

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
