### PR TITLE
servo: 0.0.1-unstable-2025-10-29 -> 0.0.1-unstable-2025-11-12

### DIFF
--- a/pkgs/by-name/se/servo/package.nix
+++ b/pkgs/by-name/se/servo/package.nix
@@ -65,13 +65,13 @@ in
 
 rustPlatform.buildRustPackage {
   pname = "servo";
-  version = "0.0.1-unstable-2025-10-29";
+  version = "0.0.1-unstable-2025-11-12";
 
   src = fetchFromGitHub {
     owner = "servo";
     repo = "servo";
-    rev = "32c0c41d118e55fda1ab9aa778c2a59fa27710e9";
-    hash = "sha256-kQbwqKTsW5gkEeHE7Yp/fbGObjUJnvOG/0U6RSZc7oU=";
+    rev = "59526928afc81c840f9890eb0a653b16e8128ba6";
+    hash = "sha256-BidSQ/c4dST5qJLHZX5Sbcnw7JxfQl/mlI2F6qg0fxw=";
     # Breaks reproducibility depending on whether the picked commit
     # has other ref-names or not, which may change over time, i.e. with
     # "ref-names: HEAD -> main" as long this commit is the branch HEAD
@@ -81,7 +81,7 @@ rustPlatform.buildRustPackage {
     '';
   };
 
-  cargoHash = "sha256-wwS4fhYG8pvmNLCgSO26yf65No7wL1Xrqm+38sP2pxM=";
+  cargoHash = "sha256-qVpQ/LK8aAy2MrcuY4Hr3cv6+xh/vtxQZfN8Et3yPik=";
 
   # set `HOME` to a temp dir for write access
   # Fix invalid option errors during linking (https://github.com/mozilla/nixpkgs-mozilla/commit/c72ff151a3e25f14182569679ed4cd22ef352328)
@@ -111,17 +111,6 @@ rustPlatform.buildRustPackage {
   ];
 
   env.UV_PYTHON = customPython.interpreter;
-
-  postPatch = ''
-    # mozjs-sys attempts to find the header path of the icu_capi crate through cargo-metadata at build time.
-    # Unfortunately, cargo-metadata also attempts to fetch optional, disabled crates in the process.
-    # As these are not part of servo's Cargo.lock, they are not included in our cache and cargo-metadata fails.
-    # We work around this by finding the header path ourselves and substituting the invocation in mozjs-sys' build.rs.
-    icu_capi_dir=$(find $cargoDepsCopy -maxdepth 2 -type d -name icu_capi-\*)
-    icu_c_include_path="$icu_capi_dir/bindings/c"
-    substituteInPlace $cargoDepsCopy/mozjs_sys-*/build.rs \
-      --replace-fail "let icu_c_include_path = get_icu_capi_include_path();" "let icu_c_include_path = \"$icu_c_include_path\".to_string();"
-  '';
 
   buildInputs = [
     fontconfig


### PR DESCRIPTION
The mozjs-sys build script was updated and doesn't require our workaround to find the capi any longer.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
