### PR TITLE
dialect: 2.5.0 -> 2.6.1

### DIFF
--- a/pkgs/by-name/di/dialect/package.nix
+++ b/pkgs/by-name/di/dialect/package.nix
@@ -16,12 +16,13 @@
   glib-networking,
   libadwaita,
   libsecret,
+  libspelling,
   nix-update-script,
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "dialect";
-  version = "2.5.0";
+  version = "2.6.1";
   pyproject = false; # built with meson
 
   src = fetchFromGitHub {
@@ -29,7 +30,7 @@ python3.pkgs.buildPythonApplication rec {
     repo = "dialect";
     tag = version;
     fetchSubmodules = true;
-    hash = "sha256-TWXJlzuSBy+Ij3s0KS02bh8vdXP10hQpgdz4QMTLf/Q=";
+    hash = "sha256-Gy5KlcY22ykoWUzVk6w46SLndOmEQxMCcvo1ClMq0LM=";
   };
 
   nativeBuildInputs = [
@@ -52,6 +53,7 @@ python3.pkgs.buildPythonApplication rec {
     glib-networking
     libadwaita
     libsecret
+    libspelling
   ];
 
   dependencies = with python3.pkgs; [
@@ -79,7 +81,7 @@ python3.pkgs.buildPythonApplication rec {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    homepage = "https://github.com/dialect-app/dialect";
+    homepage = "https://dialectapp.org";
     description = "Translation app for GNOME";
     teams = [ lib.teams.gnome-circle ];
     license = lib.licenses.gpl3Plus;


### PR DESCRIPTION


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
