### PR TITLE
mpv: update wrapper to support multiple `--script` args

### DIFF
--- a/pkgs/applications/video/mpv/scripts/buildLua.nix
+++ b/pkgs/applications/video/mpv/scripts/buildLua.nix
@@ -23,7 +23,7 @@ lib.makeOverridable (
     extendedBy (if lib.isFunction args then args else (_: args)) (
       {
         pname,
-        extraScripts ? [ ],
+        extraScriptsToCopy ? [ ],
         runtime-dependencies ? [ ],
         ...
       }@args:
@@ -59,8 +59,8 @@ lib.makeOverridable (
               echo "Script directory '${scriptPath}' does not contain 'main.lua'" >&2
               exit 1
             }
-            [ ${with builtins; toString (length extraScripts)} -eq 0 ] || {
-              echo "mpvScripts.buildLua does not support 'extraScripts'" \
+            [ ${with builtins; toString (length extraScriptsToCopy)} -eq 0 ] || {
+              echo "mpvScripts.buildLua does not support 'extraScriptsToCopy'" \
                    "when 'scriptPath' is a directory" >&2
               exit 1
             }
@@ -69,8 +69,8 @@ lib.makeOverridable (
           else
             install -m644 -Dt "${scriptsDir}" ${escaped scriptPath}
             ${lib.optionalString (
-              extraScripts != [ ]
-            ) ''cp -at "${scriptsDir}/" ${escapedList extraScripts}''}
+              extraScriptsToCopy != [ ]
+            ) ''cp -at "${scriptsDir}/" ${escapedList extraScriptsToCopy}''}
           fi
 
           runHook postInstall

--- a/pkgs/applications/video/mpv/scripts/cutter.nix
+++ b/pkgs/applications/video/mpv/scripts/cutter.nix
@@ -32,7 +32,7 @@ buildLua {
   '';
 
   passthru.scriptName = "cutter.lua";
-  extraScripts = [ "c_concat.sh" ];
+  extraScriptsToCopy = [ "c_concat.sh" ];
 
   postInstall = ''
     wrapProgram $out/share/mpv/scripts/c_concat.sh \

--- a/pkgs/applications/video/mpv/scripts/mpv-osc-tethys.nix
+++ b/pkgs/applications/video/mpv/scripts/mpv-osc-tethys.nix
@@ -8,7 +8,7 @@ buildLua (finalAttrs: {
   version = "0-unstable-2024-08-19";
 
   scriptPath = "osc_tethys.lua";
-  extraScripts = [ "mpv_thumbnail_script_server.lua" ];
+  extraScriptsToCopy = [ "mpv_thumbnail_script_server.lua" ];
 
   src = fetchFromGitHub {
     owner = "Zren";

--- a/pkgs/applications/video/mpv/scripts/mpv-osc-tethys.nix
+++ b/pkgs/applications/video/mpv/scripts/mpv-osc-tethys.nix
@@ -9,6 +9,7 @@ buildLua (finalAttrs: {
 
   scriptPath = "osc_tethys.lua";
   extraScriptsToCopy = [ "mpv_thumbnail_script_server.lua" ];
+  extraScriptsToLoad = [ "mpv_thumbnail_script_server.lua" ];
 
   src = fetchFromGitHub {
     owner = "Zren";

--- a/pkgs/applications/video/mpv/scripts/quality-menu.nix
+++ b/pkgs/applications/video/mpv/scripts/quality-menu.nix
@@ -18,7 +18,7 @@ buildLua rec {
   };
   passthru.updateScript = gitUpdater { rev-prefix = "v"; };
 
-  extraScripts = lib.optional oscSupport "quality-menu-osc.lua";
+  extraScriptsToCopy = lib.optional oscSupport "quality-menu-osc.lua";
 
   meta = with lib; {
     description = "Userscript for MPV that allows you to change youtube video quality (ytdl-format) on the fly";

--- a/pkgs/applications/video/mpv/scripts/quality-menu.nix
+++ b/pkgs/applications/video/mpv/scripts/quality-menu.nix
@@ -19,6 +19,7 @@ buildLua rec {
   passthru.updateScript = gitUpdater { rev-prefix = "v"; };
 
   extraScriptsToCopy = lib.optional oscSupport "quality-menu-osc.lua";
+  extraScriptsToLoad = lib.optional oscSupport "quality-menu-osc.lua";
 
   meta = with lib; {
     description = "Userscript for MPV that allows you to change youtube video quality (ytdl-format) on the fly";

--- a/pkgs/applications/video/mpv/scripts/sponsorblock.nix
+++ b/pkgs/applications/video/mpv/scripts/sponsorblock.nix
@@ -39,7 +39,7 @@ buildLua {
       --replace-fail 'mp.find_config_file("scripts")' "\"$out/share/mpv/scripts\""
   '';
 
-  extraScripts = [ "sponsorblock_shared" ];
+  extraScriptsToCopy = [ "sponsorblock_shared" ];
 
   passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
 

--- a/pkgs/applications/video/mpv/scripts/thumbnail.nix
+++ b/pkgs/applications/video/mpv/scripts/thumbnail.nix
@@ -23,7 +23,7 @@ buildLua rec {
   dontBuild = false;
 
   scriptPath = "mpv_thumbnail_script_client_osc.lua";
-  extraScripts = [ "mpv_thumbnail_script_server.lua" ];
+  extraScriptsToCopy = [ "mpv_thumbnail_script_server.lua" ];
   passthru.scriptName = "mpv_thumbnail_script_{client_osc,server}.lua";
 
   meta = {

--- a/pkgs/applications/video/mpv/scripts/thumbnail.nix
+++ b/pkgs/applications/video/mpv/scripts/thumbnail.nix
@@ -24,7 +24,7 @@ buildLua rec {
 
   scriptPath = "mpv_thumbnail_script_client_osc.lua";
   extraScriptsToCopy = [ "mpv_thumbnail_script_server.lua" ];
-  passthru.scriptName = "mpv_thumbnail_script_{client_osc,server}.lua";
+  extraScriptsToLoad = [ "mpv_thumbnail_script_server.lua" ];
 
   meta = {
     description = "Lua script to show preview thumbnails in mpv's OSC seekbar";

--- a/pkgs/applications/video/mpv/wrapper.nix
+++ b/pkgs/applications/video/mpv/wrapper.nix
@@ -73,12 +73,17 @@ let
             # For every script in the `scripts` argument, add the necessary flags to the wrapper
             (
               script:
-              [
-                "--add-flags"
-                # Here we rely on the existence of the `scriptName` passthru
-                # attribute of the script derivation from the `scripts`
-                "--script=${script}/share/mpv/scripts/${script.scriptName}"
-              ]
+              let
+                mkScriptArgs = script: scriptName: [
+                  "--add-flags"
+                  "--script=${script}/share/mpv/scripts/${scriptName}"
+                ];
+              in
+              # Here we rely on the existence of the `scriptName` passthru
+              # attribute of the script derivation from the `scripts`
+              (mkScriptArgs script script.scriptName)
+              # scripts might need others to be explicitly loaded
+              ++ (map (extraScriptName: mkScriptArgs script extraScriptName) (script.extraScriptsToLoad or [ ]))
               # scripts can also set the `extraWrapperArgs` passthru
               ++ (script.extraWrapperArgs or [ ])
             )


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I noticed that `mpvScripts.thumbnail` was not properly loading thumbnails following https://github.com/NixOS/nixpkgs/pull/444931 and upon further investigation realized that there was no way to provide multiple `--script` args to the mpv wrapper without relying on bash's brace expansion. At least, I think this is how it was working before.

Based on my understanding, most mpv scripts use a single "main" script file and load/include other script files from within that main script. Some others, such as those that replace the OSC, might require multiple script files to be explicitly loaded because the scripts don't load each other.

This PR renames the `extraScripts` attr in `buildLua` derivations to `extraScriptsToCopy` since all it is used for is copying extra files to the end result folder. I then introduced a new attr called `extraScriptsToLoad` that is used to provide additional `--script` args to the mpv wrapper.

I have tested all of the scripts I touched and confirmed they work as expected. `mpvScripts.mpv-osc-tethys` and `mpvScripts.thumbnail` didn't have working thumbnail previews before these changes. `mpvScripts.quality-menu` with `oscSupport` enabled was also not properly applying the OSC changes and is now fixed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
