### PR TITLE
nixos/forgejo: Change ROOT_URL default to use server protocol

### DIFF
--- a/nixos/modules/services/misc/forgejo.nix
+++ b/nixos/modules/services/misc/forgejo.nix
@@ -411,8 +411,8 @@ in
 
               ROOT_URL = mkOption {
                 type = types.str;
-                default = "http://${cfg.settings.server.DOMAIN}:${toString cfg.settings.server.HTTP_PORT}/";
-                defaultText = literalExpression ''"http://''${config.services.forgejo.settings.server.DOMAIN}:''${toString config.services.forgejo.settings.server.HTTP_PORT}/"'';
+                default = "${cfg.settings.server.PROTOCOL}://${cfg.settings.server.DOMAIN}:${toString cfg.settings.server.HTTP_PORT}/";
+                defaultText = literalExpression ''"''${config.services.forgejo.settings.server.PROTOCOL}://''${config.services.forgejo.settings.server.DOMAIN}:''${toString config.services.forgejo.settings.server.HTTP_PORT}/"'';
                 description = "Full public URL of Forgejo server.";
               };
 


### PR DESCRIPTION
I was troubleshooting an issue with my Forgejo service, and realized the issue I was having was due to the nixpkg config not following the expectations the upstream documentation sets. The [upstream documentation] (linked in the service file) says that the default value for `ROOT_URL` is `%(PROTOCOL)s://%(DOMAIN)s:%(HTTP_PORT)s/`. However, the nixpkg config does not use the value for `PROTOCOL`, and instead hard-codes the protocol as `http`. This resulted in confusion, as the value that Forgejo was reporting was not matching what I expected the default to be.

This PR changes this to instead use the `PROTOCOL` value in the default for `ROOT_URL`. This works as expected when `PROTOCOL` is either `http` or `https`. This is an improvement over the current behavior, which only works as expected when `PROTCOL` is `http`.

This does raise the question of what the correct behavior should be when `PROTOCOL` is one of `fcgi`, `http+unix`, or `fcgi+unix`. My understanding is that these are only meaningful when used with a proxy, in which case `ROOT_URL` should be overwritten anyways. Additionally, my understanding of [the upstream source code] is that this is how the project handles the default anyways, so it should be fine to leave this as-is. I can update this PR if people would rather a different default in these cases, though.

[upstream documentation]: https://forgejo.org/docs/latest/admin/config-cheat-sheet/#server-server
[the upstream source code]: https://codeberg.org/forgejo/forgejo/src/commit/b8448e7cde8f56a4b769fa74e25b18971a6c1304/modules/setting/api.go#L33

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
