### PR TITLE
python3Packages.aiomodernforms: replace async-timeout with asyncio.timeout

### DIFF
--- a/pkgs/development/python-modules/aiomodernforms/default.nix
+++ b/pkgs/development/python-modules/aiomodernforms/default.nix
@@ -53,6 +53,8 @@ buildPythonPackage rec {
     "test_empty_response"
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   pythonImportsCheck = [ "aiomodernforms" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/aiomodernforms/default.nix
+++ b/pkgs/development/python-modules/aiomodernforms/default.nix
@@ -2,6 +2,8 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
+  setuptools,
   aiohttp,
   backoff,
   yarl,
@@ -13,7 +15,7 @@
 buildPythonPackage rec {
   pname = "aiomodernforms";
   version = "0.1.8";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "wonderslug";
@@ -22,13 +24,18 @@ buildPythonPackage rec {
     hash = "sha256-Vx51WBjjNPIfLlwMnAuwHnGNljhnjKkU0tWB9M9rjsw=";
   };
 
-  postPatch = ''
-    substituteInPlace aiomodernforms/modernforms.py --replace-fail \
-      "with async_timeout.timeout(self._request_timeout):" \
-      "async with async_timeout.timeout(self._request_timeout):"
-  '';
+  patches = [
+    # https://github.com/wonderslug/aiomodernforms/pull/274
+    (fetchpatch {
+      name = "replace-async-timeout-with-asyncio.timeout.patch";
+      url = "https://github.com/wonderslug/aiomodernforms/commit/61f1330b2fc244565fd97ae392b9778faa1bab09.patch";
+      hash = "sha256-7sy5/HgPYgVpULgeEu3tFBa2iXIskAqcarf0RndxTpE=";
+    })
+  ];
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     aiohttp
     backoff
     yarl


### PR DESCRIPTION
ZHF: #457852


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
