### PR TITLE
kanata: 1.9.0 -> 1.10.0

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -11,6 +11,9 @@
 
 - `spoof` has been removed, as there are many issues upstream with it working on modern OS versions, and it appears to be unmaintained.
 
+- `kanata` now requires `karabiner-dk` version 6.0+ or later.
+  The package has been updated to use the new `karabiner-dk` package and the `darwinDriver` output stays at the version defined in the package.
+
 - All Log4Shell vulnerability scanners were removed, as they were all unmaintained upstream and are no longer relevant given that the vulnerability has been fixed upstream for several years.
 
 - `python3packages.pillow-avif-plugin` has been removed as the functionality is included in `python3packages.pillow` directly since version 11.3.

--- a/pkgs/by-name/ka/kanata/package.nix
+++ b/pkgs/by-name/ka/kanata/package.nix
@@ -16,16 +16,16 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "kanata";
-  version = "1.9.0";
+  version = "1.10.0";
 
   src = fetchFromGitHub {
     owner = "jtroo";
     repo = "kanata";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-xxAIwiwCQugDXpWga9bQ9ZGfem46rwDlmf64dX/tw7g=";
+    sha256 = "sha256-IicVuJZBHzBv9SNGQuWIIaLq2qpWfn/jMFh9KPvAThs=";
   };
 
-  cargoHash = "sha256-LfjuQHR3vVUr2e0efVymnfCnyYkFRx7ZiNdSIjBZc5s=";
+  cargoHash = "sha256-2DTL1u17jUFiRoVe7973L5/352GtKte/vakk01SSRwY=";
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     (writeShellScriptBin "sw_vers" ''
@@ -45,7 +45,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   passthru = {
-    darwinDriverVersion = "5.0.0"; # needs to be updated if karabiner-driverkit changes
+    darwinDriverVersion = "6.2.0"; # needs to be updated if karabiner-driverkit changes
     updateScript = lib.getExe (writeShellApplication {
       name = "update-script-kanata";
       runtimeInputs = [

--- a/pkgs/by-name/ka/kanata/package.nix
+++ b/pkgs/by-name/ka/kanata/package.nix
@@ -6,7 +6,7 @@
   karabiner-dk,
   fetchFromGitHub,
   versionCheckHook,
-  common-updater-scripts,
+  nix-update,
   yq,
   curl,
   jq,
@@ -53,7 +53,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
         gnused
         yq
         jq
-        common-updater-scripts
+        nix-update
       ];
       text = builtins.readFile ./update.sh;
     });

--- a/pkgs/by-name/ka/kanata/update.sh
+++ b/pkgs/by-name/ka/kanata/update.sh
@@ -1,5 +1,5 @@
 NEW_VERSION="$(curl --silent https://api.github.com/repos/jtroo/kanata/releases/latest  ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""}  | jq '.tag_name | ltrimstr("v")' --raw-output)"
-update-source-version "kanata" "$NEW_VERSION" --ignore-same-version
+nix-update --version="$NEW_VERSION"
 karabinerDriverCrateVersion="$(curl -L "https://raw.githubusercontent.com/jtroo/kanata/refs/tags/v$NEW_VERSION/Cargo.lock" | tomlq | jq --raw-output '.package[] | select(.name |  test("karabiner-driverkit")) |.version')"
 newKarabinerDkVersion="$(curl -L "https://crates.io/api/v1/crates/karabiner-driverkit/$karabinerDriverCrateVersion/download" | tar xzvf - --strip-components=1 -O "karabiner-driverkit-$karabinerDriverCrateVersion/c_src/Karabiner-DriverKit-VirtualHIDDevice/version.json" | jq --raw-output0 .package_version)"
 importTree="(let tree = import ./.; in if builtins.isFunction tree then tree {} else tree)"

--- a/pkgs/by-name/ka/kanata/update.sh
+++ b/pkgs/by-name/ka/kanata/update.sh
@@ -1,8 +1,9 @@
-NEW_VERSION="$(curl --silent https://api.github.com/repos/jtroo/kanata/releases/latest  ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""}  | jq '.tag_name | ltrimstr("v")' --raw-output)"
-nix-update --version="$NEW_VERSION"
+nix-update
+
+importTree="(let tree = import ./.; in if builtins.isFunction tree then tree {} else tree)"
+NEW_VERSION=$(nix-instantiate --eval -E "with $importTree; kanata.version" | tr -d '"')
 karabinerDriverCrateVersion="$(curl -L "https://raw.githubusercontent.com/jtroo/kanata/refs/tags/v$NEW_VERSION/Cargo.lock" | tomlq | jq --raw-output '.package[] | select(.name |  test("karabiner-driverkit")) |.version')"
 newKarabinerDkVersion="$(curl -L "https://crates.io/api/v1/crates/karabiner-driverkit/$karabinerDriverCrateVersion/download" | tar xzvf - --strip-components=1 -O "karabiner-driverkit-$karabinerDriverCrateVersion/c_src/Karabiner-DriverKit-VirtualHIDDevice/version.json" | jq --raw-output0 .package_version)"
-importTree="(let tree = import ./.; in if builtins.isFunction tree then tree {} else tree)"
 oldDarwinVersion=$(nix-instantiate --eval -E "with $importTree; kanata.passthru.darwinDriverVersion" | tr -d '"')
 nixFile=$(nix-instantiate --eval --strict -A "kanata.meta.position" | sed -re 's/^"(.*):[0-9]+"$/\1/')
 sed -i "$nixFile" -re "s|\"$oldDarwinVersion\"|\"$newKarabinerDkVersion\"|"


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updates kanata to 1.10.0
Changelog:
https://github.com/jtroo/kanata/releases/tag/v1.10.0
Has a breaking change the supported karabiner driverkit is now v6
this has been updated in the derivation

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
