### PR TITLE
nixos/vpp: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -52,6 +52,8 @@
 
 - [linux-enable-ir-emitter](https://github.com/EmixamPP/linux-enable-ir-emitter), a tool used to set up IR cameras, used with Howdy.
 
+- [FD.io's Vector Packet Processor](https://fd.io/docs/vpp/master/), a userland network stack for high-performance routing and switching on general purpose computers. Available as `services.vpp`.
+
 - [udp-over-tcp](https://github.com/mullvad/udp-over-tcp), a tunnel for proxying UDP traffic over a TCP stream. Available as `services.udp-over-tcp`.
 
 - [Komodo Periphery](https://github.com/moghtech/komodo), a multi-server Docker and Git deployment agent by Komodo. Available as [services.komodo-periphery](#opt-services.komodo-periphery.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1428,6 +1428,7 @@
   ./services/networking/v2raya.nix
   ./services/networking/vdirsyncer.nix
   ./services/networking/veilid.nix
+  ./services/networking/vpp.nix
   ./services/networking/vsftpd.nix
   ./services/networking/vwifi.nix
   ./services/networking/wasabibackend.nix

--- a/nixos/modules/services/networking/vpp.nix
+++ b/nixos/modules/services/networking/vpp.nix
@@ -1,0 +1,428 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.vpp;
+
+  mapAttrsToLines =
+    f: attrs:
+    lib.concatStringsSep "\n" (
+      lib.mapAttrsToList f (
+        lib.filterAttrs (_: value: value != null && value != { } && value != [ ]) attrs
+      )
+    );
+  prefixWith = prefix: lines: lib.replaceString "\n" ("\n" + prefix) lines;
+
+  # Parse the settings option into a string
+  parseSettings =
+    settings:
+    mapAttrsToLines (sectionName: section: ''
+      ${sectionName} {
+        ${prefixWith "  " (mapAttrsToLines parseAttr section)}
+      }
+    '') settings;
+
+  # Parse a single VPP config value (e.g. settings.unix.cli-listen) into a string
+  parseAttr =
+    name: value:
+    {
+      bool = lib.optionalString value name;
+      int = "${name} ${toString value}";
+      string = "${name} ${value}";
+
+      # Values like `foo = [ {bar = {};} {baz = {};} ];` should be transformed into
+      #   foo bar {}
+      #   foo baz {}
+      # which is equivalent to `foo = {bar = {}; baz = {};};`.
+      list = lib.concatMapStringsSep "\n" (parseAttr name) value;
+
+      # Values like `foo.bar.baz = true;` should be transformed into
+      #   foo bar {
+      #     baz
+      #   }
+      set = mapAttrsToLines (subname: subvalue: ''
+        ${name} ${subname} {
+          ${prefixWith "  " (mapAttrsToLines parseAttr subvalue)}
+        }
+      '') value;
+    }
+    .${builtins.typeOf value}
+    or (throw ''services.vpp.settings: Unsupported type "${builtins.typeOf value}"'');
+
+  # Type for the settings option
+  settingsTypes = with lib.types; {
+    atom =
+      (oneOf [
+        int
+        bool
+        str
+        (listOf settingsTypes.atom)
+        settingsTypes.nestedAttrs
+      ])
+      // {
+        # Description needs to be overridden for recursive types
+        description = "VPP atom (int, bool, string, list of VPP atoms, attrs of attrs of null or VPP atoms)";
+      };
+
+    attrs = (attrsOf (nullOr settingsTypes.atom)) // {
+      description = "attrs of null or " + settingsTypes.atom.description;
+    };
+
+    nestedAttrs = (attrsOf settingsTypes.attrs) // {
+      description = "attrs of " + settingsTypes.attrs.description;
+    };
+  };
+
+  # Documented options and defaults for settings
+  settingsOptions =
+    let
+      # Most of the defaults shouldn't ever need to be changed and all have their values
+      # documented in defaultText, so they're not visible to reduce clutter
+      mkHiddenDefault =
+        type: value:
+        lib.mkOption {
+          inherit type;
+          default = value;
+          visible = false;
+        };
+    in
+    {
+      # Config defaults
+
+      api-segment.gid = mkHiddenDefault lib.types.str cfg.group;
+      unix = with lib.types; {
+        nodaemon = mkHiddenDefault bool true;
+        nosyslog = mkHiddenDefault bool true;
+        cli-listen = mkHiddenDefault str "/run/vpp/cli.sock";
+        startup-config = mkHiddenDefault str (toString cfg.startupConfigFile);
+        gid = mkHiddenDefault str cfg.group;
+      };
+
+      logging.default-syslog-log-level = lib.mkOption {
+        type = lib.types.enum [
+          "emerg"
+          "alert"
+          "crit"
+          "err"
+          "warn"
+          "notice"
+          "info"
+          "debug"
+          "disabled"
+        ];
+        description = "Logging level for journald logs.";
+        default = "info";
+        example = "alert";
+      };
+
+      # Option documentation
+
+      plugins.plugin = lib.mkOption {
+        type = lib.types.attrsOf (
+          lib.types.submodule {
+            freeformType = settingsTypes.attrs;
+
+            options.enable = lib.mkOption {
+              type = with lib.types; nullOr bool;
+              description = ''
+                Whether to enable this plugin. Because of how the config is parsed, `false`
+                has no effect. If you want to explicitly turn a plugin off use {option}`disable`.
+              '';
+              default = null;
+              example = true;
+            };
+            options.disable = lib.mkOption {
+              type = with lib.types; nullOr bool;
+              description = ''
+                Whether to disable this plugin. Because of how the config is parsed, `false`
+                has no effect. If you want to explicitly turn a plugin on use {option}`enable`.
+              '';
+              default = null;
+              example = true;
+            };
+          }
+        );
+        description = ''
+          Configuration for specific plugins, usually used to turn a plugin on or off.
+          Special value `default` applies to all plugins.
+        '';
+        default = { };
+        example = lib.literalExpression ''
+          {
+            default.disable = true;
+            "dpdk_plugin.so".enable = true;
+          }
+        '';
+      };
+
+      dpdk = {
+        dev = lib.mkOption {
+          type = lib.types.attrsOf (
+            lib.types.submodule {
+              freeformType = settingsTypes.attrs;
+
+              options.name = lib.mkOption {
+                type = with lib.types; nullOr str;
+                description = "Override the name of this interface as seen from the CLI.";
+                default = null;
+                example = "eth0";
+              };
+              options.num-rx-queues = lib.mkOption {
+                type = with lib.types; nullOr ints.positive;
+                description = ''
+                  Number of receive queues on this interface. Useful for multi-threaded operation.
+                  Use the `cpu.*` options to setup workers if you want to use this option.
+                '';
+                default = null;
+                example = 4;
+              };
+            }
+          );
+          description = ''
+            Which DPDK network interfaces VPP should bind to.
+            Special value `default` applies to all interfaces.
+          '';
+          default = { };
+          example = lib.literalExpression ''
+            {
+              default.num-rx-queues = 4;
+              "0000:01:00.0".name = "eth0";
+            }
+          '';
+        };
+
+        blacklist = lib.mkOption {
+          type =
+            with lib.types;
+            oneOf [
+              str
+              (listOf str)
+            ];
+          description = "Device types to blacklist, using PCI vendor:device syntax.";
+          default = [ ];
+          example = "8086:10fb";
+        };
+      };
+
+      cpu = {
+        main-core = lib.mkOption {
+          type = with lib.types; nullOr ints.unsigned;
+          description = ''
+            Logical CPU core where the main thread runs, if unset VPP will use core 1 if available.
+
+            {option}`main-core` and {option}`corelist-workers` are incompatible with
+            {option}`skip-cores` and {option}`workers`.
+          '';
+          default = null;
+          example = 0;
+        };
+        corelist-workers = lib.mkOption {
+          type = with lib.types; nullOr str;
+          description = ''
+            Explicitly set logical CPUs on which VPP worker threads will run.
+
+            {option}`main-core` and {option}`corelist-workers` are incompatible with
+            {option}`skip-cores` and {option}`workers`.
+          '';
+          default = null;
+          example = "2-3,18-19";
+        };
+
+        skip-cores = lib.mkOption {
+          type = with lib.types; nullOr ints.positive;
+          description = ''
+            Set number of logical CPU cores to skip when using the {option}`workers` option.
+            Using this option, the main thread will be pinned to the next available CPU core after skipping.
+
+            {option}`skip-cores` and {option}`workers` are incompatible with
+            {option}`main-core` and {option}`corelist-workers`.
+          '';
+          default = null;
+          example = 8;
+        };
+        workers = lib.mkOption {
+          type = with lib.types; nullOr ints.positive;
+          description = ''
+            Set number of workers to be created and automatically assigned. Workers will be pinned to
+            N consecutive CPU cores while skipping {option}`skip-cores` CPU core(s) and the main thread's core.
+
+            {option}`skip-cores` and {option}`workers` are incompatible with
+            {option}`main-core` and {option}`corelist-workers`.
+          '';
+          default = null;
+          example = 4;
+        };
+      };
+    };
+in
+{
+  options.services.vpp = {
+    enable = lib.mkEnableOption "FD.io's Vector Packet Processor";
+
+    package = lib.mkPackageOption pkgs "vpp" { };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      description = "Group that grants users in it privileges to control this instance via {command}`vppctl`.";
+      default = "vpp";
+      example = "wheel";
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = settingsTypes.nestedAttrs;
+        options = settingsOptions;
+      };
+      description = ''
+        Configuration for VPP, see <https://fd.io/docs/vpp/master/configuration/reference.html> for details.
+        Nix value declared here will be translated directly to the config format VPP uses.
+
+        ::: {.note}
+        VPP requires hugepages and a loaded PCI driver to work, users are expected to configure this themselves.
+        See the
+        [upstream documentation on hugepages](https://fd.io/docs/vpp/master/gettingstarted/running/index.html#huge-pages),
+        upstream VPP (but not this module!) also defaults to loading the `uio_pci_generic` driver if you don't
+        require a specific one.
+        :::
+      '';
+      defaultText = lib.literalExpression ''
+        {
+          api-segment.gid = config.services.vpp.group;
+          unix = {
+            nodaemon = true;
+            nosyslog = true;
+            cli-listen = "/run/vpp/cli.sock";
+            startup-config = config.services.vpp.startupConfigFile;
+            gid = config.services.vpp.group;
+          };
+          logging.default-syslog-log-level = "info";
+        }
+      '';
+      example = lib.literalExpression ''
+        {
+          plugins.plugin."rdma_plugin.so".disable = true;
+
+          cpu.corelist-workers = "2-3,18-19";
+          dpdk.dev = {
+            default.num-rx-queues = 4;
+            "0000:01:00.0".name = "sfp0";
+            "0000:01:00.1".name = "sfp1";
+          };
+        }
+      '';
+    };
+
+    settingsFile = lib.mkOption {
+      type = lib.types.path;
+      description = ''
+        Configuration file passed to {command}`vpp -c`.
+        It is recommended to use the {option}`settings` option instead.
+
+        Setting this option will override the config file auto-generated
+        from the {option}`settings` option, including {option}`startupConfig`.
+      '';
+      default = pkgs.writeText "vpp.conf" (parseSettings cfg.settings);
+      defaultText = lib.literalMD "generated from {option}`settings`";
+      example = "/etc/vpp/custom.conf";
+    };
+
+    startupConfig = lib.mkOption {
+      type = lib.types.lines;
+      description = ''
+        Script to run on startup in {command}`vppctl`, passed to
+        VPP's `startup-config` option in the `unix` section as a file.
+
+        This is used to configure things like IP addresses and routes. To
+        configure interfaces, plugins, etc., see the {option}`settings` option.
+      '';
+      default = "";
+      example = ''
+        set interface state TenGigabitEthernet1/0/0 up
+        set interface state TenGigabitEthernet1/0/1 up
+        set interface ip address TenGigabitEthernet1/0/0 2001:db8:1::1/64
+        set interface ip address TenGigabitEthernet1/0/1 2001:db8:2::1/64
+      '';
+    };
+
+    startupConfigFile = lib.mkOption {
+      type = lib.types.path;
+      description = ''
+        File to run as a script on startup in {command}`vppctl`, passed
+        to VPP's `startup-config` option in the `unix` section.
+
+        Setting this option will override {option}`startupConfig`.
+      '';
+      default = pkgs.writeText "vpp-startup.conf" cfg.startupConfig;
+      defaultText = lib.literalMD "generated from {option}`startupConfig`";
+      example = "/etc/vpp/startup.conf";
+    };
+
+    silenceNoHugepages = lib.mkOption {
+      type = lib.types.bool;
+      description = ''
+        Silence warning that occurs if hugepages aren't detected on the system.
+
+        ::: {.note}
+        Alongside hugepages, users of this module are also expected to load a kernel
+        driver that VPP can use. If you aren't sure and don't require a specific one,
+        `uio_pci_generic` should work.
+        :::
+      '';
+      default = false;
+      example = true;
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    warnings =
+      let
+        hugepagesDetected =
+          config.boot.kernel.sysctl ? "vm.nr_hugepages"
+          || builtins.any (lib.hasPrefix "hugepages=") config.boot.kernelParams;
+      in
+      lib.optional (!hugepagesDetected && !cfg.silenceNoHugepages) ''
+        `services.vpp` is enabled, but hugepages aren't configured!
+
+        VPP requires hugepages and a loaded PCI driver to work, users are expected
+        to configure this themselves. See the upstream documentation on hugepages:
+
+        https://fd.io/docs/vpp/master/gettingstarted/running/index.html#huge-pages
+
+        Upstream VPP (but not this module) defaults to loading the `uio_pci_generic`
+        driver, which works if you aren't sure and don't require a specific one.
+
+        If this is a false positive, you can silence this warning by setting the
+        `services.vpp.silenceNoHugepages` option to true.
+      '';
+
+    environment.systemPackages = [ cfg.package ]; # for the vppctl tool
+
+    users.groups.${cfg.group} = { };
+
+    systemd.services.vpp = {
+      description = "Vector Packet Processing Process";
+      after = [
+        "syslog.target"
+        "network.target"
+        "auditd.service"
+      ];
+      serviceConfig = {
+        ExecStartPre = [
+          # https://s3-docs.fd.io/vpp/26.02/gettingstarted/running/index.html#systemd-file-vpp-service
+          "-${pkgs.coreutils}/bin/rm -f /dev/shm/db /dev/shm/global_vm /dev/shm/vpe-api"
+        ];
+        ExecStart = "${cfg.package}/bin/vpp -c ${cfg.settingsFile}";
+        Type = "simple";
+        Restart = "on-failure";
+        RestartSec = "5s";
+        RuntimeDirectory = "vpp";
+      };
+      wantedBy = [ "multi-user.target" ];
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ maevii ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1712,6 +1712,7 @@ in
   vikunja = runTest ./vikunja.nix;
   virtualbox = handleTestOn [ "x86_64-linux" ] ./virtualbox.nix { };
   vm-variant = handleTest ./vm-variant.nix { };
+  vpp = runTest ./vpp.nix;
   vscode-remote-ssh = handleTestOn [ "x86_64-linux" ] ./vscode-remote-ssh.nix { };
   vscodium = import ./vscodium.nix { inherit runTest; };
   vsftpd = runTest ./vsftpd.nix;

--- a/nixos/tests/vpp.nix
+++ b/nixos/tests/vpp.nix
@@ -1,0 +1,122 @@
+# This test runs FD.io's VPP and tests routing between two virtual networks.
+# Topology is similar to the `nat` test, with a client on one network, a server
+# on another, and a VPP-powered router inbetween connecting the two.
+
+{ pkgs, lib, ... }:
+{
+  name = "vpp";
+
+  meta.maintainers = with lib.maintainers; [ maevii ];
+
+  nodes = {
+    client =
+      { ... }:
+      {
+        virtualisation.vlans = [ 1 ];
+        networking.interfaces = lib.mkForce {
+          eth1.ipv6.addresses = [
+            {
+              address = "fd01::2";
+              prefixLength = 64;
+            }
+          ];
+        };
+        networking.defaultGateway6 = "fd01::1";
+        networking.useDHCP = false;
+      };
+    server =
+      { ... }:
+      {
+        virtualisation.vlans = [ 2 ];
+        networking.interfaces = lib.mkForce {
+          eth1.ipv6.addresses = [
+            {
+              address = "fd02::2";
+              prefixLength = 64;
+            }
+          ];
+        };
+        networking.defaultGateway6 = "fd02::1";
+        networking.useDHCP = false;
+
+        services.nginx.enable = true;
+        services.nginx.statusPage = true;
+
+        networking.firewall.allowedTCPPorts = [ 80 ];
+      };
+    router =
+      { config, ... }:
+      {
+        virtualisation.vlans = [
+          1
+          2
+        ];
+
+        # disable netdevs so VPP can take over them
+        networking.useDHCP = false;
+        networking.interfaces = lib.mkForce { };
+
+        # install & enable igb_uio driver
+        boot.extraModulePackages = [ config.boot.kernelPackages.dpdk-kmods ];
+        boot.kernelModules = [ "igb_uio" ];
+
+        virtualisation.memorySize = 4096;
+        boot.kernel.sysctl = {
+          # see https://fd.io/docs/vpp/master/gettingstarted/running/index.html#huge-pages
+          "vm.nr_hugepages" = 1024;
+          "vm.max_map_count" = 2048;
+          "kernel.shmmax" = 2147483648;
+        };
+
+        services.vpp = {
+          enable = true;
+
+          settings = {
+            plugins = {
+              plugin.default.disable = true;
+              plugin."dpdk_plugin.so".enable = true;
+            };
+
+            dpdk.dev."0000:00:09.0".name = "vlan1";
+            dpdk.dev."0000:00:0a.0".name = "vlan2";
+          };
+
+          startupConfig = ''
+            set int state vlan1 up
+            set int state vlan2 up
+            set int ip addr vlan1 fd01::1/64
+            set int ip addr vlan2 fd02::1/64
+          '';
+        };
+      };
+  };
+
+  testScript = ''
+    start_all()
+
+    # wait for router
+    router.wait_for_unit("vpp.service")
+
+    # make sure VPP initialized correctly
+    # wait_until_succeeds is necessary since startupConfig executes *after* the service starts
+    router.wait_until_succeeds("vppctl show int addr | grep -A1 vlan1 | grep -q fd01::1/64")
+    router.succeed("vppctl show int addr | grep -A1 vlan2 | grep -q fd02::1/64")
+
+    # wait for server
+    server.wait_for_unit("nginx.service")
+
+    # wait for client, make sure it can connect to the server through the router
+    client.wait_for_unit("network.target")
+    client.succeed("curl --fail --connect-timeout 5 http://[fd02::2]")
+
+    # disable interfaces in VPP, make sure server isn't reachable
+    router.succeed("vppctl set int state vlan1 down")
+    router.succeed("vppctl set int state vlan2 down")
+    client.fail("curl --fail --connect-timeout 5 http://[fd02::2]")
+
+    # restart VPP, make sure it restores its config & server becomes reachable again
+    router.succeed("systemctl restart vpp")
+    router.wait_for_unit("vpp.service")
+    client.succeed("curl --fail --connect-timeout 5 http://[fd02::2]")
+  '';
+}

--- a/pkgs/by-name/vp/vpp/package.nix
+++ b/pkgs/by-name/vp/vpp/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   nix-update-script,
+  nixosTests,
   writeText,
 
   cmake,
@@ -128,6 +129,10 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional enableAfXdpSkbMode ./xdp-skb-mode.patch;
 
   passthru.updateScript = nix-update-script { };
+
+  passthru.tests = {
+    inherit (nixosTests) vpp;
+  };
 
   meta = {
     description = "Fast, scalable layer 2-4 multi-platform network stack running in user space";


### PR DESCRIPTION
Supersedes #347797, since that was one of the first modules I've ever written and as a result ended up being kind of a mess...

Adds a module & tests for #346281. Main differences from the first attempt are that I dropped multi-instance since it wasn't particularly useful, removed the auto-setup of hugepages/kernel modules & rewrote the config parser - it and everything else should be significantly more readable now. Apart from that, it's mostly the same in terms of available options and defaults, and the tests are practically just copied over. Systemd hardening is also something I want to do eventually, but I think it'd be best to leave that for a future PR.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
