### PR TITLE
sdl3-shadercross: init at 0-unstable-2025-09-18

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19205,6 +19205,12 @@
     email = "nyu@nyuku.ru";
     githubId = 97425873;
   };
+  nyxonios = {
+    name = "nyxonios";
+    github = "Nyxonios";
+    email = "martin.n.seller@gmail.com";
+    githubId = 18164197;
+  };
   nzbr = {
     email = "nixos@nzbr.de";
     github = "nzbr";

--- a/pkgs/by-name/sd/sdl3-shadercross/package.nix
+++ b/pkgs/by-name/sd/sdl3-shadercross/package.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  sdl3,
+  spirv-cross,
+  directx-shader-compiler,
+  nix-update-script,
+  runCommand,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sdl3-shadercross";
+  version = "0-unstable-2025-09-18";
+
+  outputs = [
+    "out"
+    "lib"
+    "dev"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "libsdl-org";
+    repo = "SDL_shadercross";
+    rev = "3e572c3219ea438bff849cebea34f3aad7e1859b";
+    hash = "sha256-2kpW4AN5eYPY3GxxDpH++nVHtBhSVv5FM2X4I+F2iAU=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  buildInputs = [
+    sdl3
+    spirv-cross
+    directx-shader-compiler
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+    (lib.cmakeBool "SDLSHADERCROSS_INSTALL" true)
+    (lib.cmakeBool "SDLSHADERCROSS_TESTS" finalAttrs.finalPackage.doCheck)
+  ];
+
+  doCheck = true;
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  passthru.tests.example = runCommand "compile-spv-example" { } ''
+    cat > example.vert.hlsl << EOF
+    struct Input
+    {
+        float4 position : POSITION;
+        float3 color : COLOR;
+    };
+    float3 main(in Input IN) : COLOR
+    {
+        return IN.color;
+    };
+    EOF
+    ${lib.getExe finalAttrs.finalPackage} example.vert.hlsl -o example.spv
+    touch $out
+  '';
+
+  meta = {
+    description = "Shader translation library";
+    mainProgram = "shadercross";
+    homepage = "https://github.com/libsdl-org/SDL_shadercross";
+    license = lib.licenses.zlib;
+    maintainers = with lib.maintainers; [ nyxonios ];
+    teams = [ lib.teams.sdl ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Shadercross is a tool for translating shaders into different formats.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
