### PR TITLE
lima: 1.2.2 -> 2.0.3

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -72,6 +72,8 @@
 
 - `forgejo` has been updated to major version 14. For more information, see the [release blog post](https://forgejo.org/2026-01-release-v14-0/) and [full release notes](https://codeberg.org/forgejo/forgejo/src/branch/forgejo/release-notes-published/14.0.0.md)
 
+- `lima` has been updated from `1.x` to `2.x`. This major update includes several breaking changes, such as `/tmp/lima` no longer being mounted by default.
+
 - `n8n` has been updated to version 2. You can find the breaking changes here: https://docs.n8n.io/2-0-breaking-changes/.
 
 - `gurk-rs` has been updated from `0.6.4` to `0.8.0`. Version `0.8.0` includes breaking changes. For more information read the [release notes for 0.8.0](https://github.com/boxdot/gurk-rs/releases/tag/v0.8.0).

--- a/pkgs/by-name/li/lima/package.nix
+++ b/pkgs/by-name/li/lima/package.nix
@@ -4,7 +4,6 @@
   buildGoModule,
   callPackage,
   installShellFiles,
-  procps,
   qemu,
   darwin,
   makeWrapper,
@@ -41,11 +40,6 @@ buildGoModule (finalAttrs: {
     substituteInPlace Makefile \
       --replace-fail 'codesign -f -v --entitlements vz.entitlements -s -' 'codesign -f --entitlements vz.entitlements -s -' \
       --replace-fail 'rm -rf _output vendor' 'rm -rf _output'
-  ''
-  # fixed upstream, remove when version >=2.0.0
-  + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
-    substituteInPlace pkg/networks/usernet/recoincile.go \
-      --replace-fail '/usr/bin/pkill' '${lib.getExe' procps "pkill"}'
   '';
 
   # It attaches entitlements with codesign and strip removes those,

--- a/pkgs/by-name/li/lima/source.nix
+++ b/pkgs/by-name/li/lima/source.nix
@@ -3,7 +3,7 @@
 }:
 
 let
-  version = "2.0.1";
+  version = "2.0.2";
 in
 {
   inherit version;
@@ -12,8 +12,8 @@ in
     owner = "lima-vm";
     repo = "lima";
     tag = "v${version}";
-    hash = "sha256-GPrx4pvD6AxYIvAS+Mz8gFZ/Z7HeFFoHh3LOtAJ9bhI=";
+    hash = "sha256-MWNvHHyf2qZxt83D22tTKR6EXAeAgcoXE1YjXHc9SwQ=";
   };
 
-  vendorHash = "sha256-dA6zdrhN73Y8InlrCEdHgYwe5xbUlvKx0IMis2nWgWE=";
+  vendorHash = "sha256-fCqAf0buqA6GajP7SIsVPyKM3jY2n9CbS5hpa3dsWbc=";
 }

--- a/pkgs/by-name/li/lima/source.nix
+++ b/pkgs/by-name/li/lima/source.nix
@@ -3,7 +3,7 @@
 }:
 
 let
-  version = "1.2.2";
+  version = "2.0.1";
 in
 {
   inherit version;
@@ -12,8 +12,8 @@ in
     owner = "lima-vm";
     repo = "lima";
     tag = "v${version}";
-    hash = "sha256-bIYF/bsOMuWTkjD6fe6by220/WQGL+VWEBXmUzyXU98=";
+    hash = "sha256-GPrx4pvD6AxYIvAS+Mz8gFZ/Z7HeFFoHh3LOtAJ9bhI=";
   };
 
-  vendorHash = "sha256-8S5tAL7GY7dxNdyC+WOrOZ+GfTKTSX84sG8WcSec2Os=";
+  vendorHash = "sha256-dA6zdrhN73Y8InlrCEdHgYwe5xbUlvKx0IMis2nWgWE=";
 }

--- a/pkgs/by-name/li/lima/source.nix
+++ b/pkgs/by-name/li/lima/source.nix
@@ -3,7 +3,7 @@
 }:
 
 let
-  version = "2.0.2";
+  version = "2.0.3";
 in
 {
   inherit version;
@@ -12,8 +12,8 @@ in
     owner = "lima-vm";
     repo = "lima";
     tag = "v${version}";
-    hash = "sha256-MWNvHHyf2qZxt83D22tTKR6EXAeAgcoXE1YjXHc9SwQ=";
+    hash = "sha256-NoHNmJ6z7eZTzjl8ps3wFY2e68FcoBsu5ZhE0NXt95g=";
   };
 
-  vendorHash = "sha256-fCqAf0buqA6GajP7SIsVPyKM3jY2n9CbS5hpa3dsWbc=";
+  vendorHash = "sha256-SeLYVQI+ZIbR9qVaNyF89VUvXdfv1M5iM+Cbas6e2E0=";
 }


### PR DESCRIPTION
Diff: https://github.com/lima-vm/lima/compare/v1.2.2...v2.0.2

Releases

- https://github.com/lima-vm/lima/releases/tag/v2.0.0
- https://github.com/lima-vm/lima/releases/tag/v2.0.1
- https://github.com/lima-vm/lima/releases/tag/v2.0.2

2.0.0 replaced a call to the external pkill command with an internal function.
This change conflicts with the current nixpkgs patch.

Supersedes #460087
Updates #458941

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

```console
> nix-build --attr pkgs.lima.passthru.tests
...
Running phase: installCheckPhase
Executing versionCheckPhase
Successfully managed to find version 2.0.1 in the output of the command /nix/store/430cb307aas1i4abd4zaa90f7h858abj-lima-2.0.1/bin/limactl --version
limactl version 2.0.1
Finished versionCheckPhase
WARN[0000] unable to determine host timezone, falling back to default value
INFO[0000] "templates/default.yaml": OK
building '/nix/store/qx8d39n3wr5cx6fcp45k43khkyg40m48-actual.drv'...
WARN[0000] unable to determine host timezone, falling back to default value
WARN[0000] unable to determine host timezone, falling back to default value
building '/nix/store/3r6a237qs50j4vfg1x481wcqrm3m5lny-equal-contents-limactl-also-detects-additional-guest-agents-if-specified.drv'...
Checking:
limactl also detects additional guest agents if specified
expected /nix/store/v59hvrd24rsxw8nd13fd408ps0m436bz-expected and actual /nix/store/ibb8wpwcaamrmahizgnywzp5s6ygshdn-actual match.
OK
/nix/store/lk41ppi1107k3ig6cgvxj1ppp4d48f1v-equal-contents-limactl-also-detects-additional-guest-agents-if-specified
/nix/store/7k7pvj3pmzqdkhc9lq05hn8asfr6l09l-equal-contents-limactl-only-detects-host-s-architecture-guest-agent-by-default
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc: @voanhduy1512
[Imported mentions](https://github.com/NixOS/nixpkgs/pull/460087#issuecomment-3508521405): @aaschmid, @tricktron @devusb 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
