### PR TITLE
temporal_capi: init at 0.1.2

### DIFF
--- a/pkgs/by-name/te/temporal_capi/package.nix
+++ b/pkgs/by-name/te/temporal_capi/package.nix
@@ -1,0 +1,102 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  testers,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "temporal_capi";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "boa-dev";
+    repo = "temporal";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JmNYoskoQZewmWAU/SUBdjKdN+pnpMdLZUVv+jysS5A=";
+  };
+
+  cargoHash = "sha256-jIPbroAtS7D/l4QJtGCgXNa7QaQLdsF4Gh9O4NaRBCw=";
+
+  postPatch = ''
+    # Force crate-type to include staticlib
+    echo '
+    [lib]
+    crate-type = ["${if stdenv.hostPlatform.isStatic then "staticlib" else "cdylib"}"]
+    ' >> temporal_capi/Cargo.toml
+  '';
+
+  cargoBuildFlags = [
+    "--package"
+    "temporal_capi"
+    "--features"
+    "zoneinfo64,compiled_data"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 target/*/release/libtemporal_capi.* -t $out/lib
+
+    install -Dm644 -t $out/include/temporal_rs \
+      temporal_capi/bindings/cpp/temporal_rs/*.hpp
+    install -Dm644 -t $out/include \
+      temporal_capi/bindings/c/*.h
+
+    runHook postInstall
+  '';
+  postInstall = ''
+    mkdir $out/lib/pkgconfig
+    cat -> $out/lib/pkgconfig/temporal_capi.pc <<EOF
+    prefix=$out
+    exec_prefix=''${prefix}
+    libdir=''${exec_prefix}/lib
+    includedir=''${prefix}/include
+
+    Name: temporal_capi
+    Description: C API for temporal_rs
+    Version: ${finalAttrs.version}
+    Libs: -L''${libdir} -ltemporal_capi
+    Cflags: -I''${includedir}
+    EOF
+  '';
+  postFixup = lib.optional (stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isStatic) ''
+    ${stdenv.cc.targetPrefix}install_name_tool -id "$out/lib/libtemporal_capi.dylib" "$out/lib/libtemporal_capi.dylib"
+  '';
+
+  # We don't want to run Rust checks, we only check the resulting lib using C/C++ in the installCheckPhase.
+  doCheck = false;
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ stdenv.cc ];
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    cc -L $out/lib -I $out/include temporal_capi/tests/c/simple.c -ltemporal_capi -lm -o c_test
+    ./c_test
+    c++ -L $out/lib -I $out/include temporal_capi/tests/cpp/simple.cpp -ltemporal_capi -lm -o cpp_test
+    ./cpp_test
+
+    runHook postInstallCheck
+  '';
+
+  passthru.tests = {
+    pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+      moduleNames = [ "temporal_capi" ];
+    };
+    updateScript = nix-update-script { };
+  };
+
+  meta = with lib; {
+    description = "A Rust implementation of ECMAScript's Temporal API";
+    homepage = "https://github.com/boa-dev/temporal";
+    changelog = "https://github.com/boa-dev/temporal/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = with licenses; [
+      asl20
+      mit
+    ];
+    maintainers = with maintainers; [ aduh95 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/boa-dev/temporal/tree/main/temporal_capi

I need it to build Node.js with Temporal support

## Things done

I've tested it with https://github.com/nodejs/node/pull/60701 and both macOS and NixOS (ARM, I don't have a x86 machine).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
