### PR TITLE
python3Packages.dask-image: 2024.5.3 -> 2025.11.0

### DIFF
--- a/pkgs/development/python-modules/dask-image/default.nix
+++ b/pkgs/development/python-modules/dask-image/default.nix
@@ -16,29 +16,22 @@
 
   # tests
   pyarrow,
+  pytest-flake8,
   pytestCheckHook,
   scikit-image,
 }:
 
 buildPythonPackage rec {
   pname = "dask-image";
-  version = "2024.5.3";
+  version = "2025.11.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "dask";
     repo = "dask-image";
     tag = "v${version}";
-    hash = "sha256-kXCAqJ2Zgo/2Khvo2YcK+n4oGM219GyQ2Hsq9re1Lac=";
+    hash = "sha256-+nzYthnobcemunMcAWwRpHOQy6yFtjdib/7VZqWEiqc=";
   };
-
-  postPatch = ''
-    substituteInPlace dask_image/ndinterp/__init__.py \
-      --replace-fail "out_bounds.ptp(axis=1)" "np.ptp(out_bounds, axis=1)"
-
-    substituteInPlace tests/test_dask_image/test_imread/test_core.py \
-      --replace-fail "fh.save(" "fh.write("
-  '';
 
   build-system = [
     setuptools
@@ -55,6 +48,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pyarrow
+    pytest-flake8
     pytestCheckHook
     scikit-image
   ];


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/dask/dask-image/compare/v2024.5.3...v2025.11.0
Changelog: https://github.com/dask/dask-image/releases/tag/v2025.11.0

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc