### PR TITLE
postgresql: switch back to latest tags

### DIFF
--- a/pkgs/servers/sql/postgresql/13.nix
+++ b/pkgs/servers/sql/postgresql/13.nix
@@ -1,8 +1,6 @@
 import ./generic.nix {
   version = "13.23";
-  # TODO: Move back to tag, when they appear upstream:
-  # rev = "refs/tags/REL_13_23";
-  rev = "89df812eb890814b105d871185935b580478e660";
+  rev = "refs/tags/REL_13_23";
   hash = "sha256-GSIHFSt2wzaI3HkA3yX/gZZF+LKwODHYislagdhQjmE=";
   muslPatches = {
     disable-test-collate-icu-utf8 = {

--- a/pkgs/servers/sql/postgresql/14.nix
+++ b/pkgs/servers/sql/postgresql/14.nix
@@ -1,8 +1,6 @@
 import ./generic.nix {
   version = "14.20";
-  # TODO: Move back to tag, when they appear upstream:
-  # rev = "refs/tags/REL_14_20";
-  rev = "9ad034be354da9af1cea76836a9e576c110d1ff3";
+  rev = "refs/tags/REL_14_20";
   hash = "sha256-5wWuS78yn1p+ZjlUy5jCf1mLq78D3iI7mWPBVTd1Ufk=";
   muslPatches = {
     disable-test-collate-icu-utf8 = {

--- a/pkgs/servers/sql/postgresql/15.nix
+++ b/pkgs/servers/sql/postgresql/15.nix
@@ -1,8 +1,6 @@
 import ./generic.nix {
   version = "15.15";
-  # TODO: Move back to tag, when they appear upstream:
-  # rev = "refs/tags/REL_15_15";
-  rev = "32f38816779420502d4a311835d5fe939e9548a0";
+  rev = "refs/tags/REL_15_15";
   hash = "sha256-veGKXAvK+dNofBuSXsmCsPdXDJOC04+QV3HEr0XaE68=";
   muslPatches = {
     dont-use-locale-a = {

--- a/pkgs/servers/sql/postgresql/16.nix
+++ b/pkgs/servers/sql/postgresql/16.nix
@@ -1,8 +1,6 @@
 import ./generic.nix {
   version = "16.11";
-  # TODO: Move back to tag, when they appear upstream:
-  # rev = "refs/tags/REL_16_11";
-  rev = "d61dd817be70749d14e982a369e97fdda9d5cba6";
+  rev = "refs/tags/REL_16_11";
   hash = "sha256-hxv+N+OWqiXmFmsB+SSYGKQLBbHtNMnneHFvOtUz8z4=";
   muslPatches = {
     dont-use-locale-a = {

--- a/pkgs/servers/sql/postgresql/17.nix
+++ b/pkgs/servers/sql/postgresql/17.nix
@@ -1,8 +1,6 @@
 import ./generic.nix {
   version = "17.7";
-  # TODO: Move back to tag, when they appear upstream:
-  # rev = "refs/tags/REL_17_7";
-  rev = "fbb530a3dff569222bea7098ad4de3d8bde97740";
+  rev = "refs/tags/REL_17_7";
   hash = "sha256-W+505LAeiO5ln7wBhxZLv/p3GxiJp8MFfCGVDyvHREg=";
   muslPatches = {
     dont-use-locale-a = {

--- a/pkgs/servers/sql/postgresql/18.nix
+++ b/pkgs/servers/sql/postgresql/18.nix
@@ -1,8 +1,6 @@
 import ./generic.nix {
   version = "18.1";
-  # TODO: Move back to tag, when they appear upstream:
-  # rev = "refs/tags/REL_18_1";
-  rev = "4b324845ba5d24682b9b3708a769f00d160afbd7";
+  rev = "refs/tags/REL_18_1";
   hash = "sha256-cZA2hWtr5RwsUrRWkvl/yvUzFPSfdtpyAKGXfrVUr0g=";
   muslPatches = {
     dont-use-locale-a = {

--- a/pkgs/servers/sql/postgresql/libpq.nix
+++ b/pkgs/servers/sql/postgresql/libpq.nix
@@ -46,9 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "postgres";
     repo = "postgres";
     # rev, not tag, on purpose: see generic.nix.
-    # TODO: Move back to tag, when they appear upstream:
-    # rev = "refs/tags/REL_18_1";
-    rev = "4b324845ba5d24682b9b3708a769f00d160afbd7";
+    rev = "refs/tags/REL_18_1";
     hash = "sha256-cZA2hWtr5RwsUrRWkvl/yvUzFPSfdtpyAKGXfrVUr0g=";
   };
 


### PR DESCRIPTION
The commits we already switched to have now been tagged, so we can go back to these.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
