### PR TITLE
tcld: fix build on Linux

### DIFF
--- a/pkgs/by-name/tc/tcld/package.nix
+++ b/pkgs/by-name/tc/tcld/package.nix
@@ -46,9 +46,10 @@ buildGoModule (finalAttrs: {
   # FIXME: Remove after https://github.com/temporalio/tcld/pull/447 lands.
   patches = [ ./compgen.patch ];
 
-  # NOTE: Some tests appear to require (local only?) network access, which
-  # doesn't work in the sandbox.
-  __darwinAllowLocalNetworking = true;
+  checkFlags = [
+    # This test appears to require network access and does not work in the sandbox.
+    "-skip=^TestFxDependencyInjection$"
+  ];
 
   nativeBuildInputs = [ installShellFiles ];
   postInstall = lib.optionalString (stdenvNoCC.buildPlatform.canExecute stdenvNoCC.hostPlatform) ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Part of #459759
ZHF: #457852

It appears that this package does not build on Linux, but it builds on macOS.

```console
> hydra-check tcld
Build Status for nixpkgs.tcld.x86_64-linux on jobset nixos/trunk-combined
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.tcld.x86_64-linux
✖ (Failed)  tcld-0.41.0  2025-11-11  https://hydra.nixos.org/build/310489052
✖ (Failed)  tcld-0.41.0  2025-10-10  https://hydra.nixos.org/build/308929506
✖ (Failed)  tcld-0.41.0  2025-09-11  https://hydra.nixos.org/build/307008666
✖ (Failed)  tcld-0.41.0  2025-08-25  https://hydra.nixos.org/build/305689737
✖ (Failed)  tcld-0.41.0  2025-07-28  https://hydra.nixos.org/build/303464963
✖ (Failed)  tcld-0.41.0  2025-07-14  https://hydra.nixos.org/build/302492165
✖ (Failed)  tcld-0.41.0  2025-06-23  https://hydra.nixos.org/build/301104847
✖ (Failed)  tcld-0.40.0  2025-06-19  https://hydra.nixos.org/build/300686995
✖ (Failed)  tcld-0.40.0  2025-05-17  https://hydra.nixos.org/build/297248087
✖ (Failed)  tcld-0.40.0  2025-05-14  https://hydra.nixos.org/build/297035466

> hydra-check tcld --arch aarch64-darwin
Build Status for tcld.aarch64-darwin on jobset nixpkgs/trunk
https://hydra.nixos.org/job/nixpkgs/trunk/tcld.aarch64-darwin
✔  tcld-0.41.0  2025-10-23  https://hydra.nixos.org/build/310747812
✔  tcld-0.41.0  2025-10-07  https://hydra.nixos.org/build/309183082
✔  tcld-0.41.0  2025-09-11  https://hydra.nixos.org/build/307297020
✔  tcld-0.41.0  2025-08-23  https://hydra.nixos.org/build/305958448
✔  tcld-0.41.0  2025-07-28  https://hydra.nixos.org/build/303718906
✔  tcld-0.41.0  2025-07-15  https://hydra.nixos.org/build/302734898
✔  tcld-0.41.0  2025-06-24  https://hydra.nixos.org/build/301094005
✔  tcld-0.40.0  2025-06-18  https://hydra.nixos.org/build/300523609
✔  tcld-0.40.0  2025-05-16  https://hydra.nixos.org/build/297485122
✔  tcld-0.40.0  2025-05-13  https://hydra.nixos.org/build/297042457
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc: @jkachmar

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
