### PR TITLE
graylog-7_0: Init at 7.0.0

### DIFF
--- a/pkgs/tools/misc/graylog/7.0.nix
+++ b/pkgs/tools/misc/graylog/7.0.nix
@@ -1,0 +1,10 @@
+{ callPackage, lib, ... }:
+let
+  buildGraylog = callPackage ./graylog.nix { };
+in
+buildGraylog {
+  version = "7.0.0";
+  hash = "sha256-M8FM3qErHhW7ydp62ncQQ8SpaPynpG24/k2auAWeS28=";
+  maintainers = with lib.maintainers; [ etwas ];
+  license = lib.licenses.sspl;
+}

--- a/pkgs/tools/misc/graylog/graylog.nix
+++ b/pkgs/tools/misc/graylog/graylog.nix
@@ -5,6 +5,7 @@
   makeWrapper,
   openjdk11_headless,
   openjdk17_headless,
+  openjdk21_headless,
   systemd,
   nixosTests,
 }:
@@ -30,7 +31,14 @@ stdenv.mkDerivation rec {
   makeWrapperArgs = [
     "--set-default"
     "JAVA_HOME"
-    "${if (lib.versionAtLeast version "5.0") then openjdk17_headless else openjdk11_headless}"
+    "${
+      if (lib.versionAtLeast version "7.0") then
+        openjdk21_headless
+      else if (lib.versionAtLeast version "5.0") then
+        openjdk17_headless
+      else
+        openjdk11_headless
+    }"
     "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ systemd ]}"
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2872,8 +2872,10 @@ with pkgs;
   inherit
     ({
       graylog-6_1 = callPackage ../tools/misc/graylog/6.1.nix { };
+      graylog-7_0 = callPackage ../tools/misc/graylog/7.0.nix { };
     })
     graylog-6_1
+    graylog-7_0
     ;
 
   graylogPlugins = recurseIntoAttrs (


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Initialize Graylog 7.0 at `7.0.0`.
Changes can be found in the [changelog](https://go2docs.graylog.org/current/changelogs/changelog.html#Graylog700), breaking changes in the [migration guide](https://go2docs.graylog.org/current/upgrading_graylog/upgrade_to_graylog_7.0.htm).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>graylog-7_0</li>
  </ul>
</details>

