### PR TITLE
python3Packages.triton: 3.5.0 -> 3.5.1; python3Packages.torch: 2.8.0 -> 2.9.0

### DIFF
--- a/pkgs/development/python-modules/torch/source/default.nix
+++ b/pkgs/development/python-modules/torch/source/default.nix
@@ -3,7 +3,6 @@
   lib,
   fetchFromGitHub,
   fetchFromGitLab,
-  fetchpatch,
   git-unroll,
   buildPythonPackage,
   python,
@@ -281,7 +280,7 @@ in
 buildPythonPackage.override { inherit stdenv; } rec {
   pname = "torch";
   # Don't forget to update torch-bin to the same version.
-  version = "2.9.0";
+  version = "2.9.1";
   pyproject = true;
 
   outputs = [

--- a/pkgs/development/python-modules/torch/source/src.nix
+++ b/pkgs/development/python-modules/torch/source/src.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   runCommand,
 }:
-assert version == "2.9.0";
+assert version == "2.9.1";
 rec {
   src_aiter = fetchFromGitHub {
     owner = "ROCm";
@@ -99,8 +99,8 @@ rec {
   src_cudnn-frontend = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "cudnn-frontend";
-    rev = "f937055efc6d414d11f4c6577e3977fe74f35fb6";
-    hash = "sha256-LiTajW2hrDth8wEC4Vp2lZO+CeMqK+tEKPLok7gXB/s=";
+    rev = "243c7ff63be1ce6dd5bf9047668b5d4de83f55f6";
+    hash = "sha256-yJgJ4ecN7Fv5VlGyGtzoktkkBUZvxe2kbrsmaiQQmVA=";
   };
   src_cutlass = fetchFromGitHub {
     owner = "NVIDIA";
@@ -441,8 +441,8 @@ rec {
   src_pytorch = fetchFromGitHub {
     owner = "pytorch";
     repo = "pytorch";
-    rev = "v2.9.0";
-    hash = "sha256-0NdREKn9h3FtHKVe1Z3QtSOVdEcfgLlWXG/OiI+QrwA=";
+    rev = "v2.9.1";
+    hash = "sha256-9DJsjsxT+KLdSBnV08MXSVAhjg6kXkHdOAjRsq+ocd8=";
   };
   src_sleef = fetchFromGitHub {
     owner = "shibatch";

--- a/pkgs/development/python-modules/torchaudio/default.nix
+++ b/pkgs/development/python-modules/torchaudio/default.nix
@@ -77,7 +77,7 @@ let
 in
 buildPythonPackage rec {
   pname = "torchaudio";
-  version = "2.9.0";
+  version = "2.9.1";
   pyproject = true;
 
   stdenv = torch.stdenv;
@@ -86,7 +86,7 @@ buildPythonPackage rec {
     owner = "pytorch";
     repo = "audio";
     tag = "v${version}";
-    hash = "sha256-oZTe0LWqOJ0NUxmmUKZN3GhMgloOMCYMicbYoaW2pTw=";
+    hash = "sha256-tTilG/haU3OycSWqA5LR3egcxHVRg/yHJ8JB2rz3aKw=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/torchvision/default.nix
+++ b/pkgs/development/python-modules/torchvision/default.nix
@@ -28,7 +28,7 @@ let
   inherit (torch) cudaCapabilities cudaPackages cudaSupport;
 
   pname = "torchvision";
-  version = "0.24.0";
+  version = "0.24.1";
 in
 buildPythonPackage {
   format = "setuptools";
@@ -40,7 +40,7 @@ buildPythonPackage {
     owner = "pytorch";
     repo = "vision";
     tag = "v${version}";
-    hash = "sha256-EyA/d2fAdK2arMBqNtDwKtpaKb171zqEnYFrqAFQr+g=";
+    hash = "sha256-ddJWD2xjoNAuyZIaZD7ctcuSQZ9lSUGExWCq1W5prI8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/triton/default.nix
+++ b/pkgs/development/python-modules/triton/default.nix
@@ -43,7 +43,7 @@
 
 buildPythonPackage rec {
   pname = "triton";
-  version = "3.5.0";
+  version = "3.5.1";
   pyproject = true;
 
   # Remember to bump triton-llvm as well!
@@ -51,7 +51,7 @@ buildPythonPackage rec {
     owner = "triton-lang";
     repo = "triton";
     tag = "v${version}";
-    hash = "sha256-F6T0n37Lbs+B7UHNYzoIQHjNNv3TcMtoXjNrT8ZUlxY=";
+    hash = "sha256-dyNRtS1qtU8C/iAf0Udt/1VgtKGSvng1+r2BtvT9RB4=";
   };
 
   patches = [


### PR DESCRIPTION
## Things done

Update the torch ecosystem:

- **python3Packages.triton: 3.5.0 -> 3.5.1** ([Changelog](https://github.com/triton-lang/triton/releases/tag/v3.5.1), [Diff](https://github.com/triton-lang/triton/compare/v3.5.0...v3.5.1))
- **python3Packages.torch: 2.9.0 -> 2.9.1** ([Changelog](https://github.com/pytorch/pytorch/releases/tag/v2.9.1), [Diff](https://github.com/pytorch/pytorch/compare/v2.9.0...v2.9.1))
- **python3Packages.torchaudio: 2.9.0 -> 2.9.1** ([Changelog](https://github.com/pytorch/audio/releases/tag/v2.9.1), [Diff](https://github.com/pytorch/audio/compare/v2.9.0...v2.9.1))
- **python3Packages.torchvision: 2.9.0 -> 2.9.1** ([Changelog](https://github.com/pytorch/vision/releases/tag/v0.24.1), [Diff](https://github.com/pytorch/vision/compare/v0.24.0...v0.24.1))

cc @teh @thoughtpolice @tscholak @junjihashimoto @ericsagnes

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
