### PR TITLE
textlint-rule-diacritics: unbreak

### DIFF
--- a/pkgs/by-name/te/textlint-rule-diacritics/package.nix
+++ b/pkgs/by-name/te/textlint-rule-diacritics/package.nix
@@ -21,6 +21,8 @@ buildNpmPackage rec {
 
   dontNpmBuild = true;
 
+  dontCheckForBrokenSymlinks = true;
+
   passthru.tests = textlint.testPackages {
     rule = textlint-rule-diacritics;
     testFile = ./test.md;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

ZHF: #457852

```console
> hydra-check textlint-rule-diacritics
Build Status for nixpkgs.textlint-rule-diacritics.x86_64-linux on jobset nixos/trunk-combined
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.textlint-rule-diacritics.x86_64-linux
✖ (Failed)  textlint-rule-diacritics-1.0.0-unstable-2023-01-05  2025-11-13  https://hydra.nixos.org/build/313265330
✖ (Failed)  textlint-rule-diacritics-1.0.0-unstable-2023-01-05  2025-11-11  https://hydra.nixos.org/build/310491606
✖ (Failed)  textlint-rule-diacritics-1.0.0-unstable-2023-01-05  2025-10-10  https://hydra.nixos.org/build/308931917
✖ (Failed)  textlint-rule-diacritics-1.0.0-unstable-2023-01-05  2025-09-11  https://hydra.nixos.org/build/307011227
✖ (Failed)  textlint-rule-diacritics-1.0.0-unstable-2023-01-05  2025-08-25  https://hydra.nixos.org/build/305692259
✖ (Failed)  textlint-rule-diacritics-1.0.0-unstable-2023-01-05  2025-07-27  https://hydra.nixos.org/build/303467467
✖ (Failed)  textlint-rule-diacritics-1.0.0-unstable-2023-01-05  2025-07-14  https://hydra.nixos.org/build/302494677
✖ (Failed)  textlint-rule-diacritics-1.0.0-unstable-2023-01-05  2025-06-19  https://hydra.nixos.org/build/300689596
✖ (Failed)  textlint-rule-diacritics-1.0.0-unstable-2023-01-05  2025-05-16  https://hydra.nixos.org/build/297249902
✖ (Failed)  textlint-rule-diacritics-1.0.0-unstable-2023-01-05  2025-05-06  https://hydra.nixos.org/build/296254461
```

## Things done

After this change

```console
> nix-build --attr pkgs.textlint-rule-diacritics.passthru.tests
/nix/store/b7fk6anrap4zhmsfzrlkv79i008k6m73-textlint-rule-diacritics-test
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc: @natsukium

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
