### PR TITLE
vsc-leetcode-cli: unbreak

### DIFF
--- a/pkgs/by-name/vs/vsc-leetcode-cli/package.nix
+++ b/pkgs/by-name/vs/vsc-leetcode-cli/package.nix
@@ -19,6 +19,8 @@ buildNpmPackage {
 
   dontNpmBuild = true;
 
+  dontCheckForBrokenSymlinks = true;
+
   meta = with lib; {
     description = "CLI tool for leetcode.com";
     homepage = "https://github.com/leetcode-tools/leetcode-cli";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

ZHF: #457852

```console
> hydra-check vsc-leetcode-cli
Build Status for nixpkgs.vsc-leetcode-cli.x86_64-linux on jobset nixos/trunk-combined
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.vsc-leetcode-cli.x86_64-linux
✖ (Failed)  vsc-leetcode-cli-unstable-2021-04-11  2025-11-11  https://hydra.nixos.org/build/310502395
✖ (Failed)  vsc-leetcode-cli-unstable-2021-04-11  2025-10-10  https://hydra.nixos.org/build/308941600
✖ (Failed)  vsc-leetcode-cli-unstable-2021-04-11  2025-09-10  https://hydra.nixos.org/build/307020876
✖ (Failed)  vsc-leetcode-cli-unstable-2021-04-11  2025-08-25  https://hydra.nixos.org/build/305701909
✖ (Failed)  vsc-leetcode-cli-unstable-2021-04-11  2025-07-28  https://hydra.nixos.org/build/303477084
✖ (Failed)  vsc-leetcode-cli-unstable-2021-04-11  2025-07-14  https://hydra.nixos.org/build/302504284
✖ (Failed)  vsc-leetcode-cli-unstable-2021-04-11  2025-06-19  https://hydra.nixos.org/build/300698602
✖ (Failed)  vsc-leetcode-cli-unstable-2021-04-11  2025-05-16  https://hydra.nixos.org/build/297258924
✖ (Failed)  vsc-leetcode-cli-unstable-2021-04-11  2025-05-06  https://hydra.nixos.org/build/296263424
✖ (Failed)  vsc-leetcode-cli-unstable-2021-04-11  2025-04-24  https://hydra.nixos.org/build/295086079
```

## Things done

After this change

```console
> LANG=C nix run .#vsc-leetcode-cli -- --help
leetcode [command]

Commands:
  leetcode cache [keyword]       Manage local cache
  leetcode config [key] [value]  Manage user configs                                       [aliases: conf, cfg, setting]
  leetcode list [keyword]        List questions                                                            [aliases: ls]
  leetcode plugin [name]         Manage plugins                                                [aliases: extension, ext]
  leetcode session [keyword]     Manage sessions                                                       [aliases: branch]
  leetcode show [keyword]        Show question                                                     [aliases: view, pick]
  leetcode star <keyword>        Star favorite question                                        [aliases: like, favorite]
  leetcode stat                  Show statistics                                      [aliases: stats, progress, report]
  leetcode submission [keyword]  Download submission code                                                [aliases: pull]
  leetcode submit <filename>     Submit code                                                     [aliases: push, commit]
  leetcode test <filename>       Test code                                                                [aliases: run]
  leetcode user                  Manage account                                                       [aliases: account]
  leetcode version               Show version info                                                  [aliases: info, env]
  leetcode completion            generate completion script

Options:
  -h, --help  Show help                                                                                        [boolean]

Seek more help at https://skygragon.github.io/leetcode-cli/commands
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc: @cpcloud

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
