### PR TITLE
catppuccin: add palette

### DIFF
--- a/pkgs/by-name/ca/catppuccin/package.nix
+++ b/pkgs/by-name/ca/catppuccin/package.nix
@@ -11,6 +11,7 @@ let
     "kvantum"
     "lazygit"
     "lxqt"
+    "palette"
     "plymouth"
     "qt5ct"
     "refind"
@@ -142,6 +143,14 @@ let
       repo = "lxqt";
       rev = "38cf86b3e499e0c0928a102c9c030e5dc6b79255";
       hash = "sha256-3TuUkOwk6BSc7BnLnTowGAkSlNTOtGTRlEcjJ6MNJ5g=";
+    };
+
+    palette = fetchFromGitHub {
+      name = "palette";
+      owner = "catppuccin";
+      repo = "palette";
+      rev = "0df7db6fe201b437d91e7288fa22807bb0e44701";
+      hash = "sha256-R52Q1FVAclvBk7xNgj/Jl+GPCIbORNf6YbJ1nxH3Gzs=";
     };
 
     plymouth = fetchFromGitHub {
@@ -286,6 +295,11 @@ lib.checkListOfEnum "${pname}: variant" validVariants [ variant ] lib.checkListO
     + lib.optionalString (lib.elem "lxqt" themeList) ''
       mkdir -p "$out/share/lxqt/themes/catppuccin-${variant}"
       cp -r "${sources.lxqt}/src/catppuccin-${variant}/"* "$out/share/lxqt/themes/catppuccin-${variant}"
+
+    ''
+    + lib.optionalString (lib.elem "palette" themeList) ''
+      mkdir -p "$out/palette"
+      cp "${sources.palette}/palette.json" "$out/palette"
 
     ''
     + lib.optionalString (lib.elem "plymouth" themeList) ''

--- a/pkgs/by-name/ca/catppuccin/package.nix
+++ b/pkgs/by-name/ca/catppuccin/package.nix
@@ -242,43 +242,43 @@ lib.checkListOfEnum "${pname}: variant" validVariants [ variant ] lib.checkListO
     ''
     + lib.optionalString (lib.elem "alacritty" themeList) ''
       mkdir -p "$out/alacritty"
-      cp "${sources.alacritty}/catppuccin-${variant}.toml" "$out/alacritty/"
+      cp "${sources.alacritty}/catppuccin-${variant}.toml" "$out/alacritty"
 
     ''
     + lib.optionalString (lib.elem "bat" themeList) ''
       mkdir -p "$out/bat"
-      cp "${sources.bat}/themes/Catppuccin "$capitalizedVariant".tmTheme" "$out/bat/"
+      cp "${sources.bat}/themes/Catppuccin $capitalizedVariant.tmTheme" "$out/bat"
 
     ''
     + lib.optionalString (lib.elem "btop" themeList) ''
       mkdir -p "$out/btop"
-      cp "${sources.btop}/themes/catppuccin_${variant}.theme" "$out/btop/"
+      cp "${sources.btop}/themes/catppuccin_${variant}.theme" "$out/btop"
 
     ''
     + lib.optionalString (lib.elem "bottom" themeList) ''
       mkdir -p "$out/bottom"
-      cp "${sources.bottom}/themes/${variant}.toml" "$out/bottom/"
+      cp "${sources.bottom}/themes/${variant}.toml" "$out/bottom"
 
     ''
     + lib.optionalString (lib.elem "element" themeList) ''
       mkdir -p "$out/element"
-      cp -r "${sources.element}/themes/${variant}/${accent}.json" "$out/element/"
+      cp -r "${sources.element}/themes/${variant}/${accent}.json" "$out/element"
 
     ''
     + lib.optionalString (lib.elem "grub" themeList) ''
       mkdir -p "$out/grub"
-      cp -r "${sources.grub}/src/catppuccin-${variant}-grub-theme/"* "$out/grub/"
+      cp -r "${sources.grub}/src/catppuccin-${variant}-grub-theme"/* "$out/grub"
 
     ''
     + lib.optionalString (lib.elem "hyprland" themeList) ''
       mkdir -p "$out/hyprland"
-      cp "${sources.hyprland}/themes/${variant}.conf" "$out/hyprland/"
+      cp "${sources.hyprland}/themes/${variant}.conf" "$out/hyprland"
 
     ''
     + lib.optionalString (lib.elem "k9s" themeList) ''
       mkdir -p "$out/k9s"
-      cp "${sources.k9s}/dist/catppuccin-${variant}.yaml" "$out/k9s/"
-      cp "${sources.k9s}/dist/catppuccin-${variant}-transparent.yaml" "$out/k9s/"
+      cp "${sources.k9s}/dist/catppuccin-${variant}.yaml" "$out/k9s"
+      cp "${sources.k9s}/dist/catppuccin-${variant}-transparent.yaml" "$out/k9s"
 
     ''
     + lib.optionalString (lib.elem "kvantum" themeList) ''
@@ -287,14 +287,14 @@ lib.checkListOfEnum "${pname}: variant" validVariants [ variant ] lib.checkListO
 
     ''
     + lib.optionalString (lib.elem "lazygit" themeList) ''
-      mkdir -p "$out/lazygit/"{themes,themes-mergable}
-      cp "${sources.lazygit}/themes/${variant}/${accent}.yml" "$out/lazygit/themes/"
-      cp "${sources.lazygit}/themes-mergable/${variant}/${accent}.yml" "$out/lazygit/themes-mergable/"
+      mkdir -p "$out/lazygit"/themes{,-mergable}
+      cp "${sources.lazygit}/themes/${variant}/${accent}.yml" "$out/lazygit/themes"
+      cp "${sources.lazygit}/themes-mergable/${variant}/${accent}.yml" "$out/lazygit/themes-mergable"
 
     ''
     + lib.optionalString (lib.elem "lxqt" themeList) ''
       mkdir -p "$out/share/lxqt/themes/catppuccin-${variant}"
-      cp -r "${sources.lxqt}/src/catppuccin-${variant}/"* "$out/share/lxqt/themes/catppuccin-${variant}"
+      cp -r "${sources.lxqt}/src/catppuccin-${variant}"/* "$out/share/lxqt/themes/catppuccin-${variant}"
 
     ''
     + lib.optionalString (lib.elem "palette" themeList) ''
@@ -304,8 +304,8 @@ lib.checkListOfEnum "${pname}: variant" validVariants [ variant ] lib.checkListO
     ''
     + lib.optionalString (lib.elem "plymouth" themeList) ''
       mkdir -p "$out/share/plymouth/themes/catppuccin-${variant}"
-      cp ${sources.plymouth}/themes/catppuccin-${variant}/* $out/share/plymouth/themes/catppuccin-${variant}
-      sed -i 's:\(^ImageDir=\)/usr:\1'"$out"':' $out/share/plymouth/themes/catppuccin-${variant}/catppuccin-${variant}.plymouth
+      cp "${sources.plymouth}/themes/catppuccin-${variant}"/* "$out/share/plymouth/themes/catppuccin-${variant}"
+      sed -i 's:\(^ImageDir=\)/usr:\1'"$out"':' "$out/share/plymouth/themes/catppuccin-${variant}/catppuccin-${variant}.plymouth"
 
     ''
     + lib.optionalString (lib.elem "qt5ct" themeList) ''

--- a/pkgs/by-name/ca/catppuccin/package.nix
+++ b/pkgs/by-name/ca/catppuccin/package.nix
@@ -313,15 +313,15 @@ lib.checkListOfEnum "${pname}: variant" validVariants [ variant ] lib.checkListO
       cp "${sources.qt5ct}/themes/catppuccin-${variant}-${accent}.conf" "$out/qt5ct"
 
     ''
-    + lib.optionalString (lib.elem "rofi" themeList) ''
-      mkdir -p "$out/rofi"
-      cp "${sources.rofi}/themes/catppuccin-${variant}.rasi" "$out/rofi"
-
-    ''
     + lib.optionalString (lib.elem "refind" themeList) ''
       mkdir -p "$out/refind/assets"
       cp "${sources.refind}/${variant}.conf" "$out/refind"
       cp -r "${sources.refind}/assets/${variant}" "$out/refind/assets"
+
+    ''
+    + lib.optionalString (lib.elem "rofi" themeList) ''
+      mkdir -p "$out/rofi"
+      cp "${sources.rofi}/themes/catppuccin-${variant}.rasi" "$out/rofi"
 
     ''
     + lib.optionalString (lib.elem "starship" themeList) ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added [catppuccin/palette](https://github.com/catppuccin/palette)
Can be used like:
```nix
let
  flavor = "mocha";
  accent = "mauve";
  palette = (lib.importJSON "${pkgs.catppuccin}/palette/palette.json").${flavor}.colors;
in
my-color = palette.${accent}.hex;
```

I've also cleaned up inconsistencies in the installPhase.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
