### PR TITLE
fish: misc fixes for new default standalone build

### DIFF
--- a/pkgs/by-name/fi/fish/package.nix
+++ b/pkgs/by-name/fi/fish/package.nix
@@ -240,6 +240,36 @@ stdenv.mkDerivation (finalAttrs: {
   + lib.optionalString (stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isDarwin) ''
     # This test seems to consistently fail on aarch64 and darwin
     rm tests/checks/cd.fish
+  ''
+  + ''
+    substituteInPlace share/functions/grep.fish \
+      --replace-fail "command grep" "command ${lib.getExe gnugrep}"
+
+    substituteInPlace share/completions/{sudo.fish,doas.fish} \
+      --replace-fail "/usr/local/sbin /sbin /usr/sbin" ""
+  ''
+  + lib.optionalString usePython ''
+    cat > share/functions/__fish_anypython.fish <<EOF
+    # localization: skip(private)
+    function __fish_anypython
+        echo ${python3.interpreter}
+        return 0
+    end
+    EOF
+  ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
+    for cur in share/functions/*.fish; do
+      substituteInPlace "$cur" \
+        --replace-quiet '/usr/bin/getent' '${lib.getExe getent}' \
+        --replace-quiet 'awk' '${lib.getExe' gawk "awk"}'
+    done
+    for cur in share/completions/*.fish; do
+      substituteInPlace "$cur" \
+        --replace-quiet 'awk' '${lib.getExe' gawk "awk"}'
+    done
+  ''
+  + ''
+    tee -a share/__fish_build_paths.fish.in < ${fishPreInitHooks}
   '';
 
   outputs = [
@@ -338,37 +368,8 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstallCheck
   '';
 
-  postInstall = ''
-    substituteInPlace "$out/share/fish/functions/grep.fish" \
-      --replace-fail "command grep" "command ${lib.getExe gnugrep}"
-
-    substituteInPlace $out/share/fish/completions/{sudo.fish,doas.fish} \
-      --replace-fail "/usr/local/sbin /sbin /usr/sbin" ""
-  ''
-  + lib.optionalString usePython ''
-    cat > $out/share/fish/functions/__fish_anypython.fish <<EOF
-    function __fish_anypython
-        echo ${python3.interpreter}
-        return 0
-    end
-    EOF
-  ''
-  + lib.optionalString stdenv.hostPlatform.isLinux ''
-    for cur in $out/share/fish/functions/*.fish; do
-      substituteInPlace "$cur" \
-        --replace-quiet '/usr/bin/getent' '${lib.getExe getent}' \
-        --replace-quiet 'awk' '${lib.getExe' gawk "awk"}'
-    done
-    for cur in $out/share/fish/completions/*.fish; do
-      substituteInPlace "$cur" \
-        --replace-quiet 'awk' '${lib.getExe' gawk "awk"}'
-    done
-  ''
-  + lib.optionalString useOperatingSystemEtc ''
+  postInstall = lib.optionalString useOperatingSystemEtc ''
     tee -a $out/etc/fish/config.fish < ${etcConfigAppendix}
-  ''
-  + ''
-    tee -a $out/share/fish/__fish_build_paths.fish < ${fishPreInitHooks}
   '';
 
   meta = {


### PR DESCRIPTION
Fish no longer sources most files in `$out/share/fish` with 4.2.0, and instead embeds these files in the fish binary itself:

> The standalone build mode has been made the default. This means that
> the files in $CMAKE_INSTALL_PREFIX/share/fish will not be used
> anymore, except for HTML docs. As a result, future upgrades will no
> longer break running shells if one of fish’s internal helper functions
> has been changed in the updated version. For now, the data files are
> still installed redundantly, to prevent upgrades from breaking
> already-running shells. To reverse this change (which should not be
> necessary), patch out the embed-data feature from cmake/Rust.cmake.
> This option will be removed in future.

This means that any changes to these files now have to be made the input before the build system tries to embed them.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
