### PR TITLE
pianobar: 2022.04.01-unstable-2024-08-16 -> 2024.12.21

### DIFF
--- a/pkgs/by-name/pi/pianobar/package.nix
+++ b/pkgs/by-name/pi/pianobar/package.nix
@@ -10,15 +10,15 @@
   curl,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "pianobar";
-  version = "2022.04.01-unstable-2024-08-16";
+  version = "2024.12.21";
 
   src = fetchFromGitHub {
     owner = "PromyLOPh";
     repo = "pianobar";
-    rev = "41ac06c8585dc535c4b1737b4c2943bb3fe7beb0";
-    hash = "sha256-5LTZ6J9bvfsnpD/bGuojekutFVdH9feWLF+nLFvkeOA=";
+    tag = finalAttrs.version;
+    hash = "sha256-efmzc37Z6fjEOSzc29mowlaq3qEhyy3ta/gWMpuDJ+w=";
   };
 
   nativeBuildInputs = [ pkg-config ];
@@ -35,11 +35,12 @@ stdenv.mkDerivation {
   CC = "gcc";
   CFLAGS = "-std=c99";
 
-  meta = with lib; {
+  meta = {
+    changelog = "https://github.com/PromyLOPh/pianobar/raw/${finalAttrs.src.rev}/ChangeLog";
     description = "Console front-end for Pandora.com";
     homepage = "https://6xq.net/pianobar/";
-    platforms = platforms.unix;
-    license = licenses.mit; # expat version
+    platforms = lib.platforms.unix;
+    license = lib.licenses.mit; # expat version
     mainProgram = "pianobar";
   };
-}
+})


### PR DESCRIPTION
https://github.com/PromyLOPh/pianobar/compare/41ac06c8585dc535c4b1737b4c2943bb3fe7beb0...refs/tags/2024.12.21
https://github.com/PromyLOPh/pianobar/raw/refs/tags/2024.12.21/ChangeLog

#457852

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `bfe1a45c303c7d5538a2fa90b89788161ca0d37d`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>pianobar</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc