### PR TITLE
r2t: init at 0.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13535,6 +13535,12 @@
     name = "kgtkr";
     keys = [ { fingerprint = "B30D BE93 81E0 3D5D F301 88C8 1F6E B951 9F57 3241"; } ];
   };
+  Kh05ifr4nD = {
+    email = "meandSSH0219@gmail.com";
+    github = "Kh05ifr4nD";
+    githubId = 108247735;
+    name = "Kh05ifr4nD";
+  };
   khaneliman = {
     email = "khaneliman12@gmail.com";
     github = "khaneliman";

--- a/pkgs/by-name/r2/r2t/package.nix
+++ b/pkgs/by-name/r2/r2t/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  testers,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "r2t";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "T00fy";
+    repo = "r2t";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-aA2TRYZBj+dpqxvWxek3qqhezFCFsYNDrqE0AGcypxA=";
+  };
+
+  cargoHash = "sha256-5Kq16XLyuNd7QaRdDj+rx9KxkVrYNp/itQvFxOpc2Ns=";
+
+  doCheck = false;
+
+  passthru = {
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+      command = "r2t --version";
+    };
+
+    updateScript = nix-update-script { };
+  };
+
+  meta = with lib; {
+    description = "Convert a repository into a single, well-structured text file for LLMs";
+    homepage = "https://github.com/T00fy/r2t";
+    changelog = "https://github.com/T00fy/r2t/releases/tag/v${version}";
+    license = licenses.mit;
+    mainProgram = "r2t";
+    maintainers = with maintainers; [ Kh05ifr4nD ];
+    platforms = platforms.unix ++ platforms.darwin;
+  };
+})


### PR DESCRIPTION
Add new package `r2t`, a RIIR cli tool that converts a repository’s structure and contents into a single, well-structured text file for use as context for LLMs.

Package is added at version 0.3.0 from the upstream GitHub release, with a basic `passthru.tests.version` check (`r2t --version`) and an `updateScript`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
