### PR TITLE
go-sendxmpp: Add versionCheckHook

### DIFF
--- a/pkgs/by-name/go/go-sendxmpp/package.nix
+++ b/pkgs/by-name/go/go-sendxmpp/package.nix
@@ -3,7 +3,6 @@
   fetchFromGitLab,
   lib,
   nix-update-script,
-  testers,
   versionCheckHook,
 }:
 
@@ -22,9 +21,6 @@ buildGoModule (finalAttrs: {
   vendorHash = "sha256-fnaOgc8RPDQnxTWOLQx1kw0+qj1iaff+UkjnoJYdEG4=";
 
   passthru = {
-    tests.version = testers.testVersion {
-      package = finalAttrs.finalPackage;
-    };
     updateScript = nix-update-script { };
   };
 

--- a/pkgs/by-name/go/go-sendxmpp/package.nix
+++ b/pkgs/by-name/go/go-sendxmpp/package.nix
@@ -4,6 +4,7 @@
   lib,
   nix-update-script,
   testers,
+  versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
@@ -26,6 +27,12 @@ buildGoModule (finalAttrs: {
     };
     updateScript = nix-update-script { };
   };
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+  versionCheckProgramArg = "--version";
 
   meta = {
     description = "Tool to send messages or files to an XMPP contact or MUC";

--- a/pkgs/by-name/go/go-sendxmpp/package.nix
+++ b/pkgs/by-name/go/go-sendxmpp/package.nix
@@ -33,6 +33,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Tool to send messages or files to an XMPP contact or MUC";
     homepage = "https://salsa.debian.org/mdosch/go-sendxmpp";
+    changelog = "https://salsa.debian.org/mdosch/go-sendxmpp/-/releases/v${finalAttrs.version}";
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [
       jpds


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
