### PR TITLE
obfs4: 0.4.0 -> 0.6.2, modernize, adopt

### DIFF
--- a/pkgs/by-name/ob/obfs4/package.nix
+++ b/pkgs/by-name/ob/obfs4/package.nix
@@ -52,7 +52,7 @@ buildGoModule (finalAttrs: {
     homepage = "https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/lyrebird";
     maintainers = with lib.maintainers; [ thoughtpolice ];
     mainProgram = "lyrebird";
-    changelog = "https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/lyrebird/-/raw/${finalAttrs.src.rev}/ChangeLog";
+    changelog = "https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/lyrebird/-/blob/lyrebird-${finalAttrs.version}/ChangeLog";
     license = with lib.licenses; [
       bsd2
       bsd3

--- a/pkgs/by-name/ob/obfs4/package.nix
+++ b/pkgs/by-name/ob/obfs4/package.nix
@@ -36,7 +36,7 @@ buildGoModule (finalAttrs: {
     ln -s $out/share/man/man1/{lyrebird,obfs4proxy}.1
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Circumvents censorship by transforming Tor traffic between clients and bridges";
     longDescription = ''
       Obfs4proxy is a tool that attempts to circumvent censorship by
@@ -50,7 +50,7 @@ buildGoModule (finalAttrs: {
       multiple pluggable transports.
     '';
     homepage = "https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/lyrebird";
-    maintainers = with maintainers; [ thoughtpolice ];
+    maintainers = with lib.maintainers; [ thoughtpolice ];
     mainProgram = "lyrebird";
     changelog = "https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/lyrebird/-/raw/${finalAttrs.src.rev}/ChangeLog";
     license = with lib.licenses; [

--- a/pkgs/by-name/ob/obfs4/package.nix
+++ b/pkgs/by-name/ob/obfs4/package.nix
@@ -16,7 +16,7 @@ buildGoModule (finalAttrs: {
     # We don't use pname = lyrebird and we use the old obfs4 name as the first
     # will collide with lyrebird Gtk3 program.
     repo = "lyrebird";
-    rev = "lyrebird-${finalAttrs.version}";
+    tag = "lyrebird-${finalAttrs.version}";
     hash = "sha256-aPALWvngC/BVQO73yUAykHvEb6T0DZcGMowXINDqhpQ=";
   };
 

--- a/pkgs/by-name/ob/obfs4/package.nix
+++ b/pkgs/by-name/ob/obfs4/package.nix
@@ -9,7 +9,7 @@
 
 buildGoModule (finalAttrs: {
   pname = "obfs4";
-  version = "0.4.0";
+  version = "0.6.2";
 
   src = fetchFromGitLab {
     domain = "gitlab.torproject.org";
@@ -19,10 +19,10 @@ buildGoModule (finalAttrs: {
     # will collide with lyrebird Gtk3 program.
     repo = "lyrebird";
     tag = "lyrebird-${finalAttrs.version}";
-    hash = "sha256-aPALWvngC/BVQO73yUAykHvEb6T0DZcGMowXINDqhpQ=";
+    hash = "sha256-0Nny97bapiyolmCHcty+HtZTziA50bqoCD+3gyFZIQE=";
   };
 
-  vendorHash = "sha256-iR3+ZMEF0SB3EoLTf2gtqTe3CQcjtDRhfwwbwGj3pXo=";
+  vendorHash = "sha256-ifJyOhbaB7BDBayvbh1otF1hxCuxzSG9NLb7Xtvaupg=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/ob/obfs4/package.nix
+++ b/pkgs/by-name/ob/obfs4/package.nix
@@ -5,7 +5,7 @@
   installShellFiles,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "obfs4";
   version = "0.4.0";
 
@@ -16,7 +16,7 @@ buildGoModule rec {
     # We don't use pname = lyrebird and we use the old obfs4 name as the first
     # will collide with lyrebird Gtk3 program.
     repo = "lyrebird";
-    rev = "lyrebird-${version}";
+    rev = "lyrebird-${finalAttrs.version}";
     hash = "sha256-aPALWvngC/BVQO73yUAykHvEb6T0DZcGMowXINDqhpQ=";
   };
 
@@ -52,11 +52,11 @@ buildGoModule rec {
     homepage = "https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/lyrebird";
     maintainers = with maintainers; [ thoughtpolice ];
     mainProgram = "lyrebird";
-    changelog = "https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/lyrebird/-/raw/${src.rev}/ChangeLog";
+    changelog = "https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/lyrebird/-/raw/${finalAttrs.src.rev}/ChangeLog";
     license = with lib.licenses; [
       bsd2
       bsd3
       gpl3
     ];
   };
-}
+})

--- a/pkgs/by-name/ob/obfs4/package.nix
+++ b/pkgs/by-name/ob/obfs4/package.nix
@@ -3,6 +3,7 @@
   buildGoModule,
   fetchFromGitLab,
   installShellFiles,
+  versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
@@ -25,6 +26,7 @@ buildGoModule (finalAttrs: {
   ldflags = [
     "-s"
     "-w"
+    "-X main.lyrebirdVersion=${finalAttrs.version}"
   ];
 
   subPackages = [ "cmd/lyrebird" ];
@@ -35,6 +37,10 @@ buildGoModule (finalAttrs: {
     installManPage doc/lyrebird.1
     ln -s $out/share/man/man1/{lyrebird,obfs4proxy}.1
   '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
 
   meta = {
     description = "Circumvents censorship by transforming Tor traffic between clients and bridges";

--- a/pkgs/by-name/ob/obfs4/package.nix
+++ b/pkgs/by-name/ob/obfs4/package.nix
@@ -61,13 +61,13 @@ buildGoModule (finalAttrs: {
       multiple pluggable transports.
     '';
     homepage = "https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/lyrebird";
-    maintainers = with lib.maintainers; [ thoughtpolice ];
-    mainProgram = "lyrebird";
     changelog = "https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/lyrebird/-/blob/lyrebird-${finalAttrs.version}/ChangeLog";
     license = with lib.licenses; [
       bsd2
       bsd3
       gpl3
     ];
+    maintainers = with lib.maintainers; [ thoughtpolice ];
+    mainProgram = "lyrebird";
   };
 })

--- a/pkgs/by-name/ob/obfs4/package.nix
+++ b/pkgs/by-name/ob/obfs4/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitLab,
   installShellFiles,
   versionCheckHook,
+  nix-update-script,
 }:
 
 buildGoModule (finalAttrs: {
@@ -41,6 +42,10 @@ buildGoModule (finalAttrs: {
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = "--version";
   doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version-regex=^lyrebird-(\\d+\\.\\d+\\.\\d+)$" ];
+  };
 
   meta = {
     description = "Circumvents censorship by transforming Tor traffic between clients and bridges";

--- a/pkgs/by-name/ob/obfs4/package.nix
+++ b/pkgs/by-name/ob/obfs4/package.nix
@@ -67,7 +67,10 @@ buildGoModule (finalAttrs: {
       bsd3
       gpl3
     ];
-    maintainers = with lib.maintainers; [ thoughtpolice ];
+    maintainers = with lib.maintainers; [
+      thoughtpolice
+      defelo
+    ];
     mainProgram = "lyrebird";
   };
 })


### PR DESCRIPTION
Changelog: https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/lyrebird/-/blob/lyrebird-0.6.2/ChangeLog
Diff: https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/lyrebird/-/compare/lyrebird-0.4.0...lyrebird-0.6.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
