### PR TITLE
prometheus-pushgateway: Add versionCheckHook

### DIFF
--- a/nixos/tests/prometheus/pushgateway.nix
+++ b/nixos/tests/prometheus/pushgateway.nix
@@ -56,6 +56,9 @@
       + "jq '.data.result[0].metric.version' | grep '\"${pkgs.prometheus-pushgateway.version}\"'"
     )
 
+    client.systemctl("start network-online.target")
+    client.wait_for_unit("network-online.target")
+
     # Add a metric and check in Prometheus
     client.wait_until_succeeds(
       "echo 'some_metric 3.14' | curl --data-binary @- http://pushgateway:9091/metrics/job/some_job"

--- a/pkgs/by-name/pr/prometheus-pushgateway/package.nix
+++ b/pkgs/by-name/pr/prometheus-pushgateway/package.nix
@@ -6,14 +6,14 @@
   versionCheckHook,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "pushgateway";
   version = "1.11.2";
 
   src = fetchFromGitHub {
     owner = "prometheus";
     repo = "pushgateway";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-Mc4yEd9CRfLZ4ZpcMnwQpoIXQpUerdxYD90FWRBzS20=";
   };
 
@@ -22,9 +22,9 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/prometheus/common/version.Version=${version}"
-    "-X github.com/prometheus/common/version.Revision=${version}"
-    "-X github.com/prometheus/common/version.Branch=${version}"
+    "-X github.com/prometheus/common/version.Version=${finalAttrs.version}"
+    "-X github.com/prometheus/common/version.Revision=${finalAttrs.version}"
+    "-X github.com/prometheus/common/version.Branch=${finalAttrs.version}"
     "-X github.com/prometheus/common/version.BuildUser=nix@nixpkgs"
     "-X github.com/prometheus/common/version.BuildDate=19700101-00:00:00"
   ];
@@ -45,4 +45,4 @@ buildGoModule rec {
     license = licenses.asl20;
     maintainers = with maintainers; [ benley ];
   };
-}
+})

--- a/pkgs/by-name/pr/prometheus-pushgateway/package.nix
+++ b/pkgs/by-name/pr/prometheus-pushgateway/package.nix
@@ -42,6 +42,7 @@ buildGoModule (finalAttrs: {
     description = "Allows ephemeral and batch jobs to expose metrics to Prometheus";
     mainProgram = "pushgateway";
     homepage = "https://github.com/prometheus/pushgateway";
+    changelog = "https://github.com/prometheus/pushgateway/releases/tag/v${finalAttrs.version}";
     license = licenses.asl20;
     maintainers = with maintainers; [ benley ];
   };

--- a/pkgs/by-name/pr/prometheus-pushgateway/package.nix
+++ b/pkgs/by-name/pr/prometheus-pushgateway/package.nix
@@ -3,8 +3,7 @@
   buildGoModule,
   fetchFromGitHub,
   nixosTests,
-  testers,
-  prometheus-pushgateway,
+  versionCheckHook,
 }:
 
 buildGoModule rec {
@@ -32,10 +31,12 @@ buildGoModule rec {
 
   passthru.tests = {
     inherit (nixosTests.prometheus) pushgateway;
-    version = testers.testVersion {
-      package = prometheus-pushgateway;
-    };
   };
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Allows ephemeral and batch jobs to expose metrics to Prometheus";


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
