### PR TITLE
ytui-music: 2.0.0-rc1 -> 2.0.0-rc1-unstable-2025-03-03  after unbreak

### DIFF
--- a/pkgs/by-name/yt/ytui-music/fix-implicit-autoref-errors-in-ui-mod-rs-for-rust-1-80-plus.patch
+++ b/pkgs/by-name/yt/ytui-music/fix-implicit-autoref-errors-in-ui-mod-rs-for-rust-1-80-plus.patch
@@ -1,0 +1,26 @@
+From 474521f42376b8a374382994313484aa4bba9c85 Mon Sep 17 00:00:00 2001
+From: LATex <leandro.recebe@gmail.com>
+Date: Sat, 11 Oct 2025 20:34:31 -0300
+Subject: [PATCH] Fix implicit autoref errors in ui/mod.rs for Rust 1.80+
+
+---
+ front-end/src/ui/mod.rs | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/front-end/src/ui/mod.rs b/front-end/src/ui/mod.rs
+index 81a56e001a7b892d24eeb0404d2bc069fe9c07a3..296fd4711db0d9380b74e07ae933df161b437b36 100644
+--- a/front-end/src/ui/mod.rs
++++ b/front-end/src/ui/mod.rs
+@@ -215,9 +215,9 @@ pub fn draw_ui(state: &mut Arc<Mutex<State>>, cvar: &mut Arc<Condvar>) {
+                 let state_ptr = &mut state_unlocked as *mut std::sync::MutexGuard<'_, State<'_>>;
+                 let (mut music_state, mut playlist_state, mut artist_state);
+                 unsafe {
+-                    music_state = &mut (*state_ptr).musicbar.1;
+-                    playlist_state = &mut (*state_ptr).playlistbar.1;
+-                    artist_state = &mut (*state_ptr).artistbar.1;
++                    music_state = &mut (&mut (*state_ptr)).musicbar.1;
++                    playlist_state = &mut (&mut (*state_ptr)).playlistbar.1;
++                    artist_state = &mut (&mut (*state_ptr)).artistbar.1;
+                 }
+ 
+                 let music_table = MiddleLayout::get_music_container(&mut state_unlocked);

--- a/pkgs/by-name/yt/ytui-music/package.nix
+++ b/pkgs/by-name/yt/ytui-music/package.nix
@@ -15,13 +15,13 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ytui-music";
-  version = "2.0.0-rc1";
+  version = "2.0.0-rc1-unstable-2025-03-03";
 
   src = fetchFromGitHub {
     owner = "sudipghimire533";
     repo = "ytui-music";
-    rev = "d505c018fa4b093dbd76aaadcccec289b071a989";
-    hash = "sha256-f/23PVk4bpUCvcQ25iNI/UVXqiPBzPKWq6OohVF41p8=";
+    rev = "b90293d226f6fc27835372f145e55d385112768b";
+    hash = "sha256-pRD8ySpkJz8o7DURXG8DmBsbZV9MqVlMN63gAjYl4vc=";
   };
 
   cargoHash = "sha256-zwlg4BDHCM+KALjP929upaDpgy1mXEz5PYaVw+BhRp0=";

--- a/pkgs/by-name/yt/ytui-music/package.nix
+++ b/pkgs/by-name/yt/ytui-music/package.nix
@@ -15,13 +15,13 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ytui-music";
-  version = "0-unstable-2025-03-03";
+  version = "2.0.0-rc1";
 
   src = fetchFromGitHub {
     owner = "sudipghimire533";
     repo = "ytui-music";
-    rev = "b90293d226f6fc27835372f145e55d385112768b";
-    hash = "sha256-pRD8ySpkJz8o7DURXG8DmBsbZV9MqVlMN63gAjYl4vc=";
+    rev = "d505c018fa4b093dbd76aaadcccec289b071a989";
+    hash = "sha256-f/23PVk4bpUCvcQ25iNI/UVXqiPBzPKWq6OohVF41p8=";
   };
 
   cargoHash = "sha256-zwlg4BDHCM+KALjP929upaDpgy1mXEz5PYaVw+BhRp0=";
@@ -65,9 +65,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   passthru = {
     updateScript = _experimental-update-script-combinators.sequence [
       (unstableGitUpdater {
-        # Since a suitable formatted tag isn't available, using branch is a better way.
-        # ref: https://github.com/NixOS/nixpkgs/issues/258033#issuecomment-1741070349
-        hardcodeZeroVersion = true;
+        tagFormat = "v[0-9]*";
+        tagPrefix = "v";
 
         # * "main" branch is newer than "latest" branch
         # * "main" branch is newer than "main" tag

--- a/pkgs/by-name/yt/ytui-music/package.nix
+++ b/pkgs/by-name/yt/ytui-music/package.nix
@@ -10,14 +10,14 @@
   makeBinaryWrapper,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ytui-music";
   version = "2.0.0-rc1";
 
   src = fetchFromGitHub {
     owner = "sudipghimire533";
     repo = "ytui-music";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-f/23PVk4bpUCvcQ25iNI/UVXqiPBzPKWq6OohVF41p8=";
   };
 
@@ -59,11 +59,11 @@ rustPlatform.buildRustPackage rec {
     runHook postInstallCheck
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Youtube client in terminal for music";
     homepage = "https://github.com/sudipghimire533/ytui-music";
-    license = licenses.gpl2Only;
-    maintainers = with maintainers; [ kashw2 ];
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ kashw2 ];
     mainProgram = "ytui_music";
   };
-}
+})

--- a/pkgs/by-name/yt/ytui-music/package.nix
+++ b/pkgs/by-name/yt/ytui-music/package.nix
@@ -13,7 +13,7 @@
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage (finalAttrs: {
+rustPlatform.buildRustPackage {
   pname = "ytui-music";
   version = "2.0.0-rc1-unstable-2025-03-03";
 
@@ -92,4 +92,4 @@ rustPlatform.buildRustPackage (finalAttrs: {
     # This issue may be related to: https://github.com/NixOS/nixpkgs/issues/394972
     # broken = stdenv.hostPlatform.isDarwin;
   };
-})
+}

--- a/pkgs/by-name/yt/ytui-music/package.nix
+++ b/pkgs/by-name/yt/ytui-music/package.nix
@@ -28,6 +28,11 @@ rustPlatform.buildRustPackage rec {
     "--skip=tests::inspect_server_list"
   ];
 
+  patches = [
+    # This patch comes from https://github.com/sudipghimire533/ytui-music/pull/57, which was unmerged.
+    ./fix-implicit-autoref-errors-in-ui-mod-rs-for-rust-1-80-plus.patch
+  ];
+
   nativeBuildInputs = [
     pkg-config
     makeBinaryWrapper


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

* Vendoring https://github.com/sudipghimire533/ytui-music/pull/57 is a part of following issues
  * #459759
  * ZHF: #457852
* Using unstable version appears to fix https://github.com/NixOS/nixpkgs/issues/258033#issuecomment-1740903937
  Diff: https://github.com/sudipghimire533/ytui-music/compare/d505c018fa4b093dbd76aaadcccec289b071a989...b90293d226f6fc27835372f145e55d385112768b
* However, I still see a `Fetch error` in the TUI, even after setting up another instance in `~/.config/ytui_music/config.json`.
  It seems another known issue: https://github.com/sudipghimire533/ytui-music/issues/43



```console
> hydra-check ytui-music
Build Status for nixpkgs.ytui-music.x86_64-linux on jobset nixos/trunk-combined
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.ytui-music.x86_64-linux
✖ (Failed)     ytui-music-2.0.0-rc1  2025-11-11  https://hydra.nixos.org/build/312863330
⏹ (Cancelled)  ytui-music-2.0.0-rc1  2025-11-01  https://hydra.nixos.org/build/311487904
✖ (Failed)     ytui-music-2.0.0-rc1  2025-10-29  https://hydra.nixos.org/build/311417638
⏹ (Cancelled)  ytui-music-2.0.0-rc1  2025-10-28  https://hydra.nixos.org/build/311370918
✖ (Failed)     ytui-music-2.0.0-rc1  2025-10-25  https://hydra.nixos.org/build/311269463
✖ (Failed)     ytui-music-2.0.0-rc1  2025-10-21  https://hydra.nixos.org/build/310506864
✖ (Failed)     ytui-music-2.0.0-rc1  2025-10-19  https://hydra.nixos.org/build/310279473
✖ (Failed)     ytui-music-2.0.0-rc1  2025-10-10  https://hydra.nixos.org/build/308945479
✖ (Failed)     ytui-music-2.0.0-rc1  2025-09-29  https://hydra.nixos.org/build/308439137
✖ (Failed)     ytui-music-2.0.0-rc1  2025-09-25  https://hydra.nixos.org/build/308275700
```

## Things done

After this change

```console
> uname -rm
6.12.56 x86_64

> nix run .#ytui-music -- run
```

<img width="2817" height="1269" alt="image" src="https://github.com/user-attachments/assets/42afafd7-3c4c-4371-9f0b-d2ac2d27491e" />

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin # sandbox should be relaxed
  - [x] aarch64-darwin # sandbox should be relaxed
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc: @kashw2

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
