### PR TITLE
flexoptix-app: 5.48.0-latest -> 5.54.0-latest

### DIFF
--- a/pkgs/by-name/fl/flexoptix-app/package.nix
+++ b/pkgs/by-name/fl/flexoptix-app/package.nix
@@ -7,12 +7,12 @@
 }:
 let
   pname = "flexoptix-app";
-  version = "5.48.0-latest";
+  version = "5.54.0-latest";
 
   src = fetchurl {
     name = "${pname}-${version}.AppImage";
     url = "https://flexbox.reconfigure.me/download/electron/linux/x64/FLEXOPTIX%20App.${version}.AppImage";
-    hash = "sha256-VSGfExus+4dDef6V1ZEATMBVCIb0JS459+yolx5sg3c=";
+    hash = "sha256-RTzVtAd134cKIlHWgP9Yyhu3FgdDSe1fKDGMsctO3x8=";
   };
 
   udevRules = fetchurl {
@@ -70,7 +70,7 @@ appimageTools.wrapAppImage {
     homepage = "https://www.flexoptix.net";
     changelog = "https://www.flexoptix.net/en/flexoptix-app/?os=linux#flexapp__modal__changelog";
     license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [ das_j ];
+    teams = [ lib.teams.helsinki-systems ];
     platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
Upgrade to [5.54.0-latest](https://www.flexoptix.net/en/flexoptix-app/?changelog=1):

Changelog
Version 5.54.0 (release date 05.11.2025)

    added full OTDR feature integration for FLEXBOX 5
    fixed an issue that could cause transceivers to auto-reconfigure unexpectedly
    improved clarity and accuracy of error messages related to patch management and OPM functionality

Version 5.53.0 (release date 22.10.2025)

    improved stability when unplugging a transceiver during reconfiguration (older Flexbox models only)
    fixed an issue affecting Bluetooth connectivity

Version 5.52.0 (release date 13.10.2025)

    fixed delay in discovering Flexboxes
    fixed properly closing the app
    improved error handling for Flexbox 5 USB and Bluetooth detection
    fixed a few minor bugs

Version 5.51.0 (release date 24.09.2025)

    display Flexbox 5 battery percentage
    change the Flexoptix app logo
    improve error messages
    fixed WLAN password visibility toggle
    fixed issue where app could get stuck in tray after partial update
    fixed null pointer exception in OPM when handling SFP28 modules
    fixed incorrect "Transceiver is not classified" message in OPM for classified OSFP transceivers

Version 5.50.1 (release date 28.08.2025)

    fixed reconfiguration loop on Flexbox 5 when using "Automatically reconfigure next transceiver" with certain compatibilities

Version 5.50.0 (release date 22.08.2025)

    fixed a bug that prevented FLEXOPTIX App from fully closing
    improved error tolerance for accessing USB or Bluetooth device
    fixed some minor bugs related to USB connection of Flexbox 5

Version 5.49.0 (release date 14.08.2025)

    fixed issue causing unexpected "Session expired" errors
    fixed display issue related to remaining patch information
    fixed connection timeout issues for regions with bad routing to our servers
    added emergency shutdown message for OPM
    preventing issues by not allowing multiple app instance to run simultaneously

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
