### PR TITLE
ocamlPackages.lambda-term: small cleaning

### DIFF
--- a/pkgs/development/ocaml-modules/lambda-term/default.nix
+++ b/pkgs/development/ocaml-modules/lambda-term/default.nix
@@ -2,7 +2,6 @@
   lib,
   fetchFromGitHub,
   buildDunePackage,
-  ocaml,
   zed,
   lwt_log,
   lwt_react,
@@ -11,31 +10,15 @@
   logs,
 }:
 
-let
-  params =
-    if lib.versionAtLeast ocaml.version "4.08" then
-      {
-        version = "3.3.2";
-        sha256 = "sha256-T2DDpHqLar1sgmju0PLvhAZef5VzOpPWcFVhuZlPQmM=";
-      }
-    else
-      {
-        version = "3.1.0";
-        sha256 = "1k0ykiz0vhpyyj9fkss29ajas4fh1xh449j702xkvayqipzj1mkg";
-      };
-in
-
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "lambda-term";
-  inherit (params) version;
-
-  duneVersion = if lib.versionAtLeast ocaml.version "4.08" then "3" else "2";
+  version = "3.3.2";
 
   src = fetchFromGitHub {
     owner = "ocaml-community";
-    repo = pname;
-    rev = version;
-    inherit (params) sha256;
+    repo = "lambda-term";
+    tag = finalAttrs.version;
+    hash = "sha256-T2DDpHqLar1sgmju0PLvhAZef5VzOpPWcFVhuZlPQmM=";
   };
 
   propagatedBuildInputs = [
@@ -43,8 +26,6 @@ buildDunePackage rec {
     lwt_log
     lwt_react
     mew_vi
-  ]
-  ++ lib.optionals (lib.versionAtLeast version "3.3.1") [
     uucp
     logs
   ];
@@ -66,9 +47,9 @@ buildDunePackage rec {
       console applications.
     '';
 
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/ocaml-community/lambda-term";
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.gal_bolle ];
     mainProgram = "lambda-term-actions";
   };
-}
+})

--- a/pkgs/development/ocaml-modules/mew/default.nix
+++ b/pkgs/development/ocaml-modules/mew/default.nix
@@ -6,17 +6,15 @@
   trie,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "mew";
   version = "0.1.0";
 
-  useDune2 = true;
-
   src = fetchFromGitHub {
     owner = "kandu";
-    repo = pname;
-    rev = version;
-    sha256 = "0417xsghj92v3xa5q4dk4nzf2r4mylrx2fd18i7cg3nzja65nia2";
+    repo = "mew";
+    tag = finalAttrs.version;
+    hash = "sha256-QkVbjJLfjsdORKE50TP1lWThviWzEVxUH1skCZ/uJxA=";
   };
 
   propagatedBuildInputs = [
@@ -25,10 +23,10 @@ buildDunePackage rec {
   ];
 
   meta = {
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/kandu/mew";
     license = lib.licenses.mit;
     description = "Modal Editing Witch";
     maintainers = [ lib.maintainers.vbgl ];
   };
 
-}
+})

--- a/pkgs/development/ocaml-modules/mew_vi/default.nix
+++ b/pkgs/development/ocaml-modules/mew_vi/default.nix
@@ -6,17 +6,15 @@
   react,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "mew_vi";
   version = "0.5.0";
 
-  useDune2 = true;
-
   src = fetchFromGitHub {
     owner = "kandu";
-    repo = pname;
-    rev = version;
-    sha256 = "0lihbf822k5zasl60w5mhwmdkljlq49c9saayrws7g4qc1j353r8";
+    repo = "mew_vi";
+    tag = finalAttrs.version;
+    hash = "sha256-KI8yZGCYvKN59krpxBLBVNLZKoe1cGCoVr9MIZBbMFI=";
   };
 
   propagatedBuildInputs = [
@@ -25,10 +23,10 @@ buildDunePackage rec {
   ];
 
   meta = {
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/kandu/mew_vi";
     license = lib.licenses.mit;
     description = "Modal Editing Witch, VI interpreter";
     maintainers = [ lib.maintainers.vbgl ];
   };
 
-}
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
