### PR TITLE
ghostty: split xdg files into their own outputs

### DIFF
--- a/pkgs/by-name/gh/ghostty/package.nix
+++ b/pkgs/by-name/gh/ghostty/package.nix
@@ -23,7 +23,6 @@
   versionCheckHook,
   wrapGAppsHook4,
   zig_0_14,
-
   # Usually you would override `zig.hook` with this, but we do that internally
   # since upstream recommends a non-default level
   # https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/PACKAGING.md#build-options
@@ -46,6 +45,10 @@ stdenv.mkDerivation (finalAttrs: {
     "shell_integration"
     "terminfo"
     "vim"
+    "systemd"
+    "dbus_1"
+    "desktop"
+    "metainfo"
   ];
 
   src = fetchFromGitHub {
@@ -144,6 +147,20 @@ stdenv.mkDerivation (finalAttrs: {
 
 
     remove-references-to -t ${finalAttrs.deps} $out/bin/.ghostty-wrapped
+
+    # Move xdg files to their own outputs
+    if [ -d "$out/share/systemd" ]; then
+      moveToOutput share/systemd $systemd
+    fi
+    if [ -d "$out/share/dbus-1" ]; then
+      moveToOutput share/dbus-1 $dbus_1
+    fi
+    if [ -d "$out/share/applications" ]; then
+      moveToOutput share/applications $desktop
+    fi
+    if [ -d "$out/share/metainfo" ]; then
+      moveToOutput share/metainfo $metainfo
+    fi
   '';
 
   nativeInstallCheckInputs = [


### PR DESCRIPTION
Moves the systemd service, dbus service, desktop entry, and metainfo files to their own dedicated outputs for better modularity and to follow nixpkgs conventions. I needed this to override the specified exe to use nixGL on home-manager.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
