### PR TITLE
jj-run: init at 7

### DIFF
--- a/pkgs/by-name/jj/jj-run/package.nix
+++ b/pkgs/by-name/jj/jj-run/package.nix
@@ -1,0 +1,33 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+}:
+
+buildGoModule (final: {
+  pname = "jj-run";
+  version = "7";
+
+  src = fetchFromGitHub {
+    owner = "neongreen";
+    repo = "mono";
+    tag = "jj-run--main.${final.version}";
+    hash = "sha256-EHfM8DOp77GC+U3Xa55cnW+QC7g5psZUjCQhr/8dZlE=";
+  };
+
+  subPackages = "jj-run/cmd";
+
+  vendorHash = "sha256-5o7jwiZs9Xn0iXDHMQ5rum9kife4ChbVSljcGPUDOIU=";
+
+  postFixup = "mv $out/bin/cmd $out/bin/jj-run";
+
+  meta = {
+    description = "Jujutsu subcommand to execute shell commands against multiple revisions.";
+    homepage = "https://github.com/neongreen/mono";
+    changelog = "https:github.com/neongreen/mono/releases/tag/jj-run--main.${final.version}";
+    license = lib.licenses.unlicense;
+    mainProgram = "jj-run";
+    maintainers = with lib.maintainers; [ nobbz ];
+    platforms = with lib.platforms; unix;
+  };
+})


### PR DESCRIPTION
Adds `jj-run`, an external implementation of the `jj run` command, which is currently only a stub in jujutsu.

https://github.com/neongreen/mono/tree/main/jj-run

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
