### PR TITLE
rPackages.iscream: fix build and optimize

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -609,6 +609,10 @@ let
       libpng.dev
     ];
     iBMQ = [ pkgs.gsl ];
+    iscream = with pkgs; [
+      pkg-config
+      which
+    ];
     jack = [ pkgs.pkg-config ];
     JavaGD = [ pkgs.jdk ];
     jpeg = [ pkgs.libjpeg.dev ];
@@ -1179,6 +1183,11 @@ let
     chebpol = [ pkgs.pkg-config ];
     baseline = [ pkgs.lapack ];
     eds = [ pkgs.zlib.dev ];
+    iscream = with pkgs; [
+      bzip2.dev
+      xz.dev
+      zlib.dev
+    ];
     pgenlibr = [ pkgs.zlib.dev ];
     fftw = [ pkgs.pkg-config ];
     gdtools = [ pkgs.pkg-config ];
@@ -3003,6 +3012,18 @@ let
         patchShebangs configure
       '';
     });
+
+    iscream = let
+      # https://huishenlab.github.io/iscream/articles/htslib.html
+      htslib-deflate = pkgs.htslib.overrideAttrs (attrs: {
+        buildInputs = attrs.buildInputs ++ [ pkgs.libdeflate ];
+      });
+    in
+    old.iscream.overrideAttrs (attrs: {
+      # Rhtslib (in LinkingTo) is not needed if we provide a proper htslib
+      propagatedBuildInputs = builtins.filter (el: el != pkgs.rPackages.Rhtslib ) attrs.propagatedBuildInputs ++ [ htslib-deflate];
+    });
+
 
     torch = old.torch.overrideAttrs (attrs: {
       preConfigure = ''


### PR DESCRIPTION
 - Add missing build inputs
 - Compile htslib with libdeflate 
 - Remove superfluous Rhtslib dependency
(https://huishenlab.github.io/iscream/articles/htslib.html)

https://github.com/NixOS/nixpkgs/pull/457385
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
