### PR TITLE
python3Packages.amazon-ion: include c_ext module

### DIFF
--- a/pkgs/development/python-modules/amazon-ion/default.nix
+++ b/pkgs/development/python-modules/amazon-ion/default.nix
@@ -4,12 +4,14 @@
   cbor2,
   docopt,
   fetchFromGitHub,
+  fetchpatch2,
   jsonconversion,
   pytestCheckHook,
   pytest_7,
   setuptools,
   six,
   tabulate,
+  cmake,
 }:
 
 buildPythonPackage rec {
@@ -23,15 +25,60 @@ buildPythonPackage rec {
     tag = "v${version}";
     # Test vectors require git submodule
     fetchSubmodules = true;
-    hash = "sha256-ZnslVmXE2YvTAkpfw2lbpB+uF85n/CvA22htO/Y7yWk=";
+    leaveDotGit = true; # During ion-c submodule build git history/hash used to infer version
+    postFetch = ''
+      # Generated file should match output of command in ion-c/cmake/VersionHeader.cmake
+      # Run Git before creating any files to avoid triggering false dirty suffix.
+      (cd "$out/ion-c" && v="$(git describe --long --tags --dirty --match "v*")" && echo -n "$v" > .nixpkgs-patching-IONC_FULL_VERSION.txt)
+
+      # Based on https://github.com/NixOS/nixpkgs/blob/183125f9/pkgs/build-support/fetchgit/nix-prefetch-git#L358
+      find "$out" -name .git -exec rm -rf '{}' '+'
+    '';
+    hash = "sha256-VBbxGXPAwS3jwEsm64yEKqJKVKGvPStboLjHoRcoonE=";
   };
+
+  patches = [
+    # backport changes that adapt code to more strict compilers
+    (fetchpatch2 {
+      name = "46aebb0-Address-incompatible-pointer-errors.patch";
+      url = "https://github.com/amazon-ion/ion-c/commit/46aebb0b650a4cf61425ef1a8e78e2443023e853.patch?full_index=1";
+      hash = "sha256-5qzSbZV9Oe5soJzkyCtVtWejedLEjAz7yuVotATPmbs=";
+      stripLen = 1;
+      extraPrefix = "ion-c/";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace setup.py \
       --replace "'pytest-runner'," ""
+
+    # Ion C building is in _download_ion_c() which will try to remove sources and re-download
+    substituteInPlace install.py \
+      --replace-fail "isdir(_CURRENT_ION_C_DIR)" "False"
+    substituteInPlace install.py \
+      --replace-fail "check_call(['git'" "check_call(['true'"
+
+    # Ion-C infers version based on Git. But there are issues with making .git folders deterministic.
+    # See https://github.com/NixOS/nixpkgs/issues/8567
+    # Hence, we'll inject version ourselves
+    substituteInPlace ion-c/cmake/VersionHeader.cmake \
+      --replace-fail 'set(IONC_FULL_VERSION "''${CMAKE_PROJECT_VERSION}")' \
+                     "set(IONC_FULL_VERSION \"$(cat ion-c/.nixpkgs-patching-IONC_FULL_VERSION.txt)\")"
   '';
 
-  build-system = [ setuptools ];
+  build-system = [
+    setuptools
+  ];
+
+  dontUseCmakeConfigure = true; # CMake invoked by install.py
+
+  # Can't use cmakeFlags since we do not control invocation of cmake.
+  # But build-release.sh in ion-c is sensitive to this env variable.
+  env.CMAKE_FLAGS = "-DCMAKE_SKIP_BUILD_RPATH=ON";
+
+  nativeBuildInputs = [
+    cmake
+  ];
 
   dependencies = [
     jsonconversion
@@ -55,7 +102,10 @@ buildPythonPackage rec {
     "tests/test_benchmark_cli.py"
   ];
 
-  pythonImportsCheck = [ "amazon.ion" ];
+  pythonImportsCheck = [
+    "amazon.ion"
+    "amazon.ion.ionc" # C extension module for speedup
+  ];
 
   meta = with lib; {
     description = "Python implementation of Amazon Ion";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -656,7 +656,7 @@ self: super: with self; {
 
   amarna = callPackage ../development/python-modules/amarna { };
 
-  amazon-ion = callPackage ../development/python-modules/amazon-ion { };
+  amazon-ion = callPackage ../development/python-modules/amazon-ion { inherit (pkgs) cmake; };
 
   amberelectric = callPackage ../development/python-modules/amberelectric { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Address problem of slow `amazon-ion` package due to miss of C extension module ([link claiming 60x speedup vs pure implementation](https://github.com/amazon-ion/ion-python/blob/master/C_EXTENSION.md#performance-improvement)).

See https://github.com/NixOS/nixpkgs/issues/461284

* Why ion-c v1.1.2? Why not v1.1.4 that already includes [46aebb0](https://github.com/amazon-ion/ion-c/commit/46aebb0b650a4cf61425ef1a8e78e2443023e853) patch?
  Latest release of [ion-python/amazon-ion](https://github.com/amazon-ion/ion-python/tree/v0.13.0) at the moment is 0.13.0 where submodule is pointing to [commit of ion-c with version 1.1.2](https://github.com/amazon-ion/ion-c/blob/6d4de4150fe162dde3fad55cefee8d3ec64fb974/CMakeLists.txt#L3).


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage] ².
- [X] Tested basic functionality of all binary files, usually in `./result/bin/` ¹.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


---
¹ Tested effect with next commands

```bash
nix build --print-build-logs '.#python3Packages.amazon-ion'
nix develop '.#python3Packages.amazon-ion'
cd result/lib/python3*/site-packages
python3
```
*(changed folder so `python` will load modulers relative to built `site-packages` folder where `amazon` package/module resides)*

```console
>>> import amazon.ion.simpleion
>>> amazon.ion.simpleion.c_ext
True
```

```bash
python -c 'import amazon.ion.simpleion as ion; print(ion.__IS_C_EXTENSION_SUPPORTED)'
```
```python
True
```

---
² part of the output of `nixpkgs-review rev --print-result 4b6dea07` (`pr` fails with `urllib.error.HTTPError: HTTP Error 401: Unauthorized`)

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `4b6dea07193748d86a1a2ff889e9f6bc0c0e8e37`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 8 packages built:</summary>
  <ul>
    <li>python312Packages.amazon-ion</li>
    <li>python312Packages.amazon-ion.dist</li>
    <li>python312Packages.kestra</li>
    <li>python312Packages.kestra.dist</li>
    <li>python313Packages.amazon-ion</li>
    <li>python313Packages.amazon-ion.dist</li>
    <li>python313Packages.kestra</li>
    <li>python313Packages.kestra.dist</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
