### PR TITLE
nixos/mysql: rename mariadb exes due to deprecation

### DIFF
--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -10,6 +10,9 @@ let
 
   isMariaDB = lib.getName cfg.package == lib.getName pkgs.mariadb;
 
+  isRenamedMariaDB = isMariaDB && lib.versionAtLeast cfg.package.version "10.5";
+  binaryPrefix = if isRenamedMariaDB then "mariadb" else "mysql";
+
   mysqldOptions = "--user=${cfg.user} --datadir=${cfg.dataDir} --basedir=${cfg.package}";
 
   format = pkgs.formats.ini { listsAsDuplicateKeys = true; };
@@ -560,14 +563,16 @@ in
         if isMariaDB then
           ''
             if ! test -e ${cfg.dataDir}/mysql; then
-              ${cfg.package}/bin/mysql_install_db --defaults-file=/etc/my.cnf ${mysqldOptions}
+              ${
+                lib.getExe' cfg.package (if isRenamedMariaDB then "mariadb-install-db" else "mysql_install_db")
+              } --defaults-file=/etc/my.cnf ${mysqldOptions}
               touch ${cfg.dataDir}/mysql_init
             fi
           ''
         else
           ''
             if ! test -e ${cfg.dataDir}/mysql; then
-              ${cfg.package}/bin/mysqld --defaults-file=/etc/my.cnf ${mysqldOptions} --initialize-insecure
+              ${lib.getExe' cfg.package "mysqld"} --defaults-file=/etc/my.cnf ${mysqldOptions} --initialize-insecure
               touch ${cfg.dataDir}/mysql_init
             fi
           '';
@@ -581,7 +586,7 @@ in
         fi
 
         # The last two environment variables are used for starting Galera clusters
-        exec ${cfg.package}/bin/mysqld --defaults-file=/etc/my.cnf ${mysqldOptions} $_WSREP_NEW_CLUSTER $_WSREP_START_POSITION
+        exec ${lib.getExe' cfg.package "${binaryPrefix}d"} --defaults-file=/etc/my.cnf ${mysqldOptions} $_WSREP_NEW_CLUSTER $_WSREP_START_POSITION
       '';
 
       postStart =
@@ -595,10 +600,10 @@ in
             # If MariaDB is used in an Galera cluster, we have to check if the sync is done,
             # or it will fail to init the database while joining, so we get in an broken non recoverable state
             # so we wait until we have an synced state
-            if ${cfg.package}/bin/mysql -u ${superUser} -N -e "SHOW VARIABLES LIKE 'wsrep_on'" 2>/dev/null | ${lib.getExe' pkgs.gnugrep "grep"} -q 'ON'; then
+            if ${lib.getExe' cfg.package binaryPrefix} -u ${superUser} -N -e "SHOW VARIABLES LIKE 'wsrep_on'" 2>/dev/null | ${lib.getExe' pkgs.gnugrep "grep"} -q 'ON'; then
               echo "Galera cluster detected, waiting for node to be synced..."
               while true; do
-                STATE=$(${cfg.package}/bin/mysql -u ${superUser} -N -e "SHOW STATUS LIKE 'wsrep_local_state_comment'" | ${lib.getExe' pkgs.gawk "awk"} '{print $2}')
+                STATE=$(${lib.getExe' cfg.package binaryPrefix} -u ${superUser} -N -e "SHOW STATUS LIKE 'wsrep_local_state_comment'" | ${lib.getExe' pkgs.gawk "awk"} '{print $2}')
                 if [ "$STATE" = "Synced" ]; then
                   echo "Node is synced"
                   break
@@ -618,7 +623,7 @@ in
                 if isMariaDB then "unix_socket" else "auth_socket"
               };"
                 echo "GRANT ALL PRIVILEGES ON *.* TO '${cfg.user}'@'localhost' WITH GRANT OPTION;"
-              ) | ${cfg.package}/bin/mysql -u ${superUser} -N
+              ) | ${lib.getExe' cfg.package binaryPrefix} -u ${superUser} -N
 
               ${lib.concatMapStrings (database: ''
                 # Create initial databases
@@ -639,7 +644,7 @@ in
                             cat ${database.schema}/mysql-databases/*.sql
                         fi
                       ''}
-                    ) | ${cfg.package}/bin/mysql -u ${superUser} -N
+                    ) | ${lib.getExe' cfg.package binaryPrefix} -u ${superUser} -N
                 fi
               '') cfg.initialDatabases}
 
@@ -650,7 +655,7 @@ in
                   echo "CREATE USER '${cfg.replication.masterUser}'@'${cfg.replication.slaveHost}' IDENTIFIED WITH mysql_native_password;"
                   echo "SET PASSWORD FOR '${cfg.replication.masterUser}'@'${cfg.replication.slaveHost}' = PASSWORD('${cfg.replication.masterPassword}');"
                   echo "GRANT REPLICATION SLAVE ON *.* TO '${cfg.replication.masterUser}'@'${cfg.replication.slaveHost}';"
-                ) | ${cfg.package}/bin/mysql -u ${superUser} -N
+                ) | ${lib.getExe' cfg.package binaryPrefix} -u ${superUser} -N
               ''}
 
               ${lib.optionalString (cfg.replication.role == "slave") ''
@@ -659,19 +664,19 @@ in
                 ( echo "STOP SLAVE;"
                   echo "CHANGE MASTER TO MASTER_HOST='${cfg.replication.masterHost}', MASTER_USER='${cfg.replication.masterUser}', MASTER_PASSWORD='${cfg.replication.masterPassword}';"
                   echo "START SLAVE;"
-                ) | ${cfg.package}/bin/mysql -u ${superUser} -N
+                ) | ${lib.getExe' cfg.package binaryPrefix} -u ${superUser} -N
               ''}
 
               ${lib.optionalString (cfg.initialScript != null) ''
                 # Execute initial script
                 # using toString to avoid copying the file to nix store if given as path instead of string,
                 # as it might contain credentials
-                cat ${toString cfg.initialScript} | ${cfg.package}/bin/mysql -u ${superUser} -N
+                cat ${toString cfg.initialScript} | ${lib.getExe' cfg.package binaryPrefix} -u ${superUser} -N
               ''}
 
               # Secure root@localhost for MySQL/Percona on first initialization
               ${lib.optionalString (cfg.secureSuperUserByDefault && !isMariaDB) ''
-                echo "ALTER USER root@localhost IDENTIFIED WITH auth_socket;" | ${cfg.package}/bin/mysql -u ${superUser} -N
+                echo "ALTER USER root@localhost IDENTIFIED WITH auth_socket;" | ${lib.getExe' cfg.package binaryPrefix} -u ${superUser} -N
               ''}
 
               rm ${cfg.dataDir}/mysql_init
@@ -681,14 +686,14 @@ in
             # We try to detect if we are in the default insecure auth mode for MySQL (all users can connect with password)
             # If the configuration has been moved to the socket-peer credential authentication we do nothing
             # If we are not able to connect it also means the default setup has been adjusted, so we also skip and do not do any changes
-            if plugin_info=$(${cfg.package}/bin/mysql -u ${superUser} --skip-column-names 2>/dev/null -e "SELECT plugin FROM mysql.user WHERE user = 'root' AND host = 'localhost';"); then
+            if plugin_info=$(${lib.getExe' cfg.package binaryPrefix} -u ${superUser} --skip-column-names 2>/dev/null -e "SELECT plugin FROM mysql.user WHERE user = 'root' AND host = 'localhost';"); then
               case "$plugin_info" in
                 *auth_socket*) ;;
                 *)
                   ${lib.optionalString isStateVersion2611Plus ''
                     # Attempt to auto-fix to prevent local authentication without a password
                     echo "Securing root@localhost with auth_socket to local connection without password, see https://github.com/NixOS/nixpkgs/security/advisories/GHSA-6qxx-6rg8-c4p8" >&2
-                    echo "ALTER USER root@localhost IDENTIFIED WITH auth_socket;" | ${cfg.package}/bin/mysql -u ${superUser} -N
+                    echo "ALTER USER root@localhost IDENTIFIED WITH auth_socket;" | ${lib.getExe' cfg.package binaryPrefix} -u ${superUser} -N
                   ''}
                   ${lib.optionalString (!isStateVersion2611Plus) ''
                     echo "Security warning: root@localhost seems to have open authentication, consider adjusting your configuration. See https://github.com/NixOS/nixpkgs/security/advisories/GHSA-6qxx-6rg8-c4p8" >&2
@@ -703,7 +708,7 @@ in
             ${lib.concatMapStrings (database: ''
               echo "CREATE DATABASE IF NOT EXISTS \`${database}\`;"
             '') cfg.ensureDatabases}
-            ) | ${cfg.package}/bin/mysql -N
+            ) | ${lib.getExe' cfg.package binaryPrefix} -N
           ''}
 
           ${lib.concatMapStrings (user: ''
@@ -715,7 +720,7 @@ in
                   echo "GRANT ${permission} ON ${database} TO '${user.name}'@'localhost';"
                 '') user.ensurePermissions
               )}
-            ) | ${cfg.package}/bin/mysql -N
+            ) | ${lib.getExe' cfg.package binaryPrefix} -N
           '') cfg.ensureUsers}
         '';
 


### PR DESCRIPTION
Since MariaDB 11.0, the mysql* binaries have been [deprecated](https://mariadb.com/docs/release-notes/community-server/old-releases/release-notes-mariadb-11-0-series/mariadb-11-0-0-release-notes#removing-deprecating-old-code), and now they emit a warning whenever they're called: `Deprecated program name. It will be removed in a future release, use `. This PR updates the binaries called to MariaDB equivalents whenever possible.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
