### PR TITLE
nixos/tailscale: fix tailscale up when using extraSetFlags

### DIFF
--- a/nixos/modules/services/networking/tailscale.nix
+++ b/nixos/modules/services/networking/tailscale.nix
@@ -213,7 +213,7 @@ in
             if [[ "$state" != "$lastState" ]]; then
               # https://github.com/tailscale/tailscale/blob/v1.72.1/ipn/backend.go#L24-L32
               case "$state" in
-                NeedsLogin|NeedsMachineAuth|Stopped)
+                NeedsLogin)
                   echo "Server needs authentication, sending auth key"
                   tailscale up --auth-key "$(cat ${cfg.authKeyFile})${params}" ${escapeShellArgs cfg.extraUpFlags}
                   ;;
@@ -221,6 +221,9 @@ in
                   echo "Tailscale is running"
                   systemd-notify --ready
                   exit 0
+                  ;;
+                Stopped)
+                  tailscale up
                   ;;
                 *)
                   echo "Waiting for Tailscale State = Running or systemd timeout"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
# Changes

1. Run `tailscale up` with `--auth-key` only when the machine needs to login to the tailnet (state = `NeedsLogin`). After the initial `tailscale up` with the key, the machine remains authorized until the key expires or is removed; the key should not be passed again until it `NeedsLogin`.

1. If the state is `Stopped`, only run `tailscale up`; `tailscale down` is the opposite and puts the state in `Stopped`.

1. Remove handling for `NeedsMachineAuth` (again). This state requires manual approval for a machine to join the admin console and will match the catch-all `*)`, waiting for approval until timeout.

## History:
This change addresses requested changes in https://github.com/NixOS/nixpkgs/pull/409924/files/ffca56ed9c97ef98d65f4d56b5b60b999097834b that resolve an issue as explained in https://github.com/NixOS/nixpkgs/pull/409924#issuecomment-3091922397

The `tailscale up --help` command states:

> With no flags, "tailscale up" brings the network online without
changing any settings. (That is, it's the opposite of "tailscale
down").

> **If flags are specified, the flags must be the complete set of desired
settings. An error is returned if any setting would be changed as a
result of an unspecified flag's default value** unless the --reset flag
is also used. (The flags --auth-key, --force-reauth, and --qr are not
considered settings that need to be re-specified when modifying
settings.)

When the state is simply in `Stopped`, an error occurs when running tailscale up with `--auth-key` and `extraUpFlags` if [services.tailscale.extraSetFlags](https://search.nixos.org/options?channel=unstable&show=services.tailscale.extraSetFlags&query=tailscale) are used while tailscale is in the `Stopped` state and any setting would be changed as a result of an unspecified flag's default value.

/cc @SuperSandro2000 @DerRockWolf 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
