### PR TITLE
linuxPackages.rtl8189fs: 2025-05-04 -> 2025-09-26

### DIFF
--- a/pkgs/os-specific/linux/rtl8189fs/default.nix
+++ b/pkgs/os-specific/linux/rtl8189fs/default.nix
@@ -17,11 +17,11 @@ rtl8189es.overrideAttrs (drv: rec {
     hash = "sha256-3v40I09TDGWdpllS3WfshPkXbT5Q2pWMTalHLUlU3lU=";
   };
 
-  meta = with lib; {
+  meta = {
     description = "Driver for Realtek rtl8189fs";
     homepage = "https://github.com/jwrdegoede/rtl8189ES_linux/tree/rtl8189fs";
-    license = licenses.gpl2Only;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ puffnfresh ];
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ puffnfresh ];
   };
 })

--- a/pkgs/os-specific/linux/rtl8189fs/default.nix
+++ b/pkgs/os-specific/linux/rtl8189fs/default.nix
@@ -8,13 +8,13 @@
 # rtl8189fs is a branch of the rtl8189es driver
 rtl8189es.overrideAttrs (drv: rec {
   name = "rtl8189fs-${kernel.version}-${version}";
-  version = "2025-05-04";
+  version = "2025-09-26";
 
   src = fetchFromGitHub {
     owner = "jwrdegoede";
     repo = "rtl8189ES_linux";
-    rev = "06e89edce6817616d963414825dccf87094a7e54";
-    sha256 = "sha256-W+gBpK17PmF8BdmBoUHPX7hZoSNOyGe3W1NypR8bc6A=";
+    rev = "876e627a5b6a8021700391b4249a4a31edfebe5c";
+    hash = "sha256-3v40I09TDGWdpllS3WfshPkXbT5Q2pWMTalHLUlU3lU=";
   };
 
   meta = with lib; {


### PR DESCRIPTION
### `linuxPackages.rtl8189fs`: 2025-05-04 -> 2025-09-26

- This driver is failing to build on [Hydra](https://hydra.nixos.org/eval/1820137?filter=rtl8189fs&compare=1820130&full=).
- This update adds support to the driver for Linux kernel versions `6.16.y` and `6.17.y`, [Diff](https://github.com/jwrdegoede/rtl8189ES_linux/compare/06e89edce6817616d963414825dccf87094a7e54%E2%80%A6876e627a5b6a8021700391b4249a4a31edfebe5c).

**Tracking:** https://github.com/NixOS/nixpkgs/issues/457852
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
