### PR TITLE
wildergarden-maim: init at 0-unstable-2025-12-17

### DIFF
--- a/pkgs/by-name/wi/wildergarden-maim/package.nix
+++ b/pkgs/by-name/wi/wildergarden-maim/package.nix
@@ -1,0 +1,130 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  cmake,
+  ninja,
+  pkg-config,
+  libx11,
+  libxrandr,
+  libxinerama,
+  libxext,
+  libxcursor,
+  freetype,
+  fontconfig,
+  alsa-lib,
+
+  buildStandalone ? true,
+  buildVST3 ? true,
+}:
+
+let
+  pluginFormats = [
+    (lib.optionalString buildStandalone "Standalone")
+    (lib.optionalString buildVST3 "VST3")
+  ];
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  name = "wildergarden-maim";
+  version = "1.1.1-unstable-2025-12-17";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "ArdenButterfield";
+    repo = "Maim";
+    rev = "181fe240ff99b446858f054074f8241401304e84";
+    hash = "sha256-Ht8Mj8nViXyQm/uHabSxYG1RuJj60MEsCJmISSrn6x0=";
+    fetchSubmodules = true;
+  };
+
+  preConfigure = ''
+    pushd lib/lame
+      ./configure --disable-frontend --enable-expopt=full --disable-shared --enable-static
+      make -j$NIX_BUILD_CORES
+    popd
+  '';
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "set(FORMATS Standalone AU VST3 AUv3)" "set(FORMATS ${lib.concatStringsSep " " pluginFormats})"
+
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "COPY_PLUGIN_AFTER_BUILD TRUE" "COPY_PLUGIN_AFTER_BUILD FALSE"
+
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "include(Tests)" "# No tests" \
+      --replace-fail "include(Benchmarks)" "# No benchmarks"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    fontconfig
+    freetype
+    libx11
+    libxcursor
+    libxext
+    libxinerama
+    libxrandr
+    alsa-lib
+  ];
+
+  # Needed for standalone
+  NIX_LDFLAGS = "-lX11";
+
+  cmakeFlags = [
+    (lib.cmakeFeature "LAME_LIB" "lib/lame/libmp3lame/.libs/libmp3lame.a")
+  ];
+
+  env.NIX_CFLAGS_COMPILE = toString [
+    # juce, compiled in this build as part of a Git submodule, uses `-flto` as
+    # a Link Time Optimization flag, and instructs the plugin compiled here to
+    # use this flag to. This breaks the build for us. Using _fat_ LTO allows
+    # successful linking while still providing LTO benefits. If our build of
+    # `juce` was used as a dependency, we could have patched that `-flto` line
+    # in our juce's source, but that is not possible because it is used as a
+    # Git Submodule.
+    "-ffat-lto-objects"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    pushd Maim_artefacts/Release
+      ${lib.optionalString buildStandalone ''
+        mkdir -p $out/bin
+        install -Dm755 -t $out/bin Standalone/Maim
+      ''}
+
+      ${lib.optionalString buildVST3 ''
+        mkdir -p $out/lib/vst3
+        cp -r VST3/Maim.vst3 $out/lib/vst3/
+      ''}
+    popd
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  meta = {
+    description = "Audio plugin for custom MP3 distortion and digital glitches";
+    homepage = "https://github.com/ArdenButterfield/Maim";
+    platforms = lib.platforms.linux;
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ lib.maintainers.mrtnvgr ];
+  }
+  // lib.optionalAttrs buildStandalone {
+    mainProgram = "Maim";
+  };
+})


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
