### PR TITLE
auburn-sounds-lens: init at 1.3.1

### DIFF
--- a/pkgs/by-name/au/auburn-sounds-lens/package.nix
+++ b/pkgs/by-name/au/auburn-sounds-lens/package.nix
@@ -1,0 +1,55 @@
+{
+  stdenvNoCC,
+  lib,
+  fetchzip,
+  autoPatchelfHook,
+  libX11,
+  libgcc,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  name = "auburn-sounds-lens";
+  version = "1.3.1";
+
+  src = fetchzip {
+    url = "https://www.auburnsounds.com/downloads/Lens-FREE-${finalAttrs.version}.zip";
+    hash = "sha256-Ozu+9wrDK2S0A2HrW1R/Zt6USGG9qXu0xSc/Xu8OnHs=";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  buildInputs = [
+    libX11
+    libgcc
+  ];
+
+  installPhase =
+    let
+      mkInstaller = format: ''
+        mkdir -p $out/lib/${format}
+        cp -r "Linux-64b-${lib.toUpper format}-FREE/Auburn Sounds Lens.${format}" $out/lib/${format}
+      '';
+      mkInstallers = formats: lib.concatStringsSep "\n" (map mkInstaller formats);
+    in
+    ''
+      runHook preInstall
+
+      pushd Linux
+        ${mkInstallers [
+          "clap"
+          "lv2"
+          "vst3"
+        ]}
+      popd
+
+      runHook postInstall
+    '';
+
+  meta = {
+    description = "Spectral dynamics processor with unbelievable punch and clarity";
+    homepage = "https://www.auburnsounds.com/products/Lens.html";
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    platforms = [ "x86_64-linux" ];
+    license = lib.licenses.unfree;
+    maintainers = [ lib.maintainers.mrtnvgr ];
+  };
+})


### PR DESCRIPTION
This plugin is paid, but has a free version which works fine without any license, "time bombing" or random audio cuts.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
