### PR TITLE
libcue-lang: init at 0-unstable-2025-11-12

### DIFF
--- a/pkgs/by-name/li/libcue-lang/package.nix
+++ b/pkgs/by-name/li/libcue-lang/package.nix
@@ -1,0 +1,62 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+  stdenv,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "libcue-lang";
+  version = "0-unstable-2025-11-12";
+
+  src = fetchFromGitHub {
+    owner = "cue-lang";
+    repo = "libcue";
+    rev = "3dea836f38b69a36d1e87752c4bfa7e78d99fc04";
+    hash = "sha256-ARWPFxM17pqfAuspNPR9wZSq+hcnTFuGlN+jm07sX/M=";
+  };
+
+  vendorHash = "sha256-iZhICV5FpkJyHl42gP0rPrxobHKFId54sVVES7JZR9E=";
+
+  env.CGO_ENABLED = "1";
+
+  buildPhase = ''
+    runHook preBuild
+
+    go build -buildmode=c-shared -o libcue${stdenv.hostPlatform.extensions.sharedLibrary} -v .
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 libcue.h  $out/include/libcue.h
+    install -Dm644 cue.h     $out/include/cue.h
+    install -Dm644 libcue.so $out/lib/libcue.so
+
+    # Create pkgconfig
+    mkdir -p $out/lib/pkgconfig
+    cat > $out/lib/pkgconfig/libcue.pc <<EOF
+    prefix=${placeholder "out"}
+    libdir=''${prefix}/lib
+    includedir=''${prefix}/include
+
+    Name: libcue
+    Description: ${finalAttrs.meta.description}
+    Version: ${finalAttrs.version}
+    Libs: -L\''${libdir} -lcue
+    Cflags: -I\''${includedir}
+    EOF
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Use CUE from C and C-like languages";
+    homepage = "https://cuelang.org/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ nobbz ];
+    platforms = with lib.platforms; linux ++ darwin;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

C bindings to cuelang

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
