### PR TITLE
gcc15: fix build on aarch64-darwin

### DIFF
--- a/pkgs/development/compilers/gcc/patches/15/libgcc-darwin-detection.patch
+++ b/pkgs/development/compilers/gcc/patches/15/libgcc-darwin-detection.patch
@@ -1,11 +1,12 @@
 --- a/libgcc/config.host
 +++ b/libgcc/config.host
-@@ -239,7 +239,7 @@ case ${host} in
+@@ -239,8 +239,8 @@ case ${host} in
      x86_64-*-darwin2[0-2]*)
        tmake_file="t-darwin-min-11 t-darwin-libgccs1 $tmake_file"
        ;;
 -    *-*-darwin2*)
+-      tmake_file="t-darwin-min-11 $tmake_file"
 +    *-*-darwin2* | *-*-darwin)
-       tmake_file="t-darwin-min-11 $tmake_file"
++      tmake_file="t-darwin-min-11 t-darwin-libgccs1 $tmake_file"
        ;;
      *-*-darwin1[89]*)

--- a/pkgs/development/compilers/gcc/patches/15/libgcc-darwin-fix-reexport.patch
+++ b/pkgs/development/compilers/gcc/patches/15/libgcc-darwin-fix-reexport.patch
@@ -1,0 +1,11 @@
+--- a/libgcc/config/t-slibgcc-darwin
++++ b/libgcc/config/t-slibgcc-darwin
+@@ -139,8 +139,7 @@ libgcc_s.1.dylib: all-multi libgcc_s.$(SHLIB_SOVERSION)$(SHLIB_EXT)
+ 	  $(CC) -arch $${arch} -nodefaultlibs -dynamiclib -nodefaultrpaths \
+ 	    -o libgcc_s.1$(SHLIB_EXT)_T_$${mlib} \
+ 	    -Wl,-reexport_library,libgcc_s.$(SHLIB_SOVERSION)$(SHLIB_EXT)_T_$${mlib} \
+ 	    -lSystem \
+-	    -Wl,-reexported_symbols_list,$(srcdir)/config/darwin-unwind.ver \
+ 	    -install_name $(SHLIB_RPATH)/libgcc_s.1.dylib \
+ 	    -compatibility_version 1 -current_version 1.1 ; \
+ 	done

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -160,13 +160,14 @@ optionals noSysDirs (
 
 ## Darwin
 
-# Fixes detection of Darwin on x86_64-darwin. Otherwise, GCC uses a deployment target of 10.5, which crashes ld64.
+# Fixes detection of Darwin on x86_64-darwin and aarch64-darwin. Otherwise, GCC uses a deployment target of 10.5, which crashes ld64.
+++ optional (is14 && stdenv.hostPlatform.isDarwin) ../patches/14/libgcc-darwin-detection.patch
+++ optional (atLeast15 && stdenv.hostPlatform.isDarwin) ../patches/15/libgcc-darwin-detection.patch
+
+# Fix libgcc_s.1.dylib build on Darwin 11+ by not reexporting unwind symbols that don't exist
 ++ optional (
-  is14 && stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64
-) ../patches/14/libgcc-darwin-detection.patch
-++ optional (
-  atLeast15 && stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64
-) ../patches/15/libgcc-darwin-detection.patch
+  atLeast15 && stdenv.hostPlatform.isDarwin
+) ../patches/15/libgcc-darwin-fix-reexport.patch
 
 # Fix detection of bootstrap compiler Ada support (cctools as) on Nix Darwin
 ++ optional (stdenv.hostPlatform.isDarwin && langAda) ./ada-cctools-as-detection-configure.patch


### PR DESCRIPTION
This fixes the GCC 15.2.0 build on aarch64-darwin by addressing two issues in the libgcc build process:

1. Update libgcc-darwin-detection.patch:
- Catch arm64-apple-darwin (which lacks a version number)
- Add t-darwin-libgccs1 to enable libgcc_s.1.dylib compatibility build

2. Added libgcc-darwin-fix-reexport.patch:
- Remove reexport of darwin-unwind.ver symbols in libgcc_s.1.dylib
- These symbols (___register_frame_info, etc.) don't exist in libgcc on modern macOS as they come from libSystem

The original build failed with:

```
  Undefined symbols for architecture arm64: "___deregister_frame_info", referenced from: -reexported_symbols_list command line option ...
```

This occurred because darwin-unwind.ver lists unwinder symbols that are excluded from libgcc (via libgcc-libsystem.ver) on macOS 11+ where they are provided by the system's libSystem.

ZHF: #457852


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
