### PR TITLE
lambda-delta: fix build with modern GCC

### DIFF
--- a/pkgs/by-name/la/lambda-delta/fix-implicit-int.patch
+++ b/pkgs/by-name/la/lambda-delta/fix-implicit-int.patch
@@ -1,0 +1,25 @@
+diff --git a/src/lpart.c b/src/lpart.c
+index 1234567..abcdefg 100644
+--- a/src/lpart.c
++++ b/src/lpart.c
+@@ -485,7 +485,7 @@ dump_part(char *partition)
+ 	return 0;
+ }
+
+-main(int argc, char *argv[])
++int main(int argc, char *argv[])
+ {
+ 	char *partition;
+ 	int ret;
+diff --git a/tools/decode_lmfl.c b/tools/decode_lmfl.c
+index 1234567..abcdefg 100644
+--- a/tools/decode_lmfl.c
++++ b/tools/decode_lmfl.c
+@@ -33,6 +33,7 @@
+ #include <string.h>
+ #include <errno.h>
+ #include <sys/stat.h>
++#include <ctype.h>
+
+ /* Globals */
+ FILE *ifile;

--- a/pkgs/by-name/la/lambda-delta/package.nix
+++ b/pkgs/by-name/la/lambda-delta/package.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation rec {
     sha256 = "02m43fj9dzc1i1jl01qwnhjiq1rh03jw1xq59sx2h3bhn7dk941x";
   };
 
+  patches = [ ./fix-implicit-int.patch ];
+
   nativeBuildInputs = [
     autoreconfHook
     pkg-config


### PR DESCRIPTION
- Add explicit int return type to main() in lpart.c
- Include <ctype.h> in decode_lmfl.c for tolower()

ZHF: #457852

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
