### PR TITLE
python313Packages.tables: switch to pyproject build system

### DIFF
--- a/pkgs/development/python-modules/tables/default.nix
+++ b/pkgs/development/python-modules/tables/default.nix
@@ -14,6 +14,7 @@
   numpy,
   numexpr,
   packaging,
+  pkg-config,
   setuptools,
   sphinx,
   typing-extensions,
@@ -26,7 +27,7 @@
 buildPythonPackage rec {
   pname = "tables";
   version = "3.10.2";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.8";
 
@@ -49,6 +50,10 @@ buildPythonPackage rec {
     cython
     setuptools
     sphinx
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
   ];
 
   buildInputs = [
@@ -77,17 +82,21 @@ buildPythonPackage rec {
     substituteInPlace tables/__init__.py \
       --replace-fail 'find_library("blosc2")' '"${lib.getLib c-blosc}/lib/libblosc${stdenv.hostPlatform.extensions.sharedLibrary}"'  '';
 
+  env = {
+    HDF5_DIR = lib.getDev hdf5;
+  };
+
   # Regenerate C code with Cython
   preBuild = ''
     make distclean
   '';
 
-  setupPyBuildFlags = [
-    "--hdf5=${lib.getDev hdf5}"
-    "--lzo=${lib.getDev lzo}"
-    "--bzip2=${lib.getDev bzip2}"
-    "--blosc=${lib.getDev c-blosc}"
-    "--blosc2=${lib.getDev blosc2.c-blosc2}"
+  pypaBuildFlags = [
+    "--config-setting=--build-option=--hdf5=${lib.getDev hdf5}"
+    "--config-setting=--build-option=--lzo=${lib.getDev lzo}"
+    "--config-setting=--build-option=--bzip2=${lib.getDev bzip2}"
+    "--config-setting=--build-option=--blosc=${lib.getDev c-blosc}"
+    "--config-setting=--build-option=--blosc2=${lib.getDev blosc2.c-blosc2}"
   ];
 
   nativeCheckInputs = [ pytest ];


### PR DESCRIPTION
Convert from setuptools format to pyproject to enable proper Python 3.13 support. The package was using build-system but format = "setuptools", which caused build failures.

Changes:
- Switch from format = "setuptools" to pyproject = true
- Replace setupPyBuildFlags with pypaBuildFlags using --config-setting
- Add pkg-config to nativeBuildInputs for dependency detection
- Set HDF5_DIR environment variable to help locate HDF5 headers
- All 6851 tests pass successfully


ZHF: #457852

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
