### PR TITLE
eduvpn-client: 4.5.1 -> 4.6.0

### DIFF
--- a/pkgs/by-name/ed/eduvpn-client/package.nix
+++ b/pkgs/by-name/ed/eduvpn-client/package.nix
@@ -13,7 +13,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "eduvpn-client";
-  version = "4.5.1";
+  version = "4.6.0";
   format = "pyproject";
 
   src = fetchFromGitea {
@@ -21,7 +21,7 @@ python3Packages.buildPythonApplication rec {
     owner = "eduVPN";
     repo = "linux-app";
     rev = version;
-    hash = "sha256-lDmPDM3BEiZ97m8jEtYrpmVrk0D7x01iKxOe/09T0zY=";
+    hash = "sha256-oI/hc1XAddXGtwaLY6+zFoshs82lDTRESF4+xUmi+jc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/libeduvpn-common/package.nix
+++ b/pkgs/by-name/li/libeduvpn-common/package.nix
@@ -6,11 +6,11 @@
 
 buildGoModule rec {
   pname = "libeduvpn-common";
-  version = "3.0.0";
+  version = "4.0.0";
 
   src = fetchurl {
     url = "https://codeberg.org/eduVPN/eduvpn-common/releases/download/${version}/eduvpn-common-${version}.tar.xz";
-    hash = "sha256-aQpOoY3rDF9DeQ/8tRYdBs4s2IdwAe62y9KfXPMsb4k=";
+    hash = "sha256-pMxcHiX6Ct6QpU13JnoEyqt7bd58dmOxoncIp6PDvgo=";
   };
 
   vendorHash = null;
@@ -28,9 +28,9 @@ buildGoModule rec {
   '';
 
   meta = {
-    changelog = "https://raw.githubusercontent.com/eduvpn/eduvpn-common/${version}/CHANGES.md";
+    changelog = "https://codeberg.org/eduVPN/eduvpn-common/raw/tag/${version}/CHANGES.md";
     description = "Code to be shared between eduVPN clients";
-    homepage = "https://github.com/eduvpn/eduvpn-common";
+    homepage = "https://codeberg.org/eduVPN/eduvpn-common";
     maintainers = with lib.maintainers; [
       benneti
       jwijenbergh


### PR DESCRIPTION
This PR updates `eduvpn-client` to the latest upstream release. The current version in nixpkgs fails to build due to a version mismatch in one of its Python dependencies. Updating resolves the build error.

Since the new `eduvpn-client` requires `eduvpn-common` ≥ 4.0.0, this PR also bumps `eduvpn-common` accordingly.

Closes #459737

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
