### PR TITLE
opensearch: 2.19.2 -> 3.5.0

### DIFF
--- a/nixos/modules/services/search/opensearch.nix
+++ b/nixos/modules/services/search/opensearch.nix
@@ -210,6 +210,7 @@ in
               ln -sfT "${cfg.package}/plugins" "${cfg.dataDir}/plugins"
               ln -sfT ${cfg.package}/lib ${cfg.dataDir}/lib
               ln -sfT ${cfg.package}/modules ${cfg.dataDir}/modules
+              ln -sfT ${cfg.package}/agent ${cfg.dataDir}/agent
 
               # opensearch needs to create the opensearch.keystore in the config directory
               # so this directory needs to be writable.

--- a/pkgs/by-name/op/opensearch/package.nix
+++ b/pkgs/by-name/op/opensearch/package.nix
@@ -12,11 +12,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "opensearch";
-  version = "2.19.2";
+  version = "3.5.0";
 
   src = fetchurl {
     url = "https://artifacts.opensearch.org/releases/bundle/opensearch/${finalAttrs.version}/opensearch-${finalAttrs.version}-linux-x64.tar.gz";
-    hash = "sha256-EaOx8vs3y00ln7rUiaCGoD+HhiQY4bhQAzu18VfaTYw=";
+    hash = "sha256-0d6TQU1LTE983CsYbaK4fNuC86VAx23XD2xR6y2NuHw=";
   };
 
   nativeBuildInputs = [
@@ -31,7 +31,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook preInstall
 
     mkdir -p $out
-    cp -R bin config lib modules plugins $out
+    cp -R bin config lib modules plugins agent $out
 
     substituteInPlace $out/bin/opensearch \
       --replace 'bin/opensearch-keystore' "$out/bin/opensearch-keystore"


### PR DESCRIPTION
Release Notes:
https://github.com/opensearch-project/opensearch-build/blob/main/release-notes/opensearch-release-notes-3.5.0.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update Opensearch to version 3.5.0. This PR supersedes https://github.com/NixOS/nixpkgs/pull/405763 since one of the jars that is required during runtime has been moved to a different folder (agent/).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of ~~all~~ previously functional binary files, usually in `./result/bin/`. [^1]
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[^1]: A bunch of the scripts in the bin/ folder do not work since they rely on a bundled script called opensearch-cli which has been removed in https://github.com/NixOS/nixpkgs/pull/277065. It appears that the script that is bundled with the `opensearch` package is different from the separately packaged `pkgs.opensearch-cli`, see https://github.com/NixOS/nixpkgs/issues/319323 and https://github.com/NixOS/nixpkgs/issues/237057#issuecomment-2330682138. The bundled version is required for scripts in the `opensearch` package such as `opensearch-plugin`, `opensearch-node` and `opensearch-shard`.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
