### PR TITLE
python3Packages.warp-lang: unbreak on darwin

### DIFF
--- a/pkgs/development/python-modules/warp-lang/darwin-libcxx.patch
+++ b/pkgs/development/python-modules/warp-lang/darwin-libcxx.patch
@@ -2,14 +2,6 @@ diff --git a/warp/build_dll.py b/warp/build_dll.py
 index 2218ff13..53786017 100644
 --- a/warp/build_dll.py
 +++ b/warp/build_dll.py
-@@ -408,6 +408,7 @@ def build_dll_for_arch(args, dll_path, cpp_paths, cu_path, arch, libs: Optional[
-         cpp_includes += f' -I"{warp_home_path.parent}/_build/host-deps/llvm-project/release-{arch}/include"'
-         cuda_includes = f' -I"{cuda_home}/include"' if cu_path else ""
-         includes = cpp_includes + cuda_includes
-+        includes += " -isystem @LIBCXX_DEV@/include/c++/v1"
- 
-         if sys.platform == "darwin":
-             version = f"--target={arch}-apple-macos11"
 @@ -441,6 +442,7 @@ def build_dll_for_arch(args, dll_path, cpp_paths, cu_path, arch, libs: Optional[
                  build_cmd = f'{cpp_compiler} {cpp_flags} -c "{cpp_path}" -o "{cpp_out}"'
                  run_cmd(build_cmd)

--- a/pkgs/development/python-modules/warp-lang/default.nix
+++ b/pkgs/development/python-modules/warp-lang/default.nix
@@ -67,7 +67,6 @@ buildPythonPackage {
   ]
   ++ lib.optionals effectiveStdenv.hostPlatform.isDarwin [
     (replaceVars ./darwin-libcxx.patch {
-      LIBCXX_DEV = llvmPackages.libcxx.dev;
       LIBCXX_LIB = llvmPackages.libcxx;
     })
 

--- a/pkgs/development/python-modules/warp-lang/default.nix
+++ b/pkgs/development/python-modules/warp-lang/default.nix
@@ -223,22 +223,24 @@ buildPythonPackage {
     inherit libmathdx;
 
     # Scripts which provide test packages and implement test logic.
-    testers.unit-tests = writeShellApplication {
-      name = "warp-lang-unit-tests";
-      runtimeInputs = [
+    testers.unit-tests =
+      let
         # Use the references from args
-        (python.withPackages (_: [
+        python' = python.withPackages (_: [
           warp-lang
           jax
           torch
-        ]))
+        ]);
         # Disable paddlepaddle interop tests: malloc(): unaligned tcache chunk detected
         #  (paddlepaddle.override { inherit cudaSupport; })
-      ];
-      text = ''
-        python3 -m warp.tests
-      '';
-    };
+      in
+      writeShellApplication {
+        name = "warp-lang-unit-tests";
+        runtimeInputs = [ python' ];
+        text = ''
+          ${python'}/bin/python3 -m warp.tests
+        '';
+      };
 
     # Tests run within the Nix sandbox.
     tests =


### PR DESCRIPTION
This is a fix for `python3Packages.warp-lang` on darwin. We actually had a fix for this package in #456471 earlier this cycle, but I’m not sure why it’s broken again on my `aarch64-darwin` machine :sweat_smile:

I noticed that version `1.10.0` has been released, but I’m waiting for the branch-off. Version `1.10.0` isn’t suitable for `25.11` since it includes several breaking changes, such as dropping support for `x86_64-darwin` and removing the `warp.sim` module.

ZHF: #457852

**Update**: I suspect this might be caused by #447364.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
