### PR TITLE
nixos/onlyoffice: allow specifying a nonce

### DIFF
--- a/nixos/modules/services/web-apps/onlyoffice.nix
+++ b/nixos/modules/services/web-apps/onlyoffice.nix
@@ -7,6 +7,10 @@
 
 let
   cfg = config.services.onlyoffice;
+  defaultNginxNonceFileContent = "set $secure_link_secret \"mynonce\";";
+  defaultNginxNonceFile = pkgs.writeText "onlyoffice-nonce-nginx.conf" ''
+    ${defaultNginxNonceFileContent}
+  '';
 in
 {
   options.services.onlyoffice = {
@@ -18,6 +22,22 @@ in
       type = lib.types.str;
       default = "localhost";
       description = "FQDN for the OnlyOffice instance.";
+    };
+
+    securityNonceFile = lib.mkOption {
+      type = lib.types.str;
+      default = "${defaultNginxNonceFile}";
+      defaultText = lib.literalExpression ''
+        (pkgs.writeText "onlyoffice-nonce-nginx.conf" \'\'
+          ${defaultNginxNonceFileContent}
+        \'\').outPath;
+      '';
+      description = ''
+        Path to a file that contains a secret to sign web requests.
+        This file should set a 'secure_link_secret' nginx variable,
+        and ideally be managed by a
+        [secret managing scheme](https://wiki.nixos.org/wiki/Comparison_of_secret_managing_schemes).
+      '';
     };
 
     jwtSecretFile = lib.mkOption {
@@ -83,6 +103,12 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    warnings = [
+      (lib.optionalString (cfg.securityNonceFile == "${defaultNginxNonceFile}") ''
+        Please set `options.services.onlyoffice.securityNonceFile`
+        to avoid an (albeit unlikely) information disclosure issue.
+      '')
+    ];
     services = {
       nginx = {
         enable = lib.mkDefault true;
@@ -147,7 +173,7 @@ in
               alias /var/lib/onlyoffice/documentserver/App_Data$1;
               more_set_headers "Content-Disposition: attachment; filename*=UTF-8''$arg_filename";
 
-              set $secure_link_secret verysecretstring;
+              include ${cfg.securityNonceFile};
               secure_link $arg_md5,$arg_expires;
               secure_link_md5 "$secure_link_expires$uri$secure_link_secret";
 
@@ -279,7 +305,9 @@ in
 
             # for a mapping of environment variables from the docker container to json options see
             # https://github.com/ONLYOFFICE/Docker-DocumentServer/blob/master/run-document-server.sh
+            FS_SECRET_STRING=$(cut -d '"' -f 2 < ${cfg.securityNonceFile})
             jq '
+              .storage.fs.secretString = "'$FS_SECRET_STRING'" |
               .services.CoAuthoring.server.port = ${toString cfg.port} |
               .services.CoAuthoring.sql.dbHost = "${cfg.postgresHost}" |
               .services.CoAuthoring.sql.dbName = "${cfg.postgresName}" |


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
