### PR TITLE
apache-orc: 2.1.2 -> 2.2.1, arrow-cpp: 20.0.0 -> 22.0.0

### DIFF
--- a/pkgs/by-name/ap/apache-orc/package.nix
+++ b/pkgs/by-name/ap/apache-orc/package.nix
@@ -3,32 +3,37 @@
   stdenv,
   fetchFromGitHub,
   fetchurl,
-  fetchpatch,
   cmake,
   gtest,
   lz4,
-  protobuf_30,
+  protobuf,
   snappy,
   zlib,
   zstd,
 }:
 
 let
-  orc-format = fetchurl {
-    name = "orc-format-1.1.0.tar.gz";
-    url = "https://www.apache.org/dyn/closer.lua/orc/orc-format-1.1.0/orc-format-1.1.0.tar.gz?action=download";
-    hash = "sha256-1KesdsVEKr9xGeLLhOcbZ34HWv9TUYqoZgVeLq0EUNc=";
-  };
+  orc-format =
+    let
+      version = "1.1.1";
+      name = "orc-format-${version}";
+      archiveName = "${name}.tar.gz";
+    in
+    fetchurl {
+      name = archiveName;
+      url = "https://www.apache.org/dyn/closer.lua/orc/${name}/${archiveName}?action=download";
+      hash = "sha256-WE3+KkIClGF4/Y/H0SOb54BbntRZarIELe5znniAmSs=";
+    };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "apache-orc";
-  version = "2.1.2";
+  version = "2.2.1";
 
   src = fetchFromGitHub {
     owner = "apache";
     repo = "orc";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-hNKzqNOagBJOWQRebkVHIuvqfpk9Mi30bu4z7dGbsxk=";
+    hash = "sha256-H7nowl2pq31RIAmTUz15x48Wc99MljFJboc4F7Ln/zk=";
   };
 
   nativeBuildInputs = [
@@ -38,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     gtest
     lz4
-    protobuf_30
+    protobuf
     snappy
     zlib
     zstd
@@ -62,7 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
     GTEST_HOME = gtest.dev;
     LZ4_ROOT = lz4;
     ORC_FORMAT_URL = orc-format;
-    PROTOBUF_HOME = protobuf_30;
+    PROTOBUF_HOME = protobuf;
     SNAPPY_ROOT = snappy.dev;
     ZLIB_ROOT = zlib.dev;
     ZSTD_ROOT = zstd.dev;

--- a/pkgs/by-name/ar/arrow-cpp/package.nix
+++ b/pkgs/by-name/ar/arrow-cpp/package.nix
@@ -37,7 +37,7 @@
   openssl,
   perl,
   pkg-config,
-  protobuf_31,
+  protobuf,
   python3,
   rapidjson,
   re2,
@@ -66,19 +66,21 @@ let
     name = "arrow-testing";
     owner = "apache";
     repo = "arrow-testing";
-    rev = "d2a13712303498963395318a4eb42872e66aead7";
-    hash = "sha256-c8FL37kG0uo7o0Zp71WjCl7FD5BnVgqUCCXXX9gI0lg=";
+    rev = "9a02925d1ba80bd493b6d4da6e8a777588d57ac4";
+    hash = "sha256-dEFCkeQpQrU61uCwJp/XB2umbQHjXtzado36BGChoc0=";
   };
 
   parquet-testing = fetchFromGitHub {
     name = "parquet-testing";
     owner = "apache";
     repo = "parquet-testing";
-    rev = "18d17540097fca7c40be3d42c167e6bfad90763c";
-    hash = "sha256-gKEQc2RKpVp39RmuZbIeIXAwiAXDHGnLXF6VQuJtnRA=";
+    rev = "a3d96a65e11e2bbca7d22a894e8313ede90a33a3";
+    hash = "sha256-Xd6o3RT6Q0tPutV77J0P1x3F6U3RHdCBOKGUKtkQCKk=";
   };
 
-  version = "20.0.0";
+  version = "22.0.0";
+
+  # protobuf = protobuf_32;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "arrow-cpp";
@@ -88,7 +90,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "apache";
     repo = "arrow";
     rev = "apache-arrow-${version}";
-    hash = "sha256-JFPdKraCU+xRkBTAHyY4QGnBVlOjQ1P5+gq9uxyqJtk=";
+    hash = "sha256-i4Smt43oi4sddUt3qH7ePjensBSfPW+w/ExLVcVNKic=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/cpp";
@@ -107,21 +109,21 @@ stdenv.mkDerivation (finalAttrs: {
   ARROW_MIMALLOC_URL = fetchFromGitHub {
     owner = "microsoft";
     repo = "mimalloc";
-    rev = "v2.0.6";
-    hash = "sha256-u2ITXABBN/dwU+mCIbL3tN1f4c17aBuSdNTV+Adtohc=";
+    tag = "v3.1.5";
+    hash = "sha256-fk6nfyBFS1G0sJwUJVgTC1+aKd0We/JjsIYTO+IOfyg=";
   };
 
   ARROW_XSIMD_URL = fetchFromGitHub {
     owner = "xtensor-stack";
     repo = "xsimd";
-    rev = "13.0.0";
+    tag = "13.0.0";
     hash = "sha256-qElJYW5QDj3s59L3NgZj5zkhnUMzIP2mBa1sPks3/CE=";
   };
 
   ARROW_SUBSTRAIT_URL = fetchFromGitHub {
     owner = "substrait-io";
     repo = "substrait";
-    rev = "v0.44.0";
+    tag = "v0.44.0";
     hash = "sha256-V739IFTGPtbGPlxcOi8sAaYSDhNUEpITvN9IqdPReug=";
   };
 
@@ -145,7 +147,7 @@ stdenv.mkDerivation (finalAttrs: {
     libbacktrace
     lz4
     nlohmann_json # alternative JSON parser to rapidjson
-    protobuf_31 # substrait requires protobuf
+    protobuf # substrait requires protobuf
     rapidjson
     re2
     snappy
@@ -157,7 +159,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals enableFlight [
     grpc
     openssl
-    protobuf_31
+    protobuf
     sqlite
   ]
   ++ lib.optionals enableS3 [
@@ -188,55 +190,60 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   cmakeFlags = [
-    "-DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON"
-    "-DARROW_BUILD_SHARED=${if enableShared then "ON" else "OFF"}"
-    "-DARROW_BUILD_STATIC=${if enableShared then "OFF" else "ON"}"
-    "-DARROW_BUILD_TESTS=${if enableShared then "ON" else "OFF"}"
-    "-DARROW_BUILD_INTEGRATION=ON"
-    "-DARROW_BUILD_UTILITIES=ON"
-    "-DARROW_EXTRA_ERROR_CONTEXT=ON"
-    "-DARROW_VERBOSE_THIRDPARTY_BUILD=ON"
-    "-DARROW_DEPENDENCY_SOURCE=SYSTEM"
-    "-Dxsimd_SOURCE=AUTO"
-    "-DARROW_DEPENDENCY_USE_SHARED=${if enableShared then "ON" else "OFF"}"
-    "-DARROW_COMPUTE=ON"
-    "-DARROW_CSV=ON"
-    "-DARROW_DATASET=ON"
-    "-DARROW_FILESYSTEM=ON"
-    "-DARROW_FLIGHT_SQL=${if enableFlight then "ON" else "OFF"}"
-    "-DARROW_HDFS=ON"
-    "-DARROW_IPC=ON"
-    "-DARROW_JEMALLOC=${if enableJemalloc then "ON" else "OFF"}"
-    "-DARROW_JSON=ON"
-    "-DARROW_USE_GLOG=ON"
-    "-DARROW_WITH_BACKTRACE=ON"
-    "-DARROW_WITH_BROTLI=ON"
-    "-DARROW_WITH_BZ2=ON"
-    "-DARROW_WITH_LZ4=ON"
-    "-DARROW_WITH_NLOHMANN_JSON=ON"
-    "-DARROW_WITH_SNAPPY=ON"
-    "-DARROW_WITH_UTF8PROC=ON"
-    "-DARROW_WITH_ZLIB=ON"
-    "-DARROW_WITH_ZSTD=ON"
-    "-DARROW_MIMALLOC=ON"
-    "-DARROW_SUBSTRAIT=ON"
-    "-DARROW_FLIGHT=${if enableFlight then "ON" else "OFF"}"
-    "-DARROW_FLIGHT_TESTING=${if enableFlight then "ON" else "OFF"}"
-    "-DARROW_S3=${if enableS3 then "ON" else "OFF"}"
-    "-DARROW_GCS=${if enableGcs then "ON" else "OFF"}"
-    "-DARROW_ORC=ON"
+    (lib.cmakeBool "CMAKE_FIND_PACKAGE_PREFER_CONFIG" true)
+    (lib.cmakeBool "ARROW_BUILD_SHARED" enableShared)
+    (lib.cmakeBool "ARROW_BUILD_STATIC" enableShared)
+    (lib.cmakeBool "ARROW_BUILD_TESTS" enableShared)
+    (lib.cmakeBool "ARROW_BUILD_INTEGRATION" true)
+    (lib.cmakeBool "ARROW_BUILD_UTILITIES" true)
+    (lib.cmakeBool "ARROW_EXTRA_ERROR_CONTEXT" true)
+    (lib.cmakeBool "ARROW_VERBOSE_THIRDPARTY_BUILD" true)
+    (lib.cmakeFeature "ARROW_DEPENDENCY_SOURCE" "SYSTEM")
+    (lib.cmakeFeature "xsimd_SOURCE" "AUTO")
+    (lib.cmakeBool "ARROW_DEPENDENCY_USE_SHARED" enableShared)
+    (lib.cmakeBool "ARROW_COMPUTE" true)
+    (lib.cmakeBool "ARROW_CSV" true)
+    (lib.cmakeBool "ARROW_DATASET" true)
+    (lib.cmakeBool "ARROW_FILESYSTEM" true)
+    (lib.cmakeBool "ARROW_FLIGHT_SQL" enableFlight)
+    (lib.cmakeBool "ARROW_HDFS" true)
+    (lib.cmakeBool "ARROW_IPC" true)
+    (lib.cmakeBool "ARROW_JEMALLOC" enableJemalloc)
+    (lib.cmakeBool "ARROW_JSON" true)
+    (lib.cmakeBool "ARROW_USE_GLOG" true)
+    (lib.cmakeBool "ARROW_WITH_BACKTRACE" true)
+    (lib.cmakeBool "ARROW_WITH_BROTLI" true)
+    (lib.cmakeBool "ARROW_WITH_BZ2" true)
+    (lib.cmakeBool "ARROW_WITH_LZ4" true)
+    (lib.cmakeBool "ARROW_WITH_NLOHMANN_JSON" true)
+    (lib.cmakeBool "ARROW_WITH_SNAPPY" true)
+    (lib.cmakeBool "ARROW_WITH_UTF8PROC" true)
+    (lib.cmakeBool "ARROW_WITH_ZLIB" true)
+    (lib.cmakeBool "ARROW_WITH_ZSTD" true)
+    (lib.cmakeBool "ARROW_MIMALLOC" true)
+    (lib.cmakeBool "ARROW_SUBSTRAIT" true)
+    (lib.cmakeBool "ARROW_FLIGHT" enableFlight)
+    (lib.cmakeBool "ARROW_FLIGHT_TESTING" enableFlight)
+    (lib.cmakeBool "ARROW_S3" enableS3)
+    (lib.cmakeBool "ARROW_GCS" enableGcs)
+    (lib.cmakeBool "ARROW_ORC" true)
     # Parquet options:
-    "-DARROW_PARQUET=ON"
-    "-DPARQUET_BUILD_EXECUTABLES=ON"
-    "-DPARQUET_REQUIRE_ENCRYPTION=ON"
+    (lib.cmakeBool "ARROW_PARQUET" true)
+    (lib.cmakeBool "PARQUET_BUILD_EXECUTABLES" true)
+    (lib.cmakeBool "PARQUET_REQUIRE_ENCRYPTION" true)
   ]
-  ++ lib.optionals (!enableShared) [ "-DARROW_TEST_LINKAGE=static" ]
+  ++ lib.optionals (!enableShared) [
+    (lib.cmakeFeature "ARROW_TEST_LINKAGE" "static")
+  ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    "-DCMAKE_INSTALL_RPATH=@loader_path/../lib" # needed for tools executables
+    # needed for tools executables
+    (lib.cmakeFeature "CMAKE_INSTALL_RPATH" "@loader_path/../lib")
   ]
-  ++ lib.optionals (!stdenv.hostPlatform.isx86_64) [ "-DARROW_USE_SIMD=OFF" ]
+  ++ lib.optionals (!stdenv.hostPlatform.isx86_64) [
+    (lib.cmakeBool "ARROW_USE_SIMD" false)
+  ]
   ++ lib.optionals enableS3 [
-    "-DAWSSDK_CORE_HEADER_FILE=${aws-sdk-cpp-arrow}/include/aws/core/Aws.h"
+    (lib.cmakeFeature "AWSSDK_CORE_HEADER_FILE" "${aws-sdk-cpp-arrow}/include/aws/core/Aws.h")
   ];
 
   doInstallCheck = true;
@@ -259,13 +266,6 @@ stdenv.mkDerivation (finalAttrs: {
           "TestMinioServer.Connect"
           "TestS3FS.*"
           "TestS3FSGeneric.*"
-        ]
-        ++ lib.optionals stdenv.hostPlatform.isDarwin [
-          # TODO: revisit at 12.0.0 or when
-          # https://github.com/apache/arrow/commit/295c6644ca6b67c95a662410b2c7faea0920c989
-          # is available, see
-          # https://github.com/apache/arrow/pull/15288#discussion_r1071244661
-          "ExecPlanExecution.StressSourceSinkStopped"
         ];
     in
     lib.optionalString finalAttrs.doInstallCheck "-${lib.concatStringsSep ":" filteredTests}";
@@ -306,12 +306,13 @@ stdenv.mkDerivation (finalAttrs: {
       runHook postInstallCheck
     '';
 
-  meta = with lib; {
+  meta = {
     description = "Cross-language development platform for in-memory data";
     homepage = "https://arrow.apache.org/docs/cpp/";
-    license = licenses.asl20;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [
+    changelog = "https://arrow.apache.org/release/${finalAttrs.version}.html";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
       tobim
       veprbl
       cpcloud

--- a/pkgs/by-name/go/google-cloud-cpp/package.nix
+++ b/pkgs/by-name/go/google-cloud-cpp/package.nix
@@ -14,32 +14,32 @@
   nlohmann_json,
   openssl,
   pkg-config,
-  protobuf_31,
+  protobuf,
   pkgsBuildHost,
-  # default list of APIs: https://github.com/googleapis/google-cloud-cpp/blob/v1.32.1/CMakeLists.txt#L173
+  # default list of APIs: https://github.com/googleapis/google-cloud-cpp/blob/v2.43.0/cmake/GoogleCloudCppFeatures.cmake#L24
   apis ? [ "*" ],
   staticOnly ? stdenv.hostPlatform.isStatic,
 }:
 let
   # defined in cmake/GoogleapisConfig.cmake
-  googleapisRev = "f01a17a560b4fbc888fd552c978f4e1f8614100b";
+  googleapisRev = "2193a2bfcecb92b92aad7a4d81baa428cafd7dfd";
   googleapis = fetchFromGitHub {
     name = "googleapis-src";
     owner = "googleapis";
     repo = "googleapis";
     rev = googleapisRev;
-    hash = "sha256-eJA3KM/CZMKTR3l6omPJkxqIBt75mSNsxHnoC+1T4gw=";
+    hash = "sha256-M+3ywDd1kyo6U/9o7fpsqYIPuulf8fDe3a4mjJKEN2U=";
   };
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "google-cloud-cpp";
-  version = "2.38.0";
+  version = "2.43.0";
 
   src = fetchFromGitHub {
     owner = "googleapis";
     repo = "google-cloud-cpp";
-    rev = "v${version}";
-    sha256 = "sha256-TF3MLBmjUbKJkZVcaPXbagXrAs3eEhlNQBjYQf0VtT8=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2OnzObCTmB6E4Ut0blmL7CRAJJ9EKl6eSVdfuPS4B2Y=";
   };
 
   patches = [
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     grpc
     nlohmann_json
     openssl
-    protobuf_31
+    protobuf
     gbenchmark
     gtest
   ];
@@ -87,7 +87,7 @@ stdenv.mkDerivation rec {
       ];
       ldLibraryPathName = "${lib.optionalString stdenv.hostPlatform.isDarwin "DY"}LD_LIBRARY_PATH";
     in
-    lib.optionalString doInstallCheck (
+    lib.optionalString finalAttrs.doInstallCheck (
       lib.optionalString (!staticOnly) ''
         export ${ldLibraryPathName}=${lib.concatStringsSep ":" additionalLibraryPaths}
       ''
@@ -114,32 +114,33 @@ stdenv.mkDerivation rec {
       runHook postInstallCheck
     '';
 
-  nativeInstallCheckInputs = lib.optionals doInstallCheck [
+  nativeInstallCheckInputs = lib.optionals finalAttrs.doInstallCheck [
     gbenchmark
     gtest
   ];
 
   cmakeFlags = [
-    "-DBUILD_SHARED_LIBS:BOOL=${if staticOnly then "OFF" else "ON"}"
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!staticOnly))
     # unconditionally build tests to catch linker errors as early as possible
     # this adds a good chunk of time to the build
-    "-DBUILD_TESTING:BOOL=ON"
-    "-DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES:BOOL=OFF"
+    (lib.cmakeBool "BUILD_TESTING" true)
+    (lib.cmakeBool "GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES" false)
   ]
   ++ lib.optionals (apis != [ "*" ]) [
-    "-DGOOGLE_CLOUD_CPP_ENABLE=${lib.concatStringsSep ";" apis}"
+    (lib.cmakeFeature "GOOGLE_CLOUD_CPP_ENABLE" (lib.concatStringsSep ";" apis))
   ]
   ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
-    "-DGOOGLE_CLOUD_CPP_GRPC_PLUGIN_EXECUTABLE=${lib.getBin pkgsBuildHost.grpc}/bin/grpc_cpp_plugin"
+    (lib.cmakeFeature "GOOGLE_CLOUD_CPP_GRPC_PLUGIN_EXECUTABLE" "${lib.getBin pkgsBuildHost.grpc}/bin/grpc_cpp_plugin")
   ];
 
   requiredSystemFeatures = [ "big-parallel" ];
 
-  meta = with lib; {
-    license = with licenses; [ asl20 ];
+  meta = {
+    license = with lib.licenses; [ asl20 ];
     homepage = "https://github.com/googleapis/google-cloud-cpp";
     description = "C++ Idiomatic Clients for Google Cloud Platform services";
+    changelog = "https://github.com/googleapis/google-cloud-cpp/blob/v${finalAttrs.version}/CHANGELOG.md";
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
-    maintainers = with maintainers; [ cpcloud ];
+    maintainers = with lib.maintainers; [ cpcloud ];
   };
-}
+})


### PR DESCRIPTION
## Things done

**Motivation:** Use latest `protobuf` to avoid multiple different `protobuf` versions ending in downstream closures.

Diff: https://github.com/apache/orc/compare/v2.1.2...v2.2.1
Changelog: https://github.com/apache/orc/releases/tag/v2.2.1

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc