### PR TITLE
youtui: init at 0.0.26

### DIFF
--- a/pkgs/by-name/yo/youtui/package.nix
+++ b/pkgs/by-name/yo/youtui/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  installShellFiles,
+  openssl,
+  alsa-lib,
+  stdenv,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "youtui";
+  version = "0.0.26";
+
+  src = fetchFromGitHub {
+    owner = "nick42d";
+    repo = "youtui";
+    tag = "youtui/v${finalAttrs.version}";
+    hash = "sha256-OcAoaIpM6EA2ZrvPEnSzYZrRf7AakwTSEvjMm7g2xfE=";
+  };
+
+  cargoHash = "sha256-/ThEvscSrdZDNJxa+aLacg3/jnkQmevdDJngnHoGgaw=";
+
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
+  ];
+
+  buildInputs = [
+    openssl
+    alsa-lib
+  ];
+
+  doCheck = false; # All tests require network access
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd youtui \
+      --bash <($out/bin/youtui --generate-completions bash) \
+      --fish <($out/bin/youtui --generate-completions fish) \
+      --zsh <($out/bin/youtui --generate-completions zsh)
+  '';
+
+  meta = {
+    description = "TUI for YouTube Music written in Rust";
+    homepage = "https://github.com/nick42d/youtui";
+    changelog = "https://github.com/nick42d/youtui/releases/tag/youtui%2Fv${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ aleksana ];
+    mainProgram = "youtui";
+  };
+})


### PR DESCRIPTION
Currently can't play music due to an api change, similar to https://github.com/ccgauche/ytermusic/issues/118

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
