### PR TITLE
python3Packages.visions: skip failing tests, cleanup

### DIFF
--- a/pkgs/development/python-modules/visions/default.nix
+++ b/pkgs/development/python-modules/visions/default.nix
@@ -2,21 +2,28 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonOlder,
-  pytestCheckHook,
+
+  # build-system
   setuptools,
+
+  # dependencies
   attrs,
-  imagehash,
-  matplotlib,
   multimethod,
   networkx,
   numpy,
   pandas,
-  pillow,
   puremagic,
+
+  # optional-dependencies
+  shapely,
+  imagehash,
+  pillow,
+  matplotlib,
   pydot,
   pygraphviz,
-  shapely,
+
+  # tests
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -24,12 +31,10 @@ buildPythonPackage rec {
   version = "0.8.1";
   pyproject = true;
 
-  disabled = pythonOlder "3.8";
-
   src = fetchFromGitHub {
     owner = "dylan-profiler";
     repo = "visions";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-MHseb1XJ0t7jQ45VXKQclYPgddrzmJAC7cde8qqYhNQ=";
   };
 
@@ -62,19 +67,29 @@ buildPythonPackage rec {
   ]
   ++ lib.flatten (builtins.attrValues optional-dependencies);
 
+  disabledTests = [
+    # TypeError: Converting `np.inexact` or `np.floating` to a dtype not allowed
+    "test_declarative"
+  ];
+
   disabledTestPaths = [
     # requires running Apache Spark:
     "tests/spark_/typesets/test_spark_standard_set.py"
+
+    # multimethod.DispatchError
+    "tests/numpy_/typesets/test_standard_set.py::test_cast"
+    "tests/numpy_/typesets/test_standard_set.py::test_conversion"
+    "tests/numpy_/typesets/test_standard_set.py::test_inference"
   ];
 
-  pythonImportsCheck = [
-    "visions"
-  ];
+  pythonImportsCheck = [ "visions" ];
 
-  meta = with lib; {
+  meta = {
     description = "Type system for data analysis in Python";
     homepage = "https://dylan-profiler.github.io/visions";
-    license = licenses.bsdOriginal;
-    maintainers = with maintainers; [ bcdarwin ];
+    downloadPage = "https://github.com/dylan-profiler/visions";
+    changelog = "https://github.com/dylan-profiler/visions/releases/tag/${src.tag}";
+    license = lib.licenses.bsdOriginal;
+    maintainers = with lib.maintainers; [ bcdarwin ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

cc @bcdarwin

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
