### PR TITLE
openvi: 7.6.31 -> 7.7.32

### DIFF
--- a/pkgs/by-name/op/openvi/package.nix
+++ b/pkgs/by-name/op/openvi/package.nix
@@ -2,24 +2,29 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  pkg-config,
   ncurses,
   perl,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "openvi";
-  version = "7.6.31";
+  version = "7.7.32";
 
   src = fetchFromGitHub {
     owner = "johnsonjh";
     repo = "OpenVi";
-    rev = version;
-    hash = "sha256-RqmulYHQFZmTHQAYgZmB8tAG6mSquNODmssfKB8YqDU=";
+    tag = finalAttrs.version;
+    hash = "sha256-kLULaKEefMpNLANnVdWAZeH+2KY5gEWGce6vJ/R7HAI=";
   };
 
+  nativeBuildInputs = [ pkg-config ];
+
   buildInputs = [
-    ncurses
     perl
+  ]
+  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
+    ncurses
   ];
 
   makeFlags = [
@@ -29,6 +34,12 @@ stdenv.mkDerivation rec {
     # silently fail the chown command
     "IUSGR=$(USER)"
   ];
+
+  # Don't include ncurses header, but link against ncurses
+  # openvi requires GNU ncurses symbols, but ncurses headers
+  # is incompatible with macOS wchar.h, resulting in
+  # "error: expected function body after function declarator"
+  env.NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-L${lib.getLib ncurses}/lib -lncursesw";
 
   enableParallelBuilding = true;
 
@@ -40,4 +51,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ aleksana ];
     mainProgram = "ovi";
   };
-}
+})


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
