### PR TITLE
libcupsfilters: apply patches for CVE-2025-64503 and CVE-2025-57812

### DIFF
--- a/pkgs/by-name/li/libcupsfilters/package.nix
+++ b/pkgs/by-name/li/libcupsfilters/package.nix
@@ -4,6 +4,7 @@
   dbus,
   dejavu_fonts,
   fetchFromGitHub,
+  fetchpatch,
   fontconfig,
   ghostscript,
   lcms2,
@@ -30,6 +31,25 @@ stdenv.mkDerivation {
     rev = "2.1.1";
     hash = "sha256-WEcg+NSsny/N1VAR1ejytM+3nOF3JlNuIUPf4w6N2ew=";
   };
+
+  patches = [
+    (fetchpatch {
+      # https://github.com/OpenPrinting/cups-filters/security/advisories/GHSA-893j-2wr2-wrh9
+      name = "CVE-2025-64503.patch";
+      url = "https://github.com/OpenPrinting/libcupsfilters/commit/fd01543f372ca3ba1f1c27bd3427110fa0094e3f.patch";
+      # File has been renamed before the fix
+      decode = "sed -e 's/pdftoraster\.c/pdftoraster\.cxx/g'";
+      hash = "sha256-cKbDHZEc/A51M+ce3kVsRxjRUWA96ynGv/avpq4iUHU=";
+    })
+    (fetchpatch {
+      # https://github.com/OpenPrinting/libcupsfilters/security/advisories/GHSA-jpxg-qc2c-hgv4
+      # https://github.com/OpenPrinting/libcupsfilters/security/advisories/GHSA-rc6w-jmvv-v7gx
+      # https://github.com/OpenPrinting/libcupsfilters/security/advisories/GHSA-fmvr-45mx-43c6
+      name = "CVE-2025-57812.patch";
+      url = "https://github.com/OpenPrinting/libcupsfilters/commit/b69dfacec7f176281782e2f7ac44f04bf9633cfa.patch";
+      hash = "sha256-rPUbgtTu7j3uUZrtUhUPO1vFbV6naxIWsHf6x3JhS74=";
+    })
+  ];
 
   nativeBuildInputs = [
     autoreconfHook


### PR DESCRIPTION
https://github.com/OpenPrinting/libcupsfilters/security/advisories/GHSA-jpxg-qc2c-hgv4
https://github.com/OpenPrinting/libcupsfilters/security/advisories/GHSA-rc6w-jmvv-v7gx
https://github.com/OpenPrinting/libcupsfilters/security/advisories/GHSA-fmvr-45mx-43c6
https://github.com/OpenPrinting/cups-filters/security/advisories/GHSA-893j-2wr2-wrh9


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 461597`
Commit: `98fbc45e13fd8351c49fd5247de771fec33e5e78`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 16 packages built:</summary>
  <ul>
    <li>cups-browsed</li>
    <li>cups-filters</li>
    <li>foomatic-db</li>
    <li>foomatic-db-ppds</li>
    <li>foomatic-db-ppds-withNonfreeDb</li>
    <li>libcupsfilters</li>
    <li>libppd</li>
    <li>ocsinventory-agent</li>
    <li>ocsinventory-agent.devdoc</li>
    <li>perl538Packages.NetCUPS</li>
    <li>perl538Packages.NetCUPS.devdoc</li>
    <li>perlPackages.NetCUPS (perl540Packages.NetCUPS)</li>
    <li>perlPackages.NetCUPS.devdoc (perl540Packages.NetCUPS.devdoc)</li>
    <li>ptouch-driver</li>
    <li>splix</li>
    <li>system-config-printer</li>
  </ul>
</details>

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 461597`
Commit: `98fbc45e13fd8351c49fd5247de771fec33e5e78`

---
### `aarch64-linux`
<details>
  <summary>:white_check_mark: 16 packages built:</summary>
  <ul>
    <li>cups-browsed</li>
    <li>cups-filters</li>
    <li>foomatic-db</li>
    <li>foomatic-db-ppds</li>
    <li>foomatic-db-ppds-withNonfreeDb</li>
    <li>libcupsfilters</li>
    <li>libppd</li>
    <li>ocsinventory-agent</li>
    <li>ocsinventory-agent.devdoc</li>
    <li>perl538Packages.NetCUPS</li>
    <li>perl538Packages.NetCUPS.devdoc</li>
    <li>perlPackages.NetCUPS (perl540Packages.NetCUPS)</li>
    <li>perlPackages.NetCUPS.devdoc (perl540Packages.NetCUPS.devdoc)</li>
    <li>ptouch-driver</li>
    <li>splix</li>
    <li>system-config-printer</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
