### PR TITLE
actiona: fix build for Qt 6.10

### DIFF
--- a/pkgs/by-name/ac/actiona/fix-qt6-10-private-targets.diff
+++ b/pkgs/by-name/ac/actiona/fix-qt6-10-private-targets.diff
@@ -1,0 +1,13 @@
+diff --git a/actiontools/CMakeLists.txt b/actiontools/CMakeLists.txt
+index 94c809c4..eb3d7e8c 100644
+--- a/actiontools/CMakeLists.txt
++++ b/actiontools/CMakeLists.txt
+@@ -292,7 +292,7 @@ target_compile_definitions(${PROJECT} PRIVATE ACTIONTOOLS_LIBRARY)
+ setup_target(${PROJECT})
+ 
+ find_package(OpenCV REQUIRED core imgproc)
+-find_package(Qt6 ${ACT_MINIMUM_QT_VERSION} COMPONENTS Widgets Qml REQUIRED)
++find_package(Qt6 ${ACT_MINIMUM_QT_VERSION} COMPONENTS Widgets Qml QmlPrivate REQUIRED)
+ 
+ ExternalProject_Add(external_qtjsapi
+     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/qtjsapi

--- a/pkgs/by-name/ac/actiona/package.nix
+++ b/pkgs/by-name/ac/actiona/package.nix
@@ -28,7 +28,11 @@ stdenv.mkDerivation (finalAttrs: {
     fetchSubmodules = true;
   };
 
-  patches = lib.optionals (!textToSpeechSupport) [
+  patches = [
+    # Meet Qt 6.10 requirement for explicit find_package of private targets
+    ./fix-qt6-10-private-targets.diff
+  ]
+  ++ lib.optionals (!textToSpeechSupport) [
     # Removes TTS support
     ./disable-tts.patch
   ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes build broken by Qt 6.10 upgrade.

Qt 6.10 no longer provides `*Private` targets automatically when requesting a component with CMake `find_package`, so these must now be explicitly requested when linked against.

ZHF: #457852

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
