### PR TITLE
python3Packages.manim: don't override av

### DIFF
--- a/pkgs/by-name/gi/git-sim/package.nix
+++ b/pkgs/by-name/gi/git-sim/package.nix
@@ -13,17 +13,7 @@
 let
   defaultOverrides = [
     (self: super: {
-      av = (
-        super.av.overridePythonAttrs rec {
-          version = "13.1.0";
-          src = fetchFromGitHub {
-            owner = "PyAV-Org";
-            repo = "PyAV";
-            tag = "v${version}";
-            hash = "sha256-x2a9SC4uRplC6p0cD7fZcepFpRidbr6JJEEOaGSWl60=";
-          };
-        }
-      );
+      av = self.av_13;
     })
   ];
 

--- a/pkgs/by-name/gi/git-sim/package.nix
+++ b/pkgs/by-name/gi/git-sim/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   installShellFiles,
-  python312,
+  python3,
 
   # Override Python packages using
   # self: super: { pkg = super.pkg.overridePythonAttrs (oldAttrs: { ... }); }
@@ -17,7 +17,7 @@ let
     })
   ];
 
-  python = python312.override {
+  python = python3.override {
     self = python;
     packageOverrides = lib.composeManyExtensions (defaultOverrides ++ [ packageOverrides ]);
   };

--- a/pkgs/by-name/ma/manim-slides/package.nix
+++ b/pkgs/by-name/ma/manim-slides/package.nix
@@ -1,0 +1,14 @@
+{
+  python3Packages,
+}:
+
+let
+  pythonPackages = python3Packages.overrideScope (
+    self: super: {
+      av = self.av_13;
+    }
+  );
+in
+(pythonPackages.toPythonApplication pythonPackages.manim-slides).overridePythonAttrs (oldAttrs: {
+  dependencies = oldAttrs.dependencies ++ oldAttrs.optional-dependencies.pyqt6-full;
+})

--- a/pkgs/by-name/ma/manim/package.nix
+++ b/pkgs/by-name/ma/manim/package.nix
@@ -1,0 +1,12 @@
+{
+  python3Packages,
+}:
+
+let
+  pythonPackages = python3Packages.overrideScope (
+    self: super: {
+      av = self.av_13;
+    }
+  );
+in
+pythonPackages.toPythonApplication pythonPackages.manim

--- a/pkgs/development/python-modules/av_13/default.nix
+++ b/pkgs/development/python-modules/av_13/default.nix
@@ -1,0 +1,90 @@
+{
+  buildPythonPackage,
+  cython,
+  fetchFromGitHub,
+  fetchurl,
+  ffmpeg_7-headless,
+  lib,
+  linkFarm,
+  numpy,
+  pillow,
+  pkg-config,
+  pytestCheckHook,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "av";
+  version = "13.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "PyAV-Org";
+    repo = "PyAV";
+    tag = "v${version}";
+    hash = "sha256-x2a9SC4uRplC6p0cD7fZcepFpRidbr6JJEEOaGSWl60=";
+  };
+
+  build-system = [
+    cython
+    setuptools
+  ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ ffmpeg_7-headless ];
+
+  preCheck =
+    let
+      testSamples = linkFarm "pyav-test-samples" (
+        lib.mapAttrs (_: fetchurl) (lib.importTOML ../av/test-samples.toml)
+      );
+    in
+    ''
+      # ensure we import the built version
+      rm -r av
+      ln -s ${testSamples} tests/assets
+    '';
+
+  nativeCheckInputs = [
+    numpy
+    pillow
+    pytestCheckHook
+  ];
+
+  __darwinAllowLocalNetworking = true;
+
+  pythonImportsCheck = [
+    "av"
+    "av.audio"
+    "av.buffer"
+    "av.bytesource"
+    "av.codec"
+    "av.container"
+    "av._core"
+    "av.datasets"
+    "av.descriptor"
+    "av.dictionary"
+    "av.error"
+    "av.filter"
+    "av.format"
+    "av.frame"
+    "av.logging"
+    "av.option"
+    "av.packet"
+    "av.plane"
+    "av.stream"
+    "av.subtitles"
+    "av.utils"
+    "av.video"
+  ];
+
+  meta = {
+    changelog = "https://github.com/PyAV-Org/PyAV/blob/${src.tag}/CHANGELOG.rst";
+    description = "Pythonic bindings for FFmpeg";
+    homepage = "https://github.com/PyAV-Org/PyAV";
+    license = lib.licenses.bsd2;
+    mainProgram = "pyav";
+    maintainers = [ lib.maintainers.dotlambda ];
+  };
+}

--- a/pkgs/development/python-modules/manim/default.nix
+++ b/pkgs/development/python-modules/manim/default.nix
@@ -183,16 +183,6 @@ let
       cbfonts-fd
     ]
   );
-  # https://github.com/ManimCommunity/manim/pull/4037
-  av_13_1 = av.overridePythonAttrs rec {
-    version = "13.1.0";
-    src = fetchFromGitHub {
-      owner = "PyAV-Org";
-      repo = "PyAV";
-      tag = "v${version}";
-      hash = "sha256-x2a9SC4uRplC6p0cD7fZcepFpRidbr6JJEEOaGSWl60=";
-    };
-  };
 in
 buildPythonPackage rec {
   pname = "manim";
@@ -216,7 +206,7 @@ buildPythonPackage rec {
   buildInputs = [ cairo ];
 
   dependencies = [
-    av_13_1
+    av
     beautifulsoup4
     click
     cloup
@@ -278,6 +268,8 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "manim" ];
 
   meta = {
+    # https://github.com/ManimCommunity/manim/pull/4037
+    broken = lib.versionAtLeast av.version "14";
     description = "Animation engine for explanatory math videos - Community version";
     longDescription = ''
       Manim is an animation engine for explanatory math videos. It's used to

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -86,15 +86,7 @@ let
         ];
       });
 
-      av = (super.av.override { ffmpeg-headless = ffmpeg_7-headless; }).overridePythonAttrs rec {
-        version = "13.1.0";
-        src = fetchFromGitHub {
-          owner = "PyAV-Org";
-          repo = "PyAV";
-          tag = "v${version}";
-          hash = "sha256-x2a9SC4uRplC6p0cD7fZcepFpRidbr6JJEEOaGSWl60=";
-        };
-      };
+      av = self.av_13;
 
       imageio = super.imageio.overridePythonAttrs (oldAttrs: {
         disabledTests = oldAttrs.disabledTests or [ ] ++ [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11143,12 +11143,6 @@ with pkgs;
 
   m32edit = callPackage ../applications/audio/midas/m32edit.nix { };
 
-  manim-slides =
-    (python3Packages.toPythonApplication python3Packages.manim-slides).overridePythonAttrs
-      (oldAttrs: {
-        dependencies = oldAttrs.dependencies ++ oldAttrs.optional-dependencies.pyqt6-full;
-      });
-
   manuskript = libsForQt5.callPackage ../applications/editors/manuskript { };
 
   minari = python3Packages.toPythonApplication python3Packages.minari;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11143,8 +11143,6 @@ with pkgs;
 
   m32edit = callPackage ../applications/audio/midas/m32edit.nix { };
 
-  manim = python3Packages.toPythonApplication python3Packages.manim;
-
   manim-slides =
     (python3Packages.toPythonApplication python3Packages.manim-slides).overridePythonAttrs
       (oldAttrs: {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1208,6 +1208,8 @@ self: super: with self; {
 
   av = callPackage ../development/python-modules/av { };
 
+  av_13 = callPackage ../development/python-modules/av_13 { };
+
   avahi = toPythonModule (
     pkgs.avahi.override {
       inherit python;


### PR DESCRIPTION
Overriding Python packages isn't allowed within python3Packages.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
