### PR TITLE
ghidra-extensions.ghidraninja-ghidra-scripts: add useSwift overridable boolean

### DIFF
--- a/pkgs/tools/security/ghidra/extensions/ghidraninja-ghidra-scripts/default.nix
+++ b/pkgs/tools/security/ghidra/extensions/ghidraninja-ghidra-scripts/default.nix
@@ -5,6 +5,7 @@
   binwalk,
   swift,
   yara,
+  useSwift ? false,
 }:
 
 buildGhidraScripts {
@@ -20,11 +21,20 @@ buildGhidraScripts {
 
   postPatch = ''
     # Replace subprocesses with store versions
-    substituteInPlace binwalk.py --replace-fail 'subprocess.call(["binwalk"' 'subprocess.call(["${binwalk}/bin/binwalk"'
-    substituteInPlace swift_demangler.py --replace-fail '"swift"' '"${swift}/bin/swift"'
-    substituteInPlace yara.py --replace-fail 'subprocess.check_output(["yara"' 'subprocess.check_output(["${yara}/bin/yara"'
-    substituteInPlace YaraSearch.py --replace-fail '"yara "' '"${yara}/bin/yara "'
-  '';
+    substituteInPlace binwalk.py --replace-fail 'subprocess.call(["binwalk"' 'subprocess.call(["${lib.getExe binwalk}"'
+    substituteInPlace yara.py --replace-fail 'subprocess.check_output(["yara"' 'subprocess.check_output(["${lib.getExe yara}"'
+    substituteInPlace YaraSearch.py --replace-fail '"yara "' '"${lib.getExe yara} "'
+  ''
+  + (
+    if useSwift then
+      ''
+        substituteInPlace swift_demangler.py --replace-fail '"swift"' '"${lib.getExe' swift "swift"}"'
+      ''
+    else
+      ''
+        rm swift_demangler.py
+      ''
+  );
 
   meta = with lib; {
     description = "Scripts for the Ghidra software reverse engineering suite";


### PR DESCRIPTION
Swift is a very big dependency for a single script included in this package that probably isn't being used by the many of the extensions users. Also Swift has been broken on unstable a few times in the past couple months. 

Use swift from PATH if required by user to avoid this issue.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
