### PR TITLE
valent: 1.0.0.alpha.46-unstable-2024-10-26 -> 1.0.0.alpha.48

### DIFF
--- a/pkgs/by-name/va/valent/package.nix
+++ b/pkgs/by-name/va/valent/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   desktop-file-utils,
+  gobject-introspection,
   meson,
   ninja,
   pkg-config,
@@ -26,18 +27,19 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "valent";
-  version = "1.0.0.alpha.46-unstable-2024-10-26";
+  version = "1.0.0.alpha.48";
 
   src = fetchFromGitHub {
     owner = "andyholmes";
     repo = "valent";
-    rev = "165a2791d4bf3e7dee69e3dd7885dbe4948265b9";
-    hash = "sha256-7klvOvwyAg+Xno6zWo8UByjaS9OkOuCceuZcAIEgdyU=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-CB3Jb7N8vcNTLCWXKoDh/wQkPW1CH6WRlwXg4efU3GY=";
     fetchSubmodules = true;
   };
 
   nativeBuildInputs = [
     desktop-file-utils
+    gobject-introspection
     meson
     ninja
     pkg-config

--- a/pkgs/by-name/va/valent/package.nix
+++ b/pkgs/by-name/va/valent/package.nix
@@ -96,7 +96,10 @@ stdenv.mkDerivation (finalAttrs: {
       cc0
       cc-by-sa-30
     ];
-    maintainers = with lib.maintainers; [ aleksana ];
+    maintainers = with lib.maintainers; [
+      aleksana
+      baduhai
+    ];
     platforms = lib.platforms.linux;
   };
 })


### PR DESCRIPTION
Fixes https://hydra.nixos.org/build/313275244/nixlog/2
Closes https://github.com/NixOS/nixpkgs/pull/454607
Closes https://github.com/NixOS/nixpkgs/pull/454263
ZHF: https://github.com/NixOS/nixpkgs/issues/457852

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
