### PR TITLE
arx-libertatis: migrate to by-name

### DIFF
--- a/pkgs/by-name/ar/arx-libertatis/package.nix
+++ b/pkgs/by-name/ar/arx-libertatis/package.nix
@@ -16,31 +16,20 @@
   optipng,
   imagemagick,
   withCrashReporter ? !stdenv.hostPlatform.isDarwin,
-  qtbase ? null,
-  wrapQtAppsHook ? null,
+  libsForQt5 ? null,
   curl ? null,
   gdb ? null,
 }:
 
-let
-  inherit (lib)
-    licenses
-    maintainers
-    optionals
-    optionalString
-    platforms
-    ;
-in
-
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "arx-libertatis";
   version = "1.2.1";
 
   src = fetchFromGitHub {
     owner = "arx";
     repo = "ArxLibertatis";
-    rev = version;
-    sha256 = "GBJcsibolZP3oVOTSaiVqG2nMmvXonKTp5i/0NNODKY=";
+    tag = finalAttrs.version;
+    hash = "sha256-GBJcsibolZP3oVOTSaiVqG2nMmvXonKTp5i/0NNODKY=";
   };
 
   nativeBuildInputs = [
@@ -49,7 +38,7 @@ stdenv.mkDerivation rec {
     imagemagick
     optipng
   ]
-  ++ optionals withCrashReporter [ wrapQtAppsHook ];
+  ++ lib.optionals withCrashReporter [ libsForQt5.wrapQtAppsHook ];
 
   buildInputs = [
     zlib
@@ -61,11 +50,11 @@ stdenv.mkDerivation rec {
     SDL2
     libepoxy
   ]
-  ++ optionals withCrashReporter [
-    qtbase
+  ++ lib.optionals withCrashReporter [
+    libsForQt5.qtbase
     curl
   ]
-  ++ optionals stdenv.hostPlatform.isLinux [ gdb ];
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ gdb ];
 
   cmakeFlags = [
     "-DDATA_DIR_PREFIXES=$out/share"
@@ -80,7 +69,7 @@ stdenv.mkDerivation rec {
       ${dejavu_fonts}/share/fonts/truetype/DejaVuSansMono.ttf \
       $out/share/games/arx/misc/dejavusansmono.ttf
   ''
-  + optionalString withCrashReporter ''
+  + lib.optionalString withCrashReporter ''
     wrapQtApp "$out/libexec/arxcrashreporter"
   '';
 
@@ -92,9 +81,9 @@ stdenv.mkDerivation rec {
       developed by Arkane Studios.
     '';
     homepage = "https://arx-libertatis.org/";
-    license = licenses.gpl3;
-    maintainers = with maintainers; [ rnhmjoj ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ rnhmjoj ];
+    platforms = lib.platforms.linux;
   };
 
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12937,8 +12937,6 @@ with pkgs;
     fftw = fftwSinglePrec;
   };
 
-  arx-libertatis = libsForQt5.callPackage ../games/arx-libertatis { };
-
   asc = callPackage ../games/asc {
     lua = lua5_1;
     physfs = physfs_2;


### PR DESCRIPTION
- Move package from pkgs/games/arx-libertatis/default.nix to pkgs/by-name/ar/arx-libertatis/package.nix
- Switch mkDerivation to finalAttrs style
- Replace local `let inherit (lib)` bindings with explicit `lib.*` references
- Use `libsForQt5` instead of separate qtbase/wrapQtAppsHook args
- Update fetchFromGitHub to use `tag`/`hash` instead of rev/sha256
- Drop top-level all-packages.nix entry; by-name layout exposes `pkgs.arx-libertatis` automatically


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
