### PR TITLE
arcan: fix build for ffmpeg 8

### DIFF
--- a/pkgs/by-name/ar/arcan/package.nix
+++ b/pkgs/by-name/ar/arcan/package.nix
@@ -4,6 +4,7 @@
   callPackage,
   cmake,
   espeak-ng,
+  fetchpatch2,
   ffmpeg,
   file,
   freetype,
@@ -162,6 +163,17 @@ stdenv.mkDerivation (finalAttrs: {
     + ''
       popd
     '';
+
+  patches = [
+    # Upstream patch to support ffmpeg 8
+    (fetchpatch2 {
+      name = "0001-build-fix-build-with-latest-ffmpeg.patch";
+      url = "https://chiselapp.com/user/letoram/repository/arcan/vpatch?from=cc6f24de2134282a&to=25bbde5eec7033d3";
+      hash = "sha256-i8d/X/xmEGWpO9fG6BerW//JnosPwDolXvMFsuv39IM=";
+      stripLen = 1;
+      extraPrefix = "src/";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace ./src/platform/posix/paths.c \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

~~Fixes the arcan build by pinning `ffmpeg` to `ffmpeg_7`~~
Fixes the arcan build with `ffmpeg` 8 by applying an upstream patch.

This break was caused by use of the deprecated (as of ffmpeg 7) function `avcodec_close`, which was apparently removed in ffmeg 8. If desired, I have a patch that at least builds locally but I am not familiar enough with this tool to adequately test it.

ZHF: #457852

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
