### PR TITLE
gnomeExtensions.system-monitor: fix order for collisions

### DIFF
--- a/pkgs/desktops/gnome/extensions/collisions.json
+++ b/pkgs/desktops/gnome/extensions/collisions.json
@@ -37,8 +37,8 @@
     "persian-calendar@iamrezamousavi.gmail.com"
   ],
   "system-monitor": [
+    "system-monitor@gnome-shell-extensions.gcampax.github.com",
     "System_Monitor@bghome.gmail.com",
-    "system-monitor@axet.github.com",
-    "system-monitor@gnome-shell-extensions.gcampax.github.com"
+    "system-monitor@axet.github.com"
   ]
 }

--- a/pkgs/desktops/gnome/extensions/extensionOverridesPatches/system-monitor_at_gnome-shell-extensions.gcampax.github.com.patch
+++ b/pkgs/desktops/gnome/extensions/extensionOverridesPatches/system-monitor_at_gnome-shell-extensions.gcampax.github.com.patch
@@ -17,7 +17,7 @@ index 37d2eb1..232d0d5 100644
  
  import * as Main from 'resource:///org/gnome/shell/ui/main.js';
  
-+GIRepository.Repository.prepend_search_path('@gtop_path@');
++GIRepository.Repository.dup_default().prepend_search_path('@gtop_path@');
 +const GTop = (await import("gi://GTop")).default;
 +
  const THRESHOLD_HIGH = 0.80;

--- a/pkgs/desktops/gnome/extensions/extensionRenames.nix
+++ b/pkgs/desktops/gnome/extensions/extensionRenames.nix
@@ -12,6 +12,7 @@
 
   "system-monitor@gnome-shell-extensions.gcampax.github.com" = "system-monitor";
   "System_Monitor@bghome.gmail.com" = "system-monitor-2";
+  "system-monitor@axet.github.com" = "system-monitor-3";
 
   "FuzzyClock@fire-man-x" = "fuzzy-clock-3";
   "FuzzyClock@johngoetz" = "fuzzy-clock";


### PR DESCRIPTION
#461080 changed my `pkgs.gnomeExtensions.system-monitor` from https://extensions.gnome.org/extension/6807/system-monitor/ -> https://extensions.gnome.org/extension/8272/system-monitor/, which doesn't indicate support for GNOME 49 yet.
This PR fixes the order and adds a new name for the other collision.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
