### PR TITLE
victoriatraces: 0.2.0 -> 0.5.0, add myself as maintainer

### DIFF
--- a/pkgs/by-name/vi/victoriatraces/package.nix
+++ b/pkgs/by-name/vi/victoriatraces/package.nix
@@ -13,13 +13,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "VictoriaTraces";
-  version = "0.2.0";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "VictoriaMetrics";
     repo = "VictoriaTraces";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-b4/ix191xtW2HpczfRbez2gibgGx7jBRm0hvuP/rTpA=";
+    hash = "sha256-jmcwn2/UB87wOBCHvquHIgc+a/sCXnxC63nddlZuSL0=";
   };
 
   vendorHash = null;
@@ -30,12 +30,6 @@ buildGoModule (finalAttrs: {
     ++ lib.optionals withVtSelect [ "app/vtselect" ]
     ++ lib.optionals withVtStorage [ "app/vtstorage" ]
     ++ lib.optionals withVtGen [ "app/vtgen" ];
-
-  postPatch = ''
-    # Allow older go versions
-    substituteInPlace go.mod \
-      --replace-fail "go 1.24.6" "go ${finalAttrs.passthru.go.version}"
-  '';
 
   ldflags = [
     "-s"
@@ -56,7 +50,10 @@ buildGoModule (finalAttrs: {
     homepage = "https://docs.victoriametrics.com/victoriatraces/";
     description = "Fast open-source observability solution for distributed traces";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ cmacrae ];
+    maintainers = with lib.maintainers; [
+      cmacrae
+      ma27
+    ];
     changelog = "https://github.com/VictoriaMetrics/VictoriaTraces/releases/tag/${finalAttrs.src.tag}";
     mainProgram = "victoria-traces";
   };


### PR DESCRIPTION
ChangeLogs:
* https://github.com/VictoriaMetrics/VictoriaTraces/releases/tag/v0.3.0
* https://github.com/VictoriaMetrics/VictoriaTraces/releases/tag/v0.4.0
* https://github.com/VictoriaMetrics/VictoriaTraces/releases/tag/v0.4.1
* https://github.com/VictoriaMetrics/VictoriaTraces/releases/tag/v0.5.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
