### PR TITLE
ruby: re-enable yjit, and fix, on cross

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -57,13 +57,9 @@ let
     }:
     let
       ver = version;
-      isCross = stdenv.buildPlatform != stdenv.hostPlatform;
       # https://github.com/ruby/ruby/blob/v3_2_2/yjit.h#L21
       yjitSupported =
-        !isCross
-        && (
-          stdenv.hostPlatform.isx86_64 || (!stdenv.hostPlatform.isWindows && stdenv.hostPlatform.isAarch64)
-        );
+        stdenv.hostPlatform.isx86_64 || (!stdenv.hostPlatform.isWindows && stdenv.hostPlatform.isAarch64);
       rubyDrv = lib.makeOverridable (
         {
           stdenv,

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -177,6 +177,13 @@ let
           ];
           propagatedBuildInputs = op jemallocSupport jemalloc;
 
+          env = lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform && yjitSupport) {
+            # The ruby build system will use a bare `rust` command by default for its rust.
+            # We can use the Nixpkgs rust wrapper to work around the fact that our Rust builds
+            # for cross-compilation output for the build target by default.
+            NIX_RUSTFLAGS = "--target ${stdenv.hostPlatform.rust.rustcTargetSpec}";
+          };
+
           enableParallelBuilding = true;
           # /build/ruby-2.7.7/lib/fileutils.rb:882:in `chmod':
           #   No such file or directory @ apply2files - ...-ruby-2.7.7-devdoc/share/ri/2.7.0/system/ARGF/inspect-i.ri (Errno::ENOENT)


### PR DESCRIPTION
This PR fixes yjit support, after re-enabling it (see: #449938).

This was authored sometimes last year when working on fixing Mobile NixOS cross-compilation issues with Ruby. I never got around to sending the fix.

Currently verified with:

```
 $ nix-build --attr pkgsCross.aarch64-multiplatform.ruby_3_3 --attr pkgsCross.aarch64-multiplatform.ruby_3_4

~/tmp/nixpkgs/nixos-unstable $ nix-shell -p qemu-user

[nix-shell:~/tmp/nixpkgs/nixos-unstable]$ qemu-aarch64 ./result/bin/ruby --yjit-stats -e 'pp RUBY_VERSION'
"3.3.10"
***YJIT: Printing YJIT statistics on exit***
[...]
```

For the record, before this change:

```
[nix-shell:~/tmp/nixpkgs/nixos-unstable]$ qemu-aarch64 ./result/bin/ruby --yjit-stats -e 'pp RUBY_VERSION'
./result/bin/ruby: warning: Ruby was built without YJIT support. You may need to install rustc to build Ruby with YJIT.
"3.3.10"
```

> 
> 
> Ruby 3.5 has an unrelated failure, same as on `nixos-unstable`:
> 
> ```
> error: output '/nix/store/0f1s4lmddng92rwi28l1ibajiyq3ky22-ruby-aarch64-unknown-linux-> gnu-3.5.0-preview1' is not allowed to refer to the following paths:
>          /nix/store/41virlkphdik7jnvagaas5lxaqbii1hn-ruby-3.3.10
> ```
>
> Note that the build otherwise fully succeeds.

* * *

 - cc @nim65s, who turned the feature off.
 - cc @kirillrdy, who reviewed the previous change (and is getting deeper into Ruby maintenance?)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux [yes, cross]
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
