### PR TITLE
libcap: fix cross-compilation from darwin

### DIFF
--- a/pkgs/by-name/li/libcap/package.nix
+++ b/pkgs/by-name/li/libcap/package.nix
@@ -1,10 +1,10 @@
 {
   stdenv,
   lib,
-  buildPackages,
   fetchurl,
   fetchpatch,
   runtimeShell,
+  pkgsBuildBuild,
   pkgsBuildHost,
   usePam ? !isStatic,
   pam ? null,
@@ -46,10 +46,9 @@ stdenv.mkDerivation rec {
   ++ lib.optional usePam "pam";
 
   depsBuildBuild = [
-    buildPackages.stdenv.cc
-  ];
-
-  nativeBuildInputs = lib.optionals withGo [
+    pkgsBuildBuild.stdenv.cc
+  ]
+  ++ lib.optionals withGo [
     go
   ];
 
@@ -111,7 +110,7 @@ stdenv.mkDerivation rec {
   strictDeps = true;
 
   disallowedReferences = lib.optionals withGo [
-    pkgsBuildHost.go
+    pkgsBuildBuild.go
   ];
 
   passthru.tests = {


### PR DESCRIPTION
Cross-compiling libcap from darwin to linux results in:

```
libcap-aarch64-unknown-linux-gnu> CC="aarch64-unknown-linux-gnu-gcc" GOOS= GOARCH= go run -mod=vendor mknames.go --header=/nix/var/nix/builds/nix-build-libcap-aarch64-unknown-linux-gnu-2.76.drv-0/b/libcap-2.76/libcap/cap_names.h --textdir=/nix/var/nix/builds/nix-build-libcap-aarch64-unknown-linux-gnu-2.76.drv-0/b/libcap-2.76/doc/values | gofmt > good-names.go || rm -f good-names.go
libcap-aarch64-unknown-linux-gnu> # command-line-arguments
libcap-aarch64-unknown-linux-gnu> loadinternal: cannot find runtime/cgo
libcap-aarch64-unknown-linux-gnu> /nix/store/ffzhhs8dxilwii3h2hq20gaqg9xfwpw7-go-1.25.3/share/go/pkg/tool/darwin_arm64/link: running aarch64-unknown-linux-gnu-gcc failed: exit status 1
libcap-aarch64-unknown-linux-gnu> /nix/store/qm65c30im1v1kq3izk06y050w65rdgwk-aarch64-unknown-linux-gnu-gcc-wrapper-14.3.0/bin/aarch64-unknown-linux-gnu-gcc -arch arm64 -Wl,-S -Wl,-x -o $WORK/b001/exe/mknames /nix/var/nix/builds/nix-build-libcap-aarch64-unknown-linux-gnu-2.76.drv-0/b/go-link-1959905569/go.o -lresolv
libcap-aarch64-unknown-linux-gnu> aarch64-unknown-linux-gnu-gcc: error: unrecognized command-line option '-arch'; did you mean '-march='?
libcap-aarch64-unknown-linux-gnu> diff -u ../cap/names.go good-names.go
...
```

After applying #460394 I get:

```
libcap-aarch64-unknown-linux-gnu> ld: library not found for -lresolv
libcap-aarch64-unknown-linux-gnu> clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Using the native (buildBuild) go compiler with host's `GOARCH`/`GOOS` fixes the issue for me. I think this makes sense because Go is used to compile a binary that runs at build-time (hence buildBuild).

Tested  on `aarch64-darwin` with:
```
nix build -L -f . pkgsCross.aarch64-multiplatform.libcap
```
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
