### PR TITLE
openorienteering-mapper: 0.9.5 → 0.9.6

### DIFF
--- a/pkgs/by-name/op/openorienteering-mapper/package.nix
+++ b/pkgs/by-name/op/openorienteering-mapper/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   clipper,
   cmake,
   cups,
@@ -11,43 +10,25 @@
   ninja,
   proj,
   qt5,
+  xcbuild,
   zlib,
 }:
 
 stdenv.mkDerivation rec {
   pname = "OpenOrienteering-Mapper";
-  version = "0.9.5";
+  version = "0.9.6";
 
   src = fetchFromGitHub {
     owner = "OpenOrienteering";
     repo = "mapper";
-    rev = "v${version}";
-    hash = "sha256-BQbryRV5diBkOtva9sYuLD8yo3IwFqrkz3qC+C6eEfE=";
+    tag = "v${version}";
+    hash = "sha256-JfjQe7t3F/9/ik7b+6UUbsYIcpkSDxHBgnbQEYyDTMI=";
   };
 
-  patches = [
-    # https://github.com/OpenOrienteering/mapper/pull/1907
-    (fetchpatch {
-      url = "https://github.com/OpenOrienteering/mapper/commit/bc52aa567e90a58d6963b44d5ae1909f3f841508.patch";
-      hash = "sha256-pQzw2EfVay+0GOtIbh1KJOkILcj5LRMzmMYy9q+abK4=";
-    })
-    # https://github.com/OpenOrienteering/mapper/pull/2337
-    (fetchpatch {
-      url = "https://github.com/OpenOrienteering/mapper/commit/d1f214ee2abf140ae3615a2995f08c19ad81418a.patch";
-      hash = "sha256-eJZpHdFPW7A69aazI+WRSK9N87d4A6x973hMYTHdw5I=";
-    })
-    # https://github.com/OpenOrienteering/mapper/pull/2227
-    (fetchpatch {
-      url = "https://github.com/OpenOrienteering/mapper/commit/fa694d74f2840d7f18976d7f35debcb99bd173eb.patch";
-      hash = "sha256-GVlNeIFiCG7anPsJR2nDCbgXEeUEAUvTcSaJ53Q/eV4=";
-    })
-  ];
-
   postPatch = ''
-    substituteInPlace CMakeLists.txt \
-      --replace "find_package(ClangTidy" "#find_package(ClangTidy"
     substituteInPlace packaging/custom_install.cmake.in \
-      --replace "fixup_bundle_portable(" "#fixup_bundle_portable("
+      --replace-fail "fixup_bundle_portable(" "#fixup_bundle_portable("
+    substituteInPlace src/CMakeLists.txt --replace-fail plutil echo
   '';
 
   nativeBuildInputs = [
@@ -56,6 +37,9 @@ stdenv.mkDerivation rec {
     ninja
     qt5.qttools
     qt5.wrapQtAppsHook
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    xcbuild # for plutil
   ];
 
   buildInputs = [
@@ -88,13 +72,16 @@ stdenv.mkDerivation rec {
     (lib.cmakeBool "Mapper_PACKAGE_GDAL" false)
   ];
 
-  postInstall =
-    with stdenv;
-    lib.optionalString isDarwin ''
-      mkdir -p $out/{Applications,bin}
-      mv $out/Mapper.app $out/Applications
-      ln -s $out/Applications/Mapper.app/Contents/MacOS/Mapper $out/bin/Mapper
-    '';
+  postBuild = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    chmod +w src/Mapper.app/Contents/Info.plist
+    plutil -replace NSHighResolutionCapable -bool true src/Mapper.app/Contents/Info.plist
+  '';
+
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mkdir -p $out/{Applications,bin}
+    mv $out/Mapper.app $out/Applications
+    ln -s $out/Applications/Mapper.app/Contents/MacOS/Mapper $out/bin/Mapper
+  '';
 
   meta = {
     homepage = "https://www.openorienteering.org/apps/mapper/";


### PR DESCRIPTION
https://github.com/OpenOrienteering/mapper/releases/tag/v0.9.6

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
