### PR TITLE
komikku: 1.87.0 -> 1.92.0

### DIFF
--- a/pkgs/by-name/ko/komikku/package.nix
+++ b/pkgs/by-name/ko/komikku/package.nix
@@ -8,7 +8,7 @@
   blueprint-compiler,
   gtk4,
   libadwaita,
-  libnotify,
+  libglycin,
   webkitgtk_6_0,
   meson,
   ninja,
@@ -23,7 +23,7 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "komikku";
-  version = "1.87.0";
+  version = "1.92.0";
   pyproject = false;
 
   src = fetchFromGitea {
@@ -31,7 +31,7 @@ python3.pkgs.buildPythonApplication rec {
     owner = "valos";
     repo = "Komikku";
     tag = "v${version}";
-    hash = "sha256-mFHoQtZJlo412g0ElvpNdLN+Ni2Mr882VC7lvV+EVTs=";
+    hash = "sha256-eNKNVS8uSzDdXM13dQoSPy88u55RMDCh/Do3wCkscxI=";
   };
 
   nativeBuildInputs = [
@@ -50,23 +50,25 @@ python3.pkgs.buildPythonApplication rec {
     glib
     gtk4
     libadwaita
-    libnotify
+    libglycin
     webkitgtk_6_0
   ];
 
   dependencies = with python3.pkgs; [
     beautifulsoup4
     brotli
+    colorthief
     dateparser
     emoji
     keyring
     lxml
-    modern-colorthief
     natsort
     piexif
     pillow
     curl-cffi
     pygobject3
+    pyjwt
+    pypdf
     python-magic
     rarfile
     requests


### PR DESCRIPTION
https://codeberg.org/valos/Komikku/compare/v1.87.0...v1.92.0

- `libnotify` has been replaced by `gio`
- `modern-colorthief` has been replaced by `colorthief`
- added `pyjwt` and `pypdf`, which are now required dependencies
- added `libglycin` which is now used for image loading
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
