### PR TITLE
python3Packages.blivet: use GIRepository 3.0, fix `prepend_search_path` call

### DIFF
--- a/pkgs/development/python-modules/blivet/default.nix
+++ b/pkgs/development/python-modules/blivet/default.nix
@@ -51,9 +51,9 @@ buildPythonPackage rec {
         --replace \
           'gi.require_version("BlockDev",' \
           'import gi.repository
-    gi.require_version("GIRepository", "2.0")
+    gi.require_version("GIRepository", "3.0")
     from gi.repository import GIRepository
-    GIRepository.Repository.prepend_search_path("${libblockdev}/lib/girepository-1.0")
+    GIRepository.Repository.dup_default().prepend_search_path("${libblockdev}/lib/girepository-1.0")
     gi.require_version("BlockDev",'
     done
   '';


### PR DESCRIPTION
Fixing
```
Check whether the following modules can be imported: blivet
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import sys; import importlib; list(map(lambda mod: importlib.import_module(mod), sys.argv[1:]))
                                  ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                              File "<string>", line 1, in <lambda>
    import sys; import importlib; list(map(lambda mod: importlib.import_module(mod), sys.argv[1:]))                                                                                   ~~~~~~~~~~~~~~~~~~~~~~~^^^^^
  File "/nix/store/7gl4khq26h625mpqzkiiqsify3hclar1-python3-3.13.9/lib/python3.13/importlib/__init__.py", line 88, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)                                                                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import                                                                File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked                                                    File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 1027, in exec_module                                                       File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/nix/store/al09nkvckhf7mzl11lw4r4jmhp1rh52n-python3.13-blivet-3.12.1/lib/python3.13/site-packages/blivet/__init__.py", line 30, in <module>
    from . import arch                                                                                                           File "/nix/store/al09nkvckhf7mzl11lw4r4jmhp1rh52n-python3.13-blivet-3.12.1/lib/python3.13/site-packages/blivet/arch.py", line 37, in <module>                                                                                                                   from .util import read_file
  File "/nix/store/al09nkvckhf7mzl11lw4r4jmhp1rh52n-python3.13-blivet-3.12.1/lib/python3.13/site-packages/blivet/util.py", line 25, in <module>
    gi.require_version("GIRepository", "2.0")                                                                                      ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/6p1zq8x1ag4ha1b4jw08m8q6w9cjf3q9-python3.13-pygobject-3.54.3/lib/python3.13/site-packages/gi/__init__.py", line 135, in require_version
    raise ValueError(f"Namespace {namespace} not available for version {version}")                                             ValueError: Namespace GIRepository not available for version 2.0
```

And it seems that GIRepository 2.86 changed how the process-global `Repository` is being accessed: https://docs.gtk.org/girepository/type_func.Repository.dup_default.html

ZHF: https://github.com/NixOS/nixpkgs/issues/457852

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
