### PR TITLE
gnomeExtensions.easyScreenCast: 1.11.1 -> 1.12.0

### DIFF
--- a/pkgs/desktops/gnome/extensions/EasyScreenCast/default.nix
+++ b/pkgs/desktops/gnome/extensions/EasyScreenCast/default.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-shell-extension-EasyScreenCast";
-  version = "1.11.1";
+  version = "1.12.0";
 
   src = fetchFromGitHub {
     owner = "EasyScreenCast";
     repo = "EasyScreenCast";
     rev = finalAttrs.version;
-    hash = "sha256-G4JDxaUfipn9asOXGw+OPVULOdV+OmzeK5aE/FSPGes=";
+    hash = "sha256-+DVuUClLhPEVN2VIBkJJI51V9TTS5Q9y6wflEGyt6AY=";
   };
 
   patches = [

--- a/pkgs/desktops/gnome/extensions/EasyScreenCast/fix-gi-path.patch
+++ b/pkgs/desktops/gnome/extensions/EasyScreenCast/fix-gi-path.patch
@@ -1,8 +1,8 @@
-diff --git i/extension.js w/extension.js
-index c151057..1b6dfc3 100644
---- i/extension.js
-+++ w/extension.js
-@@ -717,7 +717,7 @@ const EasyScreenCastIndicator = GObject.registerClass({
+diff --git a/extension.js b/extension.js
+index 32a7c7c..a7ed98e 100644
+--- a/extension.js
++++ b/extension.js
+@@ -720,7 +720,7 @@ const EasyScreenCastIndicator = GObject.registerClass({
              Lib.TalkativeLog('-*-execute post command');
  
              // launch cmd after registration
@@ -11,22 +11,11 @@ index c151057..1b6dfc3 100644
  
              const mapObj = {
                  _fpath: pathFile,
-diff --git i/prefs.js w/prefs.js
-index e0dd1a2..9dcb87a 100644
---- i/prefs.js
-+++ w/prefs.js
-@@ -13,8 +13,8 @@
- 'use strict';
- 
- import GIRepository from 'gi://GIRepository';
--GIRepository.Repository.prepend_search_path('/usr/lib64/gnome-shell');
--GIRepository.Repository.prepend_library_path('/usr/lib64/gnome-shell');
-+GIRepository.Repository.prepend_search_path('@gnomeShell@/lib/gnome-shell');
-+GIRepository.Repository.prepend_library_path('@gnomeShell@/lib/gnome-shell');
- 
- import Adw from 'gi://Adw';
- import GObject from 'gi://GObject';
-@@ -713,7 +713,7 @@ const EasyScreenCastSettingsWidget = GObject.registerClass({
+diff --git a/prefs.js b/prefs.js
+index b58b160..2298d5a 100644
+--- a/prefs.js
++++ b/prefs.js
+@@ -709,7 +709,7 @@ const EasyScreenCastSettingsWidget = GObject.registerClass({
                  Lib.TalkativeLog('-^-NOT SET xdg-user video');
  
                  ctx.CtrlExe.Execute(
@@ -35,7 +24,7 @@ index e0dd1a2..9dcb87a 100644
                      true,
                      (success, out) => {
                          Lib.TalkativeLog(`-^-CALLBACK sync S: ${success} out: ${out}`);
-@@ -883,7 +883,7 @@ const EasyScreenCastSettingsWidget = GObject.registerClass({
+@@ -879,7 +879,7 @@ const EasyScreenCastSettingsWidget = GObject.registerClass({
                  );
  
                  ctx.CtrlExe.Execute(
@@ -44,20 +33,4 @@ index e0dd1a2..9dcb87a 100644
                      false,
                      success => {
                          Lib.TalkativeLog(`-^-CALLBACK async S= ${success}`);
-diff --git i/utilaudio.js w/utilaudio.js
-index b07e181..ed7d3ba 100644
---- i/utilaudio.js
-+++ w/utilaudio.js
-@@ -14,10 +14,8 @@
- 
- import GObject from 'gi://GObject';
- import GIRepository from 'gi://GIRepository';
--GIRepository.Repository.prepend_search_path('/usr/lib/gnome-shell');
--GIRepository.Repository.prepend_library_path('/usr/lib/gnome-shell');
--GIRepository.Repository.prepend_search_path('/usr/lib64/gnome-shell');
--GIRepository.Repository.prepend_library_path('/usr/lib64/gnome-shell');
-+GIRepository.Repository.prepend_search_path('@gnomeShell@/lib/gnome-shell');
-+GIRepository.Repository.prepend_library_path('@gnomeShell@/lib/gnome-shell');
- import Gvc from 'gi://Gvc';
- 
- import * as Lib from './convenience.js';
+


### PR DESCRIPTION
Release Notes: https://github.com/EasyScreenCast/EasyScreenCast/releases/tag/1.12.0
Changes: https://github.com/EasyScreenCast/EasyScreenCast/compare/1.11.1...1.12.0
Adds support for GNOME 49

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
