### PR TITLE
qt6Packages.qzxing: Fix build

### DIFF
--- a/pkgs/development/libraries/qzxing/default.nix
+++ b/pkgs/development/libraries/qzxing/default.nix
@@ -19,6 +19,14 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-ASgsF5ocNWAiIy2jm6ygpDkggBcEpno6iVNWYkuWcVI=";
   };
 
+  # greaterThan/lessThan don't handle versions, use versionAtLeast/versionAtMost instead
+  # Versions are different due to versionAtLeast/-Most using an inclusive limit, while greater-/lessThan use exclusive ones
+  postPatch = ''
+    substituteInPlace src/QZXing-components.pri \
+      --replace-fail 'lessThan(QT_VERSION, 6.2)' 'versionAtMost(QT_VERSION, 6.1)' \
+      --replace-fail 'greaterThan(QT_VERSION, 6.1)' 'versionAtLeast(QT_VERSION, 6.2)'
+  '';
+
   # QMake can't find qtmultimedia in buildInputs
   strictDeps = false;
 

--- a/pkgs/development/libraries/qzxing/default.nix
+++ b/pkgs/development/libraries/qzxing/default.nix
@@ -55,12 +55,12 @@ stdenv.mkDerivation (finalAttrs: {
     updateScript = nix-update-script { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Qt/QML wrapper library for the ZXing library";
     homepage = "https://github.com/ftylitak/qzxing";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ OPNA2608 ];
-    platforms = platforms.unix;
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ OPNA2608 ];
+    platforms = lib.platforms.unix;
     pkgConfigModules = [
       "QZXing"
     ];


### PR DESCRIPTION
Upstream QMake code doesn't use the correct functions for version-gating code.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
