### PR TITLE
linuxPackages.rtl8126: init at 10.016.00

### DIFF
--- a/pkgs/os-specific/linux/rtl8126/default.nix
+++ b/pkgs/os-specific/linux/rtl8126/default.nix
@@ -1,0 +1,45 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  kernel,
+  kernelModuleMakeFlags,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "rtl8126";
+  version = "${kernel.version}-${finalAttrs.src.tag}";
+
+  src = fetchFromGitHub {
+    owner = "openwrt";
+    repo = "rtl8126";
+    tag = "10.016.00";
+    hash = "sha256-Smf512av6B8b5dAwOLVRelBf6goLdLqSJ0bLCf+f2b8=";
+  };
+
+  makeFlags = kernelModuleMakeFlags ++ [
+    "KERNELRELEASE=${kernel.modDirVersion}"
+    "-C ${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "M=$(PWD)"
+  ];
+
+  buildFlags = [
+    "ENABLE_FIBER_SUPPORT=y"
+    "ENABLE_PTP_SUPPORT=y"
+    "ENABLE_RSS_SUPPORT=y"
+    "ENABLE_USE_FIRMWARE_FILE=y"
+  ];
+  buildTargets = [ "modules" ];
+
+  installFlags = [ "INSTALL_MOD_PATH=$(out)" ];
+  installTargets = [ "modules_install" ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "Realtek RTL8126 5GbE PCIe driver";
+    homepage = "https://github.com/openwrt/rtl8126";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.azahi ];
+  };
+})

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -503,6 +503,8 @@ in
 
         r8168 = callPackage ../os-specific/linux/r8168 { };
 
+        rtl8126 = callPackage ../os-specific/linux/rtl8126 { };
+
         rtl8188eus-aircrack = callPackage ../os-specific/linux/rtl8188eus-aircrack { };
 
         rtl8192eu = callPackage ../os-specific/linux/rtl8192eu { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This adds a new Realtek driver from https://github.com/openwrt/rtl8126 which is a mirror. The readme file in that repo explains why we can't just pull the tarball from Realtek's official website.

The tarball itself doesn't ship with a LICENSE file but source code file headers imply that the project is licensed under GPL-2-ONLY.

Official website mentions that the current revision supports kernel versions up to 6.15. I couldn't find a proper way to assert this during eval or build. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
