### PR TITLE
 python3Packages.fava-portfolio-returns: init at 2.3.0 

### DIFF
--- a/pkgs/development/python-modules/fava-portfolio-returns/default.nix
+++ b/pkgs/development/python-modules/fava-portfolio-returns/default.nix
@@ -1,0 +1,97 @@
+{
+  lib,
+  buildPythonPackage,
+  buildNpmPackage,
+  fetchFromGitHub,
+  stdenv,
+  fava,
+  hatch-vcs,
+  hatchling,
+  numpy,
+  pandas,
+  protobuf,
+  pytestCheckHook,
+  scipy,
+}:
+let
+  pname = "fava-portfolio-returns";
+  version = "2.3.0";
+  src = fetchFromGitHub {
+    owner = "andreasgerstmayr";
+    repo = "fava-portfolio-returns";
+    rev = "v${version}";
+    hash = "sha256-NM+0gcgSztcgzYj0nCe9DOK90lrzE0TOzH30WvTKsUA=";
+  };
+
+  frontend = buildNpmPackage (finalAttrs: {
+    pname = "${pname}-frontend";
+    inherit version;
+
+    src = "${src}/frontend";
+
+    npmDepsHash = "sha256-MDoZC5IAR9puWMLBhLb5HRoagBPyNiyJ+0879ljCNUo=";
+
+    postPatch = ''
+      substituteInPlace package.json \
+        --replace-fail '"name": "fava-portfolio-returns",' '"name": "fava-portfolio-returns", "version": "${finalAttrs.version}",'
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+      cp ../src/fava_portfolio_returns/FavaPortfolioReturns.js $out/
+
+      runHook postInstall
+    '';
+  });
+in
+buildPythonPackage {
+  inherit pname version src;
+  pyproject = true;
+
+  build-system = [
+    hatchling
+    hatch-vcs
+  ];
+
+  dependencies = [
+    fava
+    numpy
+    pandas
+    protobuf
+    scipy
+  ];
+
+  preInstall = ''
+    cp ${frontend}/FavaPortfolioReturns.js src/fava_portfolio_returns/
+  '';
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "fava_portfolio_returns" ];
+
+  # Stay in the root of the repository, so that relative paths to example files
+  # loaded by tests stay correct.
+  # Remove `src` to avoid `PYTHONPATH` issues related to `pytestCheckHook` ([1])
+  # [1]: https://github.com/NixOS/nixpkgs/issues/255262
+  preCheck = ''
+    rm -rf src
+  '';
+
+  pytestFlags = [
+    "${placeholder "out"}"
+  ];
+
+  passthru = {
+    inherit frontend;
+  };
+
+  meta = {
+    description = "Show portfolio returns in Fava";
+    homepage = "https://github.com/andreasgerstmayr/fava-portfolio-returns";
+    changelog = "https://github.com/andreasgerstmayr/fava-portfolio-returns/blob/main/CHANGELOG.md";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ ambroisie ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5328,6 +5328,8 @@ self: super: with self; {
 
   fava-investor = callPackage ../development/python-modules/fava-investor { };
 
+  fava-portfolio-returns = callPackage ../development/python-modules/fava-portfolio-returns { };
+
   favicon = callPackage ../development/python-modules/favicon { };
 
   fe25519 = callPackage ../development/python-modules/fe25519 { };


### PR DESCRIPTION
## Things done

Depends on #461703.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
