### PR TITLE
mt32emu-qt: Fix build with CMake 4

### DIFF
--- a/pkgs/by-name/mt/mt32emu-qt/package.nix
+++ b/pkgs/by-name/mt/mt32emu-qt/package.nix
@@ -59,9 +59,9 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional withJack libjack2;
 
   cmakeFlags = [
-    "-Dmt32emu-qt_USE_PULSEAUDIO_DYNAMIC_LOADING=OFF"
-    "-Dmunt_WITH_MT32EMU_QT=ON"
-    "-Dmunt_WITH_MT32EMU_SMF2WAV=OFF"
+    (lib.cmakeBool "mt32emu-qt_USE_PULSEAUDIO_DYNAMIC_LOADING" false)
+    (lib.cmakeBool "munt_WITH_MT32EMU_QT" true)
+    (lib.cmakeBool "munt_WITH_MT32EMU_SMF2WAV" false)
   ];
 
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''

--- a/pkgs/by-name/mt/mt32emu-qt/package.nix
+++ b/pkgs/by-name/mt/mt32emu-qt/package.nix
@@ -24,9 +24,21 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-PqYPYnKPlnU3PByxksBscl4GqDRllQdmD6RWpy/Ura0=";
   };
 
-  postPatch = ''
-    sed -i -e '/add_subdirectory(mt32emu)/d' CMakeLists.txt
-  '';
+  postPatch =
+    # Make sure system-installed libmt32emu is used
+    # Don't depend on in-tree mt32emu to be used
+    ''
+      substituteInPlace CMakeLists.txt \
+        --replace-fail 'add_subdirectory(mt32emu)' "" \
+        --replace-fail 'add_dependencies(mt32emu-qt mt32emu)' ""
+    ''
+    # Bump CMake minimum to something our CMake supports
+    # Fixed treewide in https://github.com/munt/munt/commit/e6af0c7e5d63680716ab350467207c938054a0df
+    # Remove when version > 1.11.1
+    + ''
+      substituteInPlace CMakeLists.txt mt32emu_qt/CMakeLists.txt \
+        --replace-fail 'cmake_minimum_required(VERSION 2.8.12)' 'cmake_minimum_required(VERSION 2.8.12...3.27)'
+    '';
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
