### PR TITLE
gpaste: fix GIRepository `prepend_search_path` call, enable for GNOME 49

### DIFF
--- a/pkgs/by-name/gp/gpaste/package.nix
+++ b/pkgs/by-name/gp/gpaste/package.nix
@@ -36,6 +36,10 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     substituteInPlace src/libgpaste/gpaste/gpaste-settings.c \
       --subst-var-by gschemasCompiled ${glib.makeSchemaPath (placeholder "out") "${finalAttrs.pname}-${finalAttrs.version}"}
+
+    substituteInPlace src/gnome-shell/metadata.json.in --replace-fail \
+      '"shell-version": [ "45", "46", "47", "48" ],' \
+      '"shell-version": [ "45", "46", "47", "48", "49" ],'
   '';
 
   nativeBuildInputs = [
@@ -59,9 +63,9 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   mesonFlags = [
-    "-Dcontrol-center-keybindings-dir=${placeholder "out"}/share/gnome-control-center/keybindings"
-    "-Ddbus-services-dir=${placeholder "out"}/share/dbus-1/services"
-    "-Dsystemd-user-unit-dir=${placeholder "out"}/etc/systemd/user"
+    (lib.mesonOption "control-center-keybindings-dir" "${placeholder "out"}/share/gnome-control-center/keybindings")
+    (lib.mesonOption "dbus-services-dir" "${placeholder "out"}/share/dbus-1/services")
+    (lib.mesonOption "systemd-user-unit-dir" "${placeholder "out"}/etc/systemd/user")
   ];
 
   postInstall = ''
@@ -78,13 +82,13 @@ stdenv.mkDerivation (finalAttrs: {
       --subst-var-by typelibDir "${placeholder "out"}/lib/girepository-1.0"
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/Keruspe/GPaste";
     changelog = "https://github.com/Keruspe/GPaste/blob/v${finalAttrs.version}/NEWS";
     description = "Clipboard management system with GNOME integration";
     mainProgram = "gpaste-client";
-    license = licenses.bsd2;
-    platforms = platforms.linux;
-    teams = [ teams.gnome ];
+    license = lib.licenses.bsd2;
+    platforms = lib.platforms.linux;
+    teams = [ lib.teams.gnome ];
   };
 })

--- a/pkgs/by-name/gp/gpaste/wrapper.js
+++ b/pkgs/by-name/gp/gpaste/wrapper.js
@@ -1,5 +1,5 @@
 import GIRepository from 'gi://GIRepository';
 
-GIRepository.Repository.prepend_search_path('@typelibDir@');
+GIRepository.Repository.dup_default().prepend_search_path('@typelibDir@');
 
 export default (await import('./.@originalName@-wrapped.js')).default;


### PR DESCRIPTION
Another `dup_default()` fix: https://gjs-docs.gnome.org/girepository30~3.0/girepository.repository#function-dup_default
Upstream already indicates support for GNOME 49: https://github.com/Keruspe/GPaste/commit/c67a4df67f8fe872143c7f616d44e9f6b214cb91

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
