### PR TITLE
 fava-investor: init at 1.0.1 

### DIFF
--- a/pkgs/by-name/fa/fava-investor/package.nix
+++ b/pkgs/by-name/fa/fava-investor/package.nix
@@ -1,0 +1,1 @@
+{ python3Packages }: python3Packages.toPythonApplication python3Packages.fava-investor

--- a/pkgs/development/python-modules/fava-investor/default.nix
+++ b/pkgs/development/python-modules/fava-investor/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  stdenv,
+  beancount,
+  click,
+  click-aliases,
+  fava,
+  packaging,
+  pytestCheckHook,
+  python-dateutil,
+  setuptools,
+  setuptools-scm,
+  tabulate,
+  yfinance,
+}:
+buildPythonPackage rec {
+  pname = "fava-investor";
+  version = "1.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "redstreet";
+    repo = "fava_investor";
+    tag = version;
+    hash = "sha256-WuXbZcia0n9SoiCSB2SkMUjBHsMOA0gCIf9ZEU9pTPA=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    beancount
+    click
+    click-aliases
+    fava
+    packaging
+    python-dateutil
+    tabulate
+    yfinance
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "fava_investor" ];
+
+  meta = {
+    description = "Comprehensive set of reports, analyses, and tools for investments, for Beancount and Fava";
+    homepage = "https://github.com/redstreet/fava_investor";
+    changelog = "https://github.com/redstreet/fava_investor/blob/main/CHANGELOG.md";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ ambroisie ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5220,6 +5220,8 @@ self: super: with self; {
 
   fava-dashboards = callPackage ../development/python-modules/fava-dashboards { };
 
+  fava-investor = callPackage ../development/python-modules/fava-investor { };
+
   favicon = callPackage ../development/python-modules/favicon { };
 
   fe25519 = callPackage ../development/python-modules/fe25519 { };


### PR DESCRIPTION
## Things done

Depends on https://github.com/NixOS/nixpkgs/pull/461703.

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
