### PR TITLE
bluesky-pds: 0.4.188 -> 0.4.193, nixos/bluesky-pds: increase blobsize

### DIFF
--- a/nixos/modules/services/web-apps/bluesky-pds.nix
+++ b/nixos/modules/services/web-apps/bluesky-pds.nix
@@ -73,7 +73,7 @@ in
 
           PDS_BLOB_UPLOAD_LIMIT = mkOption {
             type = types.str;
-            default = "52428800";
+            default = "104857600";
             description = "Size limit of uploaded blobs in bytes";
           };
 

--- a/pkgs/by-name/bl/bluesky-pds/package.nix
+++ b/pkgs/by-name/bl/bluesky-pds/package.nix
@@ -21,13 +21,13 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pds";
-  version = "0.4.188";
+  version = "0.4.193";
 
   src = fetchFromGitHub {
     owner = "bluesky-social";
     repo = "pds";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-t8KdyEygXdbj/5Rhj8W40e1o8mXprELpjsKddHExmo0=";
+    hash = "sha256-OCG1YR56k0syIxRVrwUr0teaBJFQXocq0H6j9JaQkh8=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/service";
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
       sourceRoot
       ;
     fetcherVersion = 2;
-    hash = "sha256-D+yjUPnBkeEkC3hV5z5n6IDswbpvHsK5aYj7POYATCY=";
+    hash = "sha256-4qKWkINpUHzatiMa7ZNYp1NauU2641W0jHDjmRL9ipI=";
   };
 
   buildPhase = ''

--- a/pkgs/by-name/bl/bluesky-pdsadmin/pdsadmin-offline.patch
+++ b/pkgs/by-name/bl/bluesky-pdsadmin/pdsadmin-offline.patch
@@ -1,24 +1,24 @@
-diff --git a/pdsadmin.sh b/pdsadmin.sh
-index 913d2b4..b09c20c 100644
---- a/pdsadmin.sh
-+++ b/pdsadmin.sh
+diff --git i/pdsadmin.sh w/pdsadmin.sh
+index 505ada3..afc3265 100644
+--- i/pdsadmin.sh
++++ w/pdsadmin.sh
 @@ -15,16 +15,11 @@ if [[ "${EUID}" -ne 0 ]]; then
    exit 1
  fi
- 
+
 -# Download the script, if it exists.
 -SCRIPT_URL="${PDSADMIN_BASE_URL}/${COMMAND}.sh"
 -SCRIPT_FILE="$(mktemp /tmp/pdsadmin.${COMMAND}.XXXXXX)"
 +SCRIPT_FILE="NIXPKGS_PDSADMIN_ROOT/lib/pds/${COMMAND}.sh"
- 
+
 -if ! curl --fail --silent --show-error --location --output "${SCRIPT_FILE}" "${SCRIPT_URL}"; then
 +if ! [ -f "${SCRIPT_FILE}" ]; then
    echo "ERROR: ${COMMAND} not found"
    exit 2
  fi
- 
+
 -chmod +x "${SCRIPT_FILE}"
 -if "${SCRIPT_FILE}" "$@"; then
--  rm --force "${SCRIPT_FILE}"
+-  rm -f "${SCRIPT_FILE}"
 -fi
 +"${SCRIPT_FILE}" "$@"


### PR DESCRIPTION
Diff: [bluesky-social/pds@v0.4.188...v0.4.193](https://github.com/bluesky-social/pds/compare/v0.4.188...v0.4.193)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
