### PR TITLE
bazel_8: fix linux-sandbox

### DIFF
--- a/pkgs/by-name/ba/bazel_8/package.nix
+++ b/pkgs/by-name/ba/bazel_8/package.nix
@@ -206,6 +206,11 @@ stdenv.mkDerivation rec {
       usrBinEnv = "${coreutils}/bin/env";
     })
 
+    # Bazel tries to run "/bin/true" to test if linux-sandbox works.
+    (replaceVars ./patches/linux_sandbox.patch {
+      binTrue = "${coreutils}/bin/true";
+    })
+
     # Provide default JRE for Bazel process by setting --server_javabase=
     # in a new default system bazelrc file
     (replaceVars ./patches/bazel_rc.patch {

--- a/pkgs/by-name/ba/bazel_8/patches/linux_sandbox.patch
+++ b/pkgs/by-name/ba/bazel_8/patches/linux_sandbox.patch
@@ -1,0 +1,13 @@
+diff --git a/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java b/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
+index dc188b4ce2..46d338c9af 100644
+--- a/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
++++ b/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
+@@ -106,7 +106,7 @@ final class LinuxSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
+     ImmutableList<String> linuxSandboxArgv =
+         LinuxSandboxCommandLineBuilder.commandLineBuilder(linuxSandbox)
+             .setTimeout(options.getLocalSigkillGraceSeconds())
+-            .buildForCommand(ImmutableList.of("/bin/true"));
++            .buildForCommand(ImmutableList.of("@binTrue@"));
+     ImmutableMap<String, String> env = ImmutableMap.of();
+     Path execRoot = cmdEnv.getExecRoot();
+     File cwd = execRoot.getPathFile();


### PR DESCRIPTION
Hi there,

this PR contains a fix for the bazel_8 package to allow the use of `linux-sandbox`. Bazel checks for compatiblity of `/bin/true`, which fails on NixOS. 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
