### PR TITLE
[wip] zot: Init at 2.1.10

### DIFF
--- a/pkgs/by-name/zo/zot/package.nix
+++ b/pkgs/by-name/zo/zot/package.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  stdenv,
+}:
+
+let
+  pname = "zot";
+  version = "2.1.10";
+
+  src = fetchFromGitHub {
+    owner = "project-zot";
+    repo = "zot";
+    tag = "v${version}";
+    hash = "sha256-Evf556J2j+qCI4OtFT40yi3fQiZ0ubOTcCL8vsGHKb8=";
+  };
+
+  vendorHash = "sha256-DRbq56mh58DRme8tgxglMtneosfgbM35Z2QH/z5fNhc=";
+
+  tags = [
+    "imagetrust"
+    "lint"
+    "mgmt"
+    "profile"
+    "scrub"
+    "search"
+    "sync"
+    "userprefs"
+    "events"
+  ];
+
+  zotCmds = (
+    lib.attrsets.genAttrs
+      [
+        "zb"
+        "zli"
+        "zot"
+        "zxp"
+      ]
+      (
+        cmd:
+        buildGoModule {
+          inherit
+            version
+            src
+            vendorHash
+            ;
+
+          pname = cmd;
+          subPackages = [ "cmd/${cmd}" ];
+          tags = tags ++ (lib.optionals (cmd != "zxp") [ "metrics" ]);
+          doCheck = false;
+        }
+      )
+  );
+
+in
+stdenv.mkDerivation {
+  inherit pname;
+  inherit version;
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+
+    cp ${zotCmds.zb}/bin/zb $out/bin/
+    cp ${zotCmds.zli}/bin/zli $out/bin/
+    cp ${zotCmds.zot}/bin/zot $out/bin/
+    cp ${zotCmds.zxp}/bin/zxp $out/bin/
+  '';
+
+  meta = with lib; {
+    description = "A production-ready vendor-neutral OCI image registry";
+    homepage = "https://zotregistry.dev";
+    license = licenses.asl20;
+    maintainers = [ ];
+  };
+}


### PR DESCRIPTION
As per https://github.com/project-zot/zot/discussions/3541 add Zot as a package.

Zot(as described by the project owners) is a scale-out production-ready vendor-neutral OCI-native container image/artifact registry (purely based on OCI Distribution Specification). Its website can be found at https://zotregistry.dev/ 

Note: I am initializing this package without a maintainer as I can not assume this responsibility at this time.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
