### PR TITLE
[staging-next] electron_38: fix build with Rust 1.91

### DIFF
--- a/pkgs/development/tools/electron/CrabbyAvif-Switch-from-no_sanitize-cfi-to-sanitize-cfi-off-2.patch
+++ b/pkgs/development/tools/electron/CrabbyAvif-Switch-from-no_sanitize-cfi-to-sanitize-cfi-off-2.patch
@@ -1,0 +1,13 @@
+diff --git a/third_party/crabbyavif/src/src/reformat/libyuv.rs b/third_party/crabbyavif/src/src/reformat/libyuv.rs
+index dd12964..4ae9dc0 100644
+--- a/third_party/crabbyavif/src/src/reformat/libyuv.rs
++++ b/third_party/crabbyavif/src/src/reformat/libyuv.rs
+@@ -823,7 +823,7 @@ fn rgb_to_yuv_conversion_function(
+     }
+ }
+ 
+-#[cfg_attr(feature = "disable_cfi", no_sanitize(cfi))]
++#[cfg_attr(feature = "disable_cfi", sanitize(cfi = "off"))]
+ pub(crate) fn rgb_to_yuv(rgb: &rgb::Image, image: &mut image::Image) -> AvifResult<()> {
+     let conversion_function = rgb_to_yuv_conversion_function(rgb, image)?;
+     let plane_u8 = image.plane_ptrs_mut();

--- a/pkgs/development/tools/electron/common.nix
+++ b/pkgs/development/tools/electron/common.nix
@@ -106,6 +106,34 @@ in
         url = "https://github.com/chromium/chromium/commit/23d818d3c7fba4658248f17fd7b8993199242aa9.patch";
         hash = "sha256-JVv36PgU/rr34jrhgCyf4Pp8o5j2T8fD1xBVH1avT48=";
       })
+      # Fix build with Rust 1.91.0
+      # https://chromium-review.googlesource.com/c/chromium/src/+/6949745
+      (fetchpatch {
+        name = "Remove-unicode_width-from-rust-dependencies.patch";
+        url = "https://github.com/chromium/chromium/commit/0420449584e2afb7473393f536379efe194ba23c.patch";
+        hash = "sha256-2x1QoKkZEBfJw0hBjaErN/E47WrVfZvDngAXSIDzJs4=";
+      })
+      (fetchpatch {
+        name = "CrabbyAvif-Switch-from-no_sanitize-cfi-to-sanitize-cfi-off-1.patch";
+        url = "https://github.com/webmproject/CrabbyAvif/commit/4c70b98d1ebc8a210f2919be7ccabbcf23061cb5.patch";
+        extraPrefix = "third_party/crabbyavif/src/";
+        stripLen = 1;
+        hash = "sha256-E8/PmL+8+ZSoDO6L0/YOygIsliCDmcaBptXsi2L6ETQ=";
+      })
+      # backport of https://github.com/webmproject/CrabbyAvif/commit/3ba05863e84fd3acb4f4af2b4545221b317a2e55
+      ./CrabbyAvif-Switch-from-no_sanitize-cfi-to-sanitize-cfi-off-2.patch
+      # https://chromium-review.googlesource.com/c/chromium/src/+/6879484
+      (fetchpatch {
+        name = "crabbyavif-BUILD-gn-Temporarily-remove-disable_cfi-feature.patch";
+        url = "https://github.com/chromium/chromium/commit/e46275404d8f8a65ed84b3e583e9b78e4298acc7.patch";
+        hash = "sha256-2Dths53ervzCPKFbAVxeBHxtPHckxYhesJhaYZbxGSA=";
+      })
+      # https://chromium-review.googlesource.com/c/chromium/src/+/6960510
+      (fetchpatch {
+        name = "crabbyavif-BUILD-gn-Enable-disable_cfi-feature.patch";
+        url = "https://github.com/chromium/chromium/commit/9415f40bc6f853547f791e633be638c71368ce56.patch";
+        hash = "sha256-+M4gI77SoQ4dYIe/iGFgIwF1fS/6KQ8s16vj8ht/rik=";
+      })
     ];
 
   npmRoot = "third_party/node";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

fixes #461710

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
