### PR TITLE
fish: ensure pexpect available for tests

### DIFF
--- a/pkgs/by-name/fi/fish/package.nix
+++ b/pkgs/by-name/fi/fish/package.nix
@@ -147,6 +147,7 @@ let
       test $fenv_status -eq 0
     end # fenv
   '';
+  testPython = python3.withPackages (ps: [ ps.pexpect ]);
 
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -317,6 +318,7 @@ stdenv.mkDerivation (finalAttrs: {
   preConfigure = ''
     patchShebangs ./build_tools/git_version_gen.sh
     patchShebangs ./tests/test_driver.py
+    substituteInPlace ./tests/test_driver.py --replace-warn '"python3",' '"${testPython}/bin/python3",'
   ''
   + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
     export CMAKE_PREFIX_PATH=
@@ -336,7 +338,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeCheckInputs = [
     coreutils
     glibcLocales
-    (python3.withPackages (ps: [ ps.pexpect ]))
+    testPython
     procps
     sphinx
   ]
@@ -350,6 +352,7 @@ stdenv.mkDerivation (finalAttrs: {
   checkTarget = "fish_run_tests";
   preCheck = ''
     export TERMINFO="${ncurses}/share/terminfo"
+    export PATH=${testPython}/bin:$PATH
   '';
 
   nativeInstallCheckInputs = [

--- a/pkgs/by-name/fi/fish/package.nix
+++ b/pkgs/by-name/fi/fish/package.nix
@@ -352,7 +352,6 @@ stdenv.mkDerivation (finalAttrs: {
   checkTarget = "fish_run_tests";
   preCheck = ''
     export TERMINFO="${ncurses}/share/terminfo"
-    export PATH=${testPython}/bin:$PATH
   '';
 
   nativeInstallCheckInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
