### PR TITLE
gnomeExtensions: GIRepository fixes

### DIFF
--- a/pkgs/by-name/gn/gnome-shell-extensions/fix_gmenu.patch
+++ b/pkgs/by-name/gn/gnome-shell-extensions/fix_gmenu.patch
@@ -15,7 +15,7 @@ index 6eb58f1..28e1195 100644
  import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
  import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
  
-+GIRepository.Repository.prepend_search_path('@gmenu_path@');
++GIRepository.Repository.dup_default().prepend_search_path('@gmenu_path@');
 +const {default: GMenu} = await import('gi://GMenu');
  const appSys = Shell.AppSystem.get_default();
  

--- a/pkgs/by-name/gn/gnome-shell-extensions/fix_gtop.patch
+++ b/pkgs/by-name/gn/gnome-shell-extensions/fix_gtop.patch
@@ -17,7 +17,7 @@ index 37d2eb1..232d0d5 100644
  
  import * as Main from 'resource:///org/gnome/shell/ui/main.js';
  
-+GIRepository.Repository.prepend_search_path('@gtop_path@');
++GIRepository.Repository.dup_default().prepend_search_path('@gtop_path@');
 +const GTop = (await import("gi://GTop")).default;
 +
  const THRESHOLD_HIGH = 0.80;

--- a/pkgs/desktops/gnome/extensions/drop-down-terminal/fix_vte_and_gjs.patch
+++ b/pkgs/desktops/gnome/extensions/drop-down-terminal/fix_vte_and_gjs.patch
@@ -4,7 +4,7 @@
  
  // Author: Stéphane Démurget <stephane.demurget@free.fr>
  
-+imports.gi.GIRepository.Repository.prepend_search_path('@vte@/lib/girepository-1.0')
++imports.gi.GIRepository.Repository.dup_default().prepend_search_path('@vte@/lib/girepository-1.0')
 +
  const Lang = imports.lang;
  const Gettext = imports.gettext.domain("drop-down-terminal");
@@ -25,7 +25,7 @@
  
  // Author: Stéphane Démurget <stephane.demurget@free.fr>
 +
-+imports.gi.GIRepository.Repository.prepend_search_path('@vte@/lib/girepository-1.0')
++imports.gi.GIRepository.Repository.dup_default().prepend_search_path('@vte@/lib/girepository-1.0')
 +
  const Lang = imports.lang;
  

--- a/pkgs/desktops/gnome/extensions/extensionOverridesPatches/apps-menu_at_gnome-shell-extensions.gcampax.github.com.patch
+++ b/pkgs/desktops/gnome/extensions/extensionOverridesPatches/apps-menu_at_gnome-shell-extensions.gcampax.github.com.patch
@@ -9,7 +9,7 @@ index c608441..2b25335 100644
 -import GMenu from 'gi://GMenu';
 +
 +import GIRepository from 'gi://GIRepository';
-+GIRepository.Repository.prepend_search_path('@gmenu_path@');
++GIRepository.Repository.dup_default().prepend_search_path('@gmenu_path@');
 +const {default: GMenu} = await import('gi://GMenu');
 +
  import GObject from 'gi://GObject';

--- a/pkgs/desktops/gnome/extensions/extensionOverridesPatches/system-monitor-next_at_paradoxxx.zero.gmail.com.patch
+++ b/pkgs/desktops/gnome/extensions/extensionOverridesPatches/system-monitor-next_at_paradoxxx.zero.gmail.com.patch
@@ -22,7 +22,7 @@ index ee8c3a9..ca72885 100644
  
  import * as Util from "resource:///org/gnome/shell/misc/util.js";
  
-+GIRepository.Repository.prepend_search_path('@gtop_path@');
++GIRepository.Repository.dup_default().prepend_search_path('@gtop_path@');
 +const GTop = (await import("gi://GTop")).default;
 +
  const NetworkManager = NM;

--- a/pkgs/desktops/gnome/extensions/extensionOverridesPatches/vitals_at_corecoding.com.patch
+++ b/pkgs/desktops/gnome/extensions/extensionOverridesPatches/vitals_at_corecoding.com.patch
@@ -6,7 +6,7 @@ index 39d175a..9815b77 100644
  import { gettext as _ } from 'resource:///org/gnome/shell/extensions/extension.js';
  import NM from 'gi://NM';
 
-+imports.gi.GIRepository.Repository.prepend_search_path('@gtop_path@');
++imports.gi.GIRepository.Repository.dup_default().prepend_search_path('@gtop_path@');
 +
  let GTop, hasGTop = true;
  try {

--- a/pkgs/desktops/gnome/extensions/gsconnect/default.nix
+++ b/pkgs/desktops/gnome/extensions/gsconnect/default.nix
@@ -68,14 +68,14 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   mesonFlags = [
-    "-Dgnome_shell_libdir=${gnome-shell}/lib"
-    "-Dchrome_nmhdir=${placeholder "out"}/etc/opt/chrome/native-messaging-hosts"
-    "-Dchromium_nmhdir=${placeholder "out"}/etc/chromium/native-messaging-hosts"
-    "-Dopenssl_path=${openssl}/bin/openssl"
-    "-Dsshadd_path=${openssh}/bin/ssh-add"
-    "-Dsshkeygen_path=${openssh}/bin/ssh-keygen"
-    "-Dsession_bus_services_dir=${placeholder "out"}/share/dbus-1/services"
-    "-Dinstalled_test_prefix=${placeholder "installedTests"}"
+    (lib.mesonOption "gnome_shell_libdir" "${gnome-shell}/lib")
+    (lib.mesonOption "chrome_nmhdir" "${placeholder "out"}/etc/opt/chrome/native-messaging-hosts")
+    (lib.mesonOption "chromium_nmhdir" "${placeholder "out"}/etc/chromium/native-messaging-hosts")
+    (lib.mesonOption "openssl_path" "${openssl}/bin/openssl")
+    (lib.mesonOption "sshadd_path" "${openssh}/bin/ssh-add")
+    (lib.mesonOption "sshkeygen_path" "${openssh}/bin/ssh-keygen")
+    (lib.mesonOption "session_bus_services_dir" "${placeholder "out"}/share/dbus-1/services")
+    (lib.mesonOption "installed_test_prefix" "${placeholder "installedTests"}")
   ];
 
   postPatch = ''

--- a/pkgs/desktops/gnome/extensions/gsconnect/fix-paths.patch
+++ b/pkgs/desktops/gnome/extensions/gsconnect/fix-paths.patch
@@ -18,7 +18,7 @@ index 00000000..d009dfd9
 +++ b/src/__nix-prepend-search-paths.js
 @@ -0,0 +1,2 @@
 +import GIRepository from 'gi://GIRepository';
-+'@typelibPath@'.split(':').forEach(path => GIRepository.Repository.prepend_search_path(path));
++'@typelibPath@'.split(':').forEach(path => GIRepository.Repository.dup_default().prepend_search_path(path));
 diff --git a/src/extension.js b/src/extension.js
 index 53ecd5fc..78782357 100644
 --- a/src/extension.js


### PR DESCRIPTION
gnomeExtensions.system-monitor is separately fixed here: https://github.com/NixOS/nixpkgs/pull/461619
This applies the patch changes to the other extensions.

I tried all the extensions, drop-down-terminal is still broken, showing
```
SyntaxError: import declarations may only appear at top level of a module @ resource:///org/gnome/Shell/Extensions/js/misc/extensionUtils.js:4:1

Stack trace:
  @file:///etc/profiles/per-user/winston/share/gnome-shell/extensions/drop-down-terminal@gs-extensions.zzrough.org/prefs.js:27:12
  _init/GLib.MainLoop.prototype.runAsync/</<@resource:///org/gnome/gjs/modules/core/overrides/GLib.js:263:34
```

Looks like it's been broken for a while now: https://github.com/zzrough/gs-extensions-drop-down-terminal/issues

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
