### PR TITLE
swift: fix build with Clang 21 by adding missing type_traits include

### DIFF
--- a/pkgs/development/compilers/swift/compiler/default.nix
+++ b/pkgs/development/compilers/swift/compiler/default.nix
@@ -347,6 +347,7 @@ stdenv.mkDerivation {
     patch -p1 -d swift -i $TMPDIR/swift-separate-lib.patch
 
     patch -p1 -d llvm-project/llvm -i ${./patches/llvm-module-cache.patch}
+    patch -p1 -d llvm-project/llvm -i ${./patches/llvm-type-traits-include.patch}
 
     for lldbPatch in ${
       lib.escapeShellArgs [

--- a/pkgs/development/compilers/swift/compiler/patches/llvm-type-traits-include.patch
+++ b/pkgs/development/compilers/swift/compiler/patches/llvm-type-traits-include.patch
@@ -1,0 +1,19 @@
+Fix missing #include <type_traits> for compatibility with Clang 21
+
+The LLVM headers bundled with Swift 5.10.1 are missing an explicit include
+of <type_traits>, which causes compilation failures with newer Clang versions
+(e.g., Clang 21.1.2) that are stricter about implicit includes.
+
+This patch adds the missing include to fix the build error:
+  error: missing '#include <type_traits>'; 'is_class' must be defined before it is used
+
+--- a/include/llvm/Support/type_traits.h
++++ b/include/llvm/Support/type_traits.h
+@@ -15,6 +15,7 @@
+ #define LLVM_SUPPORT_TYPE_TRAITS_H
+
+ #include "llvm/Support/Compiler.h"
++#include <type_traits>
+ #include <utility>
+
+ namespace llvm {


### PR DESCRIPTION
Swift 5.10.1's bundled LLVM headers are missing an explicit `#include <type_traits>` in llvm/Support/type_traits.h, which causes compilation failures with Clang 21.1.2. Modern Clang versions are stricter about implicit includes and require explicit includes for standard library types like std::is_class.

ZHF: #457852


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
