### PR TITLE
feat: add macOS support to apmplanner2

### DIFF
--- a/pkgs/applications/science/robotics/apmplanner2/default.nix
+++ b/pkgs/applications/science/robotics/apmplanner2/default.nix
@@ -1,11 +1,12 @@
 {
   lib,
+  stdenv,
   mkDerivation,
   fetchFromGitHub,
   qmake,
   qtbase,
   qtscript,
-  qtwebkit,
+  qtmultimedia,
   qtserialport,
   qtsvg,
   qtdeclarative,
@@ -29,28 +30,91 @@ mkDerivation rec {
     sha256 = "0wvbfjnnf7sh6fpgw8gimh5hgzywj3nwrgr80r782f5gayd3v2l1";
   };
 
+  # After qmake generates the Makefile, fix bundled framework and QML references
+  postConfigure = lib.optionalString stdenv.isDarwin ''
+    # Remove references to bundled SDL2 framework and use nix SDL2 instead
+    substituteInPlace Makefile \
+      --replace-fail \
+        "-F$PWD/libs/lib/Frameworks -framework SDL2" \
+        "-L${lib.getLib SDL2}/lib -lSDL2" \
+      --replace-fail \
+        "-I$PWD/libs/lib/Frameworks/SDL2.framework/Headers" \
+        "-I${lib.getDev SDL2}/include/SDL2"
+
+    # Remove bundled framework copy command (doesn't support arm64)
+    substituteInPlace Makefile \
+      --replace-fail \
+        "cp -f -R -L $PWD/libs/lib/Frameworks" \
+        "true # skip bundled frameworks copy"
+
+    # Remove install_name_tool command for bundled SDL2 framework
+    substituteInPlace Makefile \
+      --replace-fail \
+        "install_name_tool -change @rpath/SDL2.framework/Versions/A/SDL2" \
+        "true # skip SDL2 install_name_tool ||"
+
+    # Fix QtQuick QML copy commands - qtdeclarative has qml dir, not qtbase
+    substituteInPlace Makefile \
+      --replace-fail \
+        "/qml/QtQuick " \
+        "/lib/qt-${qtbase.qtCompatVersion}/qml/QtQuick " \
+      --replace-fail \
+        "/qml/QtQuick.2 " \
+        "/lib/qt-${qtbase.qtCompatVersion}/qml/QtQuick.2 "
+  '';
+
   buildInputs = [
+    qtbase
+    qtscript
+    qtmultimedia
+    qtserialport
+    qtsvg
+    qtdeclarative
+    qtquickcontrols2
+    SDL2
+  ]
+  ++ lib.optionals stdenv.isLinux [
     alsa-lib
     libsndfile
     flite
     openssl
     udev
-    SDL2
-    qtbase
-    qtscript
-    qtwebkit
-    qtserialport
-    qtsvg
-    qtdeclarative
-    qtquickcontrols2
   ];
 
   nativeBuildInputs = [ qmake ];
 
   qmakeFlags = [ "apm_planner.pro" ];
 
+  # Add SDL2 include path for Darwin
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin "-I${lib.getDev SDL2}/include/SDL2";
+
+  # Link Darwin frameworks needed by SDL2
+  NIX_LDFLAGS = lib.optionalString stdenv.isDarwin (toString [
+    "-L${SDL2}/lib"
+    "-lSDL2"
+    "-framework ApplicationServices"
+    "-framework CoreAudio"
+    "-framework AudioToolbox"
+    "-framework CoreFoundation"
+    "-framework IOKit"
+  ]);
+
+  # Post-install fixup for macOS bundle
+  postInstall = lib.optionalString stdenv.isDarwin ''
+        mkdir -p $out/Applications
+        cp -r release/apmplanner2.app $out/Applications/
+
+        # Create a wrapper script in bin for nix run
+        mkdir -p $out/bin
+        cat > $out/bin/apmplanner2 <<EOF
+    #!/bin/sh
+    exec "$out/Applications/apmplanner2.app/Contents/MacOS/apmplanner2" "\$@"
+    EOF
+        chmod +x $out/bin/apmplanner2
+  '';
+
   # this ugly hack is necessary, as `bin/apmplanner2` needs the contents of `share/APMPlanner2` inside of `bin/`
-  preFixup = ''
+  preFixup = lib.optionalString stdenv.isLinux ''
     ln --relative --symbolic $out/share/APMPlanner2/* $out/bin/
     substituteInPlace $out/share/applications/apmplanner2.desktop \
       --replace /usr $out
@@ -65,5 +129,7 @@ mkDerivation rec {
     homepage = "https://ardupilot.org/planner2/";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ wucke13 ];
+    platforms = lib.platforms.unix;
+    mainProgram = "apmplanner2";
   };
 }

--- a/pkgs/applications/science/robotics/apmplanner2/default.nix
+++ b/pkgs/applications/science/robotics/apmplanner2/default.nix
@@ -101,16 +101,9 @@ mkDerivation rec {
 
   # Post-install fixup for macOS bundle
   postInstall = lib.optionalString stdenv.isDarwin ''
-        mkdir -p $out/Applications
-        cp -r release/apmplanner2.app $out/Applications/
-
-        # Create a wrapper script in bin for nix run
-        mkdir -p $out/bin
-        cat > $out/bin/apmplanner2 <<EOF
-    #!/bin/sh
-    exec "$out/Applications/apmplanner2.app/Contents/MacOS/apmplanner2" "\$@"
-    EOF
-        chmod +x $out/bin/apmplanner2
+    mkdir -p $out/{Applications,bin}
+    cp -r release/apmplanner2.app $out/Applications
+    ln -s $out/Applications/apmplanner2.app/Contents/MacOS/apmplanner2 $out/bin/apmplanner2
   '';
 
   # this ugly hack is necessary, as `bin/apmplanner2` needs the contents of `share/APMPlanner2` inside of `bin/`


### PR DESCRIPTION
`apmplanner2` previously did not have darwin builds.
Make this package work on darwin.

The source vendors it's own source for SDL2. We have to substitute it with the nixpkgs provided version of SDL2 as the vendored version does not work on aarch64.

Switch from `qtwebkit` to `qtmultimedia` as `qtwebkit` is marked as known vulnerable: https://github.com/NixOS/nixpkgs/blob/13ef5aeff48c2f2503a356a063028dfb406856da/pkgs/development/libraries/qt-5/modules/qtwebkit.nix#L115

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
