### PR TITLE
icemon: 3.3 -> 3.3-unstable-2025-05-15, fix build, migrate to pkgs/by-name

### DIFF
--- a/pkgs/by-name/ic/icemon/package.nix
+++ b/pkgs/by-name/ic/icemon/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  asciidoc,
   fetchFromGitHub,
   cmake,
   extra-cmake-modules,
@@ -24,6 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
+    asciidoc
     cmake
     extra-cmake-modules
     qt6.wrapQtAppsHook

--- a/pkgs/by-name/ic/icemon/package.nix
+++ b/pkgs/by-name/ic/icemon/package.nix
@@ -1,19 +1,18 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
-  mkDerivation,
-  qtbase,
   cmake,
   extra-cmake-modules,
   icecream,
   libcap_ng,
+  libsForQt5,
   lzo,
   zstd,
   libarchive,
-  wrapQtAppsHook,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "icemon";
   version = "3.3";
 
@@ -27,11 +26,11 @@ mkDerivation rec {
   nativeBuildInputs = [
     cmake
     extra-cmake-modules
-    wrapQtAppsHook
+    libsForQt5.wrapQtAppsHook
   ];
   buildInputs = [
     icecream
-    qtbase
+    libsForQt5.qtbase
     libcap_ng
     lzo
     zstd

--- a/pkgs/by-name/ic/icemon/package.nix
+++ b/pkgs/by-name/ic/icemon/package.nix
@@ -12,7 +12,7 @@
   libarchive,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "icemon";
   version = "3.3-unstable-2025-05-15";
 
@@ -39,10 +39,10 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Icecream GUI Monitor";
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/icecc/icemon";
     license = lib.licenses.gpl2;
     maintainers = with lib.maintainers; [ emantor ];
     platforms = with lib.platforms; linux ++ darwin;
     mainProgram = "icemon";
   };
-}
+})

--- a/pkgs/by-name/ic/icemon/package.nix
+++ b/pkgs/by-name/ic/icemon/package.nix
@@ -6,31 +6,31 @@
   extra-cmake-modules,
   icecream,
   libcap_ng,
-  libsForQt5,
   lzo,
+  qt6,
   zstd,
   libarchive,
 }:
 
 stdenv.mkDerivation rec {
   pname = "icemon";
-  version = "3.3";
+  version = "3.3-unstable-2025-05-15";
 
   src = fetchFromGitHub {
     owner = "icecc";
     repo = "icemon";
-    rev = "v${version}";
-    sha256 = "09jnipr67dhawbxfn69yh7mmjrkylgiqmd0gmc2limd3z15d7pgc";
+    rev = "d0969453c7d4467e22dcff0f218b31e81136afbe";
+    hash = "sha256-jN374J8PytnZgVEUSZ6DakmPmi411ABJffzuZ5CodJ8=";
   };
 
   nativeBuildInputs = [
     cmake
     extra-cmake-modules
-    libsForQt5.wrapQtAppsHook
+    qt6.wrapQtAppsHook
   ];
   buildInputs = [
     icecream
-    libsForQt5.qtbase
+    qt6.qtbase
     libcap_ng
     lzo
     zstd

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2980,8 +2980,6 @@ with pkgs;
 
   hyphenDicts = recurseIntoAttrs (callPackages ../development/libraries/hyphen/dictionaries.nix { });
 
-  icemon = libsForQt5.callPackage ../applications/networking/icemon { };
-
   icepeak = haskell.lib.compose.justStaticExecutables haskellPackages.icepeak;
 
   ihaskell = callPackage ../development/tools/haskell/ihaskell/wrapper.nix {


### PR DESCRIPTION
### `icemon` updates

#### Version Update
- `icemon` currently fails to build on [Hydra](https://hydra.nixos.org/build/313363005/) due to a `cmake_minimum_required`  version that is incompatible with CMake4.
- This issue has been fixed upstream, but no new release has been cut. The package is therefore updated to track unstable.
- The latest upstream commit is avoided as the package seg faults.
- See the [diff](https://github.com/icecc/icemon/compare/v3.3...d0969453c7d4467e22dcff0f218b31e81136afbe) for details.

#### `Qt6` Migration
- Upstream has migrated from `Qt5` to `Qt6`.
- The package has been updated accordingly.

#### Migration to pkgs/by-name
- The package has been migrated to pkgs/by-name.

#### Add Man Pages to Build
- Added `asciidoc` as a build dependency to ensure man pages are generated and installed.

#### Modernisation
- Updated the package expression to align with current `nixpkgs` practices.

#### Tracking
https://github.com/NixOS/nixpkgs/issues/445447
https://github.com/NixOS/nixpkgs/issues/457852

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
