### PR TITLE
socalabs-organ: init at 1.0.7

### DIFF
--- a/pkgs/by-name/so/socalabs-organ/fix-strcasecmp.diff
+++ b/pkgs/by-name/so/socalabs-organ/fix-strcasecmp.diff
@@ -1,0 +1,12 @@
+diff --git a/plugin/setBfree/src/tonegen.c b/plugin/setBfree/src/tonegen.c
+index 314a302..132bf7a 100644
+--- a/plugin/setBfree/src/tonegen.c
++++ b/plugin/setBfree/src/tonegen.c
+@@ -29,6 +29,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <strings.h>
+ 
+ #include "global_inst.h"
+ #include "main.h"

--- a/pkgs/by-name/so/socalabs-organ/package.nix
+++ b/pkgs/by-name/so/socalabs-organ/package.nix
@@ -1,0 +1,153 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  cmake,
+  ninja,
+  pkg-config,
+  writableTmpDirAsHomeHook,
+  copyDesktopItems,
+  makeDesktopItem,
+  libx11,
+  libxrandr,
+  libxcursor,
+  libxinerama,
+  libxext,
+  freetype,
+  fontconfig,
+  expat,
+  alsa-lib,
+  curl,
+
+  buildStandalone ? true,
+  buildVST3 ? true,
+  buildLV2 ? true,
+}:
+
+let
+  cmakeFormats = [
+    (lib.optionalString buildStandalone "Standalone")
+    (lib.optionalString buildVST3 "VST3")
+    (lib.optionalString buildLV2 "LV2")
+  ];
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "socalabs-organ";
+  version = "1.0.7";
+
+  src = fetchFromGitHub {
+    owner = "FigBug";
+    repo = "Organ";
+
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-rTWT3iW3b21/uyl70ezjAH9htxvbcy0KYUYe3703bEM=";
+
+    fetchSubmodules = true;
+
+    preFetch = ''
+      export GIT_CONFIG_COUNT=1
+      export GIT_CONFIG_KEY_0=url.https://github.com/.insteadOf
+      export GIT_CONFIG_VALUE_0=git@github.com:
+    '';
+  };
+
+  patches = [
+    ./fix-strcasecmp.diff
+  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "FORMATS Standalone VST VST3 AU LV2" "FORMATS ${lib.concatStringsSep " " cmakeFormats}"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    writableTmpDirAsHomeHook
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    libx11
+    libxcursor
+    libxrandr
+    libxinerama
+    libxext
+    freetype
+    fontconfig
+    expat
+    alsa-lib
+    curl
+  ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  cmakeFlags = [
+    "--preset ninja-gcc"
+    (lib.cmakeBool "JUCE_COPY_PLUGIN_AFTER_BUILD" false)
+  ];
+
+  # Fontconfig error: Cannot load default config file: No such file: (null)
+  env.FONTCONFIG_FILE = "${fontconfig.out}/etc/fonts/fonts.conf";
+
+  preBuild = "cd ../Builds/ninja-gcc";
+
+  installPhase = ''
+    runHook preInstall
+
+    pushd Organ_artefacts/Release
+      ${lib.optionalString buildStandalone ''
+        install -Dm755 Standalone/Organ -t $out/bin
+      ''}
+
+      ${lib.optionalString buildVST3 ''
+        mkdir -p $out/lib/vst3
+        cp -r VST3/Organ.vst3 $out/lib/vst3
+      ''}
+
+      ${lib.optionalString buildLV2 ''
+        mkdir -p $out/lib/lv2
+        cp -r LV2/Organ.lv2 $out/lib/lv2
+      ''}
+
+      mkdir -p $out/lib/clap
+      cp -r CLAP/Organ.clap $out/lib/clap
+    popd
+
+    runHook postInstall
+  '';
+
+  # JUCE dlopens these at runtime, standalone executable crashes without them
+  NIX_LDFLAGS = [ "-lX11" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  desktopItems = [
+    (makeDesktopItem {
+      type = "Application";
+      name = "socalabs-organ";
+      desktopName = "Socalabs Organ";
+      comment = "Socalabs Electric Organ Emulation Plugin (Standalone)";
+      exec = "Organ";
+      categories = [
+        "Audio"
+        "AudioVideo"
+      ];
+    })
+  ];
+
+  meta = {
+    description = "Electric organ emulation based on setBfree";
+    homepage = "https://socalabs.com/synths/organ/";
+    platforms = [ "x86_64-linux" ];
+    license = [ lib.licenses.bsd3 ];
+    maintainers = [ lib.maintainers.mrtnvgr ];
+  }
+  // lib.optionalAttrs buildStandalone {
+    mainProgram = "Organ";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
