### PR TITLE
python3Packages.tesla-wall-connector: replace async-timeout with asyncio.timeout

### DIFF
--- a/pkgs/development/python-modules/tesla-wall-connector/default.nix
+++ b/pkgs/development/python-modules/tesla-wall-connector/default.nix
@@ -5,6 +5,7 @@
   backoff,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   poetry-core,
   pytest-asyncio,
   pytestCheckHook,
@@ -24,6 +25,20 @@ buildPythonPackage rec {
     rev = version;
     hash = "sha256-3jj3LU0xRIC6U5DmitkTNjejvSZJWguTS/TeotOD8oc=";
   };
+
+  patches = [
+    # https://github.com/einarhauks/tesla-wall-connector/pull/16
+    (fetchpatch {
+      name = "replace-async-timeout-with-asyncio.timeout.patch";
+      url = "https://github.com/einarhauks/tesla-wall-connector/commit/4683738b4d2cccb2be337a383243ab3f7623bf8e.patch";
+      excludes = [
+        ".github/workflows/python-package.yml"
+        "poetry.lock"
+        "pyproject.toml"
+      ];
+      hash = "sha256-V9Ra7xA5JzBGe8tE8urVJNqCCdBkNmmqUcXo0cswSoY=";
+    })
+  ];
 
   nativeBuildInputs = [ poetry-core ];
 

--- a/pkgs/development/python-modules/tesla-wall-connector/default.nix
+++ b/pkgs/development/python-modules/tesla-wall-connector/default.nix
@@ -9,20 +9,17 @@
   poetry-core,
   pytest-asyncio,
   pytestCheckHook,
-  pythonOlder,
 }:
 
 buildPythonPackage rec {
   pname = "tesla-wall-connector";
   version = "1.1.0";
-  format = "pyproject";
-
-  disabled = pythonOlder "3.8";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "einarhauks";
     repo = "tesla-wall-connector";
-    rev = version;
+    tag = version;
     hash = "sha256-3jj3LU0xRIC6U5DmitkTNjejvSZJWguTS/TeotOD8oc=";
   };
 
@@ -40,9 +37,9 @@ buildPythonPackage rec {
     })
   ];
 
-  nativeBuildInputs = [ poetry-core ];
+  build-system = [ poetry-core ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     aiohttp
     backoff
   ];
@@ -55,10 +52,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "tesla_wall_connector" ];
 
-  meta = with lib; {
+  meta = {
+    changelog = "https://github.com/einarhauks/tesla-wall-connector/releases/tag/${src.tag}";
     description = "Library for communicating with a Tesla Wall Connector";
     homepage = "https://github.com/einarhauks/tesla-wall-connector";
-    license = with licenses; [ mit ];
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
   };
 }


### PR DESCRIPTION
ZHF: https://github.com/NixOS/nixpkgs/issues/457852

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
