### PR TITLE
socalabs-rp2a03: init at 0-unstable-2025-08-08

### DIFF
--- a/pkgs/by-name/so/socalabs-rp2a03/package.nix
+++ b/pkgs/by-name/so/socalabs-rp2a03/package.nix
@@ -1,0 +1,149 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  cmake,
+  ninja,
+  pkg-config,
+  writableTmpDirAsHomeHook,
+  copyDesktopItems,
+  makeDesktopItem,
+  libx11,
+  libxrandr,
+  libxinerama,
+  libxext,
+  libxcursor,
+  freetype,
+  fontconfig,
+  curl,
+  alsa-lib,
+  expat,
+
+  buildStandalone ? true,
+  buildVST3 ? true,
+  buildLV2 ? true,
+}:
+
+let
+  cmakeFormats = [
+    (lib.optionalString buildStandalone "Standalone")
+    (lib.optionalString buildVST3 "VST3")
+    (lib.optionalString buildLV2 "LV2")
+  ];
+in
+
+stdenv.mkDerivation {
+  pname = "socalabs-rp2a03";
+  version = "0-unstable-2025-08-08";
+
+  src = fetchFromGitHub {
+    owner = "FigBug";
+    repo = "RP2A03";
+    rev = "af73e9138a5b2903c8408ff5f6502c5a38de1a68";
+    hash = "sha256-2spVflj+fCeJQFO7xwROO8hVtgRiTU8f+812u6Feeqk=";
+    fetchSubmodules = true;
+
+    preFetch = ''
+      export GIT_CONFIG_COUNT=1
+      export GIT_CONFIG_KEY_0=url.https://github.com/.insteadOf
+      export GIT_CONFIG_VALUE_0=git@github.com:
+    '';
+  };
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "FORMATS Standalone VST VST3 AU LV2" "FORMATS ${lib.concatStringsSep " " cmakeFormats}"
+
+    # -- (taken from socalabs-sid package) --
+    # we need to patch JUCE itself to enable jack MIDI support
+    # please https://github.com/juce-framework/JUCE/issues/952
+    # TODO: remove when juce updates :D
+    substituteInPlace modules/juce/modules/juce_audio_devices/native/juce_Midi_linux.cpp \
+      --replace-fail "port = client.createPort (portName, forInput, false);" "port = client.createPort (portName, forInput, true);"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    writableTmpDirAsHomeHook
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    libx11
+    libxcursor
+    libxrandr
+    libxinerama
+    libxext
+    freetype
+    fontconfig
+    expat
+    alsa-lib
+    curl
+  ];
+
+  cmakeFlags = [
+    "--preset ninja-gcc"
+    (lib.cmakeBool "JUCE_COPY_PLUGIN_AFTER_BUILD" false)
+  ];
+
+  # Fontconfig error: Cannot load default config file: No such file: (null)
+  env.FONTCONFIG_FILE = "${fontconfig.out}/etc/fonts/fonts.conf";
+
+  preBuild = "cd ../Builds/ninja-gcc";
+
+  installPhase = ''
+    runHook preInstall
+
+    pushd RP2A03_artefacts/Release
+      ${lib.optionalString buildStandalone ''
+        install -Dm755 Standalone/RP2A03 -t $out/bin
+      ''}
+
+      ${lib.optionalString buildVST3 ''
+        mkdir -p $out/lib/vst3
+        cp -r VST3/RP2A03.vst3 $out/lib/vst3
+      ''}
+
+      ${lib.optionalString buildLV2 ''
+        mkdir -p $out/lib/lv2
+        cp -r LV2/RP2A03.lv2 $out/lib/lv2
+      ''}
+    popd
+
+    runHook postInstall
+  '';
+
+  # Needed for standalone
+  NIX_LDFLAGS = [ "-lX11" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  desktopItems = [
+    (makeDesktopItem {
+      type = "Application";
+      name = "socalabs-RP2A03";
+      desktopName = "Socalabs RP2A03";
+      comment = "Socalabs Nintendo RP2A03 Emulation Plugin (Standalone)";
+      exec = "RP2A03";
+      categories = [
+        "Audio"
+        "AudioVideo"
+      ];
+    })
+  ];
+
+  meta = {
+    description = "Nintendo RP2A03 Emulation Plugin";
+    homepage = "https://socalabs.com/synths/rp2a03";
+    platforms = lib.platforms.linux;
+    license = [ lib.licenses.bsd3 ];
+    maintainers = [ lib.maintainers.mrtnvgr ];
+    mainProgram = lib.optionalString buildStandalone "RP2A03";
+  }
+  // lib.optionalAttrs buildStandalone {
+    mainProgram = "RP2A03";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
