### PR TITLE
cachix: dontCheck on darwin for now

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -3904,21 +3904,25 @@ with haskellLib;
       src = src + "/cachix-api";
     } super.cachix-api;
 
-    cachix = lib.pipe super.cachix [
-      (overrideSrc {
-        inherit version;
-        src = src + "/cachix";
-      })
-      (addBuildDepends [
-        self.pqueue
-      ])
-      (
-        drv:
-        drv.override {
-          nix = self.hercules-ci-cnix-store.nixPackage;
-          hnix-store-core = self.hnix-store-core_0_8_0_0;
-        }
-      )
-    ];
+    cachix = lib.pipe super.cachix (
+      [
+        (overrideSrc {
+          inherit version;
+          src = src + "/cachix";
+        })
+        (addBuildDepends [
+          self.pqueue
+        ])
+        (
+          drv:
+          drv.override {
+            nix = self.hercules-ci-cnix-store.nixPackage;
+            hnix-store-core = self.hnix-store-core_0_8_0_0;
+          }
+        )
+      ]
+      # https://github.com/NixOS/nixpkgs/issues/461651
+      ++ lib.optional pkgs.stdenv.isDarwin dontCheck
+    );
   }
 )


### PR DESCRIPTION
Given that it builds and reportedly runs just fine, let's not block the nixpkgs-unstable channel anymore. See https://github.com/NixOS/nixpkgs/issues/461651


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux  (no rebuild)
  - [x] aarch64-linux  (no rebuild)
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
