### PR TITLE
pgadmin: 9.9 -> 9.10

### DIFF
--- a/pkgs/by-name/pg/pgadmin4/package.nix
+++ b/pkgs/by-name/pg/pgadmin4/package.nix
@@ -20,14 +20,14 @@
 
 let
   pname = "pgadmin";
-  version = "9.9";
-  yarnHash = "sha256-QInOfpgQgx4i/gTyWG40Sl7Me5ynC/nOfjik82ltwLM=";
+  version = "9.10";
+  yarnHash = "sha256-1xbQedxNDQaEiAT9GPNzz17cVD0v4CoxEn0SugJHaz0=";
 
   src = fetchFromGitHub {
     owner = "pgadmin-org";
     repo = "pgadmin4";
     rev = "REL-${lib.versions.major version}_${lib.versions.minor version}";
-    hash = "sha256-XzjotJt02mZ0Se/bZMqAl8KL6egIVqqkbiEdcRuHcuE=";
+    hash = "sha256-AUkxv7rmlb+KYhLe4vj9OvZkmBnN+TL+b/0Xf1+Wyy4=";
   };
 
   # keep the scope, as it is used throughout the derivation and tests


### PR DESCRIPTION
Release notes: https://www.pgadmin.org/docs/pgadmin4/latest/release_notes_9_10.html

Diff: https://github.com/pgadmin-org/pgadmin4/compare/REL-9_9...REL-9_10

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
