### PR TITLE
ytdl-sub: pin to ffmpeg 7 to fix build

### DIFF
--- a/pkgs/by-name/yt/ytdl-sub/package.nix
+++ b/pkgs/by-name/yt/ytdl-sub/package.nix
@@ -1,7 +1,7 @@
 {
   python3Packages,
   fetchFromGitHub,
-  ffmpeg,
+  ffmpeg_7,
   lib,
   versionCheckHook,
 }:
@@ -38,8 +38,8 @@ python3Packages.buildPythonApplication rec {
   ];
 
   makeWrapperArgs = [
-    "--set YTDL_SUB_FFMPEG_PATH ${lib.getExe' ffmpeg "ffmpeg"}"
-    "--set YTDL_SUB_FFPROBE_PATH ${lib.getExe' ffmpeg "ffprobe"}"
+    "--set YTDL_SUB_FFMPEG_PATH ${lib.getExe' ffmpeg_7 "ffmpeg"}"
+    "--set YTDL_SUB_FFPROBE_PATH ${lib.getExe' ffmpeg_7 "ffprobe"}"
   ];
 
   nativeCheckInputs = [
@@ -49,8 +49,8 @@ python3Packages.buildPythonApplication rec {
   versionCheckProgramArg = "--version";
 
   env = {
-    YTDL_SUB_FFMPEG_PATH = "${lib.getExe' ffmpeg "ffmpeg"}";
-    YTDL_SUB_FFPROBE_PATH = "${lib.getExe' ffmpeg "ffprobe"}";
+    YTDL_SUB_FFMPEG_PATH = "${lib.getExe' ffmpeg_7 "ffmpeg"}";
+    YTDL_SUB_FFPROBE_PATH = "${lib.getExe' ffmpeg_7 "ffprobe"}";
   };
 
   disabledTests = [


### PR DESCRIPTION
ytdl-sub tests have a bunch of hash failures after [switching to ffmpeg 8](https://github.com/NixOS/nixpkgs/pull/450436). This makes them pass.

Hydra failures started here: https://hydra.nixos.org/eval/1820178?filter=ytdl-sub&compare=1820137&full=
Build failure log: https://hydra.nixos.org/build/313562159/nixlog/2
ZHF: https://github.com/NixOS/nixpkgs/issues/457852

### Without

```console
ytdl-sub> Executing pytestCheckPhase
...
ytdl-sub> tests/integration/cli/test_dl.py ..F.                                    [  0%]
ytdl-sub> tests/integration/cli/test_output_transaction_log.py ....                [  0%]
ytdl-sub> tests/integration/plugins/test_chapters.py ..F                           [  1%]
ytdl-sub> tests/integration/plugins/test_file_convert.py ..                        [  1%]
ytdl-sub> tests/integration/plugins/test_filter.py ..                              [  1%]
ytdl-sub> tests/integration/plugins/test_music_tags.py .                           [  1%]
ytdl-sub> tests/integration/plugins/test_nfo_tags.py ..                            [  1%]
ytdl-sub> tests/integration/plugins/test_output_options.py F.FF.                   [  2%]
ytdl-sub> tests/integration/plugins/test_throttle_protection.py .................  [  4%]
ytdl-sub> tests/integration/prebuilt_presets/test_filter_duration.py .......       [  5%]
ytdl-sub> tests/integration/prebuilt_presets/test_filter_keywords.py ............. [  6%]
ytdl-sub> ........                                                                 [  7%]
ytdl-sub> tests/integration/prebuilt_presets/test_prebuilt_presets_packaged.py ... [  7%]
ytdl-sub> ..                                                                       [  7%]
ytdl-sub> tests/integration/prebuilt_presets/test_tv_show_by_date.py FFFFFFFFFFFF. [  9%]
ytdl-sub> ..                                                                       [  9%]
ytdl-sub> tests/integration/prebuilt_presets/test_tv_show_collection.py FFFFFFFFFF [ 10%]
...
ytdl-sub> === 37 failed, 898 passed, 41 deselected, 762 warnings in 209.31s (0:03:29) ====
error: builder for '/nix/store/2mwih1bw9b7bkd64lj71n8w907l0s8yz-ytdl-sub-2025.11.07.post1.drv' failed with exit code 1;
       last 25 log lines:
       > FAILED tests/integration/prebuilt_presets/test_tv_show_by_date.py::TestPrebuiltTVShowPresets::test_episode_ordering_presets[release-year-release-month-day] - AssertionError: MD5 hash for Best Prebuilt TV Show by Date/Season 2000/s200...
...
⚠ ytdl-sub-2025.11.07.post1 failed with exit code 1 after ⏱ 3m32s in pytestCheckPhase
```

### With

```console
ytdl-sub> Executing pytestCheckPhase
...
ytdl-sub> tests/integration/cli/test_dl.py ....                                    [  0%]
ytdl-sub> tests/integration/cli/test_entrypoint.py .................               [  2%]
ytdl-sub> tests/integration/cli/test_output_transaction_log.py ....                [  2%]
ytdl-sub> tests/integration/plugins/test_chapters.py ...                           [  2%]
ytdl-sub> tests/integration/plugins/test_file_convert.py ..                        [  3%]
ytdl-sub> tests/integration/plugins/test_filter.py ..                              [  3%]
ytdl-sub> tests/integration/plugins/test_music_tags.py .                           [  3%]
ytdl-sub> tests/integration/plugins/test_nfo_tags.py ..                            [  3%]
ytdl-sub> tests/integration/plugins/test_output_options.py .....                   [  4%]
ytdl-sub> tests/integration/plugins/test_throttle_protection.py .................  [  5%]
ytdl-sub> tests/integration/prebuilt_presets/test_filter_duration.py .......       [  6%]
ytdl-sub> tests/integration/prebuilt_presets/test_filter_keywords.py ............. [  8%]
ytdl-sub> ........                                                                 [  8%]
ytdl-sub> tests/integration/prebuilt_presets/test_prebuilt_presets_packaged.py ... [  9%]
ytdl-sub> ..                                                                       [  9%]
ytdl-sub> tests/integration/prebuilt_presets/test_tv_show_by_date.py ............. [ 10%]
ytdl-sub> ..                                                                       [ 11%]
ytdl-sub> tests/integration/prebuilt_presets/test_tv_show_collection.py .......... [ 12%]
...
ytdl-sub> ======== 953 passed, 23 deselected, 1098 warnings in 325.41s (0:05:25) =========
...
✔ ytdl-sub-2025.11.07.post1
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
