### PR TITLE
python313Packages.sockjs: add patch for async-timeout

### DIFF
--- a/pkgs/development/python-modules/sockjs/default.nix
+++ b/pkgs/development/python-modules/sockjs/default.nix
@@ -3,25 +3,29 @@
   buildPythonPackage,
   fetchPypi,
   aiohttp,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "sockjs";
   version = "0.13.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-V+lZoj8gqNVRSdHl2ws7hwcm8rStgWbUG9z0EbNs33Y=";
   };
 
-  propagatedBuildInputs = [ aiohttp ];
+  build-system = [ setuptools ];
+
+  dependencies = [ aiohttp ];
 
   pythonImportsCheck = [ "sockjs" ];
 
   meta = with lib; {
     description = "Sockjs server";
     homepage = "https://github.com/aio-libs/sockjs";
+    changelog = "https://github.com/aio-libs/sockjs/releases/tag/v${version}";
     license = licenses.asl20;
     maintainers = with maintainers; [ freezeboy ];
   };

--- a/pkgs/development/python-modules/sockjs/default.nix
+++ b/pkgs/development/python-modules/sockjs/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  fetchpatch,
   aiohttp,
   setuptools,
 }:
@@ -15,6 +16,15 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-V+lZoj8gqNVRSdHl2ws7hwcm8rStgWbUG9z0EbNs33Y=";
   };
+
+  patches = [
+    # https://github.com/aio-libs/sockjs/pull/453
+    (fetchpatch {
+      name = "replace-async-timeout-with-asyncio.timeout.patch";
+      url = "https://github.com/aio-libs/sockjs/commit/322cec1ddc4ba35d6409565fa170eb03dbaa405b.patch";
+      hash = "sha256-DV+OFiFV/A7ts24xz7pbTYXVvy/NA5kzwayj0m9Kt3I=";
+    })
+  ];
 
   build-system = [ setuptools ];
 


### PR DESCRIPTION
ZHF: #457852

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
