### PR TITLE
heimer: Fix build with CMake 4

### DIFF
--- a/pkgs/applications/misc/heimer/default.nix
+++ b/pkgs/applications/misc/heimer/default.nix
@@ -2,6 +2,7 @@
   lib,
   mkDerivation,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   qttools,
   qtbase,
@@ -17,6 +18,20 @@ mkDerivation rec {
     rev = version;
     hash = "sha256-eKnGCYxC3b7qd/g2IMDyZveBg+jvFA9s3tWEGeTPSkU=";
   };
+
+  patches = [
+    # Fix the build with CMake 4
+    (fetchpatch {
+      name = "update-Argengine.patch";
+      url = "https://github.com/juzzlin/Heimer/commit/76d9e8458038d2da4171be3a58766b84334119e8.patch";
+      hash = "sha256-mFzfxxhaJ1jdwfFVo36N66+jzS/scEeray1s75c+T8M=";
+    })
+    (fetchpatch {
+      name = "update-SimpleLogger.patch";
+      url = "https://github.com/juzzlin/Heimer/commit/75bff37b6ebd02d9f734e70ee4d3c10ec0291e0d.patch";
+      hash = "sha256-ZPj5GaM13UsGwJbc0NW0xJd07agZT+g86674i3apqWY=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
Pick unreleased patches from upstream master to make it build with CMake 4.

#445447
#ZurichZHF

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
