### PR TITLE
midish: init at 1.4.1

### DIFF
--- a/pkgs/by-name/mi/midish/package.nix
+++ b/pkgs/by-name/mi/midish/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  alsa-lib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "midish";
+  version = "1.4.1";
+
+  src = fetchurl {
+    url = "https://midish.org/midish-${finalAttrs.version}.tar.gz";
+    hash = "sha256-f5apBZSXzL17U98nuKSYlgG15eZIY+WQVXGsiW2VGqc=";
+  };
+
+  postPatch = ''
+    substituteInPlace smfplay smfrec \
+      --replace-fail "exec midish" "exec $out/bin/midish"
+  '';
+
+  buildInputs = [ alsa-lib ];
+
+  runtimeDependencies = map lib.getLib [
+    alsa-lib
+  ];
+
+  doCheck = true;
+
+  meta = {
+    description = "MIDI sequencer/filter for Unix-like operating systems";
+    homepage = "https://midish.org/";
+    license = lib.licenses.bsd1;
+    maintainers = with lib.maintainers; [ iwanb ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Adding midish: https://midish.org/

## Things done

~~I needed a small patch to run the tests, it seems the tool does not exit by itself at the end of a script (it used to in older versions), so I've added an "exit" command explicitly. I sent a message on their mailing list to ask about this behaviour.~~ The author already provided a new version with this fixed, so I've removed the patch :)

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
