### PR TITLE
vscode-extensions.vscode-icons-team.vscode-icons: 12.14.0 -> 12.15.0

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/vscode-icons-team.vscode-icons/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/vscode-icons-team.vscode-icons/default.nix
@@ -14,19 +14,19 @@ let
   vsix = stdenvNoCC.mkDerivation (finalAttrs: {
     name = "vscode-icons-${finalAttrs.version}.zip";
     pname = "vscode-icons-vsix";
-    version = "12.14.0";
+    version = "12.15.0";
 
     src = fetchFromGitHub {
       owner = "vscode-icons";
       repo = "vscode-icons";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-uxGKgqAllwW3MG89mvZ/M6So+vtpHVUDLCnVHKYfMOA=";
+      hash = "sha256-HYMXcmK2cW01PsjwMr+SGq94oFWEXvdny6IFnXMBdKA=";
     };
 
     npmDeps = fetchNpmDeps {
       name = "${finalAttrs.pname}-npm-deps";
       inherit (finalAttrs) src;
-      hash = "sha256-QLla/7hBIi7REhix+cXscdDHy+wzVXItQypeU+NUHQo=";
+      hash = "sha256-3Jt9JKbu5QxZynbkgQX/So3PWeJDdxIU5TVM4nfvgcQ=";
     };
 
     nativeBuildInputs = [


### PR DESCRIPTION
https://github.com/vscode-icons/vscode-icons/compare/v12.14.0...v12.15.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
