### PR TITLE
polymc: init at 7.0-unstable-2025-11-15

### DIFF
--- a/pkgs/by-name/po/polymc-unwrapped/package.nix
+++ b/pkgs/by-name/po/polymc-unwrapped/package.nix
@@ -69,7 +69,10 @@ stdenv.mkDerivation (finalAttrs: {
     tomlplusplus
     ghc_filesystem
   ]
-  ++ lib.optional (lib.versionAtLeast kdePackages.qtbase.version "6") kdePackages.qtwayland
+  ++ lib.optional (lib.versionAtLeast kdePackages.qtbase.version "6") [
+    kdePackages.qtwayland
+    kdePackages.qt5compat
+  ]
   ++ lib.optional gamemodeSupport gamemode;
 
   dontWrapQtApps = true;

--- a/pkgs/by-name/po/polymc-unwrapped/package.nix
+++ b/pkgs/by-name/po/polymc-unwrapped/package.nix
@@ -1,0 +1,138 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  lib,
+  cmake,
+  ninja,
+  jdk8,
+  gamemode,
+  zlib,
+  file,
+  kdePackages,
+  extra-cmake-modules,
+  tomlplusplus,
+  ghc_filesystem,
+  msaClientID ? null,
+  msaRequired ? true,
+  gamemodeSupport ? stdenv.isLinux,
+  enableLTO ? false,
+}:
+
+/*
+    Feel free to override msaRequired to `false' on your machine, as
+    it's intended to NOT require an account to use the launcher.
+
+    It's set to true by default so (mostly) nobody complains about "muh piracy",
+    as if you couldn't just avoid any form of DRM by executing the .jar file directly.
+
+    You're paying to play on Mojang authenticated servers, singleplayer is free.
+*/
+
+let
+  libnbtplusplus = fetchFromGitHub {
+    owner = "PolyMC";
+    repo = "libnbtplusplus";
+    rev = "2203af7eeb48c45398139b583615134efd8d407f";
+    hash = "sha256-TvVOjkUobYJD9itQYueELJX3wmecvEdCbJ0FinW2mL4=";
+  };
+in
+
+assert lib.assertMsg (
+  gamemodeSupport -> stdenv.hostPlatform.isLinux
+) "gamemodeSupport is only available on Linux.";
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "polymc-unwrapped";
+  version = "7.0-unstable-2025-11-15";
+
+  src = fetchFromGitHub {
+    owner = "PolyMC";
+    repo = "PolyMC";
+    rev = "8b0558142f995dffdd3daef5fce54377d5fcb9ac";
+    hash = "sha256-pqR8JneWelshuaZj9y/Fo3BLjaMYphnDZuBKGccO2FM=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    ninja
+    jdk8
+    file
+  ];
+
+  buildInputs = [
+    kdePackages.qtbase
+    kdePackages.quazip
+    kdePackages.qtcharts
+    zlib
+
+    tomlplusplus
+    ghc_filesystem
+  ]
+  ++ lib.optional (lib.versionAtLeast kdePackages.qtbase.version "6") kdePackages.qtwayland
+  ++ lib.optional gamemodeSupport gamemode;
+
+  dontWrapQtApps = true;
+  doCheck = true;
+
+  postUnpack = ''
+    rm -rf source/libraries/libnbtplusplus
+    ln -s ${libnbtplusplus} source/libraries/libnbtplusplus
+  '';
+
+  postPatch = ''
+    ### This fix will be upstreamed. PolyMC hasn't updated the MangoHud functionality for a while.
+
+    substituteInPlace launcher/Application.cpp launcher/minecraft/MinecraftInstance.cpp \
+        --replace-fail "libMangoHud_dlsym.so" "libMangoHud_shim.so" \
+
+    ### Metadata & branding
+
+    substituteInPlace buildconfig/BuildConfig.cpp.in \
+        --replace-fail "@Launcher_GIT_COMMIT@" ${
+          if (builtins.hasAttr "rev" finalAttrs.src) && (!builtins.isNull finalAttrs.src.rev) then
+            finalAttrs.src.rev
+          else
+            "@Launcher_GIT_COMMIT@"
+        } \
+        --replace-fail "@Launcher_GIT_TAG@" ${
+          if (builtins.hasAttr "tag" finalAttrs.src) && (!builtins.isNull finalAttrs.src.tag) then
+            finalAttrs.src.tag
+          else
+            "@Launcher_GIT_TAG@"
+        } \
+        --replace-fail "@Launcher_GIT_REFSPEC@" ${
+          if (builtins.hasAttr "ref" finalAttrs.src) && (!builtins.isNull finalAttrs.src.ref) then
+            finalAttrs.src.ref
+          else
+            "@Launcher_GIT_REFSPEC@"
+        } \
+        --replace-fail "return vstr;" 'return vstr + "-NixOS";'
+  '';
+
+  cmakeFlags = [
+    "-GNinja"
+    "-DLauncher_QT_VERSION_MAJOR=${lib.versions.major kdePackages.qtbase.version}"
+    "-DLauncher_BUILD_PLATFORM=nixpkgs"
+  ]
+  ++ lib.optionals enableLTO [ "-DENABLE_LTO=on" ]
+  ++ lib.optionals (!builtins.isNull msaClientID) [ "-DLauncher_MSA_CLIENT_ID=${msaClientID}" ]
+  ++ lib.optionals msaRequired [ "-DLauncher_STRICT_DRM=on" ];
+
+  meta = with lib; {
+    homepage = "https://polymc.org/";
+    downloadPage = "https://polymc.org/download/";
+    changelog = "https://github.com/PolyMC/PolyMC/releases";
+    description = "A free, open source launcher for Minecraft";
+    longDescription = ''
+      Allows you to have multiple, separate instances of Minecraft (each with
+      their own mods, texture packs, saves, etc) and helps you manage them and
+      their associated options with a simple interface.
+    '';
+    platforms = platforms.unix;
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [
+      hustlerone
+    ];
+  };
+})

--- a/pkgs/by-name/po/polymc-unwrapped/package.nix
+++ b/pkgs/by-name/po/polymc-unwrapped/package.nix
@@ -43,13 +43,13 @@ assert lib.assertMsg (
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "polymc-unwrapped";
-  version = "7.0-unstable-2025-11-15";
+  version = "7.0-unstable-2026-03-04";
 
   src = fetchFromGitHub {
     owner = "PolyMC";
     repo = "PolyMC";
-    rev = "8b0558142f995dffdd3daef5fce54377d5fcb9ac";
-    hash = "sha256-pqR8JneWelshuaZj9y/Fo3BLjaMYphnDZuBKGccO2FM=";
+    rev = "5603242bf3b70d83a8dbd171b52be5f4fcedfc1c";
+    hash = "sha256-iPOTfk1seKcKdus3+ksnZUUr3NFxwsz9d93vtxSmg5c=";
   };
 
   nativeBuildInputs = [
@@ -84,11 +84,6 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   postPatch = ''
-    ### This fix will be upstreamed. PolyMC hasn't updated the MangoHud functionality for a while.
-
-    substituteInPlace launcher/Application.cpp launcher/minecraft/MinecraftInstance.cpp \
-        --replace-fail "libMangoHud_dlsym.so" "libMangoHud_shim.so" \
-
     ### Metadata & branding
 
     substituteInPlace buildconfig/BuildConfig.cpp.in \

--- a/pkgs/by-name/po/polymc-unwrapped/package.nix
+++ b/pkgs/by-name/po/polymc-unwrapped/package.nix
@@ -48,8 +48,8 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "PolyMC";
     repo = "PolyMC";
-    rev = "5603242bf3b70d83a8dbd171b52be5f4fcedfc1c";
-    hash = "sha256-iPOTfk1seKcKdus3+ksnZUUr3NFxwsz9d93vtxSmg5c=";
+    rev = "ac74509f1a78359ed0128b2a171abf91c43fa8ae";
+    hash = "sha256-nWtiVbf4VTDQ765s+VP8lbYeaKR3jp6yZYd1vBLm3jM=";
   };
 
   nativeBuildInputs = [
@@ -64,14 +64,13 @@ stdenv.mkDerivation (finalAttrs: {
     kdePackages.qtbase
     kdePackages.quazip
     kdePackages.qtcharts
+    kdePackages.qtwayland
+    kdePackages.qt5compat
+    kdePackages.qt6ct
     zlib
 
     tomlplusplus
     ghc_filesystem
-  ]
-  ++ lib.optional (lib.versionAtLeast kdePackages.qtbase.version "6") [
-    kdePackages.qtwayland
-    kdePackages.qt5compat
   ]
   ++ lib.optional gamemodeSupport gamemode;
 
@@ -117,7 +116,10 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals (!builtins.isNull msaClientID) [ "-DLauncher_MSA_CLIENT_ID=${msaClientID}" ]
   ++ lib.optionals msaRequired [ "-DLauncher_STRICT_DRM=on" ];
 
-  meta = with lib; {
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
     homepage = "https://polymc.org/";
     downloadPage = "https://polymc.org/download/";
     changelog = "https://github.com/PolyMC/PolyMC/releases";
@@ -127,9 +129,20 @@ stdenv.mkDerivation (finalAttrs: {
       their own mods, texture packs, saves, etc) and helps you manage them and
       their associated options with a simple interface.
     '';
-    platforms = platforms.unix;
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [
+    platforms = [
+      "aarch64-linux"
+      "x86_64-linux"
+      "i686-linux"
+      "riscv64-linux"
+      "powerpc64le-linux"
+    ]
+    ++ [
+      "x86_64-freebsd"
+    ]
+    ++ lib.platforms.darwin
+    ++ lib.platforms.windows;
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
       hustlerone
     ];
   };

--- a/pkgs/by-name/po/polymc-unwrapped/package.nix
+++ b/pkgs/by-name/po/polymc-unwrapped/package.nix
@@ -1,0 +1,173 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  fetchurl,
+  lib,
+  cmake,
+  ninja,
+  jdk8,
+  gamemode,
+  mangohud,
+  zlib,
+  file,
+  qt6Packages,
+  kdePackages,
+  tomlplusplus,
+  ghc_filesystem,
+  msaClientID ? null,
+  msaRequired ? true,
+  gamemodeSupport ? stdenv.isLinux,
+  mangohudSupport ? stdenv.isLinux,
+  enableLTO ? false,
+}:
+
+/*
+    Feel free to override msaRequired to `false' on your machine, as
+    it's intended to NOT require an account to use the launcher.
+
+    It's set to true by default to avoid any piracy-related discussion.
+*/
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "polymc-unwrapped";
+  version = "7.0-unstable-2026-03-04";
+
+  libnbtplusplus = fetchFromGitHub {
+    owner = "PolyMC";
+    repo = "libnbtplusplus";
+    rev = "2203af7eeb48c45398139b583615134efd8d407f";
+    hash = "sha256-TvVOjkUobYJD9itQYueELJX3wmecvEdCbJ0FinW2mL4=";
+  };
+
+  /*
+    Gated so it only pulls when you're on Darwin.
+    Make sure the hash matches the one in CMakeLists!
+  */
+
+  sparkle =
+    if stdenv.hostPlatform.isDarwin then
+      fetchurl {
+        url = "https://github.com/sparkle-project/Sparkle/releases/download/2.1.0/Sparkle-2.1.0.tar.xz";
+        hash = "sha256-v2rByqn40yHVeEhZyI2odPKEEvN/sye8IbexTF1h75Q=";
+      }
+    else
+      null;
+
+  src = fetchFromGitHub {
+    owner = "PolyMC";
+    repo = "PolyMC";
+    rev = "49e06691c47b6ed55f0306771c2dada301733b79";
+    hash = "sha256-K70TMZet+y4qPu0c8HZZDwuQIEhENP6XDjRzBptAiQI=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    jdk8
+    file
+  ];
+
+  buildInputs = [
+    qt6Packages.qtbase
+    qt6Packages.quazip
+    qt6Packages.qtcharts
+    zlib
+
+    tomlplusplus
+    ghc_filesystem
+    kdePackages.extra-cmake-modules
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    qt6Packages.qtwayland
+    qt6Packages.qt6ct
+  ]
+  ++ lib.optional gamemodeSupport gamemode;
+
+  dontWrapQtApps = true;
+  doCheck = true;
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  postUnpack = ''
+    rm -rf source/libraries/libnbtplusplus
+    ln -s ${finalAttrs.libnbtplusplus} source/libraries/libnbtplusplus
+  '';
+
+  substituteBuildConfigCppFlags = [
+    "--replace-fail"
+    "return vstr;"
+    "return vstr + \"+NixOS\";"
+  ]
+  ++ lib.optionals ((finalAttrs.src.rev or null) != null) [
+    "--replace-fail"
+    "@Launcher_GIT_COMMIT@"
+    finalAttrs.src.rev
+  ]
+  ++ lib.optionals ((finalAttrs.src.tag or null) != null) [
+    "--replace-fail"
+    "@Launcher_GIT_TAG@"
+    finalAttrs.src.tag
+  ]
+  ++ lib.optionals ((finalAttrs.src.ref or null) != null) [
+    "--replace-fail"
+    "@Launcher_GIT_REFSPEC@"
+    finalAttrs.src.ref
+  ];
+
+  # This is for metadata & branding.
+  postPatch = ''
+    if [ ''${#substituteBuildConfigCppFlags[@]} -gt 0 ]; then
+      substituteInPlace buildconfig/BuildConfig.cpp.in "''${substituteBuildConfigCppFlags[@]}"
+    fi
+  ''
+  # APPLE branch hardcodes INSTALL_BUNDLE=full (bundles Qt via fixup_bundle,
+  # conflicting with nixpkgs' wrapped Qt); force nodeps.
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'set(INSTALL_BUNDLE "full")' 'set(INSTALL_BUNDLE "nodeps")'
+  '';
+
+  cmakeFlags = [
+    (lib.cmakeFeature "Launcher_QT_VERSION_MAJOR" (lib.versions.major qt6Packages.qtbase.version))
+    (lib.cmakeFeature "Launcher_BUILD_PLATFORM" "nixpkgs")
+    (lib.cmakeBool "ENABLE_LTO" enableLTO)
+    (lib.cmakeBool "Launcher_STRICT_DRM" msaRequired)
+  ]
+  ++ lib.optional (msaClientID != null) (lib.cmakeFeature "Launcher_MSA_CLIENT_ID" msaClientID)
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # Inert auto-updater feed; source Sparkle from the vendored copy.
+    (lib.cmakeFeature "MACOSX_SPARKLE_UPDATE_FEED_URL" "")
+    (lib.cmakeFeature "MACOSX_SPARKLE_DOWNLOAD_URL" "file://${finalAttrs.sparkle}")
+    (lib.cmakeFeature "CMAKE_INSTALL_PREFIX" "${placeholder "out"}/Applications/")
+  ];
+
+  meta = {
+    homepage = "https://polymc.org/";
+    downloadPage = "https://polymc.org/download/";
+    changelog =
+      "https://github.com/PolyMC/PolyMC/releases"
+      + lib.optionalString ((finalAttrs.src.tag or null) != null) "/tag/${finalAttrs.src.tag}";
+    description = "A free, open source launcher for Minecraft";
+    longDescription = ''
+      Allows you to have and manage multiple, separate instances of Minecraft with a simple interface.
+      The contents of each instance are separate. That includes mods, texture packs, saves, etc.
+    '';
+    problems =
+      lib.optionalAttrs (!stdenv.hostPlatform.isLinux && gamemodeSupport) {
+        broken.message = "${gamemode.pname} is only supported on Linux.";
+      }
+      // lib.optionalAttrs (!stdenv.hostPlatform.isLinux && mangohudSupport) {
+        broken.message = "${mangohud.pname} is only supported on Linux.";
+      };
+    platforms = [
+      "x86_64-freebsd"
+    ]
+    ++ lib.platforms.linux
+    ++ lib.platforms.darwin
+    ++ lib.platforms.windows;
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      hustlerone
+    ];
+  };
+})

--- a/pkgs/by-name/po/polymc/package.nix
+++ b/pkgs/by-name/po/polymc/package.nix
@@ -10,10 +10,12 @@
   gamemodeSupport ? stdenv.isLinux,
 
   jdks ? [
+    jdk25
     jdk21
     jdk17
     jdk8
   ],
+  jdk25,
   jdk21,
   jdk17,
   jdk8,

--- a/pkgs/by-name/po/polymc/package.nix
+++ b/pkgs/by-name/po/polymc/package.nix
@@ -1,0 +1,108 @@
+{
+  stdenv,
+  lib,
+  symlinkJoin,
+  addDriverRunpath,
+
+  msaClientID ? null,
+  msaRequired ? true,
+  enableLTO ? false,
+  gamemodeSupport ? stdenv.isLinux,
+
+  jdks ? [
+    jdk21
+    jdk17
+    jdk8
+  ],
+  jdk21,
+  jdk17,
+  jdk8,
+
+  additionalLibraries ? [ ],
+  additionalBinaries ? [ ],
+
+  polymc-unwrapped,
+  kdePackages,
+  mesa-demos,
+  gamemode,
+  mangohud,
+
+  xorg,
+  libpulseaudio,
+  libGL,
+  glfw,
+  openal,
+  udev,
+  wayland,
+  vulkan-loader,
+}:
+
+/*
+    Feel free to override msaRequired to `false' on your machine, as
+    it's intended to NOT require an account to use the launcher.
+
+    It's set to true by default so (mostly) nobody complains about "muh piracy",
+    as if you couldn't just avoid any form of DRM by executing the .jar file directly.
+
+    You're paying to play on Mojang authenticated servers, singleplayer is free.
+*/
+
+let
+  polymc = polymc-unwrapped.override {
+    inherit
+      msaClientID
+      msaRequired
+      gamemodeSupport
+      enableLTO
+      ;
+  };
+in
+symlinkJoin {
+  name = "polymc";
+  inherit (polymc) version meta;
+
+  paths = [ polymc ];
+  nativeBuildInputs = [ kdePackages.wrapQtAppsHook ];
+  buildInputs = with kdePackages; [
+    qtbase
+    qtwayland
+  ];
+
+  postBuild = ''wrapQtAppsHook'';
+
+  qtWrapperArgs =
+    let
+      runtimeLibs =
+        (with xorg; [
+          libX11
+          libXext
+          libXcursor
+          libXrandr
+          libXxf86vm
+        ])
+        ++ [
+          libpulseaudio
+          libGL
+          glfw
+          openal
+          stdenv.cc.cc.lib
+          udev # OSHI
+          wayland
+          vulkan-loader # VulkanMod's lwjgl
+        ]
+        ++ lib.optional gamemodeSupport gamemode.lib
+        ++ additionalLibraries;
+
+      runtimeBins = [
+        # Required by old LWJGL versions
+        xorg.xrandr
+        mesa-demos # For glxinfo
+      ]
+      ++ additionalBinaries;
+    in
+    [
+      "--prefix POLYMC_JAVA_PATHS : ${lib.makeSearchPath "bin/java" jdks}"
+      "--set LD_LIBRARY_PATH ${addDriverRunpath.driverLink}/lib:${lib.makeLibraryPath runtimeLibs}:${mangohud}/lib/mangohud"
+      "--prefix PATH : ${lib.makeBinPath runtimeBins}"
+    ];
+}

--- a/pkgs/by-name/po/polymc/package.nix
+++ b/pkgs/by-name/po/polymc/package.nix
@@ -29,7 +29,13 @@
   gamemode,
   mangohud,
 
-  xorg,
+  libx11,
+  libxext,
+  libxcursor,
+  libxrandr,
+  libxxf86vm,
+  xrandr,
+
   libpulseaudio,
   libGL,
   glfw,
@@ -70,34 +76,33 @@ symlinkJoin {
     qtwayland
   ];
 
-  postBuild = ''wrapQtAppsHook'';
+  postBuild = "wrapQtAppsHook";
 
   qtWrapperArgs =
     let
-      runtimeLibs =
-        (with xorg; [
-          libX11
-          libXext
-          libXcursor
-          libXrandr
-          libXxf86vm
-        ])
-        ++ [
-          libpulseaudio
-          libGL
-          glfw
-          openal
-          stdenv.cc.cc.lib
-          udev # OSHI
-          wayland
-          vulkan-loader # VulkanMod's lwjgl
-        ]
-        ++ lib.optional gamemodeSupport gamemode.lib
-        ++ additionalLibraries;
+      runtimeLibs = [
+        # xorg
+        libx11
+        libxext
+        libxcursor
+        libxrandr
+        libxxf86vm
+
+        libpulseaudio
+        libGL
+        glfw
+        openal
+        stdenv.cc.cc.lib
+        udev # OSHI
+        wayland
+        vulkan-loader # VulkanMod's lwjgl
+      ]
+      ++ lib.optional gamemodeSupport gamemode.lib
+      ++ additionalLibraries;
 
       runtimeBins = [
         # Required by old LWJGL versions
-        xorg.xrandr
+        xrandr
         mesa-demos # For glxinfo
       ]
       ++ additionalBinaries;

--- a/pkgs/by-name/po/polymc/package.nix
+++ b/pkgs/by-name/po/polymc/package.nix
@@ -78,6 +78,9 @@ symlinkJoin {
 
   postBuild = "wrapQtAppsHook";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   qtWrapperArgs =
     let
       runtimeLibs = [

--- a/pkgs/by-name/po/polymc/package.nix
+++ b/pkgs/by-name/po/polymc/package.nix
@@ -79,7 +79,9 @@ symlinkJoin {
   postBuild = "wrapQtAppsHook";
 
   strictDeps = true;
-  __structuredAttrs = true;
+
+  # TODO: Maybe re-enable once #510526 is merged.
+  __structuredAttrs = false;
 
   qtWrapperArgs =
     let

--- a/pkgs/by-name/po/polymc/package.nix
+++ b/pkgs/by-name/po/polymc/package.nix
@@ -1,0 +1,144 @@
+{
+  stdenv,
+  lib,
+  symlinkJoin,
+  addDriverRunpath,
+
+  msaClientID ? null,
+  msaRequired ? true,
+  enableLTO ? false,
+  gamemodeSupport ? stdenv.isLinux,
+  mangohudSupport ? stdenv.isLinux,
+
+  jdks ? [
+    jdk25
+    jdk21
+    jdk17
+    jdk8
+  ],
+  jdk25,
+  jdk21,
+  jdk17,
+  jdk8,
+
+  additionalLibraries ? [ ],
+  additionalBinaries ? [ ],
+
+  polymc-unwrapped,
+  qt6,
+  mesa-demos,
+  gamemode,
+  mangohud,
+
+  libx11,
+  libxext,
+  libxcursor,
+  libxrandr,
+  libxxf86vm,
+  xrandr,
+
+  libpulseaudio,
+  libGL,
+  glfw,
+  openal,
+  udev,
+  wayland,
+  vulkan-loader,
+}:
+
+/*
+    Feel free to override msaRequired to `false' on your machine, as
+    it's intended to NOT require an account to use the launcher.
+
+    It's set to true by default to avoid any piracy-related discussion.
+*/
+
+let
+  polymc = polymc-unwrapped.override {
+    inherit
+      msaClientID
+      msaRequired
+      gamemodeSupport
+      enableLTO
+      ;
+  };
+in
+symlinkJoin {
+  name = "polymc";
+  inherit (polymc) version;
+
+  paths = [ polymc ];
+  nativeBuildInputs = [ qt6.wrapQtAppsHook ];
+  buildInputs = with qt6; [
+    qtbase
+    qtwayland
+  ];
+
+  postBuild = "wrapQtAppsHook";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  qtWrapperArgs =
+    let
+      runtimeLibs = [
+        # xorg
+        libx11
+        libxext
+        libxcursor
+        libxrandr
+        libxxf86vm
+
+        libpulseaudio
+        libGL
+        glfw
+        openal
+        stdenv.cc.cc.lib
+
+        vulkan-loader # VulkanMod's lwjgl
+      ]
+      ++ additionalLibraries
+      ++ lib.optionals stdenv.hostPlatform.isLinux [
+        wayland
+        udev # OSHI
+      ]
+      ++ lib.optional gamemodeSupport gamemode.lib;
+
+      runtimeBins = [
+        xrandr # Required by old LWJGL versions
+        mesa-demos # For glxinfo
+      ]
+      ++ additionalBinaries;
+    in
+    [
+      "--prefix"
+      "POLYMC_JAVA_PATHS"
+      ":"
+      (lib.makeSearchPath "bin/java" jdks)
+    ]
+
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      "--set"
+      "LD_LIBRARY_PATH"
+      "${addDriverRunpath.driverLink}/lib:${lib.makeLibraryPath runtimeLibs}${
+        if mangohudSupport then ":${mangohud}/lib/mangohud" else ""
+      }"
+      "--prefix"
+      "PATH"
+      ":"
+      (lib.makeBinPath runtimeBins)
+    ];
+
+  meta = {
+    inherit (polymc.meta)
+      homepage
+      downloadPage
+      changelog
+      description
+      longDescription
+      platforms
+      license
+      maintainers
+      ;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds PolyMC back into nixpkgs. Nix code is pretty much copypasted from upstream.

Feedback welcome.

Closes https://github.com/NixOS/nixpkgs/issues/365781
Supersedes https://github.com/NixOS/nixpkgs/pull/369915 (I assume orvitpng gave up)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
