### PR TITLE
python313Packages.pymupdf: 1.26.4 -> 1.26.6

### DIFF
--- a/pkgs/development/python-modules/pymupdf/conftest-dont-pip-install.patch
+++ b/pkgs/development/python-modules/pymupdf/conftest-dont-pip-install.patch
@@ -1,0 +1,12 @@
+diff --git a/tests/conftest.py b/tests/conftest.py
+index 8b9bd31b..472f57b8 100644
+--- a/tests/conftest.py
++++ b/tests/conftest.py
+@@ -29,7 +29,6 @@ def install_required_packages():
+     print(f'{__file__}:install_required_packages)(): Running: {command}', flush=1)
+     subprocess.run(command, shell=1, check=1)
+ 
+-install_required_packages()
+ 
+ # Need to import pymupdf only after we've installed pymupdf-fonts above,
+ # because pymupdf imports pymupdf_fonts, and copes with import failure.

--- a/pkgs/development/python-modules/pymupdf/default.nix
+++ b/pkgs/development/python-modules/pymupdf/default.nix
@@ -73,11 +73,14 @@ buildPythonPackage rec {
     unset LD
   '';
 
-  nativeBuildInputs = [
+  build-system = [
     libclang
     swig
-    psutil
     setuptools
+  ];
+
+  dependencies = [
+    mupdf-cxx-lib
   ];
 
   buildInputs = [
@@ -88,8 +91,6 @@ buildPythonPackage rec {
     libjpeg_turbo
     gumbo
   ];
-
-  propagatedBuildInputs = [ mupdf-cxx-lib ];
 
   env = {
     # force using system MuPDF (must be defined in environment and empty)
@@ -110,11 +111,9 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-  ];
-
-  checkInputs = [
     fonttools
     pillow
+    psutil
     pymupdf-fonts
   ];
 


### PR DESCRIPTION
Changelog: https://github.com/pymupdf/PyMuPDF/releases

~~Updating to 1.26.5 makes the most sense to me as the changelog suggests pymupdf 1.26.5 is based on mupdf 1.26.10, which is precisely the version of mupdf we're currently packaging in nixpkgs.~~
pymupdf 1.26.6 seems to be compatible.

This also fixes the build failure we're seeing on Hydra: https://hydra.nixos.org/build/313245469/nixlog/2

Another data point for unsetting `LD`, as done in this PR: You can also see that in an [upstream GHA job](https://github.com/pymupdf/PyMuPDF/actions/runs/19384355237/job/55468952548#step:3:2568), `c++` is used for the linking step instead of `$LD`. In fact, `LD` is unset.

Closes #461550
Supersedes #454901
ZHF: #457852

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
