### PR TITLE
i3-back: fix build on current version

### DIFF
--- a/pkgs/by-name/i3/i3-back/package.nix
+++ b/pkgs/by-name/i3/i3-back/package.nix
@@ -16,8 +16,11 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-xGfX7ttWrcIVhy+MkR5RZr2DCAwIKwGu7zkafHcrjaE=";
   };
 
-  # The tool needs a nightly compiler.
-  RUSTC_BOOTSTRAP = 1;
+  patches = [
+    # `let_chain` feature is not needed anymore with 1.90.
+    # See https://github.com/Cretezy/i3-back/pull/5
+    ./remove-feature.patch
+  ];
 
   cargoHash = "sha256-o/um/Ugm3GfDz1daBKxoDD7ailUu6QJ0rj5jcKWB0lM=";
 

--- a/pkgs/by-name/i3/i3-back/remove-feature.patch
+++ b/pkgs/by-name/i3/i3-back/remove-feature.patch
@@ -1,0 +1,22 @@
+diff --git a/Cargo.toml b/Cargo.toml
+index 68cbda32f3..0e3f6ad1f6 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -1,7 +1,7 @@
+ [package]
+ name = "i3-back"
+ version = "0.3.2"
+-edition = "2021"
++edition = "2024"
+ description = "An i3/Sway utility to switch focus to your last focused window. Allows for behavior similar to Alt+Tab on other desktop environments."
+ repository = "https://github.com/Cretezy/i3-back"
+ homepage = "https://github.com/Cretezy/i3-back"
+diff --git a/src/main.rs b/src/main.rs
+index e11a2a7550..91a34cab07 100644
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -1,4 +1,3 @@
+-#![feature(let_chains)]
+ use std::process;
+ use std::thread;
+ use std::time::Duration;


### PR DESCRIPTION
## Things done

Fix build problems related `let_chains` feature. Fixed by removing it due to not needed in newest Rust and updating Rust Edition with a patch until fixed upstream. Fixed in course of #ZurichZHF.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
