### PR TITLE
openscap: discover built-in plugins (like SCE)

### DIFF
--- a/pkgs/by-name/op/openscap/package.nix
+++ b/pkgs/by-name/op/openscap/package.nix
@@ -106,6 +106,10 @@ stdenv.mkDerivation rec {
       --replace-fail "DESTINATION ''${PERL_VENDORARCH}" "DESTINATION ''${SWIG_PERL_DIR}"
     substituteInPlace src/common/oscap_pcre.c \
       --replace-fail "#include <pcre2.h>" "#include <${pcre2.dev}/include/pcre2.h>"
+
+    # Patch SCE engine to not hardcode FHS paths, allowing it to use the transient environment's PATH
+    substituteInPlace src/SCE/sce_engine.c \
+      --replace-fail 'env_values[0] = "PATH=/bin:/sbin:/usr/bin:/usr/local/bin:/usr/sbin";' 'env_values[0] = "_PATCHED_OUT_DUMMY_VAR=patched-out";'
   '';
 
   cmakeFlags = [

--- a/pkgs/by-name/op/openscap/package.nix
+++ b/pkgs/by-name/op/openscap/package.nix
@@ -26,6 +26,7 @@
   valgrind,
   asciidoc,
   installShellFiles,
+  makeWrapper,
   rpm,
   system-sendmail,
   gnome2,
@@ -55,6 +56,7 @@ stdenv.mkDerivation rec {
     cmake
     asciidoc
     doxygen
+    makeWrapper
     rpm
     swig
     util-linux
@@ -141,6 +143,13 @@ stdenv.mkDerivation rec {
     make install
     installManPage $out/share/man8/*.8
     rm -rf $out/share/man8
+  '';
+
+  postFixup = ''
+    # Set plugin directory to discover the SCE plugin.
+    # openscap calls dlopen with this as the directory prefix.
+    wrapProgram $out/bin/oscap \
+      --set OSCAP_CHECK_ENGINE_PLUGIN_DIR $out/lib
   '';
 
   meta = {


### PR DESCRIPTION
openscap calls dlopen() to discover plugins.
It prefixes the path that is dlopened with
OSCAP_CHECK_ENGINE_PLUGIN_DIR. By setting
that env-var we can make openscap discover
the built-in plugins that it ships with by
default. (Currently only SCE).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
