### PR TITLE
python3Packages.protobuf4: Fix tests

### DIFF
--- a/pkgs/development/python-modules/protobuf/4-tests-missing-proto.patch
+++ b/pkgs/development/python-modules/protobuf/4-tests-missing-proto.patch
@@ -1,0 +1,30 @@
+From c29857d56f9f74d11b7b087de1951c8b584be151 Mon Sep 17 00:00:00 2001
+From: Kirill Elagin <kirelagin@gmail.com>
+Date: Sat, 15 Nov 2025 13:21:11 +0100
+Subject: [PATCH] tests: Generate proto for self_recusive
+
+The new functionality and the test for it were backported in
+d31100c9195819edb0a12f44705dfc2da111ea9b, however the `setup.py` file
+was not updated accordingly, so the proto for the test case was not
+actually generated.
+
+Generate the proto in `setup.py`.
+---
+ python/setup.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/python/setup.py b/python/setup.py
+index 057414d8f..c1eeeee39 100755
+--- a/setup.py
++++ b/setup.py
+@@ -135,6 +135,7 @@ def GenerateUnittestProtos():
+   GenProto('google/protobuf/internal/more_messages.proto', False)
+   GenProto('google/protobuf/internal/no_package.proto', False)
+   GenProto('google/protobuf/internal/packed_field_test.proto', False)
++  GenProto('google/protobuf/internal/self_recursive.proto', False)
+   GenProto('google/protobuf/internal/test_bad_identifiers.proto', False)
+   GenProto('google/protobuf/internal/test_proto3_optional.proto', False)
+   GenProto('google/protobuf/pyext/python.proto', False)
+-- 
+2.51.0
+

--- a/pkgs/development/python-modules/protobuf/4-tests-numpy-index.patch
+++ b/pkgs/development/python-modules/protobuf/4-tests-numpy-index.patch
@@ -1,0 +1,128 @@
+From 55c8e8a67f5f960b7597032d3e290168641b531d Mon Sep 17 00:00:00 2001
+From: Kirill Elagin <kirelagin@gmail.com>
+Date: Sat, 15 Nov 2025 13:21:11 +0100
+Subject: [PATCH] tests: Fix numpy type checking test
+
+The testing code assumes that all numpy scalars have `__index__`,
+however this is no longer true with recent numpy.
+
+Backport the fix from upstream master by cherry-picking
+64f5694cb2f9ae52ac6ffcad1eda4085e5cd5b7d.
+---
+ python/convert.c                              | 31 +++++++++++++++++++
+ .../google/protobuf/internal/type_checkers.py | 13 ++++++--
+ python/google/protobuf/pyext/message.cc       | 16 ++++++++--
+ 3 files changed, 56 insertions(+), 4 deletions(-)
+
+diff --git a/python/convert.c b/python/convert.c
+index 0c1174ba6..d4c17049e 100644
+--- a/convert.c
++++ b/convert.c
+@@ -226,6 +226,37 @@ bool PyUpb_IsNumpyNdarray(PyObject* obj, const upb_FieldDef* f) {
+   return is_ndarray;
+ }
+ 
++bool PyUpb_IsNumpyBoolScalar(PyObject* obj) {
++  PyObject* type_module_obj =
++      PyObject_GetAttrString((PyObject*)Py_TYPE(obj), "__module__");
++  bool is_numpy = !strcmp(PyUpb_GetStrData(type_module_obj), "numpy");
++  Py_DECREF(type_module_obj);
++  if (!is_numpy) {
++    return false;
++  }
++
++  PyObject* type_name_obj =
++      PyObject_GetAttrString((PyObject*)Py_TYPE(obj), "__name__");
++  bool is_bool = !strcmp(PyUpb_GetStrData(type_name_obj), "bool");
++  Py_DECREF(type_name_obj);
++  if (!is_bool) {
++    return false;
++  }
++  return true;
++}
++
++static bool PyUpb_GetBool(PyObject* obj, const upb_FieldDef* f, bool* val) {
++  if (!PyBool_Check(obj)) {
++    if (PyUpb_IsNumpyNdarray(obj, f)) return false;
++    if (PyUpb_IsNumpyBoolScalar(obj)) {
++      *val = PyObject_IsTrue(obj);
++      return !PyErr_Occurred();
++    }
++  }
++  *val = PyLong_AsLong(obj);
++  return !PyErr_Occurred();
++}
++
+ bool PyUpb_PyToUpb(PyObject* obj, const upb_FieldDef* f, upb_MessageValue* val,
+                    upb_Arena* arena) {
+   switch (upb_FieldDef_CType(f)) {
+@@ -248,9 +248,7 @@ bool PyUpb_PyToUpb(PyObject* obj, const upb_FieldDef* f, upb_MessageValue* val,
+       val->double_val = PyFloat_AsDouble(obj);
+       return !PyErr_Occurred();
+     case kUpb_CType_Bool:
+-      if (PyUpb_IsNumpyNdarray(obj, f)) return false;
+-      val->bool_val = PyLong_AsLong(obj);
+-      return !PyErr_Occurred();
++      return PyUpb_GetBool(obj, f, &val->bool_val);
+     case kUpb_CType_Bytes: {
+       char* ptr;
+       Py_ssize_t size;
+
+diff --git a/python/google/protobuf/internal/type_checkers.py b/python/google/protobuf/internal/type_checkers.py
+index e152a43f8..a0e23a0ab 100755
+--- a/google/protobuf/internal/type_checkers.py
++++ b/google/protobuf/internal/type_checkers.py
+@@ -113,12 +113,21 @@ class BoolValueChecker(object):
+   """Type checker used for bool fields."""
+ 
+   def CheckValue(self, proposed_value):
+-    if not hasattr(proposed_value, '__index__') or (
+-        type(proposed_value).__module__ == 'numpy' and
++    if not hasattr(proposed_value, '__index__'):
++      # Under NumPy 2.3, numpy.bool does not have an __index__ method.
++      if (type(proposed_value).__module__ == 'numpy' and
++          type(proposed_value).__name__ == 'bool'):
++        return bool(proposed_value)
++      message = ('%.1024r has type %s, but expected one of: %s' %
++                 (proposed_value, type(proposed_value), (bool, int)))
++      raise TypeError(message)
++
++    if (type(proposed_value).__module__ == 'numpy' and
+         type(proposed_value).__name__ == 'ndarray'):
+       message = ('%.1024r has type %s, but expected one of: %s' %
+                  (proposed_value, type(proposed_value), (bool, int)))
+       raise TypeError(message)
++
+     return bool(proposed_value)
+ 
+   def DefaultValue(self):
+diff --git a/python/google/protobuf/pyext/message.cc b/python/google/protobuf/pyext/message.cc
+index 449a11d99..f2c6fb4b7 100644
+--- a/google/protobuf/pyext/message.cc
++++ b/google/protobuf/pyext/message.cc
+@@ -558,8 +558,20 @@ bool CheckAndGetFloat(PyObject* arg, float* value) {
+ 
+ bool CheckAndGetBool(PyObject* arg, bool* value) {
+   long long_value = PyLong_AsLong(arg);  // NOLINT
+-  if (!strcmp(Py_TYPE(arg)->tp_name, "numpy.ndarray") ||
+-      (long_value == -1 && PyErr_Occurred())) {
++  if (long_value == -1 && PyErr_Occurred()) {
++    // In NumPy 2.3, numpy.bool does not have an __index__ method and cannot
++    // be converted to a long using PyLong_AsLong.
++    if (!strcmp(Py_TYPE(arg)->tp_name, "numpy.bool")) {
++      PyErr_Clear();
++      int is_true = PyObject_IsTrue(arg);
++      if (is_true >= 0) {
++        *value = static_cast<bool>(is_true);
++        return true;
++      }
++    }
++    FormatTypeError(arg, "int, bool");
++    return false;
++  } else if (!strcmp(Py_TYPE(arg)->tp_name, "numpy.ndarray")) {
+     FormatTypeError(arg, "int, bool");
+     return false;
+   }
+-- 
+2.51.0
+

--- a/pkgs/development/python-modules/protobuf/4.nix
+++ b/pkgs/development/python-modules/protobuf/4.nix
@@ -28,21 +28,24 @@ buildPythonPackage {
 
   sourceRoot = "${protobuf.src.name}/python";
 
-  patches =
-    lib.optionals (lib.versionAtLeast protobuf.version "22") [
-      # Replace the vendored abseil-cpp with nixpkgs'
-      (replaceVars ./use-nixpkgs-abseil-cpp.patch {
-        abseil_cpp_include_path = "${lib.getDev protobuf.abseil-cpp}/include";
-      })
-    ]
-    ++ lib.optionals (pythonAtLeast "3.11" && lib.versionOlder protobuf.version "22") [
-      (fetchpatch {
-        name = "support-python311.patch";
-        url = "https://github.com/protocolbuffers/protobuf/commit/2206b63c4649cf2e8a06b66c9191c8ef862ca519.diff";
-        stripLen = 1; # because sourceRoot above
-        hash = "sha256-3GaoEyZIhS3QONq8LEvJCH5TdO9PKnOgcQF0GlEiwFo=";
-      })
-    ];
+  patches = [
+    ./4-tests-missing-proto.patch
+    ./4-tests-numpy-index.patch
+  ]
+  ++ lib.optionals (lib.versionAtLeast protobuf.version "22") [
+    # Replace the vendored abseil-cpp with nixpkgs'
+    (replaceVars ./use-nixpkgs-abseil-cpp.patch {
+      abseil_cpp_include_path = "${lib.getDev protobuf.abseil-cpp}/include";
+    })
+  ]
+  ++ lib.optionals (pythonAtLeast "3.11" && lib.versionOlder protobuf.version "22") [
+    (fetchpatch {
+      name = "support-python311.patch";
+      url = "https://github.com/protocolbuffers/protobuf/commit/2206b63c4649cf2e8a06b66c9191c8ef862ca519.diff";
+      stripLen = 1; # because sourceRoot above
+      hash = "sha256-3GaoEyZIhS3QONq8LEvJCH5TdO9PKnOgcQF0GlEiwFo=";
+    })
+  ];
 
   prePatch = ''
     if [[ "$(<../version.json)" != *'"python": "'"$version"'"'* ]]; then


### PR DESCRIPTION
The tests were failing, it seems that the upstream makes backports to this branch but does not verify that the tests pass.

This includes two fixes:

* Add a missing proto generation to the build.
* Backport a NumPy compat fix from upstream master.

Fixes #418899.

#ZurichZHF

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
