### PR TITLE
vast-cli: init at 0.5.0

### DIFF
--- a/pkgs/by-name/va/vast-cli/package.nix
+++ b/pkgs/by-name/va/vast-cli/package.nix
@@ -1,0 +1,55 @@
+{
+  fetchFromGitHub,
+  lib,
+  python3Packages,
+
+  nix-update-script,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "vast-cli";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "vast-ai";
+    repo = "vast-cli";
+    tag = "v${version}";
+    hash = "sha256-9SEPWRZnFRjZHh2NH3rpL3cThDcUAuXmtiU4js48m0g=";
+  };
+
+  pyproject = true;
+
+  pythonRelaxDeps = true;
+
+  nativeBuildInputs = [
+    python3Packages.pythonRelaxDepsHook
+  ];
+
+  dependencies = with python3Packages; [
+    xdg
+    argcomplete
+    requests
+    borb
+    python-dateutil
+    pytz
+    urllib3
+    poetry-dynamic-versioning
+    gitpython
+    toml
+    curlify
+    setuptools
+    cryptography
+  ];
+
+  build-system = [ python3Packages.poetry-core ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Vast.ai python and cli api client";
+    homepage = "https://vast.ai";
+    changelog = "https://github.com/vast-ai/vast-cli/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ baileylu ];
+    mainProgram = "vastai";
+  };
+}


### PR DESCRIPTION
Adds a package for [vast.ai](https://github.com/vast-ai/vast-cli)'s command line utility for interacting with their machines/platform.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
