### PR TITLE
clipcat: fix build

### DIFF
--- a/pkgs/by-name/cl/clipcat/package.nix
+++ b/pkgs/by-name/cl/clipcat/package.nix
@@ -25,6 +25,8 @@ rustPlatform.buildRustPackage rec {
     # Fix compilation errors caused by stricter restrictions on unused code in Rust 1.89.
     # TODO: remove this patch after upstream fix it.
     ./dummy.patch
+    # https://github.com/xrelkd/clipcat/pull/871
+    ./remove_unnecessary_parenthesis.patch
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/cl/clipcat/remove_unnecessary_parenthesis.patch
+++ b/pkgs/by-name/cl/clipcat/remove_unnecessary_parenthesis.patch
@@ -1,0 +1,22 @@
+From 76e3ce46eb930dbc51c3e7aeb832a9db6194fd34 Mon Sep 17 00:00:00 2001
+From: sandroid <sandroid@posteo.net>
+Date: Sun, 9 Nov 2025 22:12:03 +0100
+Subject: [PATCH] fix(crates/server): remove unnecessary parentheses
+
+---
+ crates/server/src/snippets/mod.rs | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/crates/server/src/snippets/mod.rs b/crates/server/src/snippets/mod.rs
+index 00759b1e..8a43c326 100644
+--- a/crates/server/src/snippets/mod.rs
++++ b/crates/server/src/snippets/mod.rs
+@@ -39,7 +39,7 @@ async fn load(config: &config::SnippetConfig) -> HashMap<ClipEntry, Option<PathB
+                 clipcat_base::utils::fs::read_dir_recursively_async(&path)
+                     .await
+                     .into_iter()
+-                    .map(|file| (async move { (tokio::fs::read(&file).await.ok(), file) })),
++                    .map(|file| async move { (tokio::fs::read(&file).await.ok(), file) }),
+             )
+             .await
+             .into_iter()


### PR DESCRIPTION
Fixes https://hydra.nixos.org/build/313309609/nixlog/2
ZHF https://github.com/NixOS/nixpkgs/issues/457852

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
