### PR TITLE
gphoto2,gphoto2fs: move gphoto2 and gphoto2fs to pkgs/by-name

### DIFF
--- a/pkgs/by-name/gp/gphoto2/package.nix
+++ b/pkgs/by-name/gp/gphoto2/package.nix
@@ -13,15 +13,15 @@
   readline,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gphoto2";
   version = "2.5.32";
 
   src = fetchFromGitHub {
     owner = "gphoto";
     repo = "gphoto2";
-    rev = "v${version}";
-    sha256 = "sha256-9Tn6CBxZpzPnlyiBYdpQGViT3NEcup6AXT7Z0DqI/vA=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-9Tn6CBxZpzPnlyiBYdpQGViT3NEcup6AXT7Z0DqI/vA=";
   };
 
   nativeBuildInputs = [
@@ -53,4 +53,4 @@ stdenv.mkDerivation rec {
     maintainers = [ lib.maintainers.jcumming ];
     mainProgram = "gphoto2";
   };
-}
+})

--- a/pkgs/by-name/gp/gphoto2fs/package.nix
+++ b/pkgs/by-name/gp/gphoto2fs/package.nix
@@ -9,12 +9,12 @@
   glib,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gphoto2fs";
   version = "0.5.0";
   src = fetchurl {
-    url = "mirror://sourceforge/gphoto/gphotofs/${version}/gphotofs-0.5.tar.bz2";
-    sha256 = "1k23ncbsbh64r7kz050bg31jqamchyswgg9izhzij758d7gc8vk7";
+    url = "mirror://sourceforge/gphoto/gphotofs/${finalAttrs.version}/gphotofs-0.5.tar.bz2";
+    hash = "sha256-Z27E3mmoHBk//DG9x7WHrCosw3gLFPDnycTApRezQ8w=";
   };
 
   nativeBuildInputs = [ pkg-config ];
@@ -36,4 +36,4 @@ stdenv.mkDerivation rec {
       gpl2
     ];
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9591,10 +9591,6 @@ with pkgs;
 
   molsketch = libsForQt5.callPackage ../applications/editors/molsketch { };
 
-  gphoto2 = callPackage ../applications/misc/gphoto2 { };
-
-  gphoto2fs = callPackage ../applications/misc/gphoto2/gphotofs.nix { };
-
   graphicsmagick_q16 = graphicsmagick.override { quantumdepth = 16; };
   graphicsmagick-imagemagick-compat = graphicsmagick.imagemagick-compat;
 


### PR DESCRIPTION
gphoto2: migrate to `pkgs/by-name/gp/gphoto2/package.nix` 
- switch to `stdenv.mkDerivation (finalAttrs: { ... })` pattern
- use `tag`/`hash` instead of `rev`/`sha256`
- drop `with lib;` in meta, qualify licenses/platforms/maintainers

gphoto2fs: migrate to `pkgs/by-name/gp/gphoto2fs/package.nix` 
- switch to `stdenv.mkDerivation (finalAttrs: { ... })` pattern
- update to `hash` form • drop `with lib;` in meta, qualify licenses/platforms/maintainers
- all-packages.nix: remove old `callPackage` entries

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
