### PR TITLE
nvidia-container-toolkit: disable create-symlinks hook

### DIFF
--- a/nixos/modules/services/hardware/nvidia-container-toolkit/cdi-generate.nix
+++ b/nixos/modules/services/hardware/nvidia-container-toolkit/cdi-generate.nix
@@ -37,6 +37,7 @@ writeScriptBin "nvidia-cdi-generator" ''
       }
       --discovery-mode ${discovery-mode} \
       --device-name-strategy ${device-name-strategy} \
+      --disable-hook create-symlinks \
       --ldconfig-path ${lib.getExe' glibc "ldconfig"} \
       --library-search-path ${lib.getLib nvidia-driver}/lib \
       --nvidia-cdi-hook-path ${lib.getOutput "tools" nvidia-container-toolkit}/bin/nvidia-cdi-hook \

--- a/nixos/modules/services/hardware/nvidia-container-toolkit/default.nix
+++ b/nixos/modules/services/hardware/nvidia-container-toolkit/default.nix
@@ -232,12 +232,8 @@
                 containerPath = pkgs.addDriverRunpath.driverLink;
               }
               {
-                hostPath = "${lib.getLib nvidia-driver}/etc";
-                containerPath = "${lib.getLib nvidia-driver}/etc";
-              }
-              {
-                hostPath = "${lib.getLib nvidia-driver}/share";
-                containerPath = "${lib.getLib nvidia-driver}/share";
+                hostPath = "${lib.getLib nvidia-driver}";
+                containerPath = "${lib.getLib nvidia-driver}";
               }
               {
                 hostPath = "${lib.getLib pkgs.glibc}/lib";


### PR DESCRIPTION
This fixes the problem of not being able to run containers mounting the `/nix` directory within the container (used extensively for example by tools like `distrobox`)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Depends on: https://github.com/NixOS/nixpkgs/pull/461871
Fixes: https://github.com/NixOS/nixpkgs/issues/441227
Fixes: https://github.com/NixOS/nixpkgs/issues/412324
Fixes: https://github.com/NixOS/nixpkgs/issues/411150
Fixes: https://github.com/NixOS/nixpkgs/issues/366109

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
