### PR TITLE
ieda: 0.1.0-unstable-2025-09-10 -> 0.1.0-unstable-2025-11-08

### DIFF
--- a/pkgs/by-name/ie/ieda/package.nix
+++ b/pkgs/by-name/ie/ieda/package.nix
@@ -28,21 +28,20 @@
 let
   rootSrc = stdenv.mkDerivation {
     pname = "iEDA-src";
-    version = "2025-09-10";
+    version = "2025-11-08";
     src = fetchgit {
       url = "https://gitee.com/oscc-project/iEDA";
-      rev = "614a91b4d18ba7dc561315f2d5fdae4a5451f486";
-      sha256 = "sha256-xn1hpnSyO+jauYYhlsKjBkkD3RJ1GqbHtnWRe/My1R0=";
+      rev = "038eb6454cb7e83c6b65b933e8a21b3e4b4776e0";
+      sha256 = "sha256-wUqpiCU5ap6oda2ReHtUBwI0XMEUcuXY7qWNQ2UlL9A=";
     };
 
     patches = [
-      # This patch is to fix the build error caused by the missing of the header file,
-      # and remove some libs or path that they hard-coded in the source code.
+      # This patch is to fix the build system to properly find and link against rust libraries.
       # Due to the way they organized the source code, it's hard to upstream this patch.
       # So we have to maintain this patch locally.
       (fetchpatch {
-        url = "https://github.com/Emin017/iEDA/commit/c6b642f3db6c156eaf4f1203612592c86e49e1b5.patch";
-        hash = "sha256-L0bmW7kadmLLng9rZOT1NpvniBpuD8SUqCfeH2cCrdg=";
+        url = "https://github.com/Emin017/iEDA/commit/e5f3ce024965df5e1d400b6a1d7f8b5b307a4bf3.patch";
+        hash = "sha256-YJnY+r9A887WT0a/H/Zf++r1PpD7t567NpkesDmIsD0=";
       })
       # Comment out the iCTS test cases that will fail due to some linking issues on aarch64-linux
       (fetchpatch {
@@ -66,7 +65,7 @@ let
 in
 stdenv.mkDerivation {
   pname = "iEDA";
-  version = "0.1.0-unstable-2025-09-10";
+  version = "0.1.0-unstable-2025-11-08";
 
   src = rootSrc;
 


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
