### PR TITLE
celeste: fix rustc 1.85.0 errors

### DIFF
--- a/pkgs/by-name/ce/celeste/missing-unsafe-block.patch
+++ b/pkgs/by-name/ce/celeste/missing-unsafe-block.patch
@@ -1,0 +1,25 @@
+From 96ec13b49ee2fcb2869f87b1f9e8c6cfc92275df Mon Sep 17 00:00:00 2001
+From: Tom van Dijk <18gatenmaker6@gmail.com>
+Date: Fri, 14 Nov 2025 18:55:40 +0100
+Subject: [PATCH] rust 2024 fixes
+
+---
+ src/main.rs | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/main.rs b/src/main.rs
+index 127f649..5ef526e 100644
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -103,7 +103,7 @@ fn main() {
+         }
+     } else {
+         // Set `RUST_BACKTRACE` so we get a better backtrace for reporting.
+-        env::set_var("RUST_BACKTRACE", "1");
++        unsafe { env::set_var("RUST_BACKTRACE", "1"); }
+ 
+         // Run the command and get the stderr, checking for a backtrace.
+         let mut args = vec!["run-gui"];
+-- 
+2.51.0
+

--- a/pkgs/by-name/ce/celeste/package.nix
+++ b/pkgs/by-name/ce/celeste/package.nix
@@ -31,6 +31,9 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-OBGDnhpVLOPdYhofWfeaueklt7KBkLhM02JNvuvUQ2Q=";
 
+  # rust 2024 requires that you put an unsafe block around std::env::set_var
+  patches = [ ./missing-unsafe-block.patch ];
+
   postPatch = ''
     pushd $cargoDepsCopy/librclone-sys-*
     oldHash=$(sha256sum build.rs | cut -d " " -f 1)
@@ -45,6 +48,10 @@ rustPlatform.buildRustPackage rec {
       --replace "{{ env_var('DESTDIR') }}/usr" "${placeholder "out"}"
     # buildRustPackage takes care of installing the binary
     sed -i "#/bin/celeste#d" justfile
+
+    # fix: as of rust 1.85, it is required that you specify edition 2024 for let chains
+    substituteInPlace Cargo.toml \
+      --replace-warn 'edition = "2021"' 'edition = "2024"'
   '';
 
   RUSTC_BOOTSTRAP = 1;


### PR DESCRIPTION
ZHF: #457852

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
