### PR TITLE
google-cloud-cpp: 2.38.0 -> 2.43.0, modernize

### DIFF
--- a/pkgs/by-name/go/google-cloud-cpp/package.nix
+++ b/pkgs/by-name/go/google-cloud-cpp/package.nix
@@ -14,32 +14,32 @@
   nlohmann_json,
   openssl,
   pkg-config,
-  protobuf_31,
+  protobuf,
   pkgsBuildHost,
-  # default list of APIs: https://github.com/googleapis/google-cloud-cpp/blob/v1.32.1/CMakeLists.txt#L173
+  # default list of APIs: https://github.com/googleapis/google-cloud-cpp/blob/v2.43.0/cmake/GoogleCloudCppFeatures.cmake#L24
   apis ? [ "*" ],
   staticOnly ? stdenv.hostPlatform.isStatic,
 }:
 let
   # defined in cmake/GoogleapisConfig.cmake
-  googleapisRev = "f01a17a560b4fbc888fd552c978f4e1f8614100b";
+  googleapisRev = "2193a2bfcecb92b92aad7a4d81baa428cafd7dfd";
   googleapis = fetchFromGitHub {
     name = "googleapis-src";
     owner = "googleapis";
     repo = "googleapis";
     rev = googleapisRev;
-    hash = "sha256-eJA3KM/CZMKTR3l6omPJkxqIBt75mSNsxHnoC+1T4gw=";
+    hash = "sha256-M+3ywDd1kyo6U/9o7fpsqYIPuulf8fDe3a4mjJKEN2U=";
   };
 in
 stdenv.mkDerivation rec {
   pname = "google-cloud-cpp";
-  version = "2.38.0";
+  version = "2.43.0";
 
   src = fetchFromGitHub {
     owner = "googleapis";
     repo = "google-cloud-cpp";
     rev = "v${version}";
-    sha256 = "sha256-TF3MLBmjUbKJkZVcaPXbagXrAs3eEhlNQBjYQf0VtT8=";
+    sha256 = "sha256-2OnzObCTmB6E4Ut0blmL7CRAJJ9EKl6eSVdfuPS4B2Y=";
   };
 
   patches = [
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     grpc
     nlohmann_json
     openssl
-    protobuf_31
+    protobuf
     gbenchmark
     gtest
   ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **google-cloud-cpp: 2.38.0 -> 2.43.0**
- **google-cloud-cpp: modernize**

Diff: https://github.com/googleapis/google-cloud-cpp/compare/v2.38.0...v2.43.0
Changelog: https://github.com/googleapis/google-cloud-cpp/blob/v2.43.0/CHANGELOG.md

cc @cpcloud

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
