### PR TITLE
apache-orc: 2.1.2 -> 2.2.1

### DIFF
--- a/pkgs/by-name/ap/apache-orc/package.nix
+++ b/pkgs/by-name/ap/apache-orc/package.nix
@@ -3,32 +3,37 @@
   stdenv,
   fetchFromGitHub,
   fetchurl,
-  fetchpatch,
   cmake,
   gtest,
   lz4,
-  protobuf_30,
+  protobuf,
   snappy,
   zlib,
   zstd,
 }:
 
 let
-  orc-format = fetchurl {
-    name = "orc-format-1.1.0.tar.gz";
-    url = "https://www.apache.org/dyn/closer.lua/orc/orc-format-1.1.0/orc-format-1.1.0.tar.gz?action=download";
-    hash = "sha256-1KesdsVEKr9xGeLLhOcbZ34HWv9TUYqoZgVeLq0EUNc=";
-  };
+  orc-format =
+    let
+      version = "1.1.1";
+      name = "orc-format-${version}";
+      archiveName = "${name}.tar.gz";
+    in
+    fetchurl {
+      name = archiveName;
+      url = "https://www.apache.org/dyn/closer.lua/orc/${name}/${archiveName}?action=download";
+      hash = "sha256-WE3+KkIClGF4/Y/H0SOb54BbntRZarIELe5znniAmSs=";
+    };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "apache-orc";
-  version = "2.1.2";
+  version = "2.2.1";
 
   src = fetchFromGitHub {
     owner = "apache";
     repo = "orc";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-hNKzqNOagBJOWQRebkVHIuvqfpk9Mi30bu4z7dGbsxk=";
+    hash = "sha256-H7nowl2pq31RIAmTUz15x48Wc99MljFJboc4F7Ln/zk=";
   };
 
   nativeBuildInputs = [
@@ -38,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     gtest
     lz4
-    protobuf_30
+    protobuf
     snappy
     zlib
     zstd
@@ -62,7 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
     GTEST_HOME = gtest.dev;
     LZ4_ROOT = lz4;
     ORC_FORMAT_URL = orc-format;
-    PROTOBUF_HOME = protobuf_30;
+    PROTOBUF_HOME = protobuf;
     SNAPPY_ROOT = snappy.dev;
     ZLIB_ROOT = zlib.dev;
     ZSTD_ROOT = zstd.dev;


### PR DESCRIPTION
## Things done

Diff: https://github.com/apache/orc/compare/v2.1.2...v2.2.1
Changelog: https://github.com/apache/orc/releases/tag/v2.2.1

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
