### PR TITLE
arelle: fix build, 2.37.61 -> 2.37.72

### DIFF
--- a/pkgs/development/python-modules/arelle/default.nix
+++ b/pkgs/development/python-modules/arelle/default.nix
@@ -10,6 +10,7 @@
   certifi,
   filelock,
   isodate,
+  jaconv,
   jsonschema,
   lxml,
   numpy,
@@ -25,17 +26,17 @@
   tkinter,
 
   aniso8601,
-  pycryptodome,
+  cheroot,
+  graphviz,
+  holidays,
+  matplotlib,
   pg8000,
+  pycryptodome,
   pymysql,
   pyodbc,
-  rdflib,
-  holidays,
   pytz,
+  rdflib,
   tinycss2,
-  graphviz,
-  cheroot,
-  cherrypy,
   tornado,
 
   sphinxHook,
@@ -44,20 +45,21 @@
   sphinx-copybutton,
   furo,
 
+  writableTmpDirAsHomeHook,
   pytestCheckHook,
   boto3,
 }:
 
 buildPythonPackage rec {
   pname = "arelle${lib.optionalString (!gui) "-headless"}";
-  version = "2.37.61";
+  version = "2.37.72";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Arelle";
     repo = "Arelle";
     tag = version;
-    hash = "sha256-xz3sDAgE1Qpml8V+2y+q/tTda6uGZuMnNSEGdIjLlzI=";
+    hash = "sha256-wytYETzntY1sGHgXua/MOkceiNKjr5qddAGWPMJni98=";
   };
 
   outputs = [
@@ -71,6 +73,10 @@ buildPythonPackage rec {
         'requires = ["setuptools", "wheel", "setuptools_scm[toml]"]'
   '';
 
+  pythonRelaxDeps = [
+    "pillow" # pillow's current version is above what arelle officially supports, but it should be fine
+  ];
+
   build-system = [
     setuptools
     setuptools-scm
@@ -81,6 +87,7 @@ buildPythonPackage rec {
     certifi
     filelock
     isodate
+    jaconv
     jsonschema
     lxml
     numpy
@@ -103,14 +110,15 @@ buildPythonPackage rec {
       rdflib
     ];
     efm = [
+      aniso8601
       holidays
+      matplotlib
       pytz
     ];
     esef = [ tinycss2 ];
     objectmaker = [ graphviz ];
     webserver = [
       cheroot
-      cherrypy
       tornado
     ];
     xule = [ aniso8601 ];
@@ -131,14 +139,11 @@ buildPythonPackage rec {
   '';
 
   nativeCheckInputs = [
+    writableTmpDirAsHomeHook
     pytestCheckHook
     boto3
   ]
   ++ lib.flatten (lib.attrValues optional-dependencies);
-
-  preCheck = ''
-    export HOME=$(mktemp -d)
-  '';
 
   disabledTestPaths = [
     "tests/integration_tests"


### PR DESCRIPTION
ZHF: https://github.com/NixOS/nixpkgs/issues/457852

The build was broken because `pillow` had a version higher than what arelle officially supports. I relaxed the dependency version criterion.

Other than that, I bumped the version. Should have no breaking changes.
There were some dependencies added and removed.

Changelog: https://github.com/Arelle/Arelle/releases

I did some small cleanup as well:
- I reordered optional dependencies alphabetically.
- I opted to use `writableTmpDirAsHomeHook` instead of doing it manually.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
