### PR TITLE
[25.05] electron-{source,bin,chromedriver}: updates

### DIFF
--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -45,14 +45,14 @@
     },
     "37": {
         "hashes": {
-            "aarch64-darwin": "20cf3973cfab6cde93904209845d620d3221fd49bbf39918ed28fb140d0a8e6a",
-            "aarch64-linux": "15e237fb17f7d6bfefabee229d1585204db0d7e230c118a3d5ce8fd49af7405d",
-            "armv7l-linux": "14278dd5061358521133addd0e025e466f8012640e390753df2fa92f13eae451",
-            "headers": "0p2h0517di52sziqycn0dbf9knsg243lkrbiqv2h2f5pwnskhw3w",
-            "x86_64-darwin": "ca911295a582114438f9977e4aef18a42782da0b1fd5627cc1bf7744b2548a88",
-            "x86_64-linux": "aebb0b0d7c1cb7673753766219cd828cbf6c2e86e8b29a9571284d0f7cbc963d"
+            "aarch64-darwin": "5d953398aeb0a578f724d18755f693c8cd32125812c3e6a6f3c9ec90bdfa414a",
+            "aarch64-linux": "35e969cc0a4e779011f314311db07244235f5b2a8db9284bf0061ece7084f6dd",
+            "armv7l-linux": "015c9caf6bb919b73b5118a56f260746ec4ca1ae8c5008e3591d562a6f4c5aee",
+            "headers": "0lwcdw882hjb2vhj9vvngkwq5l6nrh7d2hr9adpqdm1any4rssl5",
+            "x86_64-darwin": "44b845bc1cac455d800cec2df1be3e72af0a3a4c54e933c803f30ab12600ffea",
+            "x86_64-linux": "e5b45933bca6acbf24a52452c976a30f5ac2614d0f08b00b7202b90efba1bc96"
         },
-        "version": "37.7.1"
+        "version": "37.9.0"
     },
     "38": {
         "hashes": {

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -56,13 +56,13 @@
     },
     "38": {
         "hashes": {
-            "aarch64-darwin": "2add03400a735823e827b5671c52d877338b08fd4733dba210b35f99d6346f24",
-            "aarch64-linux": "99fe2c76ef1571da036d4610a6f49de1aa16ea4735b0b20da1d026668d70d629",
-            "armv7l-linux": "25cbecb533ff355e85c6760729dfd822fd27c6d50a36cab800d3d07af603295a",
+            "aarch64-darwin": "e89ab60544fa0a11775baf9fe027fa8ad2cf54ecf3ec80cd7b883aba8e32a63c",
+            "aarch64-linux": "08965d6d57f78b6cd26fcef0275e3047fd90e9e55ea2ab2c811c5c19364d3813",
+            "armv7l-linux": "220d9fbd00013fa940a4178f1ec5a8b2ac27bc4288fd51d5459afd1ff7f5de6d",
             "headers": "1f1381qc705fv50sbm0g5f6wm8pkwqvrbhb1kvi3i9mk2910y14m",
-            "x86_64-darwin": "6a36e577156907ea15ca1cd393c90f0a60bebf01ca9c3414b7e76f4bb8b2d6f4",
-            "x86_64-linux": "b48627d5ce7b533170363e750d7292ecc489bce61ec2b933b9d4705c53166545"
+            "x86_64-darwin": "cdc216cca9541be10c4e2ff6a6c540ff1b2ab0947a6bd184917b243968bf9f8b",
+            "x86_64-linux": "21c15c1b6ea52d57c00551ec667d771ddb9ecc6ea2c7431012060f90868f688d"
         },
-        "version": "38.6.0"
+        "version": "38.7.0"
     }
 }

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -56,13 +56,13 @@
     },
     "38": {
         "hashes": {
-            "aarch64-darwin": "0895d02b29b26f33fc984aa0fc06005093f6128343ecce42da89855c14c22aac",
-            "aarch64-linux": "e4567921b645c8c396835b5ba2144bd104d04a7be1582bb937c53fed21170a0d",
-            "armv7l-linux": "c485210cb616057d04ee8537308c2aec76581554e793d4f5e8da0e04a1b6105c",
-            "headers": "006xw8afgy4irkfyia1idh8nvv5n6xn59gzbqjmzqslv7b1kyz95",
-            "x86_64-darwin": "483b6185c9a0e24eed8a8d5dfcc6fdfb22790f21dc84434083fd75f998f361f3",
-            "x86_64-linux": "8e0b7f6f1eb6ceb7ac04bc6be09acc58a6ab96c3ca6f53d663b0a619c0bf06f2"
+            "aarch64-darwin": "2add03400a735823e827b5671c52d877338b08fd4733dba210b35f99d6346f24",
+            "aarch64-linux": "99fe2c76ef1571da036d4610a6f49de1aa16ea4735b0b20da1d026668d70d629",
+            "armv7l-linux": "25cbecb533ff355e85c6760729dfd822fd27c6d50a36cab800d3d07af603295a",
+            "headers": "1f1381qc705fv50sbm0g5f6wm8pkwqvrbhb1kvi3i9mk2910y14m",
+            "x86_64-darwin": "6a36e577156907ea15ca1cd393c90f0a60bebf01ca9c3414b7e76f4bb8b2d6f4",
+            "x86_64-linux": "b48627d5ce7b533170363e750d7292ecc489bce61ec2b933b9d4705c53166545"
         },
-        "version": "38.4.0"
+        "version": "38.6.0"
     }
 }

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -45,14 +45,14 @@
     },
     "37": {
         "hashes": {
-            "aarch64-darwin": "5d953398aeb0a578f724d18755f693c8cd32125812c3e6a6f3c9ec90bdfa414a",
-            "aarch64-linux": "35e969cc0a4e779011f314311db07244235f5b2a8db9284bf0061ece7084f6dd",
-            "armv7l-linux": "015c9caf6bb919b73b5118a56f260746ec4ca1ae8c5008e3591d562a6f4c5aee",
+            "aarch64-darwin": "10f0143c4590a7eb9f542ff9e26db929a3690120e7010f74df546f164a4e128b",
+            "aarch64-linux": "902f4382f42b94d36d6fb5bd0b5d136b505a56649a81152d14971294ca94fff8",
+            "armv7l-linux": "099a77b3ad0fe3d71d9efa780d2a4be187ba74c03f15714d7c791e3e64b44fcd",
             "headers": "0lwcdw882hjb2vhj9vvngkwq5l6nrh7d2hr9adpqdm1any4rssl5",
-            "x86_64-darwin": "44b845bc1cac455d800cec2df1be3e72af0a3a4c54e933c803f30ab12600ffea",
-            "x86_64-linux": "e5b45933bca6acbf24a52452c976a30f5ac2614d0f08b00b7202b90efba1bc96"
+            "x86_64-darwin": "b4ea214ca58bce53f45d24acf1e3be245f787b40d3aa8532f71c91624d9502d6",
+            "x86_64-linux": "3a982dbfe21b72929ffcc80c786e0aa106a9e6ebf83ba7c8ed587dc12898c6e4"
         },
-        "version": "37.9.0"
+        "version": "37.10.0"
     },
     "38": {
         "hashes": {

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -45,14 +45,14 @@
     },
     "37": {
         "hashes": {
-            "aarch64-darwin": "fba6e9342f6414f08bb49466a8cb7028b44042342a64b55a212565af3b674bfb",
-            "aarch64-linux": "c4ee6ff8d3a3a96217557360bda4271fb49ab2383b8962f458fa0b6dc77ff8e2",
-            "armv7l-linux": "1c9d6799f14c14699fee37af08af515777f4da436b9998ba74a69613e7e957da",
-            "headers": "0p2h0517di52sziqycn0dbf9knsg243lkrbiqv2h2f5pwnskhw3w",
-            "x86_64-darwin": "066d453bd62f02ecb1ddf10cfb064e6200c2af1842bd5963546f37c03eebd426",
-            "x86_64-linux": "2ce28af3e7481126d5dd9dcacdeeed39778a28892e5c594b10c0cfba06400ddb"
+            "aarch64-darwin": "1e2b6822ec49e253f765b34e5078f8261df0fcb086c7a8bfbbebdd35bdb8801e",
+            "aarch64-linux": "66877c9863c967dc435fa18e5177673b9f9e139bd73981c5945d92546d71a5ea",
+            "armv7l-linux": "deedf5b7f387721b4bcb9cea274ceaf7625852f88f3217eabd2104f42259f8be",
+            "headers": "0lwcdw882hjb2vhj9vvngkwq5l6nrh7d2hr9adpqdm1any4rssl5",
+            "x86_64-darwin": "e367440fdc5c915cd137c49ddd2912bda893996da6d14f1d678f02bcb726b135",
+            "x86_64-linux": "62ae1633d05f165d4ee42c2d6675f46db8cb55714433fddb5cb082dc9e40bffb"
         },
-        "version": "37.7.1"
+        "version": "37.9.0"
     },
     "38": {
         "hashes": {

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -56,13 +56,13 @@
     },
     "38": {
         "hashes": {
-            "aarch64-darwin": "7249795788e05d625944f0c0234928eb8176ff0ac03177628d06606975bcfbbe",
-            "aarch64-linux": "f47d45fb8c153fee979564bca8491e2588f0848f03087bb38573ebfbe62e63aa",
-            "armv7l-linux": "36c65512c5eec0ab9741a06e91b38a503de00c1e39cf177db676f5c665f357f4",
-            "headers": "006xw8afgy4irkfyia1idh8nvv5n6xn59gzbqjmzqslv7b1kyz95",
-            "x86_64-darwin": "e3a3dfc38b5f45ad884d2ac8eb165331247c5dbed030f925508fc8ff95a53f1e",
-            "x86_64-linux": "af7e2c995608b2635ea484ed2589a7ff7f79e3b05dd8c14a332f78c13b2a6892"
+            "aarch64-darwin": "b625e3ca3e66a79a63a35c7ca2e199172237387d4739e107620485f83c8dff46",
+            "aarch64-linux": "118b35d04d28f63a10dd3f80f809648e0507f381f889130e9a9cc8e1d1d8dec4",
+            "armv7l-linux": "f5cab868e2da285d60595c7df7cc29595070c4078993516a5f55d674b4b16b7c",
+            "headers": "1f1381qc705fv50sbm0g5f6wm8pkwqvrbhb1kvi3i9mk2910y14m",
+            "x86_64-darwin": "a05015b38f4b6b25d874a5e2bd82c04813e27c34e3611fab8919af772c0e8a55",
+            "x86_64-linux": "1e087810c35b86e077a14464eaead73a8ec64eaa0e1107ac81828a985455aa70"
         },
-        "version": "38.4.0"
+        "version": "38.6.0"
     }
 }

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -56,13 +56,13 @@
     },
     "38": {
         "hashes": {
-            "aarch64-darwin": "b625e3ca3e66a79a63a35c7ca2e199172237387d4739e107620485f83c8dff46",
-            "aarch64-linux": "118b35d04d28f63a10dd3f80f809648e0507f381f889130e9a9cc8e1d1d8dec4",
-            "armv7l-linux": "f5cab868e2da285d60595c7df7cc29595070c4078993516a5f55d674b4b16b7c",
+            "aarch64-darwin": "41c15283f64be0f0773aa6a2fd44dbf2cdc9c42a5fe523420ae5b0a2f3969e61",
+            "aarch64-linux": "2bb62a5f1d46261847c95694559558dc32a8bf1b7165dce1011a9b1c31a60116",
+            "armv7l-linux": "c9605552bb48935f540f64fbe7c9cc8b3b3067a5989babfacaacf2016ce87230",
             "headers": "1f1381qc705fv50sbm0g5f6wm8pkwqvrbhb1kvi3i9mk2910y14m",
-            "x86_64-darwin": "a05015b38f4b6b25d874a5e2bd82c04813e27c34e3611fab8919af772c0e8a55",
-            "x86_64-linux": "1e087810c35b86e077a14464eaead73a8ec64eaa0e1107ac81828a985455aa70"
+            "x86_64-darwin": "3af644d66d45be674a584cf4bfd89aae4f003650222f1ced86ce9c19aaf6c0a3",
+            "x86_64-linux": "479aaeff15da7187a7e24803a2a4325ccc6e9719b00cdc754f052192a137fadc"
         },
-        "version": "38.6.0"
+        "version": "38.7.0"
     }
 }

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -45,14 +45,14 @@
     },
     "37": {
         "hashes": {
-            "aarch64-darwin": "1e2b6822ec49e253f765b34e5078f8261df0fcb086c7a8bfbbebdd35bdb8801e",
-            "aarch64-linux": "66877c9863c967dc435fa18e5177673b9f9e139bd73981c5945d92546d71a5ea",
-            "armv7l-linux": "deedf5b7f387721b4bcb9cea274ceaf7625852f88f3217eabd2104f42259f8be",
+            "aarch64-darwin": "d2c5aeb337610c011007e36142e9bac64c0c3ac225cdf8b41373267b57b1ae98",
+            "aarch64-linux": "3ec3197a0845556d03fd8389354e2e6eb1fb6dfd4ebfbf4d97448e440020777f",
+            "armv7l-linux": "6fd0945a614e98d0a14e5433e427f9e99414c11bce1dbced47e8e2180721ed09",
             "headers": "0lwcdw882hjb2vhj9vvngkwq5l6nrh7d2hr9adpqdm1any4rssl5",
-            "x86_64-darwin": "e367440fdc5c915cd137c49ddd2912bda893996da6d14f1d678f02bcb726b135",
-            "x86_64-linux": "62ae1633d05f165d4ee42c2d6675f46db8cb55714433fddb5cb082dc9e40bffb"
+            "x86_64-darwin": "049d25c8c23bbc1ff7060a56df071115895b9ba6268396cb69c6a1d6283918c7",
+            "x86_64-linux": "c0b5cd05437b13f0ad83e1bcc5d61a803962f72b29c0af21f4b19d2b8ff193a2"
         },
-        "version": "37.9.0"
+        "version": "37.10.0"
     },
     "38": {
         "hashes": {

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -1380,10 +1380,10 @@
             },
             "src/electron": {
                 "args": {
-                    "hash": "sha256-k+YDahI53rwe8o4EjrFfSWTbplUMJemN52+O4ICtz8M=",
+                    "hash": "sha256-nE6qhNX6k+TqHS6PPZcsQ3BCH1ckkn6/FNPv12TcHQ0=",
                     "owner": "electron",
                     "repo": "electron",
-                    "tag": "v37.9.0"
+                    "tag": "v37.10.0"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -2653,7 +2653,7 @@
         "electron_yarn_hash": "0hm126bl9cscs2mjb3yx2yr4b22agqp9r0c5kv25r3lvc020r9pk",
         "modules": "136",
         "node": "22.21.1",
-        "version": "37.9.0"
+        "version": "37.10.0"
     },
     "38": {
         "chrome": "140.0.7339.249",

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -2712,10 +2712,10 @@
             },
             "src/electron": {
                 "args": {
-                    "hash": "sha256-zrShSv6a2TCaMR90dfsN//PWsthHtz8m5awwNFur6hM=",
+                    "hash": "sha256-FFO1VwcyIRtmDRiQ94ar6+fxOg97eeNGfYdqUPZhXPE=",
                     "owner": "electron",
                     "repo": "electron",
-                    "tag": "v38.6.0"
+                    "tag": "v38.7.0"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -3977,6 +3977,6 @@
         "electron_yarn_hash": "1knhw3blk3bl2a8nl58ik272qj2q0cpqiih5gcsds1na3bbkbn2z",
         "modules": "139",
         "node": "22.21.1",
-        "version": "38.6.0"
+        "version": "38.7.0"
     }
 }

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -2656,7 +2656,7 @@
         "version": "37.7.1"
     },
     "38": {
-        "chrome": "140.0.7339.240",
+        "chrome": "140.0.7339.249",
         "chromium": {
             "deps": {
                 "gn": {
@@ -2665,15 +2665,15 @@
                     "version": "0-unstable-2025-07-29"
                 }
             },
-            "version": "140.0.7339.240"
+            "version": "140.0.7339.249"
         },
         "chromium_npm_hash": "sha256-R2gOpfPOUAmnsnUTIvzDPHuHNzL/b2fwlyyfTrywEcI=",
         "deps": {
             "src": {
                 "args": {
-                    "hash": "sha256-lO84baZNQgchjmLnSUQ4y2Yi1MEH8d0omB612F4vCxM=",
+                    "hash": "sha256-ny2ZfcFpdt53+UbjZExBPpxZ/SJts/3DfxgFqbz4QfI=",
                     "postFetch": "rm -r $out/third_party/blink/web_tests; rm -r $out/content/test/data; rm -rf $out/courgette/testdata; rm -r $out/extensions/test/data; rm -r $out/media/test/data; ",
-                    "tag": "140.0.7339.240",
+                    "tag": "140.0.7339.249",
                     "url": "https://chromium.googlesource.com/chromium/src.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -2712,10 +2712,10 @@
             },
             "src/electron": {
                 "args": {
-                    "hash": "sha256-HKUJyRtN5I/xOKyTfP3bHTwZ6AmpbWVzfT4BR3t9SOQ=",
+                    "hash": "sha256-zrShSv6a2TCaMR90dfsN//PWsthHtz8m5awwNFur6hM=",
                     "owner": "electron",
                     "repo": "electron",
-                    "tag": "v38.4.0"
+                    "tag": "v38.6.0"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -3049,10 +3049,10 @@
             },
             "src/third_party/electron_node": {
                 "args": {
-                    "hash": "sha256-mguNvnynyvdqpk3JEgmKTI1vMRMeiD1jICsK6gqkvLQ=",
+                    "hash": "sha256-ZfbpeoBBCULqhNQxL78ikXG1OOZI/EQDgcTqgUYY0KY=",
                     "owner": "nodejs",
                     "repo": "node",
-                    "tag": "v22.20.0"
+                    "tag": "v22.21.1"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -3976,7 +3976,7 @@
         },
         "electron_yarn_hash": "1knhw3blk3bl2a8nl58ik272qj2q0cpqiih5gcsds1na3bbkbn2z",
         "modules": "139",
-        "node": "22.20.0",
-        "version": "38.4.0"
+        "node": "22.21.1",
+        "version": "38.6.0"
     }
 }

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -1380,10 +1380,10 @@
             },
             "src/electron": {
                 "args": {
-                    "hash": "sha256-gq7gu3ZhV2W02oQUtRFSAJfcCchB8zflqexllmg9GCU=",
+                    "hash": "sha256-k+YDahI53rwe8o4EjrFfSWTbplUMJemN52+O4ICtz8M=",
                     "owner": "electron",
                     "repo": "electron",
-                    "tag": "v37.7.1"
+                    "tag": "v37.9.0"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -1717,10 +1717,10 @@
             },
             "src/third_party/electron_node": {
                 "args": {
-                    "hash": "sha256-mguNvnynyvdqpk3JEgmKTI1vMRMeiD1jICsK6gqkvLQ=",
+                    "hash": "sha256-ZfbpeoBBCULqhNQxL78ikXG1OOZI/EQDgcTqgUYY0KY=",
                     "owner": "nodejs",
                     "repo": "node",
-                    "tag": "v22.20.0"
+                    "tag": "v22.21.1"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -2652,8 +2652,8 @@
         },
         "electron_yarn_hash": "0hm126bl9cscs2mjb3yx2yr4b22agqp9r0c5kv25r3lvc020r9pk",
         "modules": "136",
-        "node": "22.20.0",
-        "version": "37.7.1"
+        "node": "22.21.1",
+        "version": "37.9.0"
     },
     "38": {
         "chrome": "140.0.7339.249",


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Partial backports of:
- #459455
- #460922

AFAIK `electron_39` would require backporting a newer rust version to 25.05. With NixOS 25.11 around the corner, I am currently leaning towards just leaving it be and to only backport updates to `electron_37`, `electron_38`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
