### PR TITLE
sv-lang: use wrapped versions of clang-tools

### DIFF
--- a/pkgs/by-name/sv/sv-lang/package.nix
+++ b/pkgs/by-name/sv/sv-lang/package.nix
@@ -7,6 +7,7 @@
   cmake,
   ninja,
   fmt,
+  llvmPackages,
   mimalloc,
   python3,
 }:
@@ -38,6 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
+    llvmPackages.clang-tools
     python3
     ninja
   ];
@@ -63,6 +65,5 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [ sharzy ];
     mainProgram = "slang";
     platforms = lib.platforms.all;
-    broken = stdenv.hostPlatform.isDarwin;
   };
 })

--- a/pkgs/by-name/ve/veridian/package.nix
+++ b/pkgs/by-name/ve/veridian/package.nix
@@ -2,6 +2,7 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  stdenv,
 
   cmake,
   makeWrapper,
@@ -76,5 +77,6 @@ rustPlatform.buildRustPackage {
     homepage = "https://github.com/vivekmalneedi/veridian";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.hakan-demirli ];
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fix the `sv-lang` build on Darwin. Previously, the build failed as `clang-scan-deps` could find C++20 module headers. This was fixed for the wrapped clang tools by #462747, however, in the `sv-lang` build cmake was using the non-wrapped version. Passing the wrapped clang tools as build inputs fixes this.

Mark `sv-lang` as not broken. Mark `veridian` explicitly as broken on Darwin which still does not build on macOS even if `sv-lang` now builds.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
