### PR TITLE
monaspace: 1.200 -> 1.301

### DIFF
--- a/pkgs/by-name/mo/monaspace/package.nix
+++ b/pkgs/by-name/mo/monaspace/package.nix
@@ -1,17 +1,18 @@
 {
   lib,
   stdenvNoCC,
-  fetchzip,
+  fetchFromGitHub,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "monaspace";
-  version = "1.200";
+  version = "1.301";
 
-  src = fetchzip {
-    url = "https://github.com/githubnext/monaspace/releases/download/v${finalAttrs.version}/monaspace-v${finalAttrs.version}.zip";
-    stripRoot = false;
-    hash = "sha256-j1xQYVxfTNDVuzCKvT5FbU29t8XsH4XqcZ477sjydts=";
+  src = fetchFromGitHub {
+    owner = "githubnext";
+    repo = "monaspace";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-8tPwm92ZtaXL9qeDL+ay9PdXLUBBsspdk7/0U8VO0Tg=";
   };
 
   outputs = [
@@ -20,16 +21,17 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   ];
 
   installPhase = ''
-    runHook preInstall
+    # Install TrueType fonts
+    install -Dm644 -t $out/share/fonts/truetype fonts/Frozen\ Fonts/*/*.ttf
+    install -Dm644 -t $out/share/fonts/truetype fonts/Variable\ Fonts/*/*.ttf
 
-    pushd monaspace-v${finalAttrs.version}/fonts/
-    install -Dm644 frozen/*.ttf -t $out/share/fonts/truetype
-    install -Dm644 otf/*.otf -t $out/share/fonts/opentype
-    install -Dm644 variable/*.ttf -t $out/share/fonts/truetype
-    install -Dm644 webfonts/*.woff -t $woff/share/fonts/woff
-    popd
+    # Install OpenType fonts
+    install -Dm644 -t $out/share/fonts/opentype fonts/Static\ Fonts/*/*.otf
+    install -Dm644 -t $out/share/fonts/opentype fonts/NerdFonts/*/*.otf
 
-    runHook postInstall
+    # Install Web fonts
+    install -Dm644 -t $woff/share/fonts/woff fonts/Web\ Fonts/*/*/*.woff
+    install -Dm644 -t $woff/share/fonts/woff fonts/Web\ Fonts/*/*/*.woff2
   '';
 
   meta = {


### PR DESCRIPTION
Update monaspace font

Changelog [here](https://github.com/githubnext/monaspace/releases)
History [here](https://github.com/githubnext/monaspace/compare/v1.200...v1.301)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
