### PR TITLE
treewide: remove obsolete instances of darwinMinVersionHook

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -9,7 +9,6 @@
   buildPackages,
   c-ares,
   cmake,
-  darwinMinVersionHook,
   fixDarwinDylibNames,
   flex,
   gettext,
@@ -148,8 +147,6 @@ stdenv.mkDerivation rec {
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     gmp
-    # Required by Qt 6
-    (darwinMinVersionHook "12.0")
   ];
 
   strictDeps = true;

--- a/pkgs/by-name/ca/capypdf/package.nix
+++ b/pkgs/by-name/ca/capypdf/package.nix
@@ -11,7 +11,6 @@
   libpng,
   libtiff,
   zlib,
-  darwinMinVersionHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -43,9 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
     libjpeg
     libtiff
     zlib
-  ]
-  # error: 'to_chars' is unavailable: introduced in macOS 13.3
-  ++ lib.optional stdenv.hostPlatform.isDarwin (darwinMinVersionHook "13.3");
+  ];
 
   meta = {
     description = "Fully color managed PDF generation library";

--- a/pkgs/by-name/do/dolfinx/package.nix
+++ b/pkgs/by-name/do/dolfinx/package.nix
@@ -12,7 +12,6 @@
   kahip,
   adios2,
   python3Packages,
-  darwinMinVersionHook,
   catch2_3,
   withParmetis ? false,
 }:
@@ -49,7 +48,6 @@ stdenv.mkDerivation (finalAttrs: {
     dolfinxPackages.kahip
     dolfinxPackages.scotch
   ]
-  ++ lib.optional stdenv.hostPlatform.isDarwin (darwinMinVersionHook "13.3")
   ++ lib.optional withParmetis dolfinxPackages.parmetis;
 
   propagatedBuildInputs = [

--- a/pkgs/by-name/fi/fizz/package.nix
+++ b/pkgs/by-name/fi/fizz/package.nix
@@ -13,7 +13,6 @@
   zstd,
   gflags,
   libevent,
-  darwinMinVersionHook,
 
   folly,
   libsodium,
@@ -57,9 +56,6 @@ stdenv.mkDerivation (finalAttrs: {
     zstd
     gflags
     libevent
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    (darwinMinVersionHook "13.3")
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/by-name/fo/folly/package.nix
+++ b/pkgs/by-name/fo/folly/package.nix
@@ -21,7 +21,6 @@
   zstd,
   libiberty,
   libunwind,
-  darwinMinVersionHook,
 
   boost,
   fmt,
@@ -77,9 +76,6 @@ stdenv.mkDerivation (finalAttrs: {
     zstd
     libiberty
     libunwind
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    (darwinMinVersionHook "13.3")
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/by-name/ke/keepassxc/package.nix
+++ b/pkgs/by-name/ke/keepassxc/package.nix
@@ -6,11 +6,9 @@
   cmake,
   libsForQt5,
 
-  apple-sdk_15,
   asciidoctor,
   botan3,
   curl,
-  darwinMinVersionHook,
   libXi,
   libXtst,
   libargon2,
@@ -161,11 +159,6 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     libsForQt5.qtmacextras
-
-    apple-sdk_15
-    # ScreenCaptureKit, required by livekit, is only available on 12.3 and up:
-    # https://developer.apple.com/documentation/screencapturekit
-    (darwinMinVersionHook "12.3")
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     libusb1

--- a/pkgs/by-name/li/livekit-libwebrtc/package.nix
+++ b/pkgs/by-name/li/livekit-libwebrtc/package.nix
@@ -9,7 +9,6 @@
   xcbuild,
   python3,
   ninja,
-  darwinMinVersionHook,
   git,
   cpio,
   pkg-config,

--- a/pkgs/by-name/on/onnxruntime/package.nix
+++ b/pkgs/by-name/on/onnxruntime/package.nix
@@ -22,7 +22,6 @@
   zlib,
   protobuf,
   microsoft-gsl,
-  darwinMinVersionHook,
   pythonSupport ? true,
   cudaSupport ? config.cudaSupport,
   ncclSupport ? cudaSupport && cudaPackages.nccl.meta.available,
@@ -186,9 +185,6 @@ effectiveStdenv.mkDerivation rec {
     rocmPackages.rccl
     rocmPackages.rocm-smi
     rocmPackages.roctracer
-  ]
-  ++ lib.optionals effectiveStdenv.hostPlatform.isDarwin [
-    (darwinMinVersionHook "13.3")
   ];
 
   nativeCheckInputs = [

--- a/pkgs/by-name/sd/sdl3/package.nix
+++ b/pkgs/by-name/sd/sdl3/package.nix
@@ -4,7 +4,6 @@
   config,
   alsa-lib,
   cmake,
-  darwinMinVersionHook,
   dbus,
   fetchFromGitHub,
   ibusMinimal,

--- a/pkgs/by-name/si/signalbackup-tools/package.nix
+++ b/pkgs/by-name/si/signalbackup-tools/package.nix
@@ -6,7 +6,6 @@
   cmake,
   pkg-config,
 
-  darwinMinVersionHook,
   dbus,
   openssl,
   sqlite,
@@ -33,9 +32,6 @@ stdenv.mkDerivation rec {
   buildInputs = [
     openssl
     sqlite
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    (darwinMinVersionHook "13.3")
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     dbus

--- a/pkgs/by-name/va/vapoursynth/package.nix
+++ b/pkgs/by-name/va/vapoursynth/package.nix
@@ -13,7 +13,6 @@
   libass,
   python3,
   testers,
-  darwinMinVersionHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -41,9 +40,6 @@ stdenv.mkDerivation rec {
         cython
       ]
     ))
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    (darwinMinVersionHook "13.3")
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/vt/vte/package.nix
+++ b/pkgs/by-name/vt/vte/package.nix
@@ -33,7 +33,6 @@
   fast-float,
   nixosTests,
   blackbox-terminal,
-  darwinMinVersionHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -90,9 +89,6 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals systemdSupport [
     systemd
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    (darwinMinVersionHook "13.3")
   ];
 
   # Required by vte-2.91.pc.

--- a/pkgs/by-name/ze/zed-editor/package.nix
+++ b/pkgs/by-name/ze/zed-editor/package.nix
@@ -30,8 +30,6 @@
   buildFHSEnv,
   cargo-bundle,
   git,
-  apple-sdk_15,
-  darwinMinVersionHook,
   makeBinaryWrapper,
   nodejs,
   libGL,
@@ -170,12 +168,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     libGL
     libX11
     libXext
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    apple-sdk_15
-    # ScreenCaptureKit, required by livekit, is only available on 12.3 and up:
-    # https://developer.apple.com/documentation/screencapturekit
-    (darwinMinVersionHook "12.3")
   ];
 
   cargoBuildFlags = [

--- a/pkgs/development/compilers/swift/compiler/default.nix
+++ b/pkgs/development/compilers/swift/compiler/default.nix
@@ -36,7 +36,6 @@
   sigtool,
   DarwinTools,
   apple-sdk_14,
-  darwinMinVersionHook,
 }:
 
 let

--- a/pkgs/development/libraries/gtk/4.x.nix
+++ b/pkgs/development/libraries/gtk/4.x.nix
@@ -55,7 +55,6 @@
   libexecinfo,
   broadwaySupport ? true,
   testers,
-  darwinMinVersionHook,
 }:
 
 let

--- a/pkgs/development/python-modules/fenics-dolfinx/default.nix
+++ b/pkgs/development/python-modules/fenics-dolfinx/default.nix
@@ -16,7 +16,6 @@
 
   # buildInputs
   dolfinx,
-  darwinMinVersionHook,
 
   # dependency
   numpy,
@@ -87,8 +86,7 @@ buildPythonPackage rec {
 
   buildInputs = [
     fenicsPackages.dolfinx
-  ]
-  ++ lib.optional stdenv.hostPlatform.isDarwin (darwinMinVersionHook "13.3");
+  ];
 
   dependencies = [
     numpy

--- a/pkgs/development/python-modules/torchvision/default.nix
+++ b/pkgs/development/python-modules/torchvision/default.nix
@@ -3,7 +3,6 @@
   stdenv,
   torch,
   buildPythonPackage,
-  darwinMinVersionHook,
   fetchFromGitHub,
 
   # nativeBuildInputs

--- a/pkgs/tools/package-management/rpm/default.nix
+++ b/pkgs/tools/package-management/rpm/default.nix
@@ -19,7 +19,6 @@
   sqlite,
   zstd,
   libcap,
-  darwinMinVersionHook,
   openssl,
   #, libselinux
   rpm-sequoia,


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Basically a follow-up to #447364 by @reckenrode, as that has only cleaned up uses of darwinMinVersionHook that were combined with a deprecated instance of apple-sdk.

The two two commits dropping the explicit apple-sdk_15 from zed-editor and keepassxc have been tested to work fine with our new default SDK (which currently is SDK 14.4).
In zed-editor, I added `apple-sdk_15` instead of SDK 12 just for ScreenCaptureKit back then mainly because there was no consensus on whether to go with the latest available SDK vs just the SDK that is enough to make it build, and seeing that keepassxc just copied this part from zed-editor, I assume it to be the same case there. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
