### PR TITLE
keymapp: cleanup arguments

### DIFF
--- a/pkgs/by-name/ke/keymapp/package.nix
+++ b/pkgs/by-name/ke/keymapp/package.nix
@@ -3,14 +3,6 @@
   lib,
   fetchurl,
   callPackage,
-  autoPatchelfHook,
-  wrapGAppsHook4,
-  libusb1,
-  libsoup_3,
-  webkitgtk_4_1,
-  makeDesktopItem,
-  copyDesktopItems,
-  undmg,
 }:
 let
   pname = "keymapp";
@@ -55,7 +47,6 @@ if stdenv.hostPlatform.isDarwin then
       version
       src
       meta
-      undmg
       ;
   }
 else
@@ -65,12 +56,5 @@ else
       version
       src
       meta
-      libusb1
-      libsoup_3
-      webkitgtk_4_1
-      autoPatchelfHook
-      wrapGAppsHook4
-      copyDesktopItems
-      makeDesktopItem
       ;
   }


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Noticed that we are passing down all the arguments from package.nix to the platform specific files.
I dont understand/remember why we should do that, so IMHO we should clean that up.

callPackage will add the needed arguments (like for package.nix itself) and unless we are overriding something it should be still fine.

Keeping it, will likely at some point end in the situation that the arguments get added to package.nix and no one would notice.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
