### PR TITLE
urbit: 3.5 -> 4.2

### DIFF
--- a/pkgs/by-name/ur/urbit/package.nix
+++ b/pkgs/by-name/ur/urbit/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  fetchzip,
+  fetchurl,
 }:
 
 let
@@ -11,22 +11,27 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "urbit";
-  version = "3.5";
+  version = "4.2";
 
-  src = fetchzip {
+  src = fetchurl {
     url = "https://github.com/urbit/vere/releases/download/vere-v${finalAttrs.version}/${platform}.tgz";
     sha256 =
       {
-        x86_64-linux = "sha256-eB80GuyNuVZbBsyNnek8UCtquZbNt5G4Co7IKqq7aeI=";
-        aarch64-linux = "sha256-imbzAsjjznLuxee9mWXpsG/dKEJxdEOTw+JFc4DbQ2Q=";
-        x86_64-darwin = "sha256-0c1ewdrVsfSUivrcLwVuxZdcyrOAKXF7P9W+B7o5aNU=";
-        aarch64-darwin = "sha256-j8PJ04zRz2sZdpetLyzwRasj0CkiRGY+GvzWXG90IaE=";
+        x86_64-linux = "0cmgm0cjcj0089dd7dnncl5lhw6ji669byjbzd72va51abdirnkq";
+        aarch64-linux = "1il2khylsxj3k757f401ph5g1sx6f4y85p87bzwgaksdb4nkq6mi";
+        x86_64-darwin = "1p09y7c81m3mx9cm0689jbg1daz0xpr2p2bzqfnnlgzjlmi9x794";
+        aarch64-darwin = "1gy64mhvk8450mv2abjc62c2sh0b1criiwrdmyj8kyfv4qpiqyc8";
       }
       .${stdenv.hostPlatform.system} or (throw "unsupported system ${stdenv.hostPlatform.system}");
   };
 
+  unpackPhase = ''
+    mkdir src
+    tar -C src -xf $src
+  '';
+
   postInstall = ''
-    install -m755 -D vere-v${finalAttrs.version}-${platform} $out/bin/urbit
+    install -m755 -D src/vere-v${finalAttrs.version}-${platform} $out/bin/urbit
   '';
 
   passthru.updateScript = ./update-bin.sh;

--- a/pkgs/by-name/ur/urbit/update-bin.sh
+++ b/pkgs/by-name/ur/urbit/update-bin.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl common-updater-scripts nix-prefetch
+#!nix-shell -i bash -p curl
 
 set -euo pipefail
 
@@ -10,31 +10,26 @@ if [ ! -f "$NIX_DRV" ]; then
   exit 1
 fi
 
-fetch_arch() {
-  VER="$1"; ARCH="$2"
-  URL="https://github.com/urbit/vere/releases/download/vere-v${VER}/${ARCH}.tgz";
-  nix-prefetch "{ stdenv, fetchzip }:
-stdenv.mkDerivation rec {
-  pname = \"vere\"; version = \"${VER}\";
-  src = fetchzip { url = \"$URL\"; };
-}
-"
+VERSION=$(curl https://bootstrap.urbit.org/vere/live/last)
+
+prefetch() {
+  nix-prefetch-url "https://github.com/urbit/vere/releases/download/vere-v${VERSION}/$1.tgz"
 }
 
-replace_sha() {
-  sed -i "s#$1 = \"sha256-.\{44\}\"#$1 = \"$2\"#" "$NIX_DRV"
+LINUX_AARCH64_SHA256=$(prefetch "linux-aarch64")
+LINUX_X64_SHA256=$(prefetch "linux-x86_64")
+DARWIN_AARCH64_SHA256=$(prefetch "macos-aarch64")
+DARWIN_X64_SHA256=$(prefetch "macos-x86_64")
+
+sed -i "s/version = \".*\"/version = \"$VERSION\"/" "$NIX_DRV"
+
+replace-sha256() {
+  local platform=$1
+  local sha256=$2
+  sed -i "s#${platform} = \"[^\"]*\"#${platform} = \"${sha256}\"#" "$NIX_DRV"
 }
 
-VERE_VER=$(curl https://bootstrap.urbit.org/vere/live/last)
-
-VERE_LINUX_AARCH64_SHA256=$(fetch_arch "$VERE_VER" "linux-aarch64")
-VERE_LINUX_X64_SHA256=$(fetch_arch "$VERE_VER" "linux-x86_64")
-VERE_DARWIN_AARCH64_SHA256=$(fetch_arch "$VERE_VER" "macos-aarch64")
-VERE_DARWIN_X64_SHA256=$(fetch_arch "$VERE_VER" "macos-x86_64")
-
-sed -i "s/version = \".*\"/version = \"$VERE_VER\"/" "$NIX_DRV"
-
-replace_sha "aarch64-linux" "$VERE_LINUX_AARCH64_SHA256"
-replace_sha "x86_64-linux" "$VERE_LINUX_X64_SHA256"
-replace_sha "aarch64-darwin" "$VERE_DARWIN_AARCH64_SHA256"
-replace_sha "x86_64-darwin" "$VERE_DARWIN_X64_SHA256"
+replace-sha256 "aarch64-linux" "$LINUX_AARCH64_SHA256"
+replace-sha256 "x86_64-linux" "$LINUX_X64_SHA256"
+replace-sha256 "aarch64-darwin" "$DARWIN_AARCH64_SHA256"
+replace-sha256 "x86_64-darwin" "$DARWIN_X64_SHA256"


### PR DESCRIPTION
Also simplify both the derivation and the updater script for robustness (nix-prefetch was having weird errors, but we can do without nix-prefetch)

https://github.com/urbit/vere/releases/tag/vere-v4.2
