### PR TITLE
fetchgit: give `leaveDotGit`, `nonConeMode`, and `sparseCheckout` a default value `null`

### DIFF
--- a/pkgs/build-support/fetchgit/builder.sh
+++ b/pkgs/build-support/fetchgit/builder.sh
@@ -19,7 +19,7 @@ $SHELL $fetcher --builder --url "$url" --out "$out" --rev "$rev" --name "$name" 
   ${deepClone:+--deepClone} \
   ${fetchSubmodules:+--fetch-submodules} \
   ${fetchTags:+--fetch-tags} \
-  ${sparseCheckout:+--sparse-checkout "$sparseCheckout"} \
+  ${sparseCheckoutText:+--sparse-checkout "$sparseCheckoutText"} \
   ${nonConeMode:+--non-cone-mode} \
   ${branchName:+--branch-name "$branchName"} \
   ${rootDir:+--root-dir "$rootDir"}

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -131,11 +131,6 @@ lib.makeOverridable (
           server admins start using the new version?
         */
 
-        if builtins.isString sparseCheckout then
-          # Changed to throw on 2023-06-04
-          throw
-            "Please provide directories/patterns for sparse checkout as a list of strings. Passing a (multi-line) string is not supported any more."
-        else
           derivationArgs
           // {
             inherit name;
@@ -155,11 +150,15 @@ lib.makeOverridable (
 
             sparseCheckout = lib.defaultTo (lib.optional (rootDir != "") rootDir) sparseCheckout;
             sparseCheckoutText =
+              # Changed to throw on 2023-06-04
+              assert (
+                lib.assertMsg (lib.isList finalAttrs.sparseCheckout) "Please provide directories/patterns for sparse checkout as a list of strings. Passing a (multi-line) string is not supported any more."
+              );
               assert finalAttrs.nonConeMode -> (finalAttrs.sparseCheckout != [ ]);
               # git-sparse-checkout(1) says:
               # > When the --stdin option is provided, the directories or patterns are read
               # > from standard in as a newline-delimited list instead of from the arguments.
-              builtins.concatStringsSep "\n" sparseCheckout;
+              builtins.concatStringsSep "\n" finalAttrs.sparseCheckout;
 
             inherit
               url

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -152,8 +152,9 @@ lib.makeOverridable (
             inherit outputHash outputHashAlgo;
             outputHashMode = "recursive";
 
-            sparseCheckout =
-              assert nonConeMode -> (sparseCheckout != [ ]);
+            inherit sparseCheckout;
+            sparseCheckoutText =
+              assert finalAttrs.nonConeMode -> (finalAttrs.sparseCheckout != [ ]);
               # git-sparse-checkout(1) says:
               # > When the --stdin option is provided, the directories or patterns are read
               # > from standard in as a newline-delimited list instead of from the arguments.

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -148,7 +148,7 @@ lib.makeOverridable (
           inherit outputHash outputHashAlgo;
           outputHashMode = "recursive";
 
-          sparseCheckout = lib.defaultTo (lib.optional (rootDir != "") rootDir) sparseCheckout;
+          sparseCheckout = lib.defaultTo (lib.optional (finalAttrs.rootDir != "") finalAttrs.rootDir) sparseCheckout;
           sparseCheckoutText =
             # Changed to throw on 2023-06-04
             assert (

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -178,7 +178,7 @@ lib.makeOverridable (
                 leaveDotGit
               else
                 deepClone || fetchTags;
-            nonConeMode = lib.defaultTo (rootDir != "") nonConeMode;
+            nonConeMode = lib.defaultTo (finalAttrs.rootDir != "") nonConeMode;
             inherit tag;
             revCustom = rev;
             rev = getRevWithTag {

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -73,7 +73,8 @@ lib.makeOverridable (
           fetchSubmodules ? true,
           deepClone ? false,
           branchName ? null,
-          sparseCheckout ? lib.optional (rootDir != "") rootDir,
+          # When null, will default to: `lib.optional (rootdir != "") rootdir`
+          sparseCheckout ? null,
           # When null, will default to: `rootDir != ""`
           nonConeMode ? null,
           nativeBuildInputs ? [ ],
@@ -152,7 +153,7 @@ lib.makeOverridable (
             inherit outputHash outputHashAlgo;
             outputHashMode = "recursive";
 
-            inherit sparseCheckout;
+            sparseCheckout = lib.defaultTo (lib.optional (rootDir != "") rootDir) sparseCheckout;
             sparseCheckoutText =
               assert finalAttrs.nonConeMode -> (finalAttrs.sparseCheckout != [ ]);
               # git-sparse-checkout(1) says:

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -74,7 +74,8 @@ lib.makeOverridable (
           deepClone ? false,
           branchName ? null,
           sparseCheckout ? lib.optional (rootDir != "") rootDir,
-          nonConeMode ? rootDir != "",
+          # When null, will default to: `rootDir != ""`
+          nonConeMode ? null,
           nativeBuildInputs ? [ ],
           # Shell code executed before the file has been fetched.  This, in
           # particular, can do things like set NIX_PREFETCH_GIT_CHECKOUT_HOOK to
@@ -164,7 +165,6 @@ lib.makeOverridable (
               fetchSubmodules
               deepClone
               branchName
-              nonConeMode
               preFetch
               postFetch
               fetchTags
@@ -178,6 +178,7 @@ lib.makeOverridable (
                 leaveDotGit
               else
                 deepClone || fetchTags;
+            nonConeMode = lib.defaultTo (rootDir != "") nonConeMode;
             inherit tag;
             revCustom = rev;
             rev = getRevWithTag {

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -131,103 +131,103 @@ lib.makeOverridable (
           server admins start using the new version?
         */
 
-          derivationArgs
-          // {
-            inherit name;
+        derivationArgs
+        // {
+          inherit name;
 
-            builder = ./builder.sh;
-            fetcher = ./nix-prefetch-git;
+          builder = ./builder.sh;
+          fetcher = ./nix-prefetch-git;
 
-            nativeBuildInputs = [
-              git
-              cacert
-            ]
-            ++ lib.optionals fetchLFS [ git-lfs ]
-            ++ nativeBuildInputs;
+          nativeBuildInputs = [
+            git
+            cacert
+          ]
+          ++ lib.optionals fetchLFS [ git-lfs ]
+          ++ nativeBuildInputs;
 
-            inherit outputHash outputHashAlgo;
-            outputHashMode = "recursive";
+          inherit outputHash outputHashAlgo;
+          outputHashMode = "recursive";
 
-            sparseCheckout = lib.defaultTo (lib.optional (rootDir != "") rootDir) sparseCheckout;
-            sparseCheckoutText =
-              # Changed to throw on 2023-06-04
-              assert (
-                lib.assertMsg (lib.isList finalAttrs.sparseCheckout) "Please provide directories/patterns for sparse checkout as a list of strings. Passing a (multi-line) string is not supported any more."
-              );
-              assert finalAttrs.nonConeMode -> (finalAttrs.sparseCheckout != [ ]);
-              # git-sparse-checkout(1) says:
-              # > When the --stdin option is provided, the directories or patterns are read
-              # > from standard in as a newline-delimited list instead of from the arguments.
-              builtins.concatStringsSep "\n" finalAttrs.sparseCheckout;
+          sparseCheckout = lib.defaultTo (lib.optional (rootDir != "") rootDir) sparseCheckout;
+          sparseCheckoutText =
+            # Changed to throw on 2023-06-04
+            assert (
+              lib.assertMsg (lib.isList finalAttrs.sparseCheckout) "Please provide directories/patterns for sparse checkout as a list of strings. Passing a (multi-line) string is not supported any more."
+            );
+            assert finalAttrs.nonConeMode -> (finalAttrs.sparseCheckout != [ ]);
+            # git-sparse-checkout(1) says:
+            # > When the --stdin option is provided, the directories or patterns are read
+            # > from standard in as a newline-delimited list instead of from the arguments.
+            builtins.concatStringsSep "\n" finalAttrs.sparseCheckout;
 
-            inherit
-              url
-              fetchLFS
-              fetchSubmodules
-              deepClone
-              branchName
-              preFetch
-              postFetch
-              fetchTags
-              rootDir
-              gitConfigFile
-              ;
-            leaveDotGit =
-              if leaveDotGit != null then
-                assert fetchTags -> leaveDotGit;
-                assert rootDir != "" -> !leaveDotGit;
-                leaveDotGit
-              else
-                deepClone || fetchTags;
-            nonConeMode = lib.defaultTo (finalAttrs.rootDir != "") nonConeMode;
-            inherit tag;
-            revCustom = rev;
-            rev = getRevWithTag {
-              inherit (finalAttrs) tag;
-              rev = finalAttrs.revCustom;
-            };
+          inherit
+            url
+            fetchLFS
+            fetchSubmodules
+            deepClone
+            branchName
+            preFetch
+            postFetch
+            fetchTags
+            rootDir
+            gitConfigFile
+            ;
+          leaveDotGit =
+            if leaveDotGit != null then
+              assert fetchTags -> leaveDotGit;
+              assert rootDir != "" -> !leaveDotGit;
+              leaveDotGit
+            else
+              deepClone || fetchTags;
+          nonConeMode = lib.defaultTo (finalAttrs.rootDir != "") nonConeMode;
+          inherit tag;
+          revCustom = rev;
+          rev = getRevWithTag {
+            inherit (finalAttrs) tag;
+            rev = finalAttrs.revCustom;
+          };
 
-            postHook =
-              if netrcPhase == null then
-                null
-              else
-                ''
-                  ${netrcPhase}
-                  # required that git uses the netrc file
-                  mv {,.}netrc
-                  export NETRC=$PWD/.netrc
-                  export HOME=$PWD
-                '';
+          postHook =
+            if netrcPhase == null then
+              null
+            else
+              ''
+                ${netrcPhase}
+                # required that git uses the netrc file
+                mv {,.}netrc
+                export NETRC=$PWD/.netrc
+                export HOME=$PWD
+              '';
 
-            impureEnvVars =
-              lib.fetchers.proxyImpureEnvVars
-              ++ netrcImpureEnvVars
-              ++ [
-                "GIT_PROXY_COMMAND"
-                "NIX_GIT_SSL_CAINFO"
-                "SOCKS_SERVER"
+          impureEnvVars =
+            lib.fetchers.proxyImpureEnvVars
+            ++ netrcImpureEnvVars
+            ++ [
+              "GIT_PROXY_COMMAND"
+              "NIX_GIT_SSL_CAINFO"
+              "SOCKS_SERVER"
 
-                # This is a parameter intended to be set by setup hooks or preFetch
-                # scripts that want per-URL control over HTTP proxies used by Git
-                # (if per-URL control isn't needed, `http_proxy` etc. will
-                # suffice). It must be a whitespace-separated (with backslash as an
-                # escape character) list of pairs like this:
-                #
-                #   http://domain1/path1 proxy1 https://domain2/path2 proxy2
-                #
-                # where the URLs are as documented in the `git-config` manual page
-                # under `http.<url>.*`, and the proxies are as documented on the
-                # same page under `http.proxy`.
-                "FETCHGIT_HTTP_PROXIES"
-              ];
+              # This is a parameter intended to be set by setup hooks or preFetch
+              # scripts that want per-URL control over HTTP proxies used by Git
+              # (if per-URL control isn't needed, `http_proxy` etc. will
+              # suffice). It must be a whitespace-separated (with backslash as an
+              # escape character) list of pairs like this:
+              #
+              #   http://domain1/path1 proxy1 https://domain2/path2 proxy2
+              #
+              # where the URLs are as documented in the `git-config` manual page
+              # under `http.<url>.*`, and the proxies are as documented on the
+              # same page under `http.proxy`.
+              "FETCHGIT_HTTP_PROXIES"
+            ];
 
-            inherit preferLocalBuild meta allowedRequisites;
+          inherit preferLocalBuild meta allowedRequisites;
 
-            passthru = {
-              gitRepoUrl = url;
-            }
-            // passthru;
+          passthru = {
+            gitRepoUrl = url;
           }
+          // passthru;
+        }
       );
 
     # No ellipsis.

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -66,7 +66,8 @@ lib.makeOverridable (
             # when rootDir is specified, avoid invalidating the result when rev changes
             append = if rootDir != "" then "-${lib.strings.sanitizeDerivationName rootDir}" else "";
           },
-          leaveDotGit ? deepClone || fetchTags,
+          # When null, will default to: `deepClone || fetchTags`
+          leaveDotGit ? null,
           outputHash ? lib.fakeHash,
           outputHashAlgo ? null,
           fetchSubmodules ? true,
@@ -171,9 +172,12 @@ lib.makeOverridable (
               gitConfigFile
               ;
             leaveDotGit =
-              assert fetchTags -> leaveDotGit;
-              assert rootDir != "" -> !leaveDotGit;
-              leaveDotGit;
+              if leaveDotGit != null then
+                assert fetchTags -> leaveDotGit;
+                assert rootDir != "" -> !leaveDotGit;
+                leaveDotGit
+              else
+                deepClone || fetchTags;
             inherit tag;
             revCustom = rev;
             rev = getRevWithTag {

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -128,10 +128,6 @@ lib.makeOverridable (
           server admins start using the new version?
         */
 
-        assert nonConeMode -> (sparseCheckout != [ ]);
-        assert fetchTags -> leaveDotGit;
-        assert rootDir != "" -> !leaveDotGit;
-
         if builtins.isString sparseCheckout then
           # Changed to throw on 2023-06-04
           throw
@@ -154,14 +150,15 @@ lib.makeOverridable (
             inherit outputHash outputHashAlgo;
             outputHashMode = "recursive";
 
-            # git-sparse-checkout(1) says:
-            # > When the --stdin option is provided, the directories or patterns are read
-            # > from standard in as a newline-delimited list instead of from the arguments.
-            sparseCheckout = builtins.concatStringsSep "\n" sparseCheckout;
+            sparseCheckout =
+              assert nonConeMode -> (sparseCheckout != [ ]);
+              # git-sparse-checkout(1) says:
+              # > When the --stdin option is provided, the directories or patterns are read
+              # > from standard in as a newline-delimited list instead of from the arguments.
+              builtins.concatStringsSep "\n" sparseCheckout;
 
             inherit
               url
-              leaveDotGit
               fetchLFS
               fetchSubmodules
               deepClone
@@ -173,6 +170,10 @@ lib.makeOverridable (
               rootDir
               gitConfigFile
               ;
+            leaveDotGit =
+              assert fetchTags -> leaveDotGit;
+              assert rootDir != "" -> !leaveDotGit;
+              leaveDotGit;
             inherit tag;
             revCustom = rev;
             rev = getRevWithTag {

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -148,7 +148,11 @@ lib.makeOverridable (
           inherit outputHash outputHashAlgo;
           outputHashMode = "recursive";
 
-          sparseCheckout = lib.defaultTo (lib.optional (finalAttrs.rootDir != "") finalAttrs.rootDir) sparseCheckout;
+          sparseCheckout =
+            let
+              default = lib.optional (finalAttrs.rootDir != "") finalAttrs.rootDir;
+            in
+            lib.defaultTo default sparseCheckout;
           sparseCheckoutText =
             # Changed to throw on 2023-06-04
             assert (

--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -68,7 +68,7 @@ lib.makeOverridable (
     varBase = "NIX${lib.optionalString (varPrefix != null) "_${varPrefix}"}_GITHUB_PRIVATE_";
     useFetchGit =
       fetchSubmodules
-      || (leaveDotGit == true)
+      || lib.defaultTo false leaveDotGit == true
       || deepClone
       || forceFetchGit
       || fetchLFS
@@ -122,6 +122,7 @@ lib.makeOverridable (
               rev
               deepClone
               fetchSubmodules
+              leaveDotGit
               sparseCheckout
               fetchLFS
               ;
@@ -135,7 +136,6 @@ lib.makeOverridable (
                 ;
             };
           }
-          // lib.optionalAttrs (leaveDotGit != null) { inherit leaveDotGit; }
         else
           let
             revWithTag = finalAttrs.rev;

--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -22,7 +22,7 @@ lib.makeOverridable (
     forceFetchGit ? false,
     fetchLFS ? false,
     rootDir ? "",
-    sparseCheckout ? lib.optional (rootDir != "") rootDir,
+    sparseCheckout ? null,
     githubBase ? "github.com",
     varPrefix ? null,
     passthru ? { },
@@ -75,7 +75,7 @@ lib.makeOverridable (
       || forceFetchGit
       || fetchLFS
       || (rootDir != "")
-      || (sparseCheckout != [ ]);
+      || lib.defaultTo [ ] sparseCheckout != [ ];
     # We prefer fetchzip in cases we don't need submodules as the hash
     # is more stable in that case.
     fetcher =

--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -13,6 +13,8 @@ lib.makeOverridable (
     rev ? null,
     # TODO(@ShamrockLee): Add back after reconstruction with lib.extendMkDerivation
     # name ? repoRevToNameMaybe finalAttrs.repo (lib.revOrTag finalAttrs.revCustom finalAttrs.tag) "github",
+    # `fetchFromGitHub` defaults to use `fetchzip` for better hash stability.
+    # We default not to fetch submodules, which is contrary to `fetchgit`'s default.
     fetchSubmodules ? false,
     leaveDotGit ? null,
     deepClone ? false,


### PR DESCRIPTION
Instead of dynamically deciding on the default value of `leaveDotGit` in `fetchgit`'s set pattern, this PR assigns a default `null` and decide on the actual default inside the function body.

This allows dependent expressions to pass `leaveDotGit = null` directly, eliminating the need of conditional passing.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
