### PR TITLE
jbang: default dependency jdk to jdk25

### DIFF
--- a/pkgs/by-name/jb/jbang/package.nix
+++ b/pkgs/by-name/jb/jbang/package.nix
@@ -2,7 +2,9 @@
   stdenv,
   lib,
   fetchzip,
-  jdk,
+  pkgs,
+  jbangJdk ? jdk25,
+  jdk25,
   makeWrapper,
   coreutils,
   curl,
@@ -24,12 +26,12 @@ stdenv.mkDerivation rec {
     rm bin/jbang.{cmd,ps1}
     cp -r . $out
     wrapProgram $out/bin/jbang \
-      --set JAVA_HOME ${jdk} \
+      --set JAVA_HOME ${jbangJdk} \
       --prefix PATH ${
         lib.makeBinPath [
           (placeholder "out")
           coreutils
-          jdk
+          jbangJdk
           curl
         ]
       }


### PR DESCRIPTION
jdk25 JEP 512 offers a huge improvement for JBang scripts, this commit
will make jdk25 available by default, but still allow overrides using
`jbangJdk`  when users want to use a different JDK.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
