### PR TITLE
open-watcom-v2-unwrapped: 0-unstable-2025-05-07 -> 0-unstable-2025-11-15, housekeeping, init full variant

### DIFF
--- a/pkgs/development/compilers/open-watcom/v2.nix
+++ b/pkgs/development/compilers/open-watcom/v2.nix
@@ -14,13 +14,13 @@
 stdenv.mkDerivation rec {
   pname = "${passthru.prettyName}-unwrapped";
   # nixpkgs-update: no auto update
-  version = "0-unstable-2025-05-07";
+  version = "0-unstable-2025-11-15";
 
   src = fetchFromGitHub {
     owner = "open-watcom";
     repo = "open-watcom-v2";
-    rev = "b168de07a7c32ad82b77dd56671b6a51a11dab70";
-    hash = "sha256-9NNJcDHxOo+NKZraGqsHqK5whO3nL0QTeh+imzhThTg=";
+    rev = "fe2ddbd2e5833a85d9ccd3937b304f3f41e44f98";
+    hash = "sha256-jv7d5DopGZDnVFQX/t0D9cZSTwgMvcb4kqCnLJSWmNI=";
   };
 
   postPatch = ''

--- a/pkgs/development/compilers/open-watcom/wrapper.nix
+++ b/pkgs/development/compilers/open-watcom/wrapper.nix
@@ -151,15 +151,15 @@ let
 
                   echo "Test file format"
                   file ./linux
-                  file ./linux | grep "32-bit" | grep -q "Linux"
+                  file ./linux | grep "ELF 32-bit" | grep -q "Linux"
                   file ./nt.exe
-                  file ./nt.exe | grep "PE32" | grep -q "Windows"
+                  file ./nt.exe | grep "PE32 executable" | grep -q "Windows"
                   file ./dos4g.exe
-                  file ./dos4g.exe | grep "MS-DOS" | grep -q "executable, LE"
+                  file ./dos4g.exe | grep "MS-DOS executable" | grep -q "LE executable"
                   file ./windows.exe
-                  file ./windows.exe | grep "MS-DOS" | grep -q "Windows 3.00"
+                  file ./windows.exe | grep "MS-DOS executable" | grep -q "NE for MS Windows 3."
                   file ./dos.exe
-                  file ./dos.exe | grep "MS-DOS" | grep -v "LE" | grep -qv "Windows 3."
+                  file ./dos.exe | grep "MS-DOS executable" | grep -q "MZ for MS-DOS"
                   touch $out
                 '';
           };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5206,9 +5206,16 @@ with pkgs;
   opam-installer = callPackage ../development/tools/ocaml/opam/installer.nix { };
 
   wrapWatcom = callPackage ../development/compilers/open-watcom/wrapper.nix { };
+
   open-watcom-v2-unwrapped = callPackage ../development/compilers/open-watcom/v2.nix { };
-  open-watcom-v2 = wrapWatcom open-watcom-v2-unwrapped { };
+  open-watcom-v2-full-unwrapped = open-watcom-v2-unwrapped.override {
+    withDocs = true;
+    withGUI = true;
+  };
   open-watcom-bin-unwrapped = callPackage ../development/compilers/open-watcom/bin.nix { };
+
+  open-watcom-v2 = wrapWatcom open-watcom-v2-unwrapped { };
+  open-watcom-v2-full = wrapWatcom open-watcom-v2-full-unwrapped { };
   open-watcom-bin = wrapWatcom open-watcom-bin-unwrapped { };
 
   rml = callPackage ../development/compilers/rml {


### PR DESCRIPTION
Half a year has passed, let's give this the usual bump-before-the-upcoming-NixOS-release treatment.

Also:
- doing some housekeeping of the `open-watcom-v2-unwrapped` derivation
- fixing some matching issues with the `.passthru.tests.cross` test of the wrapped versions, and
- adding a variant of `open-watcom-v2-unwrapped` that has the things that are normally disabled, to make sure that doesn't *completely* bitrot

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
