### PR TITLE
rabbit: fix build

### DIFF
--- a/pkgs/by-name/ra/rabbit/package.nix
+++ b/pkgs/by-name/ra/rabbit/package.nix
@@ -21,6 +21,13 @@ let
             hash = "sha256-tCN+17P90KSIJ5LmjvJUXVuqUKyju0WqffRoE4rY+U0=";
           };
 
+          # Preserve the postPatch for this scikit-learn version
+          postPatch = ''
+            substituteInPlace meson.build --replace-fail \
+              "run_command('sklearn/_build_utils/version.py', check: true).stdout().strip()," \
+              "'${version}',"
+          '';
+
           # There are 2 tests that are failing, disabling the tests for now.
           # - test_csr_polynomial_expansion_index_overflow[csr_array-False-True-2-65535]
           # - test_csr_polynomial_expansion_index_overflow[csr_array-False-True-3-2344]
@@ -50,6 +57,7 @@ python3'.pkgs.buildPythonApplication {
   pythonRelaxDeps = [
     "joblib"
     "numpy"
+    "pandas"
     "requests"
     "scikit-learn"
     "scipy"


### PR DESCRIPTION
Fixes the scikit-learn dependency build and relaxes the pandas version requirement. I've confirmed it works with the new pandas version.

ZHF: #457852

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 462050`
Commit: `4bdee80b92a65ffb04b1828f8da1a33b56fe48d7`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>rabbit</li>
    <li>rabbit.dist</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
