### PR TITLE
[25.05] podman-desktop: 1.19.1 -> 1.22.1; bump to electron_38

### DIFF
--- a/pkgs/by-name/po/podman-desktop/package.nix
+++ b/pkgs/by-name/po/podman-desktop/package.nix
@@ -27,14 +27,14 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = _experimental-update-script-combinators.sequence [
     (nix-update-script { })
     (lib.getExe (writeShellApplication {
-      name = "${finalAttrs.pname}-dependencies-updater";
+      name = "podman-desktop-dependencies-updater";
       runtimeInputs = [
         nix
         jq
         gnugrep
       ];
       runtimeEnv = {
-        PNAME = finalAttrs.pname;
+        PNAME = "podman-desktop";
         PKG_FILE = builtins.toString ./package.nix;
       };
       text = ''

--- a/pkgs/by-name/po/podman-desktop/package.nix
+++ b/pkgs/by-name/po/podman-desktop/package.nix
@@ -22,7 +22,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "podman-desktop";
-  version = "1.19.1";
+  version = "1.19.2";
 
   passthru.updateScript = _experimental-update-script-combinators.sequence [
     (nix-update-script { })
@@ -55,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "containers";
     repo = "podman-desktop";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-HTfrbMwXw+GGseVzJR2eagBJ7AmuPeFMuy/lO7EADmY=";
+    hash = "sha256-Yw4HPHtMMxaI7MLamZy+MglvHHpO6h4/kHY2TBXWErg=";
   };
 
   pnpmDeps = pnpm_10.fetchDeps {

--- a/pkgs/by-name/po/podman-desktop/package.nix
+++ b/pkgs/by-name/po/podman-desktop/package.nix
@@ -22,7 +22,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "podman-desktop";
-  version = "1.20.1";
+  version = "1.20.2";
 
   passthru.updateScript = _experimental-update-script-combinators.sequence [
     (nix-update-script { })
@@ -55,13 +55,13 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "containers";
     repo = "podman-desktop";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-diqlooa4SsFtmzl3A25PEaV0ALnghoj7htBGRgXn6As=";
+    hash = "sha256-+UdVTTm528Q9TIZwznzseBn8JazvQJOxJyjdzBmVUaA=";
   };
 
   pnpmDeps = pnpm_10.fetchDeps {
     inherit (finalAttrs) pname version src;
     fetcherVersion = 1;
-    hash = "sha256-8lNmCLfuAkXK1Du4iYYasRTozZf0HoAttf8Dfc6Jglw=";
+    hash = "sha256-GX33PE534jWX7v9jCwZALuCT6gQClBXlOTPZC09EuC8=";
   };
 
   patches = [

--- a/pkgs/by-name/po/podman-desktop/package.nix
+++ b/pkgs/by-name/po/podman-desktop/package.nix
@@ -24,7 +24,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "podman-desktop";
-  version = "1.22.0";
+  version = "1.22.1";
 
   passthru.updateScript = _experimental-update-script-combinators.sequence [
     (nix-update-script { })
@@ -57,13 +57,13 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "containers";
     repo = "podman-desktop";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-gq4RMODR7AESMAGpg6ga5LS5SrpWD6pPe6dZ+Rx7a/g=";
+    hash = "sha256-+YM1fiY2bH5nY1L/xWjMbWe5lH1LfyKW47OzCROB3nE=";
   };
 
   pnpmDeps = pnpm_10.fetchDeps {
     inherit (finalAttrs) pname version src;
     fetcherVersion = 1;
-    hash = "sha256-tWWqnxPO27RcYeix5B+R3CyyyHYQL9PMPRhlse8FyVk=";
+    hash = "sha256-2Cja6CQxjOlxjhsjGQ5C9a/C/2RfzKdvtRCKO7VztwQ=";
   };
 
   patches = [

--- a/pkgs/by-name/po/podman-desktop/package.nix
+++ b/pkgs/by-name/po/podman-desktop/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   makeWrapper,
   copyDesktopItems,
-  electron_37,
+  electron_38,
   nodejs,
   pnpm_10,
   makeDesktopItem,
@@ -19,12 +19,12 @@
 }:
 
 let
-  electron = electron_37;
+  electron = electron_38;
   appName = "Podman Desktop";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "podman-desktop";
-  version = "1.21.0";
+  version = "1.22.0";
 
   passthru.updateScript = _experimental-update-script-combinators.sequence [
     (nix-update-script { })
@@ -57,13 +57,13 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "containers";
     repo = "podman-desktop";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Wio+lETdsDhcZvluKV6gUqjT0lTE9nYL5TqPLCR4Kr0=";
+    hash = "sha256-gq4RMODR7AESMAGpg6ga5LS5SrpWD6pPe6dZ+Rx7a/g=";
   };
 
   pnpmDeps = pnpm_10.fetchDeps {
     inherit (finalAttrs) pname version src;
     fetcherVersion = 1;
-    hash = "sha256-yteFC4/raBdL4gjBtsGL/lVRpo11BuhS7Xm0mFgz3t4=";
+    hash = "sha256-tWWqnxPO27RcYeix5B+R3CyyyHYQL9PMPRhlse8FyVk=";
   };
 
   patches = [

--- a/pkgs/by-name/po/podman-desktop/package.nix
+++ b/pkgs/by-name/po/podman-desktop/package.nix
@@ -24,7 +24,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "podman-desktop";
-  version = "1.20.2";
+  version = "1.21.0";
 
   passthru.updateScript = _experimental-update-script-combinators.sequence [
     (nix-update-script { })
@@ -57,13 +57,13 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "containers";
     repo = "podman-desktop";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-+UdVTTm528Q9TIZwznzseBn8JazvQJOxJyjdzBmVUaA=";
+    hash = "sha256-Wio+lETdsDhcZvluKV6gUqjT0lTE9nYL5TqPLCR4Kr0=";
   };
 
   pnpmDeps = pnpm_10.fetchDeps {
     inherit (finalAttrs) pname version src;
     fetcherVersion = 1;
-    hash = "sha256-GX33PE534jWX7v9jCwZALuCT6gQClBXlOTPZC09EuC8=";
+    hash = "sha256-yteFC4/raBdL4gjBtsGL/lVRpo11BuhS7Xm0mFgz3t4=";
   };
 
   patches = [

--- a/pkgs/by-name/po/podman-desktop/package.nix
+++ b/pkgs/by-name/po/podman-desktop/package.nix
@@ -161,7 +161,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       booxter
-      panda2134
     ];
     inherit (electron.meta) platforms;
     mainProgram = "podman-desktop";

--- a/pkgs/by-name/po/podman-desktop/package.nix
+++ b/pkgs/by-name/po/podman-desktop/package.nix
@@ -22,7 +22,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "podman-desktop";
-  version = "1.20.0";
+  version = "1.20.1";
 
   passthru.updateScript = _experimental-update-script-combinators.sequence [
     (nix-update-script { })
@@ -55,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "containers";
     repo = "podman-desktop";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-/RvT92rX74WAp4v/OJMzNS84yNQVTcRT2dy5WepyBM4=";
+    hash = "sha256-diqlooa4SsFtmzl3A25PEaV0ALnghoj7htBGRgXn6As=";
   };
 
   pnpmDeps = pnpm_10.fetchDeps {

--- a/pkgs/by-name/po/podman-desktop/package.nix
+++ b/pkgs/by-name/po/podman-desktop/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   makeWrapper,
   copyDesktopItems,
-  electron_36,
+  electron_37,
   nodejs,
   pnpm_10,
   makeDesktopItem,
@@ -18,11 +18,11 @@
 }:
 
 let
-  electron = electron_36;
+  electron = electron_37;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "podman-desktop";
-  version = "1.19.2";
+  version = "1.20.0";
 
   passthru.updateScript = _experimental-update-script-combinators.sequence [
     (nix-update-script { })
@@ -55,13 +55,13 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "containers";
     repo = "podman-desktop";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Yw4HPHtMMxaI7MLamZy+MglvHHpO6h4/kHY2TBXWErg=";
+    hash = "sha256-/RvT92rX74WAp4v/OJMzNS84yNQVTcRT2dy5WepyBM4=";
   };
 
   pnpmDeps = pnpm_10.fetchDeps {
     inherit (finalAttrs) pname version src;
     fetcherVersion = 1;
-    hash = "sha256-6xXTzqEeWpDKhZN6z4dSHrU7qWK9AAlD2DXnr7ac0So=";
+    hash = "sha256-8lNmCLfuAkXK1Du4iYYasRTozZf0HoAttf8Dfc6Jglw=";
   };
 
   patches = [

--- a/pkgs/by-name/po/podman-desktop/package.nix
+++ b/pkgs/by-name/po/podman-desktop/package.nix
@@ -71,10 +71,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
-  # Don't attempt to sign the darwin app bundle.
-  # It's impure and may fail in some restricted environments.
-  CSC_IDENTITY_AUTO_DISCOVERY = lib.optionals stdenv.hostPlatform.isDarwin "false";
-
   nativeBuildInputs = [
     nodejs
     pnpm_10.configHook
@@ -94,9 +90,13 @@ stdenv.mkDerivation (finalAttrs: {
     chmod -R u+w electron-dist
 
     pnpm build
+
+    # Explicitly set identity to null to avoid signing on arm64 macs with newer electron-builder.
+    # See: https://github.com/electron-userland/electron-builder/pull/9007
     ./node_modules/.bin/electron-builder \
       --dir \
       --config .electron-builder.config.cjs \
+      -c.mac.identity=null \
       -c.electronDist=electron-dist \
       -c.electronVersion=${electron.version}
 


### PR DESCRIPTION
- **podman-desktop: Remove usage of finalAttrs.pname**
- **podman-desktop: 1.19.1 -> 1.19.2**
- **podman-desktop: 1.19.2 -> 1.20.0**
- **podman-desktop: force disable electron-builder signing on arm64**
- **podman-desktop: 1.20.0 -> 1.20.1**
- **podman-desktop: 1.20.1 -> 1.20.2**
- **podman-desktop: add podman to PATH**
- **podman-desktop: remove @panda2134 from maintainers**
- **podman-desktop: 1.20.2 -> 1.21.0**
- **podman-desktop: 1.21.0 -> 1.22.0**
- **podman-desktop: 1.22.0 -> 1.22.1**

Related: https://github.com/NixOS/nixpkgs/pull/461995

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
