### PR TITLE
libbladeRF: fix `clang` build

### DIFF
--- a/pkgs/by-name/li/libbladeRF/clang-fix.patch
+++ b/pkgs/by-name/li/libbladeRF/clang-fix.patch
@@ -1,0 +1,12 @@
+Fix clang build: https://github.com/Nuand/bladeRF/pull/1045.patch
+--- a/host/utilities/bladeRF-cli/src/cmd/flash_image.c
++++ b/host/utilities/bladeRF-cli/src/cmd/flash_image.c
+@@ -68,7 +68,7 @@ static int handle_param(const char *param, char *val,
+             status = CLI_RET_INVPARAM;
+         } else {
+             for (i = 0; i < len && status == 0; i++) {
+-                if (val[i] >= 'a' || val[i] <= 'f') {
++                if (val[i] >= 'a' && val[i] <= 'f') {
+                     val[i] -= 'a' - 'A';
+                 } else if (!((val[i] >= '0' && val[i] <= '9') ||
+                              (val[i] >= 'A' && val[i] <= 'F'))) {

--- a/pkgs/by-name/li/libbladeRF/package.nix
+++ b/pkgs/by-name/li/libbladeRF/package.nix
@@ -26,6 +26,11 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  patches = [
+    # fix clang build: https://github.com/Nuand/bladeRF/pull/1045
+    ./clang-fix.patch
+  ];
+
   nativeBuildInputs = [
     cmake
     pkg-config


### PR DESCRIPTION
Without the change the build fails as
https://hydra.nixos.org/build/313370704:

    /private/tmp/nix-build-libbladeRF-2025.10.drv-0/source/host/utilities/bladeRF-cli/src/cmd/flash_image.c:71:35:
      error: overlapping comparisons always evaluate to true [-Werror,-Wtautological-overlap-compare]
       71 |                 if (val[i] >= 'a' || val[i] <= 'f') {
          |                     ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~

ZHF: https://github.com/NixOS/nixpkgs/issues/457852

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
