### PR TITLE
drawy: init at 1.0.0-alpha-unstable-2025-11-16

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21361,6 +21361,12 @@
     matrix = "@zitrone:utwente.io";
     name = "quantenzitrone";
   };
+  quarterstar = {
+    email = "quarterstar+nix@proton.me";
+    github = "quarterstar";
+    githubId = 201157222;
+    name = "Quarterstar";
+  };
   qubasa = {
     email = "consulting@qube.email";
     github = "Qubasa";

--- a/pkgs/by-name/dr/drawy/package.nix
+++ b/pkgs/by-name/dr/drawy/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  qt6,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation {
+  pname = "drawy";
+  version = "1.0.0-alpha-unstable-2025-11-17";
+
+  src = fetchFromGitHub {
+    owner = "Prayag2";
+    repo = "drawy";
+    rev = "ca02b66a9615c45c78f2e29839a40c1e5bf8f71c";
+    hash = "sha256-PzIeyhF/1wKD6JyybNRzruuxzSKJZvIq+L7X0rrcQUY=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = with qt6; [
+    qtbase
+    qttools
+  ];
+
+  postInstall = ''
+    for size in 16 32 256 512; do
+      install -D --mode=644 \
+        "$src"/assets/logo-$size.png \
+        "$out/share/icons/hicolor/''${size}x''${size}/apps/drawy.png"
+    done
+
+    install -D --mode=644 \
+      "$src"/assets/logo.svg \
+      "$out"/share/icons/hicolor/scalable/apps/drawy.svg
+
+    install -D --mode=644 \
+      "$src"/deploy/appimage/AppDir/usr/share/applications/drawy.desktop \
+      --target-directory="$out"/share/applications
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Handy and infinite brainstorming tool";
+    homepage = "https://github.com/Prayag2/drawy";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      yiyu
+      quarterstar
+    ];
+    mainProgram = "drawy";
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
