### PR TITLE
rayforce: init at 0-unstable-2025-11-10

### DIFF
--- a/pkgs/by-name/ra/rayforce/package.nix
+++ b/pkgs/by-name/ra/rayforce/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  clangStdenv,
+  fetchFromGitHub,
+  debug ? false,
+}:
+
+let
+  pname = if debug then "rayforce-debug" else "rayforce";
+  version = "0-unstable-2025-11-10";
+  rev = "0d3f37c";
+  hash = "sha256-3vgSC3BE2mxSp0EQtHUUzlNsXKjwnxgB6U83wTI0buU=";
+in
+clangStdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    inherit rev hash;
+    owner = "singaraiona";
+    repo = "rayforce";
+  };
+
+  buildFlags = [
+    (if debug then "debug" else "release")
+  ];
+
+  doCheck = true;
+  checkTarget = [ "tests" ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp rayforce $out/bin
+  '';
+
+  meta = {
+    description = "Fast columnar database";
+    homepage = "https://github.com/singaraiona/rayforce";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ProducerMatt ];
+    mainProgram = "rayforce";
+    platforms = lib.platforms.x86_64;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14450,4 +14450,6 @@ with pkgs;
   gpac-unstable = callPackage ../by-name/gp/gpac/package.nix {
     releaseChannel = "unstable";
   };
+
+  rayforce-debug = callPackage ../by-name/ra/rayforce/package.nix { debug = true; };
 }


### PR DESCRIPTION
RayforceDB is a columnar database with a Lisp-inspired interface. https://rayforcedb.com/index.html

This package can also run on Darwin, if someone can test it out I'd appreciate it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
