### PR TITLE
libgaminggear, roccat-tools: fix builds

### DIFF
--- a/pkgs/by-name/li/libgaminggear/package.nix
+++ b/pkgs/by-name/li/libgaminggear/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  fetchpatch2,
   fetchurl,
   cmake,
   pkg-config,
@@ -22,6 +23,13 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/libgaminggear/${pname}-${version}.tar.bz2";
     sha256 = "0jf5i1iv8j842imgiixbhwcr6qcwa93m27lzr6gb01ri5v35kggz";
   };
+
+  patches = [
+    (fetchpatch2 {
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/cmake_min_version.patch?h=libgaminggear&id=bfe7db62db76dbcefa8ba47640a35c80183f91d3";
+      hash = "sha256-loznfqxlucYlDUSYotMdUBmivKu+DD+OYhRIWpcrSgE=";
+    })
+  ];
 
   outputs = [
     "dev"

--- a/pkgs/by-name/ro/roccat-tools/package.nix
+++ b/pkgs/by-name/ro/roccat-tools/package.nix
@@ -37,7 +37,11 @@ stdenv.mkDerivation rec {
     substituteInPlace udev/90-roccat-kone.rules \
       --replace "/bin/sh" "${runtimeShell}" \
       --replace "/sbin/modprobe" "${kmod}/bin/modprobe" \
-      --replace "/bin/echo" "${coreutils}/bin/echo"
+      --replace "/bin/echo" "${coreutils}/bin/echo" \
+      --replace '$' '$$' # fix bash variables interpreted as udev substitutions
+
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12)" "CMAKE_MINIMUM_REQUIRED(VERSION 3.10)"
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
CMake 4 required a couple of minor changes (see #445447), and udev was complaining about bash substitutions it was trying to parse. This PR fixes both packages since the only usage of libgaminggear is roccat-tools.

ZHF: #457852

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 462076`
Commit: `c6ccde4031c2e6b85a48de1b2c2b1f410e5237e5`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 4 packages built:</summary>
  <ul>
    <li>libgaminggear</li>
    <li>libgaminggear.bin</li>
    <li>libgaminggear.dev</li>
    <li>roccat-tools</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
