### PR TITLE
font-{{arabic,cursor,daewoo,dec,jis,misc}-misc,ibm-type1,misc-meltho}: refactor, move to pkgs/by-name and rename from xorg namespace

### DIFF
--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -1021,7 +1021,8 @@ in
 
     fonts.packages = [
       (if cfg.upscaleDefaultCursor then fontcursormisc_hidpi else pkgs.xorg.fontcursormisc)
-      pkgs.xorg.fontmiscmisc
+      pkgs.font-misc-misc
+      pkgs.font-alias
     ];
 
   };

--- a/pkgs/by-name/fo/font-arabic-misc/package.nix
+++ b/pkgs/by-name/fo/font-arabic-misc/package.nix
@@ -2,8 +2,6 @@
   lib,
   stdenv,
   fetchurl,
-  pkg-config,
-  fontutil,
   bdftopcf,
   mkfontscale,
   writeScript,
@@ -20,14 +18,9 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   nativeBuildInputs = [
-    pkg-config
     bdftopcf
     mkfontscale
   ];
-
-  buildInputs = [ fontutil ];
-
-  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
 
   passthru = {
     updateScript = writeScript "update-${finalAttrs.pname}" ''

--- a/pkgs/by-name/fo/font-arabic-misc/package.nix
+++ b/pkgs/by-name/fo/font-arabic-misc/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  fontutil,
+  bdftopcf,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-arabic-misc";
+  version = "1.0.4";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-arabic-misc-${finalAttrs.version}.tar.xz";
+    hash = "sha256-Rv/mG1LHih0tynD/IKny2E1pdEY5yrmghcen7hdmNGc=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    bdftopcf
+    mkfontscale
+  ];
+
+  buildInputs = [ fontutil ];
+
+  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Arabic newspaper pcf font";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/arabic-misc";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/fo/font-cursor-misc/package.nix
+++ b/pkgs/by-name/fo/font-cursor-misc/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  fontutil,
+  bdftopcf,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-cursor-misc";
+  version = "1.0.4";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-cursor-misc-${finalAttrs.version}.tar.xz";
+    hash = "sha256-JdnJWVATy4yghCBQmZOmQ0yRflPKH+w/Y6zUWhnU+YI=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    bdftopcf
+    mkfontscale
+  ];
+
+  buildInputs = [ fontutil ];
+
+  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "X Cursor as a pcf font";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/cursor-misc";
+    # "These ""glyphs"" are unencumbered"
+    license = lib.licenses.publicDomain;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/fo/font-cursor-misc/package.nix
+++ b/pkgs/by-name/fo/font-cursor-misc/package.nix
@@ -2,8 +2,6 @@
   lib,
   stdenv,
   fetchurl,
-  pkg-config,
-  fontutil,
   bdftopcf,
   mkfontscale,
   writeScript,
@@ -23,10 +21,6 @@ stdenv.mkDerivation (finalAttrs: {
     bdftopcf
     mkfontscale
   ];
-
-  buildInputs = [ fontutil ];
-
-  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
 
   passthru = {
     updateScript = writeScript "update-${finalAttrs.pname}" ''

--- a/pkgs/by-name/fo/font-daewoo-misc/package.nix
+++ b/pkgs/by-name/fo/font-daewoo-misc/package.nix
@@ -2,8 +2,6 @@
   lib,
   stdenv,
   fetchurl,
-  pkg-config,
-  fontutil,
   bdftopcf,
   mkfontscale,
   writeScript,
@@ -20,14 +18,9 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   nativeBuildInputs = [
-    pkg-config
     bdftopcf
     mkfontscale
   ];
-
-  buildInputs = [ fontutil ];
-
-  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
 
   passthru = {
     updateScript = writeScript "update-${finalAttrs.pname}" ''

--- a/pkgs/by-name/fo/font-daewoo-misc/package.nix
+++ b/pkgs/by-name/fo/font-daewoo-misc/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  fontutil,
+  bdftopcf,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-daewoo-misc";
+  version = "1.0.4";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-daewoo-misc-${finalAttrs.version}.tar.xz";
+    hash = "sha256-9jyLPcjzAJjLhot9ssLAyLWz/Szv0EQDVpekPUx6TzE=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    bdftopcf
+    mkfontscale
+  ];
+
+  buildInputs = [ fontutil ];
+
+  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Daewoo Gothic and Daewoo Mincho pcf fonts";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/daewoo-misc";
+    # no license, just a copyright notice
+    license = lib.licenses.unfree;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/fo/font-dec-misc/package.nix
+++ b/pkgs/by-name/fo/font-dec-misc/package.nix
@@ -2,8 +2,6 @@
   lib,
   stdenv,
   fetchurl,
-  pkg-config,
-  fontutil,
   bdftopcf,
   mkfontscale,
   writeScript,
@@ -20,14 +18,9 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   nativeBuildInputs = [
-    pkg-config
     bdftopcf
     mkfontscale
   ];
-
-  buildInputs = [ fontutil ];
-
-  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
 
   passthru = {
     updateScript = writeScript "update-${finalAttrs.pname}" ''

--- a/pkgs/by-name/fo/font-dec-misc/package.nix
+++ b/pkgs/by-name/fo/font-dec-misc/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  fontutil,
+  bdftopcf,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-dec-misc";
+  version = "1.0.4";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-dec-misc-${finalAttrs.version}.tar.xz";
+    hash = "sha256-gtloIB2P+L7A5R3M14G7TU6/F+EQBJRCeb3AIB4WGvc=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    bdftopcf
+    mkfontscale
+  ];
+
+  buildInputs = [ fontutil ];
+
+  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "DEC cursors in pcf font format";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/dec-misc";
+    license = lib.licenses.hpnd;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/fo/font-ibm-type1/package.nix
+++ b/pkgs/by-name/fo/font-ibm-type1/package.nix
@@ -2,8 +2,6 @@
   lib,
   stdenv,
   fetchurl,
-  pkg-config,
-  fontutil,
   mkfontscale,
   writeScript,
 }:
@@ -18,14 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  nativeBuildInputs = [
-    pkg-config
-    mkfontscale
-  ];
-
-  buildInputs = [ fontutil ];
-
-  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+  nativeBuildInputs = [ mkfontscale ];
 
   passthru = {
     updateScript = writeScript "update-${finalAttrs.pname}" ''

--- a/pkgs/by-name/fo/font-ibm-type1/package.nix
+++ b/pkgs/by-name/fo/font-ibm-type1/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  fontutil,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-ibm-type1";
+  version = "1.0.4";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-ibm-type1-${finalAttrs.version}.tar.xz";
+    hash = "sha256-xDlelbpG1AxK0XN+kcrCDAq3VBEym2DbXZn+2Stgzn8=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    mkfontscale
+  ];
+
+  buildInputs = [ fontutil ];
+
+  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "IBM Courier Type1 fonts";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/ibm-type1";
+    license = lib.licenses.unfreeRedistributable;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/fo/font-jis-misc/package.nix
+++ b/pkgs/by-name/fo/font-jis-misc/package.nix
@@ -2,8 +2,6 @@
   lib,
   stdenv,
   fetchurl,
-  pkg-config,
-  fontutil,
   bdftopcf,
   mkfontscale,
   writeScript,
@@ -20,14 +18,9 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   nativeBuildInputs = [
-    pkg-config
     bdftopcf
     mkfontscale
   ];
-
-  buildInputs = [ fontutil ];
-
-  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
 
   passthru = {
     updateScript = writeScript "update-${finalAttrs.pname}" ''

--- a/pkgs/by-name/fo/font-jis-misc/package.nix
+++ b/pkgs/by-name/fo/font-jis-misc/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  fontutil,
+  bdftopcf,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-jis-misc";
+  version = "1.0.4";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-jis-misc-${finalAttrs.version}.tar.xz";
+    hash = "sha256-eNHv9sRx96poAqJtYszPUdjlGFWGQG2bbh7mkbC/+tA=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    bdftopcf
+    mkfontscale
+  ];
+
+  buildInputs = [ fontutil ];
+
+  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "JIS X 9051: 1984 pcf font";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/jis-misc";
+    # licensing is unclear:
+    # - COPYING just says "permission to use"
+    # - The industial standard (JIS X 9051: 1984) this is from, is paid.
+    license = lib.licenses.unfree;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/fo/font-misc-meltho/package.nix
+++ b/pkgs/by-name/fo/font-misc-meltho/package.nix
@@ -18,8 +18,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ mkfontscale ];
 
-  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-
   passthru = {
     updateScript = writeScript "update-${finalAttrs.pname}" ''
       #!/usr/bin/env nix-shell

--- a/pkgs/by-name/fo/font-misc-meltho/package.nix
+++ b/pkgs/by-name/fo/font-misc-meltho/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-misc-meltho";
+  version = "1.0.4";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-misc-meltho-${finalAttrs.version}.tar.xz";
+    hash = "sha256-Y75ewXB4iY8mPCQJami0OuWwa4iFLkJUmvoD0STWUhk=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ mkfontscale ];
+
+  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Collection of otf fonts designed for the display of syriac text";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/misc-meltho";
+    # modified Bigelow & Holmes Font License
+    license = lib.licenses.unfreeRedistributable;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/fo/font-misc-misc/package.nix
+++ b/pkgs/by-name/fo/font-misc-misc/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ font-util ];
 
-  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+  configureFlags = [ "--with-fontrootdir=$(out)/share/fonts/X11" ];
 
   passthru = {
     updateScript = writeScript "update-${finalAttrs.pname}" ''

--- a/pkgs/by-name/fo/font-misc-misc/package.nix
+++ b/pkgs/by-name/fo/font-misc-misc/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  font-util,
+  bdftopcf,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-misc-misc";
+  version = "1.1.3";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-misc-misc-${finalAttrs.version}.tar.xz";
+    hash = "sha256-eavjYfWLshren1ZYmOSGMAzhzGIdUoW+wm4Utqhhj+0=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    bdftopcf
+    font-util
+    mkfontscale
+  ];
+
+  buildInputs = [ font-util ];
+
+  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Misc pcf fonts in different sizes";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/misc-misc";
+    license = lib.licenses.publicDomain;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xd/xdummy/package.nix
+++ b/pkgs/by-name/xd/xdummy/package.nix
@@ -31,8 +31,8 @@ let
       XkbDir "${xkeyboard_config}/share/X11/xkb"
       FontPath "${xorg.fontadobe75dpi}/share/fonts/X11/75dpi"
       FontPath "${xorg.fontadobe100dpi}/share/fonts/X11/100dpi"
-      FontPath "${xorg.fontmiscmisc}/lib/X11/fonts/misc"
-      FontPath "${xorg.fontcursormisc}/lib/X11/fonts/misc"
+      FontPath "${xorg.fontmiscmisc}/share/fonts/X11/misc"
+      FontPath "${xorg.fontcursormisc}/share/fonts/X11/misc"
     ${lib.optionalString unfreeFonts ''
       FontPath "${xorg.fontbhlucidatypewriter75dpi}/share/fonts/X11/75dpi"
       FontPath "${xorg.fontbhlucidatypewriter100dpi}/share/fonts/X11/100dpi"

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -24,6 +24,7 @@
   font-daewoo-misc,
   font-dec-misc,
   font-encodings,
+  font-ibm-type1,
   font-isas-misc,
   font-micro-misc,
   font-misc-cyrillic,
@@ -231,6 +232,7 @@ self: with self; {
   fontcursormisc = font-cursor-misc;
   fontdaewoomisc = font-daewoo-misc;
   fontdecmisc = font-dec-misc;
+  fontibmtype1 = font-ibm-type1;
   fontisasmisc = font-isas-misc;
   fontmicromisc = font-micro-misc;
   fontmisccyrillic = font-misc-cyrillic;
@@ -382,44 +384,6 @@ self: with self; {
         xorgproto
         libXt
       ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontibmtype1 = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-ibm-type1";
-      version = "1.0.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-ibm-type1-1.0.4.tar.xz";
-        sha256 = "0zyfc0mxkzlrbpdn16rj25abf2hcqb592zkks550rm26paamwff4";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -31,6 +31,7 @@
   font-misc-cyrillic,
   font-misc-ethiopic,
   font-misc-meltho,
+  font-misc-misc,
   font-mutt-misc,
   font-schumacher-misc,
   font-screen-cyrillic,
@@ -241,6 +242,7 @@ self: with self; {
   fontmisccyrillic = font-misc-cyrillic;
   fontmiscethiopic = font-misc-ethiopic;
   fontmiscmeltho = font-misc-meltho;
+  fontmiscmisc = font-misc-misc;
   fontmuttmisc = font-mutt-misc;
   fontschumachermisc = font-schumacher-misc;
   fontscreencyrillic = font-screen-cyrillic;
@@ -388,47 +390,6 @@ self: with self; {
         xorgproto
         libXt
       ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontmiscmisc = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      bdftopcf,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-misc-misc";
-      version = "1.1.3";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-misc-misc-1.1.3.tar.xz";
-        sha256 = "1vcgc6lbc53fqaz8alhxcb6f231hhvj9hn2nkzg1mclbymhy7avr";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        bdftopcf
-        fontutil
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -21,6 +21,7 @@
   font-bitstream-type1,
   font-cronyx-cyrillic,
   font-cursor-misc,
+  font-daewoo-misc,
   font-encodings,
   font-isas-misc,
   font-micro-misc,
@@ -227,6 +228,7 @@ self: with self; {
   fontbitstreamtype1 = font-bitstream-type1;
   fontcronyxcyrillic = font-cronyx-cyrillic;
   fontcursormisc = font-cursor-misc;
+  fontdaewoomisc = font-daewoo-misc;
   fontisasmisc = font-isas-misc;
   fontmicromisc = font-micro-misc;
   fontmisccyrillic = font-misc-cyrillic;
@@ -378,46 +380,6 @@ self: with self; {
         xorgproto
         libXt
       ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontdaewoomisc = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      bdftopcf,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-daewoo-misc";
-      version = "1.0.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-daewoo-misc-1.0.4.tar.xz";
-        sha256 = "0cagg963v94paq1l9l7g5kyv7df8q31b4zcbhv5rh07kr0yqng7n";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        bdftopcf
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -26,6 +26,7 @@
   font-encodings,
   font-ibm-type1,
   font-isas-misc,
+  font-jis-misc,
   font-micro-misc,
   font-misc-cyrillic,
   font-misc-ethiopic,
@@ -234,6 +235,7 @@ self: with self; {
   fontdecmisc = font-dec-misc;
   fontibmtype1 = font-ibm-type1;
   fontisasmisc = font-isas-misc;
+  fontjismisc = font-jis-misc;
   fontmicromisc = font-micro-misc;
   fontmisccyrillic = font-misc-cyrillic;
   fontmiscethiopic = font-misc-ethiopic;
@@ -384,46 +386,6 @@ self: with self; {
         xorgproto
         libXt
       ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontjismisc = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      bdftopcf,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-jis-misc";
-      version = "1.0.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-jis-misc-1.0.4.tar.xz";
-        sha256 = "1l7spyq93rhydsdnsh46alcfbn2irz664vd209lamxviqkvfzlbq";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        bdftopcf
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -22,6 +22,7 @@
   font-cronyx-cyrillic,
   font-cursor-misc,
   font-daewoo-misc,
+  font-dec-misc,
   font-encodings,
   font-isas-misc,
   font-micro-misc,
@@ -229,6 +230,7 @@ self: with self; {
   fontcronyxcyrillic = font-cronyx-cyrillic;
   fontcursormisc = font-cursor-misc;
   fontdaewoomisc = font-daewoo-misc;
+  fontdecmisc = font-dec-misc;
   fontisasmisc = font-isas-misc;
   fontmicromisc = font-micro-misc;
   fontmisccyrillic = font-misc-cyrillic;
@@ -380,46 +382,6 @@ self: with self; {
         xorgproto
         libXt
       ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontdecmisc = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      bdftopcf,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-dec-misc";
-      version = "1.0.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-dec-misc-1.0.4.tar.xz";
-        sha256 = "1xqs2qg21h5xg519810hw4bvykjdpf0xgk0xwp0bxy4g3lh6inc2";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        bdftopcf
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -30,6 +30,7 @@
   font-micro-misc,
   font-misc-cyrillic,
   font-misc-ethiopic,
+  font-misc-meltho,
   font-mutt-misc,
   font-schumacher-misc,
   font-screen-cyrillic,
@@ -239,6 +240,7 @@ self: with self; {
   fontmicromisc = font-micro-misc;
   fontmisccyrillic = font-misc-cyrillic;
   fontmiscethiopic = font-misc-ethiopic;
+  fontmiscmeltho = font-misc-meltho;
   fontmuttmisc = font-mutt-misc;
   fontschumachermisc = font-schumacher-misc;
   fontscreencyrillic = font-screen-cyrillic;
@@ -386,44 +388,6 @@ self: with self; {
         xorgproto
         libXt
       ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontmiscmeltho = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-misc-meltho";
-      version = "1.0.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-misc-meltho-1.0.4.tar.xz";
-        sha256 = "06ajsqjd20zsk9a44bl5i1mv1r9snil6l2947hk8z2bqf30mxgk3";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -9,6 +9,7 @@
   font-adobe-utopia-75dpi,
   font-adobe-utopia-type1,
   font-alias,
+  font-arabic-misc,
   font-bh-100dpi,
   font-bh-75dpi,
   font-bh-lucidatypewriter-100dpi,
@@ -213,6 +214,7 @@ self: with self; {
   fontadobeutopia75dpi = font-adobe-utopia-75dpi;
   fontadobeutopiatype1 = font-adobe-utopia-type1;
   fontalias = font-alias;
+  fontarabicmisc = font-arabic-misc;
   fontbh100dpi = font-bh-100dpi;
   fontbh75dpi = font-bh-75dpi;
   fontbhlucidatypewriter100dpi = font-bh-lucidatypewriter-100dpi;
@@ -374,46 +376,6 @@ self: with self; {
         xorgproto
         libXt
       ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontarabicmisc = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      bdftopcf,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-arabic-misc";
-      version = "1.0.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-arabic-misc-1.0.4.tar.xz";
-        sha256 = "0rrlcqbyx9y7hnhbkjir8rs6jkfqyalj1zvhr8niv2n7a8dydzs6";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        bdftopcf
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -20,6 +20,7 @@
   font-bitstream-75dpi,
   font-bitstream-type1,
   font-cronyx-cyrillic,
+  font-cursor-misc,
   font-encodings,
   font-isas-misc,
   font-micro-misc,
@@ -225,6 +226,7 @@ self: with self; {
   fontbitstream75dpi = font-bitstream-75dpi;
   fontbitstreamtype1 = font-bitstream-type1;
   fontcronyxcyrillic = font-cronyx-cyrillic;
+  fontcursormisc = font-cursor-misc;
   fontisasmisc = font-isas-misc;
   fontmicromisc = font-micro-misc;
   fontmisccyrillic = font-misc-cyrillic;
@@ -376,46 +378,6 @@ self: with self; {
         xorgproto
         libXt
       ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontcursormisc = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      bdftopcf,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-cursor-misc";
-      version = "1.0.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-cursor-misc-1.0.4.tar.xz";
-        sha256 = "10prshcmmm5ccczyq7yaadz92k23ls9rjl10hjh8rjqka1cwkn95";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        bdftopcf
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ ];

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -353,6 +353,7 @@ print OUT <<EOF;
   font-cronyx-cyrillic,
   font-cursor-misc,
   font-daewoo-misc,
+  font-dec-misc,
   font-encodings,
   font-isas-misc,
   font-micro-misc,
@@ -560,6 +561,7 @@ self: with self; {
   fontcronyxcyrillic = font-cronyx-cyrillic;
   fontcursormisc = font-cursor-misc;
   fontdaewoomisc = font-daewoo-misc;
+  fontdecmisc = font-dec-misc;
   fontisasmisc = font-isas-misc;
   fontmicromisc = font-micro-misc;
   fontmisccyrillic = font-misc-cyrillic;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -351,6 +351,7 @@ print OUT <<EOF;
   font-bitstream-75dpi,
   font-bitstream-type1,
   font-cronyx-cyrillic,
+  font-cursor-misc,
   font-encodings,
   font-isas-misc,
   font-micro-misc,
@@ -556,6 +557,7 @@ self: with self; {
   fontbitstream75dpi = font-bitstream-75dpi;
   fontbitstreamtype1 = font-bitstream-type1;
   fontcronyxcyrillic = font-cronyx-cyrillic;
+  fontcursormisc = font-cursor-misc;
   fontisasmisc = font-isas-misc;
   fontmicromisc = font-micro-misc;
   fontmisccyrillic = font-misc-cyrillic;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -361,6 +361,7 @@ print OUT <<EOF;
   font-micro-misc,
   font-misc-cyrillic,
   font-misc-ethiopic,
+  font-misc-meltho,
   font-mutt-misc,
   font-schumacher-misc,
   font-screen-cyrillic,
@@ -570,6 +571,7 @@ self: with self; {
   fontmicromisc = font-micro-misc;
   fontmisccyrillic = font-misc-cyrillic;
   fontmiscethiopic = font-misc-ethiopic;
+  fontmiscmeltho = font-misc-meltho;
   fontmuttmisc = font-mutt-misc;
   fontschumachermisc = font-schumacher-misc;
   fontscreencyrillic = font-screen-cyrillic;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -357,6 +357,7 @@ print OUT <<EOF;
   font-encodings,
   font-ibm-type1,
   font-isas-misc,
+  font-jis-misc,
   font-micro-misc,
   font-misc-cyrillic,
   font-misc-ethiopic,
@@ -565,6 +566,7 @@ self: with self; {
   fontdecmisc = font-dec-misc;
   fontibmtype1 = font-ibm-type1;
   fontisasmisc = font-isas-misc;
+  fontjismisc = font-jis-misc;
   fontmicromisc = font-micro-misc;
   fontmisccyrillic = font-misc-cyrillic;
   fontmiscethiopic = font-misc-ethiopic;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -355,6 +355,7 @@ print OUT <<EOF;
   font-daewoo-misc,
   font-dec-misc,
   font-encodings,
+  font-ibm-type1,
   font-isas-misc,
   font-micro-misc,
   font-misc-cyrillic,
@@ -562,6 +563,7 @@ self: with self; {
   fontcursormisc = font-cursor-misc;
   fontdaewoomisc = font-daewoo-misc;
   fontdecmisc = font-dec-misc;
+  fontibmtype1 = font-ibm-type1;
   fontisasmisc = font-isas-misc;
   fontmicromisc = font-micro-misc;
   fontmisccyrillic = font-misc-cyrillic;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -352,6 +352,7 @@ print OUT <<EOF;
   font-bitstream-type1,
   font-cronyx-cyrillic,
   font-cursor-misc,
+  font-daewoo-misc,
   font-encodings,
   font-isas-misc,
   font-micro-misc,
@@ -558,6 +559,7 @@ self: with self; {
   fontbitstreamtype1 = font-bitstream-type1;
   fontcronyxcyrillic = font-cronyx-cyrillic;
   fontcursormisc = font-cursor-misc;
+  fontdaewoomisc = font-daewoo-misc;
   fontisasmisc = font-isas-misc;
   fontmicromisc = font-micro-misc;
   fontmisccyrillic = font-misc-cyrillic;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -340,6 +340,7 @@ print OUT <<EOF;
   font-adobe-utopia-75dpi,
   font-adobe-utopia-type1,
   font-alias,
+  font-arabic-misc,
   font-bh-100dpi,
   font-bh-75dpi,
   font-bh-lucidatypewriter-100dpi,
@@ -544,6 +545,7 @@ self: with self; {
   fontadobeutopia75dpi = font-adobe-utopia-75dpi;
   fontadobeutopiatype1 = font-adobe-utopia-type1;
   fontalias = font-alias;
+  fontarabicmisc = font-arabic-misc;
   fontbh100dpi = font-bh-100dpi;
   fontbh75dpi = font-bh-75dpi;
   fontbhlucidatypewriter100dpi = font-bh-lucidatypewriter-100dpi;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -362,6 +362,7 @@ print OUT <<EOF;
   font-misc-cyrillic,
   font-misc-ethiopic,
   font-misc-meltho,
+  font-misc-misc,
   font-mutt-misc,
   font-schumacher-misc,
   font-screen-cyrillic,
@@ -572,6 +573,7 @@ self: with self; {
   fontmisccyrillic = font-misc-cyrillic;
   fontmiscethiopic = font-misc-ethiopic;
   fontmiscmeltho = font-misc-meltho;
+  fontmiscmisc = font-misc-misc;
   fontmuttmisc = font-mutt-misc;
   fontschumachermisc = font-schumacher-misc;
   fontscreencyrillic = font-screen-cyrillic;

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -800,9 +800,6 @@ self: super:
 
     # unfree, possibly not redistributable
     unfree = [
-      # no license, just a copyright notice
-      "fontdaewoomisc"
-
       # unclear license, "permission to use"?
       "fontjismisc"
     ];

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -122,14 +122,6 @@ self: super:
     };
   });
 
-  fontmiscmisc = super.fontmiscmisc.overrideAttrs (attrs: {
-    postInstall = ''
-      ALIASFILE=${xorg.fontalias}/share/fonts/X11/misc/fonts.alias
-      test -f $ALIASFILE
-      cp $ALIASFILE $out/lib/X11/fonts/misc/fonts.alias
-    '';
-  });
-
   fonttosfnt = super.fonttosfnt.overrideAttrs (attrs: {
     meta = attrs.meta // {
       license = lib.licenses.mit;

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -793,11 +793,6 @@ self: super:
 # mark some packages as unfree
 // (
   let
-    # unfree but redistributable
-    redist = [
-      "fontibmtype1"
-    ];
-
     # unfree, possibly not redistributable
     unfree = [
       # unclear license, "permission to use"?
@@ -815,8 +810,7 @@ self: super:
       f: names: lib.listToAttrs (lib.zipListsWith lib.nameValuePair names (map f names));
 
   in
-  mapNamesToAttrs (setLicense lib.licenses.unfreeRedistributable) redist
-  // mapNamesToAttrs (setLicense lib.licenses.unfree) unfree
+  mapNamesToAttrs (setLicense lib.licenses.unfree) unfree
 )
 
 # deprecate some packages

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -790,29 +790,6 @@ self: super:
   xwd = addMainProgram super.xwd { };
 }
 
-# mark some packages as unfree
-// (
-  let
-    # unfree, possibly not redistributable
-    unfree = [
-      # unclear license, "permission to use"?
-      "fontjismisc"
-    ];
-
-    setLicense =
-      license: name:
-      super.${name}.overrideAttrs (attrs: {
-        meta = attrs.meta // {
-          inherit license;
-        };
-      });
-    mapNamesToAttrs =
-      f: names: lib.listToAttrs (lib.zipListsWith lib.nameValuePair names (map f names));
-
-  in
-  mapNamesToAttrs (setLicense lib.licenses.unfree) unfree
-)
-
 # deprecate some packages
 // lib.optionalAttrs config.allowAliases {
   fontbitstreamspeedo = throw "Bitstream Speedo is an obsolete font format that hasn't been supported by Xorg since 2005"; # added 2025-09-24

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -68,6 +68,5 @@ mirror://xorg/individual/driver/xf86-video-vesa-2.6.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-vmware-13.4.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-voodoo-1.2.6.tar.xz
 mirror://xorg/individual/driver/xf86-video-wsfb-0.4.0.tar.bz2
-mirror://xorg/individual/font/font-misc-misc-1.1.3.tar.xz
 mirror://xorg/individual/lib/libXTrap-1.0.1.tar.bz2
 mirror://xorg/individual/xserver/xorg-server-21.1.20.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -68,7 +68,6 @@ mirror://xorg/individual/driver/xf86-video-vesa-2.6.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-vmware-13.4.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-voodoo-1.2.6.tar.xz
 mirror://xorg/individual/driver/xf86-video-wsfb-0.4.0.tar.bz2
-mirror://xorg/individual/font/font-arabic-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-cursor-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-daewoo-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-dec-misc-1.0.4.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -68,7 +68,6 @@ mirror://xorg/individual/driver/xf86-video-vesa-2.6.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-vmware-13.4.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-voodoo-1.2.6.tar.xz
 mirror://xorg/individual/driver/xf86-video-wsfb-0.4.0.tar.bz2
-mirror://xorg/individual/font/font-jis-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-meltho-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-misc-1.1.3.tar.xz
 mirror://xorg/individual/lib/libXTrap-1.0.1.tar.bz2

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -68,7 +68,6 @@ mirror://xorg/individual/driver/xf86-video-vesa-2.6.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-vmware-13.4.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-voodoo-1.2.6.tar.xz
 mirror://xorg/individual/driver/xf86-video-wsfb-0.4.0.tar.bz2
-mirror://xorg/individual/font/font-misc-meltho-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-misc-1.1.3.tar.xz
 mirror://xorg/individual/lib/libXTrap-1.0.1.tar.bz2
 mirror://xorg/individual/xserver/xorg-server-21.1.20.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -68,7 +68,6 @@ mirror://xorg/individual/driver/xf86-video-vesa-2.6.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-vmware-13.4.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-voodoo-1.2.6.tar.xz
 mirror://xorg/individual/driver/xf86-video-wsfb-0.4.0.tar.bz2
-mirror://xorg/individual/font/font-ibm-type1-1.0.4.tar.xz
 mirror://xorg/individual/font/font-jis-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-meltho-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-misc-1.1.3.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -68,7 +68,6 @@ mirror://xorg/individual/driver/xf86-video-vesa-2.6.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-vmware-13.4.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-voodoo-1.2.6.tar.xz
 mirror://xorg/individual/driver/xf86-video-wsfb-0.4.0.tar.bz2
-mirror://xorg/individual/font/font-dec-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-ibm-type1-1.0.4.tar.xz
 mirror://xorg/individual/font/font-jis-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-meltho-1.0.4.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -68,7 +68,6 @@ mirror://xorg/individual/driver/xf86-video-vesa-2.6.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-vmware-13.4.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-voodoo-1.2.6.tar.xz
 mirror://xorg/individual/driver/xf86-video-wsfb-0.4.0.tar.bz2
-mirror://xorg/individual/font/font-cursor-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-daewoo-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-dec-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-ibm-type1-1.0.4.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -68,7 +68,6 @@ mirror://xorg/individual/driver/xf86-video-vesa-2.6.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-vmware-13.4.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-voodoo-1.2.6.tar.xz
 mirror://xorg/individual/driver/xf86-video-wsfb-0.4.0.tar.bz2
-mirror://xorg/individual/font/font-daewoo-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-dec-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-ibm-type1-1.0.4.tar.xz
 mirror://xorg/individual/font/font-jis-misc-1.0.4.tar.xz


### PR DESCRIPTION
these are all the remaining font packages from the xorg namespace

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Build for platform:
  - [x] x86_64-linux
  - [x] x86_64-linux static
  - [x] aarch64-multiplatform
  - [x] aarch64-multiplatform-musl
  - [x] aarch64-multiplatform static
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`. (none)
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
