### PR TITLE
python3Packages.cachecontrol: 0.14.3 -> 0.14.4

### DIFF
--- a/pkgs/development/python-modules/cachecontrol/default.nix
+++ b/pkgs/development/python-modules/cachecontrol/default.nix
@@ -3,18 +3,17 @@
   buildPythonPackage,
   cherrypy,
   fetchFromGitHub,
-  flit-core,
   filelock,
-  mock,
   msgpack,
   pytestCheckHook,
   redis,
   requests,
+  uv-build,
 }:
 
 buildPythonPackage rec {
   pname = "cachecontrol";
-  version = "0.14.3";
+  version = "0.14.4";
   pyproject = true;
 
   __darwinAllowLocalNetworking = true;
@@ -23,10 +22,10 @@ buildPythonPackage rec {
     owner = "ionrock";
     repo = "cachecontrol";
     tag = "v${version}";
-    hash = "sha256-V8RWTDxhKCvf5bz2j6anp8bkCzkicTRY+Kd6eHu1peg=";
+    hash = "sha256-627SqJocVOO0AfI8vswPqOr15MA/Lx7RLAdRAXzWu84=";
   };
 
-  build-system = [ flit-core ];
+  build-system = [ uv-build ];
 
   dependencies = [
     msgpack
@@ -40,9 +39,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     cherrypy
-    mock
     pytestCheckHook
-    requests
   ]
   ++ lib.flatten (builtins.attrValues optional-dependencies);
 


### PR DESCRIPTION
Diff: https://github.com/ionrock/cachecontrol/compare/v0.14.3...v0.14.4

Changelog: https://github.com/psf/cachecontrol/releases/tag/v0.14.4


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
