### PR TITLE
BlueMap: add `modsFolder` config setting

### DIFF
--- a/nixos/modules/services/web-apps/bluemap.nix
+++ b/nixos/modules/services/web-apps/bluemap.nix
@@ -278,6 +278,14 @@ in
         loaded in alphabetical order.
       '';
     };
+
+    modsFolder = mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        The path of the folder containing the mods that contain extra resources for rendering.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -300,7 +308,9 @@ in
         UMask = "026";
       };
       script = ''
-        ${lib.getExe pkgs.bluemap} -c ${configFolder} -gs -r
+        ${lib.getExe pkgs.bluemap} -c ${configFolder} -gs -r ${
+          lib.optionalString (cfg.modsFolder != null) "-n ${cfg.modsFolder}"
+        }
       '';
     };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
The service currently doesn't offer a way to use the `-n` command line option of BlueMap, which is required to render blocks added by mods. This PR adds an option to set the mod folder, using the same name and description as BlueMap itself.

Since I don't know where the documentation for this is I figured I would just like the [source code](https://github.com/BlueMap-Minecraft/BlueMap/blob/8a0edc83bb5a93f7ae03d15bb2cff34e365a6ec4/implementations/cli/src/main/java/de/bluecolored/bluemap/cli/BlueMapCLI.java#L351) to help reviewers :)

I tested this change on the same machine my server runs on and it works perfectly.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
