### PR TITLE
mlton related changes

### DIFF
--- a/pkgs/development/compilers/mlton/20130715.nix
+++ b/pkgs/development/compilers/mlton/20130715.nix
@@ -22,24 +22,24 @@ stdenv.mkDerivation rec {
     if stdenv.hostPlatform.system == "i686-linux" then
       (fetchurl {
         url = "mirror://sourceforge/project/mlton/mlton/${version}/${pname}-${version}-1.x86-linux.tgz";
-        sha256 = "1kxjjmnw4xk2d9hpvz43w9dvyhb3025k4zvjx785c33nrwkrdn4j";
+        hash = "sha256-ktiWJ892DFbQ6XJ/MosAY0G/W+KD/H1hamJ2wm2Vss8=";
       })
     else if stdenv.hostPlatform.system == "x86_64-linux" then
       (fetchurl {
         url = "mirror://sourceforge/project/mlton/mlton/${version}/${pname}-${version}-1.amd64-linux.tgz";
-        sha256 = "0fyhwxb4nmpirjbjcvk9f6w67gmn2gkz7xcgz0xbfih9kc015ygn";
+        hash = "sha256-9vkSAJsJRrc6+I/18+cTtr5juHFpbiaXzPFWS1bn0Ds=";
       })
     else if stdenv.hostPlatform.system == "x86_64-darwin" then
       (fetchurl {
         url = "mirror://sourceforge/project/mlton/mlton/${version}/${pname}-${version}-1.amd64-darwin.gmp-macports.tgz";
-        sha256 = "044wnh9hhg6if886xy805683k0as347xd37r0r1yi4x7qlxzzgx9";
+        hash = "sha256-qb//O8Wnk+hDBvmM1g8ZWoE5kCkA+W4QctE8CBO0nBA=";
       })
     else
       throw "Architecture not supported";
 
   codeSrc = fetchurl {
     url = "mirror://sourceforge/project/mlton/mlton/${version}/${pname}-${version}.src.tgz";
-    sha256 = "0v1x2hrh9hiqkvnbq11kf34v4i5a2x0ffxbzqaa8skyl26nmfn11";
+    hash = "sha256-IVhXrRHUT42Uwn9150AXqkSyyXAzBLzsnjjCBDMUPWw=";
   };
 
   srcs = [

--- a/pkgs/development/compilers/mlton/20180207-binary.nix
+++ b/pkgs/development/compilers/mlton/20180207-binary.nix
@@ -16,12 +16,12 @@ stdenv.mkDerivation rec {
     if stdenv.hostPlatform.system == "x86_64-linux" then
       (fetchurl {
         url = "https://github.com/MLton/mlton/releases/download/on-${version}-release/${pname}-${version}-1.amd64-linux.tgz";
-        sha256 = "0f4q575yfm5dpg4a2wsnqn4l2zrar96p6rlsk0dw10ggyfwvsjlf";
+        hash = "sha256-jkq9ufPvgcAbmJpmc03KKn9BicVWc6HIu61U58spmDg=";
       })
     else if stdenv.hostPlatform.system == "x86_64-darwin" then
       (fetchurl {
         url = "https://github.com/MLton/mlton/releases/download/on-${version}-release/${pname}-${version}-1.amd64-darwin.gmp-static.tgz";
-        sha256 = "1cw7yhw48qp12q0adwf8srpjzrgkp84kmlkqw3pz8vkxz4p9hbdv";
+        hash = "sha256-uy2YLvl9bvTv4HjSOgm68+Uvb9bI8aYAFuFiRDj0h7M=";
       })
     else
       throw "Architecture not supported";

--- a/pkgs/development/compilers/mlton/20210117-binary.nix
+++ b/pkgs/development/compilers/mlton/20210117-binary.nix
@@ -18,17 +18,17 @@ stdenv.mkDerivation rec {
     if stdenv.hostPlatform.system == "x86_64-linux" then
       (fetchurl {
         url = "https://github.com/MLton/mlton/releases/download/on-${version}-release/${pname}-${version}-1.amd64-linux-glibc2.31.tgz";
-        sha256 = "1lj51xg9p75qj1x5036lvjvd4a2j21kfi6vh8d0n9kdcdffvb73l";
+        hash = "sha256-dJy1nWuszWRBQ3Cb6GYQUijSttzUDFB6kLicm14PRdI=";
       })
     else if stdenv.hostPlatform.system == "x86_64-darwin" then
       (fetchurl {
         url = "https://github.com/MLton/mlton/releases/download/on-${version}-release/${pname}-${version}-1.amd64-darwin-19.6.gmp-static.tgz";
-        sha256 = "0xndr2awlxdqr81j6snl9zqjx8r6f5fy9x65j1w899kf2dh9zsjv";
+        hash = "sha256-W+qfYBNupoR4kMX05F1xJqMu8U/UaiMDyrh1ypXIzXY=";
       })
     else if stdenv.hostPlatform.system == "aarch64-darwin" then
       (fetchurl {
         url = "https://projects.laas.fr/tina/software/mlton-${version}-1.arm64-darwin-21.6-gmp-static.tgz";
-        sha256 = "1s61ayk3yj2xw8ilqk3fhb03x5x1wcakkmbhhvcsfb2hdw2c932x";
+        hash = "sha256-XYzEBG9QLKfZhnDVORXjoZc+wIJuTEwj4l1IP6ZXweg=";
       })
     else
       throw "Architecture not supported";

--- a/pkgs/development/compilers/mlton/20241230-binary.nix
+++ b/pkgs/development/compilers/mlton/20241230-binary.nix
@@ -17,22 +17,22 @@ stdenv.mkDerivation rec {
     if stdenv.hostPlatform.system == "x86_64-linux" then
       (fetchurl {
         url = "https://github.com/MLton/mlton/releases/download/on-${version}-release/${pname}-${version}-1.amd64-linux.ubuntu-24.04_glibc2.39.tgz";
-        sha256 = "sha256-ldXnjHcWGu77LP9WL6vTC6FngzhxPFAUflAA+bpIFZM=";
+        hash = "sha256-ldXnjHcWGu77LP9WL6vTC6FngzhxPFAUflAA+bpIFZM=";
       })
     else if stdenv.hostPlatform.system == "aarch64-linux" then
       (fetchurl {
         url = "https://github.com/MLton/mlton/releases/download/on-${version}-release/${pname}-${version}-1.arm64-linux.ubuntu-24.04-arm_glibc2.39.tgz";
-        sha256 = "sha256-rn65t253SfUShAM3kXiLQJHT7JS7EO3fAPB23LWIwfc=";
+        hash = "sha256-rn65t253SfUShAM3kXiLQJHT7JS7EO3fAPB23LWIwfc=";
       })
     else if stdenv.hostPlatform.system == "x86_64-darwin" then
       (fetchurl {
         url = "https://github.com/MLton/mlton/releases/download/on-${version}-release/${pname}-${version}-1.amd64-darwin.macos-13_gmp-static.tgz";
-        sha256 = "sha256-fW0hqjrWUcy+PIN8WHb1r4EYgfuwF9Zz3q7f2ZtxOi0=";
+        hash = "sha256-fW0hqjrWUcy+PIN8WHb1r4EYgfuwF9Zz3q7f2ZtxOi0=";
       })
     else if stdenv.hostPlatform.system == "aarch64-darwin" then
       (fetchurl {
         url = "https://github.com/MLton/mlton/releases/download/on-${version}-release/${pname}-${version}-1.arm64-darwin.macos-15_gmp-static.tgz";
-        sha256 = "sha256-xhFP2plFjP/mbLz1CNtlZzkm0Kx6twfD/Dmn79Vj908=";
+        hash = "sha256-xhFP2plFjP/mbLz1CNtlZzkm0Kx6twfD/Dmn79Vj908=";
       })
     else
       throw "Architecture not supported";

--- a/pkgs/development/compilers/mlton/20241230-binary.nix
+++ b/pkgs/development/compilers/mlton/20241230-binary.nix
@@ -19,6 +19,11 @@ stdenv.mkDerivation rec {
         url = "https://github.com/MLton/mlton/releases/download/on-${version}-release/${pname}-${version}-1.amd64-linux.ubuntu-24.04_glibc2.39.tgz";
         sha256 = "sha256-ldXnjHcWGu77LP9WL6vTC6FngzhxPFAUflAA+bpIFZM=";
       })
+    else if stdenv.hostPlatform.system == "aarch64-linux" then
+      (fetchurl {
+        url = "https://github.com/MLton/mlton/releases/download/on-${version}-release/${pname}-${version}-1.arm64-linux.ubuntu-24.04-arm_glibc2.39.tgz";
+        sha256 = "sha256-rn65t253SfUShAM3kXiLQJHT7JS7EO3fAPB23LWIwfc=";
+      })
     else if stdenv.hostPlatform.system == "x86_64-darwin" then
       (fetchurl {
         url = "https://github.com/MLton/mlton/releases/download/on-${version}-release/${pname}-${version}-1.amd64-darwin.macos-13_gmp-static.tgz";

--- a/pkgs/development/compilers/mlton/20241230-binary.nix
+++ b/pkgs/development/compilers/mlton/20241230-binary.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  patchelf,
+  bash,
+  gmp,
+}:
+let
+  dynamic-linker = stdenv.cc.bintools.dynamicLinker;
+in
+stdenv.mkDerivation rec {
+  pname = "mlton";
+  version = "20241230";
+
+  src =
+    if stdenv.hostPlatform.system == "x86_64-linux" then
+      (fetchurl {
+        url = "https://github.com/MLton/mlton/releases/download/on-${version}-release/${pname}-${version}-1.amd64-linux.ubuntu-24.04_glibc2.39.tgz";
+        sha256 = "sha256-ldXnjHcWGu77LP9WL6vTC6FngzhxPFAUflAA+bpIFZM=";
+      })
+    else if stdenv.hostPlatform.system == "x86_64-darwin" then
+      (fetchurl {
+        url = "https://github.com/MLton/mlton/releases/download/on-${version}-release/${pname}-${version}-1.amd64-darwin.macos-13_gmp-static.tgz";
+        sha256 = "sha256-fW0hqjrWUcy+PIN8WHb1r4EYgfuwF9Zz3q7f2ZtxOi0=";
+      })
+    else if stdenv.hostPlatform.system == "aarch64-darwin" then
+      (fetchurl {
+        url = "https://github.com/MLton/mlton/releases/download/on-${version}-release/${pname}-${version}-1.arm64-darwin.macos-15_gmp-static.tgz";
+        sha256 = "sha256-xhFP2plFjP/mbLz1CNtlZzkm0Kx6twfD/Dmn79Vj908=";
+      })
+    else
+      throw "Architecture not supported";
+
+  buildInputs = [
+    bash
+    gmp
+  ];
+  nativeBuildInputs = lib.optional stdenv.hostPlatform.isLinux patchelf;
+  strictDeps = true;
+
+  buildPhase = ''
+    make update \
+      CC="$(type -p cc)" \
+      WITH_GMP_INC_DIR="${gmp.dev}/include" \
+      WITH_GMP_LIB_DIR="${gmp}/lib"
+  '';
+
+  installPhase = ''
+    make install PREFIX=$out
+  '';
+
+  postFixup =
+    lib.optionalString stdenv.hostPlatform.isLinux ''
+      patchelf --set-interpreter ${dynamic-linker} $out/lib/mlton/mlton-compile
+      patchelf --set-rpath ${gmp}/lib $out/lib/mlton/mlton-compile
+
+      for e in mllex mlnlffigen mlprof mlyacc; do
+        patchelf --set-interpreter ${dynamic-linker} $out/bin/$e
+        patchelf --set-rpath ${gmp}/lib $out/bin/$e
+      done
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      install_name_tool -change \
+        /opt/local/lib/libgmp.10.dylib \
+        ${gmp}/lib/libgmp.10.dylib \
+        $out/lib/mlton/mlton-compile
+
+      for e in mllex mlnlffigen mlprof mlyacc; do
+        install_name_tool -change \
+          /opt/local/lib/libgmp.10.dylib \
+          ${gmp}/lib/libgmp.10.dylib \
+          $out/bin/$e
+      done
+    '';
+
+  meta = import ./meta.nix { inherit lib; };
+}

--- a/pkgs/development/compilers/mlton/default.nix
+++ b/pkgs/development/compilers/mlton/default.nix
@@ -9,7 +9,7 @@ rec {
     mltonBootstrap = mlton20180207Binary;
     version = "20180207";
     rev = "on-20180207-release";
-    sha256 = "00rdd2di5x1dzac64il9z05m3fdzicjd3226wwjyynv631jj3q2a";
+    hash = "sha256-SuAhZRhmW+8l50aI0SSLv7lRC/iJRmKY+i30EptoLQM=";
   };
 
   mlton20210117Binary = callPackage ./20210117-binary.nix { };
@@ -18,7 +18,7 @@ rec {
     mltonBootstrap = mlton20210117Binary;
     version = "20210117";
     rev = "on-20210117-release";
-    sha256 = "sha256-rqL8lnzVVR+5Hc7sWXK8dCXN92dU76qSoii3/4StODM=";
+    hash = "sha256-rqL8lnzVVR+5Hc7sWXK8dCXN92dU76qSoii3/4StODM=";
   };
 
   mlton20241230Binary = callPackage ./20241230-binary.nix { };
@@ -27,7 +27,7 @@ rec {
     mltonBootstrap = mlton20241230Binary;
     version = "20241230";
     rev = "on-20241230-release";
-    sha256 = "sha256-gJUzav2xH8C4Vy5FuqN73Z6lPMSPQgJApF8LgsJXRWo=";
+    hash = "sha256-gJUzav2xH8C4Vy5FuqN73Z6lPMSPQgJApF8LgsJXRWo=";
     # https://github.com/MLton/mlton/issues/631
     doCheck = !(stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isDarwin);
   };
@@ -36,7 +36,7 @@ rec {
     mltonBootstrap = mlton20241230Binary;
     version = "HEAD";
     rev = "61baac7108fbd91413f0537b7a42d9a1023455f4";
-    sha256 = "sha256-nWR7ZaXfKxeXfZ9IHipAQ39ASVtva4BeDHP3Zq8mqPo=";
+    hash = "sha256-nWR7ZaXfKxeXfZ9IHipAQ39ASVtva4BeDHP3Zq8mqPo=";
     # https://github.com/MLton/mlton/issues/631
     doCheck = !(stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isDarwin);
   };

--- a/pkgs/development/compilers/mlton/default.nix
+++ b/pkgs/development/compilers/mlton/default.nix
@@ -21,8 +21,10 @@ rec {
     sha256 = "sha256-rqL8lnzVVR+5Hc7sWXK8dCXN92dU76qSoii3/4StODM=";
   };
 
+  mlton20241230Binary = callPackage ./20241230-binary.nix { };
+
   mlton20241230 = callPackage ./from-git-source.nix {
-    mltonBootstrap = mlton20210117Binary;
+    mltonBootstrap = mlton20241230Binary;
     version = "20241230";
     rev = "on-20241230-release";
     sha256 = "sha256-gJUzav2xH8C4Vy5FuqN73Z6lPMSPQgJApF8LgsJXRWo=";
@@ -31,7 +33,7 @@ rec {
   };
 
   mltonHEAD = callPackage ./from-git-source.nix {
-    mltonBootstrap = mlton20210117Binary;
+    mltonBootstrap = mlton20241230Binary;
     version = "HEAD";
     rev = "61baac7108fbd91413f0537b7a42d9a1023455f4";
     sha256 = "sha256-nWR7ZaXfKxeXfZ9IHipAQ39ASVtva4BeDHP3Zq8mqPo=";

--- a/pkgs/development/compilers/mlton/from-git-source.nix
+++ b/pkgs/development/compilers/mlton/from-git-source.nix
@@ -5,7 +5,7 @@
   mltonBootstrap,
   url ? "https://github.com/mlton/mlton",
   rev,
-  sha256,
+  hash,
   stdenv,
   version,
   which,
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
   inherit version doCheck;
 
   src = fetchgit {
-    inherit url rev sha256;
+    inherit url rev hash;
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/compilers/mlton/meta.nix
+++ b/pkgs/development/compilers/mlton/meta.nix
@@ -17,6 +17,7 @@
   platforms = [
     "i686-linux"
     "x86_64-linux"
+    "aarch64-linux"
     "x86_64-darwin"
     "aarch64-darwin"
   ];

--- a/pkgs/development/compilers/mlton/meta.nix
+++ b/pkgs/development/compilers/mlton/meta.nix
@@ -14,6 +14,7 @@
 
   homepage = "http://mlton.org/";
   license = lib.licenses.smlnj;
+  maintainers = [ lib.maintainers.poz ];
   platforms = [
     "i686-linux"
     "x86_64-linux"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4647,7 +4647,9 @@ with pkgs;
     mlton20130715
     mlton20180207Binary
     mlton20180207
+    mlton20210117Binary
     mlton20210117
+    mlton20241230Binary
     mlton20241230
     mltonHEAD
     ;


### PR DESCRIPTION
- add `mlton20241230Binary`
- add `aarch64-linux` to the package's platforms (only supported in the newest release)
- make all the `mlton*Binary` packages available in nixpkgs (only `mlton20180207Binary` was available prior)
- switch all hashes in all the packages from `sha256` to `hash` - some of them were fetched manually with the following command: `nix hash convert --from nix32 --to base64 --hash-algo sha256 $(nix-prefetch-url "$URL")`
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
