### PR TITLE
Revert "llama-cpp: 6981 -> 7062"

### DIFF
--- a/pkgs/by-name/ll/llama-cpp/package.nix
+++ b/pkgs/by-name/ll/llama-cpp/package.nix
@@ -74,13 +74,13 @@ let
 in
 effectiveStdenv.mkDerivation (finalAttrs: {
   pname = "llama-cpp";
-  version = "7062";
+  version = "6981";
 
   src = fetchFromGitHub {
     owner = "ggml-org";
     repo = "llama.cpp";
     tag = "b${finalAttrs.version}";
-    hash = "sha256-UHiyP8XVdTLH4HBF0IVK7nuXPykpqyoePdimUH1y4m4=";
+    hash = "sha256-0WtiHDlMeb+m2XcMwkPFY1mtwVTwRJUoxQSwzpiRbts=";
     leaveDotGit = true;
     postFetch = ''
       git -C "$out" rev-parse --short HEAD > $out/COMMIT


### PR DESCRIPTION
Reverts NixOS/nixpkgs#461791

This bump broke Darwin builds.

```
ld: malformed 64-bit a.b.c.d.e version number: 0.0.7062
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```