### PR TITLE
nixos/onlyoffice: require a user supplied nonce

### DIFF
--- a/nixos/modules/services/web-apps/onlyoffice.nix
+++ b/nixos/modules/services/web-apps/onlyoffice.nix
@@ -7,10 +7,6 @@
 
 let
   cfg = config.services.onlyoffice;
-  defaultNginxNonceFileContent = "set $secure_link_secret \"mynonce\";";
-  defaultNginxNonceFile = pkgs.writeText "onlyoffice-nonce-nginx.conf" ''
-    ${defaultNginxNonceFileContent}
-  '';
 in
 {
   options.services.onlyoffice = {
@@ -26,17 +22,14 @@ in
 
     securityNonceFile = lib.mkOption {
       type = lib.types.str;
-      default = "${defaultNginxNonceFile}";
-      defaultText = lib.literalExpression ''
-        (pkgs.writeText "onlyoffice-nonce-nginx.conf" \'\'
-          ${defaultNginxNonceFileContent}
-        \'\').outPath;
-      '';
+      example = "/run/keys/onlyoffice-nginx-nonce.conf";
       description = ''
-        Path to a file that contains a secret to sign web requests.
-        This file should set a 'secure_link_secret' nginx variable,
-        and ideally be managed by a
-        [secret managing scheme](https://wiki.nixos.org/wiki/Comparison_of_secret_managing_schemes).
+        File holding nginx configuration that sets the nonce used to create secret links.
+
+        Example:
+        ```
+        set $secure_link_secret "changeme";
+        ```
       '';
     };
 
@@ -103,12 +96,6 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    warnings = [
-      (lib.optionalString (cfg.securityNonceFile == "${defaultNginxNonceFile}") ''
-        Please set `options.services.onlyoffice.securityNonceFile`
-        to avoid an (albeit unlikely) information disclosure issue.
-      '')
-    ];
     services = {
       nginx = {
         enable = lib.mkDefault true;


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
