### PR TITLE
nixos/onlyoffice: add simple test

### DIFF
--- a/nixos/modules/services/web-apps/onlyoffice.nix
+++ b/nixos/modules/services/web-apps/onlyoffice.nix
@@ -330,6 +330,7 @@ in
           after = [
             "network.target"
             "postgresql.target"
+            "rabbitmq.service"
           ];
           requires = [ "postgresql.target" ];
           wantedBy = [ "multi-user.target" ];

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1139,6 +1139,7 @@ in
   ombi = runTest ./ombi.nix;
   omnom = runTest ./omnom;
   oncall = runTest ./web-apps/oncall.nix;
+  onlyoffice = runTest ./onlyoffice.nix;
   open-web-calendar = runTest ./web-apps/open-web-calendar.nix;
   open-webui = runTest ./open-webui.nix;
   openarena = runTest ./openarena.nix;

--- a/nixos/tests/onlyoffice.nix
+++ b/nixos/tests/onlyoffice.nix
@@ -1,0 +1,30 @@
+let
+  port = 8000;
+in
+{
+  name = "onlyoffice";
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.onlyoffice = {
+        enable = true;
+        inherit port;
+        hostname = "office.example.com";
+        securityNonceFile = "${pkgs.writeText "nixos-test-onlyoffice-nonce.conf" ''
+          set $secure_link_secret "nixostest";
+        ''}";
+      };
+
+      networking.hosts = {
+        "::1" = [ "office.example.com" ];
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("onlyoffice-docservice.service")
+    machine.wait_for_unit("onlyoffice-converter.service")
+    machine.wait_for_open_port(${builtins.toString port})
+    machine.succeed("curl --fail http://office.example.com/healthcheck")
+  '';
+}

--- a/pkgs/by-name/on/onlyoffice-documentserver/package.nix
+++ b/pkgs/by-name/on/onlyoffice-documentserver/package.nix
@@ -10,6 +10,7 @@
   liberation_ttf_v1,
   writeScript,
   xorg,
+  nixosTests,
 }:
 
 let
@@ -72,6 +73,7 @@ let
     dontStrip = true;
 
     passthru = {
+      tests = nixosTests.onlyoffice;
       fhs = buildFHSEnv {
         name = "onlyoffice-wrapper";
 


### PR DESCRIPTION
## Things done

depends on #462100 and #418459

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
