### PR TITLE
cryptomator-cli: init at 0.6.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16074,6 +16074,11 @@
     githubId = 29855073;
     name = "Michael Colicchia";
   };
+  masrlinu = {
+    github = "masrlinu";
+    githubId = 5259918;
+    name = "masrlinu";
+  };
   massimogengarelli = {
     email = "massimo.gengarelli@gmail.com";
     github = "massix";

--- a/pkgs/by-name/cr/cryptomator-cli/package.nix
+++ b/pkgs/by-name/cr/cryptomator-cli/package.nix
@@ -1,0 +1,108 @@
+{
+  fetchFromGitHub,
+  fuse3,
+  installShellFiles,
+  zulu25,
+  lib,
+  makeShellWrapper,
+  maven,
+  nix-update-script,
+  stdenv,
+  versionCheckHook,
+}:
+
+let
+  jdk = zulu25;
+in
+maven.buildMavenPackage rec {
+  pname = "cryptomator-cli";
+  version = "0.6.2";
+
+  src = fetchFromGitHub {
+    owner = "cryptomator";
+    repo = "cli";
+    tag = version;
+    hash = "sha256-rwARleKktGXmumIBmrPrfls4EywBqGBxOaB8/ka5ds0=";
+  };
+
+  mvnJdk = jdk;
+  mvnParameters = "-Dmaven.test.skip=true";
+  mvnHash = "sha256-54DT4C+WzyUBPxayA9YnB9I/Igd19iZygByUh5of51I=";
+
+  env = {
+    APP_VERSION = version;
+    SEMVER_STR = version;
+  };
+
+  nativeBuildInputs = [
+    jdk
+    makeShellWrapper
+    installShellFiles
+  ];
+
+  # Based on the build_linux.sh script and jpackage configuration
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin/ $out/share/cryptomator-cli/libs/ $out/share/cryptomator-cli/mods/
+    mkdir -p $out/share/bash-completion/completions/
+
+    # Copy dependencies
+    cp target/libs/* $out/share/cryptomator-cli/libs/
+    cp target/mods/* target/cryptomator-cli-*.jar $out/share/cryptomator-cli/mods/
+
+    installShellCompletion --bash target/cryptomator-cli_completion.sh
+
+    # Determine native access package based on architecture
+    NATIVE_ACCESS_PACKAGE=${
+      if stdenv.hostPlatform.isx86_64 then
+        "org.cryptomator.jfuse.linux.amd64"
+      else if stdenv.hostPlatform.isAarch64 then
+        "org.cryptomator.jfuse.linux.aarch64"
+      else
+        "no.native.access.available"
+    }
+
+    # Create wrapper script
+    makeShellWrapper ${jdk}/bin/java $out/bin/cryptomator-cli \
+      --add-flags "--enable-native-access=$NATIVE_ACCESS_PACKAGE,org.fusesource.jansi" \
+      --add-flags "--class-path '$out/share/cryptomator-cli/libs/*'" \
+      --add-flags "--module-path '$out/share/cryptomator-cli/mods'" \
+      --add-flags "-Dfile.encoding='utf-8'" \
+      --add-flags "-Dorg.cryptomator.cli.version='${version}'" \
+      --add-flags "-Xss5m" \
+      --add-flags "-Xmx256m" \
+      --add-flags "--module org.cryptomator.cli/org.cryptomator.cli.CryptomatorCli" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ fuse3 ]}" \
+      --set JAVA_HOME "${jdk.home}"
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  versionCheckProgramArg = "--version";
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Command line program to access encrypted Cryptomator vaults";
+    homepage = "https://github.com/cryptomator/cli";
+    changelog = "https://github.com/cryptomator/cli/releases/tag/${version}";
+    license = lib.licenses.agpl3Plus;
+    mainProgram = "cryptomator-cli";
+    maintainers = with lib.maintainers; [
+      masrlinu
+    ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryBytecode # maven dependencies
+    ];
+  };
+}

--- a/pkgs/by-name/cr/cryptomator/package.nix
+++ b/pkgs/by-name/cr/cryptomator/package.nix
@@ -44,7 +44,7 @@ maven.buildMavenPackage rec {
     cp target/libs/* $out/share/cryptomator/libs/
     cp target/mods/* target/cryptomator-*.jar $out/share/cryptomator/mods/
 
-    makeShellWrapper ${jdk}/bin/java $out/bin/${pname} \
+    makeShellWrapper ${jdk}/bin/java $out/bin/cryptomator \
       --add-flags "--enable-preview" \
       --add-flags "--enable-native-access=org.cryptomator.jfuse.linux.amd64,org.purejava.appindicator" \
       --add-flags "--class-path '$out/share/cryptomator/libs/*'" \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
I added the [cryptomator-cli](https://github.com/cryptomator/cli) command-line application.

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
