### PR TITLE
c-ares: fix IPv6 link-local DNS server support

### DIFF
--- a/pkgs/development/libraries/c-ares/default.nix
+++ b/pkgs/development/libraries/c-ares/default.nix
@@ -26,6 +26,11 @@ stdenv.mkDerivation rec {
     hash = "sha256-fZNXkOmvCBwlxJX9E8LPzaR5KYNBjpY1jvbnMg7gY0Y=";
   };
 
+  patches = [
+    # Fix being unable to use Ipv6 link-local DNS servers. See: https://github.com/c-ares/c-ares/pull/997.
+    ./fix-link-local-dns-servers.patch
+  ];
+
   outputs = [
     "out"
     "dev"

--- a/pkgs/development/libraries/c-ares/fix-link-local-dns-servers.patch
+++ b/pkgs/development/libraries/c-ares/fix-link-local-dns-servers.patch
@@ -1,0 +1,50 @@
+From 0fbeb87f65ad9e9e6cead10d778291db71489f34 Mon Sep 17 00:00:00 2001
+From: iucoen <68678186+iucoen@users.noreply.github.com>
+Date: Thu, 5 Jun 2025 20:08:43 -0700
+Subject: [PATCH] Fix IPv6 link-local nameservers in /etc/resolv.conf (#997)
+
+There are two issues that broke link-local nameservers in resolv.conf
+1. channel->sock_funcs needs to be initialized before
+ares_init_by_sysconfig()
+2. The aif_nametoindex and aif_indextoname function pointers were not
+initlized at all.
+---
+ src/lib/ares_init.c                 | 4 ++--
+ src/lib/ares_set_socket_functions.c | 2 ++
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/src/lib/ares_init.c b/src/lib/ares_init.c
+index ae78262a11..ce6181833c 100644
+--- a/src/lib/ares_init.c
++++ b/src/lib/ares_init.c
+@@ -271,6 +271,8 @@ int ares_init_options(ares_channel_t           **channelptr,
+     goto done;
+   }
+ 
++  ares_set_socket_functions_def(channel);
++
+   /* Initialize Server List */
+   channel->servers =
+     ares_slist_create(channel->rand_state, server_sort_cb, server_destroy_cb);
+@@ -346,8 +348,6 @@ int ares_init_options(ares_channel_t           **channelptr,
+     goto done;
+   }
+ 
+-  ares_set_socket_functions_def(channel);
+-
+   /* Initialize the event thread */
+   if (channel->optmask & ARES_OPT_EVENT_THREAD) {
+     ares_event_thread_t *e = NULL;
+diff --git a/src/lib/ares_set_socket_functions.c b/src/lib/ares_set_socket_functions.c
+index cfe434327d..9994e81df5 100644
+--- a/src/lib/ares_set_socket_functions.c
++++ b/src/lib/ares_set_socket_functions.c
+@@ -127,6 +127,8 @@ ares_status_t
+     channel->sock_funcs.asendto      = funcs->asendto;
+     channel->sock_funcs.agetsockname = funcs->agetsockname;
+     channel->sock_funcs.abind        = funcs->abind;
++    channel->sock_funcs.aif_nametoindex = funcs->aif_nametoindex;
++    channel->sock_funcs.aif_indextoname = funcs->aif_indextoname;
+   }
+ 
+   /* Implement newer versions here ...*/


### PR DESCRIPTION
My network only advertises an IPv6 link-local DNS server. After https://github.com/NixOS/nixpkgs/pull/451579, Lix is basically broken for me because it can’t access GitHub or cache.nixos.org.

Fortunately, this is fixed upstream but not yet available in a release, so the patch can be cherry-picked.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
