### PR TITLE
python3Packages.elkoep-aio-mqtt: init at 0.1.0b4

### DIFF
--- a/pkgs/development/python-modules/elkoep-aio-mqtt/default.nix
+++ b/pkgs/development/python-modules/elkoep-aio-mqtt/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  attrs,
+  paho-mqtt,
+  pytest-asyncio,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "elkoep-aio-mqtt";
+  version = "0.1.0.beta.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "epdevlab";
+    repo = "elkoep-aio-mqtt";
+    tag = "0.1.0.beta.4";
+    hash = "sha256-pQzM0wLLZk6cEizhDqLbVF4pMeyefgSUU0ay3CiGgAE=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    attrs
+    paho-mqtt
+  ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "inelsmqtt" ];
+
+  meta = {
+    description = "Python library for iNELS mqtt protocol";
+    homepage = "https://github.com/epdevlab/elkoep-aio-mqtt";
+    changelog = "https://github.com/epdevlab/elkoep-aio-mqtt/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2729,8 +2729,9 @@
     "inels" =
       ps: with ps; [
         aiohasupervisor
+        elkoep-aio-mqtt
         paho-mqtt
-      ]; # missing inputs: elkoep-aio-mqtt
+      ];
     "influxdb" =
       ps: with ps; [
         influxdb
@@ -7425,6 +7426,7 @@
     "immich"
     "improv_ble"
     "incomfort"
+    "inels"
     "influxdb"
     "inkbird"
     "input_boolean"

--- a/pkgs/servers/home-assistant/update-component-packages.py
+++ b/pkgs/servers/home-assistant/update-component-packages.py
@@ -39,6 +39,7 @@ PKG_SET = "home-assistant.python.pkgs"
 # If some requirements are matched by multiple or no Python packages, the
 # following can be used to choose the correct one
 PKG_PREFERENCES = {
+    "av": "av",
     "fiblary3": "fiblary3-fork",  # https://github.com/home-assistant/core/issues/66466
     "HAP-python": "hap-python",
     "ha-av": "av",

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4763,6 +4763,8 @@ self: super: with self; {
 
   elkm1-lib = callPackage ../development/python-modules/elkm1-lib { };
 
+  elkoep-aio-mqtt = callPackage ../development/python-modules/elkoep-aio-mqtt { };
+
   elmax = callPackage ../development/python-modules/elmax { };
 
   elmax-api = callPackage ../development/python-modules/elmax-api { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- https://pypi.org/project/elkoep-aio-mqtt/
- https://github.com/epdevlab/elkoep-aio-mqtt
- https://www.home-assistant.io/integrations/inels/

NOTE: I can't run `update-component-packages.py` as it is curretly failing with

```
Traceback (most recent call last):
  File "/home/jamie/src/code/nixpkgs/./pkgs/servers/home-assistant/update-component-packages.py", line 333, in <module>
    main()
    ~~~~^^
  File "/home/jamie/src/code/nixpkgs/./pkgs/servers/home-assistant/update-component-packages.py", line 240, in main
    attr_path = name_to_attr_path(name, packages)
  File "/home/jamie/src/code/nixpkgs/./pkgs/servers/home-assistant/update-component-packages.py", line 202, in name_to_attr_path
    assert len(attr_paths) <= 1, f"{req} matches more than one derivation: {attr_paths}"
           ^^^^^^^^^^^^^^^^^^^^
AssertionError: av matches more than one derivation: ['home-assistant.python.pkgs.av', 'home-assistant.python.pkgs.av_13']
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
