### PR TITLE
nixos/tests/ringboard: make more resistant against race condition

### DIFF
--- a/nixos/tests/ringboard.nix
+++ b/nixos/tests/ringboard.nix
@@ -6,7 +6,7 @@
 }:
 {
   name = "ringboard";
-  meta = { inherit (pkgs.ringboard.meta) maintainers; };
+  meta.maintainers = pkgs.ringboard.meta.maintainers ++ (with lib.maintainers; [ h7x4 ]);
 
   nodes.machine = {
     imports = [

--- a/nixos/tests/ringboard.nix
+++ b/nixos/tests/ringboard.nix
@@ -43,10 +43,12 @@
 
       with subtest("Ensure clipboard is monitored"):
         with gedit_running: # type: ignore[union-attr]
-          machine.send_chars("Hello world!")
+          machine.send_chars("Hello world!", delay=0.1)
+          machine.sleep(1)
           machine.send_key("ctrl-a")
+          machine.sleep(1)
           machine.send_key("ctrl-c")
-          machine.wait_for_console_text("Small selection transfer complete")
-          machine.succeed("su - '${user}' -c 'ringboard search Hello | grep world!'")
+        machine.wait_until_succeeds("su - '${user}' -c 'journalctl --user -u ringboard-listener.service --grep \'Small selection transfer complete\'''", timeout=60)
+        machine.succeed("su - '${user}' -c 'ringboard search Hello | grep world!'")
     '';
 }

--- a/nixos/tests/ringboard.nix
+++ b/nixos/tests/ringboard.nix
@@ -17,11 +17,13 @@
     test-support.displayManager.auto.user = "alice";
 
     services.xserver.displayManager.sessionCommands = ''
-      '${lib.getExe pkgs.gedit}' &
+      '${lib.getExe pkgs.gedit}' my_document &
     '';
 
     services.ringboard.x11.enable = true;
   };
+
+  enableOCR = true;
 
   testScript =
     { nodes, ... }:
@@ -31,7 +33,8 @@
     ''
       @polling_condition
       def gedit_running():
-        machine.succeed("pgrep gedit")
+        "Check that gedit is running and visible to the user"
+        machine.wait_for_text("my_document")
 
       with subtest("Wait for service startup"):
         machine.wait_for_unit("graphical.target")


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The main thing this PR does, is to change a polling target from a successful pgrep to waiting for actual screen output. This, in addition with some typing delay, should make the test less prone to failures by race conditions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
