### PR TITLE
nix-prefetch-scripts: reduce closure sizes

### DIFF
--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -2,7 +2,6 @@
   config,
   lib,
   stdenvNoCC,
-  writeText,
   git,
   git-lfs,
   cacert,

--- a/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
+++ b/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
@@ -41,7 +41,7 @@ let
         set -eu
         export PATH="${lib.makeBinPath deps}:$PATH"
         export HOME="/homeless-shelter"
-        exec ${src} "$@"
+        exec ${lib.getExe shell} ${src} "$@"
       '';
 
       checkPhase = /* sh */ ''
@@ -52,7 +52,10 @@ let
 
       meta = {
         description = "Script used to obtain source hashes for fetch${tool}";
-        maintainers = with lib.maintainers; [ bennofs ];
+        maintainers = with lib.maintainers; [
+          bennofs
+          toastal
+        ];
         platforms = lib.platforms.unix;
         mainProgram = "nix-prefetch-${tool}";
       };

--- a/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
+++ b/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
@@ -1,9 +1,10 @@
 {
   lib,
-  stdenv,
-  makeWrapper,
+  stdenvNoCC,
+  writeTextFile,
   buildEnv,
   bash,
+  dash,
   breezy,
   cacert,
   coreutils,
@@ -11,8 +12,9 @@
   darcs,
   findutils,
   gawk,
-  gitMinimal,
+  git,
   git-lfs,
+  gnugrep,
   gnused,
   jq,
   mercurial,
@@ -22,32 +24,31 @@
 
 let
   mkPrefetchScript =
-    tool: src: deps:
-    stdenv.mkDerivation {
+    {
+      tool,
+      src,
+      # most of the prefetch scripts are POSIX-compliant, so Bash’s overhead
+      # isn’t required
+      shell ? dash,
+      deps ? [ ],
+    }:
+    writeTextFile {
       name = "nix-prefetch-${tool}";
-
-      strictDeps = true;
-      nativeBuildInputs = [ makeWrapper ];
-      buildInputs = [ bash ];
-
-      dontUnpack = true;
-
-      installPhase = ''
-        install -vD ${src} $out/bin/$name;
-        wrapProgram $out/bin/$name \
-          --prefix PATH : ${
-            lib.makeBinPath (
-              deps
-              ++ [
-                coreutils
-                gnused
-              ]
-            )
-          } \
-          --set HOME /homeless-shelter
+      executable = true;
+      destination = "/bin/nix-prefetch-${tool}";
+      text = /* sh */ ''
+        #!${lib.getExe shell}
+        set -eu
+        export PATH="${lib.makeBinPath deps}:$PATH"
+        export HOME="/homeless-shelter"
+        exec ${src} "$@"
       '';
 
-      preferLocalBuild = true;
+      checkPhase = /* sh */ ''
+        runHook preCheck
+        ${stdenvNoCC.shellDryRun} "$target"
+        runHook postCheck
+      '';
 
       meta = {
         description = "Script used to obtain source hashes for fetch${tool}";
@@ -61,34 +62,77 @@ rec {
   # No explicit dependency on Nix, as these can be used inside builders,
   # and thus will cause dependency loops. When used _outside_ builders,
   # we expect people to have a Nix implementation available ambiently.
-  nix-prefetch-bzr = mkPrefetchScript "bzr" ../../../build-support/fetchbzr/nix-prefetch-bzr [
-    breezy
-  ];
-  nix-prefetch-cvs = mkPrefetchScript "cvs" ../../../build-support/fetchcvs/nix-prefetch-cvs [ cvs ];
-  nix-prefetch-darcs = mkPrefetchScript "darcs" ../../../build-support/fetchdarcs/nix-prefetch-darcs [
-    darcs
-    cacert
-    gawk
-    jq
-  ];
-  nix-prefetch-git = mkPrefetchScript "git" ../../../build-support/fetchgit/nix-prefetch-git [
-    findutils
-    gawk
-    gitMinimal
-    git-lfs
-  ];
-  nix-prefetch-hg = mkPrefetchScript "hg" ../../../build-support/fetchhg/nix-prefetch-hg [
-    mercurial
-  ];
-  nix-prefetch-svn = mkPrefetchScript "svn" ../../../build-support/fetchsvn/nix-prefetch-svn [
-    subversion
-  ];
-  nix-prefetch-pijul = mkPrefetchScript "pijul" ../../../build-support/fetchpijul/nix-prefetch-pijul [
-    gawk
-    pijul
-    cacert
-    jq
-  ];
+  nix-prefetch-bzr = mkPrefetchScript {
+    tool = "bzr";
+    src = ../../../build-support/fetchbzr/nix-prefetch-bzr;
+    deps = [
+      breezy
+      coreutils
+      gnused
+    ];
+  };
+  nix-prefetch-cvs = mkPrefetchScript {
+    tool = "cvs";
+    src = ../../../build-support/fetchcvs/nix-prefetch-cvs;
+    deps = [
+      coreutils
+      cvs
+    ];
+  };
+  nix-prefetch-darcs = mkPrefetchScript {
+    tool = "darcs";
+    src = ../../../build-support/fetchdarcs/nix-prefetch-darcs;
+    deps = [
+      cacert
+      coreutils
+      darcs
+      gawk
+      jq
+    ];
+  };
+  nix-prefetch-git = mkPrefetchScript {
+    tool = "git";
+    src = ../../../build-support/fetchgit/nix-prefetch-git;
+    shell = bash;
+    deps = [
+      coreutils
+      findutils
+      gawk
+      git
+      git-lfs
+      gnused
+    ];
+  };
+  nix-prefetch-hg = mkPrefetchScript {
+    tool = "hg";
+    src = ../../../build-support/fetchhg/nix-prefetch-hg;
+    shell = bash;
+    deps = [
+      coreutils
+      mercurial
+    ];
+  };
+  nix-prefetch-svn = mkPrefetchScript {
+    tool = "svn";
+    src = ../../../build-support/fetchsvn/nix-prefetch-svn;
+    deps = [
+      coreutils
+      gnugrep
+      gnused
+      subversion
+    ];
+  };
+  nix-prefetch-pijul = mkPrefetchScript {
+    tool = "pijul";
+    src = ../../../build-support/fetchpijul/nix-prefetch-pijul;
+    deps = [
+      coreutils
+      gawk
+      pijul
+      cacert
+      jq
+    ];
+  };
 
   nix-prefetch-scripts = buildEnv {
     name = "nix-prefetch-scripts";


### PR DESCRIPTION
No need for a C compiler, excessively long wrappers, unused sed requirement, or even Bash in most cases. See:

```bash
#! /nix/store/qsydfxm1vq6q9jac2kq3r8kn0xdmsldf-bash-5.3p3/bin/bash -e
PATH=${PATH:+':'$PATH':'}
PATH=${PATH/':''/nix/store/6m00pqnmmvyfbcihx6l0x2hinw1n6412-gnused-4.9/bin'':'/':'}
PATH='/nix/store/6m00pqnmmvyfbcihx6l0x2hinw1n6412-gnused-4.9/bin'$PATH
PATH=${PATH#':'}
PATH=${PATH%':'}
export PATH
PATH=${PATH:+':'$PATH':'}
PATH=${PATH/':''/nix/store/jbz6j4iwnrvki1zl34hwcyj2i0m6l2y1-coreutils-9.8/bin'':'/':'}
PATH='/nix/store/jbz6j4iwnrvki1zl34hwcyj2i0m6l2y1-coreutils-9.8/bin'$PATH
PATH=${PATH#':'}
PATH=${PATH%':'}
export PATH
PATH=${PATH:+':'$PATH':'}
PATH=${PATH/':''/nix/store/c6rkwr11izd7jvkrfcg6pygild509nvm-jq-1.8.1-bin/bin'':'/':'}
PATH='/nix/store/c6rkwr11izd7jvkrfcg6pygild509nvm-jq-1.8.1-bin/bin'$PATH
PATH=${PATH#':'}
PATH=${PATH%':'}
export PATH
PATH=${PATH:+':'$PATH':'}
PATH=${PATH/':''/nix/store/c7z2rbd7d9md02a85vqgj5qd4ainhsxp-nss-cacert-3.115/bin'':'/':'}
PATH='/nix/store/c7z2rbd7d9md02a85vqgj5qd4ainhsxp-nss-cacert-3.115/bin'$PATH
PATH=${PATH#':'}
PATH=${PATH%':'}
export PATH
PATH=${PATH:+':'$PATH':'}
PATH=${PATH/':''/nix/store/3dddib81zrkwmp7n503fyvx7gwqk790n-darcs-2.18.5/bin'':'/':'}
PATH='/nix/store/3dddib81zrkwmp7n503fyvx7gwqk790n-darcs-2.18.5/bin'$PATH
PATH=${PATH#':'}
PATH=${PATH%':'}
export PATH
export HOME='/homeless-shelter'
exec -a "$0" "/nix/store/9xdjxcrxwcmhgpbrlql9rjjscg1zi3ww-nix-prefetch-darcs/bin/.nix-prefetch-darcs-wrapped"  "$@"
```

vs

```sh
#!/nix/store/bphwhpaihwv3fy3sr3cw93ja9104hcdb-dash-0.5.13.1/bin/dash
set -eu
export PATH="/nix/store/3dddib81zrkwmp7n503fyvx7gwqk790n-darcs-2.18.5/bin:/nix/store/c7z2rbd7d9md02a85vqgj5qd4ainhsxp-nss-cacert-3.115/bin:/nix/store/x1hg09529m2m87r2yf5v51xws1mqcrls-gnugrep-3.12/bin:/nix/store/c6rkwr11izd7jvkrfcg6pygild509nvm-jq-1.8.1-bin/bin:/nix/store/jbz6j4iwnrvki1zl34hwcyj2i0m6l2y1-coreutils-9.8/bin:$PATH"
export HOME="/homeless-shelter"
exec /nix/store/mfp16fmbfyap4mrkwkzqgd7g8d4xixbx-nix-prefetch-darcs "$@"
```

OR closure size 96.61 MB ~~(using, the now merged, patch from #462164)~~

```sh-session
$ nix path-info -rs (nix build --print-out-paths github:toastal/nixpkgs?ref=prefetch-darcs-pijul-exposed#nix-prefetch-darcs) | awk '{sum+=$2} {printf "%s %s\n", $1, $2} END {printf "total %s\n", sum}'
/nix/store/1133bhx595n0l0ixkx3xhbyd46sph0kc-publicsuffix-list-0-unstable-2025-10-08 328504
/nix/store/4yxrw9flcvca7f3fs7c5igl2ica39zaw-xgcc-14.3.0-libgcc 201848
/nix/store/4hym1sjgn93x4m0jvnsk473559vi3hrj-libunistring-1.4.1 2078896
/nix/store/7p6xwm1aip6s2p6y6iz1i5qj23ycvx04-libidn2-2.3.8 368208
/nix/store/rcp9sdrrq8sfxkm5zdykglx7hd2gzbfy-glibc-2.40-66 30184344
/nix/store/1cpjlc8bpqzqjksx45vyaldnxpirll9q-bzip2-1.0.8 84856
/nix/store/1ivcszzgvk8hcajxy9dfcw33021sl8sv-libpsl-0.21.5 113504
/nix/store/7pf9f2s85rzacw7xcsyy5raf64g191kj-libffi-3.5.2 73816
/nix/store/l1q4cdis5blgij8ac1cwwmxgm4kl62ab-gcc-14.3.0-libgcc 201848
/nix/store/fly29nz0gwiww48y76myy0mimv12wz5w-gcc-14.3.0-lib 9982176
/nix/store/j7rjhaja4kf7w5rkrgjv9mrnv2wvay3v-numactl-2.0.18 276416
/nix/store/6wz56cnrij20lz1igjrf7kgadp398cqn-json-c-0.18 251040
/nix/store/8ig5g0qdgzz04p71mx4gp6wihrvjgzfy-zstd-1.5.7 1214576
/nix/store/6hy8wj60s4zkpx0lvp90r8lijagcww22-nghttp2-1.67.1-lib 218904
/nix/store/lycdkibz6z2awbpapmzzl2lmiv4iyrc9-openssl-3.6.0 9278592
/nix/store/82c5aiwsms7wkkagagzcvfjbv59r9afd-ngtcp2-1.15.1 472120
/nix/store/g9sl9xap0ycz1wk1pr9iayjmmxwr8dkm-nghttp3-1.12.0 216560
/nix/store/h9xlmpj5qmbs5k7dgn76mls0lp3chmqw-brotli-1.1.0-lib 955928
/nix/store/d5abxinn7ajgclbxhsa6vrpsj24vn6jg-keyutils-1.6.3-lib 42872
/nix/store/hbrfvlf0iq7wan18rymicivj8zql55b7-krb5-1.22.1-lib 2855192
/nix/store/hk5slnz8fbf2j3bli5b8rzjkrykrr5ds-c-ares-1.34.5 282744
/nix/store/rdj62gf4zjpwj5ffxdq5ql0gk3piq09w-zlib-1.3.1 132264
/nix/store/lv585p4ygynpn8f4szxy7fk0dnjz08cj-libssh2-1.11.1 333896
/nix/store/gajzimp0a2hdzxln2xiknaqxkpssdyz0-curl-8.16.0 1102344
/nix/store/y725ml8s15w81wmjfq73px2qvyrg5g97-xz-5.8.1 857952
/nix/store/k4h3ala5bwydm5lbg961690gppv3qwad-elfutils-0.194 4161208
/nix/store/vq5cxqv6vzz3pa5b04207925yvgxdhnv-gmp-with-cxx-6.3.0 787528
/nix/store/y1pvllikybfy1f5ldjxj8xq6hgkrydfb-ncurses-6.5 3799856
/nix/store/3dddib81zrkwmp7n503fyvx7gwqk790n-darcs-2.18.5 15361600
/nix/store/3j5c14y8vic6g6m5f5cfxk23mvxjywl4-readline-8.3p1 510488
/nix/store/6m00pqnmmvyfbcihx6l0x2hinw1n6412-gnused-4.9 735424
/nix/store/kg99gh369vx10w77jl1krcfll4fgxzxq-oniguruma-6.9.10-lib 709584
/nix/store/iiv41cngzdr0925wzi4z14ii7d8kx2d4-jq-1.8.1 432224
/nix/store/c6rkwr11izd7jvkrfcg6pygild509nvm-jq-1.8.1-bin 35680
/nix/store/c7z2rbd7d9md02a85vqgj5qd4ainhsxp-nss-cacert-3.115 751480
/nix/store/cfn5wfckmy8hs13zxy4bj2zlavl5z90w-bash-interactive-5.3p3 7407600
/nix/store/ac4irmhfg2l2lxmssyqyvsjm71z2hs0d-gmp-with-cxx-6.3.0 787528
/nix/store/h5m3hx1rh76knhg942q13xmx18f9wlvb-attr-2.5.2 92720
/nix/store/mi12n7l1p7mx4962sqzq4c18n8ljgnjb-acl-2.3.2 128224
/nix/store/jbz6j4iwnrvki1zl34hwcyj2i0m6l2y1-coreutils-9.8 1635328
/nix/store/qsydfxm1vq6q9jac2kq3r8kn0xdmsldf-bash-5.3p3 1848648
/nix/store/9xdjxcrxwcmhgpbrlql9rjjscg1zi3ww-nix-prefetch-darcs 7096
total 101301616
```

vs 89.91 MB (despite picking up the formerly-missing `gnugrep` input)

```sh-session
$ nix path-info -rs (nix-build -A nix-prefetch-darcs) | awk '{sum+=$2} {printf "%s %s\n", $1, $2} END {printf "total %s\n", sum}'
/nix/store/4yxrw9flcvca7f3fs7c5igl2ica39zaw-xgcc-14.3.0-libgcc 201848
/nix/store/4hym1sjgn93x4m0jvnsk473559vi3hrj-libunistring-1.4.1 2078896
/nix/store/7p6xwm1aip6s2p6y6iz1i5qj23ycvx04-libidn2-2.3.8 368208
/nix/store/rcp9sdrrq8sfxkm5zdykglx7hd2gzbfy-glibc-2.40-66 30184344
/nix/store/y1pvllikybfy1f5ldjxj8xq6hgkrydfb-ncurses-6.5 3799856
/nix/store/018zrcr0a93d9chwy5qmv06lmx3mz3w6-libedit-20251016-3.1 267656
/nix/store/0b10m2y2hxsq0pfvqyjdsz1k0y632nqs-pcre2-10.46 2065864
/nix/store/1133bhx595n0l0ixkx3xhbyd46sph0kc-publicsuffix-list-0-unstable-2025-10-08 328504
/nix/store/1cpjlc8bpqzqjksx45vyaldnxpirll9q-bzip2-1.0.8 84856
/nix/store/1ivcszzgvk8hcajxy9dfcw33021sl8sv-libpsl-0.21.5 113504
/nix/store/7pf9f2s85rzacw7xcsyy5raf64g191kj-libffi-3.5.2 73816
/nix/store/l1q4cdis5blgij8ac1cwwmxgm4kl62ab-gcc-14.3.0-libgcc 201848
/nix/store/fly29nz0gwiww48y76myy0mimv12wz5w-gcc-14.3.0-lib 9982176
/nix/store/j7rjhaja4kf7w5rkrgjv9mrnv2wvay3v-numactl-2.0.18 276416
/nix/store/6wz56cnrij20lz1igjrf7kgadp398cqn-json-c-0.18 251040
/nix/store/8ig5g0qdgzz04p71mx4gp6wihrvjgzfy-zstd-1.5.7 1214576
/nix/store/6hy8wj60s4zkpx0lvp90r8lijagcww22-nghttp2-1.67.1-lib 218904
/nix/store/lycdkibz6z2awbpapmzzl2lmiv4iyrc9-openssl-3.6.0 9278592
/nix/store/82c5aiwsms7wkkagagzcvfjbv59r9afd-ngtcp2-1.15.1 472120
/nix/store/g9sl9xap0ycz1wk1pr9iayjmmxwr8dkm-nghttp3-1.12.0 216560
/nix/store/h9xlmpj5qmbs5k7dgn76mls0lp3chmqw-brotli-1.1.0-lib 955928
/nix/store/d5abxinn7ajgclbxhsa6vrpsj24vn6jg-keyutils-1.6.3-lib 42872
/nix/store/hbrfvlf0iq7wan18rymicivj8zql55b7-krb5-1.22.1-lib 2855192
/nix/store/hk5slnz8fbf2j3bli5b8rzjkrykrr5ds-c-ares-1.34.5 282744
/nix/store/rdj62gf4zjpwj5ffxdq5ql0gk3piq09w-zlib-1.3.1 132264
/nix/store/lv585p4ygynpn8f4szxy7fk0dnjz08cj-libssh2-1.11.1 333896
/nix/store/gajzimp0a2hdzxln2xiknaqxkpssdyz0-curl-8.16.0 1102344
/nix/store/y725ml8s15w81wmjfq73px2qvyrg5g97-xz-5.8.1 857952
/nix/store/k4h3ala5bwydm5lbg961690gppv3qwad-elfutils-0.194 4161208
/nix/store/vq5cxqv6vzz3pa5b04207925yvgxdhnv-gmp-with-cxx-6.3.0 787528
/nix/store/3dddib81zrkwmp7n503fyvx7gwqk790n-darcs-2.18.5 15361600
/nix/store/ac4irmhfg2l2lxmssyqyvsjm71z2hs0d-gmp-with-cxx-6.3.0 787528
/nix/store/bphwhpaihwv3fy3sr3cw93ja9104hcdb-dash-0.5.13.1 193656
/nix/store/kg99gh369vx10w77jl1krcfll4fgxzxq-oniguruma-6.9.10-lib 709584
/nix/store/iiv41cngzdr0925wzi4z14ii7d8kx2d4-jq-1.8.1 432224
/nix/store/c6rkwr11izd7jvkrfcg6pygild509nvm-jq-1.8.1-bin 35680
/nix/store/c7z2rbd7d9md02a85vqgj5qd4ainhsxp-nss-cacert-3.115 751480
/nix/store/h5m3hx1rh76knhg942q13xmx18f9wlvb-attr-2.5.2 92720
/nix/store/mi12n7l1p7mx4962sqzq4c18n8ljgnjb-acl-2.3.2 128224
/nix/store/jbz6j4iwnrvki1zl34hwcyj2i0m6l2y1-coreutils-9.8 1635328
/nix/store/mfp16fmbfyap4mrkwkzqgd7g8d4xixbx-nix-prefetch-darcs 5056
/nix/store/x1hg09529m2m87r2yf5v51xws1mqcrls-gnugrep-3.12 954720
/nix/store/jc3yhgfgq4qj6pi4djbkll508h08xjrc-nix-prefetch-darcs 1008
total 94280320
```

Not to mention it should execute a bit faster without Bash’s overhead <https://www.baeldung.com/linux/dash-vs-bash-performance>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
