### PR TITLE
mesa: fix build on Darwin after 25.3

### DIFF
--- a/pkgs/development/libraries/mesa/darwin.nix
+++ b/pkgs/development/libraries/mesa/darwin.nix
@@ -25,6 +25,11 @@ stdenv.mkDerivation {
     meta
     ;
 
+  patches = [
+    # Backport of https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/38429
+    ./fix-darwin-build.patch
+  ];
+
   outputs = [
     "out"
     "dev"
@@ -58,7 +63,6 @@ stdenv.mkDerivation {
     "--sysconfdir=/etc"
     "--datadir=${placeholder "out"}/share"
     (lib.mesonEnable "glvnd" false)
-    (lib.mesonEnable "shared-glapi" true)
     (lib.mesonEnable "llvm" true)
   ];
 

--- a/pkgs/development/libraries/mesa/fix-darwin-build.patch
+++ b/pkgs/development/libraries/mesa/fix-darwin-build.patch
@@ -1,0 +1,34 @@
+diff --git a/src/glx/apple/apple_cgl.c b/src/glx/apple/apple_cgl.c
+index 81b6730f8e29b3920216461858b98bcd3b7a870c..9bdfe555949482ddb6153ee926967ac5c04fe7c8 100644
+--- a/src/glx/apple/apple_cgl.c
++++ b/src/glx/apple/apple_cgl.c
+@@ -34,6 +34,7 @@
+ 
+ #include "apple_cgl.h"
+ #include "apple_glx.h"
++#include "util/os_misc.h"
+ 
+ #ifndef OPENGL_FRAMEWORK_PATH
+ #define OPENGL_FRAMEWORK_PATH "/System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL"
+diff --git a/src/loader/loader.c b/src/loader/loader.c
+index d06a368c1bbff180fcc9432183db66398b75f4a3..0567beb3dee569895fbb36c7e7c3df34be8b32b7 100644
+--- a/src/loader/loader.c
++++ b/src/loader/loader.c
+@@ -139,6 +139,9 @@ iris_predicate(int fd, const char *driver)
+ bool
+ nouveau_zink_predicate(int fd, const char *driver)
+ {
++#ifndef HAVE_LIBDRM
++   return true;
++#else
+    /* Never load on nv proprietary driver */
+    if (!drm_fd_is_nouveau(fd))
+       return false;
+@@ -191,6 +194,7 @@ nouveau_zink_predicate(int fd, const char *driver)
+    if (!use_zink && !strcmp(driver, "nouveau"))
+       return true;
+    return false;
++#endif
+ }
+ 
+ 


### PR DESCRIPTION
Fixes #462078. Upstream pls.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
