### PR TITLE
tlrender: build fix due to ffmpeg update

### DIFF
--- a/pkgs/by-name/tl/tlrender/package.nix
+++ b/pkgs/by-name/tl/tlrender/package.nix
@@ -7,7 +7,7 @@
 
   bzip2,
   feather-tk,
-  ffmpeg,
+  ffmpeg_7,
   freetype,
   glfw,
   imath,
@@ -112,7 +112,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals enableTiff [ libtiff ]
   ++ lib.optionals enablePng [ libpng ]
   ++ lib.optionals enableOpenexr [ openexr ]
-  ++ lib.optionals enableFfmpeg [ ffmpeg ]
+  ++ lib.optionals enableFfmpeg [ ffmpeg_7 ]
   ++ lib.optionals enableUsd [ openusd ];
 
   cmakeFlags = [


### PR DESCRIPTION
## Things done

- Adjusted ffmpeg to version 7 to build in the course of #ZurichZHF.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
