### PR TITLE
Rabbit build failure fix

### DIFF
--- a/pkgs/by-name/ra/rabbit/package.nix
+++ b/pkgs/by-name/ra/rabbit/package.nix
@@ -3,6 +3,8 @@
   python3,
   fetchFromGitHub,
   fetchPypi,
+  testers,
+  rabbit,
 }:
 
 let
@@ -85,6 +87,12 @@ python3'.pkgs.buildPythonApplication {
   ];
 
   pythonImportsCheck = [ "rabbit" ];
+
+  passthru.tests.version = testers.testVersion {
+    package = rabbit;
+    command = "rabbit --help";
+    version = "RABBIT is an Activity Based Bot Identification Tool";
+  };
 
   meta = {
     description = "Tool for identifying bot accounts based on their recent GitHub event history";

--- a/pkgs/by-name/ra/rabbit/package.nix
+++ b/pkgs/by-name/ra/rabbit/package.nix
@@ -21,11 +21,17 @@ let
             hash = "sha256-tCN+17P90KSIJ5LmjvJUXVuqUKyju0WqffRoE4rY+U0=";
           };
 
-          # There are 2 tests that are failing, disabling the tests for now.
-          # - test_csr_polynomial_expansion_index_overflow[csr_array-False-True-2-65535]
-          # - test_csr_polynomial_expansion_index_overflow[csr_array-False-True-3-2344]
+          postPatch = ''
+            substituteInPlace pyproject.toml \
+              --replace-fail "numpy>=2" "numpy" 
+
+            substituteInPlace meson.build --replace-fail \
+              "run_command('sklearn/_build_utils/version.py', check: true).stdout().strip()," \
+              "'${version}',"
+          '';
           doCheck = false;
         });
+
     };
     self = python3;
   };
@@ -46,6 +52,11 @@ python3'.pkgs.buildPythonApplication {
     tag = version;
     hash = "sha256-icf42vqYPNH1v1wEv/MpqScqMUr/qDlcGoW9kPY2R6s=";
   };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail "pandas==2.2.3" "pandas" 
+  '';
 
   pythonRelaxDeps = [
     "joblib"


### PR DESCRIPTION
<!--
Rabbit requires scikit-learn 1.5.2 and applies it with an override, but does not use the 1.5.2 postpatch from nixpkgs 24.11, so the 25.11 postpatch for scikit-learn does a replace-on-fail that does not match any string in the 1.5.2 pyproject.toml.

## Things done
Applied scikit-learn 1.5.2 postpatch
Removed strict version constraint for pandas==2.2.3 in the same fashion it was done previously for numpy
Added a passthru.test that checks if the --help option works as expected
#ZurichZHF

- Built on platform:
  - [ x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
