### PR TITLE
gnome2.ORBit2: fix the build on aarch64-darwin

### DIFF
--- a/pkgs/desktops/gnome-2/platform/ORBit2/default.nix
+++ b/pkgs/desktops/gnome-2/platform/ORBit2/default.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
 
+  patches = [ ./implicit-int.patch ];
+
   # Processing file orbit-interface.idl
   # sh: gcc: not found
   # output does not contain binaries for build

--- a/pkgs/desktops/gnome-2/platform/ORBit2/implicit-int.patch
+++ b/pkgs/desktops/gnome-2/platform/ORBit2/implicit-int.patch
@@ -1,0 +1,122 @@
+Fix:
+
+error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
+--- a/configure	2024-09-30 16:47:50.000000000 -0500
++++ b/configure	2024-09-30 16:53:58.000000000 -0500
+@@ -12346,7 +12346,7 @@
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+  #include <stdio.h>
+-             main ()
++             int main(void)
+              {
+                return 0;
+              }
+@@ -12387,7 +12387,7 @@
+ 			typedef struct {char s1;} CORBA_struct;
+ 			typedef void *CORBA_pointer;
+ 			struct test {char s1; CORBA_octet s2;};
+-			main()
++			int main(void)
+ 			{
+ 			FILE *f=fopen("conftestval", "w");
+ 			if (!f) exit(1);
+@@ -12434,7 +12434,7 @@
+ 			typedef struct {char s1;} CORBA_struct;
+ 			typedef void *CORBA_pointer;
+ 			struct test {char s1; CORBA_boolean s2;};
+-			main()
++			int main(void)
+ 			{
+ 			FILE *f=fopen("conftestval", "w");
+ 			if (!f) exit(1);
+@@ -12481,7 +12481,7 @@
+ 			typedef struct {char s1;} CORBA_struct;
+ 			typedef void *CORBA_pointer;
+ 			struct test {char s1; CORBA_char s2;};
+-			main()
++			int main(void)
+ 			{
+ 			FILE *f=fopen("conftestval", "w");
+ 			if (!f) exit(1);
+@@ -12528,7 +12528,7 @@
+ 			typedef struct {char s1;} CORBA_struct;
+ 			typedef void *CORBA_pointer;
+ 			struct test {char s1; CORBA_wchar s2;};
+-			main()
++			int main(void)
+ 			{
+ 			FILE *f=fopen("conftestval", "w");
+ 			if (!f) exit(1);
+@@ -12575,7 +12575,7 @@
+ 			typedef struct {char s1;} CORBA_struct;
+ 			typedef void *CORBA_pointer;
+ 			struct test {char s1; CORBA_short s2;};
+-			main()
++			int main(void)
+ 			{
+ 			FILE *f=fopen("conftestval", "w");
+ 			if (!f) exit(1);
+@@ -12622,7 +12622,7 @@
+ 			typedef struct {char s1;} CORBA_struct;
+ 			typedef void *CORBA_pointer;
+ 			struct test {char s1; CORBA_long s2;};
+-			main()
++			int main(void)
+ 			{
+ 			FILE *f=fopen("conftestval", "w");
+ 			if (!f) exit(1);
+@@ -12669,7 +12669,7 @@
+ 			typedef struct {char s1;} CORBA_struct;
+ 			typedef void *CORBA_pointer;
+ 			struct test {char s1; CORBA_long_long s2;};
+-			main()
++			int main(void)
+ 			{
+ 			FILE *f=fopen("conftestval", "w");
+ 			if (!f) exit(1);
+@@ -12716,7 +12716,7 @@
+ 			typedef struct {char s1;} CORBA_struct;
+ 			typedef void *CORBA_pointer;
+ 			struct test {char s1; CORBA_float s2;};
+-			main()
++			int main(void)
+ 			{
+ 			FILE *f=fopen("conftestval", "w");
+ 			if (!f) exit(1);
+@@ -12763,7 +12763,7 @@
+ 			typedef struct {char s1;} CORBA_struct;
+ 			typedef void *CORBA_pointer;
+ 			struct test {char s1; CORBA_double s2;};
+-			main()
++			int main(void)
+ 			{
+ 			FILE *f=fopen("conftestval", "w");
+ 			if (!f) exit(1);
+@@ -12810,7 +12810,7 @@
+ 			typedef struct {char s1;} CORBA_struct;
+ 			typedef void *CORBA_pointer;
+ 			struct test {char s1; CORBA_long_double s2;};
+-			main()
++			int main(void)
+ 			{
+ 			FILE *f=fopen("conftestval", "w");
+ 			if (!f) exit(1);
+@@ -12857,7 +12857,7 @@
+ 			typedef struct {char s1;} CORBA_struct;
+ 			typedef void *CORBA_pointer;
+ 			struct test {char s1; CORBA_struct s2;};
+-			main()
++			int main(void)
+ 			{
+ 			FILE *f=fopen("conftestval", "w");
+ 			if (!f) exit(1);
+@@ -12904,7 +12904,7 @@
+ 			typedef struct {char s1;} CORBA_struct;
+ 			typedef void *CORBA_pointer;
+ 			struct test {char s1; CORBA_pointer s2;};
+-			main()
++			int main(void)
+ 			{
+ 			FILE *f=fopen("conftestval", "w");
+ 			if (!f) exit(1);


### PR DESCRIPTION
On darwin, the flag '-wno-error=implicit-int' doesn't work correctly which leads to the following error:

> error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]

This should be fixed upstream, however the repository has been archived for a while now: https://gitlab.gnome.org/Archive/orbit2

The same issue was encountered in macports here: https://trac.macports.org/ticket/70698#no1
and fixed for them here: https://github.com/macports/macports-ports/commit/bd8cb2211013ae69a8017828ff07f6db79f7c16b

The same patch (with some minor adjustments to make them work in nix) can also be applied here to get it to build on darwin.

#ZurichZHF

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
