### PR TITLE
tacent, tacentview: fix build

### DIFF
--- a/pkgs/by-name/ta/tacent/package.nix
+++ b/pkgs/by-name/ta/tacent/package.nix
@@ -3,23 +3,27 @@
   fetchFromGitHub,
   lib,
   ninja,
+  libx11,
+  libxcb,
   stdenv,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tacent";
-  version = "0.8.18";
+  version = "0.8.18-unstable-2025-10-12";
 
   src = fetchFromGitHub {
     owner = "bluescan";
     repo = "tacent";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-z8VuJS8OaVw5CeO/udvBEmcURKIy1oWVYUv6Ai8lTI8=";
+    rev = "13e08f388681e31a64b6d55c5a4667b7554e3e96";
+    hash = "sha256-zePiqdjS5y9OPpZfMiXjlV3vKjO/YN1xs7fQuNGjQMc=";
   };
 
   nativeBuildInputs = [
     cmake
     ninja
+    libx11
+    libxcb
   ];
 
   meta = {

--- a/pkgs/by-name/ta/tacentview/package.nix
+++ b/pkgs/by-name/ta/tacentview/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tacentview";
-  version = "1.0.46";
+  version = "1.0.46-unstable-2025-10-12";
 
   src = fetchFromGitHub {
     owner = "bluescan";
     repo = "tacentview";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-d4A26p1hmkYEZ+h6kRbHHr4QmAc3PMe3qYdkeKIRGkU=";
+    rev = "51569b34ecd3dac9c40106b92deceb4b56feb5de";
+    hash = "sha256-SblGqUiwYg+Bk17H41R3ytG2SQH/YfrYskyZOi5QSIc=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
see upstream commit fixing the linux build: https://github.com/bluescan/tacent/commit/b248cf2fc9831bb01b304f4a02d7f44c1d7a2d2b

also updates tacentview

ZHF: #457852

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
