### PR TITLE
eclipses.plugins: Remove bytecode-outline

### DIFF
--- a/pkgs/applications/editors/eclipse/plugins.nix
+++ b/pkgs/applications/editors/eclipse/plugins.nix
@@ -256,29 +256,6 @@ rec {
     };
   };
 
-  bytecode-outline = buildEclipsePlugin rec {
-    name = "bytecode-outline-${version}";
-    version = "1.0.1.202006062100";
-
-    srcFeature = fetchurl {
-      url = "https://github.com/iloveeclipse/plugins/blob/latest/features/org.eclipse.jdt.bcoview.feature_${version}.jar";
-      sha256 = "0zbcph72lgv8cb5n4phcl3qsybc5q5yviwbv8yjv4v12m4l15wpk";
-    };
-
-    srcPlugin = fetchurl {
-      url = "https://github.com/iloveeclipse/plugins/blob/latest/plugins/org.eclipse.jdt.bcoview_${version}.jar";
-      sha256 = "1bx860k4haqcnhy8825kn4df0pyzd680qbnvjmxfrlxrqhr66fbb";
-    };
-
-    meta = with lib; {
-      homepage = "https://github.com/iloveeclipse/plugins";
-      description = "Shows disassembled bytecode of current java editor or class file";
-      sourceProvenance = with sourceTypes; [ binaryBytecode ];
-      license = licenses.bsd2;
-      platforms = platforms.all;
-    };
-  };
-
   cdt = buildEclipseUpdateSite rec {
     name = "cdt-${version}";
     # find current version at https://github.com/eclipse-cdt/cdt/releases
@@ -715,6 +692,7 @@ rec {
 }
 // lib.optionalAttrs config.allowAliases {
   # Added 2025-11-16
+  bytecode-outline = throw "eclipses.plugins.bytecode-outline has been removed due to being removed upstream.";
   ivyde = throw "eclipses.plugins.ivyde has been removed due to being archived upstream.";
   ivyderv = throw "eclipses.plugins.inyderv has been removed due to being archived upstream.";
   ivy = throw "eclipses.plugins.ivy has been removed due to being archived upstream.";


### PR DESCRIPTION
The `bytecode-outline` plugin is no longer present in the upstream repository. There is no documentation whatsoever, so I assume it's not maintained anymore.

So I suggest removing it in accordance with [[RFC 0180]](https://github.com/NixOS/rfcs/blob/master/rfcs/0180-broken-package-removal.md)).

#ZurichZHF

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
