### PR TITLE
nvi: cleanup and fix darwin build

### DIFF
--- a/pkgs/by-name/nv/nvi/macports-patches.nix
+++ b/pkgs/by-name/nv/nvi/macports-patches.nix
@@ -1,0 +1,17 @@
+let
+  url = "https://github.com/macports/macports-ports/raw/abae7e550897dc13b7a48763a7a022b709d8793f/editors/nvi/files";
+  hashes = {
+    "dynamic_lookup-11.patch" = "sha256-eXLSMUtslSXLYd1HZRD6pfqcYMIA3EtixWL1yvx4ook=";
+    "patch-common_key.h.diff" = "sha256-AAO/2lHpmFJMYb9fyQrWnGPaJYLdwhrp87tbHu5hr/k=";
+    "patch-dist_port.h.in.diff" = "sha256-GPKgIm9pDGtN6CNqbX3+hANkZbYFql5K5JyjCr5TIKI=";
+    "patch-ex_script.c.diff" = "sha256-IUuJ7b6A5O3q6qQCwZsrc9Bt1LpjU3DgxHTwtMp16Qc=";
+    "patch-includes.diff" = "sha256-j3V4LmcJEFqnTlTHFZFd8NtycEa+GKM+ZIUwZHjq15w=";
+  };
+in
+builtins.attrValues (
+  builtins.mapAttrs (n: v: {
+    url = "${url}/${n}";
+    hash = v;
+    extraPrefix = "";
+  }) hashes
+)

--- a/pkgs/by-name/nv/nvi/package.nix
+++ b/pkgs/by-name/nv/nvi/package.nix
@@ -49,6 +49,10 @@ stdenv.mkDerivation rec {
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;
     mainProgram = "vi";
+    maintainers = with lib.maintainers; [
+      suominen
+      aleksana
+    ];
     broken = stdenv.hostPlatform.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/trunk/nvi.x86_64-darwin
   };
 }

--- a/pkgs/by-name/nv/nvi/package.nix
+++ b/pkgs/by-name/nv/nvi/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchurl,
-  fetchpatch,
   ncurses,
   db,
 }:
@@ -13,7 +12,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://deb.debian.org/debian/pool/main/n/nvi/nvi_${version}.orig.tar.gz";
-    sha256 = "13cp9iz017bk6ryi05jn7drbv7a5dyr201zqd3r4r8srj644ihwb";
+    hash = "sha256-i8NIiJFZo0zyaPgHILJvRZ29cjtWFhB9NnOdAH5Ml40=";
   };
 
   patches =
@@ -28,16 +27,28 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     cd build.unix
   '';
+
   configureScript = "../dist/configure";
+
   configureFlags = [
     "vi_cv_path_preserve=/tmp"
     "--enable-widechar"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Berkeley Vi Editor";
-    license = licenses.free;
-    platforms = platforms.unix;
+    longDescription = ''
+      nvi ("new vi") is a re-implementation of the
+      classic Berkeley text editor vi, written by
+      Keith Bostic at UC Berkeley for 4BSD. Created
+      to replace Unix-derived code in BSD, it provides
+      a clean, unencumbered version of the original
+      editor and is the default vi on all major BSD
+      systems as well as MINIX.
+    '';
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.unix;
+    mainProgram = "vi";
     broken = stdenv.hostPlatform.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/trunk/nvi.x86_64-darwin
   };
 }


### PR DESCRIPTION
Followup of #442968

Added @suominen to maintainers per #410629

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
