### PR TITLE
nixos/pantheon: Make it possible to exclude portals

### DIFF
--- a/nixos/modules/services/desktop-managers/pantheon.nix
+++ b/nixos/modules/services/desktop-managers/pantheon.nix
@@ -208,7 +208,6 @@ in
       environment.systemPackages =
         (with pkgs.pantheon; [
           elementary-session-settings
-          elementary-settings-daemon
           gala
           gnome-settings-daemon
           (switchboard-with-plugs.override {
@@ -244,6 +243,7 @@ in
             elementary-bluetooth-daemon
             elementary-capnet-assist
             elementary-notifications
+            elementary-settings-daemon
             pantheon-agent-geoclue2
             pantheon-agent-polkit
           ])
@@ -258,14 +258,16 @@ in
       xdg.icons.enable = true;
 
       xdg.portal.enable = true;
-      xdg.portal.extraPortals = [
-        pkgs.xdg-desktop-portal-gtk
-      ]
-      ++ (with pkgs.pantheon; [
-        elementary-files
-        elementary-settings-daemon
-        xdg-desktop-portal-pantheon
-      ]);
+      xdg.portal.extraPortals = utils.removePackagesByName (
+        [
+          pkgs.xdg-desktop-portal-gtk
+        ]
+        ++ (with pkgs.pantheon; [
+          elementary-files
+          elementary-settings-daemon
+          xdg-desktop-portal-pantheon
+        ])
+      ) config.environment.pantheon.excludePackages;
 
       xdg.portal.configPackages = mkDefault [ pkgs.pantheon.elementary-default-settings ];
 

--- a/nixos/modules/services/desktop-managers/pantheon.nix
+++ b/nixos/modules/services/desktop-managers/pantheon.nix
@@ -207,7 +207,6 @@ in
       # Global environment
       environment.systemPackages =
         (with pkgs.pantheon; [
-          elementary-bluetooth-daemon
           elementary-session-settings
           elementary-settings-daemon
           gala
@@ -242,6 +241,7 @@ in
             elementary-shortcut-overlay
 
             # Services
+            elementary-bluetooth-daemon
             elementary-capnet-assist
             elementary-notifications
             pantheon-agent-geoclue2


### PR DESCRIPTION
The desktop *starts* even I excluded all portals listed here. It does **not** mean everything will still function (for example some elementary apps enforce `GTK_USE_PORTAL`) but this can help e.g. the recently happened slow startup issue.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

