### PR TITLE
nixos/programs/xscreensaver: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -365,6 +365,8 @@
   ./programs/xfs_quota.nix
   ./programs/xonsh.nix
   ./programs/xppen.nix
+  ./programs/xscreensaver/sonar.nix
+  ./programs/xscreensaver/xscreensaver.nix
   ./programs/xss-lock.nix
   ./programs/xwayland.nix
   ./programs/yazi.nix

--- a/nixos/modules/programs/xscreensaver/sonar.nix
+++ b/nixos/modules/programs/xscreensaver/sonar.nix
@@ -1,0 +1,26 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.programs.xscreensaver.sonar;
+  globalCfg = config.programs.xscreensaver;
+in
+{
+  options.programs.xscreensaver.sonar = {
+    enable = lib.mkEnableOption "xscreensaver";
+  };
+  config = lib.mkIf cfg.enable {
+    security.wrappers.sonar = {
+      capabilities = "cap_net_raw+ep";
+      owner = "root";
+      group = "root";
+      source = pkgs.writeShellScript "sonar-fakeroot" ''
+        exec ${lib.getExe pkgs.fakeroot} ${globalCfg.package}/libexec/xscreensaver/sonar "$@"
+      '';
+    };
+  };
+}

--- a/nixos/modules/programs/xscreensaver/xscreensaver.nix
+++ b/nixos/modules/programs/xscreensaver/xscreensaver.nix
@@ -1,0 +1,20 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.programs.xscreensaver;
+in
+{
+  options.programs.xscreensaver = {
+    enable = lib.mkEnableOption "all of the xscreensaver programs";
+    package = lib.mkPackageOption pkgs "xscreensaver" { };
+  };
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    programs.xscreensaver.sonar.enable = true;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I noticed that nothing handled the `sonar` program from xscreensaver properly, and spent a while fixing it with @adisbladis, so thought I'd contribute this module to make it so others can just enable and use the program

<img width="1353" height="958" alt="image" src="https://github.com/user-attachments/assets/87f07559-9fc3-4188-a89a-57a1e43a8028" />

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
