### PR TITLE
x2t: update to 9.1.0

### DIFF
--- a/pkgs/by-name/x2/x2t/doctrenderer-v8-iterator.patch
+++ b/pkgs/by-name/x2/x2t/doctrenderer-v8-iterator.patch
@@ -1,0 +1,16 @@
+diff --git a/DesktopEditor/doctrenderer/js_internal/v8/v8_base.cpp b/DesktopEditor/doctrenderer/js_internal/v8/v8_base.cpp
+index bacd5dedac..4749d8fecb 100644
+--- a/DesktopEditor/doctrenderer/js_internal/v8/v8_base.cpp
++++ b/DesktopEditor/doctrenderer/js_internal/v8/v8_base.cpp
+@@ -259,10 +259,7 @@ namespace NSJSBase
+ 		m_internal->m_contextPersistent.Reset();
+ 		// destroy native object in the weak handles before isolate disposal
+ 		v8::Isolate* isolate = m_internal->m_isolate;
+-		{
+-			v8::Isolate::Scope scope(isolate);
+-			isolate->VisitHandlesWithClassIds(WeakHandleVisitor::getInstance());
+-		}
++		std::cerr << "Could not release memory. This is a nix-specific leak, but should be fine as long as it doesn't happen too frequently" << std::endl;
+ 		isolate->Dispose();
+ 		m_internal->m_isolate = NULL;
+ 	}

--- a/pkgs/by-name/x2/x2t/doctrenderer-v8-test.patch
+++ b/pkgs/by-name/x2/x2t/doctrenderer-v8-test.patch
@@ -1,0 +1,76 @@
+diff --git a/DesktopEditor/doctrenderer/test/json/main.cpp b/DesktopEditor/doctrenderer/test/json/main.cpp
+index e5c6a0e52d..9b127a9c44 100644
+--- a/DesktopEditor/doctrenderer/test/json/main.cpp
++++ b/DesktopEditor/doctrenderer/test/json/main.cpp
+@@ -472,26 +472,26 @@ TEST_F(CJSONTest, image_externalize)
+ 	int width = 1080;
+ 	int height = 480;
+ 	BYTE* bits = CValue::AllocImageBits(width, height);
+-	CValue img = CValue::CreateImage(bits, width, height, ifBGRA);
++	CValue img = CValue::CreateImage(bits, width, height, ImageFormat::ifBGRA);
+ 
+ 	EXPECT_TRUE(img.IsImage());
+ 	EXPECT_EQ(img.GetImageBits(), bits);
+ 	EXPECT_EQ(img.GetImageWidth(), width);
+ 	EXPECT_EQ(img.GetImageHeight(), height);
+-	EXPECT_EQ(img.GetImageFormat(), ifBGRA);
++	EXPECT_EQ(img.GetImageFormat(), ImageFormat::ifBGRA);
+ 
+ 	CValue::FreeImageBits(bits);
+ 
+ 	width = 50;
+ 	height = 100;
+ 	bits = CValue::AllocImageBits(width, height);
+-	img = CValue::CreateImage(bits, width, height, ifRGBA);
++	img = CValue::CreateImage(bits, width, height, ImageFormat::ifRGBA);
+ 
+ 	EXPECT_TRUE(img.IsImage());
+ 	EXPECT_EQ(img.GetImageBits(), bits);
+ 	EXPECT_EQ(img.GetImageWidth(), width);
+ 	EXPECT_EQ(img.GetImageHeight(), height);
+-	EXPECT_EQ(img.GetImageFormat(), ifRGBA);
++	EXPECT_EQ(img.GetImageFormat(), ImageFormat::ifRGBA);
+ 
+ 	CValue::FreeImageBits(bits);
+ }
+@@ -501,25 +501,25 @@ TEST_F(CJSONTest, image_not_externalize)
+ 	int width = 320;
+ 	int height = 480;
+ 	BYTE* bits = CValue::AllocImageBits(width, height);
+-	CValue img = CValue::CreateImage(bits, width, height, ifARGB, false);
++	CValue img = CValue::CreateImage(bits, width, height, ImageFormat::ifARGB, false);
+ 
+ 	EXPECT_TRUE(img.IsImage());
+ 	EXPECT_EQ(img.GetImageBits(), bits);
+ 	EXPECT_EQ(img.GetImageWidth(), width);
+ 	EXPECT_EQ(img.GetImageHeight(), height);
+-	EXPECT_EQ(img.GetImageFormat(), ifARGB);
++	EXPECT_EQ(img.GetImageFormat(), ImageFormat::ifARGB);
+ }
+ 
+ TEST_F(CJSONTest, image_wrong_size)
+ {
+ 	BYTE* bits = CValue::AllocImageBits(100, 100);
+-	CValue img = CValue::CreateImage(bits, 0, 100, ifARGB, false);
++	CValue img = CValue::CreateImage(bits, 0, 100, ImageFormat::ifARGB, false);
+ 	EXPECT_TRUE(img.IsUndefined());
+-	img = CValue::CreateImage(bits, -1, 100, ifARGB, false);
++	img = CValue::CreateImage(bits, -1, 100, ImageFormat::ifARGB, false);
+ 	EXPECT_TRUE(img.IsUndefined());
+-	img = CValue::CreateImage(bits, 0, 0, ifARGB, false);
++	img = CValue::CreateImage(bits, 0, 0, ImageFormat::ifARGB, false);
+ 	EXPECT_TRUE(img.IsUndefined());
+-	img = CValue::CreateImage(bits, -100, -100, ifARGB, false);
++	img = CValue::CreateImage(bits, -100, -100, ImageFormat::ifARGB, false);
+ 	EXPECT_TRUE(img.IsUndefined());
+ }
+ 
+@@ -593,7 +593,7 @@ TEST_F(CJSONTest, wrong_usage)
+ 	EXPECT_EQ(val.GetCount(), 0);
+ 	EXPECT_EQ(val.GetData(), nullptr);
+ 	EXPECT_EQ(val.GetImageBits(), nullptr);
+-	EXPECT_EQ(val.GetImageFormat(), ifInvalid);
++	EXPECT_EQ(val.GetImageFormat(), ImageFormat::ifInvalid);
+ 	EXPECT_EQ(val.GetImageHeight(), 0);
+ 	EXPECT_EQ(val.GetImageWidth(), 0);
+ #endif

--- a/pkgs/by-name/x2/x2t/ofdfile-test.patch
+++ b/pkgs/by-name/x2/x2t/ofdfile-test.patch
@@ -1,0 +1,10 @@
+diff --git a/OFDFile/test/main.cpp b/OFDFile/test/main.cpp
+index 92189f10ff..7aff6df96f 100644
+--- a/OFDFile/test/main.cpp
++++ b/OFDFile/test/main.cpp
+@@ -1,4 +1,4 @@
+-#include "../OfdFile.h"
++#include "../OFDFile.h"
+ #include <iostream>
+ 
+ #include "../../DesktopEditor/common/Directory.h"

--- a/pkgs/by-name/x2/x2t/package.nix
+++ b/pkgs/by-name/x2/x2t/package.nix
@@ -102,13 +102,15 @@ let
   #qmakeFlags = [ "CONFIG+=debug" ];
   qmakeFlags = [ ];
   dontStrip = false;
-  core-rev = "d257c68d5fdd71a33776a291914f2c856426c259";
+
+  # Revisions that correspond to onlyoffice-documentserver 8.3.3
+  core-rev = "fa65a546dad35b08615d616bbef92717ccb4bb32";
   core = fetchFromGitHub {
     owner = "ONLYOFFICE";
     repo = "core";
     # rev that the 'core' submodule in documentserver points at
     rev = core-rev;
-    hash = "sha256-EXeqG8MJWS1asjFihnuMnDSHeKt2x+Ui+8MYK50AnSY=";
+    hash = "sha256-fpWZqzenkSG5kB3CKdmdw6dBQOoUTryrHE0mG9zBi90=";
   };
   web-apps = buildNpmPackage (finalAttrs: {
     name = "onlyoffice-core-webapps";
@@ -119,8 +121,8 @@ let
       owner = "ONLYOFFICE";
       repo = "web-apps";
       # rev that the 'web-apps' submodule in documentserver points at
-      rev = "5255c27b1af64f6edf08d1aba20a23b8149e338c";
-      hash = "sha256-49v2h+ILQ0X/gNHny6LQcj94A6h7nS99liUAnLRNxzw=";
+      rev = "64a59dd53ca2e83c9cb34ecd75dbacb2f7a5bf4d";
+      hash = "sha256-7+XddOPDsWpxg29HkJNvp/K1LJGctej5hLIAmBHWe/o=";
     };
     sourceRoot = "${finalAttrs.src.name}/build";
 
@@ -159,8 +161,8 @@ let
       owner = "ONLYOFFICE";
       repo = "sdkjs";
       # rev that the 'sdkjs' submodule in documentserver points at
-      rev = "0e50652cb08c7753a9ab72d0558560ada5d43046";
-      hash = "sha256-fApr34aT0X8ffPwbsUEWnA3SK8pT5RKNan3YxzhvtAU=";
+      rev = "3377e3fd5cb6de4aa833dead7c37124dc83efd96";
+      hash = "sha256-qa1gm1lPJS4f1iLZLE8gjwkm+5KoMsDm2BnJPTlyLxo=";
     };
     sourceRoot = "${finalAttrs.src.name}/build";
 
@@ -648,8 +650,8 @@ let
   core-fonts = fetchFromGitHub {
     owner = "ONLYOFFICE";
     repo = "core-fonts";
-    rev = "d5d80e6ae15800ccf31e1c4dbb1ae3385992e0c2";
-    hash = "sha256-daJG/4tcdRVVmlMCUW4iuoUkEEfY7sx5icYWMva4o+c=";
+    rev = "7030c6681fb5bbed560675cb42422f91df15d5c9";
+    hash = "sha256-yNUDyIJ09Ejbyt/kMrOpDbT15QTDOe7GTQChRU5+QY4=";
   };
   allfonts = runCommand "allfonts" { } ''
     mkdir -p $out/web

--- a/pkgs/by-name/x2/x2t/package.nix
+++ b/pkgs/by-name/x2/x2t/package.nix
@@ -7,6 +7,9 @@
   fetchFromGitHub,
   glibc,
   harfbuzz,
+  libheif,
+  x265,
+  libde265,
   icu,
   jdk,
   lib,
@@ -28,7 +31,7 @@ let
   fixIcu = writeScript "fix-icu.sh" ''
     substituteInPlace \
       $BUILDRT/Common/3dParty/icu/icu.pri \
-      --replace-fail "ICU_MAJOR_VER = 58" "ICU_MAJOR_VER = ${lib.versions.major icu.version}"
+      --replace-fail "ICU_MAJOR_VER = 74" "ICU_MAJOR_VER = ${lib.versions.major icu.version}"
 
     mkdir $BUILDRT/Common/3dParty/icu/linux_64
     ln -s ${icu}/lib $BUILDRT/Common/3dParty/icu/linux_64/build
@@ -46,6 +49,13 @@ let
     rev = "be6df458d4540eee375c513958dcb862a391cdd1";
     hash = "sha256-SYJFLtrg8raGyr3zQIEzZDjHDmMmt+K0po3viipZW5c=";
   };
+  # see core/Common/3dParty/html/fetch.py
+  gumbo-parser-src = fetchFromGitHub {
+    owner = "google";
+    repo = "gumbo-parser";
+    rev = "aa91b27b02c0c80c482e24348a457ed7c3c088e0";
+    hash = "sha256-+607iXJxeWKoCwb490pp3mqRZ1fWzxec0tJOEFeHoCs=";
+  };
   # see build_tools scripts/core_common/modules/googletest.py
   googletest-src = fetchFromGitHub {
     owner = "google";
@@ -61,12 +71,33 @@ let
     rev = "73dd2967c8e1e4f6d7334ee9e539a323d6e66cbd";
     hash = "sha256-WIHpSkOwHkhMvEKxOlgf6gsPs9T3xkzguD8ONXARf1U=";
   };
-  # see core/Common/3dParty/html/fetch.py
-  gumbo-parser-src = fetchFromGitHub {
-    owner = "google";
-    repo = "gumbo-parser";
-    rev = "aa91b27b02c0c80c482e24348a457ed7c3c088e0";
-    hash = "sha256-+607iXJxeWKoCwb490pp3mqRZ1fWzxec0tJOEFeHoCs=";
+  # core/Common/3dParty/md/fetch.py
+  md4c-src = fetchFromGitHub {
+    owner = "mity";
+    repo = "md4c";
+    rev = "481fbfbdf72daab2912380d62bb5f2187d438408";
+    hash = "sha256-zhInM3R0CJUqnzh6wRxMwlUdErovplbZQ5IwXe9XzZ4=";
+  };
+  # core/Common/3dParty/apple/fetch.py
+  glm-src = fetchFromGitHub {
+    owner = "g-truc";
+    repo = "glm";
+    rev = "33b4a621a697a305bc3a7610d290677b96beb181";
+    hash = "sha256-wwGI17vlQzL/x1O0ANr5+KgU1ETnATpLw3njpKfjnKQ=";
+  };
+  # core/Common/3dParty/apple/fetch.py
+  mdds-src = fetchFromGitHub {
+    owner = "kohei-us";
+    repo = "mdds";
+    rev = "0783158939c6ce4b0b1b89e345ab983ccb0f0ad0";
+    hash = "sha256-HMGMxMRO6SadisUjZ0ZNBGQqksNDFkEh3yaQGet9rc0=";
+  };
+  # core/Common/3dParty/apple/fetch.py
+  librevenge-src = fetchFromGitHub {
+    owner = "DistroTech";
+    repo = "librevenge";
+    rev = "becd044b519ab83893ad6398e3cbb499a7f0aaf4";
+    hash = "sha256-2YRxuMYzKvvQHiwXH08VX6GRkdXnY7q05SL05Vbn0Vs=";
   };
   # core/Common/3dParty/apple/fetch.py
   libodfgen-src = fetchFromGitHub {
@@ -75,31 +106,7 @@ let
     rev = "8ef8c171ebe3c5daebdce80ee422cf7bb96aa3bc";
     hash = "sha256-Bv/smZFmZn4PEAcOlXD2Z4k96CK7A7YGDHFDsqZpuiE=";
   };
-  # core/Common/3dParty/md/fetch.py
-  md4c-src = fetchFromGitHub {
-    owner = "mity";
-    repo = "md4c";
-    rev = "481fbfbdf72daab2912380d62bb5f2187d438408";
-    hash = "sha256-zhInM3R0CJUqnzh6wRxMwlUdErovplbZQ5IwXe9XzZ4=";
-  };
-  mdds-src = fetchFromGitHub {
-    owner = "kohei-us";
-    repo = "mdds";
-    rev = "0783158939c6ce4b0b1b89e345ab983ccb0f0ad0";
-    hash = "sha256-HMGMxMRO6SadisUjZ0ZNBGQqksNDFkEh3yaQGet9rc0=";
-  };
-  glm-src = fetchFromGitHub {
-    owner = "g-truc";
-    repo = "glm";
-    rev = "33b4a621a697a305bc3a7610d290677b96beb181";
-    hash = "sha256-wwGI17vlQzL/x1O0ANr5+KgU1ETnATpLw3njpKfjnKQ=";
-  };
-  librevenge-src = fetchFromGitHub {
-    owner = "DistroTech";
-    repo = "librevenge";
-    rev = "becd044b519ab83893ad6398e3cbb499a7f0aaf4";
-    hash = "sha256-2YRxuMYzKvvQHiwXH08VX6GRkdXnY7q05SL05Vbn0Vs=";
-  };
+  # core/Common/3dParty/apple/fetch.py
   libetonyek-src = fetchFromGitHub {
     owner = "LibreOffice";
     repo = "libetonyek";
@@ -110,14 +117,14 @@ let
   qmakeFlags = [ ];
   dontStrip = false;
 
-  # Revisions that correspond to onlyoffice-documentserver 9.0.2
-  core-rev = "bcc5f67ec89602fe41941f11c7f9eb801f2a3c89";
+  # Revisions that correspond to onlyoffice-documentserver 9.1.0
+  core-rev = "82e281cf6bf89498e4de6018423b36576706c2b6";
   core = fetchFromGitHub {
     owner = "ONLYOFFICE";
     repo = "core";
     # rev that the 'core' submodule in documentserver points at
     rev = core-rev;
-    hash = "sha256-KzY/5fwZfgdEYmPsNkV3AGGYw23mEAhtGfyko3sYeTo=";
+    hash = "sha256-LzbO2A29WxM0XTAO2LGTtg9omL0Pvoh+6+q3ux4i7do=";
   };
   web-apps = buildNpmPackage (finalAttrs: {
     name = "onlyoffice-core-webapps";
@@ -128,8 +135,8 @@ let
       owner = "ONLYOFFICE";
       repo = "web-apps";
       # rev that the 'web-apps' submodule in documentserver points at
-      rev = "06bc5a77e9997c1766ba8088c255ba0b14e4fca3";
-      hash = "sha256-QSVCPnqL2mdK7irVCNna08dJAtrDVwe77k31Cof4L18=";
+      rev = "f63e9674a5d2d2e5a660ab726ec00a359fc3c750";
+      hash = "sha256-kKm6+phd6a7kP/kv6/v/FFgh96Kbs6h6jIjpFtRJgps=";
     };
     sourceRoot = "${finalAttrs.src.name}/build";
 
@@ -168,8 +175,8 @@ let
       owner = "ONLYOFFICE";
       repo = "sdkjs";
       # rev that the 'sdkjs' submodule in documentserver points at
-      rev = "649a4b57ba25a204cc7b31299652c0de8ff0e42c";
-      hash = "sha256-acKoLQemAyFGCrVRsUUbl/iAQsh/ouSW+fX/hLgT3x8=";
+      rev = "d169f841a7e9e46368c36236dd5820e3e10d4a98";
+      hash = "sha256-GQwzz3P49sWjCxh41zyuUs5MyMjBQXaMKzxUUTHq0UE=";
     };
     sourceRoot = "${finalAttrs.src.name}/build";
 
@@ -206,7 +213,7 @@ let
   dictionaries = fetchFromGitHub {
     owner = "ONLYOFFICE";
     repo = "dictionaries";
-    tag = "v9.0.3.7";
+    rev = "d3223bbb777883db66ac3cd249f71c6ebdc992c7";
     hash = "sha256-7hvztNYnYjyOl3ynGP0vqtx9jLPp09XVDNIow1RYuWM=";
   };
   buildCoreComponent =
@@ -337,9 +344,21 @@ let
     buildInputs = [
       unicodeConverter
       kernel
+      libheif.lib
+      x265
+      libde265
     ];
     preConfigure = ''
       ln -s ${katana-parser-src} $BUILDRT/Common/3dParty/html/katana-parser
+
+      mkdir -p $BUILDRT/Common/3dParty/heif/libheif/libheif
+      ln -s ${libheif.dev}/include $BUILDRT/Common/3dParty/heif/libheif/libheif/api
+      mkdir -p $BUILDRT/Common/3dParty/heif/libheif/build/linux_64/release
+      ln -s ${libheif.lib}/lib $BUILDRT/Common/3dParty/heif/libheif/build/linux_64/release/libheif
+      mkdir -p $BUILDRT/Common/3dParty/heif/x265_git/build/linux_64
+      ln -s ${x265}/lib $BUILDRT/Common/3dParty/heif/x265_git/build/linux_64/release
+      mkdir -p $BUILDRT/Common/3dParty/heif/libde265/build/linux_64/release
+      ln -s ${libde265}/lib $BUILDRT/Common/3dParty/heif/libde265/build/linux_64/release/libde265
 
       # Common/3dParty/harfbuzz/make.py
       cat >$BUILDRT/Common/3dParty/harfbuzz/harfbuzz.pri <<EOL
@@ -491,6 +510,9 @@ let
       unicodeConverter
       cryptopp
       network
+    ];
+    patches = [
+      ./pdffile-limits-include.patch
     ];
   };
   djvufile = buildCoreComponent "DjVuFile" {
@@ -676,6 +698,7 @@ let
       unicodeConverter
       kernel
       graphics
+      libheif.lib
     ];
     qmakeFlags = qmakeFlags ++ icuQmakeFlags;
     preConfigure = ''
@@ -715,7 +738,7 @@ buildCoreComponent "X2tConverter/build/Qt" {
   pname = "x2t";
   # x2t is not 'directly' versioned, so we version it after the version
   # of documentserver it's pulled into as a submodule
-  version = "9.0.2";
+  version = "9.1.0";
 
   buildInputs = [
     unicodeConverter

--- a/pkgs/by-name/x2/x2t/pdffile-limits-include.patch
+++ b/pkgs/by-name/x2/x2t/pdffile-limits-include.patch
@@ -1,0 +1,12 @@
+diff --git a/PdfFile/SrcWriter/Utils.cpp b/PdfFile/SrcWriter/Utils.cpp
+index f4fcd884c6..0454c2a75a 100644
+--- a/PdfFile/SrcWriter/Utils.cpp
++++ b/PdfFile/SrcWriter/Utils.cpp
+@@ -33,6 +33,7 @@
+ #include <vector>
+ #include <ctime>
+ #include <cwctype>
++#include <limits>
+ 
+ namespace PdfWriter
+ {


### PR DESCRIPTION
Tested by editing a docx file in nextcloud

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
