### PR TITLE
{swt,tuxguitar}: several small fixes

### DIFF
--- a/pkgs/by-name/sw/swt/package.nix
+++ b/pkgs/by-name/sw/swt/package.nix
@@ -11,8 +11,10 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "swt";
-  version = "4.34";
-  fullVersion = "R-${finalAttrs.version}-202411201800";
+  # NOTE: In case you wish to override, don't override version, override
+  # `fullVersion`.
+  version = builtins.elemAt (lib.splitString "-" finalAttrs.fullVersion) 1;
+  fullVersion = "R-4.34-202411201800";
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/by-name/sw/swt/package.nix
+++ b/pkgs/by-name/sw/swt/package.nix
@@ -144,6 +144,10 @@ stdenv.mkDerivation (finalAttrs: {
       mpl20
     ];
     maintainers = [ ];
+    # The darwin src zip file holds simply a prebuilt swt.jar file
+    sourceProvenance = lib.optionals stdenv.hostPlatform.isDarwin [
+      lib.sourceTypes.binaryNativeCode
+    ];
     platforms = lib.attrNames finalAttrs.passthru.srcMetadataByPlatform;
     # Fails with: `java.nio.file.NoSuchFileException: ../swt.jar`
     broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64;

--- a/pkgs/by-name/sw/swt/package.nix
+++ b/pkgs/by-name/sw/swt/package.nix
@@ -12,7 +12,7 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "swt";
   version = "4.34";
-  fullVersion = "${finalAttrs.version}-202411201800";
+  fullVersion = "R-${finalAttrs.version}-202411201800";
 
   hardeningDisable = [ "format" ];
 
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     in
     assert srcMetadata != null;
     fetchzip {
-      url = "https://archive.eclipse.org/eclipse/downloads/drops4/R-${finalAttrs.fullVersion}/swt-${finalAttrs.version}-${srcMetadata.platform}.zip";
+      url = "https://archive.eclipse.org/eclipse/downloads/drops4/${finalAttrs.fullVersion}/swt-${finalAttrs.version}-${srcMetadata.platform}.zip";
       inherit (srcMetadata) hash;
       stripRoot = false;
       postFetch =

--- a/pkgs/by-name/sw/swt/package.nix
+++ b/pkgs/by-name/sw/swt/package.nix
@@ -145,5 +145,7 @@ stdenv.mkDerivation (finalAttrs: {
     ];
     maintainers = [ ];
     platforms = lib.attrNames finalAttrs.passthru.srcMetadataByPlatform;
+    # Fails with: `java.nio.file.NoSuchFileException: ../swt.jar`
+    broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64;
   };
 })

--- a/pkgs/by-name/sw/swt/package.nix
+++ b/pkgs/by-name/sw/swt/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     in
     assert srcMetadata != null;
     fetchzip {
-      url = "https://archive.eclipse.org/eclipse/downloads/drops4/${finalAttrs.fullVersion}/swt-${finalAttrs.version}-${srcMetadata.platform}.zip";
+      url = "https://download.eclipse.org/eclipse/downloads/drops4/${finalAttrs.fullVersion}/swt-${finalAttrs.version}-${srcMetadata.platform}.zip";
       inherit (srcMetadata) hash;
       stripRoot = false;
       postFetch =

--- a/pkgs/by-name/tu/tuxguitar/package.nix
+++ b/pkgs/by-name/tu/tuxguitar/package.nix
@@ -78,5 +78,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.lgpl2;
     maintainers = with lib.maintainers; [ ardumont ];
     platforms = [ "x86_64-linux" ];
+    mainProgram = "tuxguitar";
   };
 })

--- a/pkgs/by-name/tu/tuxguitar/package.nix
+++ b/pkgs/by-name/tu/tuxguitar/package.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://github.com/helge17/tuxguitar";
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
-    license = lib.licenses.lgpl2;
+    license = lib.licenses.lgpl21Plus;
     maintainers = with lib.maintainers; [ ardumont ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "tuxguitar";


### PR DESCRIPTION
## Description of changes

~~Supersedes https://github.com/NixOS/nixpkgs/pull/462225~~

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
