### PR TITLE
postgresqlPackages.pgx_ulid: 0.2.1 -> 0.2.2

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pgx_ulid.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgx_ulid.nix
@@ -1,6 +1,6 @@
 {
   buildPgrxExtension,
-  cargo-pgrx_0_16_0,
+  cargo-pgrx_0_16_1,
   fetchFromGitHub,
   lib,
   nix-update-script,
@@ -9,25 +9,23 @@
 }:
 buildPgrxExtension (finalAttrs: {
   inherit postgresql;
-  cargo-pgrx = cargo-pgrx_0_16_0;
+  cargo-pgrx = cargo-pgrx_0_16_1;
 
   pname = "pgx_ulid";
-  version = "0.2.1";
+  version = "0.2.2";
 
   src = fetchFromGitHub {
     owner = "pksunkara";
     repo = "pgx_ulid";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-yjPTCJTeT1HQt8huDHBHs0DAHpmseMHeSaQhpPV6qdo=";
+    hash = "sha256-7zOAjQPdwaDwAz2Es5KX3HstTwY6wKNuB9b+xnnXNP0=";
   };
 
-  cargoHash = "sha256-LRfn/TO/bBEvvzY9m6C8Lb0qdUStQD3oAzjDovS6H1s=";
+  cargoHash = "sha256-4YuTOCE142BDDteB9ZQdxzI8EUXN+jRZfy1eq64qHtg=";
 
   postInstall = ''
-    # Upstream renames the extension when packaging
-    # https://github.com/pksunkara/pgx_ulid/blob/084778c3e2af08d16ec5ec3ef4e8f345ba0daa33/.github/workflows/release.yml#L81
-    # Upgrade scripts should be added later, so we also rename them with wildcard
-    # https://github.com/pksunkara/pgx_ulid/issues/49
+    # Upstream renames the extension when packaging as well as upgrade scripts
+    # https://github.com/pksunkara/pgx_ulid/blob/master/.github/workflows/release.yml#L80
     ${util-linux}/bin/rename pgx_ulid ulid $out/share/postgresql/extension/pgx_ulid*
   '';
 


### PR DESCRIPTION
Closes #462331

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
