### PR TITLE
psst: 0-unstable-2025-04-20 -> 0-unstable-2025-11-16

### DIFF
--- a/pkgs/by-name/ps/psst/make-build-reproducible.patch
+++ b/pkgs/by-name/ps/psst/make-build-reproducible.patch
@@ -10,11 +10,11 @@ index 4e899af..0000000
 -
 -fn main() {
 -    let outdir = env::var("OUT_DIR").unwrap();
--    let outfile = format!("{}/build-time.txt", outdir);
+-    let outfile = format!("{outdir}/build-time.txt");
 -
 -    let mut fh = fs::File::create(outfile).unwrap();
 -    let now = OffsetDateTime::now_local().unwrap_or_else(|_| OffsetDateTime::now_utc());
--    write!(fh, r#""{}""#, now).ok();
+-    write!(fh, r#""{now}""#).ok();
 -
 -    let git_config = File::from_git_dir("../.git/".into()).expect("Git Config not found!");
 -    // Get Git's 'Origin' URL
@@ -43,9 +43,9 @@ index 4e899af..0000000
 -    let trimmed_url = remote_url.trim_end_matches(".git");
 -    remote_url.clone_from(&String::from(trimmed_url));
 -
--    let outfile = format!("{}/remote-url.txt", outdir);
+-    let outfile = format!("{outdir}/remote-url.txt");
 -    let mut file = fs::File::create(outfile).unwrap();
--    write!(file, r#""{}""#, remote_url).ok();
+-    write!(file, r#""{remote_url}""#).ok();
 -}
 diff --git a/psst-core/src/lib.rs b/psst-core/src/lib.rs
 index 2faa317..b890a2d 100644

--- a/pkgs/by-name/ps/psst/package.nix
+++ b/pkgs/by-name/ps/psst/package.nix
@@ -33,16 +33,16 @@ let
 in
 rustPlatform.buildRustPackage {
   pname = "psst";
-  version = "0-unstable-2025-04-20";
+  version = "0-unstable-2025-11-16";
 
   src = fetchFromGitHub {
     owner = "jpochyla";
     repo = "psst";
-    rev = "86169f8b05c1b3502261cfe1fae9af2487b8f1bb";
-    hash = "sha256-BkGoaYflCTiElTj47r2j/ngUrZ9wIe0q4pl+zhoattA=";
+    rev = "cae05c43f4aee2c5936375225c4586ea35594835";
+    hash = "sha256-iCm5lvZq64Dmbe/stkZO0XvX0mWfmzFgl3MeCTI6/hM=";
   };
 
-  cargoHash = "sha256-gt2EDrZ+XXig5JUsmQksSLaFd7UArnttOT4UiTVASXw=";
+  cargoHash = "sha256-Q4xMsX6lJK3Or+oKuPOTCec2pe+oBWC33peCE1x7QRg=";
 
   # specify the subdirectory of the binary crate to build from the workspace
   buildAndTestSubdir = "psst-gui";


### PR DESCRIPTION
This update fixed https://github.com/jpochyla/psst/issues/687, which prevented the app from functioning.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
