### PR TITLE
linux-msm: init packages to support mobile linux

### DIFF
--- a/pkgs/by-name/qm/qmic/package.nix
+++ b/pkgs/by-name/qm/qmic/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "qmic";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "linux-msm";
+    repo = "qmic";
+    tag = "v${finalAttrs.version}";
+    sha256 = "sha256-0/mIg98pN66ZaVsQ6KmZINuNfiKvdEHMsqDx0iciF8w=";
+  };
+
+  installFlags = [ "prefix=$(out)" ];
+
+  meta = with lib; {
+    maintainers = with maintainers; [ matthewcroughan ];
+    description = "QMI IDL compiler";
+    homepage = "https://github.com/andersson/qmic";
+    license = licenses.bsd3;
+    platforms = platforms.aarch64;
+  };
+})

--- a/pkgs/by-name/qr/qrtr/package.nix
+++ b/pkgs/by-name/qr/qrtr/package.nix
@@ -1,0 +1,40 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  meson,
+  cmake,
+  pkg-config,
+  systemd,
+  ninja,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "qrtr";
+  version = "0-unstable-2025-03-01";
+
+  src = fetchFromGitHub {
+    owner = "linux-msm";
+    repo = "qrtr";
+    rev = "5923eea97377f4a3ed9121b358fd919e3659db7b";
+    hash = "sha256-iHjF/2SQsvB/qC/UykNITH/apcYSVD+n4xA0S/rIfnM=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    pkg-config
+    ninja
+  ];
+
+  buildInputs = [ systemd ];
+
+  installFlags = [ "prefix=$(out)" ];
+
+  meta = with lib; {
+    maintainers = with maintainers; [ matthewcroughan ];
+    description = "QMI IDL compiler";
+    homepage = "https://github.com/linux-msm/qrtr";
+    license = licenses.bsd3;
+    platforms = platforms.aarch64;
+  };
+})

--- a/pkgs/by-name/rm/rmtfs/package.nix
+++ b/pkgs/by-name/rm/rmtfs/package.nix
@@ -1,0 +1,36 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  udev,
+  qrtr,
+  qmic,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "rmtfs";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "andersson";
+    repo = "rmtfs";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-00KOjdkwcAER261lleSl7OVDEAEbDyW9MWxDd0GI8KA=";
+  };
+
+  buildInputs = [
+    udev
+    qrtr
+    qmic
+  ];
+
+  installFlags = [ "prefix=$(out)" ];
+
+  meta = with lib; {
+    maintainers = with maintainers; [ matthewcroughan ];
+    description = "Qualcomm Remote Filesystem Service";
+    homepage = "https://github.com/linux-msm/rmtfs";
+    license = licenses.bsd3;
+    platforms = platforms.aarch64;
+  };
+})

--- a/pkgs/by-name/tq/tqftpserv/package.nix
+++ b/pkgs/by-name/tq/tqftpserv/package.nix
@@ -1,0 +1,49 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  qrtr,
+  meson,
+  zstd,
+  pkg-config,
+  systemd,
+  ninja,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tqftpserv";
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    owner = "linux-msm";
+    repo = "tqftpserv";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Djw2rx1FXYYPXs6Htq7jWcgeXFvfCUoeidKtYUvTqZU=";
+  };
+
+  buildInputs = [
+    qrtr
+    zstd
+    systemd
+  ];
+
+  nativeBuildInputs = [
+    meson
+    pkg-config
+    ninja
+  ];
+
+  postPatch = ''
+    substituteInPlace translate.c --replace-fail '/lib/firmware/' '/run/current-system/sw/share/uncompressed-firmware'
+  '';
+
+  installFlags = [ "prefix=$(out)" ];
+
+  meta = with lib; {
+    maintainers = with maintainers; [ matthewcroughan ];
+    description = "Trivial File Transfer Protocol server over AF_QIPCRTR";
+    homepage = "https://github.com/andersson/tqftpserv";
+    license = licenses.bsd3;
+    platforms = platforms.aarch64;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

These are packages that also will get their own systemd services, they are important for interacting with the modem/remoteproc and are necessary for making calls, I've tested the programs as working, and am in the process of testing systemd services.

https://github.com/mobile-nixos/mobile-nixos/tree/development/overlay/qrtr contains some old versions of the packages, but now that linux-msm maintains them, they are suitable for merging into nixpkgs as they are properly maintained upstream.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
