### PR TITLE
logstash-filter-verifier: init at 1.6.3

### DIFF
--- a/pkgs/by-name/lo/logstash-filter-verifier/package.nix
+++ b/pkgs/by-name/lo/logstash-filter-verifier/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "logstash-filter-verifier";
+  version = "1.6.3";
+
+  src = fetchFromGitHub {
+    owner = "magnusbaeck";
+    repo = "logstash-filter-verifier";
+    tag = finalAttrs.version;
+    hash = "sha256-JpZ1b2+NaL3AwHyBFJHzf3EZCXKYBpr3kVTo81g2Fmc=";
+  };
+
+  vendorHash = "sha256-GtEdURIV5ui6YtR1Pkx4zT5djJlcvK7tQktFQ4Fn1pI=";
+
+  postPatch = ''
+    substituteInPlace logstash-filter-verifier.go \
+      --replace-fail 'GitSummary = "(unknown)"' 'GitSummary = "${finalAttrs.version}"'
+  '';
+
+  ldflags = [ "-s -w" ];
+
+  nativeCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Run test cases against your Logstash pipelines";
+    homepage = "https://github.com/magnusbaeck/logstash-filter-verifier";
+    changelog = "https://github.com/magnusbaeck/logstash-filter-verifier/blob/${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.kpbaks ];
+    mainProgram = "logstash-filter-verifier";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Init [logstash-filter-verifier](https://github.com/magnusbaeck/logstash-filter-verifier) at version `1.6.3`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
