### PR TITLE
treewide: pin GitHub source URLs to commits

### DIFF
--- a/pkgs/applications/editors/eclipse/plugins.nix
+++ b/pkgs/applications/editors/eclipse/plugins.nix
@@ -146,12 +146,12 @@ rec {
     version = "1.3.5.201612301822";
 
     srcFeature = fetchurl {
-      url = "https://github.com/mihnita/ansi-econsole/raw/refs/heads/main/AnsiConSitePublished/features/net.mihai-nita.ansicon_${version}.jar";
+      url = "https://raw.githubusercontent.com/mihnita/ansi-econsole/8dcf0a2531cbf091310c0e01db1a1310557fc383/AnsiConSitePublished/features/net.mihai-nita.ansicon_${version}.jar";
       hash = "sha256-o9hnMuZeohU+AKS+ueU8dWS9HomrnqaKpWYMG5vMeJs=";
     };
 
     srcPlugin = fetchurl {
-      url = "https://github.com/mihnita/ansi-econsole/raw/refs/heads/main/AnsiConSitePublished/plugins/net.mihai-nita.ansicon.plugin_${version}.jar";
+      url = "https://raw.githubusercontent.com/mihnita/ansi-econsole/8dcf0a2531cbf091310c0e01db1a1310557fc383/AnsiConSitePublished/plugins/net.mihai-nita.ansicon.plugin_${version}.jar";
       hash = "sha256-WK7WxNZHvmMHGycC/12sIKj4wKIhWT8x1Anp3zuggsg=";
     };
 
@@ -215,12 +215,12 @@ rec {
     version = "2.7.3.202502241151";
 
     srcFeature = fetchurl {
-      url = "https://github.com/iloveeclipse/plugins/raw/refs/heads/latest/features/AnyEditTools_${version}.jar";
+      url = "https://raw.githubusercontent.com/iloveeclipse/plugins/f0560d1c628e0dba776831b1dea98d929515ebe5/features/AnyEditTools_${version}.jar";
       hash = "sha256-liEw+H8yTCrYQMe3gVQhJuxPXlSpEs4QwB2yv8n/CiE=";
     };
 
     srcPlugin = fetchurl {
-      url = "https://github.com/iloveeclipse/plugins/raw/refs/heads/latest/plugins/de.loskutov.anyedit.AnyEditTools_${version}.jar";
+      url = "https://raw.githubusercontent.com/iloveeclipse/plugins/f0560d1c628e0dba776831b1dea98d929515ebe5/plugins/de.loskutov.anyedit.AnyEditTools_${version}.jar";
       hash = "sha256-LrWCWJWZxsnMiBnTwXdWaXUoyXMYpLqXMUkHEOna2kk=";
     };
 
@@ -590,12 +590,12 @@ rec {
     version = "6.9.13.201609291640";
 
     srcFeature = fetchurl {
-      url = "https://github.com/testng-team/testng-eclipse-update-site/raw/refs/heads/main/updatesites/${version}/features/org.testng.eclipse_${version}.jar";
+      url = "https://raw.githubusercontent.com/testng-team/testng-eclipse-update-site/0eb404d0c65dc0ef25b19145bb44a56326a53da6/updatesites/${version}/features/org.testng.eclipse_${version}.jar";
       hash = "sha256-JahgneGUJN4jVxgXdkhhj5/TENXKXG635UO9Q7Vnnws=";
     };
 
     srcPlugin = fetchurl {
-      url = "https://github.com/testng-team/testng-eclipse-update-site/raw/refs/heads/main/updatesites/${version}/plugins/org.testng.eclipse_${version}.jar";
+      url = "https://raw.githubusercontent.com/testng-team/testng-eclipse-update-site/0eb404d0c65dc0ef25b19145bb44a56326a53da6/updatesites/${version}/plugins/org.testng.eclipse_${version}.jar";
       hash = "sha256-DTE60G+1ZnBT0i6FHuYDQlzwxhwAeXbHN3hgkYbhn8g=";
     };
 

--- a/pkgs/applications/emulators/mame/default.nix
+++ b/pkgs/applications/emulators/mame/default.nix
@@ -169,7 +169,7 @@ stdenv.mkDerivation rec {
   installPhase =
     let
       icon = fetchurl {
-        url = "https://raw.githubusercontent.com/PapirusDevelopmentTeam/papirus-icon-theme/refs/heads/master/Papirus/32x32/apps/mame.svg";
+        url = "https://raw.githubusercontent.com/PapirusDevelopmentTeam/papirus-icon-theme/4256be4cf56870aa1fbd85c48cafeafa187160e0/Papirus/32x32/apps/mame.svg";
         hash = "sha256-s44Xl9UGizmddd/ugwABovM8w35P0lW9ByB69MIpG+E=";
       };
     in

--- a/pkgs/by-name/fs/fsg/package.nix
+++ b/pkgs/by-name/fs/fsg/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     name = "fsg-src-${version}.tar.gz";
-    url = "https://github.com/ctrlcctrlv/wxsand/blob/master/fsg-src-${version}-ORIGINAL.tar.gz?raw=true";
+    url = "https://raw.githubusercontent.com/ctrlcctrlv/wxsand/5716c16b655ca3670e7acd76372b43763bec20d1/fsg-src-${version}-ORIGINAL.tar.gz";
     sha256 = "1756y01rkvd3f1pkj88jqh83fqcfl2fy0c48mcq53pjzln9ycv8c";
   };
 

--- a/pkgs/by-name/li/livekit-libwebrtc/package.nix
+++ b/pkgs/by-name/li/livekit-libwebrtc/package.nix
@@ -95,7 +95,7 @@ stdenv.mkDerivation {
     })
     # Fixes "error: no matching member function for call to 'emplace'"
     (fetchpatch {
-      url = "https://raw.githubusercontent.com/zed-industries/livekit-rust-sdks/refs/heads/main/webrtc-sys/libwebrtc/patches/abseil_use_optional.patch";
+      url = "https://raw.githubusercontent.com/zed-industries/livekit-rust-sdks/5f04705ac3f356350ae31534ffbc476abc9ea83d/webrtc-sys/libwebrtc/patches/abseil_use_optional.patch";
       hash = "sha256-FOwlwOqgv5IEBCMogPACbXXxdNhGzpYcVfsolcwA7qU=";
 
       extraPrefix = "third_party/";

--- a/pkgs/by-name/me/meslo-lg/package.nix
+++ b/pkgs/by-name/me/meslo-lg/package.nix
@@ -11,13 +11,13 @@ stdenv.mkDerivation rec {
   pname = "meslo-lg";
 
   meslo-lg = fetchurl {
-    url = "https://github.com/andreberg/Meslo-Font/blob/master/dist/v${version}/Meslo%20LG%20v${version}.zip?raw=true";
+    url = "https://raw.githubusercontent.com/andreberg/Meslo-Font/09a431d546d211130352c28eb0466e5d7d5aeaf0/dist/v${version}/Meslo%20LG%20v${version}.zip";
     name = "${pname}-${version}";
     sha256 = "1l08mxlzaz3i5bamnfr49s2k4k23vdm64b8nz2ha33ysimkbgg6h";
   };
 
   meslo-lg-dz = fetchurl {
-    url = "https://github.com/andreberg/Meslo-Font/blob/master/dist/v${version}/Meslo%20LG%20DZ%20v${version}.zip?raw=true";
+    url = "https://raw.githubusercontent.com/andreberg/Meslo-Font/09a431d546d211130352c28eb0466e5d7d5aeaf0/dist/v${version}/Meslo%20LG%20DZ%20v${version}.zip";
     name = "${pname}-${version}-dz";
     sha256 = "0lnbkrvcpgz9chnvix79j6fiz36wj6n46brb7b1746182rl1l875";
   };


### PR DESCRIPTION
I verified each URL with `nix-prefetch-url` or `nix store prefetch-file` to ensure it resolves to the correct hash. In some cases the URLs were already broken, e.g. the mame icon URL resolved to a newer icon version that didn't match the hash. In these cases I just used an older commit, so this PR shouldn't change any build products.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
