### PR TITLE
pianobar: fix build/run-time

### DIFF
--- a/pkgs/by-name/pi/pianobar/package.nix
+++ b/pkgs/by-name/pi/pianobar/package.nix
@@ -6,7 +6,7 @@
   libao,
   json_c,
   libgcrypt,
-  ffmpeg,
+  ffmpeg_7,
   curl,
 }:
 
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
     libao
     json_c
     libgcrypt
-    ffmpeg
+    ffmpeg_7
     curl
   ];
 
@@ -42,5 +42,6 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.unix;
     license = lib.licenses.mit; # expat version
     mainProgram = "pianobar";
+    maintainers = with lib.maintainers; [ S0AndS0 ];
   };
 })


### PR DESCRIPTION
> Side note; please ignore the force push mess...  I had issues of the skills kind x-)

TLDR: pinning `ffmpeg` to `ffmpeg_7` resolves build and run-time issues caused by recent `nix flake update`

Details may be found via;

- https://github.com/NixOS/nixpkgs/issues/462099
- https://hydra.nixos.org/build/313209385/nixlog/2

Build log failure for those that don't have time to go clicking about;

```
Running phase: unpackPhase
unpacking source archive /nix/store/rfxpazrd134nfn7ha28nrj1c5j8m72k4-source
source root is source
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
no configure script, doing nothing
Running phase: buildPhase
build flags: SHELL=/nix/store/qsydfxm1vq6q9jac2kq3r8kn0xdmsldf-bash-5.3p3/bin/bash PREFIX=\$\(out\)
    CC  src/main.c
src/main.c: In function 'BarMainGetLoginCredentials':
src/main.c:142:33: warning: ignoring return value of 'read' declared with attribute 'warn_unused_result' [-Wunused-result]
  142 |                                 read (pipeFd[0], passBuf, sizeof (passBuf)-1);
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CC  src/debug.c
    CC  src/player.c
src/player.c: In function 'finish':
src/player.c:517:17: error: implicit declaration of function 'avcodec_close'; did you mean 'avio_close'? [-Wimplicit-function-declaration]
  517 |                 avcodec_close (player->cctx);
      |                 ^~~~~~~~~~~~~
      |                 avio_close
make: *** [Makefile:110: src/player.o] Error 1
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - ~~[ ] Module addition: when adding a new NixOS module.~~
  - ~~[ ] Module update: when the change is significant.~~
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
