### PR TITLE
[25.05] git-lfs: 3.6.1 -> 3.7.1

### DIFF
--- a/pkgs/by-name/gi/git-lfs/package.nix
+++ b/pkgs/by-name/gi/git-lfs/package.nix
@@ -12,13 +12,13 @@
 
 buildGoModule rec {
   pname = "git-lfs";
-  version = "3.7.0";
+  version = "3.7.1";
 
   src = fetchFromGitHub {
     owner = "git-lfs";
     repo = "git-lfs";
     tag = "v${version}";
-    hash = "sha256-EFuuyD83aYe6XMKbRfAykVMfGFOQ4I6ORvMRm0Q8vfM=";
+    hash = "sha256-N5ckTnyA3mueZre+rMhFZBiAFgEu4pmtzkiUidXnan8=";
   };
 
   vendorHash = "sha256-6H0KpLin+DqwEg5bdzaxj2CoNSneZ/ET43MTrrdF3h8=";

--- a/pkgs/by-name/gi/git-lfs/package.nix
+++ b/pkgs/by-name/gi/git-lfs/package.nix
@@ -12,16 +12,16 @@
 
 buildGoModule rec {
   pname = "git-lfs";
-  version = "3.6.1";
+  version = "3.7.0";
 
   src = fetchFromGitHub {
     owner = "git-lfs";
     repo = "git-lfs";
     tag = "v${version}";
-    hash = "sha256-zZ9VYWVV+8G3gojj1m74syvsYM1mX0YT4hKnpkdMAQk=";
+    hash = "sha256-EFuuyD83aYe6XMKbRfAykVMfGFOQ4I6ORvMRm0Q8vfM=";
   };
 
-  vendorHash = "sha256-JT0r/hs7ZRtsYh4aXy+v8BjwiLvRJ10e4yRirqmWVW0=";
+  vendorHash = "sha256-6H0KpLin+DqwEg5bdzaxj2CoNSneZ/ET43MTrrdF3h8=";
 
   nativeBuildInputs = [
     asciidoctor


### PR DESCRIPTION
Fixes CVE-2025-26625.

https://github.com/git-lfs/git-lfs/releases/tag/v3.7.0
https://github.com/git-lfs/git-lfs/releases/tag/v3.7.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 462304`
Commit: `31bb16fe99a4e9ff12e92f78ab4487dfa9403a0d`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 1 package marked as broken and skipped:</summary>
  <ul>
    <li>pulsar</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 51 packages built:</summary>
  <ul>
    <li>bundix</li>
    <li>cabal2nix</li>
    <li>chirpstack-concentratord</li>
    <li>crate2nix</li>
    <li>crystal2nix</li>
    <li>dub-to-nix</li>
    <li>envision</li>
    <li>gcalcli</li>
    <li>gcalcli.dist</li>
    <li>git-lfs</li>
    <li>git-unroll</li>
    <li>github-backup</li>
    <li>github-backup.dist</li>
    <li>haskellPackages.cabal2nix-unstable</li>
    <li>haskellPackages.cli-nix</li>
    <li>haskellPackages.cli-nix.doc</li>
    <li>haskellPackages.nix-thunk</li>
    <li>haskellPackages.nix-thunk.doc</li>
    <li>haskellPackages.nvfetcher</li>
    <li>haskellPackages.nvfetcher.doc</li>
    <li>haskellPackages.update-nix-fetchgit</li>
    <li>haskellPackages.update-nix-fetchgit.doc</li>
    <li>kcl</li>
    <li>lon</li>
    <li>luarocks-packages-updater</li>
    <li>luarocks-packages-updater.dist</li>
    <li>makehuman</li>
    <li>mlv-app</li>
    <li>nim_lk</li>
    <li>nix-prefetch-git</li>
    <li>nix-prefetch-scripts</li>
    <li>nix-update</li>
    <li>nix-update-source</li>
    <li>nix-update-source.dist</li>
    <li>nix-update.dist</li>
    <li>npins</li>
    <li>nvfetcher</li>
    <li>outline</li>
    <li>prefetch-yarn-deps</li>
    <li>python312Packages.nixpkgs-updaters-library</li>
    <li>python312Packages.nixpkgs-updaters-library.dist</li>
    <li>python313Packages.nixpkgs-updaters-library</li>
    <li>python313Packages.nixpkgs-updaters-library.dist</li>
    <li>sonarr</li>
    <li>sparkleshare</li>
    <li>sus-compiler</li>
    <li>typescript-language-server</li>
    <li>update-nix-fetchgit</li>
    <li>update-python-libraries</li>
    <li>vimPluginsUpdater</li>
    <li>yarn2nix</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
