### PR TITLE
fix patchShebangs in the presence of readonly scripts

### DIFF
--- a/pkgs/build-support/setup-hooks/patch-shebangs.sh
+++ b/pkgs/build-support/setup-hooks/patch-shebangs.sh
@@ -135,7 +135,7 @@ patchShebangs() {
                 # Make original file writable if it is read-only
                 local restoreReadOnly
                 if [[ ! -w "$f" ]]; then
-                    chmod +w "$f"
+                    chmod u+w "$f"
                     restoreReadOnly=true
                 fi
 
@@ -144,7 +144,7 @@ patchShebangs() {
                 cat "$tmpFile" > "$f"
                 rm "$tmpFile"
                 if [[ -n "${restoreReadOnly:-}" ]]; then
-                    chmod -w "$f"
+                    chmod u-w "$f"
                 fi
 
                 touch --date "$timestamp" "$f"

--- a/pkgs/build-support/setup-hooks/patch-shebangs.sh
+++ b/pkgs/build-support/setup-hooks/patch-shebangs.sh
@@ -133,7 +133,7 @@ patchShebangs() {
                 sed -e "1 s|.*|#\!$escapedInterpreterLine|" "$f" > "$tmpFile"
 
                 # Make original file writable if it is read-only
-                local restoreReadOnly
+                local restoreReadOnly=
                 if [[ ! -w "$f" ]]; then
                     chmod u+w "$f"
                     restoreReadOnly=true

--- a/pkgs/test/stdenv/patch-shebangs.nix
+++ b/pkgs/test/stdenv/patch-shebangs.nix
@@ -164,19 +164,30 @@ let
             . ${../../stdenv/generic/setup.sh}
             . ${../../build-support/setup-hooks/patch-shebangs.sh}
             mkdir -p $out/bin
-            echo "#!/bin/bash" > $out/bin/test
-            echo "echo -n hello" >> $out/bin/test
-            chmod 555 $out/bin/test
-            original_perms=$(stat -c %a $out/bin/test)
-            patchShebangs $out/bin/test
-            new_perms=$(stat -c %a $out/bin/test)
-            if ! [ "$original_perms" = "$new_perms" ]; then
-              echo "Permissions changed from $original_perms to $new_perms"
-              exit 1
-            fi
+            for mode in 555 575 755 775
+            do
+              target=$out/bin/test-$mode
+              echo "#!/bin/bash" > "$target"
+              echo "echo -n hello" >> "$target"
+              chmod $mode "$target"
+              if ! [ "$mode" = "$(stat -c %a "$target")" ]; then
+                echo "chmod didn't set up test permissions as expected"
+                exit 1
+              fi
+              original_perms=$(stat -c %a "$target")
+              patchShebangs "$target"
+              new_perms=$(stat -c %a "$target")
+              if ! [ "$original_perms" = "$new_perms" ]; then
+                echo "Permissions changed from $original_perms to $new_perms"
+                exit 1
+              fi
+            done
           ''
         ];
-        assertion = "grep '^#!${lib.getExe earlyBash}' $out/bin/test > /dev/null";
+        # This tests that any of the test files have this line, when we should
+        # really be testing all of them. But it's a little redundant with other
+        # tests anyway.
+        assertion = "grep '^#!${lib.getExe earlyBash}' $out/bin/test-* > /dev/null";
       })
       // {
         meta = { };

--- a/pkgs/test/stdenv/patch-shebangs.nix
+++ b/pkgs/test/stdenv/patch-shebangs.nix
@@ -164,7 +164,8 @@ let
             . ${../../stdenv/generic/setup.sh}
             . ${../../build-support/setup-hooks/patch-shebangs.sh}
             mkdir -p $out/bin
-            for mode in 555 575 755 775
+            modes=(555 575 755 775 777)
+            for mode in "''${modes[@]}"
             do
               target=$out/bin/test-$mode
               echo "#!/bin/bash" > "$target"
@@ -174,11 +175,17 @@ let
                 echo "chmod didn't set up test permissions as expected"
                 exit 1
               fi
-              original_perms=$(stat -c %a "$target")
-              patchShebangs "$target"
+            done
+            # This is structured as two loops + one patchShebangs so that at
+            # least one test exercises patchShebangs on multiple scripts in one
+            # invocation.
+            patchShebangs $out/bin
+            for mode in "''${modes[@]}"
+            do
+              target=$out/bin/test-$mode
               new_perms=$(stat -c %a "$target")
-              if ! [ "$original_perms" = "$new_perms" ]; then
-                echo "Permissions changed from $original_perms to $new_perms"
+              if ! [ "$mode" = "$new_perms" ]; then
+                echo "Permissions changed from $mode to $new_perms"
                 exit 1
               fi
             done


### PR DESCRIPTION
- Fixes #462298
- Replaces `chmod -w` with `chmod u-w` (and likewise `+w`) in `patch-shebangs.sh`, so that the only permission we touch is the one that we tested (and the one that we need). Restoring the mode just wasn't working correctly before, because `-w` isn't an inverse of `+w` (except in special cases). As documented in the issue, this is necessary to fix working on scripts with mode 575 (though who uses those?)
    - Added a test case that catches this.
- Fixes `restoreReadOnly` stale value by resetting it to an empty string on every loop iteration. This was a much more serious problem, leading the hook to break on scripts with mode 777 as long as you'd already seen a readonly script earlier this invocation.
    - Testing this requires a single invocation of `patchShebangs` that visits a readonly file before a read-write one. In general the order of `patchShebangs` is the order of the embedded `find` operation, which is nondeterministic, but I think `find` processes its command line arguments in order, so you could do something like `patchShebangs test-555 test-777` and I think that would do it. This would feel very specific to this one bug, though, and unlikely to be useful in future.

Testing this comprehensively is made more tricky by the fact that modifying this script forces a rebuild of everything. I worked around this by copying the fixed script to another location and replacing the line in the test that sources the real script with one that sources my fixed script (and cherry-picking all my test changes). The test passes in this setup (and fails on the original script).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
