### PR TITLE
newsflash: 4.1.4 -> 4.2.1

### DIFF
--- a/pkgs/by-name/ne/newsflash/package.nix
+++ b/pkgs/by-name/ne/newsflash/package.nix
@@ -22,7 +22,7 @@
   glib-networking,
   librsvg,
   gst_all_1,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -94,9 +94,11 @@ stdenv.mkDerivation (finalAttrs: {
   # For https://gitlab.com/news-flash/news_flash_gtk/-/blob/8e5fc4acf5ca6be5b8cd616466a17e7a273f9dda/src/meson.build#L47
   env.CARGO_BUILD_TARGET = stdenv.hostPlatform.rust.rustcTargetSpec;
 
-  passthru.updateScript = gitUpdater {
-    rev-prefix = "v.";
-    ignoredVersions = "(alpha|beta|rc)";
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^v.(\\d+\\.\\d+\\.\\d+)$"
+    ];
   };
 
   meta = {

--- a/pkgs/by-name/ne/newsflash/package.nix
+++ b/pkgs/by-name/ne/newsflash/package.nix
@@ -104,6 +104,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Modern feed reader designed for the GNOME desktop";
     homepage = "https://gitlab.com/news-flash/news_flash_gtk";
+    changelog = "https://gitlab.com/news-flash/news_flash_gtk/-/raw/${finalAttrs.src.tag}/data/io.gitlab.news_flash.NewsFlash.appdata.xml.in.in#:~:text=%3Crelease%20version=%22${finalAttrs.version}%22,%3C/release%3E";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       kira-bruneau

--- a/pkgs/by-name/ne/newsflash/package.nix
+++ b/pkgs/by-name/ne/newsflash/package.nix
@@ -27,18 +27,18 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "newsflash";
-  version = "4.1.4";
+  version = "4.2.1";
 
   src = fetchFromGitLab {
     owner = "news-flash";
     repo = "news_flash_gtk";
     tag = "v.${finalAttrs.version}";
-    hash = "sha256-3RGa1f+V7dIgTxQKOceVSr7RwajUgwq05ypBhg6RjMA=";
+    hash = "sha256-me9/2sA1Thne10+JrSMvicDRxXuevCnM8Tb+kwXzNDI=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-CRQH22EP/G6osjsuZJmTWwjq4C06DxiIXlz6zxgbDv4=";
+    hash = "sha256-cgu1zP85UCb/6gYNcj/khc6u1kSwX0UZ2oIjM2UUBOA=";
   };
 
   postPatch = ''
@@ -65,7 +65,6 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Provides setup hook to fix "Unrecognized image file format"
     gdk-pixbuf
-
   ];
 
   buildInputs = [
@@ -91,7 +90,7 @@ stdenv.mkDerivation (finalAttrs: {
     gst-plugins-bad
   ]);
 
-  # For https://gitlab.com/news-flash/news_flash_gtk/-/blob/8e5fc4acf5ca6be5b8cd616466a17e7a273f9dda/src/meson.build#L47
+  # For https://gitlab.com/news-flash/news_flash_gtk/-/blob/v.4.2.1/src/meson.build#L48
   env.CARGO_BUILD_TARGET = stdenv.hostPlatform.rust.rustcTargetSpec;
 
   passthru.updateScript = nix-update-script {


### PR DESCRIPTION
https://gitlab.com/news-flash/news_flash_gtk/-/raw/v.4.2.1/data/io.gitlab.news_flash.NewsFlash.appdata.xml.in.in#:~:text=%3Crelease%20version=%224.2.1%22,%3C/release%3E

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
