### PR TITLE
gopher64: fix build

### DIFF
--- a/pkgs/by-name/go/gopher64/allow-unused-type.patch
+++ b/pkgs/by-name/go/gopher64/allow-unused-type.patch
@@ -1,0 +1,12 @@
+diff --git a/src/device/cart.rs b/src/device/cart.rs
+index 97bf09f..4406fec 100644
+--- a/src/device/cart.rs
++++ b/src/device/cart.rs
+@@ -21,6 +21,7 @@ const JDT_EEPROM_16K: u16 = 0xc000; /* 16k EEPROM */
+ const EEPROM_BLOCK_SIZE: usize = 8;
+ pub const EEPROM_MAX_SIZE: usize = 0x800;
+ 
++#[allow(warnings)]
+ #[derive(serde::Serialize, serde::Deserialize)]
+ pub enum CicType {
+     CicNus6101,

--- a/pkgs/by-name/go/gopher64/package.nix
+++ b/pkgs/by-name/go/gopher64/package.nix
@@ -42,6 +42,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
     # make the build script use the @GIT_REV@ string that will be substituted in the logic below
     ./set-git-rev.patch
+
+    # enum CicType is not used, but dead code is treated as an error
+    ./allow-unused-type.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
ZHF: https://github.com/NixOS/nixpkgs/issues/457852

https://hydra.nixos.org/build/313152289/nixlog/2

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
