### PR TITLE
liboprf: don't install static libraries

### DIFF
--- a/pkgs/by-name/li/liboprf/no-static.patch
+++ b/pkgs/by-name/li/liboprf/no-static.patch
@@ -1,0 +1,37 @@
+diff --git a/makefile b/makefile
+index 444feae..0b2d482 100644
+--- a/makefile
++++ b/makefile
+@@ -134,8 +134,12 @@ clean:
+ 
+ install: install-oprf install-noiseXK
+ 
+-install-oprf: $(DESTDIR)$(PREFIX)/lib/liboprf.$(SOEXT) \
+-	$(DESTDIR)$(PREFIX)/lib/liboprf.$(STATICEXT) \
++INSTALL_EXT=$(STATICEXT)
++ifeq ($(findstring -shared,$(LDFLAGS)),)
++	INSTALL_EXT=$(SOEXT)
++endif
++
++install-oprf: $(DESTDIR)$(PREFIX)/lib/liboprf.$(INSTALL_EXT) \
+ 	$(DESTDIR)$(PREFIX)/lib/pkgconfig/liboprf.pc \
+ 	$(DESTDIR)$(PREFIX)/include/oprf/oprf.h \
+ 	$(DESTDIR)$(PREFIX)/include/oprf/toprf.h \
+diff --git a/noise_xk/makefile b/noise_xk/makefile
+index 0f18a04..b6261a5 100644
+--- a/noise_xk/makefile
++++ b/noise_xk/makefile
+@@ -56,7 +56,12 @@ clean:
+ liboprf-noiseXK.$(SOEXT).$(SOVER): liboprf-noiseXK.$(SOEXT)
+ 	ln -sf $^ $@
+ 
+-install: $(DESTDIR)$(PREFIX)/lib/liboprf-noiseXK.$(SOEXT) $(DESTDIR)$(PREFIX)/lib/liboprf-noiseXK.$(STATICEXT) $(DESTDIR)$(PREFIX)/include/oprf/noiseXK
++INSTALL_EXT=$(STATICEXT)
++ifeq ($(findstring -shared,$(LDFLAGS)),)
++        INSTALL_EXT=$(SOEXT)
++endif
++
++install: $(DESTDIR)$(PREFIX)/lib/liboprf-noiseXK.$(INSTALL_EXT) $(DESTDIR)$(PREFIX)/include/oprf/noiseXK
+ 
+ uninstall: $(DESTDIR)$(PREFIX)/lib/liboprf-noiseXK.$(SOEXT) $(DESTDIR)$(PREFIX)/lib/liboprf-noiseXK.$(STATICEXT) $(DESTDIR)$(PREFIX)/include/oprf/noiseXK
+ 	rm -rf $^

--- a/pkgs/by-name/li/liboprf/package.nix
+++ b/pkgs/by-name/li/liboprf/package.nix
@@ -20,6 +20,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/src";
 
+  patches = [
+    ./no-static.patch
+  ];
+
   strictDeps = true;
 
   nativeBuildInputs = [ pkgconf ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
