### PR TITLE
tts-mod-vault: fix desktopItem naming

### DIFF
--- a/pkgs/by-name/tt/tts-mod-vault/package.nix
+++ b/pkgs/by-name/tt/tts-mod-vault/package.nix
@@ -21,9 +21,9 @@ flutter329.buildFlutterApplication rec {
 
   desktopItems = [
     (makeDesktopItem {
-      name = "tts-mod-vault";
-      exec = "tts-mod-vault";
-      icon = "tts-mod-vault";
+      name = "tts_mod_vault";
+      exec = "tts_mod_vault";
+      icon = "tts_mod_vault";
       comment = "Tabletop Simulator Mod Vault";
       desktopName = "TTS Mod Vault";
       categories = [ "Utility" ];
@@ -33,7 +33,7 @@ flutter329.buildFlutterApplication rec {
   nativeBuildInputs = [ copyDesktopItems ];
 
   postInstall = ''
-    install -m 444 -D assets/icon/tts_mod_vault_icon.png $out/share/icons/hicolor/1024x1024/apps/tts-mod-vault.png
+    install -m 444 -D assets/icon/tts_mod_vault_icon.png $out/share/icons/hicolor/1024x1024/apps/tts_mod_vault.png
   '';
 
   meta = {
@@ -41,7 +41,7 @@ flutter329.buildFlutterApplication rec {
     homepage = "https://github.com/markomijic/TTS-Mod-Vault";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ esch ];
-    mainProgram = "tts-mod-vault";
+    mainProgram = "tts_mod_vault";
     platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
Fixes the naming of the desktopItem from using dashes to underscores, keeping it in line with upstream's naming.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [X] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
