### PR TITLE
python314Packages.duckdb: fix build

### DIFF
--- a/pkgs/development/python-modules/duckdb/default.nix
+++ b/pkgs/development/python-modules/duckdb/default.nix
@@ -3,7 +3,6 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonOlder,
   cmake,
   ninja,
   duckdb,
@@ -16,6 +15,7 @@
   psutil,
   pyarrow,
   pybind11,
+  pytz,
   scikit-build-core,
   setuptools-scm,
   pytest-reraise,
@@ -73,16 +73,11 @@ buildPythonPackage rec {
   ];
 
   optional-dependencies = {
-    # Note: ipython and adbc_driver_manager currently excluded despite inclusion in upstream
-    # https://github.com/duckdb/duckdb-python/blob/v1.4.0/pyproject.toml#L44-L52
     all = [
+      # FIXME package adbc_driver_manager
       ipython
       fsspec
       numpy
-    ]
-    ++ lib.optionals (pythonOlder "3.14") [
-      # https://github.com/duckdb/duckdb-python/blob/0ee500cfa35fc07bf81ed02e8ab6984ea1f665fd/pyproject.toml#L49-L51
-      # adbc_driver_manager noted for migration to duckdb C source
       pandas
       pyarrow
     ];
@@ -105,6 +100,7 @@ buildPythonPackage rec {
     psutil
     pytest-reraise
     pytestCheckHook
+    pytz
   ]
   ++ optional-dependencies.all;
 


### PR DESCRIPTION
pandas is required on Python 3.14, see https://hydra.lossy.network/build/4208550/nixlog/2.

Tested on x86_64-linux and aarch64-linux by building python314Packages.{duckdb,duckdb-engine,sqlglot}.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
