### PR TITLE
Revert "[Backport release-25.05] lockbook-desktop: 25.10.23 -> 25.11.11"

### DIFF
--- a/pkgs/by-name/lo/lockbook-desktop/package.nix
+++ b/pkgs/by-name/lo/lockbook-desktop/package.nix
@@ -18,16 +18,16 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "lockbook-desktop";
-  version = "25.11.11";
+  version = "25.10.23";
 
   src = fetchFromGitHub {
     owner = "lockbook";
     repo = "lockbook";
     tag = version;
-    hash = "sha256-MHeNa0MfPOslop9bdA1+5qiY9/r0TXca+UsahgyA34A=";
+    hash = "sha256-WZ6XbsIqoLfVRtxnqBPaspQQPYdn4gOrsz5WPrKFiH4=";
   };
 
-  cargoHash = "sha256-whtucq2mmhp+UZYZS2MJ9jnIg7XOh4zziGD2lO710h8=";
+  cargoHash = "sha256-t7/UK/PwnUyw61mw9BlSQuT0qSeBKvFaKkS2ocmAViE=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
Reverts NixOS/nixpkgs#460999

Hey @SigmaSquadron I was wrong, and it is broken on 1.86 -- It's fine on `unstable` which is how I tested, which is obviously incorrect. In the future I'll do the pr review tool when we add a dependency (like we did with Hayro)-- we generally don't use any of the more recent features. We're also probably going to pin our project to whatever is on nix-stable so we have a more accurate representation of what works via our CI upstream.

Excuses aside, is this the right way to restore the `stable` channel?