### PR TITLE
python3Packages.mmengine: don't test coverage

### DIFF
--- a/pkgs/development/python-modules/mmengine/default.nix
+++ b/pkgs/development/python-modules/mmengine/default.nix
@@ -21,7 +21,6 @@
 
   # tests
   bitsandbytes,
-  coverage,
   dvclive,
   lion-pytorch,
   lmdb,
@@ -89,7 +88,6 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     bitsandbytes
-    coverage
     dvclive
     lion-pytorch
     lmdb


### PR DESCRIPTION
<details>

<summary>I can't test this because mmengine's tests currently segfault on master.</summary>

```
============================= test session starts ==============================
platform linux -- Python 3.13.9, pytest-8.4.2, pluggy-1.6.0
rootdir: /build/source
configfile: pytest.ini
testpaths: tests
plugins: hypothesis-6.136.9, hydra-core-1.3.2, anyio-4.11.0, typeguard-4.4.4
collected 1007 items / 96 deselected / 911 selected                            

tests/test_analysis/test_activation_count.py ....                        [  0%]
tests/test_analysis/test_flop_count.py ..................                [  2%]
tests/test_analysis/test_jit_analysis.py ...............                 [  4%]
tests/test_analysis/test_param_count.py ...                              [  4%]
tests/test_analysis/test_print_helper.py .                               [  4%]
tests/test_config/test_collect_meta.py ..                                [  4%]
tests/test_config/test_config.py ......................sss...            [  7%]
tests/test_config/test_lazy.py ...                                       [  8%]
tests/test_data/test_data_utils.py ..                                    [  8%]
tests/test_dataset/test_base_dataset.py ................................ [ 11%]
........                                                                 [ 12%]
tests/test_dataset/test_sampler.py .......                               [ 13%]
tests/test_device/test_device.py .                                       [ 13%]
tests/test_dist/test_dist.py ...........sssssssssssssssssss              [ 16%]
tests/test_dist/test_utils.py .s.........sssssssssssssssssssss           [ 20%]
tests/test_evaluator/test_evaluator.py ....s....                         [ 21%]
tests/test_evaluator/test_metric.py ...                                  [ 21%]
tests/test_fileio/test_backends/test_backend_utils.py .                  [ 21%]
tests/test_fileio/test_backends/test_base_storage_backend.py .           [ 21%]
tests/test_fileio/test_backends/test_lmdb_backend.py ...                 [ 22%]
tests/test_fileio/test_backends/test_local_backend.py .................. [ 24%]
.......                                                                  [ 25%]
tests/test_fileio/test_backends/test_memcached_backend.py ...            [ 25%]
tests/test_fileio/test_fileio.py .......                                 [ 26%]
tests/test_fileio/test_io.py ..............                              [ 27%]
tests/test_hooks/test_checkpoint_hook.py .......                         [ 28%]
tests/test_hooks/test_early_stopping_hook.py ....                        [ 28%]
tests/test_hooks/test_ema_hook.py ...........                            [ 30%]
tests/test_hooks/test_empty_cache_hook.py s                              [ 30%]
tests/test_hooks/test_hook.py ...........................                [ 33%]
tests/test_hooks/test_iter_timer_hook.py ...                             [ 33%]
tests/test_hooks/test_logger_hook.py .......                             [ 34%]
tests/test_hooks/test_naive_visualization_hook.py .                      [ 34%]
tests/test_hooks/test_param_scheduler_hook.py ....                       [ 34%]
tests/test_hooks/test_prepare_tta_hook.py .....                          [ 35%]
tests/test_hooks/test_profiler_hook.py ......s.ssss                      [ 36%]
tests/test_hooks/test_runtime_info_hook.py .........                     [ 37%]
tests/test_hooks/test_sampler_seed_hook.py ..                            [ 37%]
tests/test_hooks/test_sync_buffers_hook.py ss                            [ 38%]
tests/test_hub/test_hub.py ss                                            [ 38%]
tests/test_infer/test_infer.py .......ss.                                [ 39%]
tests/test_logging/test_history_buffer.py ..........                     [ 40%]
tests/test_logging/test_logger.py ............                           [ 41%]
tests/test_logging/test_message_hub.py ............                      [ 43%]
tests/test_model/test_averaged_model.py .......                          [ 43%]
tests/test_model/test_base_model/test_base_model.py s...s............... [ 46%]
.................                                                        [ 47%]
tests/test_model/test_base_model/test_data_preprocessor.py ....          [ 48%]
tests/test_model/test_base_module.py .....                               [ 48%]
tests/test_model/test_efficient_conv_bn_eval.py .                        [ 49%]
tests/test_model/test_model_utils.py ...                                 [ 49%]
tests/test_model/test_test_aug_time.py ...                               [ 49%]
tests/test_model/test_wrappers/test_model_wrapper.py ssssssssss          [ 50%]
tests/test_optim/test_optimizer/test_optimizer.py ....s..........ss      [ 52%]
tests/test_optim/test_optimizer/test_optimizer_wrapper.py ssssssssssssss [ 54%]
sssssssssssssssssssssss                                                  [ 56%]
tests/test_optim/test_optimizer/test_optimizer_wrapper_dict.py ......... [ 57%]
..........                                                               [ 58%]
tests/test_optim/test_scheduler/test_lr_scheduler.py ................... [ 60%]
..................                                                       [ 62%]
tests/test_optim/test_scheduler/test_momentum_scheduler.py ............. [ 64%]
...............                                                          [ 65%]
tests/test_optim/test_scheduler/test_param_scheduler.py ................ [ 67%]
............................................................             [ 74%]
tests/test_registry/test_build_functions.py .....                        [ 74%]
tests/test_registry/test_default_scope.py ...                            [ 75%]
tests/test_registry/test_registry.py ...............                     [ 76%]
tests/test_registry/test_registry_utils.py ...                           [ 77%]
tests/test_runner/test_activation_checkpointing.py .                     [ 77%]
tests/test_runner/test_amp.py .                                          [ 77%]
tests/test_runner/test_checkpoint.py .........                           [ 78%]
tests/test_runner/test_log_processor.py ............................     [ 81%]
tests/test_runner/test_priority.py .                                     [ 81%]
tests/test_runner/test_runner.py ..........................s.s.s.        [ 85%]
tests/test_strategies/test_fsdp.py sss                                   [ 85%]
tests/test_structures/test_data_element.py ..s................           [ 87%]
tests/test_structures/test_instance_data.py ....                         [ 87%]
tests/test_structures/test_label_data.py s..                             [ 88%]
tests/test_structures/test_pixel_data.py ...                             [ 88%]
tests/test_testing/test_compare.py ...........                           [ 89%]
tests/test_testing/test_runner_test_case.py .....                        [ 90%]
tests/test_utils/test_dl_utils/test_get_env.py .                         [ 90%]
tests/test_utils/test_dl_utils/test_setup_env.py .                       [ 90%]
tests/test_utils/test_dl_utils/test_time_counter.py ..                   [ 90%]
tests/test_utils/test_dl_utils/test_torch_ops.py .                       [ 90%]
tests/test_utils/test_dl_utils/test_trace.py .                           [ 90%]
tests/test_utils/test_manager.py ...                                     [ 91%]
tests/test_utils/test_package_utils.py ..                                [ 91%]
tests/test_utils/test_progressbar.py ......                              [ 92%]
tests/test_utils/test_progressbar_rich.py ...                            [ 92%]
tests/test_utils/test_timer.py ...                                       [ 92%]
tests/test_visualizer/test_vis_backend.py ......................Fatal Python error: Segmentation fault

Current thread 0x00007ffff7603740 (most recent call first):
  File "<frozen importlib._bootstrap>", line 488 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 1321 in create_module
  File "<frozen importlib._bootstrap>", line 813 in module_from_spec
  File "<frozen importlib._bootstrap>", line 921 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1331 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1360 in _find_and_load
  File "/nix/store/6plx13l2j3alnplhzb064rjcnwfgs0s5-python3.13-pyarrow-20.0.0/lib/python3.13/site-packages/pyarrow/__init__.py", line 61 in <module>
  File "<frozen importlib._bootstrap>", line 488 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 1027 in exec_module
  File "<frozen importlib._bootstrap>", line 935 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1331 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1360 in _find_and_load
  File "<frozen importlib._bootstrap>", line 488 in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1310 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1360 in _find_and_load
  File "/nix/store/ghxqhv8v8dgbsqjaf0csm5yymvapjzw1-python3.13-mlflow-3.3.1/lib/python3.13/site-packages/mlflow/store/artifact/hdfs_artifact_repo.py", line 7 in <module>
  File "<frozen importlib._bootstrap>", line 488 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 1027 in exec_module
  File "<frozen importlib._bootstrap>", line 935 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1331 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1360 in _find_and_load
  File "/nix/store/ghxqhv8v8dgbsqjaf0csm5yymvapjzw1-python3.13-mlflow-3.3.1/lib/python3.13/site-packages/mlflow/store/artifact/artifact_repository_registry.py", line 10 in <module>
  File "<frozen importlib._bootstrap>", line 488 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 1027 in exec_module
  File "<frozen importlib._bootstrap>", line 935 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1331 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1360 in _find_and_load
  File "/nix/store/ghxqhv8v8dgbsqjaf0csm5yymvapjzw1-python3.13-mlflow-3.3.1/lib/python3.13/site-packages/mlflow/tracing/client.py", line 26 in <module>
  File "<frozen importlib._bootstrap>", line 488 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 1027 in exec_module
  File "<frozen importlib._bootstrap>", line 935 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1331 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1360 in _find_and_load
  File "/nix/store/ghxqhv8v8dgbsqjaf0csm5yymvapjzw1-python3.13-mlflow-3.3.1/lib/python3.13/site-packages/mlflow/tracking/client.py", line 91 in <module>
  File "<frozen importlib._bootstrap>", line 488 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 1027 in exec_module
  File "<frozen importlib._bootstrap>", line 935 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1331 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1360 in _find_and_load
  File "/nix/store/ghxqhv8v8dgbsqjaf0csm5yymvapjzw1-python3.13-mlflow-3.3.1/lib/python3.13/site-packages/mlflow/tracking/__init__.py", line 33 in <module>
  File "<frozen importlib._bootstrap>", line 488 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 1027 in exec_module
  File "<frozen importlib._bootstrap>", line 935 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1331 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1360 in _find_and_load
  File "/nix/store/ghxqhv8v8dgbsqjaf0csm5yymvapjzw1-python3.13-mlflow-3.3.1/lib/python3.13/site-packages/mlflow/artifacts/__init__.py", line 14 in <module>
  File "<frozen importlib._bootstrap>", line 488 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 1027 in exec_module
  File "<frozen importlib._bootstrap>", line 935 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1331 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1360 in _find_and_load
  File "<frozen importlib._bootstrap>", line 488 in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1415 in _handle_fromlist
  File "/nix/store/ghxqhv8v8dgbsqjaf0csm5yymvapjzw1-python3.13-mlflow-3.3.1/lib/python3.13/site-packages/mlflow/__init__.py", line 44 in <module>
  File "<frozen importlib._bootstrap>", line 488 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 1027 in exec_module
  File "<frozen importlib._bootstrap>", line 935 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1331 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1360 in _find_and_load
  File "/build/source/mmengine/visualization/vis_backend.py", line 705 in _init_env
  File "/build/source/mmengine/visualization/vis_backend.py", line 57 in wrapper
  File "/build/source/tests/test_visualizer/test_vis_backend.py", line 283 in test_experiment
  File "/nix/store/gx29m36wxs6vz4qk45m7n5pylpgj690y-python3.13-pytest-8.4.2/lib/python3.13/site-packages/_pytest/python.py", line 157 in pytest_pyfunc_call
  File "/nix/store/5bhzpq0n9rfpnxh4ni91cn4rw1wwprvd-python3.13-pluggy-1.6.0/lib/python3.13/site-packages/pluggy/_callers.py", line 121 in _multicall
  File "/nix/store/5bhzpq0n9rfpnxh4ni91cn4rw1wwprvd-python3.13-pluggy-1.6.0/lib/python3.13/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/nix/store/5bhzpq0n9rfpnxh4ni91cn4rw1wwprvd-python3.13-pluggy-1.6.0/lib/python3.13/site-packages/pluggy/_hooks.py", line 512 in __call__
  File "/nix/store/gx29m36wxs6vz4qk45m7n5pylpgj690y-python3.13-pytest-8.4.2/lib/python3.13/site-packages/_pytest/python.py", line 1671 in runtest
  File "/nix/store/gx29m36wxs6vz4qk45m7n5pylpgj690y-python3.13-pytest-8.4.2/lib/python3.13/site-packages/_pytest/runner.py", line 178 in pytest_runtest_call
  File "/nix/store/5bhzpq0n9rfpnxh4ni91cn4rw1wwprvd-python3.13-pluggy-1.6.0/lib/python3.13/site-packages/pluggy/_callers.py", line 121 in _multicall
  File "/nix/store/5bhzpq0n9rfpnxh4ni91cn4rw1wwprvd-python3.13-pluggy-1.6.0/lib/python3.13/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/nix/store/5bhzpq0n9rfpnxh4ni91cn4rw1wwprvd-python3.13-pluggy-1.6.0/lib/python3.13/site-packages/pluggy/_hooks.py", line 512 in __call__
  File "/nix/store/gx29m36wxs6vz4qk45m7n5pylpgj690y-python3.13-pytest-8.4.2/lib/python3.13/site-packages/_pytest/runner.py", line 246 in <lambda>
  File "/nix/store/gx29m36wxs6vz4qk45m7n5pylpgj690y-python3.13-pytest-8.4.2/lib/python3.13/site-packages/_pytest/runner.py", line 344 in from_call
  File "/nix/store/gx29m36wxs6vz4qk45m7n5pylpgj690y-python3.13-pytest-8.4.2/lib/python3.13/site-packages/_pytest/runner.py", line 245 in call_and_report
  File "/nix/store/gx29m36wxs6vz4qk45m7n5pylpgj690y-python3.13-pytest-8.4.2/lib/python3.13/site-packages/_pytest/runner.py", line 136 in runtestprotocol
  File "/nix/store/gx29m36wxs6vz4qk45m7n5pylpgj690y-python3.13-pytest-8.4.2/lib/python3.13/site-packages/_pytest/runner.py", line 117 in pytest_runtest_protocol
  File "/nix/store/5bhzpq0n9rfpnxh4ni91cn4rw1wwprvd-python3.13-pluggy-1.6.0/lib/python3.13/site-packages/pluggy/_callers.py", line 121 in _multicall
  File "/nix/store/5bhzpq0n9rfpnxh4ni91cn4rw1wwprvd-python3.13-pluggy-1.6.0/lib/python3.13/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/nix/store/5bhzpq0n9rfpnxh4ni91cn4rw1wwprvd-python3.13-pluggy-1.6.0/lib/python3.13/site-packages/pluggy/_hooks.py", line 512 in __call__
  File "/nix/store/gx29m36wxs6vz4qk45m7n5pylpgj690y-python3.13-pytest-8.4.2/lib/python3.13/site-packages/_pytest/main.py", line 367 in pytest_runtestloop
  File "/nix/store/5bhzpq0n9rfpnxh4ni91cn4rw1wwprvd-python3.13-pluggy-1.6.0/lib/python3.13/site-packages/pluggy/_callers.py", line 121 in _multicall
  File "/nix/store/5bhzpq0n9rfpnxh4ni91cn4rw1wwprvd-python3.13-pluggy-1.6.0/lib/python3.13/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/nix/store/5bhzpq0n9rfpnxh4ni91cn4rw1wwprvd-python3.13-pluggy-1.6.0/lib/python3.13/site-packages/pluggy/_hooks.py", line 512 in __call__
  File "/nix/store/gx29m36wxs6vz4qk45m7n5pylpgj690y-python3.13-pytest-8.4.2/lib/python3.13/site-packages/_pytest/main.py", line 343 in _main
  File "/nix/store/gx29m36wxs6vz4qk45m7n5pylpgj690y-python3.13-pytest-8.4.2/lib/python3.13/site-packages/_pytest/main.py", line 289 in wrap_session
  File "/nix/store/gx29m36wxs6vz4qk45m7n5pylpgj690y-python3.13-pytest-8.4.2/lib/python3.13/site-packages/_pytest/main.py", line 336 in pytest_cmdline_main
  File "/nix/store/5bhzpq0n9rfpnxh4ni91cn4rw1wwprvd-python3.13-pluggy-1.6.0/lib/python3.13/site-packages/pluggy/_callers.py", line 121 in _multicall
  File "/nix/store/5bhzpq0n9rfpnxh4ni91cn4rw1wwprvd-python3.13-pluggy-1.6.0/lib/python3.13/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/nix/store/5bhzpq0n9rfpnxh4ni91cn4rw1wwprvd-python3.13-pluggy-1.6.0/lib/python3.13/site-packages/pluggy/_hooks.py", line 512 in __call__
  File "/nix/store/gx29m36wxs6vz4qk45m7n5pylpgj690y-python3.13-pytest-8.4.2/lib/python3.13/site-packages/_pytest/config/__init__.py", line 175 in main
  File "/nix/store/gx29m36wxs6vz4qk45m7n5pylpgj690y-python3.13-pytest-8.4.2/lib/python3.13/site-packages/_pytest/config/__init__.py", line 201 in console_main
  File "/nix/store/gx29m36wxs6vz4qk45m7n5pylpgj690y-python3.13-pytest-8.4.2/lib/python3.13/site-packages/pytest/__main__.py", line 9 in <module>
  File "<frozen runpy>", line 88 in _run_code
  File "<frozen runpy>", line 198 in _run_module_as_main

Extension modules: yaml._yaml, numpy._core._multiarray_umath, numpy.linalg._umath_linalg, torch._C, torch._C._dynamo.autograd_compiler, torch._C._dynamo.eval_frame, torch._C._dynamo.guards, torch._C._dynamo.utils, torch._C._fft, torch._C._linalg, torch._C._nested, torch._C._nn, torch._C._sparse, torch._C._special, numpy.random._common, numpy.random.bit_generator, numpy.random._bounded_integers, numpy.random._pcg64, numpy.random._mt19937, numpy.random._generator, numpy.random._philox, numpy.random._sfc64, numpy.random.mtrand, markupsafe._speedups, _brotli, charset_normalizer.md, requests.packages.charset_normalizer.md, requests.packages.chardet.md, regex._regex, PIL._imaging, lmdb.cpython, kiwisolver._cext, google._upb._message, psutil._psutil_linux (total: 34)
/nix/store/ab4v2qp7q426zrizz38d4jfx025xifdf-pytest-check-hook/nix-support/setup-hook: line 23:   674 Segmentation fault         (core dumped) /nix/store/7gl4khq26h625mpqzkiiqsify3hclar1-python3-3.13.9/bin/python3.13 "${flagsArray[@]}"
```

</details>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
