### PR TITLE
porcelain: init at 0.1.0

### DIFF
--- a/pkgs/by-name/po/porcelain/package.nix
+++ b/pkgs/by-name/po/porcelain/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitea,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "porcelain";
+  version = "0.1.0";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "da157";
+    repo = "porcelain";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-Ghca4HLjz+GcCyxpl4MxRlaknL1g/mxW/riUBwyVzqU=";
+  };
+
+  cargoHash = "sha256-aWVBx/VPlRTBDMdUwpgsztH82vXdtc3Gulcnbz2tGNI=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "CLI dollcode encoder and decoder";
+    homepage = "https://codeberg.org/da157/porcelain";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.da157 ];
+    mainProgram = "porcelain";
+  };
+})


### PR DESCRIPTION
https://codeberg.org/da157/porcelain
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
