### PR TITLE
home-assistant: skip another flaky test

### DIFF
--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -500,6 +500,7 @@ python.pkgs.buildPythonApplication rec {
     "tests/test_bootstrap.py::test_setup_hass_takes_longer_than_log_slow_startup"
     "tests/test_test_fixtures.py::test_evict_faked_translations"
     "tests/helpers/test_backup.py::test_async_get_manager"
+    "tests/helpers/test_trigger.py::test_platform_multiple_triggers[sync_action]"
   ];
 
   preCheck = ''


### PR DESCRIPTION
Multiple people have seen failures like this:

    _________________ test_platform_multiple_triggers[sync_action] _________________
    [gw6] linux -- Python 3.13.9 /nix/store/7gl4khq26h625mpqzkiiqsify3hclar1-python3-3.13.9/bin/python3.13

    hass = <HomeAssistant RUNNING>
    action_method = <bound method TriggerActionFunctionTypeHelper.sync_action of <tests.helpers.test_trigger.TriggerActionFunctionTypeHelper object at 0x7fffa6c58550>>

        @pytest.mark.parametrize("action_method", ["cb_action", "sync_action", "async_action"])
        async def test_platform_multiple_triggers(
            hass: HomeAssistant, action_method: str
        ) -> None:
            """Test a trigger platform with multiple trigger."""

            class MockTrigger(Trigger):
                """Mock trigger."""

                @classmethod
                async def async_validate_config(
                    cls, hass: HomeAssistant, config: ConfigType
                ) -> ConfigType:
                    """Validate config."""
                    return config

            class MockTrigger1(MockTrigger):
                """Mock trigger 1."""

                async def async_attach_runner(
                    self, run_action: TriggerActionRunner
                ) -> CALLBACK_TYPE:
                    """Attach a trigger."""
                    run_action({"extra": "test_trigger_1"}, "trigger 1 desc")

            class MockTrigger2(MockTrigger):
                """Mock trigger 2."""

                async def async_attach_runner(
                    self, run_action: TriggerActionRunner
                ) -> CALLBACK_TYPE:
                    """Attach a trigger."""
                    run_action({"extra": "test_trigger_2"}, "trigger 2 desc")

            async def async_get_triggers(hass: HomeAssistant) -> dict[str, type[Trigger]]:
                return {
                    "_": MockTrigger1,
                    "trig_2": MockTrigger2,
                }

            mock_integration(hass, MockModule("test"))
            mock_platform(hass, "test.trigger", Mock(async_get_triggers=async_get_triggers))

            config_1 = [{"platform": "test"}]
            config_2 = [{"platform": "test.trig_2", "options": {"x": 1}}]
            config_3 = [{"platform": "test.unknown_trig"}]
            assert await async_validate_trigger_config(hass, config_1) == config_1
            assert await async_validate_trigger_config(hass, config_2) == config_2
            with pytest.raises(
                vol.Invalid, match="Invalid trigger 'test.unknown_trig' specified"
            ):
                await async_validate_trigger_config(hass, config_3)

            log_cb = MagicMock()

            action_helper = TriggerActionFunctionTypeHelper()
            action_method = getattr(action_helper, action_method)

            await async_initialize_triggers(hass, config_1, action_method, "test", "", log_cb)
    >       assert len(action_helper.action_calls) == 1
    E       assert 0 == 1
    E        +  where 0 = len([])
    E        +    where [] = <tests.helpers.test_trigger.TriggerActionFunctionTypeHelper object at 0x7fffa6c58550>.action_calls

    MockTrigger = <class 'tests.helpers.test_trigger.test_platform_multiple_triggers.<locals>.MockTrigger'>
    MockTrigger1 = <class 'tests.helpers.test_trigger.test_platform_multiple_triggers.<locals>.MockTrigger1'>
    MockTrigger2 = <class 'tests.helpers.test_trigger.test_platform_multiple_triggers.<locals>.MockTrigger2'>
    action_helper = <tests.helpers.test_trigger.TriggerActionFunctionTypeHelper object at 0x7fffa6c58550>
    action_method = <bound method TriggerActionFunctionTypeHelper.sync_action of <tests.helpers.test_trigger.TriggerActionFunctionTypeHelper object at 0x7fffa6c58550>>
    async_get_triggers = <function test_platform_multiple_triggers.<locals>.async_get_triggers at 0x7fff807a32e0>
    config_1   = [{'platform': 'test'}]
    config_2   = [{'options': {'x': 1}, 'platform': 'test.trig_2'}]
    config_3   = [{'platform': 'test.unknown_trig'}]
    hass       = <HomeAssistant RUNNING>
    log_cb     = <MagicMock id='140735954672608'>

    tests/helpers/test_trigger.py:530: AssertionError


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
