### PR TITLE
matrix-tuwunel: fix gcc & rustc leaking into closure

### DIFF
--- a/pkgs/by-name/ma/matrix-tuwunel/package.nix
+++ b/pkgs/by-name/ma/matrix-tuwunel/package.nix
@@ -161,9 +161,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
     '';
   doCheck = true;
 
+  # tuwunel writes crate compilation commands into the executable,
+  # leading to Nix picking up rustc & gcc as runtime dependencies
+  # https://github.com/matrix-construct/tuwunel/blob/728085bd1b5f7bfd7d3f87108eaa4b4d4d51f3e6/src/core/info/rustc.rs#L20
+  # https://github.com/matrix-construct/tuwunel/blob/728085bd1b5f7bfd7d3f87108eaa4b4d4d51f3e6/src/macros/mod.rs#L42
+  # this bloats the closure by ~1.8GB -> we want to remove these paths (doesn't break any functionality)
   postInstall = ''
-    # fix rustc leaking into the runtime closure (it writes crate compilation commands into the executable)
-    remove-references-to -t ${rustc-unwrapped} $out/bin/tuwunel
+    remove-references-to    \
+      -t ${rustc-unwrapped} \
+      -t ${stdenv.cc}       \
+      $out/bin/tuwunel
   '';
 
   passthru = {


### PR DESCRIPTION
Something in `matrix-tuwunel` causes Rust to write crate compilation commands into the `tuwunel` executable, leading to Nix picking up `rustc-unwrapped` as a runtime dependency. This bloats the closure by about 1.5GB. Simply replacing the path with an invalid one fixes this without affecting the functionality of tuwunel.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
