### PR TITLE
python312Packages.doubles: skip failing tests

### DIFF
--- a/pkgs/development/python-modules/doubles/default.nix
+++ b/pkgs/development/python-modules/doubles/default.nix
@@ -3,8 +3,8 @@
   buildPythonPackage,
   fetchFromGitHub,
   pytest7CheckHook,
+  pythonOlder,
   setuptools,
-  coverage,
   six,
 }:
 
@@ -25,7 +25,6 @@ buildPythonPackage rec {
   ];
 
   dependencies = [
-    coverage
     six
   ];
 
@@ -33,12 +32,10 @@ buildPythonPackage rec {
     pytest7CheckHook
   ];
 
-  # To avoid a ValueError: Plugin already registered under a different name:
-  # doubles.pytest_plugin
-  pytestFlags = [
-    "-p"
-    "no:doubles"
-  ];
+  preCheck = ''
+    # imports coverage
+    rm test/conftest.py
+  '';
 
   disabledTestPaths = [
     # nose is deprecated
@@ -52,6 +49,13 @@ buildPythonPackage rec {
     "test/expect_test.py"
     "test/class_double_test.py"
     "test/object_double_test.py"
+  ];
+
+  disabledTests = lib.optionals (pythonOlder "3.13") [
+    # doubles.exceptions.VerifyingDoubleArgumentError: class_method() missing 1 required positional argument: 'arg'
+    "test_variable_that_points_to_class_method"
+    # doubles.exceptions.VerifyingDoubleArgumentError: get_name() missing 1 required positional argument: 'self'
+    "test_variable_that_points_to_instance_method"
   ];
 
   pythonImportsCheck = [ "doubles" ];


### PR DESCRIPTION
ZHF: https://github.com/NixOS/nixpkgs/issues/457852
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
