### PR TITLE
qtscrcpy: 3.3.1 -> 3.3.3

### DIFF
--- a/pkgs/by-name/qt/qtscrcpy/package.nix
+++ b/pkgs/by-name/qt/qtscrcpy/package.nix
@@ -14,14 +14,14 @@
 
 stdenv.mkDerivation rec {
   pname = "qtscrcpy";
-  version = "3.3.1";
+  version = "3.3.3";
 
   src =
     (fetchFromGitHub {
       owner = "barry-ran";
       repo = "QtScrcpy";
       tag = "v${version}";
-      hash = "sha256-kDeMgSIEIQxaTDR/QAcIaEmPjkmUKBsGyF8fISRzu1M=";
+      hash = "sha256-UZgAFptVC67IXYdxTEmB18fJlFdaOrYrQY4JmdGEJXE=";
       fetchSubmodules = true;
     }).overrideAttrs
       (_: {
@@ -46,9 +46,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace QtScrcpy/QtScrcpyCore/{include/QtScrcpyCoreDef.h,src/device/server/server.h} \
-      --replace-fail 'serverVersion = "3.3.1"' 'serverVersion = "${scrcpy.version}"'
-    substituteInPlace QtScrcpy/util/config.cpp \
-      --replace-fail 'COMMON_SERVER_VERSION_DEF "3.3.1"' 'COMMON_SERVER_VERSION_DEF "${scrcpy.version}"'
+      --replace-fail 'serverVersion = "3.3.3"' 'serverVersion = "${scrcpy.version}"'
     substituteInPlace QtScrcpy/audio/audiooutput.cpp \
       --replace-fail 'sndcpy.sh' "$out/share/qtscrcpy/sndcpy.sh"
     substituteInPlace QtScrcpy/sndcpy/sndcpy.sh \

--- a/pkgs/by-name/qt/qtscrcpy/remove_predefined_paths.patch
+++ b/pkgs/by-name/qt/qtscrcpy/remove_predefined_paths.patch
@@ -2,7 +2,7 @@ diff --git a/QtScrcpy/main.cpp b/QtScrcpy/main.cpp
 index a24ba60..51e3d76 100644
 --- a/QtScrcpy/main.cpp
 +++ b/QtScrcpy/main.cpp
-@@ -22,22 +22,16 @@ int main(int argc, char *argv[])
+@@ -27,27 +27,16 @@
  {
      // set env
  #ifdef Q_OS_WIN32
@@ -11,17 +11,22 @@ index a24ba60..51e3d76 100644
      qputenv("QTSCRCPY_KEYMAP_PATH", "../../../keymap");
      qputenv("QTSCRCPY_CONFIG_PATH", "../../../config");
  #endif
- 
+
  #ifdef Q_OS_OSX
 -    qputenv("QTSCRCPY_ADB_PATH", "../../../../../../QtScrcpy/QtScrcpyCore/src/third_party/adb/mac/adb");
 -    qputenv("QTSCRCPY_SERVER_PATH", "../../../../../../QtScrcpy/QtScrcpyCore/src/third_party/scrcpy-server");
      qputenv("QTSCRCPY_KEYMAP_PATH", "../../../../../../keymap");
      qputenv("QTSCRCPY_CONFIG_PATH", "../../../../../../config");
  #endif
- 
+
  #ifdef Q_OS_LINUX
--    qputenv("QTSCRCPY_ADB_PATH", "../../../QtScrcpy/QtScrcpyCore/src/third_party/adb/linux/adb");
--    qputenv("QTSCRCPY_SERVER_PATH", "../../../QtScrcpy/QtScrcpyCore/src/third_party/scrcpy-server");
-     qputenv("QTSCRCPY_KEYMAP_PATH", "../../../keymap");
-     qputenv("QTSCRCPY_CONFIG_PATH", "../../../config");
- #endif
+-    // Only set environment variables if they are not already set (e.g., by AppImage AppRun)
+-    if (qgetenv("QTSCRCPY_ADB_PATH").isEmpty()) {
+-        qputenv("QTSCRCPY_ADB_PATH", "../../../QtScrcpy/QtScrcpyCore/src/third_party/adb/linux/adb");
+-    }
+-    if (qgetenv("QTSCRCPY_SERVER_PATH").isEmpty()) {
+-        qputenv("QTSCRCPY_SERVER_PATH", "../../../QtScrcpy/QtScrcpyCore/src/third_party/scrcpy-server");
+-    }
+     if (qgetenv("QTSCRCPY_KEYMAP_PATH").isEmpty()) {
+         qputenv("QTSCRCPY_KEYMAP_PATH", "../../../keymap");
+     }


### PR DESCRIPTION
Diff: https://github.com/barry-ran/QtScrcpy/compare/v3.3.1...v3.3.3
https://github.com/barry-ran/QtScrcpy/releases/tag/v3.3.3

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
