### PR TITLE
alvr: pin ffmpeg to 7

### DIFF
--- a/pkgs/by-name/al/alvr/package.nix
+++ b/pkgs/by-name/al/alvr/package.nix
@@ -10,7 +10,7 @@
   brotli,
   bzip2,
   celt,
-  ffmpeg,
+  ffmpeg_7,
   gmp,
   jack2,
   lame,
@@ -54,7 +54,7 @@ rustPlatform.buildRustPackage rec {
 
   patches = [
     (replaceVars ./fix-finding-libs.patch {
-      ffmpeg = lib.getDev ffmpeg;
+      ffmpeg = lib.getDev ffmpeg_7;
       x264 = lib.getDev x264;
     })
   ];
@@ -94,7 +94,7 @@ rustPlatform.buildRustPackage rec {
     brotli
     bzip2
     celt
-    ffmpeg
+    ffmpeg_7
     gmp
     jack2
     lame


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Broke building (https://cache.nixos.org/log/85qdgy034fk98w3qc21pkgybg2yv5klw-alvr-20.14.1.drv) when default `ffmpeg` was updated to 8 in https://github.com/NixOS/nixpkgs/pull/450436

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
