### PR TITLE
cmus: migrate to pkgs/by-name, update dependencies

### DIFF
--- a/pkgs/by-name/cm/cmus/package.nix
+++ b/pkgs/by-name/cm/cmus/package.nix
@@ -13,7 +13,7 @@
   aoSupport ? !stdenv.hostPlatform.isLinux,
   libao ? null,
   jackSupport ? false,
-  libjack ? null,
+  libjack2 ? null,
   samplerateSupport ? jackSupport,
   libsamplerate ? null,
   ossSupport ? false,
@@ -41,7 +41,7 @@
   discidSupport ? false,
   libdiscid ? null,
   ffmpegSupport ? true,
-  ffmpeg ? null,
+  ffmpeg_7 ? null,
   flacSupport ? true,
   flac ? null,
   madSupport ? true,
@@ -95,7 +95,7 @@ let
     # Audio output
     (mkFlag alsaSupport "CONFIG_ALSA=y" alsa-lib)
     (mkFlag aoSupport "CONFIG_AO=y" libao)
-    (mkFlag jackSupport "CONFIG_JACK=y" libjack)
+    (mkFlag jackSupport "CONFIG_JACK=y" libjack2)
     (mkFlag samplerateSupport "CONFIG_SAMPLERATE=y" libsamplerate)
     (mkFlag ossSupport "CONFIG_OSS=y" alsa-oss)
     (mkFlag pulseaudioSupport "CONFIG_PULSE=y" libpulseaudio)
@@ -115,7 +115,7 @@ let
     ])
     (mkFlag cueSupport "CONFIG_CUE=y" libcue)
     (mkFlag discidSupport "CONFIG_DISCID=y" libdiscid)
-    (mkFlag ffmpegSupport "CONFIG_FFMPEG=y" ffmpeg)
+    (mkFlag ffmpegSupport "CONFIG_FFMPEG=y" ffmpeg_7)
     (mkFlag flacSupport "CONFIG_FLAC=y" flac)
     (mkFlag madSupport "CONFIG_MAD=y" libmad)
     (mkFlag mikmodSupport "CONFIG_MIKMOD=y" libmikmod)
@@ -133,14 +133,14 @@ let
   ];
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "cmus";
   version = "2.12.0";
 
   src = fetchFromGitHub {
     owner = "cmus";
     repo = "cmus";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-8hgibGtkiwzenMI9YImIApRmw2EzTwE6RhglALpUkp4=";
   };
 
@@ -163,11 +163,11 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "LD=$(CC)" ];
 
-  meta = with lib; {
+  meta = {
     description = "Small, fast and powerful console music player for Linux and *BSD";
     homepage = "https://cmus.github.io/";
-    license = licenses.gpl2;
-    maintainers = [ maintainers.oxij ];
-    platforms = platforms.linux ++ platforms.darwin;
+    license = lib.licenses.gpl2;
+    maintainers = [ lib.maintainers.oxij ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10727,11 +10727,6 @@ with pkgs;
 
   clipgrab = libsForQt5.callPackage ../applications/video/clipgrab { };
 
-  cmus = callPackage ../applications/audio/cmus {
-    libjack = libjack2;
-    ffmpeg = ffmpeg_7;
-  };
-
   cni = callPackage ../applications/networking/cluster/cni { };
   cni-plugins = callPackage ../applications/networking/cluster/cni/plugins.nix { };
 


### PR DESCRIPTION
- Moved package from pkgs/applications/audio/cmus/default.nix to pkgs/by-name/cm/cmus/package.nix
- Switched to `libjack2` instead of `libjack`
- Updated ffmpeg input to `ffmpeg_7`
- Adopted `finalAttrs` style in stdenv.mkDerivation
- Adjusted `src` to use `tag` instead of `rev`
- Updated meta to reference `lib.licenses`, `lib.maintainers`, and `lib.platforms`
- Removed old cmus entry from all-packages.nix


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
