### PR TITLE
kiro: 0.5.9 -> 0.6.0

### DIFF
--- a/pkgs/by-name/ki/kiro/package.nix
+++ b/pkgs/by-name/ki/kiro/package.nix
@@ -15,7 +15,7 @@ in
   inherit useVSCodeRipgrep;
   commandLineArgs = extraCommandLineArgs;
 
-  version = "0.5.9";
+  version = "0.6.0";
   pname = "kiro";
 
   # You can find the current VSCode version in the About dialog:

--- a/pkgs/by-name/ki/kiro/sources.json
+++ b/pkgs/by-name/ki/kiro/sources.json
@@ -1,14 +1,14 @@
 {
   "x86_64-linux": {
-    "url": "https://prod.download.desktop.kiro.dev/releases/202511032205--distro-linux-x64-tar-gz/202511032205-distro-linux-x64.tar.gz",
-    "hash": "sha256-Xm7uRogux3bQMsWjdaamrHELnxNltRmjPLM8Mgt5+5Y="
+    "url": "https://prod.download.desktop.kiro.dev/releases/stable/linux-x64/signed/0.6.0/tar/kiro-ide-0.6.0-stable-linux-x64.tar.gz",
+    "hash": "sha256-FOMfF/rJIzBnAqR5dxUlcDaMV2I/7dWMqU2UtMvJZIo="
   },
   "x86_64-darwin": {
-    "url": "https://prod.download.desktop.kiro.dev/releases/202511032205-Kiro-dmg-darwin-x64.dmg",
-    "hash": "sha256-oJ5Xr/wJQIX3R5cLnBCv1kpULLy3ljW53LGqw4zYY5c="
+    "url": "https://prod.download.desktop.kiro.dev/releases/stable/darwin-x64/signed/0.6.0/kiro-ide-0.6.0-stable-darwin-x64.dmg",
+    "hash": "sha256-3Bf5a+9yw4WyCy1ADn64YomkjH4Qr7wGPO0kMVd8ZzM="
   },
   "aarch64-darwin": {
-    "url": "https://prod.download.desktop.kiro.dev/releases/202511032205-Kiro-dmg-darwin-arm64.dmg",
-    "hash": "sha256-dtc/Wfs8GzVPHny58MDRFSr9gG0hwdZC5qz5uIJh6N4="
+    "url": "https://prod.download.desktop.kiro.dev/releases/stable/darwin-arm64/signed/0.6.0/kiro-ide-0.6.0-stable-darwin-arm64.dmg",
+    "hash": "sha256-H5AEQgvG1JtBUVUaQp2cYLkpxOgaZdblVUWLCo0HweU="
   }
 }

--- a/pkgs/by-name/ki/kiro/update.sh
+++ b/pkgs/by-name/ki/kiro/update.sh
@@ -42,7 +42,7 @@ for platform in "${!PLATFORM_URLS[@]}"; do
 
     # Extract file URL and version from metadata
     file_url=$(echo "$response" | jq -r '
-        .releases[0].updateTo
+        .releases[].updateTo
         | select(.url | test("\\.(tar|dmg)(\\.|$)"))
         | .url' | head -1)
 


### PR DESCRIPTION
Hello, I changed part of the update.sh file. The reason for this (check here https://prod.download.desktop.kiro.dev/stable/metadata-linux-x64-stable.json) is that Kiro's version JSON information contains a certificate and signature. When we look at the update script, it takes the 0th index of “releases,” but there is no Kiro archive there, only a certificate (for now). Other than that, I ran this script and updated it. Have a nice day.

I've tested this on [my config](https://github.com/bariscodefxy/nix-config/tree/f4fa46865dda8d9c08c28f8fe719908f424dd7e1/pkgs/kiro).

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
