### PR TITLE
gnugrep: re-enable gnulib suite on aarch64-darwin

### DIFF
--- a/pkgs/tools/text/gnugrep/darwin-disable-test-nl_langinfo-mt.patch
+++ b/pkgs/tools/text/gnugrep/darwin-disable-test-nl_langinfo-mt.patch
@@ -1,0 +1,12 @@
+diff -urN grep-3.12.orig/gnulib-tests/Makefile.in grep-3.12/gnulib-tests/Makefile.in
+--- grep-3.12.orig/gnulib-tests/Makefile.in	2025-11-16 21:11:03.803988000 -0500
++++ grep-3.12/gnulib-tests/Makefile.in	2025-11-16 21:12:37.850272926 -0500
+@@ -185,7 +185,7 @@
+ 	test-mcel-5.sh test-memchr$(EXEEXT) test-memchr2$(EXEEXT) \
+ 	test-memrchr$(EXEEXT) test-nanosleep$(EXEEXT) \
+ 	test-netinet_in-h$(EXEEXT) test-nl_langinfo1.sh \
+-	test-nl_langinfo2.sh test-nl_langinfo-mt$(EXEEXT) \
++	test-nl_langinfo2.sh \
+ 	test-nullptr$(EXEEXT) test-once1$(EXEEXT) test-once2$(EXEEXT) \
+ 	test-open$(EXEEXT) test-openat-safer$(EXEEXT) \
+ 	test-openat$(EXEEXT) test-pathmax$(EXEEXT) test-perror.sh \

--- a/pkgs/tools/text/gnugrep/default.nix
+++ b/pkgs/tools/text/gnugrep/default.nix
@@ -33,6 +33,20 @@ stdenv.mkDerivation {
     # https://lists.gnu.org/archive/html/bug-gnulib/2025-07/msg00021.html
     # Multiple upstream commits squashed with adjustments, see header
     ./gnulib-float-h-tests-port-to-C23-PowerPC-GCC.patch
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # nl_langinfo is no longer thread safe on macOS 26.x+. (POSIX doesn't require it.)
+    #
+    # gnulib worked around the issue for macOS in:
+    # https://github.com/coreutils/gnulib/commit/8ebd5a9aa7e24dce4ac2fd4f5074b43b00759d54
+    #
+    # We do not need to backport the gnulib fix for GNU grep because GNU grep
+    # is not multi-threaded. See: https://debbugs.gnu.org/cgi/bugreport.cgi?bug=20768
+    # Instead, we simply disable the relevant test that fails due to the issue.
+    #
+    # We can re-enable the test case once GNU grep updates their gnulib submodule to
+    # include the above commit.
+    ./darwin-disable-test-nl_langinfo-mt.patch
   ];
 
   # Some gnulib tests fail

--- a/pkgs/tools/text/gnugrep/default.nix
+++ b/pkgs/tools/text/gnugrep/default.nix
@@ -52,9 +52,8 @@ stdenv.mkDerivation {
   # Some gnulib tests fail
   # - on Musl: https://github.com/NixOS/nixpkgs/pull/228714
   # - on x86_64-darwin: https://github.com/NixOS/nixpkgs/pull/228714#issuecomment-1576826330
-  # - when building on Darwin (cross-compilation): test-nl_langinfo-mt fails
   postPatch =
-    if stdenv.hostPlatform.isMusl || stdenv.buildPlatform.isDarwin then
+    if stdenv.hostPlatform.isMusl || (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) then
       ''
         sed -i 's:gnulib-tests::g' Makefile.in
       ''


### PR DESCRIPTION
The only test suite that doesn't pass for darwin atm is nl_langinfo related.

It's testing non-POSIX compliant (thread safe) behavior of `nl_langinfo`
that is no longer implemented on macOS 26.x+.

---

I am trying to recover my Savannah account to report the issue for GNU grep but they don't seem to send an email to me. :( If someone with better luck could [report](https://savannah.gnu.org/bugs/?group=grep) a request to update their gnulib git submodule to latest, I'd be grateful.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
