### PR TITLE
rtl*: update rtl88x2bu and mark broken on kernel 6.17

### DIFF
--- a/pkgs/os-specific/linux/rtl8188eus-aircrack/default.nix
+++ b/pkgs/os-specific/linux/rtl8188eus-aircrack/default.nix
@@ -39,6 +39,8 @@ stdenv.mkDerivation {
     homepage = "https://github.com/aircrack-ng/rtl8188eus";
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ moni ];
-    broken = (lib.versions.majorMinor kernel.version) == "5.4" && kernel.isHardened;
+    broken =
+      ((lib.versions.majorMinor kernel.version) == "5.4" && kernel.isHardened)
+      || kernel.kernelAtLeast "6.17";
   };
 }

--- a/pkgs/os-specific/linux/rtl8192eu/default.nix
+++ b/pkgs/os-specific/linux/rtl8192eu/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/Mange/rtl8192eu-linux-driver";
     license = licenses.gpl2Only;
     platforms = platforms.linux;
-    broken = stdenv.hostPlatform.isAarch64;
+    broken = stdenv.hostPlatform.isAarch64 || kernel.kernelAtLeast "6.17";
     maintainers = with maintainers; [ troydm ];
   };
 }

--- a/pkgs/os-specific/linux/rtl8723ds/default.nix
+++ b/pkgs/os-specific/linux/rtl8723ds/default.nix
@@ -47,5 +47,6 @@ stdenv.mkDerivation {
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ chuangzhu ];
+    broken = kernel.kernelAtLeast "6.17";
   };
 }

--- a/pkgs/os-specific/linux/rtl8852au/default.nix
+++ b/pkgs/os-specific/linux/rtl8852au/default.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.gpl2Only;
     platforms = [ "x86_64-linux" ];
     # FIX: error: invalid initializer
-    broken = kernel.kernelOlder "6" && kernel.isHardened;
+    broken = (kernel.kernelOlder "6" && kernel.isHardened) || kernel.kernelAtLeast "6.17";
     maintainers = with maintainers; [ lonyelon ];
   };
 })

--- a/pkgs/os-specific/linux/rtl88x2bu/default.nix
+++ b/pkgs/os-specific/linux/rtl88x2bu/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation {
   pname = "rtl88x2bu";
-  version = "${kernel.version}-unstable-2024-06-09";
+  version = "${kernel.version}-unstable-2025-05-29";
 
   src = fetchFromGitHub {
     owner = "morrownr";
     repo = "88x2bu-20210702";
-    rev = "62f3a86a2687fe98bd441e0aff5adf87d95c238a";
-    hash = "sha256-gQWk1nhtT0W2dY5uQitWabBGEDfZpmJAoJg+j2ndO00=";
+    rev = "fe48647496798cac77976e310ee95da000b436c9";
+    hash = "sha256-h20vwCgLOiNh0LN3MGwPl3F/PSWGc2XS4t1sdeFAOko=";
   };
 
   hardeningDisable = [ "pic" ];

--- a/pkgs/os-specific/linux/rtl88x2bu/default.nix
+++ b/pkgs/os-specific/linux/rtl88x2bu/default.nix
@@ -42,5 +42,6 @@ stdenv.mkDerivation {
     license = licenses.gpl2Only;
     platforms = platforms.linux;
     maintainers = with maintainers; [ otavio ];
+    broken = kernel.kernelAtLeast "6.17";
   };
 }

--- a/pkgs/os-specific/linux/rtl88xxau-aircrack/default.nix
+++ b/pkgs/os-specific/linux/rtl88xxau-aircrack/default.nix
@@ -48,5 +48,6 @@ stdenv.mkDerivation {
       "i686-linux"
       "aarch64-linux"
     ];
+    broken = kernel.kernelAtLeast "6.17";
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Changes in kernel 6.17 had incompatible API changes that cause many of the rtl drivers to fail to build on newer kernel versions. Some of them are already marked broken, this adds more asserts for the other rtl drivers. #459759

ZHF: #457852

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
