### PR TITLE
[25.05] rust: 1.89.0 -> 1.90.0

### DIFF
--- a/pkgs/development/compilers/rust/1_90.nix
+++ b/pkgs/development/compilers/rust/1_90.nix
@@ -1,0 +1,140 @@
+# New rust versions should first go to staging.
+# Things to check after updating:
+# 1. Rustc should produce rust binaries on x86_64-linux, aarch64-linux and x86_64-darwin:
+#    i.e. nix-shell -p fd or @GrahamcOfBorg build fd on github
+#    This testing can be also done by other volunteers as part of the pull
+#    request review, in case platforms cannot be covered.
+# 2. The LLVM version used for building should match with rust upstream.
+#    Check the version number in the src/llvm-project git submodule in:
+#    https://github.com/rust-lang/rust/blob/<version-tag>/.gitmodules
+
+{
+  stdenv,
+  lib,
+  newScope,
+  callPackage,
+  pkgsBuildTarget,
+  pkgsBuildBuild,
+  pkgsBuildHost,
+  pkgsHostTarget,
+  pkgsTargetTarget,
+  makeRustPlatform,
+  wrapRustcWith,
+  llvmPackages_20,
+  llvm_20,
+  wrapCCWith,
+  overrideCC,
+  fetchpatch,
+}@args:
+let
+  llvmSharedFor =
+    pkgSet:
+    pkgSet.llvmPackages_20.libllvm.override (
+      {
+        enableSharedLibraries = true;
+      }
+      // lib.optionalAttrs (stdenv.targetPlatform.useLLVM or false) {
+        # Force LLVM to compile using clang + LLVM libs when targeting pkgsLLVM
+        stdenv = pkgSet.stdenv.override {
+          allowedRequisites = null;
+          cc = pkgSet.pkgsBuildHost.llvmPackages_20.clangUseLLVM;
+        };
+      }
+    );
+in
+import ./default.nix
+  {
+    rustcVersion = "1.90.0";
+    rustcSha256 = "sha256-eZqfnLpO1TUeBxBIvPa1VgdV2QCWSN7zOkB91JYfm34=";
+
+    llvmSharedForBuild = llvmSharedFor pkgsBuildBuild;
+    llvmSharedForHost = llvmSharedFor pkgsBuildHost;
+    llvmSharedForTarget = llvmSharedFor pkgsBuildTarget;
+
+    # For use at runtime
+    llvmShared = llvmSharedFor pkgsHostTarget;
+
+    # Expose llvmPackages used for rustc from rustc via passthru for LTO in Firefox
+    llvmPackages =
+      if (stdenv.targetPlatform.useLLVM or false) then
+        callPackage (
+          {
+            pkgs,
+            bootBintoolsNoLibc ? if stdenv.targetPlatform.linker == "lld" then null else pkgs.bintoolsNoLibc,
+            bootBintools ? if stdenv.targetPlatform.linker == "lld" then null else pkgs.bintools,
+          }:
+          let
+            llvmPackages = llvmPackages_20;
+
+            setStdenv =
+              pkg:
+              pkg.override {
+                stdenv = stdenv.override {
+                  allowedRequisites = null;
+                  cc = pkgsBuildHost.llvmPackages_20.clangUseLLVM;
+                };
+              };
+          in
+          rec {
+            inherit (llvmPackages) bintools;
+
+            libunwind = setStdenv llvmPackages.libunwind;
+            llvm = setStdenv llvmPackages.llvm;
+
+            libcxx = llvmPackages.libcxx.override {
+              stdenv = stdenv.override {
+                allowedRequisites = null;
+                cc = pkgsBuildHost.llvmPackages_20.clangNoLibcxx;
+                hostPlatform = stdenv.hostPlatform // {
+                  useLLVM = !stdenv.hostPlatform.isDarwin;
+                };
+              };
+              inherit libunwind;
+            };
+
+            clangUseLLVM = llvmPackages.clangUseLLVM.override { inherit libcxx; };
+
+            stdenv = overrideCC args.stdenv clangUseLLVM;
+          }
+        ) { }
+      else
+        llvmPackages_20;
+
+    # Note: the version MUST be the same version that we are building. Upstream
+    # ensures that each released compiler can compile itself:
+    # https://github.com/NixOS/nixpkgs/pull/351028#issuecomment-2438244363
+    bootstrapVersion = "1.90.0";
+
+    # fetch hashes by running `print-hashes.sh ${bootstrapVersion}`
+    bootstrapHashes = {
+      i686-unknown-linux-gnu = "8f389b9eb1513785f5589816b60b5a7ca3b24c29bedce7ec0d1c2f8c3ccfb0cc";
+      x86_64-unknown-linux-gnu = "e453bae1c68d02fe2eae065c5452d5731308164cd154154c6ee442d2fa590685";
+      x86_64-unknown-linux-musl = "251c9fe4e3374f2f9f629a7a83238c618e016b1bda1b9de5e8385cb3a6f057fa";
+      arm-unknown-linux-gnueabihf = "61f3987f61bf73562f04dcacfee1a2bad8d16d41f7a3f81ad82dd9b9cbc559ce";
+      armv7-unknown-linux-gnueabihf = "06cfb7f1bd3ce50480eed73ad9ae4f8f665d154fa4c713bc08541197eecd4ae0";
+      aarch64-unknown-linux-gnu = "293f412e3412c3aa3398c78ebbdf898fa08eacad80c85a7332ce1a455504c5fc";
+      aarch64-unknown-linux-musl = "b3ac31ca2e1a720709bf4fb678b2a2f98464c55662c516dfffcbdadd95a420c9";
+      x86_64-apple-darwin = "3d1d24e1d4bedb421ca1a16060c21f4d803eaefba585c0b5b5d0b1e56692ef4b";
+      aarch64-apple-darwin = "a11b52e34f5e80cb25d49f7943ae60e0b069b431727a4c09b2c890ceebee3687";
+      powerpc64-unknown-linux-gnu = "39720c905b8a730cfa725b7e201cd238d15c33112bd4c31b168ca6d1cb898cac";
+      powerpc64le-unknown-linux-gnu = "4061405099dc0aba379fe7b7a616d320272ef9325114dfa8f106c303f9b5695c";
+      riscv64gc-unknown-linux-gnu = "42cc3b3bb008e24a39bd98887c43ef32c2d997f801c86ca47f2119e5e3589fcb";
+      s390x-unknown-linux-gnu = "345c9b902ebee656533d2cfba39c1a020e6a41a4a9609f87430ff8a5d680d649";
+      loongarch64-unknown-linux-gnu = "1c116041a2bc7ab2697218f99ad8cccbe3d6b63fcbf516cb9d985cb00efcdb09";
+      loongarch64-unknown-linux-musl = "0ae18468c7cd3872d1b685cf960426aeb7467629f69eabb497bee6f0fff9cb04";
+      x86_64-unknown-freebsd = "6c7ebf6acbe00873680a190152d47aeebe76e237195b974c593a67227123b2ef";
+    };
+
+    selectRustPackage = pkgs: pkgs.rust_1_90;
+  }
+
+  (
+    removeAttrs args [
+      "llvmPackages_20"
+      "llvm_20"
+      "wrapCCWith"
+      "overrideCC"
+      "pkgsHostTarget"
+      "fetchpatch"
+    ]
+  )

--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -64,6 +64,16 @@ rustPlatform.buildRustPackage.override
       # fixes: the cargo feature `edition` requires a nightly version of Cargo, but this is the `stable` channel
       RUSTC_BOOTSTRAP = 1;
 
+      RUSTFLAGS =
+        if
+          stdenv.hostPlatform.rust.rustcTargetSpec == "x86_64-unknown-linux-gnu"
+          && lib.strings.hasPrefix "1.90" rustc.unwrapped.version
+        then
+          # Upstream defaults to lld on x86_64-unknown-linux-gnu, we want to use our linker
+          "-Clinker-features=-lld -Clink-self-contained=-linker"
+        else
+          null;
+
       postInstall = ''
         wrapProgram "$out/bin/cargo" --suffix PATH : "${rustc}/bin"
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6052,6 +6052,9 @@ with pkgs;
   rust_1_89 = callPackage ../development/compilers/rust/1_89.nix {
     llvm_20 = llvmPackages_20.libllvm;
   };
+  rust_1_90 = callPackage ../development/compilers/rust/1_90.nix {
+    llvm_20 = llvmPackages_20.libllvm;
+  };
   rust = rust_1_86;
 
   mrustc = callPackage ../development/compilers/mrustc { };
@@ -6063,6 +6066,7 @@ with pkgs;
   rustPackages_1_86 = rust_1_86.packages.stable;
   rustPackages_1_88 = rust_1_88.packages.stable;
   rustPackages_1_89 = rust_1_89.packages.stable;
+  rustPackages_1_90 = rust_1_90.packages.stable;
   rustPackages = rustPackages_1_86;
 
   inherit (rustPackages)


### PR DESCRIPTION
Backport of #451179.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
