### PR TITLE
nixos/hardware: add option to set package for tuxedo-drivers

### DIFF
--- a/nixos/modules/hardware/tuxedo-drivers.nix
+++ b/nixos/modules/hardware/tuxedo-drivers.nix
@@ -1,7 +1,7 @@
 { config, lib, ... }:
 let
   cfg = config.hardware.tuxedo-drivers;
-  tuxedo-drivers = config.boot.kernelPackages.tuxedo-drivers;
+  tuxedo-drivers = config.hardware.tuxedo-drivers.package;
 in
 {
   imports = [
@@ -26,6 +26,15 @@ in
 
       For more inforation it is best to check at the source code description: <https://gitlab.com/tuxedocomputers/development/packages/tuxedo-drivers>
     '';
+    package = lib.mkOption {
+      default = config.boot.kernelPackages.tuxedo-drivers;
+      defaultText = "config.boot.kernelPackages.tuxedo-drivers";
+      example = "pkgs.linuxPackages.tuxedo-drivers";
+      description = ''
+        Allows replacing the tuxedo-drivers with different version.
+        Please use a version that matches your kernel release version.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {


### PR DESCRIPTION
This should implement #462043 and mitigate #447483.

Adds a new option to override the driver package which should be used by the kernel (tuxedo-drivers).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
