### PR TITLE
podman: use `systemdMinimal`, {crun,conmon}: minor cleanup

### DIFF
--- a/pkgs/by-name/co/conmon/package.nix
+++ b/pkgs/by-name/co/conmon/package.nix
@@ -8,6 +8,7 @@
   libseccomp,
   systemdMinimal,
   nixosTests,
+  versionCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -48,6 +49,10 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   passthru.tests = { inherit (nixosTests) cri-o podman; };
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
 
   meta = {
     changelog = "https://github.com/containers/conmon/releases/tag/${finalAttrs.src.tag}";

--- a/pkgs/by-name/co/conmon/package.nix
+++ b/pkgs/by-name/co/conmon/package.nix
@@ -19,8 +19,19 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "containers";
     repo = "conmon";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-XsVWcJsUc0Fkn7qGRJDG5xrQAsJr6KN7zMy3AtPuMTo=";
+    hash = "sha256-/Kt49c8a+R/+Z3KmFLpRTG+BdfPDAOEUtSis3alLAUQ=";
+    leaveDotGit = true;
+    postFetch = ''
+      cd $out
+      git rev-parse HEAD > COMMIT
+      rm -rf .git
+    '';
   };
+
+  preConfigure = ''
+    substituteInPlace Makefile \
+      --replace-fail "(GIT_COMMIT)" "(shell cat COMMIT)"
+  '';
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
@@ -36,7 +47,6 @@ stdenv.mkDerivation (finalAttrs: {
   # manpage requires building the vendored go-md2man
   makeFlags = [
     "bin/conmon"
-    "VERSION=${finalAttrs.version}"
   ];
 
   installPhase = ''

--- a/pkgs/by-name/co/conmon/package.nix
+++ b/pkgs/by-name/co/conmon/package.nix
@@ -10,14 +10,14 @@
   nixosTests,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "conmon";
   version = "2.1.13";
 
   src = fetchFromGitHub {
     owner = "containers";
     repo = "conmon";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-XsVWcJsUc0Fkn7qGRJDG5xrQAsJr6KN7zMy3AtPuMTo=";
   };
 
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   # manpage requires building the vendored go-md2man
   makeFlags = [
     "bin/conmon"
-    "VERSION=${version}"
+    "VERSION=${finalAttrs.version}"
   ];
 
   installPhase = ''
@@ -49,13 +49,13 @@ stdenv.mkDerivation rec {
 
   passthru.tests = { inherit (nixosTests) cri-o podman; };
 
-  meta = with lib; {
-    changelog = "https://github.com/containers/conmon/releases/tag/${src.rev}";
+  meta = {
+    changelog = "https://github.com/containers/conmon/releases/tag/${finalAttrs.src.tag}";
     homepage = "https://github.com/containers/conmon";
     description = "OCI container runtime monitor";
-    license = licenses.asl20;
-    teams = [ teams.podman ];
-    platforms = platforms.linux;
+    license = lib.licenses.asl20;
+    teams = [ lib.teams.podman ];
+    platforms = lib.platforms.linux;
     mainProgram = "conmon";
   };
-}
+})

--- a/pkgs/by-name/co/conmon/package.nix
+++ b/pkgs/by-name/co/conmon/package.nix
@@ -6,7 +6,7 @@
   glib,
   glibc,
   libseccomp,
-  systemd,
+  systemdMinimal,
   nixosTests,
 }:
 
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     glib
     libseccomp
-    systemd
+    systemdMinimal
   ]
   ++ lib.optionals (!stdenv.hostPlatform.isMusl) [
     glibc

--- a/pkgs/by-name/cr/crun/package.nix
+++ b/pkgs/by-name/cr/crun/package.nix
@@ -49,6 +49,12 @@ stdenv.mkDerivation (finalAttrs: {
     tag = finalAttrs.version;
     hash = "sha256-WBAwyDODMrUDlgonRbxaNQ+aN8K6YicY2JVArXDJem8=";
     fetchSubmodules = true;
+    leaveDotGit = true;
+    postFetch = ''
+      cd $out
+      git rev-parse HEAD > COMMIT
+      rm -rf .git
+    '';
   };
 
   nativeBuildInputs = [
@@ -77,10 +83,10 @@ stdenv.mkDerivation (finalAttrs: {
   # config.h with the correct values
   postPatch = ''
     echo ${finalAttrs.version} > .tarball-version
-    echo '#define GIT_VERSION "${finalAttrs.src.tag}"' > git-version.h
+    echo "#define GIT_VERSION \"$(cat COMMIT)\"" > git-version.h
 
     ${lib.concatMapStringsSep "\n" (
-      e: "substituteInPlace Makefile.am --replace 'tests/${e}' ''"
+      e: "substituteInPlace Makefile.am --replace-fail 'tests/${e}' ''"
     ) disabledTests}
   '';
 

--- a/pkgs/by-name/cr/crun/package.nix
+++ b/pkgs/by-name/cr/crun/package.nix
@@ -12,6 +12,7 @@
   yajl,
   nixosTests,
   criu,
+  versionCheckHook,
 }:
 
 let
@@ -86,6 +87,10 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = true;
 
   passthru.tests = { inherit (nixosTests) podman; };
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
 
   meta = {
     changelog = "https://github.com/containers/crun/releases/tag/${finalAttrs.version}";

--- a/pkgs/by-name/cr/crun/package.nix
+++ b/pkgs/by-name/cr/crun/package.nix
@@ -8,7 +8,7 @@
   libcap,
   libseccomp,
   python3,
-  systemd,
+  systemdMinimal,
   yajl,
   nixosTests,
   criu,
@@ -61,7 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
     criu
     libcap
     libseccomp
-    systemd
+    systemdMinimal
     yajl
   ];
 

--- a/pkgs/by-name/po/podman/package.nix
+++ b/pkgs/by-name/po/podman/package.nix
@@ -11,7 +11,7 @@
   libapparmor,
   libseccomp,
   libselinux,
-  systemd,
+  systemdMinimal,
   go-md2man,
   nixosTests,
   python3,
@@ -83,7 +83,7 @@ buildGoModule (finalAttrs: {
     libseccomp
     libselinux
     lvm2
-    systemd
+    systemdMinimal
   ];
 
   env = {
@@ -134,7 +134,7 @@ buildGoModule (finalAttrs: {
 
   postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
     RPATH=$(patchelf --print-rpath $out/bin/.podman-wrapped)
-    patchelf --set-rpath "${lib.makeLibraryPath [ systemd ]}":$RPATH $out/bin/.podman-wrapped
+    patchelf --set-rpath "${lib.makeLibraryPath [ systemdMinimal ]}":$RPATH $out/bin/.podman-wrapped
     substituteInPlace "$out/share/systemd/user/podman-user-wait-network-online.service" \
       --replace-fail sleep '${coreutils}/bin/sleep' \
       --replace-fail /bin/sh '${runtimeShell}'


### PR DESCRIPTION
```
❯ nix path-info -Sh ./result.conmon.old
/nix/store/3axaghvgxwpabw2vsm3rsc5sbnk4pak7-conmon-2.1.13        187.6 MiB
❯ nix path-info -Sh ./result.conmon.new
/nix/store/nmk7lvjcaqzwizv652a9lhpknmdqwqs7-conmon-2.1.13         84.9 MiB

❯ nix path-info -Sh ./result.crun.old
/nix/store/pnac5frbfbyivwyhbacasb1bg2mm2nnr-crun-1.24    318.9 MiB
❯ nix path-info -Sh ./result.crun.new
/nix/store/59l453gsrp50zry736b3izwgd1iyqs5g-crun-1.24    239.6 MiB

❯ nix path-info -Sh ./result.podman.old
/nix/store/v0hfz5idlmz1axzs6i3syzvmjgjhxjp1-podman-5.7.0         483.5 MiB
❯ nix path-info -Sh ./result.podman.new
/nix/store/p9gx403n403za3pwvhixls2gfwzydn2z-podman-5.7.0         428.4 MiB
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
