### PR TITLE
postgresql_13: drop as it's EOL

### DIFF
--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -64,6 +64,8 @@
 
 - `postgresql` and `libpq` don't provide `pg_config` by default anymore. Instead, `pg_config` is available via `postgresql.pg_config` or `libpq.pg_config`. This allowed implementing it as a shell script, which can be built for both the build and host systems when cross-compiling. If your build fails to find `pg_config`, add `postgresql.pg_config` or `libpq.pg_config` to `nativeBuildInputs`.
 
+- `postgresql_13` has been removed since it reached its end of life.
+
 - The [`no-broken-symlinks` hook](https://nixos.org/manual/nixpkgs/unstable/#no-broken-symlinks.sh) was added to catch builds containing dangling or reflexive symlinks, as these are indicative of problems with packaging.
   The hook can be disabled by providing `dontCheckForBrokenSymlinks = true;` as an argument to `mkDerivation`.
   For more information, [check the docs](https://nixos.org/manual/nixpkgs/unstable/#no-broken-symlinks.sh) or [see this PR](https://github.com/NixOS/nixpkgs/pull/370750).

--- a/nixos/modules/services/databases/postgresql.md
+++ b/nixos/modules/services/databases/postgresql.md
@@ -167,7 +167,7 @@ Best practice is to name the map after the database role it manages to avoid nam
 ## Upgrading {#module-services-postgres-upgrading}
 
 ::: {.note}
-The steps below demonstrate how to upgrade from an older version to `pkgs.postgresql_13`.
+The steps below demonstrate how to upgrade from an older version to `pkgs.postgresql_15`.
 These instructions are also applicable to other versions.
 :::
 
@@ -176,8 +176,8 @@ each major version has some internal changes in the databases' state. Because of
 NixOS places the state into {file}`/var/lib/postgresql/&lt;version&gt;` where each `version`
 can be obtained like this:
 ```
-$ nix-instantiate --eval -A postgresql_13.psqlSchema
-"13"
+$ nix-instantiate --eval -A postgresql_15.psqlSchema
+"15"
 ```
 For an upgrade, a script like this can be used to simplify the process:
 ```nix
@@ -193,7 +193,7 @@ For an upgrade, a script like this can be used to simplify the process:
       let
         # XXX specify the postgresql package you'd like to upgrade to.
         # Do not forget to list the extensions you need.
-        newPostgres = pkgs.postgresql_13.withPackages (pp: [
+        newPostgres = pkgs.postgresql_15.withPackages (pp: [
           # pp.plv8
         ]);
         cfg = config.services.postgresql;
@@ -229,22 +229,7 @@ The upgrade process is:
   2. Login as root (`sudo su -`).
   3. Run `upgrade-pg-cluster`. This will stop the old postgresql cluster, initialize a new one and migrate the old one to the new one. You may supply arguments like `--jobs 4` and `--link` to speedup the migration process. See <https://www.postgresql.org/docs/current/pgupgrade.html> for details.
   4. Change the postgresql package in NixOS configuration to the one you were upgrading to via [](#opt-services.postgresql.package). Rebuild NixOS. This should start the new postgres version using the upgraded data directory and all services you stopped during the upgrade.
-  5. After the upgrade it's advisable to analyze the new cluster:
-
-       - For PostgreSQL ≥ 14, use the `vacuumdb` command printed by the upgrades script.
-       - For PostgreSQL < 14, run (as `su -l postgres` in the [](#opt-services.postgresql.dataDir), in this example {file}`/var/lib/postgresql/13`):
-
-         ```
-         $ ./analyze_new_cluster.sh
-         ```
-
-     ::: {.warning}
-     The next step removes the old state-directory!
-     :::
-
-     ```
-     $ ./delete_old_cluster.sh
-     ```
+  5. After the upgrade it's advisable to analyze the new cluster with the `vacuumdb` command printed by the upgrades script.
 
 ## Versioning and End-of-Life {#module-services-postgres-versioning}
 

--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -120,10 +120,8 @@ in
             pkgs.postgresql_16
           else if versionAtLeast config.system.stateVersion "23.11" then
             pkgs.postgresql_15
-          else if versionAtLeast config.system.stateVersion "22.05" then
-            pkgs.postgresql_14
           else
-            pkgs.postgresql_13
+            pkgs.postgresql_14
         '';
         description = ''
           The package being used by postgresql.
@@ -697,7 +695,7 @@ in
           else if versionAtLeast config.system.stateVersion "22.05" then
             pkgs.postgresql_14
           else if versionAtLeast config.system.stateVersion "21.11" then
-            mkWarn "13" pkgs.postgresql_13
+            mkThrow "13"
           else if versionAtLeast config.system.stateVersion "20.03" then
             mkThrow "11"
           else if versionAtLeast config.system.stateVersion "17.09" then

--- a/nixos/tests/pleroma.nix
+++ b/nixos/tests/pleroma.nix
@@ -226,7 +226,7 @@ import ./make-test-python.nix (
             };
             postgresql = {
               enable = true;
-              package = pkgs.postgresql_13;
+              package = pkgs.postgresql_14;
             };
             nginx = {
               enable = true;

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -9,7 +9,6 @@ let
   # version. In other words: Do not remove the second-to-last minor version from nixpkgs,
   # yet. Update first.
   versions = {
-    postgresql_13 = ./13.nix;
     postgresql_14 = ./14.nix;
     postgresql_15 = ./15.nix;
     postgresql_16 = ./16.nix;

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1278,10 +1278,13 @@ mapAliases {
   postgis = throw "'postgis' has been removed. Use 'postgresqlPackages.postgis' instead."; # Added 2025-07-19
   postgres-lsp = warnAlias "'postgres-lsp' has been renamed to 'postgres-language-server'" postgres-language-server; # Added 2025-10-28
   postgresql13JitPackages = throw "'postgresql13JitPackages' has been renamed to/replaced by 'postgresql13Packages'"; # Converted to throw 2025-10-27
+  postgresql13Packages = throw "postgresql13Packages has been removed since it reached its EOL upstream"; # Added 2025-11-17
   postgresql14JitPackages = throw "'postgresql14JitPackages' has been renamed to/replaced by 'postgresql14Packages'"; # Converted to throw 2025-10-27
   postgresql15JitPackages = throw "'postgresql15JitPackages' has been renamed to/replaced by 'postgresql15Packages'"; # Converted to throw 2025-10-27
   postgresql16JitPackages = throw "'postgresql16JitPackages' has been renamed to/replaced by 'postgresql16Packages'"; # Converted to throw 2025-10-27
   postgresql17JitPackages = throw "'postgresql17JitPackages' has been renamed to/replaced by 'postgresql17Packages'"; # Converted to throw 2025-10-27
+  postgresql_13 = throw "postgresql_13 has been removed since it reached its EOL upstream"; # Added 2025-11-17
+  postgresql_13_jit = throw "postgresql_13_jit has been removed since it reached its EOL upstream"; # Added 2025-11-17
   postgresqlJitPackages = throw "'postgresqlJitPackages' has been renamed to/replaced by 'postgresqlPackages'"; # Converted to throw 2025-10-27
   pot = throw "'pot' has been removed as it requires libsoup 2.4 which is EOL"; # Added 2025-10-09
   powerdns = throw "'powerdns' has been renamed to/replaced by 'pdns'"; # Converted to throw 2025-10-27

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9507,7 +9507,6 @@ with pkgs;
     ;
 
   inherit (postgresqlVersions)
-    postgresql_13
     postgresql_14
     postgresql_15
     postgresql_16
@@ -9516,7 +9515,6 @@ with pkgs;
     ;
 
   inherit (postgresqlJitVersions)
-    postgresql_13_jit
     postgresql_14_jit
     postgresql_15_jit
     postgresql_16_jit
@@ -9526,7 +9524,6 @@ with pkgs;
   postgresql = postgresql_17;
   postgresql_jit = postgresql_17_jit;
   postgresqlPackages = recurseIntoAttrs postgresql.pkgs;
-  postgresql13Packages = recurseIntoAttrs postgresql_13.pkgs;
   postgresql14Packages = recurseIntoAttrs postgresql_14.pkgs;
   postgresql15Packages = recurseIntoAttrs postgresql_15.pkgs;
   postgresql16Packages = recurseIntoAttrs postgresql_16.pkgs;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
