### PR TITLE
socalabs-loser-ports: init at 0-unstable-2025-09-01

### DIFF
--- a/pkgs/by-name/so/socalabs-loser-ports/package.nix
+++ b/pkgs/by-name/so/socalabs-loser-ports/package.nix
@@ -1,0 +1,142 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  cmake,
+  ninja,
+  pkg-config,
+  writableTmpDirAsHomeHook,
+  copyDesktopItems,
+  libx11,
+  libxcursor,
+  libxrandr,
+  libxinerama,
+  libxext,
+  freetype,
+  fontconfig,
+  expat,
+  alsa-lib,
+  curl,
+
+  buildStandalone ? true,
+  buildVST3 ? true,
+  buildLV2 ? true,
+}:
+
+let
+  cmakeFormats = [
+    (lib.optionalString buildStandalone "Standalone")
+    (lib.optionalString buildVST3 "VST3")
+    (lib.optionalString buildLV2 "LV2")
+  ];
+in
+
+stdenv.mkDerivation {
+  pname = "socalabs-loser-ports";
+  version = "0-unstable-2025-09-01";
+
+  src = fetchFromGitHub {
+    owner = "FigBug";
+    repo = "LoserPorts";
+    rev = "eeeff7eedd6456224a92ba8fad968abbcec628f3";
+    hash = "sha256-u1Q2Vx/aebvtRryqegYFr8eqTigjpRvc7Wc6jD+fLUU=";
+    fetchSubmodules = true;
+
+    preFetch = ''
+      export GIT_CONFIG_COUNT=1
+      export GIT_CONFIG_KEY_0=url.https://github.com/.insteadOf
+      export GIT_CONFIG_VALUE_0=git@github.com:
+    '';
+  };
+
+  patches = [ ./use-plugin-formats.diff ];
+
+  postPatch = ''
+    substituteInPlace plugins/*/CMakeLists.txt \
+      --replace-fail "juce::juce_recommended_lto_flags" "# no lto"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    writableTmpDirAsHomeHook
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    libx11
+    libxcursor
+    libxrandr
+    libxinerama
+    libxext
+    freetype
+    fontconfig
+    expat
+    alsa-lib
+    curl
+  ];
+
+  cmakeFlags = [
+    "--preset ninja-gcc"
+    (lib.cmakeBool "JUCE_COPY_PLUGIN_AFTER_BUILD" false)
+    (lib.cmakeFeature "PLUGIN_FORMATS" (lib.concatStringsSep ";" cmakeFormats))
+  ];
+
+  # Fontconfig error: Cannot load default config file: No such file: (null)
+  env.FONTCONFIG_FILE = "${fontconfig.out}/etc/fonts/fonts.conf";
+
+  preBuild = "cd ../Builds/ninja-gcc";
+
+  installPhase =
+    let
+      plugins = [
+        "SimpleVerb"
+        "StereoEnhancer"
+        "StereoProcessor"
+      ];
+
+      mkPlugin = plugin: ''
+        pushd ${plugin}/${plugin}_artefacts/Release
+          ${lib.optionalString buildStandalone ''
+            install -Dm755 Standalone/${plugin} -t $out/bin
+          ''}
+
+          ${lib.optionalString buildVST3 ''
+            mkdir -p $out/lib/vst3
+            cp -r VST3/${plugin}.vst3 $out/lib/vst3
+          ''}
+
+          ${lib.optionalString buildLV2 ''
+            mkdir -p $out/lib/lv2
+            cp -r LV2/${plugin}.lv2 $out/lib/lv2
+          ''}
+        popd
+      '';
+    in
+    ''
+      runHook preInstall
+
+      pushd plugins
+        ${lib.concatStringsSep "\n" (map mkPlugin plugins)}
+      popd
+
+      runHook postInstall
+    '';
+
+  # Needed for standalone
+  NIX_LDFLAGS = [
+    "-lX11"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Various plugins by Michael Gruhn ported to JUCE";
+    homepage = "https://github.com/FigBug/LoserPorts";
+    platforms = [ "x86_64-linux" ];
+    license = [ lib.licenses.bsd3 ];
+    maintainers = [ lib.maintainers.mrtnvgr ];
+  };
+}

--- a/pkgs/by-name/so/socalabs-loser-ports/use-plugin-formats.diff
+++ b/pkgs/by-name/so/socalabs-loser-ports/use-plugin-formats.diff
@@ -1,0 +1,48 @@
+--- a/plugins/SimpleVerb/CMakeLists.txt
++++ b/plugins/SimpleVerb/CMakeLists.txt
+@@ -12,12 +12,7 @@ juce_add_plugin(SimpleVerb
+   COMPANY_WEBSITE "www.socalabs.com"
+   COMPANY_EMAIL "info@socalabs.com"
+ 
+-  FORMATS
+-    "VST3"
+-    "AU"
+-    "Standalone"
+-    "VST"
+-    "LV2"
++  FORMATS "${PLUGIN_FORMATS}"
+   PLUGIN_NAME "SimpleVerb"
+   DESCRIPTION "SimpleVerb"
+   PLUGIN_MANUFACTURER_CODE "Soca"
+--- a/plugins/StereoEnhancer/CMakeLists.txt
++++ b/plugins/StereoEnhancer/CMakeLists.txt
+@@ -12,12 +12,7 @@ juce_add_plugin(StereoEnhancer
+   COMPANY_WEBSITE "www.socalabs.com"
+   COMPANY_EMAIL "info@socalabs.com"
+ 
+-  FORMATS
+-    "VST3"
+-    "AU"
+-    "Standalone"
+-    "VST"
+-    "LV2"
++  FORMATS "${PLUGIN_FORMATS}"
+   PLUGIN_NAME "StereoEnhancer"
+   DESCRIPTION "StereoEnhancer"
+   PLUGIN_MANUFACTURER_CODE "Soca"
+--- a/plugins/StereoProcessor/CMakeLists.txt
++++ b/plugins/StereoProcessor/CMakeLists.txt
+@@ -12,12 +12,7 @@ juce_add_plugin(StereoProcessor
+   COMPANY_WEBSITE "www.socalabs.com"
+   COMPANY_EMAIL "info@socalabs.com"
+ 
+-  FORMATS
+-    "VST3"
+-    "AU"
+-    "Standalone"
+-    "VST"
+-    "LV2"
++  FORMATS "${PLUGIN_FORMATS}"
+   PLUGIN_NAME "StereoProcessor"
+   DESCRIPTION "StereoProcessor"
+   PLUGIN_MANUFACTURER_CODE "Soca"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
