### PR TITLE
animeko: reinit at 5.2.0

### DIFF
--- a/pkgs/by-name/an/animeko/deps.json
+++ b/pkgs/by-name/an/animeko/deps.json
@@ -1,0 +1,7087 @@
+{
+ "!comment": "This is a nixpkgs Gradle dependency lockfile. For more details, refer to the Gradle section in the nixpkgs manual.",
+ "!version": 1,
+ "https://dl.google.com/dl/android/maven2": {
+  "androidx/activity#activity-compose/1.10.1": {
+   "module": "sha256-HtE6UO27iFlidR4by1uKQgeiDLeA6iSP+mU6qz+xD+k=",
+   "pom": "sha256-5k22txJvtRI5S8PPQzKjiCgAnaqN1W7L5sDHMAshJ/U="
+  },
+  "androidx/activity#activity-compose/1.8.0": {
+   "module": "sha256-O6fpL5LpTTSRk8LG4WYIRoTnL+H/PgZu1Prrxwf5vB8=",
+   "pom": "sha256-Indw1+AfBvTAuezN/T05E7dexB5wgJEpZv0iu20fcgU="
+  },
+  "androidx/activity#activity-ktx/1.10.1": {
+   "module": "sha256-fBg4lRiaJ/16pZ/c9QKfpk+tKOnTkSmpyzDkC15CZ64=",
+   "pom": "sha256-QhNJDkzitXUOREUkbf6d5PZlXCEjwEp5qCSMyIk+K/Q="
+  },
+  "androidx/activity#activity-ktx/1.7.1": {
+   "module": "sha256-fJITcHl4PZxWnJAORdCHb8xubJJOvWEI55VQB3Ralho=",
+   "pom": "sha256-0OTHd9w3j+JjvEA+/oqXVpRW+cfmW8KKnt5QUbdhW4E="
+  },
+  "androidx/activity#activity-ktx/1.8.0": {
+   "module": "sha256-AlGoJtlIl9XGiealOfxTO0t2hNP2PiQCIRgtfLS0+xM=",
+   "pom": "sha256-yUOdGOyxut9ZADJZebKmWHpAvtTwdNq2nOvQDPrjkbc="
+  },
+  "androidx/activity#activity/1.0.0": {
+   "pom": "sha256-J6S+dGJinDEtoLgxoJeNIHb8NAdBRfth3U6G18hGm4I="
+  },
+  "androidx/activity#activity/1.10.1": {
+   "module": "sha256-iTtzpLFtGcAzhnWtC5+lEi2cacRPYRhxvYxAfTviOmg=",
+   "pom": "sha256-CuTeiIl09c75gmYJAOwyoz8QlodQ23r6lDja7Bg/FOc="
+  },
+  "androidx/activity#activity/1.7.0": {
+   "module": "sha256-KnRrASaoqy9XbnFn8aeFtFLvfumXq9l57gxaKcNvbqY=",
+   "pom": "sha256-7eFnck23n8fFLPAv4JeZtFqUpTHX8CaFp4M3vAYsA5s="
+  },
+  "androidx/activity#activity/1.8.0": {
+   "module": "sha256-0UXYtTz9Ef0m5H591FwAcTPvluok9nFctlPHN2RdHfY=",
+   "pom": "sha256-ZRMShfU8sELo/9GJ5wXa/JuK5tYkNeh3ismrO44/dW8="
+  },
+  "androidx/annotation#annotation-experimental/1.3.0": {
+   "module": "sha256-Xuvq/wHQQuBtzykqv4lkrTkeSwFZ8AkPFiU9YEXTjaA=",
+   "pom": "sha256-ui/kb3T2iFHiNCRhk6uJbAwB+glM03LBBRtr8E15sLs="
+  },
+  "androidx/annotation#annotation-experimental/1.3.1": {
+   "module": "sha256-m2l0p9/ibTwgndY+FvjuJGG1egkXiRYMoetJK7G/P4Q=",
+   "pom": "sha256-Qm+UMQtHvfAE3CA42uqpQ8XOT0sGPob3i8U24jLj3fw="
+  },
+  "androidx/annotation#annotation-experimental/1.4.0": {
+   "module": "sha256-WTDqfyH8ttDesroydIoO98j9LEI4SGBYK6fNIN65A3k=",
+   "pom": "sha256-QdK52Hn8kiGs2o6HPsfSaxU7m44EdwrHlJHgV2uu8Dg="
+  },
+  "androidx/annotation#annotation-experimental/1.4.1": {
+   "module": "sha256-KsL3EG4S8mNCW0pN/ICYlEf7iVZ1/pAthnWap0/RK30=",
+   "pom": "sha256-/leyKEF/TXxneQPcYftKfPmT1gNJneJtjYET5HfMTxs="
+  },
+  "androidx/annotation#annotation-iosarm64/1.7.0": {
+   "module": "sha256-AC0rtA4C7N7Y533F1nTe4s5f538pUxgcl+vVDSRlAY0=",
+   "pom": "sha256-ehf34KZP5hR8zaxQyF0Qo7AY/PHd/ip3e6YAA8pa3FY="
+  },
+  "androidx/annotation#annotation-iosarm64/1.9.0": {
+   "module": "sha256-6DJvdch3vV6HpxGXejlvW+xtpU1QTP3BBdQH6tTdXtc=",
+   "pom": "sha256-r5RTiIOEj6z73kf5Xg2fNWerA2l/Nc6e7NnkS/y4JQc="
+  },
+  "androidx/annotation#annotation-iosarm64/1.9.1": {
+   "module": "sha256-gWifMc5Ndyzq5Nm4EKEPjSJlSrdSk/9EbJwgEfi6MjE=",
+   "pom": "sha256-JTmoAKO24c6Fefs5T7n0Yi81sDPGYvSj9Zc9+O+IilI="
+  },
+  "androidx/annotation#annotation-iossimulatorarm64/1.7.0": {
+   "module": "sha256-OikdRa70npj492Pcc+iJJnOSmeiUyqGrKZhWZp7hjRI=",
+   "pom": "sha256-5+KpIB5thn7QIZaNGTjoBHdboYieIemh6IMcSL4iOYk="
+  },
+  "androidx/annotation#annotation-iossimulatorarm64/1.9.0": {
+   "module": "sha256-b8ECz4xqGmk7qL083JGilvz/Ag6SMrz+MAS1VRXMhpI=",
+   "pom": "sha256-8G4LBU16fBWN4e++C66OrN0vy1Oak7n/ZOmYOAuoVHo="
+  },
+  "androidx/annotation#annotation-iossimulatorarm64/1.9.1": {
+   "module": "sha256-OhLs8Xz/n9hGBAOEZm3Anu8RLJ9/5amhEMwKkPKUyf0=",
+   "pom": "sha256-IHXU+JyXjVY1e5Ns223yInIz4lx1wrgMVL+qxDLFdPo="
+  },
+  "androidx/annotation#annotation-jvm/1.6.0": {
+   "module": "sha256-P1qPqhneZn5j3KlzD/jvDkeOS6+1/uuCWOXAhiRtyQw=",
+   "pom": "sha256-K+ZlunzbBGtBtAnHmj3gxtnhJVJCwIf2uUssdJO+CPQ="
+  },
+  "androidx/annotation#annotation-jvm/1.7.0": {
+   "jar": "sha256-42uOS4OTpK3HTj1KsirVo2OW8M6i5AtXNOrhSTff0iQ=",
+   "module": "sha256-B85gw3erlOR8jJAlibl3YDAGT9Gn5NWgGjjXAONeXbQ=",
+   "pom": "sha256-LT/MEucHiGmSA5JmI39FEUDKqPlMHmLn/E1gLeNFsNc="
+  },
+  "androidx/annotation#annotation-jvm/1.8.1": {
+   "module": "sha256-yVnjsM3HXBXv4BYF+laqefAz45I44VBji4+r3mqhIaA=",
+   "pom": "sha256-1JIDczqm+uBGw6PeTnlu7TR1lXVUhqZCc5iYRHWXULQ="
+  },
+  "androidx/annotation#annotation-jvm/1.9.0": {
+   "jar": "sha256-Mjbh5ExB2jeMGsm1Fb7gUB2NxRKZFGUQCstN/mQFmk4=",
+   "module": "sha256-S1hpnRTWadIj2lC7hf/md3UH0x9JDVMFA4ODZ0l15Tg=",
+   "pom": "sha256-PEA0l9/stnxrIZqvVYVD8wnJSOIoxAB7ADMBEYDw6+U="
+  },
+  "androidx/annotation#annotation-jvm/1.9.1": {
+   "jar": "sha256-HjQ5F+vye6lv5NxSscrX/TK3OPvGNVu2zVs7MF1yEtA=",
+   "module": "sha256-A/tlkXfIYY5HQlklwRvJHzhHA+omwmW+myXNeSkrURw=",
+   "pom": "sha256-ibmcIY1gAZMWtQqreYFnB7whaWyJagMOGxrgOJYby44="
+  },
+  "androidx/annotation#annotation/1.0.0": {
+   "pom": "sha256-oXnBLbQ9nAMAydtj9IEdtJZQS+VAG5UdQit4SQrR5bQ="
+  },
+  "androidx/annotation#annotation/1.1.0": {
+   "pom": "sha256-LpNyuneA70SVKtv4a2bh8IaCweUnfJJhhfZWShN5nv4="
+  },
+  "androidx/annotation#annotation/1.2.0": {
+   "module": "sha256-Lvyrge+RshG6zSBuqs2ZWlH2M6Lpa1eo/AAUTF+cVrM=",
+   "pom": "sha256-Yvttyid37+COcHfWuHLWkRBhnff8Icmab1QGZJnMA4M="
+  },
+  "androidx/annotation#annotation/1.3.0": {
+   "module": "sha256-lRbCrkQoTqC9PQ6t4O5jiHm3CMvjHjr5K6lsMAYE68M=",
+   "pom": "sha256-BJUXxSVqS7yFKfzckMTqrzWBgKwgXJFmB2ffJkZe+7A="
+  },
+  "androidx/annotation#annotation/1.6.0": {
+   "module": "sha256-YUa2E4ZDsqwFkN9QndUauup2nHn9dgLrIXFo/lr3jNI=",
+   "pom": "sha256-3YgrTBlFrRMSHs32UeumZKmyJrVduE+nVTkt5eENHls="
+  },
+  "androidx/annotation#annotation/1.7.0": {
+   "module": "sha256-UwcIZW04BgUHfqi8qa4TcvvRrzjjdfQR1OQyY71RDDw=",
+   "pom": "sha256-IcYYrIxwkt2VGT8FwLGWGDp86PE2anqRLIAOvuNoqFg="
+  },
+  "androidx/annotation#annotation/1.8.0": {
+   "module": "sha256-1ZCg2OAvQF3nSejcgLdB3FA8bj5MnAFtYU12tl8LWe8=",
+   "pom": "sha256-fDjBim6KzHvYjvrNfhR6iXqUW5nbci5U4LnOJEYQLVs="
+  },
+  "androidx/annotation#annotation/1.8.1": {
+   "module": "sha256-5jhuha/dhlBE4hZXXkk+05pjpjJb2SU3miFCnDlByLU=",
+   "pom": "sha256-txIll07Ah+uWwl72gZ9VscIvUw6FykRrpzX7Zu0E/1w="
+  },
+  "androidx/annotation#annotation/1.9.0": {
+   "module": "sha256-dHz857uARn6ipotGGHOPdjoUHND1Yvw1p8IVBCf1oxo=",
+   "pom": "sha256-73DxHmNYnrfKKI079t8q0gNPFR6F8gux9F0MyeQwhRk="
+  },
+  "androidx/annotation#annotation/1.9.1": {
+   "module": "sha256-8gSwW3KKl1YXGLxxYkLkfGKcAIWoDudPylPU1ji8vj8=",
+   "pom": "sha256-xzOIHC4X1ffIZhzAKpFZyxYLeyCUon1ZORbIfT4lBjY="
+  },
+  "androidx/appcompat#appcompat-resources/1.7.0": {
+   "module": "sha256-18ygtVPsEJ7yCscK5kOPWE/Gu16yaaf1tAmOAsbWh/k=",
+   "pom": "sha256-u/Kluax4kEydp5LhZzF5MnT5X7SmEjBxkUCz4O9za6o="
+  },
+  "androidx/appcompat#appcompat/1.7.0": {
+   "module": "sha256-OIQq8rlsmVQMx1Yzd1SzAw3giwKdS/OqBuTs90HaaL8=",
+   "pom": "sha256-pXtCj0KKkzfXtIOiFipXDU5nK87/QRpkZeU+h0dQasM="
+  },
+  "androidx/arch/core#core-common/2.0.0": {
+   "pom": "sha256-S28dRZ3dFGtOhe1tRuhuuMJjnF3keQTm201phyEzQiA="
+  },
+  "androidx/arch/core#core-common/2.1.0": {
+   "pom": "sha256-g7uzlg6qvGAKw2bJTLWUFORBUyodaqk4iwuL/6zlzwE="
+  },
+  "androidx/arch/core#core-common/2.2.0": {
+   "jar": "sha256-ZTCKBrHADuGGy54ZMhOD8EO5k4E/FSLEf0o+MwO9ukE=",
+   "module": "sha256-7fQgDP3C2UYjIlLJnl3LnGG7kJ61RQsmE9HU/cl0uYE=",
+   "pom": "sha256-HhfUr41kJb4qafivTWVKh+BFYlmp7vFUKGm8sCNUfig="
+  },
+  "androidx/arch/core#core-runtime/2.0.0": {
+   "pom": "sha256-4gB9Qd3GnuKnf+17XB3FpB4BEikmullpaqt7GNImRBE="
+  },
+  "androidx/arch/core#core-runtime/2.2.0": {
+   "module": "sha256-qLF1E5SeXbbJYBwwvhnflTdi3Yd1EvHiz8+ugdJECUQ=",
+   "pom": "sha256-D5U3BlmBQNnYc1zdWusfo1kz9OLzHAvz64GgU6TIwaU="
+  },
+  "androidx/browser#browser/1.8.0": {
+   "module": "sha256-sTorfGTA8vNJoZ31EjYO2RemP4lPw94peh/eT7KHVGw=",
+   "pom": "sha256-jJ19VEqBvl8eje0qT/R0wn6V1S1Qj1nUeSker3/gM38="
+  },
+  "androidx/collection#collection-iosarm64/1.4.5": {
+   "module": "sha256-TtsEwgdJ7I6enmfz0u4EwSs0+LfGCgGNCDTpdXCOSGY=",
+   "pom": "sha256-aO4pVLp0LuPEuFP1GHqM1n7z5OC9dB2OJBqkUZ5sxbA="
+  },
+  "androidx/collection#collection-iosarm64/1.5.0": {
+   "module": "sha256-4BI522AfrLPnQejEjT40+mO2B5dSljMhvdPhH0i7/FA=",
+   "pom": "sha256-aJXBVc/ZLR4Wbo8YWaQeFut3s7p6KhCShRY+z6MD5WE="
+  },
+  "androidx/collection#collection-iossimulatorarm64/1.4.5": {
+   "module": "sha256-IOhSzz89muuJk0mEXp263qOyWUHiBYIKUlfrhCGAdnk=",
+   "pom": "sha256-E3YGjgqzsMLMFowdAOBr85i1+ciiwCmgWObjsOS7Fdw="
+  },
+  "androidx/collection#collection-iossimulatorarm64/1.5.0": {
+   "module": "sha256-nMsScGocgND1gPJzT6tjHL1S1R57uRaXb+W84J1Wcqw=",
+   "pom": "sha256-fKZKrcG1QM6ncxkcV638qdIJO7G18UD6fbdGWeejpSw="
+  },
+  "androidx/collection#collection-jvm/1.4.0": {
+   "module": "sha256-IbCwLqaKvkGPPdTk1Ch27PO9mhytpFi0YMrhzZ1Y720=",
+   "pom": "sha256-WSTeoD4BjjIbPXlfI/tmWXJmQDJuCjIHWK5ZpnmStto="
+  },
+  "androidx/collection#collection-jvm/1.4.5": {
+   "jar": "sha256-U5pDQo34ozdiL7eBQB9fDNzVLYs2FfAIWvUckAAv8zM=",
+   "module": "sha256-0kq0tJY72cP4nhwA15eqeV6wK6/HGNzf0mYhH5k/KyM=",
+   "pom": "sha256-0eYk/dD1wygCSsORVHJkScQzfZ5WoFR/sLsW1Dn6FlY="
+  },
+  "androidx/collection#collection-jvm/1.5.0": {
+   "jar": "sha256-cLNZJOS6vN/6N9Dlde4DnFai2XEjNCYkxItgMjNwQ0E=",
+   "module": "sha256-3eheKSUJIxtUcbsJG1dQmdT0MWHrKB6HOFA4oBYQcuY=",
+   "pom": "sha256-EcQVhk00AvYdQm5nIQFY3OGwRoBBJSaplPGCPs08s4g="
+  },
+  "androidx/collection#collection-ktx/1.1.0": {
+   "pom": "sha256-ch52507kFY0/6XWQdLfs7tT/fYTtNKP6ylhD+4dKyUY="
+  },
+  "androidx/collection#collection-ktx/1.5.0": {
+   "module": "sha256-QiiJTiXux+FzKbIGunLoqtJVvFNQGNxirMXv87XHqqU=",
+   "pom": "sha256-mD+NBjDQctW/zRZqSYrHIT86RKmMCQUQBM6WQp2GfOo="
+  },
+  "androidx/collection#collection/1.0.0": {
+   "pom": "sha256-p5E6UnWtaOVV0mEuvowUw2exU+FMpIoYcqZImQIOVO8="
+  },
+  "androidx/collection#collection/1.1.0": {
+   "pom": "sha256-Z+kGbKSs/cbjzFCCk8MboDmAV/8Rjk9wseGBPJo0VtE="
+  },
+  "androidx/collection#collection/1.4.0": {
+   "module": "sha256-L9O1I+gnbAJUxBe2bY5/7MWwuXWvXReK+n9bgTgSz6s=",
+   "pom": "sha256-HNhaZRBlOBpYfuKERMl6sLyQP/CivXObBPIuMcKZoGw="
+  },
+  "androidx/collection#collection/1.4.5": {
+   "module": "sha256-I34e/Faj4lqOpM7sJlWMKZhEv8U6rQb/P1PKHINeKMg=",
+   "pom": "sha256-DA39zlfaULfpyifTsZv/vjuY8x3cfgPNWEz3eAmns0k="
+  },
+  "androidx/collection#collection/1.5.0": {
+   "module": "sha256-v+t72E8/fdp71ztnCdSh9h9aN/hDcouuCKBn49+aCu8=",
+   "pom": "sha256-LWXI0LNtS0+q3ESv+breI9hx1xWe7fKz8C2AKzS3elc="
+  },
+  "androidx/compose/animation#animation-android/1.10.0-alpha02": {
+   "module": "sha256-UxtYTSo4nmOLcW7ly/OlNtInBxMgaz8fLqM8tXkM4PQ=",
+   "pom": "sha256-wc8B8wV5eOz5LGxu/XVI2Ko3t+eH3v4nv6nDYGQQBcU="
+  },
+  "androidx/compose/animation#animation-android/1.7.5": {
+   "module": "sha256-dtRTg+o2dtkp8if+6BhOuhc98qLBAUdLNIVtM74Bo9U=",
+   "pom": "sha256-qOfEFAf/UuAqJHWCWEmP6XoYOXzR9yS0fjSHIrhqVhM="
+  },
+  "androidx/compose/animation#animation-android/1.9.0": {
+   "module": "sha256-rEBAoAP5w5+e++8m7y9vqfXVOmSymdKCcRSdbpD+OyM=",
+   "pom": "sha256-++2hTrXh08XBL9Ej/Sgk3LaepVMGLiCc0/3pBCPXLTI="
+  },
+  "androidx/compose/animation#animation-core-android/1.10.0-alpha02": {
+   "module": "sha256-56x3twE6vkluM69NsR0x5aZoBpUx/GINiQDa2wz/1g8=",
+   "pom": "sha256-J3IJnsalg4SxoZ5l+3vSBwTS1AsLjel6NTZmMMXObEA="
+  },
+  "androidx/compose/animation#animation-core-android/1.7.5": {
+   "module": "sha256-jmslKfrPxikFRn5SejyWt3B05Z0kcM3lrPvC6EPZ/lo=",
+   "pom": "sha256-tfkE0WVHgf1Ox3YoyIbVzFNp6hgPxTIx6/tpVyVsRZo="
+  },
+  "androidx/compose/animation#animation-core/1.10.0-alpha02": {
+   "module": "sha256-xSfNN9DK5C9TR/v5X6WQf28fxL++JBwFirFFo3OxTWo=",
+   "pom": "sha256-iNzlxUyc3QkqGKY/hOFLe1IQDdfE+tooMKluXZd77TU="
+  },
+  "androidx/compose/animation#animation-core/1.7.5": {
+   "module": "sha256-RvzTebglmueV6ygbZZSWd2isLu5XC4N26PLk+GNZSKo=",
+   "pom": "sha256-xuXTBx8/9mfaJdh3R4UbYpGUsJQgigEUfPwTEMpq6K8="
+  },
+  "androidx/compose/animation#animation-core/1.7.8": {
+   "module": "sha256-vBMFrP+C/3v20CTLjl+k7W69mqTgqiCUwO3r+sBtToo=",
+   "pom": "sha256-HY0md2TpTAx1zLphj1G9tn9ZgQ95eygOvM3fe1E6sMk="
+  },
+  "androidx/compose/animation#animation-core/1.9.0": {
+   "module": "sha256-TGyOqOV3NJnuq0hzNsCD9r2WaZdSCyCPBWkf1wCwUqw=",
+   "pom": "sha256-q+kWiYWRTtlN/zos2X/yWKHE0yalM8Cgv3hv1pZ9RjI="
+  },
+  "androidx/compose/animation#animation/1.10.0-alpha02": {
+   "module": "sha256-46iluWMsusArlWHw/Rlol1qriV4jJFGGaGdJKl8z924=",
+   "pom": "sha256-qCFXJ6fkhXUT10cwvNmOWQbv8kZt1EMTB4JTc7JxONs="
+  },
+  "androidx/compose/animation#animation/1.7.5": {
+   "module": "sha256-fHQrtAdJf7TDIr09Sr74N0HqYQehIWj1eUODA0M0l/8=",
+   "pom": "sha256-nPiI+gZgxCwR4bB+TnV515ve3wv4gEvlcc+t7qmPnDE="
+  },
+  "androidx/compose/animation#animation/1.9.0": {
+   "module": "sha256-G+NKFCc2IYbQtasv7vgF+xUjJ9Jj7cJ/QKHmN3wE7O8=",
+   "pom": "sha256-6f9yAbWa5pa4p6hnGwYzxHssrmnyQQjkR5wawe3tQhI="
+  },
+  "androidx/compose/foundation#foundation-android/1.10.0-alpha02": {
+   "module": "sha256-PP+CuYcrzSh6MulLSP5j64UBNIvYgsIv+4WQQKTT78I=",
+   "pom": "sha256-JPMOIfPRBRz018YgsdEpcdkV0idBnNTrJNFLcnoPoys="
+  },
+  "androidx/compose/foundation#foundation-android/1.7.5": {
+   "module": "sha256-ebLSYYsRui4hl2NVPuuYCU/X+xaiKsh6dJwwsBe12XE=",
+   "pom": "sha256-EBBa/ME1MRqzvNbsDHxAS3yDy8BtKvnUiSlQDJsfRYg="
+  },
+  "androidx/compose/foundation#foundation-layout-android/1.10.0-alpha02": {
+   "module": "sha256-ogvU9pFPwOfIPPDp2j7uJPUaqXiAGZzKoZnkE/wpsEI=",
+   "pom": "sha256-0AKgdknK8hR0SrQ3Twa+F64pjL4VIjLlfmE0gPALd5k="
+  },
+  "androidx/compose/foundation#foundation-layout-android/1.7.5": {
+   "module": "sha256-b3wM8i/F9mkN9nZ/swWMWZuUd/Hk7kzQy11vgOSpVhA=",
+   "pom": "sha256-ygi1SvCK4hgBDohS8JXnxqczR+0MBhZD8LxPdaftyQo="
+  },
+  "androidx/compose/foundation#foundation-layout/1.10.0-alpha02": {
+   "module": "sha256-BKn+fcV0JLJjx05pkFSrPySdAN9Whcc6tZgosILMF9A=",
+   "pom": "sha256-+GtY2UVcAKyUfA/vAPxZx/3waiFZyMtDvgECc5h99jQ="
+  },
+  "androidx/compose/foundation#foundation-layout/1.7.5": {
+   "module": "sha256-pkuh3wy/T8Z7/VZ474s8vPs6tf6b2S9HhSYf4fOo7Tw=",
+   "pom": "sha256-/CP+gA822gzHgI0d3rR4kMHj3sOScuPZvrpRjC7d/e8="
+  },
+  "androidx/compose/foundation#foundation-layout/1.8.1": {
+   "module": "sha256-wkbH9NweLaFjvSy5kMqnqcECAstH0YmTZaFCm0qMmIw=",
+   "pom": "sha256-FGa4s3L2KRVLULaIWL5Wf9jfXG+0+n0ioVM7+F3ZRl0="
+  },
+  "androidx/compose/foundation#foundation-layout/1.9.0": {
+   "module": "sha256-hUa6IaFTI3QY4P8IB+SnzCCpOPJwCRhlcgg+a1x8xM8=",
+   "pom": "sha256-0VX3Oiu490VAfCn3q6vMPLOd7N7JWIbsV4ukLW6RsX0="
+  },
+  "androidx/compose/foundation#foundation/1.10.0-alpha02": {
+   "module": "sha256-6dm7XVcXNvIv+Oe7Dsc0cTqQTA3InB2tCl4RI//mb+A=",
+   "pom": "sha256-Dw/N8UWc8Holop9aypV6bI9zuuDOacqDdJ9DdZns/Zo="
+  },
+  "androidx/compose/foundation#foundation/1.7.5": {
+   "module": "sha256-TwGA0z+Iiyvd+LAYjwxyUmBM15WUXm/GVRnR88GuUEw=",
+   "pom": "sha256-axgiPp8bf5Dj0BDViv7w4Q2109QzG6YSzEX7RY6QpMM="
+  },
+  "androidx/compose/foundation#foundation/1.9.0": {
+   "module": "sha256-AKGusxFEb9AE8/ZvwyBJtTzm9rNTSThautPnuBEgYLM=",
+   "pom": "sha256-p0ATLUDh6YmepIlAH6+vwtoiFurfnbjWQLrekHwS0hI="
+  },
+  "androidx/compose/material#material-icons-core-android/1.7.5": {
+   "module": "sha256-uxjYC69ctUgQDH4IQ5SNmQKiEHtAuPH44DkY0IOwMFc=",
+   "pom": "sha256-IVAUghpAp1EduktXTeEYsQ1gDFsChVeqtfyLTmyzWEY="
+  },
+  "androidx/compose/material#material-icons-core-android/1.7.6": {
+   "module": "sha256-eietGojQmSEqfhomiis0BXeFUrAtAgvl8Gprn2o+yUI=",
+   "pom": "sha256-DyMnhhbx+raN5Ipg2UQGjelGROS3JucFqIHB53gJj9Q="
+  },
+  "androidx/compose/material#material-icons-core/1.7.5": {
+   "module": "sha256-ypkx5dgAfp/FkejyIxv5ccyWJnOIUNAg7uFhceaeW+E=",
+   "pom": "sha256-yFXNhvtbSweZk6m8QDD0cGxxZuKtyeZgWt/NlwII4sg="
+  },
+  "androidx/compose/material#material-icons-core/1.7.6": {
+   "module": "sha256-sRuDHpv+L6ZMeSiVb5/otZT4uPQLQliwmEAGKz9Wsr8=",
+   "pom": "sha256-itunFh4OocV1LwuYYW7lKi2Jm5qgYHzzUA+lQyquXEo="
+  },
+  "androidx/compose/material#material-icons-extended-android/1.7.5": {
+   "module": "sha256-yXHwWJyYUR2dBMQeAgN4m+ToeZ4SPTYFpmExNtJsbiw=",
+   "pom": "sha256-mLUsnodvPo6Rpgx2eOjNA0Ih6cZxxO6b/mzrB3mHSLs="
+  },
+  "androidx/compose/material#material-icons-extended-android/1.7.6": {
+   "module": "sha256-YGlqfsGPzoI3DMbiFqT56yFgMth8q0A0LjNKdHI+vas=",
+   "pom": "sha256-JdIXQwTDF55rO/3YzjzpXJCpLEvUro4Me5QeWBeEAGA="
+  },
+  "androidx/compose/material#material-icons-extended/1.7.5": {
+   "module": "sha256-Xhps2Xt01WgHdqsOF41f14xMeEaouRV6ksWzeSau7AU=",
+   "pom": "sha256-sGsqeoplw/M1dIWae3dnUhZbIi8AM4Pp7hRdvBl4/Qw="
+  },
+  "androidx/compose/material#material-icons-extended/1.7.6": {
+   "module": "sha256-7NczNuE23rRe267g3qEPelSQHh54FcS9FicJeXmJN4M=",
+   "pom": "sha256-rFSvA/qAXWNsC/pFi+Fqw1mL+7NtvsGA9loGGFA/o70="
+  },
+  "androidx/compose/material#material-ripple-android/1.10.0-alpha02": {
+   "module": "sha256-6EjsDGBn938s6+yIWUHLK1tvoGue5QoAvyDcghr3nhM=",
+   "pom": "sha256-7xa/zXOnqj4BFO5ifw//A8WUkDrGUPy9U4HbzCl09Ik="
+  },
+  "androidx/compose/material#material-ripple-android/1.7.5": {
+   "module": "sha256-pVC0zDNcV4dq2j1Z56ufNa/od3bfNDEMquOqD6wzHK4=",
+   "pom": "sha256-6tiSsY1o2nA9XSA4d5cyWHqoMgJAIYBxOwbvr4wa/Vc="
+  },
+  "androidx/compose/material#material-ripple/1.10.0-alpha02": {
+   "module": "sha256-wCm5JfQzftLqOZNRJqQGq9/t4XjSNByRF7p5MRW3HLs=",
+   "pom": "sha256-mdpvCUPWCPH7+qCjK1lIdkz4Eo9LN0yVyr/AcQooZN0="
+  },
+  "androidx/compose/material#material-ripple/1.7.5": {
+   "module": "sha256-QfNwSeALLXV0c7V1A7IjpnydewyE6k9PUuaG7wSF4Ac=",
+   "pom": "sha256-vrEUSSwdGNyt7ZVEl8EFWchM83EyY8/eZcniM8561B0="
+  },
+  "androidx/compose/material3#material3-adaptive-navigation-suite-android/1.5.0-alpha03": {
+   "module": "sha256-TvukprdU9Eq7PguXZg1NzQJ8ViKYkaVlssHazjCZalo=",
+   "pom": "sha256-vfCJojOPHjsTJYxomnn1hIIz3T4LIzhaJdX8eHVtpGw="
+  },
+  "androidx/compose/material3#material3-adaptive-navigation-suite/1.5.0-alpha03": {
+   "module": "sha256-G5PZXV16B5j5S+7YxzLoxZJMlH2Xt9yy/UTXpYPbpXM=",
+   "pom": "sha256-zg5Q9B/fi5+stO1q7wXlJrMDYHL8YahoFbMSNqI8Fec="
+  },
+  "androidx/compose/material3#material3-android/1.3.1": {
+   "module": "sha256-KCga/SeeyHWhJzZ2nPgKz8bBtNJPhgShAyPS/z0sjjg=",
+   "pom": "sha256-zSFP27CCUhJIjE4Cxw/MDXpoiAdmoOKj3RGuPlhd3Co="
+  },
+  "androidx/compose/material3#material3-android/1.5.0-alpha03": {
+   "module": "sha256-ehUkTDklXh3NjpLZQl0VEai+D75mv+iEF437/g7uaBo=",
+   "pom": "sha256-OZcb9pqD3bZfTWgEShiiaObEoqXaGIydXeXym1/zlYk="
+  },
+  "androidx/compose/material3#material3/1.3.1": {
+   "module": "sha256-nNUeKtICSvTKdD6IN4dGQJcWKlulTRP2ojR7MBS9S6E=",
+   "pom": "sha256-TcHJ85BJwmS3Em3oE8MlI4EmUBDTH9kycxZ++rtd5gI="
+  },
+  "androidx/compose/material3#material3/1.5.0-alpha03": {
+   "module": "sha256-XbyzztGdDT4somU/Ovc91N7NpEybIHAaauOElhEeE5E=",
+   "pom": "sha256-DQwIPGshVKzETJ+qOn8hSjIjDDfelDhOl4c7p3e1pEE="
+  },
+  "androidx/compose/material3/adaptive#adaptive-android/1.2.0-alpha11": {
+   "module": "sha256-CVBfeCX4b8CWoqpt092tEQNLEo5K9xDS/hn2LyvOh7Q=",
+   "pom": "sha256-OBKtJXMOyR7oULy00zOtegiY6Xm0xnB8Thm9WidNkg4="
+  },
+  "androidx/compose/material3/adaptive#adaptive-layout-android/1.2.0-alpha11": {
+   "module": "sha256-mHfGN0QmyjIFiZ6ZQlAYsCETM+PFocgxoYHOPk3Hm3c=",
+   "pom": "sha256-LOhFai8eouESrvXAW4hBAKTvBpniLeD14ICvvT6qpd4="
+  },
+  "androidx/compose/material3/adaptive#adaptive-layout/1.2.0-alpha11": {
+   "module": "sha256-FiG1QcC9Z8VhSn9+6BoqtkSwqpaYLfbHmKWOas+Yryw=",
+   "pom": "sha256-7VLtAEQU1wVgJSJidvptyvnUi3/5/lf52fAK4HQjxIw="
+  },
+  "androidx/compose/material3/adaptive#adaptive-navigation-android/1.2.0-alpha11": {
+   "module": "sha256-4XXGnCmAr5gQ1luZaQZxI/Q28n9K2fiSsUX8VlKagqY=",
+   "pom": "sha256-yBN8/idGnZaeYCmNKUQMQ6EU2Uf69RXosNDoyj1IcQY="
+  },
+  "androidx/compose/material3/adaptive#adaptive-navigation/1.2.0-alpha11": {
+   "module": "sha256-Lt2sabHFR/HCh3zAT6Pl1DQ+X9RYLYTHP76KHvMzHJU=",
+   "pom": "sha256-YtwXT+NylSdu2o2wbsiX5seQOrlgXhUMAzp0H+WQmV4="
+  },
+  "androidx/compose/material3/adaptive#adaptive/1.2.0-alpha11": {
+   "module": "sha256-TVfwFegXLlpKCF0UUftO7KFeUYlgUpEezyhfgI4ZYhk=",
+   "pom": "sha256-wlYxJ3MRiTFhQ6KbwvrdCvMmB70PpIAXeA1ij4PvNZM="
+  },
+  "androidx/compose/runtime#runtime-android/1.10.0-alpha02": {
+   "module": "sha256-jeIbMCYbxd7uaXKV30trqvG94vSZO1jvOW8J2v7vnxs=",
+   "pom": "sha256-QSWMFUOPXCWiDfhHvtA9W2/xOMqU9CjuJ3M3E9Qd4oM="
+  },
+  "androidx/compose/runtime#runtime-android/1.7.0": {
+   "module": "sha256-o0ILrQ7tzorf5j5qJEb3cL7gvI0X7MPhRvNXrjhK5dA=",
+   "pom": "sha256-kRYc0CyaY/Img0M9Dys4KBoLMJoLVm8n0Ipdt0An0Wk="
+  },
+  "androidx/compose/runtime#runtime-android/1.7.5": {
+   "module": "sha256-NmlKodTu1c7FPSjMDkBlnztuMmgCz9man+LrJEscLxc=",
+   "pom": "sha256-YFJq2QKlehDGyLNGPFzhqIwa37YuWr9D79927imziVw="
+  },
+  "androidx/compose/runtime#runtime-annotation-android/1.10.0-alpha02": {
+   "module": "sha256-TcwCcSeT+XhBZSymj360C1m4mGVAVkM8vEwKfYScoqE=",
+   "pom": "sha256-Wy6AVIHF1EcIObuUSrekPSSxoGFJcxXfQwldFzf0seM="
+  },
+  "androidx/compose/runtime#runtime-annotation-iosarm64/1.10.0-alpha02": {
+   "module": "sha256-lKlFtOF4zsZUj3mFO0WgicgPXSlkLWQnL+MFZz6TZ/U=",
+   "pom": "sha256-HZUvNTDkAU7cONI/pE6p7qK7yk3O4I6Tg18E5rc/iPg="
+  },
+  "androidx/compose/runtime#runtime-annotation-iossimulatorarm64/1.10.0-alpha02": {
+   "module": "sha256-XqT7nsF5epE+2ci+iGswMEMGxle3bIyrcu5WjdVRiIM=",
+   "pom": "sha256-f17E3SZEH8+UTB3fl3VhHOkz4FfRgJE9pH4/cSQ7D0M="
+  },
+  "androidx/compose/runtime#runtime-annotation-jvm/1.10.0-alpha02": {
+   "jar": "sha256-+J3ai81zh20PwWVohEsr15RD7nymKBCHTSXH3Ko5S9Y=",
+   "module": "sha256-mwZCtAAy0N67h6yT2xkDq1ZKGKRV88D6Grs5HkjbjoY=",
+   "pom": "sha256-ixa8HqG8h7r1MyX6XjrpHTwd05OXhNbnibmK67Q02I0="
+  },
+  "androidx/compose/runtime#runtime-annotation/1.10.0-alpha02": {
+   "module": "sha256-WaLtLSbXaW/VB4jw18YJ2RaQYWGKJCXqHD2u2LJCuUw=",
+   "pom": "sha256-4pkcGu67hSz2y5WHMKpoo2zH8wzOfQk1I7BdQozk8kc="
+  },
+  "androidx/compose/runtime#runtime-desktop/1.10.0-alpha02": {
+   "jar": "sha256-Y/LJX8tkqQNw0GTS/DLn2zbgRLbDlHbFGaNXnId65zQ=",
+   "module": "sha256-QGXTTzm9BY6f+NNzEOUyqWoKlW/JVpxUbXgfW2KYs6U=",
+   "pom": "sha256-z3uBraGleRqLkJ5QePgi2PzvjgEA9Tnd7/yQUM4ZmoU="
+  },
+  "androidx/compose/runtime#runtime-iosarm64/1.10.0-alpha02": {
+   "module": "sha256-XwVocSFZI/Xzb9oQMt9vNllSDMDCYcIDzyi/Tr9RIzY=",
+   "pom": "sha256-/UHzdXFo1lLGOGQcDZNG6t19s0ygaH3cV0UvtfsNntI="
+  },
+  "androidx/compose/runtime#runtime-iossimulatorarm64/1.10.0-alpha02": {
+   "module": "sha256-NN3pAl4PTuz+D5h3CBiYnGLUFTc030Yzxz/ev1fvqRE=",
+   "pom": "sha256-DM4cUFunvE6YCy+9vyqgyudu+B92x0KSHVY7YGB6obk="
+  },
+  "androidx/compose/runtime#runtime-saveable-android/1.10.0-alpha02": {
+   "module": "sha256-41uYLJKlgAwj4TEEb9ytXx2/+BsPHwtU/Wna2C0DK/o=",
+   "pom": "sha256-r1T88YT6a4S3qs0K1KzI1/GUCOd6nU2sSgogO+EHHgw="
+  },
+  "androidx/compose/runtime#runtime-saveable-android/1.7.0": {
+   "module": "sha256-FPU88sgBBcde61vxmQRDmtXfpDJ93ZRIKdy3KDraCWA=",
+   "pom": "sha256-NB5w5ZLSQyjAvfAz9nk5Wz1r6Ps/T/hh2GBkvUrZw3E="
+  },
+  "androidx/compose/runtime#runtime-saveable-android/1.7.5": {
+   "module": "sha256-2jVHsdNWz6ZcYn4iBeFDp1Hqa5RVvcNWNYfAahEcPO4=",
+   "pom": "sha256-1Etf3KcEfuaiHlrx3js7uW3gp0wQ3yt9Zb0bilinNGw="
+  },
+  "androidx/compose/runtime#runtime-saveable-android/1.9.0": {
+   "module": "sha256-l01ZfsLMOoKXuML/1fng9OaGDQ65YlhitgVZiKXOoFU=",
+   "pom": "sha256-1e/W0nL2Bq1SPqNbgexBKoDgqiBiqzEYGwGAt6zNrrA="
+  },
+  "androidx/compose/runtime#runtime-saveable-desktop/1.10.0-alpha02": {
+   "jar": "sha256-7ftTKziJlbUUeTa5NCk21PICyLtwsQIrYlHTZWgMeQk=",
+   "module": "sha256-PX4ULbHGSQT7UGlT4ArdaXH9tShzqihB4+M4UWdW4AM=",
+   "pom": "sha256-0YzoLuFr/Tax0JJG2RVvpDIZ8GY30OmDV74JKZfQjRQ="
+  },
+  "androidx/compose/runtime#runtime-saveable-iosarm64/1.10.0-alpha02": {
+   "module": "sha256-g+Q62RdlHmgEXroBxsJiWB2lSjz06h5SQT3iFg3MXEs=",
+   "pom": "sha256-zS+s2hQbz+x2E4dg2lXJog6sZr7CWqJnqgeeY201Ry4="
+  },
+  "androidx/compose/runtime#runtime-saveable-iossimulatorarm64/1.10.0-alpha02": {
+   "module": "sha256-H6d8LEYKnGwo7qyoyR7k1FjhG2Ri8GiY1Zxl6LD+Waw=",
+   "pom": "sha256-lwBZ9gQ99KvQkvQPsuuKpIfScvwfSaZ2JeDPPqfHIxI="
+  },
+  "androidx/compose/runtime#runtime-saveable/1.10.0-alpha02": {
+   "module": "sha256-USvslcRIDPAQPMBwKMuZFWpiXXAyO/Y3K6OBCgDjhZ0=",
+   "pom": "sha256-XXF4SBMwKhU9j2hOq75AEdSX0bGikbjM4umUidvLxn4="
+  },
+  "androidx/compose/runtime#runtime-saveable/1.7.0": {
+   "module": "sha256-V096AtKqST7Zo0pfOFZyJm6XS77qNQMnRU6gCL3S7Zc=",
+   "pom": "sha256-UG3TGS4UUkxsHClvNFl7hGoyZPqtF820AuHszCJNDko="
+  },
+  "androidx/compose/runtime#runtime-saveable/1.7.2": {
+   "module": "sha256-FxVMRcWwgYnTBIuFW4qKh8oW6tPrSSlNPwgb5fU8gNU=",
+   "pom": "sha256-IYnj3yw5lvauRmHnJdS/Are46F3PWcULaM5lay0SjJc="
+  },
+  "androidx/compose/runtime#runtime-saveable/1.7.5": {
+   "module": "sha256-EPd9GdGF6KLN1LDa+ymy2hgM61G1PuwstFu40CeVSpg=",
+   "pom": "sha256-4itFFcGCYOqcksHaHQsJqkb+gnCr1mg4oveFn/JzJds="
+  },
+  "androidx/compose/runtime#runtime-saveable/1.8.2": {
+   "module": "sha256-bvgfp/FklhULLb9r4gHEEt7T80PKH5Xt5EIYdR7WbHI=",
+   "pom": "sha256-zkIRKN1Z/3cq3hv5T61DdKbcxe64Az4xQPawbvbZlCw="
+  },
+  "androidx/compose/runtime#runtime-saveable/1.9.0": {
+   "module": "sha256-dWS0MU7dgdDxwPp2MH9HPDl7Y0hWIdPO4KKRiwUvJS4=",
+   "pom": "sha256-hqVscAR77b6wjyPOhtoJ3LR38J+MUjnvp5CV4uzgYLM="
+  },
+  "androidx/compose/runtime#runtime/1.10.0-alpha02": {
+   "module": "sha256-Xp/T4NnGgg77cy6cgrwVeUaM/Az/UHyz5bCqJBTMZJs=",
+   "pom": "sha256-e9GQE39x3fhf/ntB2Eu58wykX07LDx7tM3k8pd6T/Xo="
+  },
+  "androidx/compose/runtime#runtime/1.7.0": {
+   "module": "sha256-e5NRsP9t+SdtAtQPEnZa5Vv1xt+4/430x338oTj7n8E=",
+   "pom": "sha256-eUHY/NaDVXGG0vU8gXPDX3GqrJ1OZI6a6x7cS5L702E="
+  },
+  "androidx/compose/runtime#runtime/1.7.5": {
+   "module": "sha256-jIZGu+W3dvLI0i8h0hmsHTbtgHNliB5cafS2jdxd7mQ=",
+   "pom": "sha256-+aAHsxD+BGfY3e7tezGglFzxP15Si1KcVwBtk/oeVw4="
+  },
+  "androidx/compose/runtime#runtime/1.9.0": {
+   "module": "sha256-sR6bZBtlR39obhm0mdqkNbr0INE7t56Y2wXsAYktsi4=",
+   "pom": "sha256-0vrrNhehR8vOsH6B2tI8+wHi/QiJ3hO5kJWQChpe030="
+  },
+  "androidx/compose/ui#ui-android/1.10.0-alpha02": {
+   "module": "sha256-ioRgDzx8bEj/ZTExiQK47X4wyfKyo4FrnrwA/4GczYE=",
+   "pom": "sha256-wRyk3UZVAsRi015EUaq99HIj2LU4v2xU5oFaAqYINVU="
+  },
+  "androidx/compose/ui#ui-android/1.7.5": {
+   "module": "sha256-rsijVvwjsHp4XS2J9RvCpColPhtYAK7/EFVeKWtmT8M=",
+   "pom": "sha256-SKsgUNqJP22OgVo71Fy7ZjjpbYrK8tws7i+JD3a8cVg="
+  },
+  "androidx/compose/ui#ui-android/1.9.0": {
+   "module": "sha256-HfKPt6GgXvAJYa88aH7cO+2kVo16XUM0U/zUboWmlpY=",
+   "pom": "sha256-53Zwewv+BWhnw6iLmta5Q5QjTco4XO25oVfuvF4Awi4="
+  },
+  "androidx/compose/ui#ui-geometry-android/1.10.0-alpha02": {
+   "module": "sha256-E9IFjD8A2H5du2p2NjmTxrgE+phUudGqOPvOobfrQdk=",
+   "pom": "sha256-mQmSuCki+TkllBMFk7F7h/aSN4Zqij1zqciDbRVVy+8="
+  },
+  "androidx/compose/ui#ui-geometry-android/1.7.5": {
+   "module": "sha256-Qum/v6Jtmks+71alryrs+1YgI7d7UYYSsIYYMyG4CN4=",
+   "pom": "sha256-4yoSd+TBiMFC7iW/zrKV8rbebbjK7a4oYWWZqpeZHpU="
+  },
+  "androidx/compose/ui#ui-geometry-android/1.9.0": {
+   "module": "sha256-aZZQtgRwbSzX8J3zdcAYGxGtwPsXDBOfgoc0tN2n+aM=",
+   "pom": "sha256-f3omF3CXHBCJyE6r45Du96rzjYRMJrBoZbQmhrKxj5I="
+  },
+  "androidx/compose/ui#ui-geometry/1.10.0-alpha02": {
+   "module": "sha256-AiPXNmXlDW6hB+9ioA1Tf4pe3nwydNq68W14pGdeFG0=",
+   "pom": "sha256-Yak0lTT1DQ2VEF+PoAl5YVAdB30p8+r0SIflaa+wQW8="
+  },
+  "androidx/compose/ui#ui-geometry/1.7.5": {
+   "module": "sha256-MVkWiinNCp2BbAIEPAOO6PyTZJB452bblU0t9ckNcJg=",
+   "pom": "sha256-lXEvJyhU/0WzWsouijrkgW2/onJtXmia88hbCkmAyC0="
+  },
+  "androidx/compose/ui#ui-geometry/1.9.0": {
+   "module": "sha256-Ol2oKNXBCPqmPNstY4hQ9+mp4PsAcbLWtSmOdvuWzp4=",
+   "pom": "sha256-mzsyxQeXyvOBV2LDEVTMzTBGBVFVkB9wAIkP+iJMq+0="
+  },
+  "androidx/compose/ui#ui-graphics-android/1.10.0-alpha02": {
+   "module": "sha256-4H9+cqYkjNAc4M3RP8Qjf8PuDD3Y8kNxzBOYFOiSX6o=",
+   "pom": "sha256-hy2jlkECSph/OJxFLBlJohXSbzQuP04ErBFxuxJ926I="
+  },
+  "androidx/compose/ui#ui-graphics-android/1.7.5": {
+   "module": "sha256-0TTti2GBjult8w8dTlEgLT1giMDpjgKZAm6bS1+KMo8=",
+   "pom": "sha256-dHBCKgxsu/fXmUKSEY3wkH0rMohabmgxiTjSgeOpZ58="
+  },
+  "androidx/compose/ui#ui-graphics/1.10.0-alpha02": {
+   "module": "sha256-vzk/zu/8gIlTyqfE0/kIMrA5CXmESYN7OVkYimzkeyM=",
+   "pom": "sha256-C4+t2rogzASzPoTTK49Cn5/nqIPXp2Niq75fjZ+aTn0="
+  },
+  "androidx/compose/ui#ui-graphics/1.7.5": {
+   "module": "sha256-+p5GtUcl9ZTv7Vowpmn8QKtfecQpN5/sjyWk+qZCU7k=",
+   "pom": "sha256-3frVKlSPuVS3FCPhi1E+ZCXB8nIWZVAKpPtYYUK21Gw="
+  },
+  "androidx/compose/ui#ui-text-android/1.10.0-alpha02": {
+   "module": "sha256-OUDJtZQ98+nGrIfEKlxZNx2yK7gugoJC/tDf+vaZe8k=",
+   "pom": "sha256-l5zjUjgcA3mGneQtTb/MHKj5EPZueaKG64OF7x68HDM="
+  },
+  "androidx/compose/ui#ui-text-android/1.7.5": {
+   "module": "sha256-kVtlIBhTpLX7Y6MaLb5o2q0Yp/vqc8KIyeeKWC3uOAE=",
+   "pom": "sha256-GCQz+dCMg+gkULGgZpHvS8ieucnQJen7GCAK0EDKMEM="
+  },
+  "androidx/compose/ui#ui-text/1.10.0-alpha02": {
+   "module": "sha256-afLb3eGGlPoKe0FtUKhmv7jqg536eRLHitfCO0/miBE=",
+   "pom": "sha256-osaDJugjuhY17VLjxqSrwU8bWd7/Gp8hLcpuEzZ6xd8="
+  },
+  "androidx/compose/ui#ui-text/1.7.5": {
+   "module": "sha256-Pop7F/PL+oQCWuMCfIdqyhyaiUwO5J0g//mZ7Pn1Td8=",
+   "pom": "sha256-XKp8Sw8SJT1Q0JzDI77hRnGnYgYOCPHvstW+JS1Or+g="
+  },
+  "androidx/compose/ui#ui-tooling-android/1.10.0-alpha02": {
+   "module": "sha256-rjcnLPneHULyUdcRnz2procCS4uX2Wj0p155HcKKVto=",
+   "pom": "sha256-e24JbQ/KfkhvzhuwK5STDipS24lHzKg23Op1sy0pjkI="
+  },
+  "androidx/compose/ui#ui-tooling-android/1.9.0": {
+   "module": "sha256-KoD8Uq98m7OR4rIhQqDf6B1TmzCOcM5FEfXUDlY7XKs=",
+   "pom": "sha256-nsO0odkysfWztRHBLvfOxb5nlEb4blDLCcX/wBiK7kM="
+  },
+  "androidx/compose/ui#ui-tooling-data-android/1.10.0-alpha02": {
+   "module": "sha256-Fv7D9AmVLh6DL1uNM4QV4MUWUYPQqslmduN3aG2SHjU=",
+   "pom": "sha256-Y9HL7cNtnXKRuqGBoSv1dKXEB+d/qQ6rez93ZXdEGdo="
+  },
+  "androidx/compose/ui#ui-tooling-data-android/1.9.0": {
+   "module": "sha256-SL12c0Bg77CjhUAFfKLj5ACqit2H3/Hrsc6+O1GPxls=",
+   "pom": "sha256-hTjL8NeuwAVybM2SDepQPoH0cCC+ZZkZwotS7BLcAUQ="
+  },
+  "androidx/compose/ui#ui-tooling-data/1.10.0-alpha02": {
+   "module": "sha256-SxaFApIJp8P3tN5BjE/0JtFkGAxmDXjoenH4K7GhXQ4=",
+   "pom": "sha256-czJTrTehDvaP34s+ttsDsOT3mVudo2VE107Lvfq4l88="
+  },
+  "androidx/compose/ui#ui-tooling-data/1.9.0": {
+   "module": "sha256-iqMtlGddI1myNMdAMIs4teXKV05i88JARTGhYRpWYI4=",
+   "pom": "sha256-g8xpHCxGVU70rgPUOldkoX8khO0bcnWzQDIVVAoXTHU="
+  },
+  "androidx/compose/ui#ui-tooling-preview-android/1.10.0-alpha02": {
+   "module": "sha256-j+/r825UfW3hcxNFsHZof2mA48v6ibjjVKyxdwmypq0=",
+   "pom": "sha256-nzGH/zlrxOu60izfs0qDbDQFLtUhrBGjexbz7OgZxrs="
+  },
+  "androidx/compose/ui#ui-tooling-preview-android/1.9.0": {
+   "module": "sha256-IDIragvtG63Gc0QO3r6JWoRhsxeHe+kp6U1/x6fJF6g=",
+   "pom": "sha256-7tn2WCRJPDJGI4eNXONKIkAyWZxNVWOFUOLgHqk9hVU="
+  },
+  "androidx/compose/ui#ui-tooling-preview/1.10.0-alpha02": {
+   "module": "sha256-YGSAGvtxCZb/pizVnR8A4/+meC8/jDDwAEe6jgICrzY=",
+   "pom": "sha256-AI58FszD464QUqreTMwLGtygfUBulNtppjYcY2eiDfo="
+  },
+  "androidx/compose/ui#ui-tooling-preview/1.9.0": {
+   "module": "sha256-SSWWZuqK6hcAdXxKgZsFzVCUymF+oZ6uPmG1xpt5yF4=",
+   "pom": "sha256-FtIThSEk5i6j3M5T8KFDhoI3h93OTRNlbteLVndpUOk="
+  },
+  "androidx/compose/ui#ui-tooling/1.10.0-alpha02": {
+   "module": "sha256-VRV4ROVLM+0t8nWANOfCTO4nomiKkFs1t4vdsIN4b0c=",
+   "pom": "sha256-ObT4uVd4SiV+MzFQzWkGo/xkd5br+ho4eq3H4EI1P3U="
+  },
+  "androidx/compose/ui#ui-tooling/1.9.0": {
+   "module": "sha256-k446vV6s+ekhNg42sVDgH6f5ZXDZke3rD1kfDS9rLXg=",
+   "pom": "sha256-YVevEJiXm70WhqHiTnALnP2/wNBWYDheD3llADey6mc="
+  },
+  "androidx/compose/ui#ui-unit-android/1.10.0-alpha02": {
+   "module": "sha256-YEhGgwKdoYR8hM4qD/ISsFzSovXmLhQXkK4q/Nb7/sE=",
+   "pom": "sha256-sQy/QACT3QfDwobTX6jqCjxyZZS0D5EqHt/vF2IPAyY="
+  },
+  "androidx/compose/ui#ui-unit-android/1.7.5": {
+   "module": "sha256-weGHan5OpWhyynBC4tVGewLYdeuJBM9qFD7oeL8r6CE=",
+   "pom": "sha256-/oha+91iqias6WmqVH/DK2yOdkB8FG/UOD76/0Mi6Rc="
+  },
+  "androidx/compose/ui#ui-unit-android/1.9.0": {
+   "module": "sha256-8+6abl0/tTi/WVPkVtk+9V4GDnCtSt14UTGcPlK+tG0=",
+   "pom": "sha256-nODolEkBGGZ6qJH3i+NwUrs5rhLP6irv3YNxBl0aGRc="
+  },
+  "androidx/compose/ui#ui-unit/1.10.0-alpha02": {
+   "module": "sha256-Lewkic3jdHZlTkkic1znn41gAtIQY9xIrwfon2nVtU4=",
+   "pom": "sha256-ZHSoy+z1Tw3HZ42GGuG2JfVP3/HH9NhfgFtm8bvFq9s="
+  },
+  "androidx/compose/ui#ui-unit/1.7.5": {
+   "module": "sha256-/F4qYQrRiuhqMvL6TYM5RpbwlmcPABt3bJjfc4b7miE=",
+   "pom": "sha256-+hT3PpkxTg5HOxNh5gIwhJYcvVrubNOsZfkIHqDURIU="
+  },
+  "androidx/compose/ui#ui-unit/1.9.0": {
+   "module": "sha256-Rkp5SVWGKHDK348R/uxSFZm5Zbfr467dqckITMCQros=",
+   "pom": "sha256-J80XLbz+/pI2nS+yT9IjDHega/0BqZ4RGv0RU9DXW9w="
+  },
+  "androidx/compose/ui#ui-util-android/1.10.0-alpha02": {
+   "module": "sha256-kxRoXMOZNt44j9gxWnP/N7mL3FqExkCGbvSodSLmUn8=",
+   "pom": "sha256-cduQysKr0wq3G0BmGm6vkADSzUqeJWzhZFo43zHhvXQ="
+  },
+  "androidx/compose/ui#ui-util-android/1.7.5": {
+   "module": "sha256-AvS+BtwgG6WnTXQIUllnwxRmrdZqQ7Za8ZZrk1h0M98=",
+   "pom": "sha256-Kr/DQnkKO+hS3QW+g/uXjDJrwLovYyXZ2k9fCi6SkQ4="
+  },
+  "androidx/compose/ui#ui-util-android/1.9.0": {
+   "module": "sha256-ZhPddnDOooqCkhI3SiQ8OJqRSlcYPh8vnZ3kewgOF/0=",
+   "pom": "sha256-Uja6w+dKIPwyrNceSc3TIiZIPXL5NnJtjKZJtsDHfwI="
+  },
+  "androidx/compose/ui#ui-util/1.10.0-alpha02": {
+   "module": "sha256-dUnqGMMoqMiLslVIjcTRDULgIrkfFCKBYuAyrhZMj7g=",
+   "pom": "sha256-5YqbQ/Bdn8b8mAsKfWHw4zkZGsRUhDPeqfKDKc3MeD4="
+  },
+  "androidx/compose/ui#ui-util/1.7.5": {
+   "module": "sha256-iSN9m3SZroivjuP/bEWdloRPTt5cXo5ET2jMHHJ7ATo=",
+   "pom": "sha256-3ZZrcKSh7wU2dFOPf/zYBse/zKQHBuAIi3kJE+f0YbA="
+  },
+  "androidx/compose/ui#ui-util/1.9.0": {
+   "module": "sha256-oxq1OSFs/lYIYB28LiX4Oo4RBFbbDimOydbu0jfVSkk=",
+   "pom": "sha256-OQljCYjXL5lJLQYjuh7a3Ecr2qBRagglzo9Kb0qtYoQ="
+  },
+  "androidx/compose/ui#ui/1.0.1": {
+   "module": "sha256-VwMaasm2DltWeS6/XN5uFoEv9WbtkZDL0YiwC0bBN3k=",
+   "pom": "sha256-IfZaw0n3m8YNhGbQ64DNBj8YUvRMrKShyfN8GandvWY="
+  },
+  "androidx/compose/ui#ui/1.10.0-alpha02": {
+   "module": "sha256-K8VXkfA40ZvJ6YwfYM9Ir5ardwlH+0CKMBP3VHIGLKI=",
+   "pom": "sha256-fODnc905COpkPfxK+iqETH4y4p2SVipIbYx871M/eyM="
+  },
+  "androidx/compose/ui#ui/1.7.5": {
+   "module": "sha256-htJouX9w7uswremZh/5vv2ymXb8LMIyTmJRIUz6drdE=",
+   "pom": "sha256-F+UACzBQKK1JmdaEcmDIpyU/Dr186a55fiTXKkXLZdk="
+  },
+  "androidx/compose/ui#ui/1.9.0": {
+   "module": "sha256-g2Do9FmCAXSCn/5YV6pF2tQpeGpgEo+DwsQH9eWCDOA=",
+   "pom": "sha256-uSP2kBIm0XSl5TmJOkw4WEdKTrOkpujz6WbL1H/iSgM="
+  },
+  "androidx/core#core-ktx/1.15.0": {
+   "module": "sha256-vum0RmT/N+LiIuvN5LMOOClKP5J0Ue3GEf7H9FT/pEI=",
+   "pom": "sha256-QXxqoCeex42wL+OV1AGgm8qqnYLZNRSKPi3pD9842Uw="
+  },
+  "androidx/core#core-ktx/1.8.0": {
+   "module": "sha256-qRvD4C8gn2Q92CdTRanjADziDWT8B2Dsz0ecFwmEL3I=",
+   "pom": "sha256-jQesWFVMKRbo0z3/u3sTtKdXhpAeUIrig6dbjC6wK68="
+  },
+  "androidx/core#core-ktx/1.9.0": {
+   "module": "sha256-TUZkYGbHlPKBLVszqUItN+T5GMTYCc0fsleccCLvKBg=",
+   "pom": "sha256-Gu0iT4f3ZkHsoC95qONl1y6cy5AphPj1MYPEQgyUVQA="
+  },
+  "androidx/core#core-viewtree/1.0.0": {
+   "module": "sha256-EThs+kbLv922pAWfFDVMAGkc9l09Y8NhiBioMybvPH8=",
+   "pom": "sha256-1PLtEXb6jFYSuA90yVKoeZFCqe02AioaI4/eWxQFgNk="
+  },
+  "androidx/core#core/1.0.0": {
+   "pom": "sha256-OE1SmtZoraSAjeKbKaY0jwAHwoQa15yumloIm9aIEPU="
+  },
+  "androidx/core#core/1.1.0": {
+   "pom": "sha256-2uRhMs3NRreYQl98t4/WWJCGm20mEBzNzUNGGk9RdUw="
+  },
+  "androidx/core#core/1.13.0": {
+   "module": "sha256-Lg5uXBIFt0YqDFw+MrWMLlJUNYEu2JlGx75nN0k7UeM=",
+   "pom": "sha256-RQLk7YtZEiAhrJocExLiMm5LD0P37Lu8m1Dud0KVdNQ="
+  },
+  "androidx/core#core/1.15.0": {
+   "module": "sha256-6KbDhuF2XYcAEv7SIhFz1KLo0v1a7HMsUa+0qfRoRRk=",
+   "pom": "sha256-4WiuVgZLjlpAvOQV75X/1agTq7VFbSd18P70Ju1J41o="
+  },
+  "androidx/core#core/1.2.0": {
+   "pom": "sha256-PR9ON7d92SNTh5oECrTOL3BnmLy98GYUdJHDZCs/eaY="
+  },
+  "androidx/core#core/1.8.0": {
+   "module": "sha256-UF8YOIaWEVGdZex/62UOiIVuNoLjfkKioktz5lWpjXQ=",
+   "pom": "sha256-eezHl6XSAMS+P2dW0su2+kb+WCGSMEN36KZBD2Bm6z4="
+  },
+  "androidx/core#core/1.9.0": {
+   "module": "sha256-hnSt4dEpYkad0tHm7cA7Rl8g0YCwhAoSm8QLNR6GUdE=",
+   "pom": "sha256-naZhCFuyo8pEwHEl0M773UoA1luEGlO9stVgC2Qh4Oo="
+  },
+  "androidx/cursoradapter#cursoradapter/1.0.0": {
+   "pom": "sha256-YtlciYUK8hAwsZ8U1ffs1ti8yaMBTFkALsmWJMqsgQA="
+  },
+  "androidx/customview#customview/1.0.0": {
+   "pom": "sha256-zp5HuHGE9b1eE56b7NWyZHbULXjDG/L97cN6y0G5rUk="
+  },
+  "androidx/databinding#databinding-common/8.9.3": {
+   "jar": "sha256-Zsq4JjnawPbCQzRkwJOwdNYIxLuIfsOKm4vErJgSZzI=",
+   "pom": "sha256-Y9HxLjPsMfBGjCoAIbo3quIgwNwRBfFcds2pfZdjnm8="
+  },
+  "androidx/databinding#databinding-compiler-common/8.9.3": {
+   "jar": "sha256-EFG0KHFupUfPUd28PZHudtk74jY+50y7ixRHrjqJF3A=",
+   "pom": "sha256-8HWbJj0BhNeT5q+at7meSp0+JsR7M8SOLnzci8ewSH4="
+  },
+  "androidx/datastore#datastore-android/1.1.3": {
+   "module": "sha256-Ia8ApjmgEA8JeDYh0Ews+v93ECTC4lYbqjp88mUJvkI=",
+   "pom": "sha256-UoEKEruUurmCJ8YYixKFydowJo1fuLg4Ijia143BQmg="
+  },
+  "androidx/datastore#datastore-core-android/1.1.3": {
+   "module": "sha256-k6ES7ejCFj+gy7PVvRwFI7gEvw0cbLZyCHfVm9qmH+o=",
+   "pom": "sha256-9B4kmIb5bWPtC4+gWFPbSDRSAWb7TUFCy6HM0VkOvzQ="
+  },
+  "androidx/datastore#datastore-core-iosarm64/1.1.3": {
+   "module": "sha256-zJWf9F/0bOcJPW9PHio6eljd3soIbPotOHfrkCPsifM=",
+   "pom": "sha256-6tz0q2PwZySlEBlLpDJGjm2klOd30z2ZZOmIozXCUIc="
+  },
+  "androidx/datastore#datastore-core-iossimulatorarm64/1.1.3": {
+   "module": "sha256-f+HfuP52CxfDBG+5+aWePDH6xaV+vn30wP8iuHq6Wqk=",
+   "pom": "sha256-r5Nr2pxO6Wi485jOu5UbAW0uYr2vINBtDqlU0V91xCo="
+  },
+  "androidx/datastore#datastore-core-jvm/1.1.3": {
+   "jar": "sha256-Niy60fE4dKIsc2ChjrmVylKjYDeboOpa8bHPDfAxmi8=",
+   "module": "sha256-UmGZehK21geoJRfnYSIzci3SVeQVrOanr1IzItT1nzk=",
+   "pom": "sha256-PjzxV7ZBhO8a829Fvu/J4NSxQXboljpDobvM6mUIUxI="
+  },
+  "androidx/datastore#datastore-core-okio-iosarm64/1.1.3": {
+   "module": "sha256-Ggzv0JMYj4wudoPKGOIM32ho2vYtUlHzZbAqBCpkUd0=",
+   "pom": "sha256-Rvjf/SWNSEq56xprzmHc4Yq98AmQFRUaEMHbIhmPTtA="
+  },
+  "androidx/datastore#datastore-core-okio-iossimulatorarm64/1.1.3": {
+   "module": "sha256-zPOmSQMDw19OxgIvlY0NluQWiKpZfgTJLZAxxwX9iqU=",
+   "pom": "sha256-/uYObVHJ661Dn+BzHWT8CVEDnnLWRPbQCTxKC84NcK0="
+  },
+  "androidx/datastore#datastore-core-okio-jvm/1.1.3": {
+   "jar": "sha256-KRUGtPzjmCSXk+MnIHY1vU3yUYHZU5gI1xgaSr0IdfU=",
+   "module": "sha256-zVmKuJgBFPskrdXyfKxVldwxG2gi7jUnVC3FwFcWc1s=",
+   "pom": "sha256-A6bYrsZtSOpv1VS/p0vx77pOBIkA1WipNAoU8qVy3Rw="
+  },
+  "androidx/datastore#datastore-core-okio/1.1.3": {
+   "module": "sha256-SWvvC38Y/ZPd0+j/mrdvWq4YdDNrSpwe7n7YgjBdY+w=",
+   "pom": "sha256-qNiO7HMQohfDyzlAjArdOuyd+iuKJaia8av+HRMUegk="
+  },
+  "androidx/datastore#datastore-core/1.1.3": {
+   "module": "sha256-8lm5afpDZrxe0WT0Alngj23e25rLD+1E3BClSnZ0p9Y=",
+   "pom": "sha256-R0vKoLsIzJYBd+VxG5sKaHqMo/EZdLMSDOLAU9CmDlI="
+  },
+  "androidx/datastore#datastore-preferences-android/1.1.3": {
+   "module": "sha256-wa3gr4Xb1ZPOIMGpRPQr9tMW9+4rCAKS9kMneWlE508=",
+   "pom": "sha256-2Ajpz1bVA+/5RRA5hmlksHSB8/DqP8fgEMwHYSeN1us="
+  },
+  "androidx/datastore#datastore-preferences-core-iosarm64/1.1.3": {
+   "module": "sha256-IM0oQko1vZJSraxpBFSgARJgPNNIiuiGlZ/rK7LorK8=",
+   "pom": "sha256-KsDZU8pfmHiXSfSCpdMqVt5CZu6sR/TuUn71aWorMtU="
+  },
+  "androidx/datastore#datastore-preferences-core-iossimulatorarm64/1.1.3": {
+   "module": "sha256-mJ14p4ywp0Dpie2SeYDHE2yGpxT9EZOaqY7pd1hzve4=",
+   "pom": "sha256-pnPmqxbeBMZnCW353T5Ikh2hzJDvPsEm0Ep1Pkso5Fw="
+  },
+  "androidx/datastore#datastore-preferences-core-jvm/1.1.3": {
+   "jar": "sha256-yznhIjtDJNcwxXOivOo6NTCevZNY++YwiZcFo/vKyvY=",
+   "module": "sha256-jUuuxy3XADVcSt/3NT91dMlHKa0ooV/Z4VCPYllsSLo=",
+   "pom": "sha256-QPd7mcpDHTWea5G1Fgb8EilaqOJmsQgu0ZpUCiEovAg="
+  },
+  "androidx/datastore#datastore-preferences-core/1.1.3": {
+   "module": "sha256-/1gXB5+CMCjyAVpNkP9lmYuGAN9e6mIv1DHHxUy+818=",
+   "pom": "sha256-4JQxqWCBKD841vntXUIwGhHRtxPmuDAAA1Bl+hB2Z7g="
+  },
+  "androidx/datastore#datastore-preferences-external-protobuf/1.1.3": {
+   "jar": "sha256-/LPzc890NCbIXrsNPMZErvrybzm3+lW7kCONQbaJ7Kc=",
+   "module": "sha256-BN/dYC2DAcG/IiN+nxIO+SJvvAKi/OUSGfsxmGrjAIA=",
+   "pom": "sha256-DMlR5kOJ0MeRDCa32XgweqPIjMDLtj5r3d8puNH6MeE="
+  },
+  "androidx/datastore#datastore-preferences-proto/1.1.3": {
+   "jar": "sha256-Y2hqYS85uMpgO+vjN21V+2ye4opKUXPvpJyJy8yooSc=",
+   "module": "sha256-lOdNtE+L1YmQpJEE+suE7qeOQ/xdYG3OWFJ4EDO0J4s=",
+   "pom": "sha256-/4WW0Y9dfYVv9AtvG5hCRNzIYdc28gydatF4RyI6waI="
+  },
+  "androidx/datastore#datastore-preferences/1.1.3": {
+   "module": "sha256-7zfnlS5MEN2TKMd9BHCmEXN5gKWN6u0GMb2ye00fwvw=",
+   "pom": "sha256-vkTXSLoTqcd7UxoW1WXUDPWZ+HKEpNPm3xnSu8Rk3EE="
+  },
+  "androidx/datastore#datastore/1.1.3": {
+   "module": "sha256-UEBVmDlYmeWwjibDQPlTaIOd9khhej1hSLxRgwvGynQ=",
+   "pom": "sha256-G+LnrIS9OYt8avVvMFOdlBSl5fI/XIHdGy7ofy7R3tY="
+  },
+  "androidx/documentfile#documentfile/1.0.0": {
+   "pom": "sha256-ATKIqTF6VScGzmJfskST6CIyiFKSI+xXjPhVpa6cFuU="
+  },
+  "androidx/drawerlayout#drawerlayout/1.0.0": {
+   "pom": "sha256-2mczQlqD9c6FCHj6cgEII0X+18Zo3VhVD90ZwDlsb6Q="
+  },
+  "androidx/fragment#fragment-ktx/1.6.2": {
+   "module": "sha256-96Mz2AI7u8WWrn/0qnZzjTHn1aMYw6bkU+5aYesAmK4=",
+   "pom": "sha256-woIaKdNaIZImrTnBdh1FCJF68EwA7EPhXtRRGBAXS9Q="
+  },
+  "androidx/fragment#fragment/1.1.0": {
+   "pom": "sha256-73jrJ6wC3fNUXV+KOFfHOig3oBhT+NX893JRAR21JUQ="
+  },
+  "androidx/fragment#fragment/1.5.4": {
+   "module": "sha256-rzJggI3OtlMu/C1yFb5Fhywkppna2n13v/c4zjuFp/A=",
+   "pom": "sha256-+MoYd8ZuZCxVSQfhzlpJOol8opJwyxniu21CS6Q7bJg="
+  },
+  "androidx/fragment#fragment/1.6.2": {
+   "module": "sha256-ni5n1Wtnfw9auzk2d0hrLc0uHnZWghXng3BtJMvN6MU=",
+   "pom": "sha256-SuQXdiPaFsZB11VdqSpUf0D3ZgGGzoZGmTGnlCgxOdQ="
+  },
+  "androidx/graphics#graphics-shapes-android/1.1.0-beta01": {
+   "module": "sha256-617XHLgErDer6jTJUEkC4ka4JiVEYDRBfUXT+kYyx64=",
+   "pom": "sha256-/fmlS/QuQDfMEdQfL9/ab0vbkC3UZFl15h27qqo86fU="
+  },
+  "androidx/graphics#graphics-shapes-desktop/1.1.0-beta01": {
+   "jar": "sha256-0SkQ2pDIFlDkv4iTRkUuPPtBnYfIRG8q2xIprRfzXxA=",
+   "module": "sha256-00zRNxS3g+FiwL94MuEXJ8mBvHp7pjKgbfnx4qBzygA=",
+   "pom": "sha256-FT1DaZpouHwbU02IR37GQ3ayrCEFHNxIeTiSV1nS86g="
+  },
+  "androidx/graphics#graphics-shapes-iosarm64/1.1.0-beta01": {
+   "module": "sha256-wZCKHl4jyouxk5ZBXJc4/BwU6ob6af+1vB01hkE3SSY=",
+   "pom": "sha256-wGxASdrcynwcECXtJ08hmQlsGk41muBMmakssyuOLf4="
+  },
+  "androidx/graphics#graphics-shapes-iossimulatorarm64/1.1.0-beta01": {
+   "module": "sha256-KCpmtJqVVTpLBlAFcbfPKPDHIRDYaucTpQZ1M2Eom2U=",
+   "pom": "sha256-tvh2vZr2KFNNbik3AsSBgSUmO8bN3JfNLOOyrzpyTXI="
+  },
+  "androidx/graphics#graphics-shapes/1.1.0-beta01": {
+   "module": "sha256-qlt4/UMD9X7vCUvcOA7mlQDq/aBiXMHi2MuMFMPiBrk=",
+   "pom": "sha256-rHcW+lOL15LZHsGqbL2npQlCUL+r4xk9h2JM+iqitYg="
+  },
+  "androidx/interpolator#interpolator/1.0.0": {
+   "pom": "sha256-DdwHzDlpn0js2eyJS1gwwPCeIugpWSlO3zchciTIi3s="
+  },
+  "androidx/legacy#legacy-support-core-utils/1.0.0": {
+   "pom": "sha256-j9CTAIs+58BuUseNoq+YCntHtpuWf6kdrXr0ZvegCjg="
+  },
+  "androidx/lifecycle#lifecycle-common-iosarm64/2.10.0-alpha03": {
+   "module": "sha256-VKP5OF+1eoemYOouXLq1Qyp/GjsA4l7/KmzI7WQm1pY=",
+   "pom": "sha256-zPkGnhYdEsAUjmzUVSEeG5wHz2321n5RcZqFWQNK4m0="
+  },
+  "androidx/lifecycle#lifecycle-common-iosarm64/2.8.5": {
+   "module": "sha256-PQ0Lb24jXUylIv0d40CjGH3wcZGZGWEXJaIozvqV4Ek=",
+   "pom": "sha256-/NS8X5KII86FtHOvvJPE1R9Ya1SEhTakKOhIynDmZdY="
+  },
+  "androidx/lifecycle#lifecycle-common-iosarm64/2.9.2": {
+   "module": "sha256-EKNBqeg0M+ZfI5xRxerp5tt1lOLuDr9iX++KN6zZ+gk=",
+   "pom": "sha256-8PUXmJyLffUgpJVcIofC0Tt/qmxkb7TfHUG6B3+U21w="
+  },
+  "androidx/lifecycle#lifecycle-common-iossimulatorarm64/2.10.0-alpha03": {
+   "module": "sha256-WO3La+UyCTbhpDHtYdb8OfiMVsU9RXkOYvhfJ57WhqA=",
+   "pom": "sha256-GH9ro6nm2QVR0JluszJO7XNJLLJnHpXv9TF5r4VkOtw="
+  },
+  "androidx/lifecycle#lifecycle-common-iossimulatorarm64/2.8.5": {
+   "module": "sha256-OZyhmox8b/ppwcc34Rf325DnI+W/OQntPuqGvXM3+Zc=",
+   "pom": "sha256-GPV2OEhfGxWtmyuAMB3oqkowrWt6lVIFKMCCKNEOLDY="
+  },
+  "androidx/lifecycle#lifecycle-common-iossimulatorarm64/2.9.2": {
+   "module": "sha256-jBjHD5n3pa+x+rr7VbkCLtyXt80/oPofXVEJiOdUzLA=",
+   "pom": "sha256-5oGev1SNSQqnRDnnIXYGWChHJ57JJNhtN51nIyZvZ8Q="
+  },
+  "androidx/lifecycle#lifecycle-common-java8/2.10.0-alpha03": {
+   "module": "sha256-6+m5/yfSBtUljwQfDVVsYLwNTHk/eaLmMEWIKGss62Y=",
+   "pom": "sha256-F23em1efvGTnLSZMoqukdgRujblb1dTtstPlRtIF8T8="
+  },
+  "androidx/lifecycle#lifecycle-common-java8/2.6.2": {
+   "module": "sha256-PVOCB9aOuJqgFm7awJQiuTdIGVBto5vmLAHwwPY4T34=",
+   "pom": "sha256-8te1zA64I4IJqXyQ5mKokFwYRZOBt6kNqI1DHynzz7E="
+  },
+  "androidx/lifecycle#lifecycle-common-java8/2.8.7": {
+   "module": "sha256-4n3yqy+cHAL8Fv6H4Z2g67ebSz8eK9KvFzZL7Vmgoqk=",
+   "pom": "sha256-zEOFGQO3qZ3sDr7/sVVKXaerWBNYGOPYbIFni7VP3TU="
+  },
+  "androidx/lifecycle#lifecycle-common-java8/2.9.2": {
+   "module": "sha256-YcgczDfG6s+HKbzjijt/aZ6oGKfZy11YS9lOfeSz2+E=",
+   "pom": "sha256-USvJ19mHj2hrgX8zds/CoN9ptCE1jsV/HrFhPcBZQ04="
+  },
+  "androidx/lifecycle#lifecycle-common-jvm/2.10.0-alpha03": {
+   "jar": "sha256-7jfXkn26bP/RZ8YkT8M+SD8rbUB974k5XIophrwlBMU=",
+   "module": "sha256-6EyeX15TyEqEuznrzIn3ujFSZd0ImctE11TxJRpXIG8=",
+   "pom": "sha256-eABif42hzhI4LLFEuUipgwDNRqF0VZ6xNdetBUaijCI="
+  },
+  "androidx/lifecycle#lifecycle-common-jvm/2.8.3": {
+   "module": "sha256-0FT7CO+eeJiGzssgu0uWt/XEPxpM+4e/EgBG/5YZszc=",
+   "pom": "sha256-wNUPsvF01q78YGQ/2ZfWApzLqSK8nCkCWXQC7iWF4jg="
+  },
+  "androidx/lifecycle#lifecycle-common-jvm/2.9.2": {
+   "module": "sha256-cjad+SZiA6QqezjE5J9n5ueWL55I4ihiftfvRmsFFIE=",
+   "pom": "sha256-jQ3Ks2SXw0q09G3Hm+cCWsQDWdDUK/SL1pqaa6FzQnI="
+  },
+  "androidx/lifecycle#lifecycle-common/2.10.0-alpha01": {
+   "module": "sha256-2uaKugVkmgbUga2faGfdbI6cVNit6tZC3J42vB7Zy3o=",
+   "pom": "sha256-w5Ycm/V5nmDYO43oeSlzaFB6Yb0dooX3JAlCFc9AL8Y="
+  },
+  "androidx/lifecycle#lifecycle-common/2.10.0-alpha03": {
+   "module": "sha256-4DmZitdlw7LZyy+fDo+WHFo9A3OXBB7jsFqS2e3Idzw=",
+   "pom": "sha256-dxUXSQ/RIcw8L52myDJzNg+t5ThgrMMzJMDug/Dzhjc="
+  },
+  "androidx/lifecycle#lifecycle-common/2.3.1": {
+   "module": "sha256-X7fIUU2MVsraXinvidwCiecZQqtMsLLm3KE3udy4/dQ=",
+   "pom": "sha256-jNI9iJoUCVxs4WhA0psaY4j6XhFRRMEwnU1tRpwbw1E="
+  },
+  "androidx/lifecycle#lifecycle-common/2.6.1": {
+   "module": "sha256-k3R6kUXLNrxxAF9Zjt4y4rEUmt5aFuYrDklpNFvGLYU=",
+   "pom": "sha256-PmaDDVn65S4QMLS+ckseV3rIFNJzNf34GnEoPcCCnxo="
+  },
+  "androidx/lifecycle#lifecycle-common/2.6.2": {
+   "module": "sha256-D6fyj1z/ikBqT3hwskPLDW16fCD6p6K+yv9ZB64S+cw=",
+   "pom": "sha256-VzBM2sTaKJpuzdBzjhax2IWPHvjp+r4tZaljcZ/YHbo="
+  },
+  "androidx/lifecycle#lifecycle-common/2.8.3": {
+   "module": "sha256-BW24q338wlSXBRFD2Sjnz4oRFg+fshfbzSd6b6NP4gg=",
+   "pom": "sha256-5QL4efQuwb63PV26SE70Vl6sB+2QurKrC/Vpy3hTVf4="
+  },
+  "androidx/lifecycle#lifecycle-common/2.8.5": {
+   "module": "sha256-AwuN8Z5JeKwb6WnCopoBv8LMVihPUSY5oK00wi2mxPE=",
+   "pom": "sha256-KCYLDQ/KghpeL0Ug1DKLt94SYCGz3c1Hgt1WQRLsn2E="
+  },
+  "androidx/lifecycle#lifecycle-common/2.8.7": {
+   "module": "sha256-DeePwG7lBF1o/H6BwxOio9U6x9En95+byVq/e+SeV2Q=",
+   "pom": "sha256-9Vz/SvKIUl1CXEZ43bNrqGRZH18O2huSIFZ8NshRO0k="
+  },
+  "androidx/lifecycle#lifecycle-common/2.9.2": {
+   "module": "sha256-SDP4jjmhvSZO1eoYciAj6+UedLGaBBEkaqPXQOFukIE=",
+   "pom": "sha256-bLkiyxFc6PYeffjRkl4tHTDvPP0I2G7Tl66qc32V+S8="
+  },
+  "androidx/lifecycle#lifecycle-livedata-core-ktx/2.10.0-alpha03": {
+   "module": "sha256-C0v5kIrAvnf1tBBDmvCf9+XmoNzvds5F7WmRAxNVzA8=",
+   "pom": "sha256-tkO9GMnJSaAKe0CklSLX7VRC1aieTkSxMXNahF1CdsI="
+  },
+  "androidx/lifecycle#lifecycle-livedata-core-ktx/2.6.2": {
+   "module": "sha256-HW75NzauABwia/LLSxgLywcYGZodOGjuiEb0zIMYt3k=",
+   "pom": "sha256-TETDnf42aTQIH2LyfNl1/FFNHwOYX1miGOhCZ0qigls="
+  },
+  "androidx/lifecycle#lifecycle-livedata-core-ktx/2.8.7": {
+   "module": "sha256-PRiLtiL8uwIdk8wAfTxHfU9AKub1i3/EakQdCrcGeK0=",
+   "pom": "sha256-L+CUUbL5uqaNBcClSer9urSh5P69PvpHSraHXY5rJxw="
+  },
+  "androidx/lifecycle#lifecycle-livedata-core-ktx/2.9.2": {
+   "module": "sha256-ZApi77nfhfLeAtdH86Xd/QAUO3aLsBpsystkaV/4+f0=",
+   "pom": "sha256-0dHPDKaLTd9SZ/W84NSjmdrkw8NsWzscq2UPrqmloY4="
+  },
+  "androidx/lifecycle#lifecycle-livedata-core/2.0.0": {
+   "pom": "sha256-ZQ/aGiMvVml0IUBXFXDMrS9HpxIlqw8CF5vI0US5gsg="
+  },
+  "androidx/lifecycle#lifecycle-livedata-core/2.10.0-alpha03": {
+   "module": "sha256-YECi5btak+iLA5+h+ZpSIr0WPqRhCijpFn10aYukm0s=",
+   "pom": "sha256-721sA7IMhYNiPftUlhDm1OcExKGz9hiI8I1D31jgmPE="
+  },
+  "androidx/lifecycle#lifecycle-livedata-core/2.5.1": {
+   "module": "sha256-PziOngeJAZcMK/z8Av7K6UjeS0a+UhGRmuB9ASyimA0=",
+   "pom": "sha256-ZC8Oldo/OGux0TbvihFIHczThMKKCT2Utce82qLvpbM="
+  },
+  "androidx/lifecycle#lifecycle-livedata-core/2.6.1": {
+   "module": "sha256-6cDcPwrFRBnAz+2P9c7LgpQ6fFj3pUFp8NhJssYKNVI=",
+   "pom": "sha256-4PZ+Ky5hLxO8Dzzqck2u3vpdRJQFHrRfW+5tiKbaiFk="
+  },
+  "androidx/lifecycle#lifecycle-livedata-core/2.6.2": {
+   "module": "sha256-Un0OGsRn0fR8wg7Xww2xcCFymfq7hoFUz10XZeTk2tk=",
+   "pom": "sha256-H6+Ov1Pyiy8K4sIJU3GuZ9DKFqwyj85/FjYJpDIUtaQ="
+  },
+  "androidx/lifecycle#lifecycle-livedata-core/2.8.7": {
+   "module": "sha256-sKHafx/jYGDseEfxlyhXokt9sp5s1FFuYsVSAAnYE8I=",
+   "pom": "sha256-5eML08Ctu0JGtP6vXTjgs+q25JWxJu6USX90kMo1FWo="
+  },
+  "androidx/lifecycle#lifecycle-livedata-core/2.9.2": {
+   "module": "sha256-2UWsrRwE0xqEYbIPipugShrUYHw0FNOvKrR3qdSB3QA=",
+   "pom": "sha256-4cKZ/fWjnbpVX6Z3hRnMnQAXrsGfwVYKjKsCqzrmEsU="
+  },
+  "androidx/lifecycle#lifecycle-livedata/2.0.0": {
+   "pom": "sha256-qEhC/8DxTlGNt1wFzBEmgKikoWT6eDlb4y2IMEpDlCM="
+  },
+  "androidx/lifecycle#lifecycle-livedata/2.10.0-alpha03": {
+   "module": "sha256-saElC2MWrdo0C5359n/eRbz/ju0904E1NB+tfJN6epM=",
+   "pom": "sha256-1gd7OLUwmxNjQtePQgbJtBclzx+ZYFdSKrkYQVLejjs="
+  },
+  "androidx/lifecycle#lifecycle-livedata/2.9.2": {
+   "module": "sha256-KXXzp121pVX+0Ku3o8ZgbjC+BZeEqHCyVLMqYqvZvpg=",
+   "pom": "sha256-Br/AH3BfSw+aOxDUXSMD8/V++gNO37uRG6uACJK62Ps="
+  },
+  "androidx/lifecycle#lifecycle-process/2.10.0-alpha03": {
+   "module": "sha256-qSdjI4qVU6G8Wc47uWrPVUO2vW1ZgHJFZaegWo6TXQg=",
+   "pom": "sha256-t5Duu5wW3FE87MXnF+XPsOVHQBZg17iEJn3IRSjHeUI="
+  },
+  "androidx/lifecycle#lifecycle-process/2.8.7": {
+   "module": "sha256-mKHAjBDP1L2qienCVqm5bAnN1bz7sDqSYIF6bYnMI3g=",
+   "pom": "sha256-gbo66f/iWUvyGjXhgctTzns5bzV/fDy/++j906IzAzk="
+  },
+  "androidx/lifecycle#lifecycle-process/2.9.2": {
+   "module": "sha256-sLST7Nw14vme9f3lNAYMPQqe70YGocxMeMY+p5Nje0U=",
+   "pom": "sha256-Q0y5BeqcHXkoyHKoXddkfoh0WfdYo+mPIoExXu8f0yk="
+  },
+  "androidx/lifecycle#lifecycle-runtime-android/2.10.0-alpha03": {
+   "module": "sha256-L5B4r1zcnxi5hgslwSsqMPr6kk0MrRjAuhXWBa1FOYA=",
+   "pom": "sha256-VMdpjyH8CrJx1+OZMuSYTteLaqE0uJE8FIqIjDjmMlc="
+  },
+  "androidx/lifecycle#lifecycle-runtime-android/2.8.3": {
+   "module": "sha256-f4gYErYbK07N56WkY6P9gAU2bUXbNvFOW1OaJAlTefc=",
+   "pom": "sha256-KAlRmyO/M5ny/giDoWxiSm+d1pxMWtJioOhMzoKuFK4="
+  },
+  "androidx/lifecycle#lifecycle-runtime-android/2.8.7": {
+   "module": "sha256-TRs4gcmNQpNMuNXefIqeEgSVSaUUdxhkfXvmym2VjEY=",
+   "pom": "sha256-KMsZDeh94F08Gk92dNH0WLerk151z4O6KLFTm1+pPBo="
+  },
+  "androidx/lifecycle#lifecycle-runtime-android/2.9.2": {
+   "module": "sha256-Q6WFnbJfEuIKRFa3SRBCVFNV/iONfDbHqfvsQLK6Fdk=",
+   "pom": "sha256-IjoKshxi6SEBQzSZFIWbh+131Zu0C9k5/wBf/8XTYSM="
+  },
+  "androidx/lifecycle#lifecycle-runtime-compose-android/2.10.0-alpha03": {
+   "module": "sha256-TJybOTT2fc3//ZeL8yMpDSrGzvd/w1R0g1MqWnFmG38=",
+   "pom": "sha256-Z3Bs7ll+/APZCjr3SC5/hn6xdzfQu27i/GmfNd0k978="
+  },
+  "androidx/lifecycle#lifecycle-runtime-compose-android/2.8.3": {
+   "module": "sha256-4BN25atpiqXFj9leF4A6NHit3IsaMwFKY93VDkheWf4=",
+   "pom": "sha256-wmFIqCOexHtaNhEGqLujisg7t9GXkmYmlFtviWFSoG0="
+  },
+  "androidx/lifecycle#lifecycle-runtime-compose-android/2.8.7": {
+   "module": "sha256-wCShZpTItcQeyO8O3iNl62Evij2iUBf98v80MCnzOQI=",
+   "pom": "sha256-DMi8bSk7qjYAj3HfaNrMZWx2D/6y8CsxNKY23LlHBeU="
+  },
+  "androidx/lifecycle#lifecycle-runtime-compose-android/2.9.2": {
+   "module": "sha256-6qrHlY2rziZczYeMz36qD9k3fCg+eWfE/DQIWh24tjo=",
+   "pom": "sha256-BGestEch6jhyHCPkTWKAipyUAGqt2++L1oGYgbo+2U8="
+  },
+  "androidx/lifecycle#lifecycle-runtime-compose-desktop/2.10.0-alpha03": {
+   "jar": "sha256-6Uu/kf+11xW4x1kpCVHWONc+74/RJIopoDK73JplB8A=",
+   "module": "sha256-8vtzYhkWLMJK+9sgHE9dd5cEi8D4BJHYMTQxnZm7j9Y=",
+   "pom": "sha256-yP+XB6k8l6P4MDmQsrblzgB3Qm/jxNX/kTFt4ip5Vjs="
+  },
+  "androidx/lifecycle#lifecycle-runtime-compose-iosarm64/2.10.0-alpha03": {
+   "module": "sha256-dvRj/ctlKoESULm5NK8bgtZMB5DrSdnDWlAtNC6KgIE=",
+   "pom": "sha256-rbHEsVURZ5IXgTD4Jiif4T1J9klXWzr18Ut0sn8u0qI="
+  },
+  "androidx/lifecycle#lifecycle-runtime-compose-iossimulatorarm64/2.10.0-alpha03": {
+   "module": "sha256-hHlNddm5NV/J9vxja7Y5hS34tvqJGf12dXjLZVgzJ48=",
+   "pom": "sha256-052q4+kb81WOKjKDktaB6qaRuLwWNJdKSUru9ZGC+Mw="
+  },
+  "androidx/lifecycle#lifecycle-runtime-compose/2.10.0-alpha03": {
+   "module": "sha256-5bnEZYB+HnigjIy2pCId/PxWTcwnuEx4BlXnXmB6MUk=",
+   "pom": "sha256-mSZv06UcUnAO0GO8QU3cN5zKeHWyl78fN8yMo35NGoI="
+  },
+  "androidx/lifecycle#lifecycle-runtime-compose/2.8.3": {
+   "module": "sha256-POyc8o8qExazPQeJGG66Pqewzm6gEKfCRUiYldWELVY=",
+   "pom": "sha256-hNFPBfqFpnyYzLCCLEA/gi4BfYeYuKbbYB4TrFUpjeU="
+  },
+  "androidx/lifecycle#lifecycle-runtime-compose/2.8.7": {
+   "module": "sha256-zJiohJ2B2rMGS8n/hx5D6RtI4Lp9Uh98mbomr+wlZXw=",
+   "pom": "sha256-zskvxmBNjuu5WJpsEdS75jYigPY62/hqns3GzD0UO6s="
+  },
+  "androidx/lifecycle#lifecycle-runtime-compose/2.9.2": {
+   "module": "sha256-0ZcgheKUrMEJwvw0v72UQH/udqhIoaj3/im40+/VEx8=",
+   "pom": "sha256-qCjG5xfj7AwANCLhYcEFQnk8wLvAVxxDrVy4Rg2Dnbk="
+  },
+  "androidx/lifecycle#lifecycle-runtime-desktop/2.10.0-alpha03": {
+   "jar": "sha256-cGNK21T5JoaF5FIm44ap84VqJWjfw94ttJtrTHXIMf4=",
+   "module": "sha256-KsVvtUjKH13FLvgVCTf+34O+XpTffL4Z+ySekEadKyA=",
+   "pom": "sha256-5Rc1QvFA8mAXGP4aEmyUjYS2VX+EacLIYqFzwSxOums="
+  },
+  "androidx/lifecycle#lifecycle-runtime-desktop/2.9.2": {
+   "module": "sha256-LlSqpZmBsgH4wWFd8SOPcCXy/z82H+FNwOcJJhaJOu4=",
+   "pom": "sha256-mSJ0JPvUDXx17N+uiOXDVuDEuWVAtKui88RAyFnOU1s="
+  },
+  "androidx/lifecycle#lifecycle-runtime-iosarm64/2.10.0-alpha03": {
+   "module": "sha256-9kPlkRf40eDWQ+38Z02reEd2YwgL0mu5NCaleMgqtIo=",
+   "pom": "sha256-BTFXj3/yTqzfOUHRt8Zsruee6rxfWw04ym07QpspbZ4="
+  },
+  "androidx/lifecycle#lifecycle-runtime-iosarm64/2.8.5": {
+   "module": "sha256-woiY5t6YFA2pORFbrmBo2ABCR3wOdMz7yk5I7Av8ZHU=",
+   "pom": "sha256-Wh7Wl4n3gLb8f7oBpD5etlI/JcZy1AakiyS5ehXkS28="
+  },
+  "androidx/lifecycle#lifecycle-runtime-iosarm64/2.9.2": {
+   "module": "sha256-Zzh+yDvOpZCEBxst6k8mWpkh+QOPDeIadwbZs5b+6yA=",
+   "pom": "sha256-u4aa5/xDbHpY/f1vPpNFgN5COm3dX6AR5Tc0+TcLsbs="
+  },
+  "androidx/lifecycle#lifecycle-runtime-iossimulatorarm64/2.10.0-alpha03": {
+   "module": "sha256-9vmVgxLTuHPiuwpipjM+jCvUZm1lGiVnHVKf+M505PQ=",
+   "pom": "sha256-YXkWMScgtWT3+HHmSbcmLRPsrteQDe/A9+zF+efM82o="
+  },
+  "androidx/lifecycle#lifecycle-runtime-iossimulatorarm64/2.8.5": {
+   "module": "sha256-5sJf1Xo3TvnZ5R1g3fZ5bDk8Jt3TMTc8nkfdh3r/+1w=",
+   "pom": "sha256-zzMQCKZF4R8vwIfIw8fPObxqsEYT/+gzlhSbUtFSeKQ="
+  },
+  "androidx/lifecycle#lifecycle-runtime-iossimulatorarm64/2.9.2": {
+   "module": "sha256-M+5b+BB5hw1YajHj1ldm15jLy0PyD6LQ/FIsgr57zJc=",
+   "pom": "sha256-X6njmn/UqmjmAc+5fn0606j1gtq/tgLjb6oVgUz3xCM="
+  },
+  "androidx/lifecycle#lifecycle-runtime-ktx-android/2.10.0-alpha03": {
+   "module": "sha256-V2/QOYzka+RHnVnMunEhsVs+Wr3uPK1QhLMudfGXGog=",
+   "pom": "sha256-2gdoAoW0WENIsC3Svoe+fqQI83meR5/tytHh++e6Ujg="
+  },
+  "androidx/lifecycle#lifecycle-runtime-ktx-android/2.8.3": {
+   "module": "sha256-lq9v6wJXP9UX1bSn1hNcro8OBXioIr+IshNIOYUoPDM=",
+   "pom": "sha256-R9jgfa1iyXpwyi4BiviY/42gJJLlsnwdrzqE9I8vEHk="
+  },
+  "androidx/lifecycle#lifecycle-runtime-ktx-android/2.8.7": {
+   "module": "sha256-rcYVIeiU8WO+7jrtyMTA37WZFmO4jqHqd5j6yVaU4X0=",
+   "pom": "sha256-Htpm9jgGDNOY5EiW+TTCc/ADuejtNplc/fPrEx8HI2U="
+  },
+  "androidx/lifecycle#lifecycle-runtime-ktx-android/2.9.2": {
+   "module": "sha256-KPcpdIYWOB1J6Qm9oChWH6LRURMTUuXQ6YZM88+zhfU=",
+   "pom": "sha256-iTPlGLVeqBwWux9fYnqnFy5VpCRmgfWM2U7x1/n1V7Y="
+  },
+  "androidx/lifecycle#lifecycle-runtime-ktx/2.10.0-alpha03": {
+   "module": "sha256-rcfKibJ51lwI4XoWjnbAC/oB2YDKA49RcH17/hpp/uk=",
+   "pom": "sha256-xNYYvSK4wN543EIUuWiCeQc6kWtaC+nsgBCpCMLzAU4="
+  },
+  "androidx/lifecycle#lifecycle-runtime-ktx/2.6.1": {
+   "module": "sha256-OYVPMsmwEPZS9OUEHKTOBpgdy2lUEowejhzALmOrGF8=",
+   "pom": "sha256-UF6EiRwSTXiwivfASJMOzc09FpDlBFNZoftGrmzybro="
+  },
+  "androidx/lifecycle#lifecycle-runtime-ktx/2.8.3": {
+   "module": "sha256-ac00EGBGh/7EcQZYCYeh7C3HHD1UlsGe0w/RPA0M27k=",
+   "pom": "sha256-YJvVyz6Fqob0Sf5WA5TXyMyXwaQJIwjqmJk+bysdfHM="
+  },
+  "androidx/lifecycle#lifecycle-runtime-ktx/2.8.7": {
+   "module": "sha256-Ccbc8P7irWnFI9tsKjQxaKjZ6dJ3Q8+Etpx1e3/KskM=",
+   "pom": "sha256-sONluppAXk2pi58FCLmRzXb01aaCKQhHJMUFDied/BI="
+  },
+  "androidx/lifecycle#lifecycle-runtime-ktx/2.9.2": {
+   "module": "sha256-/edqfOymbbSbEwD6rX0iIHYGJAWSJpCeq7/tHvTNeKQ=",
+   "pom": "sha256-d/i5UFhMLiAK1hUNRrLK8Cqu7CZuv172Xnzl0aa+FQc="
+  },
+  "androidx/lifecycle#lifecycle-runtime/2.10.0-alpha03": {
+   "module": "sha256-ILtX4EtuwV1Tq/q4+jalOSKJe5irBAAYIfYiKP3P9/E=",
+   "pom": "sha256-qtOvaN4u5hCf0n7kTZh0j/09OJTmNA+uCRSl++55vPs="
+  },
+  "androidx/lifecycle#lifecycle-runtime/2.3.1": {
+   "module": "sha256-KnuQ5QSbZ0s2vM/WhnezoLMXiz98Lvfd9hjTiVWYxM4=",
+   "pom": "sha256-tEQqhPw5ftsukIof33E8aufTqHZBoJ7hPRDsjuELMx8="
+  },
+  "androidx/lifecycle#lifecycle-runtime/2.6.2": {
+   "module": "sha256-6gExhGq+H+nepZrG3+Hw+52LbWAMnv+aH9StXuXny8c=",
+   "pom": "sha256-gXUlVUbipfUQhl+ErOaAZglUcwJAsZBdkXW0NFvtqXc="
+  },
+  "androidx/lifecycle#lifecycle-runtime/2.8.3": {
+   "module": "sha256-uwO070vM2Knl/ThMhEl3Ra331MIX4SyxXfjZvkpinvE=",
+   "pom": "sha256-fK+bYEqOD0TWv6X7CgtKZAPC4MMwFLyOlvdChdaGxyo="
+  },
+  "androidx/lifecycle#lifecycle-runtime/2.8.5": {
+   "module": "sha256-PnYlwcbHpLz6iHTZ2Xe08VX8M/bwKtbZQaQnAxENxHU=",
+   "pom": "sha256-BvksaPPGjzu339Gs/7yzNLuf+HxjWHQ9XUvCslds87Q="
+  },
+  "androidx/lifecycle#lifecycle-runtime/2.8.7": {
+   "module": "sha256-ywDly5KDt1lI3MDScjT7bXKoDDTct7O41JMYXkMWv4U=",
+   "pom": "sha256-YeEGnpk4pBTWv4OmwIjIpDaKJ6sjjmLvuN5E6dbqMfo="
+  },
+  "androidx/lifecycle#lifecycle-runtime/2.9.2": {
+   "module": "sha256-Tt2F+xoXbKfoOxW0dltc7hqTSqMX5BcQ+grBM0HXODo=",
+   "pom": "sha256-C7WGx+arw98w0Xnqn72uhnREwnmoF6IQHAzJQ/ks79w="
+  },
+  "androidx/lifecycle#lifecycle-service/2.10.0-alpha03": {
+   "module": "sha256-0iQy4urnqN8OzhBuM60apzyoU3D4mvN+o3shGcsmny0=",
+   "pom": "sha256-9l5zWRfi9RUSXE95JYI8ZGvfiR8Vtm5ap4ZX7lJKbWU="
+  },
+  "androidx/lifecycle#lifecycle-service/2.8.7": {
+   "module": "sha256-I+v8q5+3glFqwUquwvHTj/3s6IBJvLLxH8s1oZijiaQ=",
+   "pom": "sha256-yzKkLisV3did2Lo26zd29KNW/okwOgIcDc9HLh/lTVA="
+  },
+  "androidx/lifecycle#lifecycle-service/2.9.2": {
+   "module": "sha256-YMDqoAGqMPSJFGombtTQe2R7ONFEcyi01+krOTiHaZ0=",
+   "pom": "sha256-1GVq1kiZUVUwW/kb9zypR3I3h9ArnJ6LELgQhxw3AWU="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-android/2.10.0-alpha03": {
+   "module": "sha256-XI6N7+Y+aAzjhpFudzIuaqLebKpIAxTLVWxT3Pm4FcU=",
+   "pom": "sha256-oX39M0WiXWfEKYTV1IqucU6MMPEJcYpaWHKLxmd/aXc="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-android/2.9.2": {
+   "module": "sha256-07Z5p/JqSFVh7VhXP/euCBD8YW7pVvie5I5JpQzNjdw=",
+   "pom": "sha256-1d6EHGGIsb7oEBDd7qi2Z/1FhiCgbVka30CS/Opbvbg="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-compose-android/2.10.0-alpha03": {
+   "module": "sha256-HIfNPn7PeqgHOoW9oIRSlDvu+MYcElFJdtdhj0dmfNQ=",
+   "pom": "sha256-Rd5LgascZgZs4ZsN0LTq+394FtRicDOF+NgfrcbB7XQ="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-compose-android/2.9.2": {
+   "module": "sha256-DvbZn5id1sssVwKjRSQQ9oj/Dp5b3VKUiAvS0Nuf8uE=",
+   "pom": "sha256-or6l1+X5FT00mHN8EuqnCdzH0QZFJVcaDCgmgDQCor0="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-compose/2.10.0-alpha03": {
+   "module": "sha256-coaoYziQdIgqHMXFfChr8i9Au/BIOXbpkP7vFDY2onQ=",
+   "pom": "sha256-Ql4Dco2W5c5d5TV+cNvol04QV9j22i0eIK4OermvqBI="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-compose/2.9.2": {
+   "module": "sha256-ra4r8rWWbZ3Tfrfaaa23BM3KNtIB6HL3Gz87SO0ML/E=",
+   "pom": "sha256-UfAxmT7BC23vC526cq4DiRBXXebidk41hQRNfOAwHT0="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-desktop/2.10.0-alpha03": {
+   "jar": "sha256-Ko+E7nm5Efq1LKmwXOnCm+DVSRkBBNdsD/hy+8NZc8I=",
+   "module": "sha256-ksx0Y3xgNT7TruusVgkqZ60KONX/LBv3dlPN3buIXS0=",
+   "pom": "sha256-+FP+d71ihk2HIeN3OK4XEy2Xota0EIzBWKm4EeANbD0="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-desktop/2.9.2": {
+   "module": "sha256-EDoC/VlNnhlqMQF7rZ69in05EOKKt5Shi2CvS4F18s8=",
+   "pom": "sha256-AZqq8EgWPVXoTyiQpYWpVQGn1KqbbhSByOWPcXsvDJ0="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-iosarm64/2.10.0-alpha03": {
+   "module": "sha256-RYjDpeFiX76ICI7H/7m/E0SreRz5VqeywcNMHth+CHE=",
+   "pom": "sha256-y6c2YkRmPZrFOhBHtKJ8/bbMnvO4I5PzXbvgJbSTw9M="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-iosarm64/2.8.5": {
+   "module": "sha256-tC5hO63p86WKnse7jXmJhK7g/ty9e8eMpSB3sVvfnhE=",
+   "pom": "sha256-bh0jxYupNblfTw8B91pGY7lAbp+rsp0IOrtw0F/oepo="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-iosarm64/2.9.2": {
+   "module": "sha256-/1K+x1EdAHJ/yY/kuEKLM30+gGfiW/GxNjk/vNA6k+g=",
+   "pom": "sha256-P9OuzdyW9ZTz9fIxf6AwOEB12yXBKCSAhZxBz3RrJa0="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-iossimulatorarm64/2.10.0-alpha03": {
+   "module": "sha256-aYkTyw0gECH5/fgRakq5EzM0vfQ1RPHJbcST9HT2n8Y=",
+   "pom": "sha256-cvhOoQUbTIhJ3eG6oq2NgdR18hNkIaSoKNNLXkGmlcc="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-iossimulatorarm64/2.8.5": {
+   "module": "sha256-J+WeKiAA4prSd0eqcjqZ8oPJmI+uupVg/xiziKnqW40=",
+   "pom": "sha256-OTXu21r9iUOsR4xXpBtYrUf+3I9wd1h33z3oVK8H1UM="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-iossimulatorarm64/2.9.2": {
+   "module": "sha256-yTBU49KGv1fkwJgruFTTth9zaAsUyasDeHM1CcGDz4s=",
+   "pom": "sha256-hNECQyi+hYidIQqEdr2W7gu9Ff4voHKge8xem7rqt0c="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-ktx/2.10.0-alpha03": {
+   "module": "sha256-hJDGKM+HFEAsr/xpo752Z4aHTKCxcJQmK5EPToZd8Bk=",
+   "pom": "sha256-rCVPrczDERR4kUz0l5xaEGVVb7z+ODSOv/Jh8bWKwAw="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-ktx/2.6.1": {
+   "module": "sha256-pREPhXiLwWffn+j74IAE3cXF3ZsVy3N2zurvAl/Mqvg=",
+   "pom": "sha256-D0XiJCYK980beeN8VfnSPf+U/UExbtn2ACU/rM/0wc8="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-ktx/2.6.2": {
+   "module": "sha256-FtMUxux3TPgyFsRubn+pbGFeHSYRmV02g4kVS1d0GGE=",
+   "pom": "sha256-HTNvv5FHH8SXr9+dh1mJJh0ItWTQIerydZRIZfUm3O8="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-ktx/2.8.7": {
+   "module": "sha256-qZ49Ahjukr2o9cHr8l1IMrMB71gQYE4uluS2B+v2p/U=",
+   "pom": "sha256-kzgneQTN8EjY8dNZ+uVTejUMZPDeFrcf+k4gpCPIp8I="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-ktx/2.9.2": {
+   "module": "sha256-y4SLtnJXBWOSmoa6bINhgfSoqIQrE4+mdo6+AS9YJeY=",
+   "pom": "sha256-kVzYQ90QvT1aPgrNUQ99tZN/8U9oHb6GrePjBORoMGU="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-savedstate-android/2.10.0-alpha03": {
+   "module": "sha256-TWM1PORKxWXMH4uZkXO9UEHkUh89hawH/E3PR4z7qpk=",
+   "pom": "sha256-AoBStX6BrGKTFLCuawKcl+GWEebAIrLuujdjim+g850="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-savedstate-android/2.9.2": {
+   "module": "sha256-Pdf7u7jbGuyG6pLzHDbU6/5R2HiMprZqb9pEGTad0P4=",
+   "pom": "sha256-EFyoASTeqUKvw1W8uoQdMRsM4AytZLh85lcp98JIDE8="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-savedstate-desktop/2.10.0-alpha03": {
+   "jar": "sha256-izuiKL+tkB+E0+2NpTiWdzIDjAgus8qs6dwKTibztxA=",
+   "module": "sha256-pI4cQXs4eZAxtw/Qykjda8Wrg13Lhgcdg8VTj2/774M=",
+   "pom": "sha256-iUacXXyk7kuwy0W9inXErptJczX2wmR3ovgJmMYtopk="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-savedstate-desktop/2.9.2": {
+   "module": "sha256-lIcA/BG62P5o4na+85NOzf889H12tSMRrtMMunDB3Dw=",
+   "pom": "sha256-SB3uYNMEYo+2QdsKJ3dGBi4D0eIIefF5AgLQaydM6ws="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-savedstate-iosarm64/2.10.0-alpha03": {
+   "module": "sha256-mxQ9ZadD5Q69WLC6bPPA6aOrrbkIyCp3IwEYDYEcwEA=",
+   "pom": "sha256-GtJPVaCMT8cfzpK2Ky997iBwkotHA6rG/kxTe+kC+z4="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-savedstate-iosarm64/2.9.2": {
+   "module": "sha256-2GAehhWx58TcGY+Okt1cb2uXOlyr7xFyV0heULqhvR0=",
+   "pom": "sha256-l6n74YqnfIYeZ/UigbieIHftcRs4w6prFrEEoh0Rz38="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-savedstate-iossimulatorarm64/2.10.0-alpha03": {
+   "module": "sha256-QDgeM2J1s3CJ7i01pP3tad1APFETcCOw9Gay0WDaTbo=",
+   "pom": "sha256-NZA9a+HGH+1D3rxpdcZSSjrxA7y2YEHsLFDNkdb/jRw="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-savedstate-iossimulatorarm64/2.9.2": {
+   "module": "sha256-OLjt/eabCwPjF6fkUwuv5T+xaLxRFXMzXjbGcNTIH0Y=",
+   "pom": "sha256-yl/7e7czbT+Ru7sLh/poGo74tBIW0AWrkZVAmDhGsHw="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-savedstate/2.10.0-alpha03": {
+   "module": "sha256-gmjHfJimEBRekKRSognZiydw7TuKm9sJx+QApYIMs/8=",
+   "pom": "sha256-0Wwt1zFVZBigBtx8yfckfYuuHwe/f2kZdhDTTqGv2VE="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-savedstate/2.5.1": {
+   "module": "sha256-KazV/mFLP4kSPrg49ojWJeqotCLI0ZBbSK2OdgzXrYs=",
+   "pom": "sha256-PXf6Ow4CbYa3I7vBNHQuIy6Pmc4YoR31t4lWLppsCm8="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-savedstate/2.6.1": {
+   "module": "sha256-2vuGSXY9KcKc2ie8IvzauanvxTwP/5rj3pCILquqiUQ=",
+   "pom": "sha256-qjTLhYY4S44xTP1lsYExl/Mve6cdJSmhHAcerwJ0Hls="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-savedstate/2.6.2": {
+   "module": "sha256-efnZKIDC+3gnrGc563RyZCRa5Fb0wh93zzn9tqUKdq4=",
+   "pom": "sha256-f8hURAZEz1LDWJTVjZRrII5Cdp6FF9caXvy6F4ZUMt4="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-savedstate/2.8.7": {
+   "module": "sha256-urIsBn8lV3pqwzToaCQUgYBz6fRFA40ZA5yQ+HFvv20=",
+   "pom": "sha256-m5HFWPwxzZpBgaQQ3bk2g1nLAjYqUK9koaMKEsPVwak="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-savedstate/2.9.2": {
+   "module": "sha256-wXhdcTP8/hFpz0tPbxgER3wdpv/XmtVg9M7brfFsHo4=",
+   "pom": "sha256-8no6SPJjUb0t4pEq7j9zarJufDfXj4fz9VR18piHIKc="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel/2.0.0": {
+   "pom": "sha256-YLdY/RxmQIn4LRwBjtT/eVXBSisWIK96oQZZH3M+CCc="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel/2.1.0": {
+   "pom": "sha256-Kapy4znD4ifnTJc6TIXHt5ySbw03th7ZT02ZoTfJpLQ="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel/2.10.0-alpha01": {
+   "module": "sha256-5OKYuR3CZPRNEkPFMh7Jtn3QhV0g0BFSsgoz5699ZxU=",
+   "pom": "sha256-cmtIyBXuUQSqJpJ5Y7ux4n2VPIFMoFPBSTHXe0HtC/c="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel/2.10.0-alpha03": {
+   "module": "sha256-YuHgnuehkqk045/VVgYUVJk6sNrqirB+JzbXar37XqA=",
+   "pom": "sha256-6ZDo7vdS22NN+ZP3k5QQiCFgvg3cOJ31OjC4YQPlGqU="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel/2.6.1": {
+   "module": "sha256-K0BvrqXBLyuN9LemCTH4RmSPLh9NeDYeGY0RhPGaR5c=",
+   "pom": "sha256-3C6OZdtT0hZZon7ZO5Zt7jNsHC6OhyhhZ3OJqZuLkTQ="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel/2.6.2": {
+   "module": "sha256-dOmp6kaEKiVkLJHeIZCsJNzB6gFzlarg6yUAV9MmmcY=",
+   "pom": "sha256-qfsLOag2C+73vcjzlT1NePPYUwT8gK2sPI6vUw11gFA="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel/2.8.5": {
+   "module": "sha256-UjEhedy+2gwntKyQIFdv5BBbBH/0V+dLbaQiRft3RXM=",
+   "pom": "sha256-zzU+toek04gE0IYSpbxV5aO22ZWWdRC9yypfSH91bPY="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel/2.8.7": {
+   "module": "sha256-8dgh/BgDbdIMwh/74C9UcSC/AFHgaunhl3FAITyTQ3I=",
+   "pom": "sha256-7h37GDtTqmIzrVLtp6dU9y2Vptttyi85FEoWDetBlfs="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel/2.9.2": {
+   "module": "sha256-uBT8ApPfHqN+GfIGrRg3A/+bslTdbarvXl59H4V/4Yw=",
+   "pom": "sha256-qsFQVEEJtWQoOeo5u2P7e5B6jSK3wXEWmD7YpaI0unw="
+  },
+  "androidx/loader#loader/1.0.0": {
+   "pom": "sha256-yXjVUICLR0NKpJpjFkEQpQtVsLzGFgqTouN9URDfjF4="
+  },
+  "androidx/localbroadcastmanager#localbroadcastmanager/1.0.0": {
+   "pom": "sha256-oAAEH1ofeSg8UXXhu2DPNoN4D0Acap00++l1ElP6b/k="
+  },
+  "androidx/media#media/1.7.0": {
+   "module": "sha256-mW9kYoSi2YGJnNrDKCJJ4OHyCrgoOKCHXcZr0mTSSWE=",
+   "pom": "sha256-aWZWt+Pr3u8hbtsti7qg85UkiGTC/DSxmfvCTzJmuOE="
+  },
+  "androidx/media3#media3-common/1.6.1": {
+   "module": "sha256-tpkgggC1pv6KnXLvh9+u+DXui7Ah0fGdK8dtpCivWdE=",
+   "pom": "sha256-F5ph/i8kAjdnFdXKkzPEMtcGdKb4fXNxpTjDvz7V7bI="
+  },
+  "androidx/media3#media3-container/1.6.1": {
+   "module": "sha256-QMgdc9Ezfcx7fbenUpopyC3OW2jq3fUyHUhqCBMeZEU=",
+   "pom": "sha256-EAPxx5wICL4trAbmlICFbaEA+JWNbp5GLBubKBL/S/8="
+  },
+  "androidx/media3#media3-database/1.6.1": {
+   "module": "sha256-eJlKQwC/R8qCFMgK62mACcuztW7b0ZgiiqYci9WZEwo=",
+   "pom": "sha256-yUMX8z0KQlTn8oJxVI/2CTn0nYbbWiCSgfElihD7ISk="
+  },
+  "androidx/media3#media3-datasource/1.6.1": {
+   "module": "sha256-jiLHNSD1bJV6+JoRhUOhfaq2UMZXkZWE8wa0SXvNN7E=",
+   "pom": "sha256-48OexORR0miCDR74oPV+daV8A9GCto07Kzyufh2Nkkw="
+  },
+  "androidx/media3#media3-decoder/1.6.1": {
+   "module": "sha256-aEWbKakeqczmOvHEkG8E8fhJPqSghiTH/5ZUTxglX+8=",
+   "pom": "sha256-SqmwEawdhaKUB3272XXO4O1/hhQxtIqSo2hpA1Ly8UU="
+  },
+  "androidx/media3#media3-exoplayer-dash/1.6.1": {
+   "module": "sha256-vk6ZksZwFanIaYNkRc5bJNvwI1Q1pRqdaalDbfVHt4o=",
+   "pom": "sha256-ScqmVMhO4brBRe60+9GwkITu2NpzkhWEKLETgyrqfWw="
+  },
+  "androidx/media3#media3-exoplayer-hls/1.6.1": {
+   "module": "sha256-ck1mTh1LuMufayyncEQEawvDDHMnE2B9Wnh+gEzjK9Q=",
+   "pom": "sha256-gGeD8/yFIeVPWG0zeRdXh9vv101xLOjiNLjZGxb1Wmw="
+  },
+  "androidx/media3#media3-exoplayer/1.6.1": {
+   "module": "sha256-O8fUHtFubIdwL9/crYbLF4pMtw3k6A/7sKjq8dTURNo=",
+   "pom": "sha256-VWp2FtYTEZvteZ28ELn2dcJV9YuQ6Jm2JIUEwlsiSAA="
+  },
+  "androidx/media3#media3-extractor/1.6.1": {
+   "module": "sha256-b7Ve214X3d3ShXnQYvsV8uXCgP2+KJ7l44JOXPZ0D0w=",
+   "pom": "sha256-6p+nQ3zrJav2CvjWsPfJqy7byOqN2xdfZIf3UhfoWj8="
+  },
+  "androidx/media3#media3-ui/1.6.1": {
+   "module": "sha256-8oxoOAEgvYbq33f3qtc9qdRvMdXsdQLM5V4PeYcgvww=",
+   "pom": "sha256-bIUN3hJNkvKCXE+GlpVpZ5yzOoP9sg8TCkWSMZS5gWA="
+  },
+  "androidx/navigation#navigation-common-android/2.9.1": {
+   "module": "sha256-42qfbUJOaZ4REBP6DVIqUOOqOVNkXGlIOmjhSNDHdNk=",
+   "pom": "sha256-KB3amu88ge7TztdzaLNA6jqyvcoGpNzkqabr/zBJTfU="
+  },
+  "androidx/navigation#navigation-common/2.9.1": {
+   "module": "sha256-pNmj8bM9HxUUNwwqv5Z+bEvM0NgNnKpy04BBFg/vWqU=",
+   "pom": "sha256-9vnSRJk48+mt7XvbiPTjWBiXLLCu0Nj+tfr7nZuVrOY="
+  },
+  "androidx/navigation#navigation-compose-android/2.9.1": {
+   "module": "sha256-Cml23WgW5mx537Z3HoIhu+mAgpF+IldAo7XK50rD+dc=",
+   "pom": "sha256-urjC1CMn25jS762e5SX/ST36vUts72i5iLj2nEvz83c="
+  },
+  "androidx/navigation#navigation-compose/2.9.1": {
+   "module": "sha256-Y5+Yg1CxqKD8RbMx2/t4LaIMCwzonxKteU67UO3qQ9g=",
+   "pom": "sha256-2IAzg3+cFWOLMMDXeqG4yzAsn5+WdE6IS9DPzgyD+gk="
+  },
+  "androidx/navigation#navigation-runtime-android/2.9.1": {
+   "module": "sha256-dmVL8J8+i3MzARSyAqHhemr5Eis+919+sL0qUgBfkTM=",
+   "pom": "sha256-BuVfpQ1Cxi97BtP+E7dH798PxMlzfvipJAjAVLJDBso="
+  },
+  "androidx/navigation#navigation-runtime/2.9.1": {
+   "module": "sha256-bDnQod0onhjd7FAAIIHUjcmoxCi16TYwQHv1nsJnEfQ=",
+   "pom": "sha256-UtMJ6jxhzpXy710EhccbOIPNhZPuvweNItkzg2iaPuU="
+  },
+  "androidx/paging#paging-common-android/3.3.6": {
+   "module": "sha256-dIic+1P6ycCeSvdRIByhfgHKIptR24fxCb4fNu/WWFw=",
+   "pom": "sha256-qcz72Cl4YJqgLKyhX1LY3g6JcYjC9iJU3OQXjb1fPhs="
+  },
+  "androidx/paging#paging-common-iosarm64/3.3.6": {
+   "module": "sha256-mRZfTbdZBxnNDl3MNc7fhzcjC1Fd3I/qtry8Ev0S92E=",
+   "pom": "sha256-u3sMbyXv4kBjvyRfwP8r+WTeiwjSip8mNfgVri6oh3c="
+  },
+  "androidx/paging#paging-common-iossimulatorarm64/3.3.6": {
+   "module": "sha256-BlWCJ4SfY3VrCZJBh5Gwvx7thr0RhKBBUn1qE/weqw8=",
+   "pom": "sha256-JU3BDUJ4lSn8gN068gHcWHvSsfCA62iAokf1fbhVmqs="
+  },
+  "androidx/paging#paging-common-jvm/3.3.6": {
+   "jar": "sha256-m6OQ1JxJCDe+xyT+9mBGVJWnMY3oG2kdRjNOvk2Dqio=",
+   "module": "sha256-qyJqL/6Vbk7NPrvGJpWo44YTDeJ2ShAPaZMnvX1KJZ4=",
+   "pom": "sha256-Xm1r7BhBdGnccg6//qQsMgsdYEO9uNS9Os5UP3pWnIg="
+  },
+  "androidx/paging#paging-common/3.3.6": {
+   "module": "sha256-laMPLlShL85R6fLzDMER+rayFuBB29jCbYZinBi1fHY=",
+   "pom": "sha256-QqEut6WreMa24QK2w0SLzhmCfeFj3fwvT6PT9sCjd0A="
+  },
+  "androidx/performance#performance-annotation-iosarm64/1.0.0-alpha01": {
+   "module": "sha256-4ou1jkOXCLQ4wEdmMfbuM3HPU8WbhcCv0srctvf+GaE=",
+   "pom": "sha256-Wgz4+TZ1WrJ3Abs8j/ue4q/sb+58Em2gwW04innY3Qs="
+  },
+  "androidx/performance#performance-annotation-iossimulatorarm64/1.0.0-alpha01": {
+   "module": "sha256-KTv7tnL+2fB+zhPos/m+ggwUBDbaZpu7+aRpWkXBdTg=",
+   "pom": "sha256-yOx0LzLafB9V/wMysJWexb0Ob/5SAXRd/NbZmqZkJU4="
+  },
+  "androidx/performance#performance-annotation/1.0.0-alpha01": {
+   "module": "sha256-p+/urPLRetxNBttusv/ZkRf/UllUPqjH1vLzbWLawTw=",
+   "pom": "sha256-2iS/vOWDd2juWR/jxTs3X9GFbeXMYPX9OTDffLANuWM="
+  },
+  "androidx/print#print/1.0.0": {
+   "pom": "sha256-YkgsBZSEG+4ku5lqu2y3syCmo7d9yp8KC6T+O+VTCqc="
+  },
+  "androidx/privacysandbox/ads#ads-adservices-java/1.0.0-beta05": {
+   "module": "sha256-vmbDkKy0AHyQiSLrvbwBYMUa3n9TLuf5TzZEEdy5fTQ=",
+   "pom": "sha256-vK9xf9bwhHtuJTXYxUUgtzfqaE2L42Y5HuiJj9YhFgQ="
+  },
+  "androidx/privacysandbox/ads#ads-adservices/1.0.0-beta05": {
+   "module": "sha256-+zlsWwe1d5qQ0kC9H2hm+B+ANhnjgTku0ZxxzeWjtw4=",
+   "pom": "sha256-pLWsZsp+eXmLWodQv0wst1w49OU561YWT8m5wxPb354="
+  },
+  "androidx/room#androidx.room.gradle.plugin/2.8.2": {
+   "pom": "sha256-NS3V0HRU3nJ4t0Isa3/MQd0ULPkcBpIQXndkUpDYzpw="
+  },
+  "androidx/room#room-common-iosarm64/2.8.2": {
+   "module": "sha256-90poyEGlEbRmQqr1qLvwFYaXLuDjXS0d75Yik847XyA=",
+   "pom": "sha256-CBtFh2HH9E2NpfOU4hH77av7rZ1J0CjtPF4M/JjiYxA="
+  },
+  "androidx/room#room-common-iossimulatorarm64/2.8.2": {
+   "module": "sha256-m4M2XWqjyKNjzqcTgvARV4uPDh19QcaWtmRH0W6tsZw=",
+   "pom": "sha256-saqnyYolfY/RMiwZ5Cp4AUh1GSD6poXD3YqY9iReC94="
+  },
+  "androidx/room#room-common-jvm/2.8.2": {
+   "jar": "sha256-3HtOGnWnkPKcl6/VUWuL+AAtm26D4pW8VpszVm87HsA=",
+   "module": "sha256-aeSvajTlgjcBSdUio6i/wfvUbPMz18vbPXvwobNK1Y8=",
+   "pom": "sha256-2PLSipAH5XR/t9vSJouUkkCjt2wbA/ZdvnTARkibJ2Y="
+  },
+  "androidx/room#room-common/2.8.2": {
+   "module": "sha256-QY1jOYYuv2xTOrfC5ESYDbtQAkXPitvO1X+zB3slgDM=",
+   "pom": "sha256-1odBxPrFb1jmDjJLaPFybeviBehW7UbdCoFlM8h7sr8="
+  },
+  "androidx/room#room-compiler-processing/2.8.2": {
+   "jar": "sha256-E/dxIXt1HPJmE1Vm1X6LFIZ7puwPZIxQ36ij5XMX7uo=",
+   "module": "sha256-WWUjYkpieaEy+4RbdWMFMnrNGYlpUzE9zZOOSUAGSbk=",
+   "pom": "sha256-Zz3jpEEQJzerT+hLX23F/macpjWk08cqaBPj4JWGMoI="
+  },
+  "androidx/room#room-compiler/2.8.2": {
+   "jar": "sha256-jGeCfDn3WN0iEZ11FGkoMhlJrLTeMXoMXu6yxzcY7gY=",
+   "module": "sha256-Bhh3h/YDkOIUr53LwV1Svzis6aKg0x4paJbTR9F90DM=",
+   "pom": "sha256-wwix6nGZwOWI5IhAj0K6srrhRcPZWUUbxbFkCaz5juA="
+  },
+  "androidx/room#room-external-antlr/2.8.2": {
+   "jar": "sha256-a/eUv/6N4mOCZQJRG0x98FcDErbMmTEsp/xr2wiAyh4=",
+   "module": "sha256-phv0PnHclFMWGycvzf1FNLDOaIuqtu5WZZz/xV3lcjo=",
+   "pom": "sha256-+IhCwdgiQVfdBP9q8Gwbq+3LBnytuKjvWe9Qa+Z8tA8="
+  },
+  "androidx/room#room-gradle-plugin/2.8.2": {
+   "jar": "sha256-0zZGGl/qn8bCq2qrmRv9iRjDnySChtfKL/aXALjkhR8=",
+   "module": "sha256-T/nmYEQmqil3fG1lzMndb11eIhtZgAJiU/w3wlAg1HM=",
+   "pom": "sha256-1xVG95UHFPXGjkj6CQBDQMQDrKaXJYF5LBl8KlU1Btc="
+  },
+  "androidx/room#room-migration-jvm/2.8.2": {
+   "jar": "sha256-GOY/TsKJzz9FRfrOhJxrvdM+6pWW7r4LcpPUnADFEeI=",
+   "module": "sha256-Dvvqmo/pIADcgVTJjNwOffPkZy3128hYhmSRS6/dHOY=",
+   "pom": "sha256-CHjNHzOHF63JL1XLfJXdqZHioRQvTjKeNt7F8A55v9c="
+  },
+  "androidx/room#room-migration/2.8.2": {
+   "module": "sha256-c2tQ/s9OmHBSuggwHSAM8i2ik3Lt97/ctCRivqsaplk=",
+   "pom": "sha256-DJME9Ajo+osOOyzgc6DjEUj68CVR7owVxw+37wE7hEQ="
+  },
+  "androidx/room#room-paging-android/2.8.2": {
+   "module": "sha256-PgXtxoxbLy836u0xXlZYBUH3gONMh58HjZhmlQCLVB4=",
+   "pom": "sha256-L22xCTPeW0RxKSCuUSo01YWF5CKmTb6sS51Q6Iwcnpc="
+  },
+  "androidx/room#room-paging-iosarm64/2.8.2": {
+   "module": "sha256-kW5hPB25hWBJmK3pEuMlKS/L/ULwdlpgZiqGRDd4Ays=",
+   "pom": "sha256-9sFXHYK2dRLtBsGu933gvH6P2Y2dwKnd1EiXPr4zRs8="
+  },
+  "androidx/room#room-paging-iossimulatorarm64/2.8.2": {
+   "module": "sha256-EHXSonpi5ILy1HoDebtoI2ItqDs6b9bEw18sOyQgrAE=",
+   "pom": "sha256-XCWrUWdu3pHIrksTTWaVB+fJDBcnjb4vyy1/wQY2CHY="
+  },
+  "androidx/room#room-paging-jvm/2.8.2": {
+   "jar": "sha256-0WmQ4wxKaUrKaFJhf/UcWY4k/3ipnEo8PkWope20ac0=",
+   "module": "sha256-k8+l7GAfphAXYjyINclxkfEdO+RlMoWy5SPVRDNskXY=",
+   "pom": "sha256-Y12cnu2g5HnMY9Vea1inYJ6xyCAlsNy/WcSg5RG+g40="
+  },
+  "androidx/room#room-paging/2.8.2": {
+   "module": "sha256-AnCJm+J+GNHcNd+CAXfDyZBentNXCycuPjt5LX4QRnw=",
+   "pom": "sha256-oDUrAn7fbpql01BpWgAIVuW0xtqfoOvSvjMLpABGmTU="
+  },
+  "androidx/room#room-runtime-android/2.8.2": {
+   "module": "sha256-tRqObX/hX6iv+RCPBzl7wsusXhDN79f5uxJrK4V5Qhc=",
+   "pom": "sha256-aCtMOZeY2t9pK6FBklHcaPvJn3uCz6EZLucRgux72zA="
+  },
+  "androidx/room#room-runtime-iosarm64/2.8.2": {
+   "module": "sha256-N/Q1+KP7te/dYWA5p1tbPaaZK/nvL4hfNVgEG1xzhd0=",
+   "pom": "sha256-xN3boIgFamTkdVp5ZZAtbut2vWx1D2Fo/jXM8Dv0wCw="
+  },
+  "androidx/room#room-runtime-iossimulatorarm64/2.8.2": {
+   "module": "sha256-FOzyYLCUvNnm6i3KSWqqVRv7/rGWUK4VVunvC+bIMfU=",
+   "pom": "sha256-AD5ZA6OqhsHBAX1xCwA5DrZG77QV23lWB4s7q29aNYk="
+  },
+  "androidx/room#room-runtime-jvm/2.8.2": {
+   "jar": "sha256-XSbdEGXd4oMshRAOMglhlwSA5fFCPxMwqYOQPAhW26o=",
+   "module": "sha256-pwnpyejzJV/ERY1q5jyWEHuVqowN3xaXe2jXSqBtHGo=",
+   "pom": "sha256-85aD2wp5+XT6/QFOWPSSlH/WB+Fqn46vjQPt2kzHLr0="
+  },
+  "androidx/room#room-runtime/2.8.2": {
+   "module": "sha256-LEjpwmOW1QdMkU+Ls9NeACLd6x3gScnpo1RjGN4SMhU=",
+   "pom": "sha256-oanOEBDLRLwfVJ6o+HotY26zSdMGNTPEb3kXL6RGDzw="
+  },
+  "androidx/savedstate#savedstate-android/1.3.1": {
+   "module": "sha256-6ZSZTH3vYMBxFxko7cRaAeOwfjaSYcZp9QgtMGobiF8=",
+   "pom": "sha256-jZu80vbC0Z5MSBeOubvqX/IAk8gjY/uyUQtx/q+OUNE="
+  },
+  "androidx/savedstate#savedstate-android/1.4.0-alpha03": {
+   "module": "sha256-FsZ/DMUelT5snMcnYcqbWNKP5ZRfawqInM78NjDDpJ4=",
+   "pom": "sha256-DQG4g6Fc5Qq1iP6fEku4ZpqjuswJgq/TgoKh6KTzRO4="
+  },
+  "androidx/savedstate#savedstate-compose-android/1.3.0": {
+   "module": "sha256-gjqVAGQT/B/XZ2JB3zpg4OcQLt47c6ChUU37grSm8Bg=",
+   "pom": "sha256-TaF/vR2zb6kx+9v4c62nk6FtdhOP1ERlF9gXKqIerzE="
+  },
+  "androidx/savedstate#savedstate-compose-android/1.3.1": {
+   "module": "sha256-QLtNjciEeURymieqZobXzmWrIzfc8hpazdhj9wwoN9U=",
+   "pom": "sha256-KP4ZGZ3GkZARvUxidRiRhn5pFx5f8QQfLQDzdA08YDM="
+  },
+  "androidx/savedstate#savedstate-compose-android/1.4.0-alpha03": {
+   "module": "sha256-BdANjFB6UX0QKsILUw5Nzi3OGVCsbbILFIJ506EpkxM=",
+   "pom": "sha256-Bkg8/h0wFy82X448gQDv//CIWmARDpkm/vB/UH/LeUg="
+  },
+  "androidx/savedstate#savedstate-compose-desktop/1.4.0-alpha03": {
+   "jar": "sha256-wCqYsMKzXN3iRcC/5uf/RTx7bQal64aB0lt/VLh06kg=",
+   "module": "sha256-XJrc/BVYX9nOHzNuk3RdzGtSGHMv3LewdsIWO5Xryn4=",
+   "pom": "sha256-PaCAT8q72cqpHstxyar6otlVA0Gb9S8AmC8ByBtM07o="
+  },
+  "androidx/savedstate#savedstate-compose-iosarm64/1.4.0-alpha03": {
+   "module": "sha256-OuhNdLUxAeWANkdiUmelGdCMZcezLvmAtwudSHHPiYo=",
+   "pom": "sha256-usoTHzffxVGP186ZNaJwmN7XxqSmNWugLNC0fNqxXD8="
+  },
+  "androidx/savedstate#savedstate-compose-iossimulatorarm64/1.4.0-alpha03": {
+   "module": "sha256-ERrKn/+BBkjDsLvRWjg3oDsWOa/p8fDADqJpYtD7Veg=",
+   "pom": "sha256-yXspctq0/xMJw3/WeiX8P2UynztAu/iD1MCUJsv/B7E="
+  },
+  "androidx/savedstate#savedstate-compose/1.3.0": {
+   "module": "sha256-FaB6D9uO1YpIyiHpgdOKtysrv9lkY8M6cFDfHCdpmnU=",
+   "pom": "sha256-3g1au6p2vBLitADSqFaxVl7mo8L/242umV5fDYgTIpY="
+  },
+  "androidx/savedstate#savedstate-compose/1.3.1": {
+   "module": "sha256-I8H6RVmg/LWb6rZOTnCte+RZMGB+Di9PJ1FSm40zccc=",
+   "pom": "sha256-BluruKWnLNBLPemiuGZ5p9VYRQpJ+SN5sYZh9C69CbU="
+  },
+  "androidx/savedstate#savedstate-compose/1.4.0-alpha03": {
+   "module": "sha256-411Mbnf4L0DJtJdruXaUk8QHkuCpv0McyxPpPZUgGMY=",
+   "pom": "sha256-J7XjRCmuIca4ZI39hM91xJWHfOALB25meus0T2ztLTg="
+  },
+  "androidx/savedstate#savedstate-desktop/1.3.1": {
+   "module": "sha256-ojpT27hho7dWpXwBrJXnD6zUEC9SbAIFFR8fJ+YeoaE=",
+   "pom": "sha256-kEAj2DEYw/jOLa5imbljIWCRTOjsZf7MS2lnZOTsPlU="
+  },
+  "androidx/savedstate#savedstate-desktop/1.4.0-alpha03": {
+   "jar": "sha256-Th31+yVTPsTrVLOq+80gZ4L6jHYz/9m1qsRAhY6S9TE=",
+   "module": "sha256-s/Z63gHGXto5rgavz9cItgTcwhYe9fAr+VkYmy6JOJ0=",
+   "pom": "sha256-lcNnBR3n8if/Ts6AMQPqI6qhAOesQVHYuDrxIclb62w="
+  },
+  "androidx/savedstate#savedstate-iosarm64/1.3.1": {
+   "module": "sha256-9LvHDPXhPq+86Bpi1RPKHFfnD6bmXcfI/Z6P+BS0dNw=",
+   "pom": "sha256-8Fw7S1Y2bNBrbOFYH+YHKJJsYmbjp2nMMdZ8SwvjUbw="
+  },
+  "androidx/savedstate#savedstate-iosarm64/1.4.0-alpha03": {
+   "module": "sha256-0B4KMWBkioF7u/wJpliFeC4swpmup7oJD+/64zc+png=",
+   "pom": "sha256-jirT4c7OB9nlcqIbjcwCgEzB6Is6kML67bbJVq5YkY0="
+  },
+  "androidx/savedstate#savedstate-iossimulatorarm64/1.3.1": {
+   "module": "sha256-cMEQXAV8a2btft2HaV+HcuK/mqzn420Y9JVfZYu92og=",
+   "pom": "sha256-N9+CJmwmnuuWOIStJHEgWgUAh4nQ5FiB//KJTJUo8pk="
+  },
+  "androidx/savedstate#savedstate-iossimulatorarm64/1.4.0-alpha03": {
+   "module": "sha256-oiuD7sf2wIhGtplDuTzwCTX0nfR+Yj+0fXkGPfNW10w=",
+   "pom": "sha256-HWC3WK+DopbKkAONrhoekFAIHcBF2eIRoRR/lf0FKuY="
+  },
+  "androidx/savedstate#savedstate-ktx/1.2.1": {
+   "module": "sha256-lDWRhLK6UcD0mKK5BV03s3IjHvm8xUpJcqyZ8DA6//E=",
+   "pom": "sha256-0JVTIR9nA7Ga79YI1gB8dxMtJ6KBVWqOaJ2Sdk7CfTs="
+  },
+  "androidx/savedstate#savedstate-ktx/1.3.1": {
+   "module": "sha256-WQB9jTPPFm/f0am/Vsz9IS6YIsBLOnQZZvrOWRhhBlU=",
+   "pom": "sha256-FM7JH3Pd5NTHoR7GYLbF0IPd3zDvQSz2oXQ9wQpipbg="
+  },
+  "androidx/savedstate#savedstate-ktx/1.4.0-alpha03": {
+   "module": "sha256-xvZO+PcJuMba0NmAWxhrBdqHk8hGQFuh9FKZbcMorf4=",
+   "pom": "sha256-71ylc60Z+RCPSwZvyH/6zAbld/unC26LM9wGW9Xl2BI="
+  },
+  "androidx/savedstate#savedstate/1.0.0": {
+   "pom": "sha256-hE19IvzqeYx4v1VZIp2viOycrYE29e6gopqnaz+P3nw="
+  },
+  "androidx/savedstate#savedstate/1.2.1": {
+   "module": "sha256-W7ZW/HYNnjmWtTUWDLtBBgM8n3NukInm706wxml4UGY=",
+   "pom": "sha256-DTO8KF3x4S8ieA8WJKbws46iphgbCVXsZkHK9iDFDL8="
+  },
+  "androidx/savedstate#savedstate/1.3.1": {
+   "module": "sha256-f0RPZf6XnogYNnLa1arxvTn5HYDKyXFtPYTgZkyVkz4=",
+   "pom": "sha256-GhLo7FM8a1UtSX37R/rRo5zQuZY5e3S5YDeo4breW1k="
+  },
+  "androidx/savedstate#savedstate/1.4.0-alpha03": {
+   "module": "sha256-3n7Nsr6OHv5ypgilF3jDc62ASVlscDONFQUHASceVS0=",
+   "pom": "sha256-QKTw+JpbUapPtwtbstOz74CouVJOVQX7kr/C5/CLXk4="
+  },
+  "androidx/sqlite#sqlite-android/2.6.1": {
+   "module": "sha256-4fCnz6zSXx+LzPQAD6eeAwIrjbyoAPv48I6E+V9IQ7M=",
+   "pom": "sha256-tOzoCCMQvqsPObcIKlYfVLzUc/1CKSfrIuOwMtqkqEU="
+  },
+  "androidx/sqlite#sqlite-bundled-android/2.6.1": {
+   "module": "sha256-yMnC1EwxdA7ngro/EuVaVYBfN2aWCtFjzJW//uPSS9w=",
+   "pom": "sha256-xVG2OcdxVOL0pCZBBF74wCvok9hGRQpnzy7rvelMX48="
+  },
+  "androidx/sqlite#sqlite-bundled-iosarm64/2.6.1": {
+   "module": "sha256-pPmp8r39HdboQ0NK6NC7o7sl4yy56Oqi/XM3CT5syJU=",
+   "pom": "sha256-NSDzujOeNLZ4O+nDgrSq1EnC9pjBIPW7Bvcq4FS+LwI="
+  },
+  "androidx/sqlite#sqlite-bundled-iossimulatorarm64/2.6.1": {
+   "module": "sha256-HFYrGheAPmxAF/LsBq/bGcTKnjLFiFnoRchLt3K4e8A=",
+   "pom": "sha256-W6MsTVRWf03I0/pOUqr4uJxLdC++6CUvoesy/8UhQd8="
+  },
+  "androidx/sqlite#sqlite-bundled-jvm/2.6.1": {
+   "jar": "sha256-142L+PH6J72kQdCuI/nJqX/H3MLBM8pmTmd9S8QBUsg=",
+   "module": "sha256-qyj7FetlhU6CKCEILqx38W9klTIr8p2BRog+N3JA+sY=",
+   "pom": "sha256-44HHnq6tr+AgTWf/7BKUSGncYSjknhEzJZERcCaUxnA="
+  },
+  "androidx/sqlite#sqlite-bundled/2.6.1": {
+   "module": "sha256-qjeG5bE7onZ1py8tJacgs4Xk29WTD1Q/vL7ArS1LFGw=",
+   "pom": "sha256-Wwhw7oGR5YU5uAHQdp1Ays6y2cSAsi8ijqvwo9SrqhE="
+  },
+  "androidx/sqlite#sqlite-framework-android/2.6.1": {
+   "module": "sha256-ccn4pbSMD211tFgJtZJDnfvyIbpcAzf4qYaWHWrJq3Q=",
+   "pom": "sha256-xwiXsrA6pyEnH+Oi5Bumm6h+fhJCcI1MJ5oaTKViigM="
+  },
+  "androidx/sqlite#sqlite-framework-iosarm64/2.6.1": {
+   "module": "sha256-YX0xffL0LNDvV96eT2z//a/L0CqQV0nhvULzA6Zhf/U=",
+   "pom": "sha256-twXmjLsqmVerta7LQWwlkse1U6QleAC2Hjw3XyTUFVs="
+  },
+  "androidx/sqlite#sqlite-framework-iossimulatorarm64/2.6.1": {
+   "module": "sha256-AoLfUuTC3P7DMgZ1uufBv/Iv2F2Vjoh3O+OJk9oERMU=",
+   "pom": "sha256-YMRPENrAABeG5+48Oa0XRVFNXK5STq/tPM9EYj9gj5I="
+  },
+  "androidx/sqlite#sqlite-framework/2.6.1": {
+   "module": "sha256-p3JuUYoKTwBTFHShwnqRU79rInVajCxc1I/S8k7K4KE=",
+   "pom": "sha256-fmKMZt4ittvvE8sFO/yBAeZl0TwliqQEsziiE3+7OOQ="
+  },
+  "androidx/sqlite#sqlite-iosarm64/2.6.1": {
+   "module": "sha256-E/Wgn+QqX7b+o8Zwbzx1h5Ps/DIoo1KpkUYkQBtYW1Y=",
+   "pom": "sha256-MF8HAgHFAgkEZKLdM8SRucYkPlEEXmfnOfa39sgPo3A="
+  },
+  "androidx/sqlite#sqlite-iossimulatorarm64/2.6.1": {
+   "module": "sha256-b7dmjerjfxvYNi0GCMmIrv7i6Wn73HlI9BA+3YWmz1E=",
+   "pom": "sha256-TXdFdIIpoLJWlCooVIsnI30bQImGwVBNEqz9yXIEXCc="
+  },
+  "androidx/sqlite#sqlite-jvm/2.6.1": {
+   "jar": "sha256-U7BQuA5mYiihKgrnLUlTGz1pYVuo+2JzP2l/j9x/1vM=",
+   "module": "sha256-YdqW5lg0UpKJu0tPHi93jG+6lTLdsS2fTkcKw4DZqG0=",
+   "pom": "sha256-xHG+XXMUdySnv7IF7e0mcMowX89qMts7RzcoLvW97WU="
+  },
+  "androidx/sqlite#sqlite/2.6.1": {
+   "module": "sha256-+OMocU+eCqDqO3F19VzsOqjZk/6sHd8hltZTItsRvQ8=",
+   "pom": "sha256-yO9ny8PHv+o/HO5YN2kYgri+mh+slBXQTy6Bk8yFM8Y="
+  },
+  "androidx/startup#startup-runtime/1.1.1": {
+   "module": "sha256-z9ls9kUMbitpdZiSRymtmgSVxaT89Ovufi+BsH5BWGU=",
+   "pom": "sha256-9BFLXGhZuxvDyvKBy21vJZmPp/cpLGTOrqdKkyEOdGs="
+  },
+  "androidx/vectordrawable#vectordrawable-animated/1.1.0": {
+   "pom": "sha256-J2ogEWtwX7dbkAPulJbFb2/TsyN1+yMkcoEeumCgQL0="
+  },
+  "androidx/vectordrawable#vectordrawable/1.1.0": {
+   "pom": "sha256-Ww4tWyF55UgEeFy8Ic5fRzteHd1VpX2kgulNzTlJK7I="
+  },
+  "androidx/versionedparcelable#versionedparcelable/1.1.0": {
+   "pom": "sha256-xynHvgzAYyO9qCnUYGZuedvUO3maIQiaRL07KT3CU7U="
+  },
+  "androidx/versionedparcelable#versionedparcelable/1.1.1": {
+   "pom": "sha256-X1HmWHPKYS3jg4+pDS7pW40EDv0xucOQoZv5TWFc2y8="
+  },
+  "androidx/viewpager#viewpager/1.0.0": {
+   "pom": "sha256-H3L4NjOdA8brAT9lB152yocHWld1eOtPlfdKOl0lMSg="
+  },
+  "androidx/window#window-core-android/1.4.0": {
+   "module": "sha256-/4IwKX+nd52QxOAWVxE53AbKw5QpJn1MYw2tNvSG5jE=",
+   "pom": "sha256-AkIETKlxxBZ6CZQhpjBk8TIhYyV6I5Ko71Atv18I/ZE="
+  },
+  "androidx/window#window-core-android/1.5.0-beta02": {
+   "module": "sha256-8gBxDb10vowusDN4asV6qHStRHLP63ELLKwiMDeM0/I=",
+   "pom": "sha256-Gkt91HakBLkCAbVqpkhKvLM6g4gV7CoEg3W91xSXvDY="
+  },
+  "androidx/window#window-core-iosarm64/1.5.0-beta02": {
+   "module": "sha256-sD9nkZ5e7Diih76XNLEHHv7fAKKrbhRk7gHpQ/ceKa8=",
+   "pom": "sha256-cdXOpW5GD0eDiVT04Bu/8PelkTX3jfVOeVCLvzsy/mk="
+  },
+  "androidx/window#window-core-iossimulatorarm64/1.5.0-beta02": {
+   "module": "sha256-f5qjyb1xnzutoAdsc5507Or/zDGBKEEN9Ln8VmNFcwU=",
+   "pom": "sha256-t6aQj8xC9yYgtPN5MaquC9TDXdRuuOCy0pi7Y52DPG4="
+  },
+  "androidx/window#window-core-jvm/1.5.0-beta02": {
+   "jar": "sha256-w774N7vrnK65rCVw7gFfb6As2AzfowouNg+WceYHN+A=",
+   "module": "sha256-EJkOGA/fDGoo/X4ox/m9K2YknpMtqBYnDfWyhXnjZwY=",
+   "pom": "sha256-kJbaG9DEKpnipr/VhuuZg6BsPu/DkrNo987rVgp1TvE="
+  },
+  "androidx/window#window-core/1.4.0": {
+   "module": "sha256-K/5VXX/qVFbFy21NFArIjY3LbbvShEQ6jSN26qHeCbo=",
+   "pom": "sha256-+eWr7iu4rIMkkkSaWB6/m5RQE9Kf4qvYKnR5MDFlipk="
+  },
+  "androidx/window#window-core/1.5.0-beta02": {
+   "module": "sha256-Jzj/iEpUJmWitqY/snr0FxnYmcoo0RDL9SWGu9/2FMI=",
+   "pom": "sha256-ypIAKKkszXJFl+QSwFOAh2EUyZ2gilKzzAq5SbxhfOo="
+  },
+  "androidx/window#window/1.4.0-rc01": {
+   "module": "sha256-ZppRQAXUX0q9RnmHJ6psxCXndXIuZvK+BK3YwK3PRTc=",
+   "pom": "sha256-vy74YXDlkfORbqn1gIS1hrzTXvH1aRssSHDjrQkCPDs="
+  },
+  "androidx/window#window/1.5.0-beta02": {
+   "module": "sha256-2FuwQ/7gguQpWAFX3V1fQjczLqkw9idOd7DO7nwarwY=",
+   "pom": "sha256-1VrNaMqspE9jpHKf/V1zFK4e7cZHdG3FxmsqzRWGs0I="
+  },
+  "com/android#signflinger/8.9.3": {
+   "jar": "sha256-wdyixoNjTuGilCmPnHF5V4r2qG4IC9xA+WGRW8XIFC8=",
+   "pom": "sha256-vzV4VrF4NqyaBx6YPBOtdoGVhBghbW/fjEteoPwWG88="
+  },
+  "com/android#zipflinger/8.9.3": {
+   "jar": "sha256-uh8yqiVavk2rZlcd2RlTBdMCfyYfn09GWJizDN/9CbM=",
+   "pom": "sha256-gaLhZraQeuz3JTGh61OQkvkJAgPcifzISGPN60mHytU="
+  },
+  "com/android/application#com.android.application.gradle.plugin/8.9.3": {
+   "pom": "sha256-saitv6/aK7c9hdhNeXeIbSrWKRh6ADPJTDWHUJmCIYg="
+  },
+  "com/android/databinding#baseLibrary/8.9.3": {
+   "jar": "sha256-eUETcJ2rIbBsJis3lec8twj7rK5hcV80Nh4a9iN6GHA=",
+   "pom": "sha256-qQo/DF8JjYuI0scI9Qnj6dm3zMQXHPg3WwcgvrsHtGs="
+  },
+  "com/android/library#com.android.library.gradle.plugin/8.9.3": {
+   "pom": "sha256-8VUM8InVl0mv77Lfgqx10vuR4LTJBLZTJR2RlaVl8MM="
+  },
+  "com/android/tools#annotations/31.9.3": {
+   "jar": "sha256-slmV+nsiDTX7uOMl3wcfgpFpG/uv+XNMmOOPRewqc+4=",
+   "pom": "sha256-2T9rMtSH5swNZJKFKaz4q0AEnUsWVLDPFB5LIdUFY3Q="
+  },
+  "com/android/tools#common/31.9.3": {
+   "jar": "sha256-A4AoexpA/BSVkMYa6zqckn21bRkgkx8wuk4fJGVk8VQ=",
+   "pom": "sha256-i+IwH12jBbjd1K3zcVXToKrHPQhc0/2Q6XFKgGl4IDI="
+  },
+  "com/android/tools#dvlib/31.9.3": {
+   "jar": "sha256-488/3JR3iN7o1bqnbLcqZlcRdLxHQe3w47q5enypDhs=",
+   "pom": "sha256-AQzeeaQv/FPF+Wj60BU4g7kqXmAP/1zlVlXmoTMEvcU="
+  },
+  "com/android/tools#repository/31.9.3": {
+   "jar": "sha256-7nMxExttgNyD6n14+2YAhHMAcz8pZNGIYXCcTSMHXgg=",
+   "pom": "sha256-7Hbzw2jbvgcST4OJvjxy5gKIJO7kLp9OK41Z19pVAVc="
+  },
+  "com/android/tools#sdk-common/31.9.3": {
+   "jar": "sha256-iUOli2esf7GgMh56Uqh8+q7CSNORJTbD1yio3Acf/yQ=",
+   "pom": "sha256-CZ6j7BCMAaSv8HRbDHOthBUdy4MUlCzTpDChlI8A/A0="
+  },
+  "com/android/tools#sdklib/31.9.3": {
+   "jar": "sha256-7p2BGH2rl5AGQMQeKuMMDrr0Vy3Van1+NER8k9eUwv0=",
+   "pom": "sha256-3ROiogm12/ivHa/xsB3rzrzm2G5OGeyNUqN+xOby5g8="
+  },
+  "com/android/tools/analytics-library#crash/31.9.3": {
+   "jar": "sha256-zKl6wpoTKb0xCj6DK25X9GIn5QGqUpwApj3yF8XX30E=",
+   "pom": "sha256-ZdtOaSlrogIa+asWw27cNYa6sWM64gHrJA1tP32eCiE="
+  },
+  "com/android/tools/analytics-library#protos/31.9.3": {
+   "jar": "sha256-3SDU5HyokLfDUvb3PIfCLxTCGAg/Hl662cAT6Lp+SvA=",
+   "pom": "sha256-s4GbFtb/IgWcUWgHdcC0+dTu3laDHs1ZBzWRyHNbiBA="
+  },
+  "com/android/tools/analytics-library#shared/31.9.3": {
+   "jar": "sha256-ONP9oaxMsPiXSkho2hNhoDz6uTDlLlcp2Zut5AOCRZw=",
+   "pom": "sha256-4Z6uAKFnARsFGOdsXkHLhbllWrYo+Owv+ombVAndd8A="
+  },
+  "com/android/tools/analytics-library#tracker/31.9.3": {
+   "jar": "sha256-D8VeTSFfSwIdiBFyrO+CRkBh2WLf67EToFQNxwRZKOU=",
+   "pom": "sha256-Uz3ZSt8JBuV5WnHeyLzl/YDTv8/TRh8pDxvqNnJDKm0="
+  },
+  "com/android/tools/build#aapt2-proto/8.9.3-12782657": {
+   "jar": "sha256-0PX1/qmzydnCyq9o9GIJkxwO9hyxwzeBW6kBOokUFIU=",
+   "module": "sha256-WKm1RajmCgyQQoTgYCmoLnpB5iFqVapkqev31nyTchs=",
+   "pom": "sha256-Qe1CEZZtes9v1ZyN7SZMz6OtmiyhuszbePzd8HRJvAI="
+  },
+  "com/android/tools/build#aaptcompiler/8.9.3": {
+   "jar": "sha256-XdAZesVesYQMM65jkd9sDTJOz9AJsuPXjWvRjW/mUIU=",
+   "module": "sha256-GGwFjHII1llEdFNvqpk8GnZtvbx64w4ODUJmHi6DlK0=",
+   "pom": "sha256-pwGkjE8S4lhq+ysXpLZHqoVr6owBefFqwifKJDY8ZmE="
+  },
+  "com/android/tools/build#apksig/8.9.3": {
+   "jar": "sha256-wHDtE5RinXRkGqCQb2Cy/6Hud+Y2ah+TQ39ZcXsa64k=",
+   "pom": "sha256-BpX2lARK1TsqJKTC2RRdw4ULH5Nqkctdy4fS/YSEDZg="
+  },
+  "com/android/tools/build#apkzlib/8.9.3": {
+   "jar": "sha256-HBpn1vTxhkJ6wWbrqg3YZ/WV1RRPySUlKwX/udGhVrc=",
+   "pom": "sha256-M8HF7JAg+a7hSYRS6MUWhCZLuz6g36FdBI8b7Y8b6g4="
+  },
+  "com/android/tools/build#builder-model/8.9.3": {
+   "jar": "sha256-TjbC7E61pBki29HXgm87a1LdAppaBymCQMc0/+EpNyg=",
+   "module": "sha256-YbElHAa1eO+XF9Zez7dVFYfHPAgnYrnl7zpe3e+F/9o=",
+   "pom": "sha256-XbpsDw8/Osy7JCVsbXsw/KLdn6OYlv7ZJOK+cWzYCFE="
+  },
+  "com/android/tools/build#builder-test-api/8.9.3": {
+   "jar": "sha256-4w0I6FTTHqXm/BQJMq8W4ZVV1ULhqoJQPYeyDcSBu1o=",
+   "module": "sha256-aCSzve/hl0ZGKzIFlLvqBG3AFLKGSrG3Fpo2sLyxhp8=",
+   "pom": "sha256-LRy7VfH2ZMUraRe8oaoC2PkIUKhx2/t/HJIKQaT0MSM="
+  },
+  "com/android/tools/build#builder/8.9.3": {
+   "jar": "sha256-OMEPnN1WNEPlIGKBoymwn/DAx/BaIct+0guM9supIBc=",
+   "module": "sha256-31qHPDtikbqpV8uN31dUstvGtCfdLAqiwCPAp0R5bec=",
+   "pom": "sha256-HEyuiPK5/pg3zWhpr+n1ktmr78trpQdeGRtUmz6lZhc="
+  },
+  "com/android/tools/build#bundletool/1.17.2": {
+   "jar": "sha256-FmhVy4HhDyMoopMQBvSAH0Itj03l1xfsD38W/CBJoIk=",
+   "pom": "sha256-80LQa1GA5uq6B2oqGKjn/Waum18EiWSvtu9CoCP6N1I="
+  },
+  "com/android/tools/build#gradle-api/8.9.3": {
+   "jar": "sha256-Bp0fYno3cDZqghZS8ZssDOeonCKimzRdvn4e7UAKm64=",
+   "module": "sha256-sJZNsZNXxjNrDnysYHG+UfoOs+3KFhcSIq/PIoILXbg=",
+   "pom": "sha256-WOTYdxYkAxkVyCa4eiBmT1EEgaAres/Dnr5OR4hGzSk="
+  },
+  "com/android/tools/build#gradle-settings-api/8.9.3": {
+   "jar": "sha256-/OWbYclpQvWKYU+bMcdwYTFFcd1890QK6U6hPto85Ag=",
+   "module": "sha256-OVZRczxxmn6ZHH9AYtAXiv+o4cqW6FEcv7Ulu5j5WQU=",
+   "pom": "sha256-/hWn97PlAPN0zlLdChGH7VwV9U+FnxbByEbCCN+KQKg="
+  },
+  "com/android/tools/build#gradle/8.9.3": {
+   "jar": "sha256-G3GopSwKx19V4VDfbs2Gt59+UDr8cj8fs0pQRmldZIc=",
+   "module": "sha256-tuISJY5KdS/N5W5f6VhcLHhswGnomLLLa5NQ13Zlgpk=",
+   "pom": "sha256-4XnQknqdZ5uF1eheNsM2ahFBJo7BWWB8t1otipNHmHo="
+  },
+  "com/android/tools/build#manifest-merger/31.9.3": {
+   "jar": "sha256-KNDYx44mrFZeb4AbliUyY/w+eOTfdmPh/BY1PLEqIQc=",
+   "module": "sha256-oFPGfbvB1s/OdnK8mPc2+/0Z2QXi2BKS94pIClYWbyE=",
+   "pom": "sha256-AVfsruVmdebx4yaN1KICCYIGc6ax1VKqsJM1rJ3Dzhk="
+  },
+  "com/android/tools/build/jetifier#jetifier-core/1.0.0-beta10": {
+   "jar": "sha256-Jqu0oTkn2QYhacUEyelP6A6a46T3tauIdasAdTapH14=",
+   "module": "sha256-8JF1iaQtJ2Fj8QBAq1hC6RiD3L2x1Iv9Hx/Kpywcp7c=",
+   "pom": "sha256-XJ1C5rfjXU2NAuCjIs8maTs+w2QrEHyPC+WnIdRaDG0="
+  },
+  "com/android/tools/build/jetifier#jetifier-processor/1.0.0-beta10": {
+   "jar": "sha256-xQZ6e5KCN6EnGl6ctXEOn4C0lzKTlFvFHjpMhk6kv+0=",
+   "module": "sha256-NsJVdrGZk982AXBSjMYrckbDd3bWFYFUpnzfj8LVjhM=",
+   "pom": "sha256-M7F/OWmJQEpJF0dIVpvI7fTjmmKkKjXOk9ylwOS6CEI="
+  },
+  "com/android/tools/ddms#ddmlib/31.9.3": {
+   "jar": "sha256-nNyiBuCPvB8B2qGg1k6tKmK4zMWUFWn1GB4n5Kb1+6A=",
+   "pom": "sha256-Go2RDQIvVRGvTjQV7Adwp6Wcsq22SQiLWmE/S+Wlkk0="
+  },
+  "com/android/tools/layoutlib#layoutlib-api/31.9.3": {
+   "jar": "sha256-KSMuYAdiW1aegnmNLY9VnYlB7OYw/iduhCzYGOv5Sxc=",
+   "pom": "sha256-nWPruxFX627ET4lRg8yvoeslulqf3oxU+Cxrfo4wHhY="
+  },
+  "com/android/tools/lint#lint-model/31.9.3": {
+   "jar": "sha256-/Vx9Zgnqot9h3uIN/tRkByg44G0vsugvQ0qOC5eGM3Q=",
+   "pom": "sha256-HFCAV9L78xltv2qNq0WIOUbrQfoZ3Um1/lfDvpbYVA0="
+  },
+  "com/android/tools/lint#lint-typedef-remover/31.9.3": {
+   "jar": "sha256-Sjujur/Xnm/Ge872R/tOz+r1m0gbEI98LrpNHFxt6o4=",
+   "pom": "sha256-2MgiPs+musfpBM/Kwbw/Lw782x4Rw13FI7ONUVVSXvI="
+  },
+  "com/android/tools/utp#android-device-provider-ddmlib-proto/31.9.3": {
+   "jar": "sha256-BHrs3WbhBhN/d6UsRC8bg9t9boSWiZgAJR8gbH853mU=",
+   "pom": "sha256-IH2X0sToTkPm1uIWbOCxaNumNjDTdyKHWEnvtxX2Cko="
+  },
+  "com/android/tools/utp#android-device-provider-gradle-proto/31.9.3": {
+   "jar": "sha256-ZagpFgS/3h9vdcqFMqOBQ57IH9lY8yeCqwBH+2HZp6E=",
+   "pom": "sha256-LYlz8zUu1HTTQU5CTrpsd6yeLVBjNCMbGw08DapinBI="
+  },
+  "com/android/tools/utp#android-device-provider-profile-proto/31.9.3": {
+   "jar": "sha256-PnsJj24+yuMbb3kJw0O07AmqGNion0G/kgd7pLBW9FM=",
+   "pom": "sha256-ch13f3/9Hao1arPtY000RU19moIkWaj9WUq1hnzgLWM="
+  },
+  "com/android/tools/utp#android-test-plugin-host-additional-test-output-proto/31.9.3": {
+   "jar": "sha256-a6fmrCII10wbtfHRRkq6/GpF2HELIEVaLcAq34cmvIM=",
+   "pom": "sha256-5wDwoNZ0vqcZYYeZYM6TsKUafIcL5QrY8W64ASjDuOw="
+  },
+  "com/android/tools/utp#android-test-plugin-host-apk-installer-proto/31.9.3": {
+   "jar": "sha256-RXBdYbIQBuhTPmz4q3lYp95t7KzmjtbAnbit4SFthZw=",
+   "pom": "sha256-FwRUH8TLQUwKftUwCEb4epArWoJOQxFnw70eR6BDQoo="
+  },
+  "com/android/tools/utp#android-test-plugin-host-coverage-proto/31.9.3": {
+   "jar": "sha256-+oZxmj3F3kZffgwCMYRBTCf4/VOjT9VXKJwL9t80AkQ=",
+   "pom": "sha256-J3tGNxLiNSVcNql78BwcvQxeklqBWjg73C5KNyKZePc="
+  },
+  "com/android/tools/utp#android-test-plugin-host-emulator-control-proto/31.9.3": {
+   "jar": "sha256-pPNKrg+f+gJtv3FRQ23XrlO+y3JiK0DyxHnKyJQ9kxk=",
+   "pom": "sha256-CzevwadZ3rFPwy7KdtwWkB598FE81GS2csNYmWWYSew="
+  },
+  "com/android/tools/utp#android-test-plugin-host-logcat-proto/31.9.3": {
+   "jar": "sha256-wfbrus2tVZtu/k6qKVYVUrMxVjlfBpzZcD/aCcRi3qY=",
+   "pom": "sha256-3jd76uV/U7tbFiJM/oycjSFFeypFJzwLE6eknkfAR/A="
+  },
+  "com/android/tools/utp#android-test-plugin-host-retention-proto/31.9.3": {
+   "jar": "sha256-CPGvlhFbK9As1LaE4ZT1xcJ2PwHI9Z4BHZrsyz/vGGM=",
+   "pom": "sha256-rJL1SYwaXdEdNh8pBzbsHAo068P7Trq7tGAAX4mhzVU="
+  },
+  "com/android/tools/utp#android-test-plugin-result-listener-gradle-proto/31.9.3": {
+   "jar": "sha256-1Cm5MS3/oFAzgdHuGxipmb2QHnRWYSsvtIxqXVosr4g=",
+   "pom": "sha256-1nmR8KGkdrfbJCxdLqyhXlhOzOHscTpafvJldWGeqFU="
+  },
+  "com/google/android/gms#play-services-ads-identifier/18.0.0": {
+   "pom": "sha256-T7byzYsik6Sujlx1It7Qg4Dsj0/KYP5Fg4f1qvTUhGo="
+  },
+  "com/google/android/gms#play-services-basement/18.3.0": {
+   "pom": "sha256-nO9dyaaVD/Cahf9SK0dvhV637yNzqkwXM5yxFKxTl+I="
+  },
+  "com/google/android/gms#play-services-measurement-api/22.0.1": {
+   "pom": "sha256-GLaNju04scWe9bIe6OS25dZMM7ybmBq//Zm8dnFzofo="
+  },
+  "com/google/android/gms#play-services-measurement-base/22.0.1": {
+   "pom": "sha256-yQyrL2Kj8ibFdUAF+dtZUb3EVWhD8ilRhaJr81n0hgY="
+  },
+  "com/google/android/gms#play-services-measurement-impl/22.0.1": {
+   "pom": "sha256-d41OmYatla/9bUnySeYNOUubeG+LXdPIWDIoiw88fpM="
+  },
+  "com/google/android/gms#play-services-measurement-sdk-api/22.0.1": {
+   "pom": "sha256-RJPeySnD7tfC08Mb5TULz1hr5fGC6LaPcwJB0bGPqRI="
+  },
+  "com/google/android/gms#play-services-measurement-sdk/22.0.1": {
+   "pom": "sha256-sgOHLwXVkgUeTcZ+abf4YV/G42C7vMLXbslJNoOqoVI="
+  },
+  "com/google/android/gms#play-services-measurement/22.0.1": {
+   "pom": "sha256-dRVuGqT3jgcZrpOietK7Q9nzSh0oGBwKkdhNYJXB2Ow="
+  },
+  "com/google/android/gms#play-services-stats/17.0.2": {
+   "pom": "sha256-aLsrwTHAk5hY4xZvd3xjkDuZDH/K48HepwoxKTf2pz8="
+  },
+  "com/google/android/gms#play-services-tasks/16.0.1": {
+   "pom": "sha256-oO34IFOPDRyuwxT7Talr634gvJuqbYopZrji5DpjHko="
+  },
+  "com/google/android/gms#play-services-tasks/18.1.0": {
+   "pom": "sha256-zynthGEI16jywX2O9bYzmXNXV8Wgm7Zj1+eE4CrYS80="
+  },
+  "com/google/android/gms#strict-version-matcher-plugin/1.2.4": {
+   "jar": "sha256-3xtItno8X+pyZ+nlHSDeR1eBi26O1XZITHTJbqKVEgA=",
+   "module": "sha256-W/ThPqqW+o8eWxxG6epdvdOORWUyR7RJ1jvkn1Z3kqw=",
+   "pom": "sha256-Ihy7TNpqqRBzw7xi31oNpgXA/nF5qLdPCVWC0cKclMw="
+  },
+  "com/google/firebase#firebase-analytics/22.0.1": {
+   "pom": "sha256-m7Tcr/r6e0AKBVG1bNsSF1nlxKZzkW0HnjdmJRHZKOc="
+  },
+  "com/google/firebase#firebase-annotations/17.0.0": {
+   "module": "sha256-Z19xdCWZ2MpuhuILly/DQ5dVpMYDEI2FUl8qrPrbIzc=",
+   "pom": "sha256-eskt/D+7321oyAaO38R1BejHN/7liUZ4jPFBSMF/dtI="
+  },
+  "com/google/firebase#firebase-bom/33.15.0": {
+   "pom": "sha256-NA+M50EB7f0LmFIAur2EfEGGxo61tTzL6wZ8CGvSJ1s="
+  },
+  "com/google/firebase#firebase-common-ktx/21.0.0": {
+   "pom": "sha256-wn7MtIuViBFtb9MvRle8Wd+FUAJDIpNVjbuX6YeK3rg="
+  },
+  "com/google/firebase#firebase-common/22.0.1": {
+   "pom": "sha256-4JqExTq5XWxymg0hSGzzm9vPCApUyrsZyKP8qYM6J7A="
+  },
+  "com/google/firebase#firebase-components/19.0.0": {
+   "pom": "sha256-Rf0ej9Po1DqGiUjuMXcbeNLl/CgbdyVNkKmV4U4plpE="
+  },
+  "com/google/firebase#firebase-installations-interop/17.0.0": {
+   "pom": "sha256-elnlCUKrJ+YL3Ke2ZLS/Ytf1TA6csBrvF+zCHwMgOqM="
+  },
+  "com/google/firebase#firebase-installations-interop/17.0.1": {
+   "pom": "sha256-Hr6ccPB7E/j9O8KDsQcx4mA/Rb8vFVGwq3GEz1hHi94="
+  },
+  "com/google/firebase#firebase-installations/17.0.1": {
+   "pom": "sha256-pYofWQz4ryi30W24Dl3B468gRa47hROjsla865SdNiI="
+  },
+  "com/google/firebase#firebase-measurement-connector/19.0.0": {
+   "pom": "sha256-lUQjVEKpW1Qu7V9j49/nhuPtC/JqH2Ax2rTfqWWkzBo="
+  },
+  "com/google/gms#google-services/4.4.2": {
+   "jar": "sha256-M6xbjCDHycyB6JjZ9Ncvjl8Xo1UFGCaDzYFexpOS7I0=",
+   "module": "sha256-tom98xESY+QuQd13QS5i2ekNttWrm+sYeA5jNF5G6Sc=",
+   "pom": "sha256-a76JZLzWRJhZBaoRsvY7iHgQ7gFK13cSY9KvFxTQLrk="
+  },
+  "com/google/gms/google-services#com.google.gms.google-services.gradle.plugin/4.4.2": {
+   "pom": "sha256-Ek7V66l1JrYW7Kc6w4LRwbm/5R66UttX1nGFSkDBgdw="
+  },
+  "com/google/testing/platform#core-proto/0.0.9-alpha03": {
+   "jar": "sha256-0AHrDMu/yMueqhk6NY5jcSl0Y5d1ZHvpSasjLCsptAc=",
+   "pom": "sha256-O7RSgN8d0clrmgFySmFFZrfWDTNFP81SwsdB+ZmcOk4="
+  }
+ },
+ "https://plugins.gradle.org/m2": {
+  "com/fasterxml#oss-parent/56": {
+   "pom": "sha256-/UkfeIV0JBBtLj1gW815m1PTGlZc3IaEY8p+h120WlA="
+  },
+  "com/fasterxml#oss-parent/61": {
+   "pom": "sha256-NklRPPWX6RhtoIVZhqjFQ+Er29gF7e75wSTbVt0DZUQ="
+  },
+  "com/fasterxml/jackson#jackson-base/2.16.2": {
+   "pom": "sha256-2+E1aBujNdhSI0UNczbqmrJnBPbXHWY2aVcOPXvkDrY="
+  },
+  "com/fasterxml/jackson#jackson-base/2.18.2": {
+   "pom": "sha256-71dLcvW0iUgET2g3a4dMiK4JoCncjgX2Shwwvftt4Uo="
+  },
+  "com/fasterxml/jackson#jackson-bom/2.16.2": {
+   "pom": "sha256-CZW2YqaOsTyz6Qj7biN58Mo+7rxmVnd8xVhLDCcRHS8="
+  },
+  "com/fasterxml/jackson#jackson-bom/2.18.2": {
+   "pom": "sha256-UkfNwwFyXT9n9+8EkDconVr3CdaXK89LFwluRUjSlWs="
+  },
+  "com/fasterxml/jackson#jackson-parent/2.16": {
+   "pom": "sha256-i/YUKBIUiiq/aFCycvCvTD2P8RIe1gTEAvPzjJ5lRqs="
+  },
+  "com/fasterxml/jackson#jackson-parent/2.18.1": {
+   "pom": "sha256-0IIvrBoCJoRLitRFySDEmk9hkWnQmxAQp9/u0ZkQmYw="
+  },
+  "com/fasterxml/jackson/core#jackson-annotations/2.18.2": {
+   "jar": "sha256-WBvWEADvdkiUP3gcoFaJ5W0D9gUnSDZajis6m10/oy8=",
+   "module": "sha256-4Ruvm1NubflNqmNaEBPsPgabhmuOES3cKqBEahVQUNw=",
+   "pom": "sha256-CyvWlOqJJn7qSBJqilskplI0xkM4dULSRGnRlb+6HPg="
+  },
+  "com/fasterxml/jackson/core#jackson-core/2.18.2": {
+   "jar": "sha256-2AVK58DRwtL1XSjkYCbr5YkogfP6tfQ5IzGEOBw7Sh8=",
+   "module": "sha256-ynjGBDZ2f8w2zhRrd05PUKnLn2MtExcsRLrojgwDz6I=",
+   "pom": "sha256-4GWwA50h9N/ORr1DEEx9dtWFa9cy4qqGDMWkonDtct4="
+  },
+  "com/fasterxml/jackson/core#jackson-databind/2.18.2": {
+   "jar": "sha256-SzZOaFDciRcvzx1N0muP9UiO2kT/RlfiLdJlID3Vqzw=",
+   "module": "sha256-jH2sL3J4GNiEeoKqTqxrAXTXnPBN+Q3iJGBy5t005wA=",
+   "pom": "sha256-STo9tkR7eo7Ls3JCNMbOZ31y20sE9roAjw6+rqe+Wp0="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformat-yaml/2.16.2": {
+   "module": "sha256-dJwa2Kf8wceyqxu28cVdj0aO7N52dj8XOnBqhbYDu9I=",
+   "pom": "sha256-PX/SUZIuX9QxAM3Q2LYv8XqhGcbwfkziEa+hRCWLCbk="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformat-yaml/2.18.2": {
+   "jar": "sha256-OBocBxHku4hWGmwACLWpRUZWKMoHdkzNZqDZfuB61hI=",
+   "module": "sha256-evxmQXLDpubGw1hHZaAyncb+q7/mu6ibrq2L0un77Hs=",
+   "pom": "sha256-9W9UNh5DSV7TuiShoG8OO3QZA+Q+0TLxpq086QErhBU="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformats-text/2.16.2": {
+   "pom": "sha256-0pd0eUdcVynnGNdKFrH0sDOlhPNKqINfgOy/MHJKnUA="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformats-text/2.18.2": {
+   "pom": "sha256-4h1diLBHShG3H+lBAMT1KVv6F08u5q5LCtArdhZHhkg="
+  },
+  "com/fasterxml/jackson/datatype#jackson-datatype-guava/2.18.2": {
+   "jar": "sha256-cb8hy/lU9EZcPgGHpiwwueDi7WEvpk3cuomoeTGyoIo=",
+   "module": "sha256-GvbeQyGW2+HaV18d3FiWKF3DS/pg6o3/+5/RN8rPnG8=",
+   "pom": "sha256-7i25uOpx1O5KQrwGqqcT0jbh69iM2JJ/ajKEcCMcPNM="
+  },
+  "com/fasterxml/jackson/datatype#jackson-datatype-joda/2.18.2": {
+   "jar": "sha256-Hd3EfKqnKAeD1ylsd/anBbepK8lapGkJP84EsTZ4c1c=",
+   "module": "sha256-l7/z2hhe3gfky7GdnuLX7aQbYeQlaRfLA9EF7fhxaNs=",
+   "pom": "sha256-fhIcCK11w60LpYCsK1K1Rz3DSIYw1QfituIuTjeeJjU="
+  },
+  "com/fasterxml/jackson/datatype#jackson-datatype-jsr310/2.18.2": {
+   "jar": "sha256-4tIC1GBuI66vilqWMtsG9f79W2PSUcP1A/n6qnhTDlw=",
+   "module": "sha256-Jd8o9WC1kI6hAYUATV/Bkyk0hHBj5mcpJID2dbOx7eQ=",
+   "pom": "sha256-FivnrZea9eDHOc1+0BiJ+Br0ggDJ+RJ5lqElrFGzSkc="
+  },
+  "com/fasterxml/jackson/datatype#jackson-datatypes-collections/2.18.2": {
+   "pom": "sha256-VB0YzwMSgDw1e8lKVSkC4P5MdlieH4+dVtJOuwThRLc="
+  },
+  "com/fasterxml/jackson/module#jackson-modules-java8/2.18.2": {
+   "pom": "sha256-s6z7kQ0CPpOkGZr8zeH/nsX6sMVQ3E+WilBXEXrLCzY="
+  },
+  "com/github/ben-manes/caffeine#caffeine/2.9.3": {
+   "jar": "sha256-Hgp7vvHdeRZTFD8/BdDkiZNL9UgeWKh8nmGc1Gtocps=",
+   "module": "sha256-J9/TStZlaZDTxzF2NEsJkfLIJwn6swcJs93qj6MAMHA=",
+   "pom": "sha256-b6TxwQGSgG+O8FtdS+e9n1zli4dvZDZNTpDD/AkjI9w="
+  },
+  "com/github/curious-odd-man#rgxgen/1.4": {
+   "jar": "sha256-sTsHS/BFeKORAEFwh0RmSKB54tYmzYQfl5TjTmim6Ow=",
+   "pom": "sha256-rwIHmlYZmNS7r7ypKLxD5qSjfa6svs0ziBypPNW6TnQ="
+  },
+  "com/github/java-json-tools#btf/1.3": {
+   "jar": "sha256-Z8PkYutQgH9OCl9N7jBLvxfNmGpC7l6wsvTJv2TRMNk=",
+   "pom": "sha256-qb8bOVbm1Gy99zeRKOsXMs3hrGVAl5RNxlobbcQlcPA="
+  },
+  "com/github/java-json-tools#jackson-coreutils-equivalence/1.0": {
+   "jar": "sha256-60qa19gD+whL/895PIqB9R10W21DjChHDvnVql+4oYI=",
+   "pom": "sha256-0Vd8uaSY6Et0+ADXdRiQb/ErXT4vKJ2SqTauCU6sxeE="
+  },
+  "com/github/java-json-tools#jackson-coreutils/2.0": {
+   "jar": "sha256-FrOqvTqeslZV3aQz41+b2cfBqnmRQncC9fEfAAgT27A=",
+   "pom": "sha256-jZ7pOk/dXSvYDrqUonoTDWBo8/heSI61vxSUOHEc6eo="
+  },
+  "com/github/java-json-tools#json-patch/1.13": {
+   "jar": "sha256-H3lNJWlltT7zfnC1VQXi7QDdwBhNROLo4f3OWjysx94=",
+   "pom": "sha256-59lec35Uwo1EuFv2Qw8VNvZEZU1pQr2ogzM4r5aWSw8="
+  },
+  "com/github/java-json-tools#json-schema-core/1.2.14": {
+   "jar": "sha256-yFmUL92inCbMsr6DqEU6Ew3jX95viK4Yl4VRa10U+Bw=",
+   "pom": "sha256-pR/BAI6VN7vFJbpywl4Lz4LzXxscwwfC53jS7fO9V18="
+  },
+  "com/github/java-json-tools#json-schema-validator/2.2.14": {
+   "jar": "sha256-zZ48WZuzIpZRf9OsOL7qxwnwpquBstQolJXQNhulmJk=",
+   "pom": "sha256-W8HTDGddkv+DV3ldOvN172JqvffrMjS2TahmKqEeqZs="
+  },
+  "com/github/java-json-tools#msg-simple/1.2": {
+   "jar": "sha256-vvQRG5k6Wz5hSNj1hWIczqwqGInNvDREixFjLg2Kmo8=",
+   "pom": "sha256-bvPzUgcukUz6FzkzRoXyotAAJRL8Ul+kEtSQ1FCUMKM="
+  },
+  "com/github/java-json-tools#uri-template/0.10": {
+   "jar": "sha256-OTb2fY59+j7t7+RQ/1iHF0kwiYLGuLcGU1qIQ5HfT7A=",
+   "pom": "sha256-MXithX0gGmwpZy4rFGrAuj7MUlNquZaUpGuxJfoBxrk="
+  },
+  "com/github/jknack#handlebars-jackson2/4.3.1": {
+   "jar": "sha256-UjLit9Od6+U8/YQ54FLF4i2rnUPROkrm+QziV2D8iRY=",
+   "pom": "sha256-GLG2aavIFa3VZFQXH3O77lXF8EKe+3P74Wk8E+rWL3A="
+  },
+  "com/github/jknack#handlebars.java/4.3.1": {
+   "pom": "sha256-UECkDYFTRzveednE1O+4cSChaQ+uWFtYKAcH1DdCCZk="
+  },
+  "com/github/jknack#handlebars/4.3.1": {
+   "jar": "sha256-VCT9EukRzxW+/RY0G0bg4bxoGqYePLHAcMV+aNzNW70=",
+   "pom": "sha256-/DAp8kYk6YvWC1pGmSEPP1YKOUiTQpzQbMrYROj41BU="
+  },
+  "com/github/joschi/jackson#jackson-datatype-threetenbp/2.18.2": {
+   "jar": "sha256-WhH8ZX6ZfW2tJsOilRNaWDRHqkoPoB9CSj2Y4TcZHTA=",
+   "pom": "sha256-0PmnYltkM3ZwhFZ7X310MqvuZHwX/b/WxFyx4zYvRcU="
+  },
+  "com/github/mifmif#generex/1.0.2": {
+   "jar": "sha256-j4ziM8M14I4ROj+Ved4QRvsZkn6CRosbvrzWy6h2C4E=",
+   "pom": "sha256-R2QJlPzU46EZStsn0s/kEQII7qlCwgSDTZailCVt5hQ="
+  },
+  "com/github/zafarkhaja#java-semver/0.10.2": {
+   "jar": "sha256-qOMuF1ddAYjB8+Lle7ldsJeTiDyIU/3oKLY+yx+Zpjo=",
+   "pom": "sha256-fwBf8/kA6GlV9aU0tamqjqVLtdYLtgrCN1lVCjZnaDU="
+  },
+  "com/google/code/findbugs#jsr305/3.0.2": {
+   "jar": "sha256-dmrSoHg/JoeWLIrXTO7MOKKLn3Ki0IXuQ4t4E+ko0Mc=",
+   "pom": "sha256-GYidvfGyVLJgGl7mRbgUepdGRIgil2hMeYr+XWPXjf4="
+  },
+  "com/google/code/gson#gson-parent/2.10.1": {
+   "pom": "sha256-QkjgiCQmxhUYI4XWCGw+8yYudplXGJ4pMGKAuFSCuDM="
+  },
+  "com/google/code/gson#gson-parent/2.8.5": {
+   "pom": "sha256-jx/scrkaceo57Dn193jE0RJLawl8bVWzpQtVSlIjeyc="
+  },
+  "com/google/code/gson#gson-parent/2.8.9": {
+   "pom": "sha256-sW4CbmNCfBlyrQ/GhwPsN5sVduQRuknDL6mjGrC7z/s="
+  },
+  "com/google/code/gson#gson/2.10.1": {
+   "jar": "sha256-QkHBSncnw0/uplB+yAExij1KkPBw5FJWgQefuU7kxZM=",
+   "pom": "sha256-0rEVY09cCF20ucn/wmWOieIx/b++IkISGhzZXU2Ujdc="
+  },
+  "com/google/code/gson#gson/2.8.5": {
+   "jar": "sha256-IzoBSfw2XJ9u29aDz+JmsZvcdzvpjqva9rPJJLSOfYE=",
+   "pom": "sha256-uDCFV6f8zJLZ/nyM0FmSWLNhKF0uzedontqYhDJVoJI="
+  },
+  "com/google/code/gson#gson/2.8.9": {
+   "jar": "sha256-05mSkYVd5JXJTHQ3YbirUXbP6r4oGlqw2OjUUyb9cD4=",
+   "pom": "sha256-r97W5qaQ+/OtSuZa2jl/CpCl9jCzA9G3QbnJeSb91N4="
+  },
+  "com/google/devtools/ksp#com.google.devtools.ksp.gradle.plugin/2.2.20-2.0.3": {
+   "pom": "sha256-nHpe0AhkUetGkMJVRCsqNRdOkorGssj1BmkAvDHir2s="
+  },
+  "com/google/devtools/ksp#symbol-processing-api/2.2.20-2.0.3": {
+   "jar": "sha256-ogZEVp7MAUZ9Pv5Pi5eHqHGc4n7RK2o0da4dgr+xag4=",
+   "module": "sha256-HVGBrIyxsW2CXjLznfHy74WtGZVjXqrzU5sy3gVuXY8=",
+   "pom": "sha256-AoGBVPu0W8crSiPLJCqgFlpIMk1rjsQ8srl8itLm3rA="
+  },
+  "com/google/devtools/ksp#symbol-processing-common-deps/2.2.20-2.0.3": {
+   "jar": "sha256-YY22G1qnU4OO+G5ybnPzWb6MKbbNRn42hxvBfqhnNdA=",
+   "module": "sha256-81zPz69PmruVgozq6rg+c50dlnwvONNiAARI+yBNEYQ=",
+   "pom": "sha256-VkkIx9TbM8y8QObiWMTLpcDe1YbAATIx/0QBezxkqVI="
+  },
+  "com/google/devtools/ksp#symbol-processing-gradle-plugin/2.2.20-2.0.3": {
+   "jar": "sha256-djjiJA3gPrkHW7UEv1Y+7bERsc5DkP/f+/5Jk/QNHV8=",
+   "module": "sha256-3Uc2kSQ8kok3Js6CPflPgVfv4l+G7r05fjg9Gw/Y174=",
+   "pom": "sha256-Ae5R9JmSh/AfrzjIDYH5loRi93+HcMf6rskWeEOGy/M="
+  },
+  "com/google/errorprone#error_prone_annotations/2.2.0": {
+   "jar": "sha256-br0iyhudjsBtQd6NZOBZaYHZYHtCA1+e03T53icaSBo=",
+   "pom": "sha256-XgJY6huk5RoTN0JoC8IkSPerIUvkBz6GGfZF7xvkLdU="
+  },
+  "com/google/errorprone#error_prone_annotations/2.21.1": {
+   "jar": "sha256-0fPGaqkaxSVJ4Arjsgi6S5r31y1o8jBkNVO+s45hGKw=",
+   "pom": "sha256-9ZiID+766p1nTcQdsTqzcAS/A3drW7IcBN7ejpIMHxI="
+  },
+  "com/google/errorprone#error_prone_parent/2.2.0": {
+   "pom": "sha256-xGCQLd9ezmiDLGsnHOUqCSiwXPOmrIGo9UjHPL1UETg="
+  },
+  "com/google/errorprone#error_prone_parent/2.21.1": {
+   "pom": "sha256-MrsLX/JB/Wuh/upEiuu5zt7xaZvnPLbzGTZTh7gr+Sw="
+  },
+  "com/google/guava#failureaccess/1.0.1": {
+   "jar": "sha256-oXHuTHNN0tqDfksWvp30Zhr6typBra8x64Tf2vk2yiY=",
+   "pom": "sha256-6WBCznj+y6DaK+lkUilHyHtAopG1/TzWcqQ0kkEDxLk="
+  },
+  "com/google/guava#guava-parent/26.0-android": {
+   "pom": "sha256-+GmKtGypls6InBr8jKTyXrisawNNyJjUWDdCNgAWzAQ="
+  },
+  "com/google/guava#guava-parent/27.0.1-jre": {
+   "pom": "sha256-MX6IKRJi4M8oBelWwYhQ8dRWXIXC4REvXZ0Iqxcy5pY="
+  },
+  "com/google/guava#guava-parent/32.1.3-jre": {
+   "pom": "sha256-8oPB8EiXqaiKP6T/RoBOZeghFICaCc0ECUv33gGxhXs="
+  },
+  "com/google/guava#guava/27.0.1-jre": {
+   "jar": "sha256-4cgU/QRJKifDjgMX6r6qGz6VDsgBAjnkAP6QrWyRB7Q=",
+   "pom": "sha256-ao3QQfI6a7FKhuRA/MuZNTe2InE1eg2sCjyw/zkVjzY="
+  },
+  "com/google/guava#guava/32.1.3-jre": {
+   "jar": "sha256-bU4rWhGKq2Lm5eKdGFoCJO7YLIXECsPTPPBKJww7N0Q=",
+   "module": "sha256-9f/3ZCwS52J7wUKJ/SZ+JgLBf5WQ4jUiw+YxB/YcKUI=",
+   "pom": "sha256-cA5tRudbWTmiKkHCXsK7Ei88vvTv7UXjMS/dy+mT2zM="
+  },
+  "com/google/guava#listenablefuture/9999.0-empty-to-avoid-conflict-with-guava": {
+   "jar": "sha256-s3KgN9QjCqV/vv/e8w/WEj+cDC24XQrO0AyRuXTzP5k=",
+   "pom": "sha256-GNSx2yYVPU5VB5zh92ux/gXNuGLvmVSojLzE/zi4Z5s="
+  },
+  "com/google/j2objc#j2objc-annotations/1.1": {
+   "jar": "sha256-KZSn63jycQvT07+2ObLJTiGc7awNTQhNUW54wW3d7PY=",
+   "pom": "sha256-8MmMVx6Tp8tN0Y3w+jCPCWPnoGIKwtQkTmHnCdA61r4="
+  },
+  "com/googlecode/libphonenumber#libphonenumber-parent/8.11.1": {
+   "pom": "sha256-X12sUXT4TGCi6Z56g8eCb3NJgfvCDqHUN/em/Piq2hY="
+  },
+  "com/googlecode/libphonenumber#libphonenumber/8.11.1": {
+   "jar": "sha256-9DDJI5TCBT8WhxWFPaltmZlulONOWikbl8XIalrWKpg=",
+   "pom": "sha256-irUVuq10qC2rsC6+nm8XLUj0r+0KyAxn7aKIRqbN7dA="
+  },
+  "com/ibm/icu#icu4j/72.1": {
+   "jar": "sha256-PfVyskCmjRO1zXeK0jk+iF0mQRQ0zY8JisWYfqLmTOM=",
+   "pom": "sha256-Pe8rKa9KGa2AXLFTBWklqJqQP5L77hre4S7S/BTETug="
+  },
+  "com/samskivert#jmustache/1.15": {
+   "jar": "sha256-GuuWudwXvClUC4wzQujpHul01cYEFl7NRp3XawQcJQw=",
+   "pom": "sha256-Z77EYiZJjJBFuqct8cnH9mG4XOObYni2TWign0Xry1k="
+  },
+  "com/strumenta#antlr-kotlin-gradle-plugin/1.0.2": {
+   "jar": "sha256-neZCtD2Y8AS8TX0wkpVdsuBaL8XKa8Q+tBVqNZVVkos=",
+   "module": "sha256-t1m4LoiMovlmQAXj1oy58wM2Vdv7KBrG0yqf6XxQ3c4=",
+   "pom": "sha256-MfifVba08ApogkXzkhvTzCO4Z9PizyAgYSRplmhZPJ0="
+  },
+  "com/strumenta#antlr-kotlin-target/1.0.2": {
+   "jar": "sha256-PNB1k/m4DnGNobdHHpfbjjuxU1hTkQk5qnvq+hlpFHQ=",
+   "module": "sha256-tzg2oj8tHSx6Zij3FLPcGB+QdvuWCRabJ/QwM6bz5AE=",
+   "pom": "sha256-CH31pxn7CrLgjHvQjgtP8YccIHqWvuz3Sz5sOgKO2UI="
+  },
+  "com/strumenta/antlr-kotlin#com.strumenta.antlr-kotlin.gradle.plugin/1.0.2": {
+   "pom": "sha256-k9f3Q5oTfttR/u3P53O0DEMrCq215CigG8erzV8Vn5E="
+  },
+  "com/sun/activation#all/1.2.2": {
+   "pom": "sha256-GXPUmcwsEmSv8tbQUqHHFq5hPQGK4cL2EN1qTRwkV44="
+  },
+  "commons-cli#commons-cli/1.5.0": {
+   "jar": "sha256-vIuwH8D60lA4VwbiD5J93P9hc/Yzmzh9yHkjd1JWesY=",
+   "pom": "sha256-TuxDxPwoBMvrQ2mcq/qC+gYocfzB3P0QkCpdglIGdMA="
+  },
+  "commons-codec#commons-codec/1.11": {
+   "jar": "sha256-5ZnVMY6Xqkj0ITaikn5t+k6Igd/w5sjjEJ3bv/Ude30=",
+   "pom": "sha256-wecUDR3qj981KLwePFRErAtUEpcxH0X5gGwhPsPumhA="
+  },
+  "commons-io#commons-io/2.16.1": {
+   "jar": "sha256-9B97qs1xaJZEes6XWGIfYsHGsKkdiazuSI2ib8R3yE8=",
+   "pom": "sha256-V3fSkiUceJXASkxXAVaD7Ds1OhJIbJs+cXjpsLPDj/8="
+  },
+  "commons-logging#commons-logging/1.2": {
+   "jar": "sha256-2t3qHqC+D1aXirMAa4rJKDSv7vvZt+TmMW/KV98PpjY=",
+   "pom": "sha256-yRq1qlcNhvb9B8wVjsa8LFAIBAKXLukXn+JBAHOfuyA="
+  },
+  "de/mannodermaus/android-junit5#de.mannodermaus.android-junit5.gradle.plugin/1.11.2.0": {
+   "pom": "sha256-t/WMW61Or7HykDeck2obA02h7vt/4A0usFyRxSXbehE="
+  },
+  "de/mannodermaus/gradle/plugins#android-junit5/1.11.2.0": {
+   "jar": "sha256-GAKPIqrV1Zx4DhD5Rlg55HpudC8eieZ7iFJSv5BRkAE=",
+   "module": "sha256-C2TlYxgPaaZloRD36F1C/M3F5Nc2o443uPGUhkmqYBw=",
+   "pom": "sha256-JUDnyFj7pBcEusJ6/+oBZ+ldhhfxyBwJ3iEjhKr4wbA="
+  },
+  "de/undercouch#gradle-download-task/5.6.0": {
+   "jar": "sha256-zkN6arnKcZzIVrVbp0kuQsTODumC5tIvtDLNVYh2gb4=",
+   "module": "sha256-P+YJN66Dzs2qpOD2EykVaQKD7d+IQ54m8efjgEV4NSI=",
+   "pom": "sha256-RqMBkMaLY9AegKQEQJfCULu8MgmkXw3FpNDioe1bgKc="
+  },
+  "de/undercouch/download#de.undercouch.download.gradle.plugin/5.6.0": {
+   "pom": "sha256-BlPzNGaIqBMNjjYy3kQHyDC1Iaoa7euqsYRUICAN/7E="
+  },
+  "dk/brics/automaton#automaton/1.11-8": {
+   "jar": "sha256-okR19sz+HMek/p404Fzmh7DODG6Mt4Hg7O07GGSCxh4=",
+   "pom": "sha256-N1e360Vz2a4E37ViqPa9WqtKZbiD31RKTzYJTXz+I78="
+  },
+  "io/sentry#sentry-kotlin-multiplatform-gradle-plugin/0.12.0": {
+   "jar": "sha256-fNWyQ/wl4q5Yu2Z5949zRNSKFn2bwkPY62K6/gohNfc=",
+   "module": "sha256-2SanANsKdiFM/8djX4XR4cKignE1dYiR61vaHTRCNLc=",
+   "pom": "sha256-hMx9AcxMCi+9wW3PuhojMcosp5tvk01+G8FYTR95fCo="
+  },
+  "io/sentry/kotlin/multiplatform/gradle#io.sentry.kotlin.multiplatform.gradle.gradle.plugin/0.12.0": {
+   "pom": "sha256-dWlEf6xFV/F5LqZfMmDGp/HXhYB66H+rGHOLYjr+nkA="
+  },
+  "io/swagger#swagger-annotations/1.6.14": {
+   "jar": "sha256-J22F3CEgy8MLCL40t7rlQYRnymmDgUsNHgcYKeu1xQA=",
+   "pom": "sha256-XG0N2eUofKfwGeaH5i3HsGdnbwSJGV9fW+fmBTlVzLs="
+  },
+  "io/swagger#swagger-compat-spec-parser/1.0.70": {
+   "jar": "sha256-QG1OJJTrvLfBPUhPYEuBQEe34mgsw7cg0ixmXXaYjEg=",
+   "pom": "sha256-ypicQ+g5ALJ/rxXlx5zK+/mzpFs8UDoSgjrvf50BJjk="
+  },
+  "io/swagger#swagger-core/1.6.14": {
+   "jar": "sha256-2Xj1GhtYw8rtvflugONH7SndoNr4lEEw54WukqTdnyc=",
+   "pom": "sha256-zW3kbGB6HDQQElKqyX2EPQnpCxZAfZY2OcDqlQteTaI="
+  },
+  "io/swagger#swagger-models/1.6.14": {
+   "jar": "sha256-GMZMZwzhhe7VMZEqXQkj3RpbclxxRyGNcDsoNGyvlMM=",
+   "pom": "sha256-UXFllcHcdBALjQwb02lzqQ9W0PXI0aPgfk4J/IA3K6s="
+  },
+  "io/swagger#swagger-parser-project/1.0.70": {
+   "pom": "sha256-naIUULAVDE+U1YmsSIEtQh3mmNtIPDZ6PXiXbz3X9YU="
+  },
+  "io/swagger#swagger-parser-safe-url-resolver/1.0.70": {
+   "jar": "sha256-Ln6L9oFHtNvSS+JcEhd/Tig+krfDxvoD8EZjNkLzVcg=",
+   "pom": "sha256-pnrulNravyrPHrLB98dCdiweijfcRqflq95yDsNh7LU="
+  },
+  "io/swagger#swagger-parser/1.0.70": {
+   "jar": "sha256-lX6gThFPIQq8h6VDkm1mTB/ubvFePd1bhGtPrIPpEYE=",
+   "pom": "sha256-t1ioajcZscT68y1v4XxTalKGXxYjr1YXidKasKw0r6c="
+  },
+  "io/swagger#swagger-project/1.6.14": {
+   "pom": "sha256-9F5u6XAwQIotCRByYaFCqb8e9Y2WXZWYcBDfWZBqmL0="
+  },
+  "io/swagger/core/v3#swagger-annotations/2.2.21": {
+   "jar": "sha256-ZEUU+9oJzwvYwql2bsqaQofWxsOzRktc97Qx51sW0W8=",
+   "pom": "sha256-f+e4Efwks28d4ZBh3M2NNu8TxzAClbrDUq/ODZXhS5Q="
+  },
+  "io/swagger/core/v3#swagger-core/2.2.21": {
+   "jar": "sha256-wkL+SD0YHvsxYcjO8jLS8U03T2Cl/3xhrM59YeZBFJ0=",
+   "pom": "sha256-dfPAX969TtOmiCL93OV4dbFYMeLkfeSPWoWS83nrkNo="
+  },
+  "io/swagger/core/v3#swagger-models/2.2.21": {
+   "jar": "sha256-kQ9VvG+elOuM9mB0G8ghVnSkbdtmG1uKdSWyW2VStTg=",
+   "pom": "sha256-fxD+bKOG8XLV2U71emtTC1WJpP88pxJ6DFy9S4pv8yg="
+  },
+  "io/swagger/core/v3#swagger-project/2.2.21": {
+   "pom": "sha256-oiRjNjBIh36joj69WOGddbieayxhGJnmxjZ11e2kopQ="
+  },
+  "io/swagger/parser/v3#swagger-parser-core/2.1.22": {
+   "jar": "sha256-Vrr9/sIPaeCstC8QZ/yJdUwO/5MKjmUYdS+1EFnpPro=",
+   "pom": "sha256-VXT1Zc9Z+wntNm6Aw1PFu6tnEMP+hdMtrsV0RcEUUpM="
+  },
+  "io/swagger/parser/v3#swagger-parser-project/2.1.22": {
+   "pom": "sha256-m9KOOxqc4ku4hYtZMikKU/uWTFzTLwuiYIHSiRaGU8U="
+  },
+  "io/swagger/parser/v3#swagger-parser-safe-url-resolver/2.1.22": {
+   "jar": "sha256-TLSrNBq3mzOnl3YUVYmG0Spl99F+s5jUZYcxDJhAZkQ=",
+   "pom": "sha256-pTqKn9Mt9uyasjgEdLq02XOVTkKoEk3PJjg/gW5V0nQ="
+  },
+  "io/swagger/parser/v3#swagger-parser-v2-converter/2.1.22": {
+   "jar": "sha256-ZdYDOEa7MOP77YKQKHUh1+4+qciFv4wRKLyAbCGuX5c=",
+   "pom": "sha256-ro9VZVRvOHC/5RFdggAUVkKw7Y9aDqHS13LtVfLcohI="
+  },
+  "io/swagger/parser/v3#swagger-parser-v3/2.1.22": {
+   "jar": "sha256-BG/B+afec2a/unwbF5Dh77DnIN3JR1rVX8Wz00rOkXU=",
+   "pom": "sha256-28v9n4aXUQZyxQg2+vyMfAs5CbOa8UI3rANkAJsL2AA="
+  },
+  "io/swagger/parser/v3#swagger-parser/2.1.22": {
+   "jar": "sha256-F2yeSuhlXHy2sOilbA+kBLFasK6wy3LkopTurQhK6yM=",
+   "pom": "sha256-jCk5Kv5uPnYrDDmEgP7oSkymWNWr5G7DeTtsvuQkIa0="
+  },
+  "jakarta/activation#jakarta.activation-api/1.2.2": {
+   "jar": "sha256-oYepORA671hJp6+EvX4nvi0SDEEK8pFDc3X/4GH08J0=",
+   "pom": "sha256-XlD+k4BoRx9QSn78QHGCNCW1IOq8b4DHLZNevVRoMJE="
+  },
+  "jakarta/validation#jakarta.validation-api/2.0.2": {
+   "jar": "sha256-tC1CQo89kiyJKpCfoEMofVd8DFsWWtm31WjOv4f8nqQ=",
+   "pom": "sha256-Oy5Oh3+3C6+h2tdcDemZxFYTEoLUcbpR3z25bDt02pI="
+  },
+  "jakarta/xml/bind#jakarta.xml.bind-api-parent/2.3.3": {
+   "pom": "sha256-KA2lMXYBZtRBI2jQ3Yme9K6/0KfYK/IzUC4phWgGrak="
+  },
+  "jakarta/xml/bind#jakarta.xml.bind-api/2.3.3": {
+   "jar": "sha256-wEU59HLppt0MdoXqgtZ3KCJpq457rKLhRQDjgeDGzsU=",
+   "pom": "sha256-f+LKXc5LFKZGu/kh0TykLK8qLAZU2hVcdWOGXJiTlv0="
+  },
+  "javax/validation#validation-api/1.1.0.Final": {
+   "jar": "sha256-8517pyU+NfWsSAgewbwoxd+bMqxLfbIIU+Wo52v3sO0=",
+   "pom": "sha256-uGNJEebL5sFLML0G44N9fmko/H4clieN7GFwi2qu4hw="
+  },
+  "joda-time#joda-time/2.12.7": {
+   "jar": "sha256-OFKCsAWBjPrM2+i9JCmBHn5kF4LyuIkyprj/UdZo9hY=",
+   "pom": "sha256-hf3b+kfCmf2OzhyT//1H2cLTyQNaM7XbAXswTGd+hCg="
+  },
+  "net/java/dev/jna#jna/5.12.1": {
+   "jar": "sha256-kagUrE9A1g3ukdhC4aith0xiGXmEQD0OPDDTnlXPU7M=",
+   "pom": "sha256-Zf8lhJuthZVUtQMXeS9Wia20UprkAx6aUkYxnLK4U1Y="
+  },
+  "net/sf/jopt-simple#jopt-simple/5.0.4": {
+   "jar": "sha256-3ybMWPI19HfbB/dTulo6skPr5Xidn4ns9o3WLqmmbCg=",
+   "pom": "sha256-amd2O3avzZyAuV5cXiR4LRjMGw49m0VK0/h1THa3aBU="
+  },
+  "org/abego/treelayout#org.abego.treelayout.core/1.0.3": {
+   "jar": "sha256-+l4xOVw5wufUasoPgfcgYJMWB7L6Qb02A46yy2+5MyY=",
+   "pom": "sha256-o7KyI3lDcDVeeSQzrwEvyZNmfAMxviusrYTbwJrOSgw="
+  },
+  "org/antlr#ST4/4.3.4": {
+   "jar": "sha256-+SesOExG10n4texolypTrtIeADE1CSmWFu23O/oV/zM=",
+   "pom": "sha256-nnwfPkiZGUQOjBMInlljcp1bf4D3AjO/uuMJxkmryj4="
+  },
+  "org/antlr#antlr-master/3.5.3": {
+   "pom": "sha256-6p43JQ9cTC52tlOL6XtX8zSb2lhe31PzypfiB7OFuJU="
+  },
+  "org/antlr#antlr-runtime/3.5.3": {
+   "jar": "sha256-aL+fWjPfyzQDNJXFh+Yja+9ON6pmEpGfWx6EO5Bmn7k=",
+   "pom": "sha256-EymODgqvr0FP99RAZCfKtuxPv6NkJ/bXEDxDLzLAfSU="
+  },
+  "org/antlr#antlr4-master/4.13.1": {
+   "pom": "sha256-28/JebgFKPwMtFP8to28nSsGA6e+LNzpmrL8aHFGnRg="
+  },
+  "org/antlr#antlr4-runtime/4.13.1": {
+   "jar": "sha256-VGZdKDjMZkWDQ0aO/FOeRU/JW0aooEsTxqxD/JvmNQU=",
+   "pom": "sha256-GSJrF7+jj5nqImsi6XQg4qjt4JqXQg+xrPGG2a2kZXE="
+  },
+  "org/antlr#antlr4/4.13.1": {
+   "jar": "sha256-ziYdzmlSWDmqn8W9IyzhuBOnpAp1AwcTzEqA74Fw89U=",
+   "pom": "sha256-ahWaEs/WYoqnNuw//ZM/qUEuXLy3zn7FIXo/9CDGapk="
+  },
+  "org/apache#apache/13": {
+   "pom": "sha256-/1E9sDYf1BI3vvR4SWi8FarkeNTsCpSW+BEHLMrzhB0="
+  },
+  "org/apache#apache/18": {
+   "pom": "sha256-eDEwcoX9R1u8NrIK4454gvEcMVOx1ZMPhS1E7ajzPBc="
+  },
+  "org/apache#apache/21": {
+   "pom": "sha256-rxDBCNoBTxfK+se1KytLWjocGCZfoq+XoyXZFDU3s4A="
+  },
+  "org/apache#apache/23": {
+   "pom": "sha256-vBBiTgYj82V3+sVjnKKTbTJA7RUvttjVM6tNJwVDSRw="
+  },
+  "org/apache#apache/27": {
+   "pom": "sha256-srD8aeIqZQw4kvHDZtdwdvKVdcZzjfTHpwpEhESEzfk="
+  },
+  "org/apache#apache/30": {
+   "pom": "sha256-Y91KOTqcDfyzFO/oOHGkHSQ7yNIAy8fy0ZfzDaeCOdg="
+  },
+  "org/apache#apache/31": {
+   "pom": "sha256-VV0MnqppwEKv+SSSe5OB6PgXQTbTVe6tRFIkRS5ikcw="
+  },
+  "org/apache/commons#commons-lang3/3.12.0": {
+   "pom": "sha256-gtMfHcxFg+/9dE6XkWWxbaZL+GvKYj/F0bA+2U9FyFo="
+  },
+  "org/apache/commons#commons-lang3/3.14.0": {
+   "jar": "sha256-e5a/PuaJSau1vEZVWawnDgVRWW+jRSP934kOxBjd4Tw=",
+   "pom": "sha256-EQQ4hjutN8KPkGv4cBbjjHqMdYujIeCdEdxaI2Oo554="
+  },
+  "org/apache/commons#commons-parent/34": {
+   "pom": "sha256-Oi5p0G1kHR87KTEm3J4uTqZWO/jDbIfgq2+kKS0Et5w="
+  },
+  "org/apache/commons#commons-parent/42": {
+   "pom": "sha256-zTE0lMZwtIPsJWlyrxaYszDlmPgHACNU63ZUefYEsJw="
+  },
+  "org/apache/commons#commons-parent/52": {
+   "pom": "sha256-ddvo806Y5MP/QtquSi+etMvNO18QR9VEYKzpBtu0UC4="
+  },
+  "org/apache/commons#commons-parent/54": {
+   "pom": "sha256-AA2Bh5UrIjcC/eKW33mVY/Nd6CznKttOe/FXNCN4++M="
+  },
+  "org/apache/commons#commons-parent/64": {
+   "pom": "sha256-bxljiZToNXtO1zRpb5kgV++q+hI1ZzmYEzKZeY4szds="
+  },
+  "org/apache/commons#commons-parent/69": {
+   "pom": "sha256-1Q2pw5vcqCPWGNG0oDtz8ZZJf8uGFv0NpyfIYjWSqbs="
+  },
+  "org/apache/commons#commons-text/1.10.0": {
+   "jar": "sha256-dwzZA/p7YE0ffve6F/hBCGZylLK0eL6O0a87/7SuABg=",
+   "pom": "sha256-OI3VI0i6GEKqOK64l8kdJwsUZh64daIP2YAxU1qydWc="
+  },
+  "org/apache/httpcomponents#httpclient/4.5.14": {
+   "jar": "sha256-yLx+HFGm1M5y9A0uu6vxxLaL/nbnMhBLBDgbSTR46dY=",
+   "pom": "sha256-8YNVr0z4CopO8E69dCpH6Qp+rwgMclsgldvE/F2977c="
+  },
+  "org/apache/httpcomponents#httpcomponents-client/4.5.14": {
+   "pom": "sha256-W60d5PEBRHZZ+J0ImGjMutZKaMxQPS1lQQtR9pBKoGE="
+  },
+  "org/apache/httpcomponents#httpcomponents-core/4.4.16": {
+   "pom": "sha256-8tdaLC1COtGFOb8hZW1W+IpAkZRKZi/K8VnVrig9t/c="
+  },
+  "org/apache/httpcomponents#httpcomponents-parent/11": {
+   "pom": "sha256-qQH4exFcVQcMfuQ+//Y+IOewLTCvJEOuKSvx9OUy06o="
+  },
+  "org/apache/httpcomponents#httpcore/4.4.16": {
+   "jar": "sha256-bJs90UKgncRo4jrTmq1vdaDyuFElEERp8CblKkdORk8=",
+   "pom": "sha256-PLrYSbNdrP5s7DGtraLGI8AmwyYRQbDSbux+OZxs1/o="
+  },
+  "org/apache/maven#maven-parent/41": {
+   "pom": "sha256-di/N1M6GIcX6Ciz2SVrSaXKoCT60Mqo+QCvC1OJQDFM="
+  },
+  "org/apache/maven/resolver#maven-resolver-api/1.9.18": {
+   "jar": "sha256-6/ueHf7qPCAXkFGEWB4AeHS06qydKL//z+UTPXCsYzk=",
+   "pom": "sha256-gpDaoM1/u6B2ewc2hmkig4fKuumaE8NDP71FcGKa44Q="
+  },
+  "org/apache/maven/resolver#maven-resolver-util/1.9.18": {
+   "jar": "sha256-LrDqZnvEiThEeCMd2nUWQH1LWyKhOAdyKYcd6TYqeuI=",
+   "pom": "sha256-qY5q9c3xskVkhq4LuBKOUv7o1plmKa9gYGu8nBqt+Ow="
+  },
+  "org/apache/maven/resolver#maven-resolver/1.9.18": {
+   "pom": "sha256-+x3U5VTNLbzt6WFSlJIecLGDUz9GeROs2aN4f/3WlDs="
+  },
+  "org/checkerframework#checker-qual/2.5.2": {
+   "jar": "sha256-ZLAmkci51OdwD47i50Lc5+osboHmYrdSLJ7jv1aMBAo=",
+   "pom": "sha256-3EzUOKNkYtATwjOMjiBtECoyKgDzNynolV7iGYWcnt4="
+  },
+  "org/checkerframework#checker-qual/3.37.0": {
+   "jar": "sha256-5M4TdswnNeHd4iC2KtCRP1EpdwTarRVaM/OGvF2w2fc=",
+   "module": "sha256-clinadyqJrmBVNIp2FzHLls2ZrC8tjfS2vFuxJiVZjg=",
+   "pom": "sha256-AjkvvUziGQH5RWFUcrHU1NNZGzqr3wExBfXJLsMstPA="
+  },
+  "org/codehaus/mojo#animal-sniffer-annotations/1.17": {
+   "jar": "sha256-kmVPST7P7FIILnY1Tw6/h2SNw9XOwuPDzblHwBZ0elM=",
+   "pom": "sha256-6VarXS60j6uuEjANDNLTKU1KKkGrwgaMI8tNYK12y+U="
+  },
+  "org/codehaus/mojo#animal-sniffer-parent/1.17": {
+   "pom": "sha256-GKA98W4qGExYLbexJWM8Fft3FAJ6hMG1MtcpM9wIuB8="
+  },
+  "org/codehaus/mojo#mojo-parent/40": {
+   "pom": "sha256-/GSNzcQE+L9m4Fg5FOz5gBdmGCASJ76hFProUEPLdV4="
+  },
+  "org/commonmark#commonmark-parent/0.21.0": {
+   "pom": "sha256-qeGddPQOEj3jbHAaUlIg2r5eMjVDZUfbek/TwJi31Qs="
+  },
+  "org/commonmark#commonmark/0.21.0": {
+   "jar": "sha256-gQhKcDUEb+MG8NvxbvV6aNCO5clwBOqGfmK120bpivs=",
+   "pom": "sha256-RhGg7TfAGTzGANRRrUxFfT0NVBxaxlbI2ANL0s0NB1g="
+  },
+  "org/eclipse/ee4j#project/1.0.5": {
+   "pom": "sha256-kWtHlNjYIgpZo/32pk2+eUrrIzleiIuBrjaptaLFkaY="
+  },
+  "org/eclipse/ee4j#project/1.0.6": {
+   "pom": "sha256-Tn2DKdjafc8wd52CQkG+FF8nEIky9aWiTrkHZ3vI1y0="
+  },
+  "org/gradle/kotlin#gradle-kotlin-dsl-plugins/5.2.0": {
+   "jar": "sha256-SKlcMPRlehDfloYC01LJ2GTZemYholfoFQjINWDE/q4=",
+   "module": "sha256-fxo3x8yLU7tmBAqrbAacidiqWOJ/+nH3s2HGROtaD7A=",
+   "pom": "sha256-uB9ZcQ4lOEW0+Pbe27BWPWfD5/UPg7AiQZXjo2GAtH8="
+  },
+  "org/gradle/kotlin/kotlin-dsl#org.gradle.kotlin.kotlin-dsl.gradle.plugin/5.2.0": {
+   "pom": "sha256-pXu0ObpCYKJW8tYIRx1wgRiQd6Ck3fsCjdGBe+W8Ejc="
+  },
+  "org/gradle/toolchains#foojay-resolver/0.9.0": {
+   "jar": "sha256-woQImj+HVX92Ai2Z8t8oNlaKpIs/5OKSI5LVZrqBQXY=",
+   "module": "sha256-huXl1QMWJYbAlW/QKippt22nwHIPSuAj82bRkaqXtLg=",
+   "pom": "sha256-wdtMSmUHZ5Y7dl/Q3d7P4eqLjp9kQo+H3iB/V48DeOc="
+  },
+  "org/gradle/toolchains/foojay-resolver-convention#org.gradle.toolchains.foojay-resolver-convention.gradle.plugin/0.9.0": {
+   "pom": "sha256-23zxG+5ohO+yiQQTn2LAD4tFhT5gwPQXFc9pV2tr/fA="
+  },
+  "org/jetbrains#annotations/13.0": {
+   "jar": "sha256-rOKhDcji1f00kl7KwD5JiLLA+FFlDJS4zvSbob0RFHg=",
+   "pom": "sha256-llrrK+3/NpgZvd4b96CzuJuCR91pyIuGN112Fju4w5c="
+  },
+  "org/jetbrains/compose/hot-reload#hot-reload-annotations-jvm/1.0.0-rc01": {
+   "jar": "sha256-9QbjmAxn+HbJUUvgIJW8rTvv969P3tu/WXlD2G3wcPM=",
+   "module": "sha256-pMW44iDKUOWwp6WUWmfPNbHJHAF0LzS3TPVdy0sVMcc=",
+   "pom": "sha256-Gu86o3/f2DNJr7Ja5trqwes36kxr8MmdnGZ46i78EmM="
+  },
+  "org/jetbrains/compose/hot-reload#hot-reload-annotations/1.0.0-rc01": {
+   "module": "sha256-XqDogqLkHfLNoWbMd+QMHifDI/bcU+Vttlfmh4HRxjM=",
+   "pom": "sha256-Nd8kDoiPcdjmAS2sjmviYvW3JNIPArRNpXdmsaYsmkE="
+  },
+  "org/jetbrains/compose/hot-reload#hot-reload-core/1.0.0-rc01": {
+   "jar": "sha256-uh9ABBaWpW61/guC6TAkCsjda2LdhYzb0admI03dMWU=",
+   "module": "sha256-/5lYGmR198oig8RT7m6VFS8LEYYSYncI8m9GuZt+v5Q=",
+   "pom": "sha256-bEvcENrK/FMIkHtIq/b2mIH7ESGHV2xFGYgMmq1XogE="
+  },
+  "org/jetbrains/compose/hot-reload#hot-reload-gradle-core/1.0.0-rc01": {
+   "jar": "sha256-ev6qd1FAzKuI61SwXOdJ2b3kW3B81tg5A3jVnMrnDMA=",
+   "module": "sha256-6l8vUcC6mIhFVsCADoym+0mU3k44S9M4OAMW3yhP4Sk=",
+   "pom": "sha256-WO8PiGy+xAAP0yFXO1Ljpyex84YW25bjuO9uZNj0lUE="
+  },
+  "org/jetbrains/compose/hot-reload#hot-reload-gradle-idea/1.0.0-rc01": {
+   "jar": "sha256-ucaLCehaiUPNXWMRIjDeQbkhtykjwyvVbW+Ti7QyUPQ=",
+   "module": "sha256-WAnXBBPUZs4BwNMK+VwTsDiPfbhE5Ikdphi4Orl7MQo=",
+   "pom": "sha256-+4lasLEfoJa53ThnJrEBMMIOb8NgJ5za6qU1J0eab+w="
+  },
+  "org/jetbrains/compose/hot-reload#hot-reload-gradle-plugin/1.0.0-rc01": {
+   "jar": "sha256-clTQvAqamRjoPzIrlnZbRHiuRqCaMJgZwRFOhQrpye0=",
+   "module": "sha256-rjE25QjjJ3CV3VopwFK7pCfm2mBqbjjtHw2/q7bgkD4=",
+   "pom": "sha256-7nhjWn9rQ0uCJ4qQ3NLzatCyXXX6P7Q/62sHwhK2LTg="
+  },
+  "org/jetbrains/compose/hot-reload#hot-reload-orchestration/1.0.0-rc01": {
+   "jar": "sha256-sP5TOsN9Z6NPWe6OZHFMuv/LTt0nEBXYsqu7xgZjY7w=",
+   "module": "sha256-ai2xm6od2LcQRE+SoRC9JdlNRvP76zBCv5iTayRPyCI=",
+   "pom": "sha256-oIFke7aT1AYYzcBTN0FPEcqCZM0hO6R9bewEUJPhaxk="
+  },
+  "org/jetbrains/compose/hot-reload#org.jetbrains.compose.hot-reload.gradle.plugin/1.0.0-rc01": {
+   "pom": "sha256-xzyHXrT9s/v6p3tY/q+rV4bTuDOmUT7vIOWQV3iKx58="
+  },
+  "org/jetbrains/intellij/deps#trove4j/1.0.20200330": {
+   "jar": "sha256-xf1yW/+rUYRr88d9sTg8YKquv+G3/i8A0j/ht98KQ50=",
+   "pom": "sha256-h3IcuqZaPJfYsbqdIHhA8WTJ/jh1n8nqEP/iZWX40+k="
+  },
+  "org/jetbrains/kotlin#kotlin-assignment/2.0.21": {
+   "module": "sha256-8638yrZURNtqqzwNfSVoZG7AyS8kWCh/KLKu5POXNtw=",
+   "pom": "sha256-QBfCQqfb3Oca6ApXB7S/OyOoIr8jpodahFp7UTYhzQ8="
+  },
+  "org/jetbrains/kotlin#kotlin-assignment/2.0.21/gradle85": {
+   "jar": "sha256-USUeNCELiNTJCAXKZS6Xe93IR4OkVAY5ydIQkJhbrOY="
+  },
+  "org/jetbrains/kotlin#kotlin-build-statistics/2.0.21": {
+   "jar": "sha256-gBILdN8DYz1veeCIZBMe7jt6dIb2wF0vLtyGg3U8VNo=",
+   "pom": "sha256-/iTcYG/sg+yY3Qi8i7HPmeVAXejpF8URnVoMt++sVZ0="
+  },
+  "org/jetbrains/kotlin#kotlin-build-tools-api/2.0.21": {
+   "jar": "sha256-j8orSvbEzyRWXZp/ZMMXhIlRjQSeEGmB22cY7yLK4Y4=",
+   "pom": "sha256-zL2XaTA2Y0gWKVGY5JRFNPr7c9d4+M1NQ588h7CQ9JQ="
+  },
+  "org/jetbrains/kotlin#kotlin-build-tools-api/2.2.20": {
+   "jar": "sha256-/ZlHs6F2Iahvq9lTr4fzS9K7f4sm2uksHte+dHL0TDs=",
+   "pom": "sha256-AtR9SHfsMktJbZMTMkXNTTSLZSMDzyfvpj44ry+zzyo="
+  },
+  "org/jetbrains/kotlin#kotlin-compiler-embeddable/2.0.21": {
+   "jar": "sha256-n6jN0d4NzP/hVMmX1CPsa19TzW2Rd+OnepsN4D+xvIE=",
+   "pom": "sha256-vUZWpG7EGCUuW8Xhwg6yAp+yqODjzJTu3frH6HyM1bY="
+  },
+  "org/jetbrains/kotlin#kotlin-compiler-runner/2.0.21": {
+   "jar": "sha256-COYFvoEGD/YS0K65QFihm8SsmWJcNcRhxsCzAlYOkQQ=",
+   "pom": "sha256-+Wdq1JVBFLgc39CR6bW0J7xkkc+pRIRmjWU9TRkCPm0="
+  },
+  "org/jetbrains/kotlin#kotlin-daemon-client/2.0.21": {
+   "jar": "sha256-Nx6gjk8DaILMjgZP/PZEWZDfREKVuh7GiSjnzCtbwBU=",
+   "pom": "sha256-8oY4JGtQVSC/6TXxXz7POeS6VSb6RcjzKsfeejEjdAA="
+  },
+  "org/jetbrains/kotlin#kotlin-daemon-embeddable/2.0.21": {
+   "jar": "sha256-saCnPFAi+N0FpjjGt2sr1zYYGKHzhg/yZEEzsd0r2wM=",
+   "pom": "sha256-jbZ7QN1gJaLtBpKU8sm8+2uW2zFZz+927deEHCZq+/A="
+  },
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-annotations/2.0.21": {
+   "jar": "sha256-W0cHoy5GfvvhIsMY/2q9yhei/H2Mg/ZgN8mhILbcvC8=",
+   "pom": "sha256-P+CLlUN7C074sWt39hqImzn1xGt+lx1N+63mbUQOodg="
+  },
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-annotations/2.2.20": {
+   "jar": "sha256-T8MqG+ZFynQE4hskRSCI+T6OmT6v/Sbza9Ndv3XGB1I=",
+   "pom": "sha256-sbbgEXktfKkv7K+/+sSlCPdvA5yfeuijI9GJKIgl9P4="
+  },
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-api/2.0.21": {
+   "jar": "sha256-Uur1LOMDtSneZ6vDusE+TxNZY1dUPfqDHE1y0tYxDlA=",
+   "module": "sha256-z29dNExVVVS/rGQFHq0AhcvUM4Z2uqP8h7UD6eSrvjQ=",
+   "pom": "sha256-gV5yqZ4ZFD1mLSTkYlKlnOdWMC18W9/FlIF9fMexI3g="
+  },
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-api/2.0.21/gradle85": {
+   "jar": "sha256-Uur1LOMDtSneZ6vDusE+TxNZY1dUPfqDHE1y0tYxDlA="
+  },
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-api/2.2.20": {
+   "module": "sha256-T8vx/H5Uzr/pC5peD7RpYv7Vwi03I52iNfXi37xtUog=",
+   "pom": "sha256-C5E9oNIYhCAmOpBLtApkD9s1pTWnLwWC/llkHjoMSi4="
+  },
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-api/2.2.20/gradle813": {
+   "jar": "sha256-dgfuXHoMpT+lku58VA7oCJYqe62P7p7Xj+Z0hBRj2V0="
+  },
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-idea-proto/2.0.21": {
+   "jar": "sha256-UzVXQrV7qOFvvfCiBDn4s0UnYHHtsUTns9puYL42MYg=",
+   "pom": "sha256-OMyaLLf55K/UOcMQdvgzFThIsfftITMgCDXRtCDfbqs="
+  },
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-idea/2.0.21": {
+   "jar": "sha256-wfTqDBkmfx7tR0tUGwdxXEkWes+/AnqKL9B8u8gbjnI=",
+   "module": "sha256-YqcNAg27B4BkexFVGIBHE+Z2BkBa6XoQ2P2jgpOI0Uk=",
+   "pom": "sha256-1GjmNf3dsw9EQEuFixCyfcVm6Z1bVIusEMIjOp7OF74="
+  },
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-model/2.0.21": {
+   "jar": "sha256-lR13mJs1cAljH/HvsSsBYczzKcUpxUalKfih0x+bwDw=",
+   "module": "sha256-6qn9n4b71E/2BwoZfce90ZgPDUHo20myUoA9A6pMVaw=",
+   "pom": "sha256-5RVeYOyr2v1kUmVKaYALyyp37n0fxucH+tOo5p8HTCw="
+  },
+  "org/jetbrains/kotlin#kotlin-gradle-plugin/2.0.21": {
+   "module": "sha256-D5iXoGwHo+h9ZHExzDSQofctGuVMEH8T9yJp1TRLCHo=",
+   "pom": "sha256-RenM7OM+TY36mUHMkS81RYIBqdPwQ3IMMket3lf0f/Y="
+  },
+  "org/jetbrains/kotlin#kotlin-gradle-plugin/2.0.21/gradle85": {
+   "jar": "sha256-nfXH/xOx/GislFDKY8UxEYkdb2R73ewPQ5iz5yJb9tk="
+  },
+  "org/jetbrains/kotlin#kotlin-gradle-plugins-bom/2.0.21": {
+   "module": "sha256-8JRUh/5RlZ/fi2oUQXB6Ke1fGsMaIxx/3r4sPd0i/fE=",
+   "pom": "sha256-Z1AT1Mvu4JyIkgriuiRvmfKKeJuHT2NASeAS+j7r9Mg="
+  },
+  "org/jetbrains/kotlin#kotlin-gradle-plugins-bom/2.2.20": {
+   "module": "sha256-P7tFda43xKd2rrhtj/k8aqEbDPLadXScUyDiWFCwIp4=",
+   "pom": "sha256-PG1GnpFfuzCWrEy4wvRsedAnw8WQ5lihBoihVx61eNg="
+  },
+  "org/jetbrains/kotlin#kotlin-klib-commonizer-api/2.0.21": {
+   "jar": "sha256-R1eJEWW2mPvazo9NpvK8DpiOrvnvNnE1SIZajycGmv0=",
+   "pom": "sha256-Y/6HvSI1sSlAnHIqCbYsIKe3eueQGeIgMSSK9zawPFQ="
+  },
+  "org/jetbrains/kotlin#kotlin-native-utils/2.0.21": {
+   "jar": "sha256-ResIo5Kfl8SKkpEsliV3nRVAvG8/IS+56UYg0DJrzAA=",
+   "pom": "sha256-ZpB3PnZJ0dD61V0GCaTiHh68mF3Q+iYenG/9OJhnBh0="
+  },
+  "org/jetbrains/kotlin#kotlin-native-utils/2.2.20": {
+   "jar": "sha256-UBd3SirqQf+HEhNxFs1NgAP+mroSAMEG5lcw/rW7dEI=",
+   "pom": "sha256-U+++4FpxIhiQYPXuXspodjnOr+KfXlmW3phiopxnJyU="
+  },
+  "org/jetbrains/kotlin#kotlin-sam-with-receiver/2.0.21": {
+   "module": "sha256-kJCVCx7oa4b+KWmV2AKG6opPN5+yshjoVvzt0ErS1Hk=",
+   "pom": "sha256-7lYZBmzLB5zDMy4kcnQ1n9dQXeLVQPuRtyd5ICW2Siw="
+  },
+  "org/jetbrains/kotlin#kotlin-sam-with-receiver/2.0.21/gradle85": {
+   "jar": "sha256-HSNuNiIzuaJx5QsiOlDI2+rdA1C2OiRkYIJWhS2jaKM="
+  },
+  "org/jetbrains/kotlin#kotlin-serialization/2.2.20": {
+   "module": "sha256-iuU6MFsYxCBiyzt+qNRd0AvKEmDZfJZIr1SlaHnhz9g=",
+   "pom": "sha256-pP7tPG9RvldyFRaRsNKW4AyPESX3s3jg8TvQ43Te81k="
+  },
+  "org/jetbrains/kotlin#kotlin-serialization/2.2.20/gradle813": {
+   "jar": "sha256-dBE+hnGOJqOlpa8177uXaa2lBcVarELp14xoYEC3vUY="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk7/1.9.25": {
+   "jar": "sha256-+1Nz3XYbTpPj9TjF6FO7o4pxFDoYFTbo8ZPtbk7ds7g=",
+   "pom": "sha256-ckCZBrgP9PZNYa6k78tXnSAVKEJm36nXnL2R56IzPzU="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk8/1.7.22": {
+   "pom": "sha256-6vPC0+N6UU9C60yVVhpGVpFaJldJeWr53K4ox8pgQ1g="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk8/1.9.25": {
+   "jar": "sha256-+U/feDkM6b4wODvwOcWpNcrqM7EfA3/H+Gu87hkoflo=",
+   "pom": "sha256-iFJunaBb6fYOQo2CJojL5PW7mpJAxaz5W7fHJH4F0lc="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib/2.0.21": {
+   "jar": "sha256-8xzFPxBafkjAk2g7vVQ3Vh0SM5IFE3dLRwgFZBvtvAk=",
+   "module": "sha256-gf1tGBASSH7jJG7/TiustktYxG5bWqcpcaTd8b0VQe0=",
+   "pom": "sha256-/LraTNLp85ZYKTVw72E3UjMdtp/R2tHKuqYFSEA+F9o="
+  },
+  "org/jetbrains/kotlin#kotlin-tooling-core/2.0.21": {
+   "jar": "sha256-W28UhUj+ngdN9R9CJTREM78DdaxbOf/NPXvX1/YC1ik=",
+   "pom": "sha256-MiVe/o/PESl703OozHf4sYXXOYTpGxieeRZlKb36XVo="
+  },
+  "org/jetbrains/kotlin#kotlin-tooling-core/2.2.20": {
+   "jar": "sha256-dAFOxPPveM59p+Pmlk8sUmoxIdXFj++MopeeXzRFgvQ=",
+   "pom": "sha256-jvep2QYs59w/xlVxXdAoqZRLeElhPgEYR8XWs7mSgXE="
+  },
+  "org/jetbrains/kotlin#kotlin-util-io/2.0.21": {
+   "jar": "sha256-Dv7kwg8+f5ErMceWxOR/nRTqaIA+x+1OXU8kJY46ph4=",
+   "pom": "sha256-4gD5F2fbCFJsjZSt3OB7kPNCVBSwTs/XzPjkHJ8QmKA="
+  },
+  "org/jetbrains/kotlin#kotlin-util-io/2.2.20": {
+   "jar": "sha256-1DGva+puLcmInE/iawc84VfxEchgj+laGL/gi4F8/3Q=",
+   "pom": "sha256-xqXQGEjNBAz8j3uuYjLXktcFwpOi2nJmrmJszbNdagM="
+  },
+  "org/jetbrains/kotlin#kotlin-util-klib/2.0.21": {
+   "jar": "sha256-oTtziWVUtI5L702KRjDqfpQBSaxMrcysBpFGORRlSeo=",
+   "pom": "sha256-724nWZiUO5b1imSWQIUyDxAxdNYJ7GakqUnmASPHmPU="
+  },
+  "org/jetbrains/kotlin/plugin/serialization#org.jetbrains.kotlin.plugin.serialization.gradle.plugin/2.2.20": {
+   "pom": "sha256-gKoyphE31QXES7HhNdkolZOm+UTOyAg6tZXAcd66xdg="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.6.4": {
+   "pom": "sha256-qyYUhV+6ZqqKQlFNvj1aiEMV/+HtY/WTLnEKgAYkXOE="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core-jvm/1.6.4": {
+   "jar": "sha256-wkyLsnuzIMSpOHFQGn5eDGFgdjiQexl672dVE9TIIL4=",
+   "module": "sha256-DZTIpBSD58Jwfr1pPhsTV6hBUpmM6FVQ67xUykMho6c=",
+   "pom": "sha256-Cdlg+FkikDwuUuEmsX6fpQILQlxGnsYZRLPAGDVUciQ="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-bom/1.9.0": {
+   "pom": "sha256-bX/zZcDvHNN2+1SxoWyAoh7Vj+tGwz80ULbPIuKxNT0="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-core-jvm/1.9.0": {
+   "jar": "sha256-Hwr6FyEQ5FpyMe8bRK6P2Eweuv+W8/w61o74xIEgtZw=",
+   "module": "sha256-cMh+MWGSq3cpqmOZIgKQ98jZ/dTZNC3J+cDkKFarNG0=",
+   "pom": "sha256-hxkNQ05icv7WBa8PztFfa8CC2KVQQMUZjm1LLWovysI="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-core/1.9.0": {
+   "module": "sha256-jNEYEwvyIIAgKeI5l0oz0nL00COlYQ9Vfs5rD4mV+J8=",
+   "pom": "sha256-lTt2Dcs2Ooqgz+X5GMPd0SRmh4XZGKw/QAsZGZasrJ0="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json-jvm/1.9.0": {
+   "jar": "sha256-2UzDTK45JGoa90/aY/nEgSzhIhbvZB1fo7u7U5ppItg=",
+   "module": "sha256-u634x2urP82I/ORbO7tj37FIfzgCHhvdg7+5MQ735po=",
+   "pom": "sha256-azQzwqqesmYo26vxbJYzTKqzD24HcQ0Q7n+HkGznMN0="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json/1.9.0": {
+   "module": "sha256-T8E+xBK3uaIToX39qjNkV4Ab4W/BZa2GsLcxT9CW5ww=",
+   "pom": "sha256-mUGX39Wqub9VhVbCFW/eIoK6b8OtR/RmoIznk1zPR2Q="
+  },
+  "org/junit#junit-bom/5.10.0": {
+   "module": "sha256-6z7mEnYIAQaUqJgFbnQH0RcpYAOrpfXbgB30MLmIf88=",
+   "pom": "sha256-4AbdiJT5/Ht1/DK7Ev5e2L5lZn1bRU+Z4uC4xbuNMLM="
+  },
+  "org/junit#junit-bom/5.10.2": {
+   "module": "sha256-3iOxFLPkEZqP5usXvtWjhSgWaYus5nBxV51tkn67CAo=",
+   "pom": "sha256-Fp3ZBKSw9lIM/+ZYzGIpK/6fPBSpifqSEgckzeQ6mWg="
+  },
+  "org/junit#junit-bom/5.11.2": {
+   "module": "sha256-iDoFuJLxGFnzg23nm3IH4kfhQSVYPMuKO+9Ni8D1jyw=",
+   "pom": "sha256-9I6IU4qsFF6zrgNFqevQVbKPMpo13OjR6SgTJcqbDqI="
+  },
+  "org/junit#junit-bom/5.7.1": {
+   "module": "sha256-mFTjiU1kskhSB+AEa8oHs9QtFp54L0+oyc4imnj67gQ=",
+   "pom": "sha256-C5sUo9YhBvr+jGinF7h7h60YaFiZRRt1PAT6QbaFd4Q="
+  },
+  "org/junit#junit-bom/5.9.0": {
+   "module": "sha256-oFTq9QFrWLvN6GZgREp8DdPiyvhNKhrV/Ey1JZecGbk=",
+   "pom": "sha256-2D6H8Wds3kQZHuxc2mkEkjkvJpI7HkmBSMpznf7XUpU="
+  },
+  "org/junit#junit-bom/5.9.1": {
+   "module": "sha256-kCbBZWaQ+hRa117Og2dCEaoSrYkwqRsQfC9c3s4vGxw=",
+   "pom": "sha256-sWPBz8j8H9WLRXoA1YbATEbphtdZBOnKVMA6l9ZbSWw="
+  },
+  "org/junit/platform#junit-platform-commons/1.11.2": {
+   "jar": "sha256-A848YFTAEaJpU6Bl2mpISJ0fvBmV5Mo8bXACk+cbWAA=",
+   "module": "sha256-JDUwwaksy3kIxfplM+srI8HhSb64v/Kx6w3jIbnM35U=",
+   "pom": "sha256-AsIlCWXiPhdtqNtEtxYTPNZcOFIzwdMf7DF9zxZCpKA="
+  },
+  "org/mozilla#rhino/1.7.7.2": {
+   "jar": "sha256-XG2uBQzrcXdKX8gs5uPwOS2vD/qew1lvcNTQfuULiXA=",
+   "pom": "sha256-B2kGiYfBiVPlHUGeBi9AlW8egvOioUD+qITXxeb6lH8="
+  },
+  "org/openapi/generator#org.openapi.generator.gradle.plugin/7.13.0": {
+   "pom": "sha256-A/FfCYCIybz5wyzOeb2sN2tL4zdlukTuWjg6s7zgRJQ="
+  },
+  "org/openapitools#openapi-generator-core/7.13.0": {
+   "jar": "sha256-n7plf8d6mdWi/DZnQYfXKXXQsJCmLxDEqTvTUec008Q=",
+   "pom": "sha256-4A37qQ4rz5A9MAw7jpSHK75kwKJNPEMqpNrSuYwq3RE="
+  },
+  "org/openapitools#openapi-generator-gradle-plugin/7.13.0": {
+   "jar": "sha256-Vn+ccypbRFhcQAz50yVv9FG0faCQzlevjzNYsm8PgNg=",
+   "module": "sha256-St3nf6BZlw1+SV8tYxzEqIXZk7YorYL0YfqfBJWsh8c=",
+   "pom": "sha256-+P6z2p64CQKNPXx8ChxH+zIIln9GfMyjTGxXgfiCzIo="
+  },
+  "org/openapitools#openapi-generator-project/7.13.0": {
+   "pom": "sha256-AeRXMAyBhvpk66o1Tb5dbgDF6BZWQZiBGKetSZC6k4g="
+  },
+  "org/openapitools#openapi-generator/7.13.0": {
+   "jar": "sha256-INRkTgmGKVuSWaYvBl78EhBEXjhgjfBIfkzWRcgpa/M=",
+   "pom": "sha256-ra5VbbSkyJqYT0npzNIhry1IVEAbm29KuFZiSwJPHSg="
+  },
+  "org/projectlombok#lombok/1.18.30": {
+   "jar": "sha256-FBUbR1gtVwtN4WoUfs4729GazkruW946VXjIfbnsuZg=",
+   "pom": "sha256-ZQAfOC9dHORWkjEbsbp8JDyFYZXUkkc9cv+afRzHdpk="
+  },
+  "org/slf4j#slf4j-api/1.7.36": {
+   "pom": "sha256-+wRqnCKUN5KLsRwtJ8i113PriiXmDL0lPZhSEN7cJoQ="
+  },
+  "org/slf4j#slf4j-api/2.0.9": {
+   "jar": "sha256-CBiTDcjX3rtAMgRhFpHaWOSdQsULb/z9zgLa23w8K2w=",
+   "pom": "sha256-nDplT50KoaNLMXjr5TqJx2eS4dgfwelznL6bFhBSM4U="
+  },
+  "org/slf4j#slf4j-bom/2.0.9": {
+   "pom": "sha256-6u9FhIB9gSxqC2z4OdXkf1DHVDJ3GbnOCB4nHRXaYkM="
+  },
+  "org/slf4j#slf4j-ext/1.7.36": {
+   "jar": "sha256-mlXkRTG1xiOgxTqqn0yr2RG7AFx1EqBMXTTlZNv7N6s=",
+   "pom": "sha256-VTdBQZqrqQ3JxJgXs2fFQjihNXzVFXZzDVF2e3fKUzE="
+  },
+  "org/slf4j#slf4j-parent/1.7.36": {
+   "pom": "sha256-uziNN/vN083mTDzt4hg4aTIY3EUfBAQMXfNgp47X6BI="
+  },
+  "org/slf4j#slf4j-parent/2.0.9": {
+   "pom": "sha256-wwfwQkFB8cUArlzw04aOSGbLIZ7V45m2bFoHxh6iH9U="
+  },
+  "org/slf4j#slf4j-simple/1.7.36": {
+   "jar": "sha256-Lzm+2UPWJN+o9BAtBXEoOhCHC2qjbxl6ilBvFHAQwQ8=",
+   "pom": "sha256-xWuAoKa+oqBGPnDQiSrjOKnlB+SGdnpSBFNAmBIFjRs="
+  },
+  "org/sonatype/oss#oss-parent/5": {
+   "pom": "sha256-FnjUEgpYXYpjATGu7ExSTZKDmFg7fqthbufVqH9SDT0="
+  },
+  "org/sonatype/oss#oss-parent/7": {
+   "pom": "sha256-tR+IZ8kranIkmVV/w6H96ne9+e9XRyL+kM5DailVlFQ="
+  },
+  "org/sonatype/oss#oss-parent/9": {
+   "pom": "sha256-+0AmX5glSCEv+C42LllzKyGH7G8NgBgohcFO8fmCgno="
+  },
+  "org/threeten#threetenbp/1.7.0": {
+   "jar": "sha256-hXkX0jGaTpLcHF4663Wg2shERe0xXnrD2Cu40rKYl38=",
+   "pom": "sha256-nLthSu/sbVcp7MrdZMmhnpshg/w6Dgk8APN2rPptC0Q="
+  },
+  "org/yaml#snakeyaml/2.3": {
+   "jar": "sha256-Y6dv5mtlI2C9TCwQfm8CWNqn1LtJIAi6jCb80jD/kUY=",
+   "pom": "sha256-D1omWgYzGwBJ41K+MsoyLeGLF/PU27cGNdQNppLjWC8="
+  }
+ },
+ "https://repo.maven.apache.org/maven2": {
+  "co/touchlab#stately-common-iosarm64/2.0.7": {
+   "module": "sha256-5qCnKD4e9H5SPSivVB9eTcYMq+s4Yu9TN+j5k+U8rLc=",
+   "pom": "sha256-DfO2HWeRr5JLa5FhXHcq2jdN6HzVLefyLYTAQOmN6SE="
+  },
+  "co/touchlab#stately-common-iossimulatorarm64/2.0.7": {
+   "module": "sha256-L9ktxknSTgcQfjDT9qTXYnV9KXZY52kjixgnZeVzCug=",
+   "pom": "sha256-SqPZmvaoPoQOgviYaoEinhTweAiAt8PdduZ1t2bKbdY="
+  },
+  "co/touchlab#stately-common/2.0.7": {
+   "module": "sha256-M0drZlKBmUsWIs33zZ2CBZmrubRJRPIcqdVcExxfRNM=",
+   "pom": "sha256-gRExHQwKq3lLBRdMMnv1FKHDK6CpZAuvWD2SOwtaVzc="
+  },
+  "co/touchlab#stately-concurrency-iosarm64/2.0.6": {
+   "module": "sha256-KzwhmLT5ULvKOEvqX6vykAs3mwNmQn8HWA+53gtofcA=",
+   "pom": "sha256-yijD6cOhb4hBMU1F/a/fiJPHotOdwwZroCo5P9ceHt8="
+  },
+  "co/touchlab#stately-concurrency-iosarm64/2.1.0": {
+   "module": "sha256-pj+ggrL/5E6WHqh7IWlcDx5mnoPKi9udxLD1hHqVO7k=",
+   "pom": "sha256-GOUzK34ACxVKxv1lu6ENLz96ChLThgFl7s++38qxIJU="
+  },
+  "co/touchlab#stately-concurrency-iossimulatorarm64/2.0.6": {
+   "module": "sha256-9+JgR0VXsPBC1GKv9lfEnG9IMr+TDBKionrcQt7OYaU=",
+   "pom": "sha256-BGdIlH9RBM110Ic6x6U654yJEqgs0///DNwENV5zbQA="
+  },
+  "co/touchlab#stately-concurrency-iossimulatorarm64/2.1.0": {
+   "module": "sha256-h6BcPcNmIjApFkgwhk3WKTvcfeRGWuv+La5Xi9jCHaw=",
+   "pom": "sha256-Y3E01OvYCRBpx3ZOhd34qtkJ2AkFgc4ciu5jisVxPN8="
+  },
+  "co/touchlab#stately-concurrency-jvm/2.0.6": {
+   "jar": "sha256-xXzbbhXYgkYbZMLTW+5HStX2u2n292NYsAMbjpdifMU=",
+   "module": "sha256-n0VLzay0uQBBPuzIjvnxynJaJf5WgxZ195hTywqesxc=",
+   "pom": "sha256-Sn16ELtB2tpniuJG9su7Zq+TkEEA4VA+L+ejydzS4Zw="
+  },
+  "co/touchlab#stately-concurrency/2.0.6": {
+   "module": "sha256-IlN5jSsDf4/hgTUWU7fNF1k4fs1pF5rMUNn0B4A/64s=",
+   "pom": "sha256-L5e3PLF1pEI0TLUmCdQ75sPOwnzOpyekuBs49H+kbDg="
+  },
+  "co/touchlab#stately-concurrency/2.1.0": {
+   "module": "sha256-El5bZc1Vi4mhXnZF/6zCbBvMBuQdrw45XdMKcJKo2Xw=",
+   "pom": "sha256-77jL8SXaldDjBfhpMKO0N5Ny3PtcWdnM6ZfN4M0yQVo="
+  },
+  "co/touchlab#stately-concurrent-collections-iosarm64/2.0.6": {
+   "module": "sha256-HXDFiz4RKKmvKcUPTCvtgtp6flt84fJHCb5HzW/KbBU=",
+   "pom": "sha256-lkVRNE6LKSaXYDSkBZkidP1VE0JTFUC03QkGqMluDrk="
+  },
+  "co/touchlab#stately-concurrent-collections-iossimulatorarm64/2.0.6": {
+   "module": "sha256-VrWQTH3g2giG17gK1CtS4ceANOL4M9caVL3+XFP3Has=",
+   "pom": "sha256-idL7Rn8PceojtaKs50lxhG0rP5nwr2JwvHGFQWF6AJg="
+  },
+  "co/touchlab#stately-concurrent-collections-jvm/2.0.6": {
+   "jar": "sha256-eiZz5zS76bg3OXVlw+lvAZM1VrZIpBvy5/LHiM0KJt4=",
+   "module": "sha256-QP8Kqzsjmb7vobUCrAqy1a1wfRcLYqftfLSVu2QQnZk=",
+   "pom": "sha256-CRJBRhJXMyyjdGw4Sy/lj7Q/n/ep6ZjZVEqmddCAdqs="
+  },
+  "co/touchlab#stately-concurrent-collections/2.0.6": {
+   "module": "sha256-/Pqut7oYe99qycvB0HNJiWSbCn/8bfteU5TBcJYfaLI=",
+   "pom": "sha256-sid4YljDlKaO0ntiFyaB+JdOQoJHeTBU0XxAxlDEEfI="
+  },
+  "co/touchlab#stately-strict-iosarm64/2.1.0": {
+   "module": "sha256-8UOjj43DzTJcUh82aMb3UuxN99vKlf/A4kJWhNubHN4=",
+   "pom": "sha256-80CheYAdvDwZ0/xiJNOnySnM+3NmfP2EujE5jtZDafY="
+  },
+  "co/touchlab#stately-strict-iossimulatorarm64/2.1.0": {
+   "module": "sha256-HvYz59tOHPEu88DkMv3YAiaIBbb+M+0PSE1by2jplTw=",
+   "pom": "sha256-VhGaJG2F4fwijbx4TjMj7ld6FdxnVnykeHqKgbMbon4="
+  },
+  "co/touchlab#stately-strict-jvm/2.0.6": {
+   "jar": "sha256-cM/Ua0UA8Z6fF7hakUCrQC9c8S1RAtLVbBNPp2vtpHw=",
+   "module": "sha256-3dQ2UrC12fnIuNPe+e1XZ9OaNKWvQ74o4MQ46Ohsrvk=",
+   "pom": "sha256-poFWwpzfT/g8rvcucNWk0oSDVxYdNwbJnz3OceVgEbQ="
+  },
+  "co/touchlab#stately-strict/2.0.6": {
+   "module": "sha256-TyxtwTMLI7F5yQS56cxGPAip+d0LOXKawSy9I8at6f8=",
+   "pom": "sha256-A9TEJqxQFp4ofkJnI97GkZOI2npXJF605qNVeWsvswE="
+  },
+  "co/touchlab#stately-strict/2.1.0": {
+   "module": "sha256-x5MXricP6pt1sugRZxQjoG+C+ogkTPlG/3lZhbTwtwE=",
+   "pom": "sha256-FsSmQjGZoCtg7Q7PuzyvcImUdcO5ODT9Oyi4Bj6pb0A="
+  },
+  "com/android/tools/build#transform-api/2.0.0-deprecated-use-gradle-api": {
+   "jar": "sha256-6LQVGuFnnxq+ehTuNxrJs8ZRrntjKQ0fWGvdD3j6zpo=",
+   "pom": "sha256-1J0Xn3B9PzoAsqfTYTa1SqjUT6IncHA82C/lL7OeIus="
+  },
+  "com/eygraber#jsonpathkt-core-iosarm64/3.0.2": {
+   "module": "sha256-1WcjrAUmsgizSdj9HDQTVMn/ilK/ARTfu5RdL2bTtTs=",
+   "pom": "sha256-3dsLO48zu0Iz9BJtQfnQbTp1wKStUsQrMCn3KlFkJxI="
+  },
+  "com/eygraber#jsonpathkt-core-iossimulatorarm64/3.0.2": {
+   "module": "sha256-bBGY3NgXW2+LFxQsN153eeY1x3pNJ5DobBX2sSkAcd8=",
+   "pom": "sha256-mHiZweVFiVSR3c3/M7UsLMvpmdeJlucBRMK8MpsdRxU="
+  },
+  "com/eygraber#jsonpathkt-core-jvm/3.0.2": {
+   "jar": "sha256-p5YDAMnGB+mrTGfGsfI1Q31i1XlsAKM8qNLSTEsAlRc=",
+   "module": "sha256-xoNNMOycXFQLQunNVozBdhA1vAac71PlgGanCaCAGps=",
+   "pom": "sha256-xsHLkcRuA4Y0aCpEoOO/k6UEwyigwTuZfh/CS/jWUvo="
+  },
+  "com/eygraber#jsonpathkt-core/3.0.2": {
+   "module": "sha256-t/rlfihk0gBJtP5H37obpKZ7nZs4QnPTdrth+fOzHMA=",
+   "pom": "sha256-nBE2rnSk5zRu3Dw67dLZIjzi4auz/NhLHJu6BSf3Bm4="
+  },
+  "com/eygraber#jsonpathkt-kotlinx-iosarm64/3.0.2": {
+   "module": "sha256-BJlyJ+SfdydNiXUUJ5jphTCC+TYowyrqhwEMTCo8df0=",
+   "pom": "sha256-+JC2nC8QublegKWYOkkD01PuGi5ILVmwLMhR9nrlSlU="
+  },
+  "com/eygraber#jsonpathkt-kotlinx-iossimulatorarm64/3.0.2": {
+   "module": "sha256-vBboQ4Cp3O+8y7R8EViwEqDb9Zz5S9uBtCwZ8oH+6uM=",
+   "pom": "sha256-BJGwMdizVfudG95m3389M1IiU8QJGItuMDT/llihSYU="
+  },
+  "com/eygraber#jsonpathkt-kotlinx-jvm/3.0.2": {
+   "jar": "sha256-tyo9Ns009XB66Jr679syLsRojca6knCx79BXqGJDOSQ=",
+   "module": "sha256-mt9oMtVSnT9dFCYgiR1Dlo9Svl9+b2P/fgyJ2P01Sxk=",
+   "pom": "sha256-DbV9LdB2fAqSwcRZjt7l42eq0WiA1UMPAwWhHpzgvUw="
+  },
+  "com/eygraber#jsonpathkt-kotlinx/3.0.2": {
+   "module": "sha256-D6X/2rSnMu5nKkWKtijyx4sAAAwvI/EE8ovfpUwUuC8=",
+   "pom": "sha256-1Tqg0V7psdzgrm2Vh3UjYYFR2koOK4k8uh5aCdGWSFo="
+  },
+  "com/fasterxml#oss-parent/48": {
+   "pom": "sha256-EbuiLYYxgW4JtiOiAHR0U9ZJGmbqyPXAicc9ordJAU8="
+  },
+  "com/fasterxml#oss-parent/58": {
+   "pom": "sha256-VnDmrBxN3MnUE8+HmXpdou+qTSq+Q5Njr57xAqCgnkA="
+  },
+  "com/fasterxml/jackson#jackson-bom/2.14.1": {
+   "pom": "sha256-eP35nlBQ/EhfQRfauMzL+2+mxoOF6184oJtlU3HUpsw="
+  },
+  "com/fasterxml/jackson#jackson-bom/2.17.2": {
+   "pom": "sha256-H0crC8IATVz0IaxIhxQX+EGJ5481wElxg4f9i0T7nzI="
+  },
+  "com/fasterxml/jackson#jackson-parent/2.14": {
+   "pom": "sha256-CQat2FWuOfkjV9Y/SFiJsI/KTEOl/kM1ItdTROB1exk="
+  },
+  "com/fasterxml/jackson#jackson-parent/2.17": {
+   "pom": "sha256-rubeSpcoOwQOQ/Ta1XXnt0eWzZhNiSdvfsdWc4DIop0="
+  },
+  "com/fleeksoft/charset#charset-iosarm64/0.0.3": {
+   "module": "sha256-AFKpeHZh7i/A1Cn95bOFYvfIsdDgrOlGORAZCBZ0m80=",
+   "pom": "sha256-Va2zlDd8p9Tdhq41BHP39zxzYwirOLTJ8AXugQgmH1g="
+  },
+  "com/fleeksoft/charset#charset-iossimulatorarm64/0.0.3": {
+   "module": "sha256-75icyU0D0KsG1aVR5BGZeo1Bl/IyFNzjKxxQA5W33IU=",
+   "pom": "sha256-8A2t2c6YIaFVRKsCKNHOzSU7LLWmecjH72m7YbOkBAs="
+  },
+  "com/fleeksoft/charset#charset/0.0.3": {
+   "module": "sha256-mvrZ9PNuPMHx0aPH26nA/4uRbCLWH4OqAwFI5XQ+2AY=",
+   "pom": "sha256-uy42VOqDvBkwsP+XVz+8V1UCWhLSgFJBiutEvhb+zsI="
+  },
+  "com/fleeksoft/io#io-core-iosarm64/0.0.3": {
+   "module": "sha256-EvzWtvok/L1aFV+mbbBgzcnoAuNxr1f6wTDfNgcFNDw=",
+   "pom": "sha256-I5v7kyYEpmvtJtpY9Pwb/Y1MW17dao82e/oob28TfBA="
+  },
+  "com/fleeksoft/io#io-core-iossimulatorarm64/0.0.3": {
+   "module": "sha256-pKVjoN5NnwwUgiMij3voBEbt4iLUyI1W0kpyHQ1eomc=",
+   "pom": "sha256-ielNzT0rxbZXzGY6+YOAhQkcMqQgIYo2AVq5rFk79u0="
+  },
+  "com/fleeksoft/io#io-core/0.0.3": {
+   "module": "sha256-ee8rmNdnJ91ToIcZE7+toVfobvqxDpgvfG6ykmqS/Aw=",
+   "pom": "sha256-h4lPrv2is1ankrsoozIwb/RMk6Jxr7gFfkrDfKbfMmo="
+  },
+  "com/fleeksoft/io#io-iosarm64/0.0.3": {
+   "module": "sha256-BrjLMRhntElHx6MaIQXdhYTLUdFN5jAmsp3PXmsKq8k=",
+   "pom": "sha256-TjQjaKprfL3ogpMGyFl283rjhCoAA+NX8c/VPdlAtm8="
+  },
+  "com/fleeksoft/io#io-iossimulatorarm64/0.0.3": {
+   "module": "sha256-VeN5L2soyyJi9cyuIvJbc/iJGxPtZHyDZjBb7UUAZd8=",
+   "pom": "sha256-IqClTqHex7JPs0FXJXsnxoAX5bhnsOhNV39CAMXRIXA="
+  },
+  "com/fleeksoft/io#io/0.0.3": {
+   "module": "sha256-kcQnykI9qTEFUWz6Kd8mRinjrr6ZatyiQ63I0MRL7yI=",
+   "pom": "sha256-SiLvhwX54hciwxxQaVg3dEfIWOJKPB0wOAPqFe+wa4k="
+  },
+  "com/fleeksoft/io#kotlinx-io-iosarm64/0.0.3": {
+   "module": "sha256-JYdk37/xe1miL/j1Jh3w5uneCbFQlbu9sO0oU/H4l7w=",
+   "pom": "sha256-1ZXisl8gyB3Oeu8rPwtoh/z0tOHR9IX6uR9vrYya0R4="
+  },
+  "com/fleeksoft/io#kotlinx-io-iossimulatorarm64/0.0.3": {
+   "module": "sha256-xbmo7pEi0zHmTMci1ajUGROb4QjA3juUmwRJXQCf5Zo=",
+   "pom": "sha256-No5+Mo2itWnITjsN7bKrxKKGg0+GxvEYMb5vCKfLRZo="
+  },
+  "com/fleeksoft/io#kotlinx-io/0.0.3": {
+   "module": "sha256-doWecQJXI7YKXwUbzfzplU8hYXPcXvMq4OMTIIBYeaM=",
+   "pom": "sha256-S0rKzuOAfxaHWDM6wHV6jUE9WZIoa5cdGKPhp+fhKDI="
+  },
+  "com/fleeksoft/ksoup#ksoup-io-iosarm64/0.2.2": {
+   "module": "sha256-8ZWphsUnW5Zy+zOle0DFROWfxMO1oeZt/1RRqT4JoTQ=",
+   "pom": "sha256-QojqoX/+pavmOGHA+Moif1DVahjdlG+B5jPSUeBQjvc="
+  },
+  "com/fleeksoft/ksoup#ksoup-io-iossimulatorarm64/0.2.2": {
+   "module": "sha256-wLV2bvW1oL305ofQQ1yA+g22fE579+NNHwo39FM6xr8=",
+   "pom": "sha256-6wWnq+7oF1w2Hlm3lqtjFbsX/DAvv5HQYmwArkVnEms="
+  },
+  "com/fleeksoft/ksoup#ksoup-io/0.2.2": {
+   "module": "sha256-/LhcCrd7b4dbKG/WFoOn+P7+iuVJmu6A40ECMqz2DTQ=",
+   "pom": "sha256-yxWMdgSq/M2k8GxD7Caur+7fGFx6/zi+CTLORa7KxhE="
+  },
+  "com/fleeksoft/ksoup#ksoup-iosarm64/0.2.2": {
+   "module": "sha256-j06zv0nesejwq8pUcYbud8+K6zZlGR3ousT14j3jvsg=",
+   "pom": "sha256-wNqrOQj4uKwDMZgHg2W3LLZCT3iUtxRp35pPTrH9gmA="
+  },
+  "com/fleeksoft/ksoup#ksoup-iossimulatorarm64/0.2.2": {
+   "module": "sha256-TakOq2ZdZHzpcYPgZTaXL39SK0/z2j95K2+3JNTDM+U=",
+   "pom": "sha256-gG410Jac+mWrLgcfO2kJfcMcpj1SusrywJP0xHQirVM="
+  },
+  "com/fleeksoft/ksoup#ksoup-kotlinx-iosarm64/0.2.2": {
+   "module": "sha256-RZp8MzHrEp9dgVLtPwCo/XzPETH84mPIEQuJW4nkumc=",
+   "pom": "sha256-GdId+MUnUOH9AXmxpF6xwgvrQ4Rt4XyXdG+gA48H3a4="
+  },
+  "com/fleeksoft/ksoup#ksoup-kotlinx-iossimulatorarm64/0.2.2": {
+   "module": "sha256-uppz6b4i91z+/8e6ZugEmheIhoLvDj6q0y1vzz7yqiE=",
+   "pom": "sha256-/RNfKCMAeZn2veL9AsA1x6yPtTNt9d3XHDZ+KRrVlmQ="
+  },
+  "com/fleeksoft/ksoup#ksoup-kotlinx/0.2.2": {
+   "module": "sha256-vitEKsGC3sfWZLHY7+xG5PGXH+UXfItEBvwHgJIyyHo=",
+   "pom": "sha256-S1QsZzL6aaDyyzhZQ2Wl3Y4KDSNjFrwGu8mXjVE5Z+I="
+  },
+  "com/fleeksoft/ksoup#ksoup/0.2.2": {
+   "module": "sha256-UH8J2pS9ifebN5qtQ9PF428MLaZLN0IHRQtjPsawIBs=",
+   "pom": "sha256-b6CmVxV8pxCKt9Qx4R5sKcaqPvfEm/Zm3nVLcKx1Jsw="
+  },
+  "com/github/ajalt/colormath#colormath-iosarm64/3.6.1": {
+   "module": "sha256-pQJZVbn6j3XfpkWYr7iFkuZ9sl7KraZ6pWjorMAEYXA=",
+   "pom": "sha256-eX7fpZ283lV8vr98bkEd+XUEFGABrvmzKwiM3tH8Vwo="
+  },
+  "com/github/ajalt/colormath#colormath-iossimulatorarm64/3.6.1": {
+   "module": "sha256-oeVRSO+AaSRi+cI7Ehm0uWEZQkeVljAvR8UMILy1U3Y=",
+   "pom": "sha256-byAODgwRsVw3FfUr69hJVCc/dC+R2FkjoF0QsuINmtc="
+  },
+  "com/github/ajalt/colormath#colormath-jvm/3.6.1": {
+   "jar": "sha256-oYU+5KX+xjbbu4xElVt6MBXwLOj5z6HCNQeRwsLTY5w=",
+   "module": "sha256-fHKvGnzj4EFMhBqBgWvDwVpy6X9lKMwHqp+lSFCHpYc=",
+   "pom": "sha256-PeaemJMjZ5OF480HME/v08BfRFa7MsoyJ8s7y/RNHAo="
+  },
+  "com/github/ajalt/colormath#colormath/3.6.1": {
+   "module": "sha256-xA0F1dTNksc2qxDVkR6HjjsIqBRa76mjy20/VUPM8Bc=",
+   "pom": "sha256-uBYdwuDrGNPXm8koHtFxA3IcwcEvFYo1QydbqSlw/jg="
+  },
+  "com/github/hypfvieh#dbus-java-core/5.1.1": {
+   "jar": "sha256-fSBud79i3+AOwgR2bsnMP1d8Q7V5DV8G4y0z+DSQtA4=",
+   "pom": "sha256-Mc5TzmTFMUe9rMPnCbwf4V42DaWHMfGGmX1OuR+qMGQ="
+  },
+  "com/github/hypfvieh#dbus-java-parent/5.1.1": {
+   "pom": "sha256-55zzxdrw2w3FxWI5KEueLCSGtu5TVHIGcvXVKjXrqWw="
+  },
+  "com/github/hypfvieh#dbus-java-transport-native-unixsocket/5.1.1": {
+   "jar": "sha256-ke5p53OpJ9EQPGV/a8iKGF5mLrjA8bLwpuvPLhhhV7U=",
+   "pom": "sha256-SDR+djhSNOBsN1gDuqBQPL9Fkzlk/8KleG1xRAX8LNY="
+  },
+  "com/github/oshi#oshi-core/5.8.6": {
+   "jar": "sha256-avZFtrMZxaH+alrAPB+0seypajtifK6JU1L5ibcgkBc=",
+   "pom": "sha256-iNcNOxnby2YuXDxFceX8mavCZldu+Cv6u7RGkm9MISo="
+  },
+  "com/github/oshi#oshi-parent/5.8.6": {
+   "pom": "sha256-Fe+B2OTv+TYQPJ+HYGMM7LNXs5OGTFuvnKWHQTOzkMc="
+  },
+  "com/github/seancfoley#ipaddress/5.5.1": {
+   "jar": "sha256-XqReV9sMLWJBkqUEbO6kGwrK95t2ilShTIZ5G7ZFknA=",
+   "pom": "sha256-SgNmB8ql/IEESw4z3aBYEuXIwwk8rZwtAYkF+up2Klo="
+  },
+  "com/github/tony19#logback-android/3.0.0": {
+   "pom": "sha256-QTw1l/E7c6p3GRjSlXeh7vfC1BNqyn5U5of8ygvdx9M="
+  },
+  "com/github/zafarkhaja#java-semver/0.10.2": {
+   "jar": "sha256-qOMuF1ddAYjB8+Lle7ldsJeTiDyIU/3oKLY+yx+Zpjo=",
+   "pom": "sha256-fwBf8/kA6GlV9aU0tamqjqVLtdYLtgrCN1lVCjZnaDU="
+  },
+  "com/google/android#annotations/4.1.1.4": {
+   "jar": "sha256-unNOHoTAnWFa9qCdMwNLTwRC+Hct7BIO+zdthqVlrhU=",
+   "pom": "sha256-5LtUdTw2onoOXXAVSlA0/t2P6sQoIpUDS/1IPWx6rng="
+  },
+  "com/google/api/grpc#proto-google-common-protos/2.17.0": {
+   "jar": "sha256-TvH+DDJ/wVIdHXU7CxxKh1pUvRTr3tOv/wyjlTILbqk=",
+   "pom": "sha256-PwKBU6WFxZ9Viz5Dp8mAmmAai7XpEGHWxlj/+iTLjiY="
+  },
+  "com/google/auto#auto-common/1.2.1": {
+   "jar": "sha256-9D8p/ipuuvBLJZjN7sMqTjRtSalATpkPX8GcGfOijQ4=",
+   "pom": "sha256-E7S1AGKUn4sTQ5J8WBU207sFG4r+pQmqb5AvTeKLwbI="
+  },
+  "com/google/auto#auto-parent/6": {
+   "pom": "sha256-BfdAxmSBZdsAz2GN1WwgDEcl41jm1U9YU+C+wVc06go="
+  },
+  "com/google/auto#auto-parent/7": {
+   "pom": "sha256-pGQm/MtdMnBa2cu8mW94a9BIzIy90h2wRlABafFaQ1Y="
+  },
+  "com/google/auto/value#auto-value-annotations/1.6.2": {
+   "jar": "sha256-tIsE3bpA6KwzvwNvBvxDmV/FCEvZS9qs6AfOJ9O+o/s=",
+   "pom": "sha256-HHbNRi/JbnqpbccM6C8NVAY9bfFts1ycfZzA0amdP/8="
+  },
+  "com/google/auto/value#auto-value-annotations/1.6.3": {
+   "jar": "sha256-DpUf7owx9gJwvEZVOoWGABt7k9uxKuwGNzqpmhUDksA=",
+   "pom": "sha256-4fx4D37gJeZis9pycj2+KsjawKL4kg8mUxXE4b49dlw="
+  },
+  "com/google/auto/value#auto-value-parent/1.6.2": {
+   "pom": "sha256-J7ZAyCF59c/2IAnAtyAz2bxg9g6ZAqZoAidLf+N/yBw="
+  },
+  "com/google/auto/value#auto-value-parent/1.6.3": {
+   "pom": "sha256-5Z31cytMs01XJxgURvne2c5EJRMaChBiUZ7qGW3k2KE="
+  },
+  "com/google/code/findbugs#jsr305/3.0.2": {
+   "jar": "sha256-dmrSoHg/JoeWLIrXTO7MOKKLn3Ki0IXuQ4t4E+ko0Mc=",
+   "pom": "sha256-GYidvfGyVLJgGl7mRbgUepdGRIgil2hMeYr+XWPXjf4="
+  },
+  "com/google/code/gson#gson-parent/2.10.1": {
+   "pom": "sha256-QkjgiCQmxhUYI4XWCGw+8yYudplXGJ4pMGKAuFSCuDM="
+  },
+  "com/google/code/gson#gson-parent/2.11.0": {
+   "pom": "sha256-issfO3Km8CaRasBzW62aqwKT1Sftt7NlMn3vE6k2e3o="
+  },
+  "com/google/code/gson#gson/2.10.1": {
+   "pom": "sha256-0rEVY09cCF20ucn/wmWOieIx/b++IkISGhzZXU2Ujdc="
+  },
+  "com/google/code/gson#gson/2.11.0": {
+   "jar": "sha256-V5KNblpu3rKr03cKj5W6RNzkXzsjt6ncKzCcWBVSp4s=",
+   "pom": "sha256-wOVHvqmYiI5uJcWIapDnYicryItSdTQ90sBd7Wyi42A="
+  },
+  "com/google/crypto/tink#tink/1.7.0": {
+   "jar": "sha256-iJcKRWoIukxmsBsj5YRsoQlcwU5Uy0g2Pl0uFaEwcwg=",
+   "pom": "sha256-Ku41I3FfjyzRCyYDyNGeVhrHWDELfiyYU5RtLF57S/c="
+  },
+  "com/google/dagger#dagger/2.28.3": {
+   "jar": "sha256-8d0j+K40qOkTZnI5kerQ1kmdGj6RY85VDCALAtdqhys=",
+   "pom": "sha256-JlupWajhPDoGEz8EtTkWnBAY2v/U0z9TxFOrTLOG9XA="
+  },
+  "com/google/devtools/ksp#symbol-processing-aa-embeddable/2.2.20-2.0.3": {
+   "jar": "sha256-6AfnwvNOxvROUvITmDbxigvmbAi9d6uWavjCjYe+zm8=",
+   "pom": "sha256-t4VqOFMKoWp8MdtM56q8QG+40hbCT84PtfFuM4VRH/A="
+  },
+  "com/google/devtools/ksp#symbol-processing-api/2.0.10-1.0.24": {
+   "jar": "sha256-3X3eBwvlTeZse91N4ExD+0KeDGK7EypkSM+jNlOvsik=",
+   "module": "sha256-v8OiFHE2oHw5IP2mGeugc8uTgcVlf++xYc/ViZSPmVI=",
+   "pom": "sha256-RSj+eY/v7sCVpz6GHBIG+oJUlqDntlInL0D/yWCBTmI="
+  },
+  "com/google/devtools/ksp#symbol-processing-api/2.2.20-2.0.3": {
+   "jar": "sha256-ogZEVp7MAUZ9Pv5Pi5eHqHGc4n7RK2o0da4dgr+xag4=",
+   "module": "sha256-HVGBrIyxsW2CXjLznfHy74WtGZVjXqrzU5sy3gVuXY8=",
+   "pom": "sha256-AoGBVPu0W8crSiPLJCqgFlpIMk1rjsQ8srl8itLm3rA="
+  },
+  "com/google/devtools/ksp#symbol-processing-common-deps/2.2.20-2.0.3": {
+   "jar": "sha256-YY22G1qnU4OO+G5ybnPzWb6MKbbNRn42hxvBfqhnNdA=",
+   "module": "sha256-81zPz69PmruVgozq6rg+c50dlnwvONNiAARI+yBNEYQ=",
+   "pom": "sha256-VkkIx9TbM8y8QObiWMTLpcDe1YbAATIx/0QBezxkqVI="
+  },
+  "com/google/devtools/ksp#symbol-processing/2.2.20-2.0.3": {
+   "jar": "sha256-YcY7pC0tTFlVra5jbN5WJEtFggGZ0BuggGsOjA5E/uM=",
+   "pom": "sha256-SRuZDkca3usjugR3F7Wmrf1oQmpk7SvWpNKEWprNKbg="
+  },
+  "com/google/errorprone#error_prone_annotations/2.11.0": {
+   "pom": "sha256-AmHKAfLS6awq4uznXULFYyOzhfspS2vJQ/Yu9Okt3wg="
+  },
+  "com/google/errorprone#error_prone_annotations/2.26.1": {
+   "jar": "sha256-3iXy2aIVZSm9dl9R2O/fwN+nMB4E77nMdbfxDPXQ4Ps=",
+   "pom": "sha256-rqfpkeLf3LR/X71QhYdTX3gCvLni/C1Ou1C+QbaE2p8="
+  },
+  "com/google/errorprone#error_prone_annotations/2.27.0": {
+   "jar": "sha256-JMkjNyxY410LnxagKJKbua7cd1IYZ8J08r0HNd9bofU=",
+   "pom": "sha256-TKWjXWEjXhZUmsNG0eNFUc3w/ifoSqV+A8vrJV6k5do="
+  },
+  "com/google/errorprone#error_prone_annotations/2.28.0": {
+   "jar": "sha256-8/yKOgpAIHBqNzsA5/V8JRLdJtH4PSjH04do+GgrIx4=",
+   "pom": "sha256-DOkJ8TpWgUhHbl7iAPOA+Yx1ugiXGq8V2ylet3WY7zo="
+  },
+  "com/google/errorprone#error_prone_annotations/2.3.1": {
+   "pom": "sha256-PtzmtxG6No7+Frm3qssCFPvWSEFMublllTouftiagZo="
+  },
+  "com/google/errorprone#error_prone_annotations/2.3.3": {
+   "pom": "sha256-v9aSVaDAETr+5NoBNruAsSaMuw1h3wBp2NIrO+8laNU="
+  },
+  "com/google/errorprone#error_prone_parent/2.11.0": {
+   "pom": "sha256-goPwy0TGJKedMwtv2AuLinFaaLNoXJqVHD3oN9RUBVE="
+  },
+  "com/google/errorprone#error_prone_parent/2.26.1": {
+   "pom": "sha256-SmrQDTGwpa3Nmk9gUGXVtEX65KBMv4J+XRrBB34vgU0="
+  },
+  "com/google/errorprone#error_prone_parent/2.27.0": {
+   "pom": "sha256-+oGCnQSVWd9pJ/nJpv1rvQn4tQ5tRzaucsgwC2w9dlQ="
+  },
+  "com/google/errorprone#error_prone_parent/2.28.0": {
+   "pom": "sha256-rM79u1QWzvX80t3DfbTx/LNKIZPMGlXf5ZcKExs+doM="
+  },
+  "com/google/errorprone#error_prone_parent/2.3.1": {
+   "pom": "sha256-dnUl2agRKc0IGWg4KYAzYye+QWKx4iUaGCkR2qczwSM="
+  },
+  "com/google/errorprone#error_prone_parent/2.3.3": {
+   "pom": "sha256-awWm9S4rZbTvzjy7pTNbCBsdykuX3mkCNM1TZHmkDzI="
+  },
+  "com/google/flatbuffers#flatbuffers-java/1.12.0": {
+   "jar": "sha256-P4wIi03QSphYch8uFiUIyU2w3Yb5YeMG7mPvLtqHG/c=",
+   "pom": "sha256-yyJrr1RiYHcPIegVKmqoi6FSMNc591DfSA8qZo1D4Os="
+  },
+  "com/google/guava#failureaccess/1.0.1": {
+   "jar": "sha256-oXHuTHNN0tqDfksWvp30Zhr6typBra8x64Tf2vk2yiY=",
+   "pom": "sha256-6WBCznj+y6DaK+lkUilHyHtAopG1/TzWcqQ0kkEDxLk="
+  },
+  "com/google/guava#failureaccess/1.0.2": {
+   "jar": "sha256-io+Bz5s1nj9t+mkaHndphcBh7y8iPJssgHU+G0WOgGQ=",
+   "pom": "sha256-GevG9L207bs9B7bumU+Ea1TvKVWCqbVjRxn/qfMdA7I="
+  },
+  "com/google/guava#guava-parent/26.0-android": {
+   "pom": "sha256-+GmKtGypls6InBr8jKTyXrisawNNyJjUWDdCNgAWzAQ="
+  },
+  "com/google/guava#guava-parent/28.1-android": {
+   "pom": "sha256-+K/LQ/0kw7YibkCL25zsVpFzcVpMLIAXPMrt2E4VGJE="
+  },
+  "com/google/guava#guava-parent/31.1-android": {
+   "pom": "sha256-chYh8BUxLnop8NtXDQi7NjJ/vUpTo+6T3zIUNjzlOXE="
+  },
+  "com/google/guava#guava-parent/32.0.1-jre": {
+   "pom": "sha256-Q+0ONrNT9B5et1zXVmZ8ni35fO8G6xYGaWcVih0DTSo="
+  },
+  "com/google/guava#guava-parent/33.2.1-android": {
+   "pom": "sha256-WvKHot63QfOMJKCzkKejiPruXXzw7cTHt7mFWaXyn78="
+  },
+  "com/google/guava#guava-parent/33.2.1-jre": {
+   "pom": "sha256-kJX22O43ZZUCB1EHhYMMwigOeBBnkV+pnP4XQNSGXBQ="
+  },
+  "com/google/guava#guava-parent/33.3.1-android": {
+   "pom": "sha256-bhGYbqclC1H4RxV+Lck38yowaATfzgAHpegd25uVxXk="
+  },
+  "com/google/guava#guava/28.1-android": {
+   "pom": "sha256-AZa+urqiZWDxCO6xBNYph62L6mB9mxPto/Aoa3ZdbqY="
+  },
+  "com/google/guava#guava/31.1-android": {
+   "pom": "sha256-ZikplWROlVN+6XqJ6JkBcdjzwmrPmEgwp3kZlwc9RR0="
+  },
+  "com/google/guava#guava/32.0.1-jre": {
+   "jar": "sha256-vX+iJ1kfuFCWd9DREiz5UVjzuKn0VlP1goHYefbcSMU=",
+   "pom": "sha256-QsJX9/c203ezGv7u6XirJtcwzXCvYN3nZi4YI1LiSCo="
+  },
+  "com/google/guava#guava/33.2.1-android": {
+   "module": "sha256-LWonjbAyw+pgOvz1mEVo0rZVZgwnvO0jL6TCxp7UULs=",
+   "pom": "sha256-Ay5RBGgjJbBC8SFALYp8EbnT/v3ykgrEg1NqgDGtw2s="
+  },
+  "com/google/guava#guava/33.2.1-jre": {
+   "jar": "sha256-RSstl4e302b6jPXtmhxAQEVC0F7/p6WY2gO7u7dtnzE=",
+   "module": "sha256-0j7aahwsC9JfijNGzd7sQ7Ufdb+Bm5MeqpgybqZEdCI=",
+   "pom": "sha256-QoF73BwMjHN9a0Ec+vSoR2nn0nHoebAW/QhQJIoG2rU="
+  },
+  "com/google/guava#guava/33.3.1-android": {
+   "module": "sha256-aXFhTd7uAD5U0racawyUzopbXrqYDRZFXIHfkImnrLc=",
+   "pom": "sha256-xyjbbycFyj6mo88s8SYNvv86RSQkmhsbkA7c/p1yFC8="
+  },
+  "com/google/guava#listenablefuture/1.0": {
+   "pom": "sha256-U4c8rya8HtilZ+psk5qyqqP0el4y1creld31CA0jI4o="
+  },
+  "com/google/guava#listenablefuture/9999.0-empty-to-avoid-conflict-with-guava": {
+   "jar": "sha256-s3KgN9QjCqV/vv/e8w/WEj+cDC24XQrO0AyRuXTzP5k=",
+   "pom": "sha256-GNSx2yYVPU5VB5zh92ux/gXNuGLvmVSojLzE/zi4Z5s="
+  },
+  "com/google/j2objc#j2objc-annotations/1.3": {
+   "pom": "sha256-X6yoJLoRW+5FhzAzff2y/OpGui/XdNQwTtvzD6aj8FU="
+  },
+  "com/google/j2objc#j2objc-annotations/2.8": {
+   "jar": "sha256-8CqV+hpele2z7YWf0Pt99wnRIaNSkO/4t03OKrf01u0=",
+   "pom": "sha256-N/h3mLGDhRE8kYv6nhJ2/lBzXvj6hJtYAMUZ1U2/Efg="
+  },
+  "com/google/j2objc#j2objc-annotations/3.0.0": {
+   "pom": "sha256-I7PQOeForYndEUaY5t1744P0osV3uId9gsc6ZRXnShc="
+  },
+  "com/google/jimfs#jimfs-parent/1.1": {
+   "pom": "sha256-xxVVdR5X4O+RKHDorJYlrnglAqalucGcz4OyqX2LJr0="
+  },
+  "com/google/jimfs#jimfs/1.1": {
+   "jar": "sha256-xIKOKNfAqTCvk4dRCzutp9qlwE18Jadce4sIHxwlfd0=",
+   "pom": "sha256-76huXNki8XtHL9/K5XI02NSsPhSLYlBzffzkVK96ekQ="
+  },
+  "com/google/protobuf#protobuf-bom/3.22.3": {
+   "pom": "sha256-E6Mt+53m/Bw8P3r1Pk1cd/130rR2uuOLdLdYHN7i5lU="
+  },
+  "com/google/protobuf#protobuf-bom/3.24.4": {
+   "pom": "sha256-BOz9UsUN8Hp1VR+bCeDvMGMO5CN9CRyg7KceW/t4zOU="
+  },
+  "com/google/protobuf#protobuf-bom/3.25.3": {
+   "pom": "sha256-tG4/Jv4PRz/zMHfuEkX4jUuNs1zHn1VM0P2Td2akXlg="
+  },
+  "com/google/protobuf#protobuf-java-util/3.22.3": {
+   "jar": "sha256-xhX3aHncXDA+TfW5Smr6OVNAWMdUXbLUg/2V2fY8i/4=",
+   "pom": "sha256-tEcBsGoGSGXsm1YUqT6eKPrdfU38S0YPIcgZ71Pb4tY="
+  },
+  "com/google/protobuf#protobuf-java/3.22.3": {
+   "pom": "sha256-GG6nlBUPW0Kup+xgQd83PR2KioMWJPWKVd67YEPscxI="
+  },
+  "com/google/protobuf#protobuf-java/3.24.4": {
+   "jar": "sha256-5WVVIr4apcwfLwkqoDawRFFX8pSSju3xMyrJOMe2loY=",
+   "pom": "sha256-OUEiHKZXgZ3evZX+i3QPRwr3q/MEYLE+ocmrefEPq5E="
+  },
+  "com/google/protobuf#protobuf-javalite/3.25.3": {
+   "jar": "sha256-s8wbgCBMSaMXhr2QTHiuVlTUuEkAZc1To7kBnWNQAMk=",
+   "pom": "sha256-A/29VdcVaF3mlc6/NoVCZJfUeOPmO80s6Hp5TUxiqW0="
+  },
+  "com/google/protobuf#protobuf-parent/3.22.3": {
+   "pom": "sha256-OZEz1/b1eTTddsSxjoY0j0JFMhCNr0oByPgguGZfCSk="
+  },
+  "com/google/protobuf#protobuf-parent/3.24.4": {
+   "pom": "sha256-+37AUFh2/bnseVEKztLR6wTDuM/GkLWJBJdXypgcrbM="
+  },
+  "com/google/protobuf#protobuf-parent/3.25.3": {
+   "pom": "sha256-vCdEYIzqOnotTNC3Thw/iBOMZM5aphudfwr9hGiCvno="
+  },
+  "com/google/truth#truth-parent/1.0.1": {
+   "pom": "sha256-HH/IY4Mu2YCOQ9jBdpH/Fn0xPxETTvx1Yf9R0UIZbX4="
+  },
+  "com/google/truth#truth/1.0.1": {
+   "jar": "sha256-HM9DNOepTPAKIKYZtUYrU6zzJ04AtwSYv1soo7wb6bE=",
+   "pom": "sha256-BGhsbq3NYNi3sKTT9Vk4phaHYObiwkETOQNra/BGow8="
+  },
+  "com/googlecode/java-diff-utils#diffutils/1.3.0": {
+   "jar": "sha256-YbpNxJrcqVJDvqoFaa3CojrttSkq54qgEYb6eC69xcI=",
+   "pom": "sha256-L+Md1jCbD18ZW73EdJz8CvBl1h8Gz+GD39LyCSq4R7Y="
+  },
+  "com/googlecode/juniversalchardet#juniversalchardet/1.0.3": {
+   "jar": "sha256-dXv+kGGTuLZR553CbNZ9a1XQdwos37A4FZFQT3edSnY=",
+   "pom": "sha256-eEY5mzXHzWQqmzoADD4tYtBOs3pFR7aTPMixi8wvCGs="
+  },
+  "com/guardsquare#proguard-base/7.7.0": {
+   "jar": "sha256-Qt/52lNIJaXmlHUjWOAre41dqTm+m50H+Zh0SEkubnk=",
+   "module": "sha256-mfDPLg56BcGCyaRwa4WU/Xp60uP7EvIs0ScMyphKspM=",
+   "pom": "sha256-fRxMbEcM4UY59Ls3tn+l+EeffxVn85pETtBHhLS4544="
+  },
+  "com/guardsquare#proguard-core/9.1.10": {
+   "jar": "sha256-5v9XISTgrysj0kM8W3JVfx+QXmgMthl5NCy5Fe6TgZg=",
+   "module": "sha256-ejuRDXtS4yOBDnAaJrxJ/nycq3jxOtW1i43GAeJ84oE=",
+   "pom": "sha256-m3dB6tjNAZt47jNV6D9ECJy56Xt6EhBdXLWMzgTUoM0="
+  },
+  "com/guardsquare#proguard-gradle/7.7.0": {
+   "jar": "sha256-DM48bBo11BqFqyWZXB7PUELuwUibNjwM/cjgvNhebUA=",
+   "module": "sha256-yzzOVMh0LhKMfokR8CU4cnxUtI2QqvxIMPTlyeBMdss=",
+   "pom": "sha256-TFcJ7uYXjL1kpw5T0Lpp55qim7wB+r7hkHQ8v2qkjgM="
+  },
+  "com/intellij#annotations/12.0": {
+   "jar": "sha256-+KsTsUvggP4vYX+Q5VWZdg5KG03u6lxZXfY9DWN17W0=",
+   "pom": "sha256-+vgt4NwC4MCuMnzWU/NyVUlrLlP84oCzq0yzRVOokIY="
+  },
+  "com/materialkolor#material-color-utilities-android/2.0.2": {
+   "module": "sha256-Bog5B76Y2KGGb/ijjkfxhE/D3BpuYl7+aMffxTniHXA=",
+   "pom": "sha256-EXwk2clb5JHEPRdTOFjRF9INfudDoaASfY+NfaB0l9A="
+  },
+  "com/materialkolor#material-color-utilities-iosarm64/2.0.2": {
+   "module": "sha256-RSwe/cvgQt4W7jsQExb0ZqIdJEenZKbt1VaBCRoUGYM=",
+   "pom": "sha256-GvZK0vwp6t5+sk6KhLJoMoycC3bHWzZlIKxsx+/vp38="
+  },
+  "com/materialkolor#material-color-utilities-iossimulatorarm64/2.0.2": {
+   "module": "sha256-z7598sKs2O+wmH6jkvcQsgHAHW4Yy2vzU+Q7cAQm8Pg=",
+   "pom": "sha256-nNPcrYKVg+a8OFAYz26iLdQhd4SSBW0WoXCkKh3XNRE="
+  },
+  "com/materialkolor#material-color-utilities-jvm/2.0.2": {
+   "jar": "sha256-ehw5WMVYOvirrpQhsrFd9NwzwNTdBre8MPt5lVBOUvU=",
+   "module": "sha256-kPEIT/8zQ6SXWgx4tVu3ihklHZ+5xQ2nWxq4I60HxJg=",
+   "pom": "sha256-X2qIr8xO02UgBwGJfn81ofQc+oKhq4UwsJGWw99ll8M="
+  },
+  "com/materialkolor#material-color-utilities/2.0.2": {
+   "module": "sha256-u3ChedRjiAQYquydGdokwnMI1v97Y6njUeODeqAmOgs=",
+   "pom": "sha256-hI1hgNrDQj9o+61ebYVQ5CvhnSEw4ZKpi2kIi3N97FU="
+  },
+  "com/materialkolor#material-kolor-android/2.0.2": {
+   "module": "sha256-RFsrZZlRLygOMHL137YeStZ2qNuluhhusshd1gZpr0M=",
+   "pom": "sha256-73KoUIjwuPp4lhiiKCMbETXvNonqvAkVfdWUv32BRUk="
+  },
+  "com/materialkolor#material-kolor-iosarm64/2.0.2": {
+   "module": "sha256-VSD1OESNh5T5/9o3g4jPlw8eCepTx2N8uF8H9NlUhWU=",
+   "pom": "sha256-N4atDWV5Evw7xzPMcGdMTFeB7xnlW/ffLmtxd1uH/0E="
+  },
+  "com/materialkolor#material-kolor-iossimulatorarm64/2.0.2": {
+   "module": "sha256-1rYP5U57UHcWXCbUl6LznnO1hJE80W8hitjWNyec+Xo=",
+   "pom": "sha256-8ck6ewcBL51uzPpTkUB4QJ4a+aiERyUhnLu6k2YDQhY="
+  },
+  "com/materialkolor#material-kolor-jvm/2.0.2": {
+   "jar": "sha256-3xSWEBi6K+/P5wTLqUXhjWV5e5Cjv3kH2n+LwMEqcdE=",
+   "module": "sha256-FGKbUUptRNpHaUEIPdemeJayYZg5PKtvEuVju3zkDqE=",
+   "pom": "sha256-8/9psHfIIKrR9URczybPUmUfMbcZNvo3t9L6aZOdFls="
+  },
+  "com/materialkolor#material-kolor/2.0.2": {
+   "module": "sha256-2rR3ErARsdPdnh0oVnlcwm1+eqd1cHr8YxFhex6PUEc=",
+   "pom": "sha256-YTrDfhrG8ubIcdEdmZD0G7K8rHytPn1S0RdHHL+SCVA="
+  },
+  "com/squareup#javapoet/1.10.0": {
+   "jar": "sha256-IO9LguQ/98ZSKBohMTzzuUEJJGet0/pzUJwm9pae/as=",
+   "pom": "sha256-FpA0CiIiefLLrfNz6Igm+iD388w+wCUvNoGP7TJwGrE="
+  },
+  "com/squareup#javapoet/1.13.0": {
+   "jar": "sha256-THUX6EinGzbQadErs79Gpw/UzaMQXYIrDtLhnAC2kpE=",
+   "pom": "sha256-VKNPqFAqRryQ79tJJiYAWR+oC/mjT1pMeYMRrsFsqXc="
+  },
+  "com/squareup#javawriter/2.5.0": {
+   "jar": "sha256-/PsJ+w6gqpfTz+fqeSOYCBNI5GjxJrNgPLOAPyQBl/A=",
+   "pom": "sha256-4avX8RFs9eDFmUdpPiGJII7JQpayozlMlZ41EdOZp7A="
+  },
+  "com/squareup#kotlinpoet-javapoet/2.0.0": {
+   "jar": "sha256-KSnzuajXOdCupAvzx70B+tOnzS0PtW8t4kjrubRndKQ=",
+   "module": "sha256-QBrtmARyMg/TvaTMtauCIEcnlJNw8zAadpXcnssIisg=",
+   "pom": "sha256-ru9aexDvKlqGjl1/lLf0WTEHC4yF1v81Djk9UmqovEQ="
+  },
+  "com/squareup#kotlinpoet-jvm/2.0.0": {
+   "jar": "sha256-ZeLV4ceESGHRNGNWknkffbrICK2wYNpzKcGMS9iNKss=",
+   "module": "sha256-00uNSKfU64to5hGiPhK0+HHLmWOkZoOO4IFtiT7DuUA=",
+   "pom": "sha256-T3Q6EXspaaqkvf9zTr1T1gWXbMmOaefwZitFrbH7yu0="
+  },
+  "com/squareup#kotlinpoet/2.0.0": {
+   "module": "sha256-uZBCyTTsx1JotnUEgJJ/8ZC3ljbOPq4ECauWn7xKbXI=",
+   "pom": "sha256-EMM0mmyFlXbluDpkqTnDfOzrvMRpv1wWatpaWQTjXDo="
+  },
+  "com/squareup/okhttp3#okhttp-sse/4.12.0": {
+   "jar": "sha256-v/T7yu96rC2RDU/0ba+qTm0V2hJ99rrJchbaRpQ6fUw=",
+   "module": "sha256-c+RIzK9gfU9gO4tuZmGHKk/6PCZBGTyLvE1r2h5Ww0I=",
+   "pom": "sha256-lKunzO96e5DcolIFhb8LEjNtyO+U1ZGWPu2sV3lnkzw="
+  },
+  "com/squareup/okhttp3#okhttp/4.12.0": {
+   "jar": "sha256-sQUAgbFLt6On5VpNPvAbXc+rxFO0VzpPwBl2cZHV9OA=",
+   "module": "sha256-YH4iD/ghW5Kdgpu/VPMyiU8UWbTXlZea6vy8wc6lTPM=",
+   "pom": "sha256-fHNwQKlBlSLnxQzAJ0FqcP58dinlKyGZNa3mtBGcfTg="
+  },
+  "com/squareup/okio#okio-iosarm64/3.10.2": {
+   "module": "sha256-hBsEZDGOmNJCzsXCh2Txs52apoa5BZtzgaFug/keqlU=",
+   "pom": "sha256-eQJPUBZR/WtNAdO+NeXGWqkFrJstpH28mphxwRQoXAU="
+  },
+  "com/squareup/okio#okio-iosarm64/3.9.1": {
+   "module": "sha256-7q2cu3fMWwEsMmFBqcGubwrmlHLT+nHEVzt/YQnGU4g=",
+   "pom": "sha256-viFhS7FvP+F5pabViWzz2C2T0ju/Ny89GPexqH6S4U8="
+  },
+  "com/squareup/okio#okio-iossimulatorarm64/3.10.2": {
+   "module": "sha256-G3K8xUh2IXZiTRc8o6IhGoY1rCdFBUd+epbBFl/GhCk=",
+   "pom": "sha256-2gOuYAtx+opc8LMk851WBpt4xtu2XqLo1qMgbkTDIXw="
+  },
+  "com/squareup/okio#okio-iossimulatorarm64/3.9.1": {
+   "module": "sha256-xWf9sxKEoY77CImjY3p8baBtFb5PvLsa2G1g7SP5tKc=",
+   "pom": "sha256-h7GUhSTsWUNCED+Atg2SM/xJkOV/Mo3DX6PztqEZCzY="
+  },
+  "com/squareup/okio#okio-jvm/3.10.2": {
+   "jar": "sha256-/Qp+dsZzHwDpILe8EcBdgjqTIEVDGt1Ujgld4CCmnt4=",
+   "module": "sha256-p4CkJMVx4odVASiuADMjVibf/iFsuNs7ICRkmWrZaPA=",
+   "pom": "sha256-AP000Iv0YxNiofVSLKpXyuKMosfpOS76My72Vs/anUM="
+  },
+  "com/squareup/okio#okio-jvm/3.4.0": {
+   "module": "sha256-b+wTzzNhYANkv8xoAEr3x2DOrx/Bu8yVh0KuTWHbFRI=",
+   "pom": "sha256-ZqiFeYHqbD7IuGE6QJvxLxR5Ze+UmMt6jzcXKMTi2k0="
+  },
+  "com/squareup/okio#okio/3.10.2": {
+   "module": "sha256-P94fn79yxsMm1eiktTL0/Z/aLdDLFEK8pODHl9FBI4c=",
+   "pom": "sha256-7lbAIUoPqfER2nExxVDo3ICvDL9WCVbBzNosZtdQa0E="
+  },
+  "com/squareup/okio#okio/3.4.0": {
+   "module": "sha256-aRc2CEF6IRPm+mr+t7RUCyDfcM/aP6Fsc6qk+nAv+tM=",
+   "pom": "sha256-QOr9s+epasxcFR3pzL7BKFDy37XL53Ph90zrU2JVggM="
+  },
+  "com/squareup/okio#okio/3.9.1": {
+   "module": "sha256-m5C0J0pa1gLdV01tS0iQNmOy3ppgufw0AiSCk9hD4SE=",
+   "pom": "sha256-06DDd+epr8zbsCqrXgUNwhL/2pQNvUcOo5cSpDQt8I4="
+  },
+  "com/strumenta#antlr-kotlin-runtime-iosarm64/1.0.2": {
+   "module": "sha256-UWieHcxT1ET3NoNOF/yKjV8M3gS+UmjMJRw7jwqEhes=",
+   "pom": "sha256-4MYT/mDpeoakf8zrTbI8zDKKpx0owIBKaJFMrsPRRuk="
+  },
+  "com/strumenta#antlr-kotlin-runtime-iossimulatorarm64/1.0.2": {
+   "module": "sha256-l4L5AYqg2oGbB7vhIegiA2zM/V/yDpDMTGHimhmUJoc=",
+   "pom": "sha256-Ta+q3Erg/N376+4MrKRzucKnK7PIqg7q0oALxTutTMs="
+  },
+  "com/strumenta#antlr-kotlin-runtime-jvm/1.0.2": {
+   "jar": "sha256-Hy+1MJxqlAq1K0GMHWN055qy79+mqcYbPd16f5VgROQ=",
+   "module": "sha256-ZOXc7bM5dAyT31zG6rPoWuT/Aj/B46AqnkzPtM4cD1Y=",
+   "pom": "sha256-/0wnuIMb7JgQPTarjPSKYzVCP64knOwQKFBEWOeDiBc="
+  },
+  "com/strumenta#antlr-kotlin-runtime/1.0.2": {
+   "module": "sha256-/O5noEMQ823oFiypQt8rH+rqYf+SWEoJ3KXnYLYkGZA=",
+   "pom": "sha256-JRjb+jPn3pMMJ1dBpUTwPo86/BRnCMEGvIxRcKVBIPU="
+  },
+  "com/sun/activation#all/1.2.0": {
+   "pom": "sha256-HYUY46x1MqEE5Pe+d97zfJguUwcjxr2z1ncIzOKwwsQ="
+  },
+  "com/sun/activation#all/1.2.1": {
+   "pom": "sha256-NgiDv2RIbs7xYbjygvZQNTbdGmcNU6Coccj7IBcOZ5U="
+  },
+  "com/sun/activation#javax.activation/1.2.0": {
+   "jar": "sha256-mTMCsWzXBW8h53nMV30XWoELtJAO9zzY+/K1D5KLqc4=",
+   "pom": "sha256-+Hm26UWFTGkAsNvuHIOE16s95+FX/XrISTdAXEFtKl4="
+  },
+  "com/sun/istack#istack-commons-runtime/3.0.8": {
+   "jar": "sha256-T/q7Br5FSgXkOY4gx3+itjCNS4jfvvfKMKdrW31VBe8=",
+   "pom": "sha256-wuAU00y4TtKH0GSYbEXDBaQSQiinM37M9sQh0U1wjxw="
+  },
+  "com/sun/istack#istack-commons/3.0.8": {
+   "pom": "sha256-oPBRfoUS8PvMe4KVwS9lZqPQwthtZVY53GYu+MDH6+U="
+  },
+  "com/sun/xml/bind#jaxb-bom-ext/2.3.2": {
+   "pom": "sha256-Gn3sKyfn4FV0TNuM8bkN70/Uc6zRuATv8JgTk1iVm9c="
+  },
+  "com/sun/xml/bind/mvn#jaxb-parent/2.3.2": {
+   "pom": "sha256-IN1tw0q3VJrEDaHYLpIiLsQ0etDsDLEY72xXA77VOhg="
+  },
+  "com/sun/xml/bind/mvn#jaxb-runtime-parent/2.3.2": {
+   "pom": "sha256-sk+NUfGEpovBuG1IwOPP7+shpE7eHF9zA8WK4EiFM+w="
+  },
+  "com/sun/xml/bind/mvn#jaxb-txw-parent/2.3.2": {
+   "pom": "sha256-tV0++psVj0g6MOkseMy2APkzFHM9CJ66m3RDbwGzFKQ="
+  },
+  "com/sun/xml/fastinfoset#FastInfoset/1.2.16": {
+   "jar": "sha256-BW86HhRECfIe0Wr8JoBfWOmiHz/OFUPELUAHGdJQxRE=",
+   "pom": "sha256-4UfSWKtuZpH3BZmpUkAObmx1WPjJwCjb4b4jF4MI6DA="
+  },
+  "com/sun/xml/fastinfoset#fastinfoset-project/1.2.16": {
+   "pom": "sha256-kFgkJa3B9AtBNi2vuVFzkxIlrKpeeWINXmvVL2Rikro="
+  },
+  "commons-codec#commons-codec/1.11": {
+   "jar": "sha256-5ZnVMY6Xqkj0ITaikn5t+k6Igd/w5sjjEJ3bv/Ude30=",
+   "pom": "sha256-wecUDR3qj981KLwePFRErAtUEpcxH0X5gGwhPsPumhA="
+  },
+  "commons-codec#commons-codec/1.15": {
+   "jar": "sha256-s+n21jp5AQm/DQVmEfvtHPaQVYJt7+uYlKcTadJG7WM=",
+   "pom": "sha256-yG7hmKNaNxVIeGD0Gcv2Qufk2ehxR3eUfb5qTjogq1g="
+  },
+  "commons-io#commons-io/2.16.1": {
+   "jar": "sha256-9B97qs1xaJZEes6XWGIfYsHGsKkdiazuSI2ib8R3yE8=",
+   "pom": "sha256-V3fSkiUceJXASkxXAVaD7Ds1OhJIbJs+cXjpsLPDj/8="
+  },
+  "commons-logging#commons-logging/1.2": {
+   "jar": "sha256-2t3qHqC+D1aXirMAa4rJKDSv7vvZt+TmMW/KV98PpjY=",
+   "pom": "sha256-yRq1qlcNhvb9B8wVjsa8LFAIBAKXLukXn+JBAHOfuyA="
+  },
+  "de/jangassen#jfa/1.2.0": {
+   "jar": "sha256-8cwY8VldRBroOc2hRlwIsefbRrcsHX87NzIK4WQexys=",
+   "pom": "sha256-tNgod+BwsV0dTmdrQV9qVCnw4i3U75gX2F5MWcU7yr8="
+  },
+  "dev/dirs#directories/26": {
+   "jar": "sha256-bRj+Jaowt+CLkIzSEVHY+W4illxkCs13Ua3Zu/5hN9Q=",
+   "pom": "sha256-/I3n/GawcvT21bNv67uZx1DG75JxViX1o9hJlAWpRoI="
+  },
+  "dev/drewhamilton/poko#poko-annotations-iosarm64/0.18.2": {
+   "module": "sha256-swP/qyKtmZMzrw51p/9Y/vvcLDQNYgn7b7+HCThji9o=",
+   "pom": "sha256-NJ6p13jw44yAb0PuL2Vf3thN+fyomLHjEoAUvGiLsFA="
+  },
+  "dev/drewhamilton/poko#poko-annotations-iossimulatorarm64/0.18.2": {
+   "module": "sha256-dJzCY6MD7L0YgTQYqcZuOxM8dEyxZL0CJRsZDin6x6g=",
+   "pom": "sha256-ocoLzGZ4/3pTT0iEtdBHmQp4+3A3qnzhNNfcR1Z4CDg="
+  },
+  "dev/drewhamilton/poko#poko-annotations-jvm/0.18.2": {
+   "jar": "sha256-5U2qgc0DiSljOuxZYGAi4eqjQyo8pnNJS78a5V5CI00=",
+   "module": "sha256-oGDXCDj/aGYX9DElgx0QV7KBCBr0bZlC8MCuOM1ge6c=",
+   "pom": "sha256-BVtbvG8ajpBWbCaYSrVLS4HMmA1QzKilZlIkFmFilN0="
+  },
+  "dev/drewhamilton/poko#poko-annotations/0.18.2": {
+   "module": "sha256-SGjNwVoyGxGrPIxbbqrE092oUghR/NLbI0/Deq7r5M4=",
+   "pom": "sha256-TdmQ/XvDu3R2lhMzoVAl/4Sc7XL5736bCmQankBb5FI="
+  },
+  "dev/gitlive#firebase-analytics-android/2.3.0": {
+   "module": "sha256-L4UjdSpxgQbvcBEi0AfpR/5px4EP1Ew9YCDPzeMpedA=",
+   "pom": "sha256-in7OFTwfYgAD7VJQtBbey2x7cD2LOfa8vs9DFC5lsfE="
+  },
+  "dev/gitlive#firebase-analytics-jvm/2.3.0": {
+   "jar": "sha256-1LIjj78jWq0dryQiaMT23882zG9PNyhtFBnD/vz/atM=",
+   "module": "sha256-n7N1b9ThGWOi5jhkcaIjzsJMp1VnnHVk/WMA9gdBg9I=",
+   "pom": "sha256-p7h9XyaEgiC7XQ+bnGowELjJwjyL38w4jT4t0mdEHTc="
+  },
+  "dev/gitlive#firebase-analytics/2.3.0": {
+   "module": "sha256-Q0nPEy0rkT4dd6Rno34NZqJj145Eci0Sh87GQ+Wjiq4=",
+   "pom": "sha256-iKVwFXgRl8RgM5w7aIB2erqcNj+DaZbxNpxFGTz2SD4="
+  },
+  "dev/gitlive#firebase-app-android/2.3.0": {
+   "module": "sha256-c9If2TaoFgXceqplIP/nI0kYYJ9jwEVMHwcBYd7k37c=",
+   "pom": "sha256-sHVZ5U9dSdrPHQin2iHxnzt6mBq+8qt97jlG4We8JBk="
+  },
+  "dev/gitlive#firebase-app-jvm/2.3.0": {
+   "jar": "sha256-pGAm3rUWr5DH5Br/YyMo/ovqMeuiipptXGeaDLChJBo=",
+   "module": "sha256-bN6RykHzK/8O6SjH0m3wSpYBp3NG5sKl6kGm4485K78=",
+   "pom": "sha256-jtefC293ELb10md1hftTEiIi9YVShr4PfSkdSMk7rM8="
+  },
+  "dev/gitlive#firebase-app/2.3.0": {
+   "module": "sha256-IIdeuiQEdJU29WR+ugHZd+P8O8IK8a3Vlx3cbNUdVx0=",
+   "pom": "sha256-dgfztr53Sc7HQ6wocQR+999Pub5eb2IvWs/upT8L5bo="
+  },
+  "dev/gitlive#firebase-common-jvm/2.3.0": {
+   "jar": "sha256-J3JhNJqcI9a7zGcGwO4fHnVmPgf7r+9quEE03twRYFQ=",
+   "module": "sha256-ZS8CtUvDeHiOOY9DLTxeRCJM0dhnbLZuKNubrvNE4hU=",
+   "pom": "sha256-dWVHt2W7o1y6wksWdwp5wKuhs3HBPGyDZ2nyj2x37dY="
+  },
+  "dev/gitlive#firebase-common/2.3.0": {
+   "module": "sha256-ei028JjShL+Q+PhPWvHdxL3K3ax5ckJUBET2O/GFhs4=",
+   "pom": "sha256-t5GBo0uoUmGF924ey61809G2IrfvjHVKpH6ssdeSeE0="
+  },
+  "dev/gitlive#firebase-java-sdk/0.6.1": {
+   "jar": "sha256-32uVWB5FF1l0mAio9gWG3QGm33qv+u4fCuqcE+FcQBo=",
+   "module": "sha256-ARzl7vEJgNC8nXGvOkM0/LK/RgDKfiJp09o2SBvOvc0=",
+   "pom": "sha256-7G8+REKFaY27rORhVYcZSlZ2MlgwA2wm6XoTH7MHDjY="
+  },
+  "io/coil-kt/coil3#coil-android/3.1.0": {
+   "module": "sha256-A3UBATrisXqlobZ+kqKqa1VOXIOlAzYyKh6EYXEevDw=",
+   "pom": "sha256-Yi0c4/VkzJDqeQtIMgtf+YXKr/E5ptA712FRiGE0L3k="
+  },
+  "io/coil-kt/coil3#coil-compose-core-android/3.1.0": {
+   "module": "sha256-D3fOQBtbVIXLCqxs7IpkXrIbBy56a/WgFHzkpj5xJpY=",
+   "pom": "sha256-8Me5mIfEwcjFuvddcgLX7pHXz+pYFbGWVH+5iA3HqBI="
+  },
+  "io/coil-kt/coil3#coil-compose-core-iosarm64/3.1.0": {
+   "module": "sha256-HQl7iPfeOg40ys9JHJtQqmxKUnbnjwlm5TpHeEU7yXs=",
+   "pom": "sha256-nnAJY6mtZG5ANbub3qyWso7nM8njs0dDYQ8/AkqSu0A="
+  },
+  "io/coil-kt/coil3#coil-compose-core-iossimulatorarm64/3.1.0": {
+   "module": "sha256-rknIA/bINR4UeZKuFKb7OBPfeQrJRXYtV5adHPtKe54=",
+   "pom": "sha256-ox9TfVvqvu9ji6oS/eviLwpmY/1Euk+X4UVo70w0oag="
+  },
+  "io/coil-kt/coil3#coil-compose-core-jvm/3.1.0": {
+   "jar": "sha256-iqHXrh0R+WnozcyP7kK37moDbiH3BWfjw0hu3Z19xZQ=",
+   "module": "sha256-6ucdZ4HM4ykKPjiM2fpZ0mctNIjahwbqiRFkcBrisQ4=",
+   "pom": "sha256-IkVryyLUfV3o4sKdbElAZNznVYtdGfMTBpw1f+r5B20="
+  },
+  "io/coil-kt/coil3#coil-compose-core/3.1.0": {
+   "module": "sha256-LCfu/rg6PgVENUharnPuHLz0w9SGQy0qqzfkxk7xE44=",
+   "pom": "sha256-CmIgsinPftmV0VSvssT3YXFBxcqY3S8LuF60CDDmGkQ="
+  },
+  "io/coil-kt/coil3#coil-core-android/3.1.0": {
+   "module": "sha256-/hM3HNmVEXEk5kqfzqivXbdi/q1bvRgGUzz+ctb6suU=",
+   "pom": "sha256-yUygNs0JNf+IJFMY//ZXGL+nrsZYnxZsKbuAn85IaYI="
+  },
+  "io/coil-kt/coil3#coil-core-iosarm64/3.1.0": {
+   "module": "sha256-pJszJoDxubRMbbr+cxYCFUFpRh/f610Gll6HOd2RTqY=",
+   "pom": "sha256-b0FgYRgKpOMVL2akCTdetbOTUyc94KtM1GZcvzwFkjU="
+  },
+  "io/coil-kt/coil3#coil-core-iossimulatorarm64/3.1.0": {
+   "module": "sha256-JeSppG5d/rR38MGSHpAgfVvHnXxFB8Zx213rjGmZuYY=",
+   "pom": "sha256-LEchQjbmDjFOA9JaxxOPf7GVGPzv5W2BUpyN4DLdo64="
+  },
+  "io/coil-kt/coil3#coil-core-jvm/3.1.0": {
+   "jar": "sha256-bUShEYjFP07qLofrrcaq2QBpEyybAp/Bs1rrCt3tXvc=",
+   "module": "sha256-maObXGZpxFXtE10hgduI0HIYJVehl1oT8DKKEmw8iDk=",
+   "pom": "sha256-dGE3HEWhgeyUR4vPDvALWuaGr8mmlmRUG2wbdmoSteU="
+  },
+  "io/coil-kt/coil3#coil-core/3.1.0": {
+   "module": "sha256-KvywLPZHytam/fsYywCHVoSfevdHpKAemBuIMPSIMKE=",
+   "pom": "sha256-NPm6Yg431Ruux7rY05bTJDzAbe7Kw1pil0/MUGlZCuo="
+  },
+  "io/coil-kt/coil3#coil-network-core-android/3.1.0": {
+   "module": "sha256-4nQKBqY2PPZpxhdo6V6/Ta7JbAh5KBjZtJAJdYS+A+4=",
+   "pom": "sha256-Gs90S5zb11JiFjUGNkYUwZmp4oqApC1GihVBGxwmjWY="
+  },
+  "io/coil-kt/coil3#coil-network-core-iosarm64/3.1.0": {
+   "module": "sha256-Z5YrrN7+Oj1T8gpBsJyzIyGPh4YLKCDEz1oBBrOcK+U=",
+   "pom": "sha256-GwuxoGM2K/Z9i19nw4Oh7FRv8B31JF38+NVVbdXo8fY="
+  },
+  "io/coil-kt/coil3#coil-network-core-iossimulatorarm64/3.1.0": {
+   "module": "sha256-e8ZrNDdOUCLYvmscSyZxcqh1A1IHhvhEZlE1BiYMoU0=",
+   "pom": "sha256-h3Y836Ivk/OnoAVdqiLxSgUDXBShEyUnJpPV62GTZBM="
+  },
+  "io/coil-kt/coil3#coil-network-core-jvm/3.1.0": {
+   "jar": "sha256-gzLkXPeSzSTZgUdE24Sw5tM+xurwckvQfdwfznxVWR8=",
+   "module": "sha256-2GSNiy+ATWSIq79fIIe3XJRs/s5bGO1kCNvAV4Htobw=",
+   "pom": "sha256-3bv13KN1OnzvdpV8dm0JssLUGlImUCEWHMCCouklg0Y="
+  },
+  "io/coil-kt/coil3#coil-network-core/3.1.0": {
+   "module": "sha256-7KfwcYeJQrG/0cIZiwHKX9E+nCev5wEkXDe1OUOGxQY=",
+   "pom": "sha256-2pkj5T1iBNefNQHFuJ9eDIfpEesc/RgO9FuCRFdhuso="
+  },
+  "io/coil-kt/coil3#coil-network-ktor3-android/3.1.0": {
+   "module": "sha256-B0uTg8MZ1/hpOWEXYpK/1LBmR/z7AeVdC9p9iGGBNT4=",
+   "pom": "sha256-jN4UoNfuYF5c1zd3Yv0OiUgRqe8PdEEIIinHAmsH2SQ="
+  },
+  "io/coil-kt/coil3#coil-network-ktor3-iosarm64/3.1.0": {
+   "module": "sha256-mHfuXB05Mq/iboj1PsaPnBKnMFlmthayowaWlvW33to=",
+   "pom": "sha256-J2IZNfngnoaZVIrxVkMio4/RwXwKPZY7BMIS/71noQE="
+  },
+  "io/coil-kt/coil3#coil-network-ktor3-iossimulatorarm64/3.1.0": {
+   "module": "sha256-FXKvKZ3MiA+52MMgaZ8bXCj3zfWrc53K83r8wjR7MD4=",
+   "pom": "sha256-ngy6cyscD8tk6CS7kEUxLkmXcoj2JM2IrjFeL6WtEts="
+  },
+  "io/coil-kt/coil3#coil-network-ktor3-jvm/3.1.0": {
+   "jar": "sha256-zE+fjW1EfnVZy5cXw6Rd+9NR3dBqNHJAATIlEhYLAhU=",
+   "module": "sha256-NL4hHQNYOOVzu8BW1MTBE/0j9mDWQDE/sT49mtouPnI=",
+   "pom": "sha256-J9d+GTns0g4uh1xv+g1qFaOIRm2BLSxDHqf7Lj1LDSQ="
+  },
+  "io/coil-kt/coil3#coil-network-ktor3/3.1.0": {
+   "module": "sha256-RNdytNnbOOlTvpZSG2OLq4/5ytNrU0+FhydwhVLDr8M=",
+   "pom": "sha256-kS6c9+OHz0df40DvQy4r5spGydJG1mrfan0Mj3LnPoE="
+  },
+  "io/coil-kt/coil3#coil-svg-android/3.1.0": {
+   "module": "sha256-8r3gsNLNMotSCNh4rabpLj4U5PbDewma5Ea1oWdjIiA=",
+   "pom": "sha256-/lbulpe3WZj0ks1pmjSbpgogDCQoukLWeEeYP/cwBts="
+  },
+  "io/coil-kt/coil3#coil-svg-iosarm64/3.1.0": {
+   "module": "sha256-Ohxwr2z+bqNbigdzcnxbMBuW2hNuYQyJOFOgAZzYzsk=",
+   "pom": "sha256-NHpGmR6cJKeZEbgwGpL3VjqWa/iwpNimw60kQDTDgCY="
+  },
+  "io/coil-kt/coil3#coil-svg-iossimulatorarm64/3.1.0": {
+   "module": "sha256-+3pzhPJZTLdKpbhGU9e9Wmz6O37eelH534dCBGaq/lo=",
+   "pom": "sha256-uHCnGv3oK4L1FQiWyo1hD5Rs4Cd6VqeQnQ4gelmP9wY="
+  },
+  "io/coil-kt/coil3#coil-svg-jvm/3.1.0": {
+   "jar": "sha256-QTpTtLbgpAuFHRqZoBpM2RrA3Gj6zv3det/bLVRWWI8=",
+   "module": "sha256-mau2YXPP/ryK24Fec4o/60Q3hykNUYBZaKfkmq/Cj18=",
+   "pom": "sha256-+ZVXTLorw3vi6CDxPjSm58ixTJJ41UohDoFJR6B84vE="
+  },
+  "io/coil-kt/coil3#coil-svg/3.1.0": {
+   "module": "sha256-EGfUH5lQDPAcbXABXm6leUBHiMNJBBxAhIfMYjofx9k=",
+   "pom": "sha256-kMjSxVq5L64ip85AistZYi0F2ytsLqpEoESIbMd3Y2o="
+  },
+  "io/coil-kt/coil3#coil/3.1.0": {
+   "module": "sha256-Xpm/pm5tdr7GlS9rzLjA0xqaw4UFct6hxLHhx4hq0jI=",
+   "pom": "sha256-3OBSVWaMTDpXHHiQOi4SPo24BiEWIHu0O0LzRcEM1i0="
+  },
+  "io/fabric8#kubernetes-client-bom/5.12.2": {
+   "pom": "sha256-6qA8FpVlaNVKa6Q31J1Ay/DdjpOXf5hDGCQldrZQvDs="
+  },
+  "io/github/g00fy2#versioncompare/1.4.1": {
+   "jar": "sha256-0mgnvHDjpuBw9bco4vhNvwopE5siGBr2Vm4MFvCNRGU=",
+   "module": "sha256-rHAoh4apAuF5CeYvf7dyrkIcRgqxDnIAtQIfWONIE2w=",
+   "pom": "sha256-6nUQLRXjrmYp7wResnYd5EAyW24RYSjC8P1MFj3Slj0="
+  },
+  "io/github/vinceglb#filekit-core-android/0.10.0-beta04": {
+   "module": "sha256-byWCAom19i9cSCUyyYsKJg9OumWVLrxfhLA5fPeEZvw=",
+   "pom": "sha256-ZM7/vO3+3FqdQVwF/dyqhnYT9+ElKEJ/wduRGf8FoBs="
+  },
+  "io/github/vinceglb#filekit-core-iosarm64/0.10.0-beta04": {
+   "module": "sha256-pQsRYxv4rJal3GupZF+dgsea8YDfrC7H5/3Ob9r/zG0=",
+   "pom": "sha256-3mxt9VVp9e0hKbNNSQyBYXBbF7JDa6+1/jI3buiv8og="
+  },
+  "io/github/vinceglb#filekit-core-iossimulatorarm64/0.10.0-beta04": {
+   "module": "sha256-jTEcpDf8fiEAPLl41yEUcHpSRRZ4TfR8IpQNTBYhukc=",
+   "pom": "sha256-xOrIW/GsLmIGhy3jRQuQo5VkN87SKzz13eCOF/NV+eo="
+  },
+  "io/github/vinceglb#filekit-core-jvm/0.10.0-beta04": {
+   "jar": "sha256-GWZzGFGjSZ+Hkyn6OxQqNjc+0tlhicTua2R6PvaP6vU=",
+   "module": "sha256-qZki67wQ9Got5/APssrPmJs0NfUUKLY5FgRmYMh78AU=",
+   "pom": "sha256-n1PEG4Qvn7qI2uD6PxpmZ7+Pu5cx61P/0XBSrzEVjmQ="
+  },
+  "io/github/vinceglb#filekit-core/0.10.0-beta04": {
+   "module": "sha256-sp77ASP+po07qDky8cmhGKZOFjRjIOjd3PfqtOQMIvU=",
+   "pom": "sha256-h70rRCWMXJ9kW+kyODBxBxaQgjs7JGMioIdl+Cv59wc="
+  },
+  "io/github/vinceglb#filekit-dialogs-android/0.10.0-beta04": {
+   "module": "sha256-a52H+e9TpCu4rLs0h3ouF/WGU/GGO92K2tXoFh24784=",
+   "pom": "sha256-MhHI0XQnmYHt5z96ZdsedpUo4NyueJgQspHGopzkK4I="
+  },
+  "io/github/vinceglb#filekit-dialogs-compose-android/0.10.0-beta04": {
+   "module": "sha256-U+BhMRCgepxUlYbcyV194ge7xVJEhc7Vd6FurfBuZ3I=",
+   "pom": "sha256-i+utEkVOq2RkcV/JHtbC5xPON+wzQh1lqBefiQO+r9o="
+  },
+  "io/github/vinceglb#filekit-dialogs-compose-iosarm64/0.10.0-beta04": {
+   "module": "sha256-Vqa8adKfXWliVpHjnoEXZLKCUV6c/1UVnIxKnvIxayo=",
+   "pom": "sha256-YmA/uym1v3CYtWH0z6iUlAKpPPeEtoRRp3rzz9hqIig="
+  },
+  "io/github/vinceglb#filekit-dialogs-compose-iossimulatorarm64/0.10.0-beta04": {
+   "module": "sha256-Sc3G+2zj56VbXrR5sogYJ2MaIAql2FfVZ3LVa+A8rqA=",
+   "pom": "sha256-v8QYVl2og4eToLODgnZykcoguLRIcPCDzYzuATbgCaQ="
+  },
+  "io/github/vinceglb#filekit-dialogs-compose-jvm/0.10.0-beta04": {
+   "jar": "sha256-DiLQCkaVgQANwgm9TZXFUXYr5mwtXLfvInuEg7xomMs=",
+   "module": "sha256-Dz5FHaaal2XCw5DTFg/j3FCpX5fTc32CgnsjdZcuii4=",
+   "pom": "sha256-mtTfkuOKFGRvAOzWpQhG5pb5TAVBgfuAWjEk1e682eU="
+  },
+  "io/github/vinceglb#filekit-dialogs-compose/0.10.0-beta04": {
+   "module": "sha256-szIm9+FcbW4YWXYRfd6TZy0i4K7KJQbDA7P3HjoPV9s=",
+   "pom": "sha256-RaoeHArZewK6txlVJAIByOSMhCqDIa2YcJt+E2HrT6s="
+  },
+  "io/github/vinceglb#filekit-dialogs-iosarm64/0.10.0-beta04": {
+   "module": "sha256-JPDe0ZxTumFPatW5UUx5ubCSyMRmSuplzpeW2XbHcHs=",
+   "pom": "sha256-Lf11oMTTBiZwA/Ahh5n4vxxPO6NRYwbqVT0bh8Yo5Tk="
+  },
+  "io/github/vinceglb#filekit-dialogs-iossimulatorarm64/0.10.0-beta04": {
+   "module": "sha256-1QDpl0NJRKFV3ub/wSL0xVgEve2r7+73rn1O+GtVFqo=",
+   "pom": "sha256-EgeptQ2nDmgLYGFZlQxW/I3jYzWVcylFBAT44BwWSXU="
+  },
+  "io/github/vinceglb#filekit-dialogs-jvm/0.10.0-beta04": {
+   "jar": "sha256-esZVgeBxbgIWJA828pqFDrWydodyEFZ6kpfOeOgskA8=",
+   "module": "sha256-th+oYNXh2n8R4dcwX03/CEl7My4iVe2GcuuuSXYJqG4=",
+   "pom": "sha256-uyf1cpos073hiDtP8c2m/JosczjluNx3mW8HEsqsv0k="
+  },
+  "io/github/vinceglb#filekit-dialogs/0.10.0-beta04": {
+   "module": "sha256-fTwlgEILLf42hrg4KL8imhrEVLL47F2JsurahgcVLig=",
+   "pom": "sha256-M9B4GUtHwJNcnSWwoss0wFbs6a1DOnDW+TywjvAei3E="
+  },
+  "io/grpc#grpc-api/1.57.2": {
+   "jar": "sha256-QrcuZXLAhAVaw84D5u/kM+sF72ILPa9RNqQ1n8csw+E=",
+   "pom": "sha256-x99FUaZPAoKnZugJUU1COEUKdCkFX5x3GIgdFqMQoCY="
+  },
+  "io/grpc#grpc-api/1.68.0": {
+   "jar": "sha256-tRIKEdpc5d36sBm7tp9YaFKcm13vG6WygyUcyV+zupE=",
+   "pom": "sha256-l9GZESPraPsH1IO9TVXYKnAJa7E6Wt4io43KwA3e3KE="
+  },
+  "io/grpc#grpc-context/1.57.2": {
+   "jar": "sha256-m4rIjZzvKBna/+1729LyJoAjfUgsbGcf4C022j8IzwA=",
+   "pom": "sha256-iSf3fWOB4kSHaCcIGWpspyg2i4/XzrsQT9kyS2sSSRc="
+  },
+  "io/grpc#grpc-context/1.68.0": {
+   "jar": "sha256-RfhaOURm+WPx96XFVV5t2jXv0FzhxocgOiF9cEj28Ik=",
+   "pom": "sha256-Af2CJefnueurQIKHsHqG8g73PQucMUQ9rw238Vu9gN0="
+  },
+  "io/grpc#grpc-core/1.57.0": {
+   "pom": "sha256-gYQEX1eR4Azyzbz16IRq/Uj1z35aTzj7W4MDx7Lv5Vs="
+  },
+  "io/grpc#grpc-core/1.57.2": {
+   "jar": "sha256-WhAHCr/rSWbsTVgJYdzE5/afqDqyUkL5LBdl77B7hgY=",
+   "pom": "sha256-CpcgGv4Xh08DX4ol/7lwZ45Jqt8pksfZfG/5+x1dohE="
+  },
+  "io/grpc#grpc-core/1.68.0": {
+   "jar": "sha256-qN1oTDIrqKhqlbJlP6QQbJGKVu3YY+Rar2ODnWpuoII=",
+   "pom": "sha256-uqHNgCmoPMwZ5lFQGqkXc51PfXMtAdTet8S3B1mFZS8="
+  },
+  "io/grpc#grpc-netty/1.57.0": {
+   "pom": "sha256-7Z3917HtQ1avs8XRQH3ttjTIYC+0EEebSArYwROe4Xs="
+  },
+  "io/grpc#grpc-netty/1.57.2": {
+   "jar": "sha256-mAnUwQyU0R57KUbN61sohL4goJUQKJVE83Vp8CyHeiE=",
+   "pom": "sha256-ixIWHPKqz785j7Wvw7DXOiGvIGulDD2Pe/T2xLN16/g="
+  },
+  "io/grpc#grpc-okhttp/1.68.0": {
+   "jar": "sha256-vAqrP4W3FzwlslrkR/seTB3wP+a2cPmZIXHkWTXX8m8=",
+   "pom": "sha256-sFlRvY5vCaexVEmzUnwHhG1JfNpgou4FVmSdpYIdlnY="
+  },
+  "io/grpc#grpc-protobuf-lite/1.57.2": {
+   "jar": "sha256-/EkX3F1BmsgQ+z8nUjwU514f5QNyFU+rKTJCFe5qlVo=",
+   "pom": "sha256-YHeMHqQHo7oKfw8J3wmegnInjoq8KYIsnPUOGgUvG3U="
+  },
+  "io/grpc#grpc-protobuf-lite/1.68.0": {
+   "jar": "sha256-YOkuFItPhsBoha+nmoa+t0v/zcukf4tl3HAQumcB+oA=",
+   "pom": "sha256-p/epDxXInZJYc9MRra7AWro6Sopt9LU5rcrI+Hb+n6M="
+  },
+  "io/grpc#grpc-protobuf/1.57.0": {
+   "pom": "sha256-wNy4xn/QHapjJW8Pi2jTcHzrfKhc2qt6PGw/9GDhPdE="
+  },
+  "io/grpc#grpc-protobuf/1.57.2": {
+   "jar": "sha256-MWMNip6fCKlZhiAV4wpIY5CL42gMOmhvTB8I0v/q9wY=",
+   "pom": "sha256-xeIpKAIFOXfwRhCxcEhKmh6mrxVBwUSyfRiECsVE+p0="
+  },
+  "io/grpc#grpc-stub/1.57.0": {
+   "pom": "sha256-bURZSHxiHf8xUQqIgpBjYx6RXS3Md01xkoQYEW5ZqI0="
+  },
+  "io/grpc#grpc-stub/1.57.2": {
+   "jar": "sha256-hNKvEnGRaPdjdfKv39brUTOoZe26kkTUDmuWjjrd4dM=",
+   "pom": "sha256-IVnmFKh5R3XrmOLhyFg0q05ZEb4cSnXHFjqZPpyJK6w="
+  },
+  "io/grpc#grpc-stub/1.68.0": {
+   "jar": "sha256-fECQUJzW6gQyMF+Tl9ohEntpGQW9zxY6MGvtscb06tc=",
+   "pom": "sha256-6+GdccEKNrbjSNAPZb9IaCMFEJWlgdRIfdiYCOfDerg="
+  },
+  "io/grpc#grpc-util/1.68.0": {
+   "jar": "sha256-qXSEUZ11pvUwuV6rdyMxh1Kyxf68oR/JFB3Xi9Cefto=",
+   "pom": "sha256-QqkpJhzp6EVGH61Q+vitK1HYZ3SfcIm614ewze8vhlU="
+  },
+  "io/insert-koin#koin-android/3.5.6": {
+   "module": "sha256-rbHGgeTH9PUimq5MMOzn9GyryIPEoKrF4cXkTdhg/Y4=",
+   "pom": "sha256-VAygS6FzTHKbkaeOpfXA0i3Fe/Fr7l0+bqTHuV99z1A="
+  },
+  "io/insert-koin#koin-core-iosarm64/3.5.6": {
+   "module": "sha256-lDjXC8CnLdjLMNCxrBw/IQB4OOIXX9LL7qnNRWwHVwo=",
+   "pom": "sha256-+BruWg71wUGqC1Qmv/rEdDfJ4rgQZjPqIOn/VWbIi3A="
+  },
+  "io/insert-koin#koin-core-iossimulatorarm64/3.5.6": {
+   "module": "sha256-oiUYcVT0zHnmjX1tilnVwApM8ECXpGTXxghrQ5HYZjQ=",
+   "pom": "sha256-X2BaYu30OggO+aY7q92qog/DKdA9uG312dk++Xx7X7Y="
+  },
+  "io/insert-koin#koin-core-jvm/3.5.6": {
+   "jar": "sha256-gjubMViP+QIVwfzq4w36FB0lKOPU5CwoQ+pAyDUr32k=",
+   "module": "sha256-IiurmbCubv5NKYHgt8fLYFRc6AGHTBVZkVBlZgYm6yE=",
+   "pom": "sha256-yxpqM0oiFH6G7kBL5IZ5NsBo2bEjuG4p9/Muj5gigok="
+  },
+  "io/insert-koin#koin-core/3.5.6": {
+   "module": "sha256-WnEdfzLKDSCiFism3KeuouftaTuHAhG2JSbDNRLJOVk=",
+   "pom": "sha256-q6P4ZLcET4XYNsJX/+7xpw2qfzR+wrLru0B7lNurny4="
+  },
+  "io/ktor#ktor-client-auth-iosarm64/3.1.1": {
+   "module": "sha256-NESvZB5KCx8+f3ss3vgQY+9pSZaQmlDC4cxizrkkZWc=",
+   "pom": "sha256-XLb7De6TpZXDG+2/wv6viVfBl42Kf7zVoueRvGgzHUM="
+  },
+  "io/ktor#ktor-client-auth-iossimulatorarm64/3.1.1": {
+   "module": "sha256-EZ9jN7cb1U/+eoJG28bt95RUTkpPLeGKLdhvO+s/ahg=",
+   "pom": "sha256-AHlhRqiDZDXaPcXldq8g3l6MOCDZ4S/gut+2T/QM/Bw="
+  },
+  "io/ktor#ktor-client-auth-jvm/3.1.1": {
+   "jar": "sha256-329l/zrE5Z84mcVbIUNozKBO7wA+J52/DJLcH3fR3ls=",
+   "module": "sha256-sZqQXc/2jXqOAYCozlbZvQhTMg1y42nHFO/xaGW8/Eg=",
+   "pom": "sha256-ChKNLmW/7F6SfniGwera1NAyllUZaOd7JiSLl8fFmqM="
+  },
+  "io/ktor#ktor-client-auth/3.1.1": {
+   "module": "sha256-DWnrM+1rLvNXs5QDEElR5y0U+B1t5KhGGsnnYRBz7HY=",
+   "pom": "sha256-3q0S+EmOKsqGyFJc6YDq7yYwYDejlOImpH3d2SvJxxw="
+  },
+  "io/ktor#ktor-client-content-negotiation-iosarm64/3.1.1": {
+   "module": "sha256-BRqo9b9jKLY4jLms0GlBV/MDxehqpu0D8asPvHLsc1Q=",
+   "pom": "sha256-MVE+wW66h6nD27BtuGCt+AxTYOd8+cbI3qQVM6nAKQY="
+  },
+  "io/ktor#ktor-client-content-negotiation-iossimulatorarm64/3.1.1": {
+   "module": "sha256-Hrh623wSaYprFA3Rpoi3y4S3h5Alc0oZTB0kI4tBL2Y=",
+   "pom": "sha256-BNt2wzfMQMMwwVGdItba8IOakBrBqnL8U/+1uafjVPk="
+  },
+  "io/ktor#ktor-client-content-negotiation-jvm/3.1.1": {
+   "jar": "sha256-9fYVfyPmDpqiCpLSsbSW1A6gxQJeB8lveBKmBarupAM=",
+   "module": "sha256-SCZUx0znKxyZZCV1RpL2GwyxM4BLizYtuH26ka6y1xY=",
+   "pom": "sha256-ia79EEhHe0Pym1iWYkc26LQj+PRTk2bMkLaMSn8nA2M="
+  },
+  "io/ktor#ktor-client-content-negotiation/3.1.1": {
+   "module": "sha256-dnr9WD7WI8oU7iTsSbhAO1bUNWoeQQpyYFr02bfFj2U=",
+   "pom": "sha256-Di1JFt/rE+LSRzCiv+v1W69RlRjX8hnBUqbmrW6qLbU="
+  },
+  "io/ktor#ktor-client-core-iosarm64/3.1.1": {
+   "module": "sha256-/+b3NOidAz5x2fQtcHk2NZj9Jg/tyUipFSqZRQbx70Q=",
+   "pom": "sha256-5O0KevcOXdBf0VR2J8Q1wt3+JOgqba+3omzHrg6Ra3E="
+  },
+  "io/ktor#ktor-client-core-iossimulatorarm64/3.1.1": {
+   "module": "sha256-3DIW+USqw79iB/B7BRk3Lx47x1CqJN9U2x54GNvpiCI=",
+   "pom": "sha256-90zpNIX9ajczzzFzxBpwi2fOCbPu83ngHTL2XaJUwag="
+  },
+  "io/ktor#ktor-client-core-jvm/3.1.1": {
+   "jar": "sha256-3HNSBoFanfp2nJZNhjsX852CcVWpWVMs5xesy6EuzZg=",
+   "module": "sha256-CENjXDvN3YfWsKfm958QwlH4rTUGzBkrp+MtmPqdVmA=",
+   "pom": "sha256-FmsvLevYylLL8MQrpe3a5QS7Ebbcpupj8vDhkRJNjcY="
+  },
+  "io/ktor#ktor-client-core/3.0.3": {
+   "module": "sha256-xct1TTMOkdHNf3fMCCBeeT57xmmpyuGHqiEPs+dc2as=",
+   "pom": "sha256-6f576kgFKdQhOWzkAMDGhPHLZDpd2O9w40xrOSPU0WA="
+  },
+  "io/ktor#ktor-client-core/3.1.1": {
+   "module": "sha256-HENLQIV+SHTQkQeY2WWDys7TW7VcdZN+SqrXXXSZVKg=",
+   "pom": "sha256-pwvXeScZY9OUOsWxO4t8fDJMYB8n/E5eVUe4cs0Hbzg="
+  },
+  "io/ktor#ktor-client-darwin-iosarm64/3.1.1": {
+   "module": "sha256-RRDbySf8pk/QQuVDdMeQXMBlNgnxU8+9iqvse4BChSE=",
+   "pom": "sha256-ldwrs6kBYs907kEhNpsChgM5bGIFhauYzzeHUZaAevA="
+  },
+  "io/ktor#ktor-client-darwin-iossimulatorarm64/3.1.1": {
+   "module": "sha256-CtovVCxm8BOVI4IqLEUmJ6gD+bpP5zGRpPYdeq2WdmA=",
+   "pom": "sha256-ebAgrli0MpJPfPtUC7I+ovbcmgEsMSodLXAq1mQsegQ="
+  },
+  "io/ktor#ktor-client-darwin/3.1.1": {
+   "module": "sha256-PI92hxoOYAtmcYmXhJ9+9yqzJRBgOClivh2HcWki0kA=",
+   "pom": "sha256-Sgd4DBsHZ95/2t3vfRuljMa3EZUbp0Lwzr+Jrg3zKBQ="
+  },
+  "io/ktor#ktor-client-logging-iosarm64/3.1.1": {
+   "module": "sha256-OqpdL0W817oA65ptXvMDrKNsm+LyJR35FxrJkuD5xpo=",
+   "pom": "sha256-MkhzMCFr8trcYCymIOdf+PinA47x7CKzmjg0jxabmMU="
+  },
+  "io/ktor#ktor-client-logging-iossimulatorarm64/3.1.1": {
+   "module": "sha256-QzHlcD3v9Nskra9sS1//ixnPFRIYWj+r2wNtegG9/rE=",
+   "pom": "sha256-NBC2Us9VWxMcsTgruipLHqUMb8CcTRBu6XWeO1lWFPM="
+  },
+  "io/ktor#ktor-client-logging-jvm/3.1.1": {
+   "jar": "sha256-scU9pJ/ECVY/TG+5oPfOsz7SoUYpNMmTkuWxzKDmqcE=",
+   "module": "sha256-f7fPWljnLO1KkqMpaj+2GEJ6sLksLArpQMacO9Jc/DU=",
+   "pom": "sha256-xBM/E1VdDRDkmrg0W1PtbsSIuer6z/klJC1jHHF/JJw="
+  },
+  "io/ktor#ktor-client-logging/3.1.1": {
+   "module": "sha256-5+ChGRMReioaTYFqFmrXAX4SNuP2A1sI7wiCB61wJLs=",
+   "pom": "sha256-HNgSST22zmdv05YtF8nvkxlUuJAIG1kFUn9Jk1aTZE0="
+  },
+  "io/ktor#ktor-client-okhttp-jvm/3.1.1": {
+   "jar": "sha256-T+9oV25+/zsrNG8AbTFhdX3/CuBEItSd8msBwPhdPsk=",
+   "module": "sha256-q5hd6r5DVjOOBS/BxArKsoYyEZh8TzGS7cUGBpi3tRE=",
+   "pom": "sha256-VM5iQXFRshxgKoGGb/MHk9VNUYb+Vk+dSWKPUIBDvzY="
+  },
+  "io/ktor#ktor-client-okhttp/3.1.1": {
+   "module": "sha256-lHmI2EdO0QQw8tOXS5byK0a9McDNOhio18BQOlTfx60=",
+   "pom": "sha256-bigHx/DYkJLQgIC3Seq2A4/Syoq91pHrFmxmeK5kgVw="
+  },
+  "io/ktor#ktor-client-websockets-iosarm64/3.1.1": {
+   "module": "sha256-eP2+IOz2dVVLEHlmstHXsidUUrBj6XUNQQ5mxgymgcM=",
+   "pom": "sha256-vlMOy9CuDrFyGj4eefP3sm4Cwl4SS9fghTUdSxi9gfc="
+  },
+  "io/ktor#ktor-client-websockets-iossimulatorarm64/3.1.1": {
+   "module": "sha256-VlqdjEDKa5tZarGFhXWkXbpZo5Qn8U0WahpKhjm+wMI=",
+   "pom": "sha256-ocmWevjmtZsQKiHEGmSnlobdgeAxzTLvIIJIkunN61Y="
+  },
+  "io/ktor#ktor-client-websockets-jvm/3.1.1": {
+   "jar": "sha256-x+SdwwC+Z/PsxAt/w1643p32hcM6pbSqaYMsRzoNGmM=",
+   "module": "sha256-K9DsnywbSE/xkIHD/2mjNwuTrKsMACav66KPpIu0JxQ=",
+   "pom": "sha256-77mNIPrzcCEmODMnUmFJtSaKovcisJSX0/kDljVV1KY="
+  },
+  "io/ktor#ktor-client-websockets/3.1.1": {
+   "module": "sha256-ODpIQKD4NNlTGOV4MEiGZ2kwcpm6ZoVuGp9ZbMpGEBM=",
+   "pom": "sha256-hbNOfoLxMoHliwVRIMaLyP9GhTSRfjvzMZ92vJP2Hjs="
+  },
+  "io/ktor#ktor-events-iosarm64/3.1.1": {
+   "module": "sha256-x8xf8mhqMVDxf+wBNcZkqUVyfQrTmx3PuV5zDOZuNQA=",
+   "pom": "sha256-g2mc9SVEhLl/GZYWwID+A2dY/JMkB3ghw+3wHhQE1NU="
+  },
+  "io/ktor#ktor-events-iossimulatorarm64/3.1.1": {
+   "module": "sha256-pfolHmbyvYO+6bYKCOhUpKuVVyah6J5zTUf3rIth2ms=",
+   "pom": "sha256-1y/OX8TDHNwqMtYtMgV6mdIT3YfYtErpD66/ZD4Qik4="
+  },
+  "io/ktor#ktor-events-jvm/3.1.1": {
+   "jar": "sha256-edJ+rfJ6J433kMSQ9XyZG+2TYLVaBbyfH3RLIjMLUFs=",
+   "module": "sha256-WJLv/yddO0Mise6kS906BoD3z/iXiO8WyAl3cKjF+eQ=",
+   "pom": "sha256-RUqm3g/VPlJIOZnKSd6VjwNBKx1GlF14lqJBsQbBjqg="
+  },
+  "io/ktor#ktor-events/3.1.1": {
+   "module": "sha256-wzRhIZmbL3rNh0doWOTY9aZkInpcOyQcc52dQoJb250=",
+   "pom": "sha256-mgwRaawFQZcZe8CPF8yCeXgjqcJWZHQd04GnazL9QDs="
+  },
+  "io/ktor#ktor-http-cio-iosarm64/3.1.1": {
+   "module": "sha256-WSBe+QexhxvY7fctkJlnEVJyOpex76v00UjC+aSnbz4=",
+   "pom": "sha256-fw4kxX0Lq6qVcJBokTMeAftoZ+x5eBNgYPKYOQVfSNE="
+  },
+  "io/ktor#ktor-http-cio-iossimulatorarm64/3.1.1": {
+   "module": "sha256-adndKrm5KnpZFf/PZl9uVVocN7FuDwizFV9StnJzEVU=",
+   "pom": "sha256-RdQnKBxsYJ/mb/SSrHt/gYhmwPKMCniT9mUOIcgun7Y="
+  },
+  "io/ktor#ktor-http-cio-jvm/3.1.1": {
+   "jar": "sha256-ZZVfvsiA9mb/MOXN7MM+Of/XwLZYwJ2niUlOhSjJTGA=",
+   "module": "sha256-peUjznqqEclSfeB7wxRak6lzc4Jl/TyB959reYeS5gQ=",
+   "pom": "sha256-/qMR8z1NKfV6m/wkrecn6vtFullv9JZ5qkVSpewTpo0="
+  },
+  "io/ktor#ktor-http-cio/3.1.1": {
+   "module": "sha256-zpUnEGKYRlbN9wmx3vIwThGij+tQpQM07Xnk+F8E7A8=",
+   "pom": "sha256-sCIN4cXz3pHqhu7SxkHXu0lSfD1iqeivo97xFkeLbaA="
+  },
+  "io/ktor#ktor-http-iosarm64/3.1.1": {
+   "module": "sha256-AuY1/KQo0JaSLUkcXjvYVPppDi3Vr/ZWK2IQDMuRwJs=",
+   "pom": "sha256-iUpo24x1Z/e/oVks8dtU6jChD3NhDK1v3E21sPynJJU="
+  },
+  "io/ktor#ktor-http-iossimulatorarm64/3.1.1": {
+   "module": "sha256-UO/zOyEYHl58oBpJ9bARq+H9fGdkaPJCBf7aNcnuetI=",
+   "pom": "sha256-E64kQ7VdwuGlkSSrJkK9zPDDs7lUSeJaAtnd8hN6hCs="
+  },
+  "io/ktor#ktor-http-jvm/3.1.1": {
+   "jar": "sha256-wQ4iEltDk+ZhJN35ediJmc/7C/vo1boZIkD7oQTRX7o=",
+   "module": "sha256-mzpLiic6QZ7i2L5SIsgbJvKRdrakojuBX/RKvDmrDeM=",
+   "pom": "sha256-8j+CYetHYjfH2lXKZ8awMFS+kGpCF1+/iIvOtIAhKGk="
+  },
+  "io/ktor#ktor-http/3.1.1": {
+   "module": "sha256-Bj/oGNpM0JsqAR/mb8lAX/fiuetFaPVekpbQoG8sPA0=",
+   "pom": "sha256-scSnlJ/nls6z8YMjWYqDxfk9J7U2VFFg4o+WIGGPn7s="
+  },
+  "io/ktor#ktor-io-iosarm64/3.1.1": {
+   "module": "sha256-0CyDxI/c3LdtslzfcKaLrMqk8a3mk40PLm3nZgIzISY=",
+   "pom": "sha256-eKuHnwC+3VusYuG4wHVFAx+7YlHOl09ZI+sZdlaCA3Y="
+  },
+  "io/ktor#ktor-io-iossimulatorarm64/3.1.1": {
+   "module": "sha256-YcTsBh/nWR3X+E3QU2n50z2cyPdFu4+aBBZkmLhDapI=",
+   "pom": "sha256-291du4FNgjIOz47bcPHnzXhOiBCAMs7GRd4EyIRkb9Q="
+  },
+  "io/ktor#ktor-io-jvm/3.1.1": {
+   "jar": "sha256-MYuRb0fIUXCvS+6fD0VQsODt7Ky14dwsKCl3bI17yas=",
+   "module": "sha256-J2rXuOWEtkb7XV76b+hFYvhC9Dzwvj/UlkVd/z51ydE=",
+   "pom": "sha256-YRjAOam6H6htK4CxoZ7Iy/xKIvUZ6vA/VFdXzTqxd8w="
+  },
+  "io/ktor#ktor-io/3.1.1": {
+   "module": "sha256-4u15APMHK4VkiSseR1fzRWyJ5HV+nnfcqf8W3DmIiFA=",
+   "pom": "sha256-mna6AnP0Vy1oTURo784BtATSSsWzokuK4ceWQhx5D+c="
+  },
+  "io/ktor#ktor-network-iosarm64/3.1.1": {
+   "module": "sha256-z1LUGqMSF72BVE248WEGOl7NLrviiVJ7BK1HMWGU5qY=",
+   "pom": "sha256-J7F7uMyGLkRF/s0mzFkx7TlQJNEUJiOgMHQcTCh58+M="
+  },
+  "io/ktor#ktor-network-iossimulatorarm64/3.1.1": {
+   "module": "sha256-eSXFO8rc316OH0jgqv5CmEz5dQ3xyqUauiAHZEsnn9k=",
+   "pom": "sha256-Xz2X0oALsj6WIYQVjYCa2B/gc+9eX/ZoQsSMAARA8yc="
+  },
+  "io/ktor#ktor-network-jvm/3.1.1": {
+   "jar": "sha256-CJy7uU8kt14+TEQBuu/ZWG9bFcnYAKbpPzCmSxlZsjk=",
+   "module": "sha256-AiZQk2xYwEEStePfJD4zaQDmtyKbCkUl8cn1nIPeeis=",
+   "pom": "sha256-GUk3Y9TxFQvCKfqdD8yERJOQw+q8txxc+yRVupmmkWU="
+  },
+  "io/ktor#ktor-network-tls-iosarm64/3.1.1": {
+   "module": "sha256-3bhrDu2FlOhXQUyldI9GpiT7Vl/0owQkF0+Fl5SKEu0=",
+   "pom": "sha256-C/apWV2COClKJpx8LPmKLglRJPn3crWiBVnrVk04Qzw="
+  },
+  "io/ktor#ktor-network-tls-iossimulatorarm64/3.1.1": {
+   "module": "sha256-UzYprspJ/4z5QChowg3ja+D7HancTQ0bfjCPn2IYnt4=",
+   "pom": "sha256-u9NmlHzbzkqMvO7z3EGV/8NPTutJSw5D7jaekTmHpG4="
+  },
+  "io/ktor#ktor-network-tls/3.1.1": {
+   "module": "sha256-7QDiY7BG27xcHhyySXhhezvE4aU/SdgoooaFrsLwrFs=",
+   "pom": "sha256-SS5pN1pWKwNxPnfyOTVcjIwfrkDjZy3fhpiovscJRf0="
+  },
+  "io/ktor#ktor-network/3.1.1": {
+   "module": "sha256-gP7XcFwFdzTMk8+cf55cD0lo+nWMqlDjvpH+YrpoL5g=",
+   "pom": "sha256-QLSG36c91ynR99yevJNL5z3pJSKFnbKWqE/28gyGw2Y="
+  },
+  "io/ktor#ktor-serialization-iosarm64/3.1.1": {
+   "module": "sha256-Abz3pekgb94/vAWX1E/r9hOpYBZBAzCysdLcdetd/o8=",
+   "pom": "sha256-+9pcv3pxopUo4Yinpg4ziVxIAJ0bMyoJGBPWHx/VdgY="
+  },
+  "io/ktor#ktor-serialization-iossimulatorarm64/3.1.1": {
+   "module": "sha256-3opaXlFY5IOMHNhhl/cNnUq4toy4SXb85HCKyvF5W0k=",
+   "pom": "sha256-8aY4SnhDoqjlsK0QvrpoP8VnvnlZ5xNRdIlr1Fk7wrA="
+  },
+  "io/ktor#ktor-serialization-jvm/3.1.1": {
+   "jar": "sha256-nJldXoF13kgYMCplAbuZqOEZ1GI8dVUt32DuPWbF594=",
+   "module": "sha256-TvQH316/TX58e5s19DVmPe10KsUeJcoelb6dOWJtv6c=",
+   "pom": "sha256-N7BrHSbkoMBbuMk+puGnHZ54zf+XndPAmkwaFFPS4aM="
+  },
+  "io/ktor#ktor-serialization-kotlinx-iosarm64/3.1.1": {
+   "module": "sha256-rL1AlSYF26xrhYxGu0NTQHkFln6h0misNnwO6+CrBg8=",
+   "pom": "sha256-dfNkRNC38s5NAzn1qSFrbAFrBs8SShjCysLw7rMszIo="
+  },
+  "io/ktor#ktor-serialization-kotlinx-iossimulatorarm64/3.1.1": {
+   "module": "sha256-zvVvKqvt+q/6JLsC8lNsfbajVWEmJDEK8MQ7LGpRj/U=",
+   "pom": "sha256-sMBWzYM8zLB5eZLv4Yi0q/S5tKi+rJewedr+hYPr0uo="
+  },
+  "io/ktor#ktor-serialization-kotlinx-json-iosarm64/3.1.1": {
+   "module": "sha256-Ha3Erqcz3Q8LyFU6jz+IN3smbLcVdxhfUOu8oE960Hs=",
+   "pom": "sha256-0cIo3SgWXCZuNHJpEZ18mYbNZKF3dPke51LAvIj5lCg="
+  },
+  "io/ktor#ktor-serialization-kotlinx-json-iossimulatorarm64/3.1.1": {
+   "module": "sha256-oIDnPGMB4ChCD22beIVixVd12vjgISYwRgPAR6fBFmo=",
+   "pom": "sha256-IZrUEWM5/CtjUhEatLL/4ltDtahL+2/rAJWwjJuPi1o="
+  },
+  "io/ktor#ktor-serialization-kotlinx-json-jvm/3.1.1": {
+   "jar": "sha256-gdtumyFpbgVyaerBobZE6HHOnnWj2o5oBTq3c5fvwBs=",
+   "module": "sha256-CEkEG0MWhxZhDsR+ZEv8QOVnvIJhIZsbMQg6ZEjfh3g=",
+   "pom": "sha256-TpiA/27FDdaawiouv423bdGB43ROw/rLCF+DdPJwfSw="
+  },
+  "io/ktor#ktor-serialization-kotlinx-json/3.1.1": {
+   "module": "sha256-zmVZ1QiGCaXMpCVrSXZUnyjQXio8jPjeY+vGE8DVvwI=",
+   "pom": "sha256-J+jZHK6F3ud002BmizCLErAsuaRt7EI9L4C/+izqYXI="
+  },
+  "io/ktor#ktor-serialization-kotlinx-jvm/3.1.1": {
+   "jar": "sha256-UGynsB5FAvvYlIZP5A1KhGwLR6WVTU01+8TI+ABI16A=",
+   "module": "sha256-R3hXpALaI/FAd8cdDC3qsL9YfRkonR2JIjBQLK5nGbI=",
+   "pom": "sha256-+qg/wXYrGtneZ6sAj4apLQ0FibrTvA8KyEoKYNSGN0k="
+  },
+  "io/ktor#ktor-serialization-kotlinx/3.1.1": {
+   "module": "sha256-A/l5EFJLtQLF2/pkXc8PdIlRT25cynPWbPh85oX9PFk=",
+   "pom": "sha256-xTkjB+ik4dwgJZoqIre628d2DM8ICoyH0cFXAPuV9OA="
+  },
+  "io/ktor#ktor-serialization/3.1.1": {
+   "module": "sha256-Lnp0xtJFkGOeRvOt5X4D4hGL0l27Kn4FFP5PiMoCA2o=",
+   "pom": "sha256-e0xBuMWwvFPneI6U80sg2Tee1pkMkCuLna4CHKvBoUI="
+  },
+  "io/ktor#ktor-sse-iosarm64/3.1.1": {
+   "module": "sha256-g2MVLicslgyfeGxKyvgJtV9izqijuoYbGo8v7Nz6zwY=",
+   "pom": "sha256-NsQgfW7XHJg5JqjaJpg80dNJ/KGc3tNp2uQ0APjP4q4="
+  },
+  "io/ktor#ktor-sse-iossimulatorarm64/3.1.1": {
+   "module": "sha256-h9jKjk/rBleUC1rtjlKtdHiSEI1WajqsUXp1mhO4Qr0=",
+   "pom": "sha256-XvsN4HeYhB5G7q6wIyNS8r7J/7soFdceJxD7TaGDP/0="
+  },
+  "io/ktor#ktor-sse-jvm/3.1.1": {
+   "jar": "sha256-9MoU6LzJPLDfazwRhRyAzeDsTFMvOifdxPbhfN9QlfI=",
+   "module": "sha256-wnFsMZK+6WMzsz49jrTSdLuqZYKOdwAAJfzFky0xhcQ=",
+   "pom": "sha256-Ebf9pIb6xeXY0vs0ey8bLdpvGMIgozJ7FdwEDv7vxcI="
+  },
+  "io/ktor#ktor-sse/3.1.1": {
+   "module": "sha256-O/XgdWtXZX72kbUV/UekraLWexcmh2C9pJCe7KXs94U=",
+   "pom": "sha256-555aU506JSbasDuU/4PFFVe46G0dHBFveXLdb4qB9ZU="
+  },
+  "io/ktor#ktor-utils-iosarm64/3.1.1": {
+   "module": "sha256-cNet7SAoj9O4SPVc7Baw8rhXdcOfEdn787qo2w3/hW0=",
+   "pom": "sha256-soAGj19e7k9wg4OmFhsVmWQswZBaj8s+UROJpT4DbcM="
+  },
+  "io/ktor#ktor-utils-iossimulatorarm64/3.1.1": {
+   "module": "sha256-wAXAIXdjpfCYi2ju0vG+4Fs444N3xEVWzx71zkxXQ6Y=",
+   "pom": "sha256-Vf3pcFmwDNDHgoSnf6DSfhg/D8Q5qvvkLjZ3204M3cU="
+  },
+  "io/ktor#ktor-utils-jvm/3.1.1": {
+   "jar": "sha256-MXZ8uCHKB3KftclmDjjYgZ3Jo7jKm4u2q1D/a9BMuCk=",
+   "module": "sha256-YE7wk8++XQq2CD/73rAjNXZASXMZs/ipoN1a1SYRQh8=",
+   "pom": "sha256-LUGC3pBGlMdY+c9CxicYgMpM2EFWdBYB2t0zKyMZ7wQ="
+  },
+  "io/ktor#ktor-utils/3.1.1": {
+   "module": "sha256-vnVD0+g6f+TAgP1UWgXSXPsYfcAwg2IkCbv3Yg7HibU=",
+   "pom": "sha256-OWwgs5DCmMIdK4M24tPWSSfzmoj5zPOaew2h/xkcP40="
+  },
+  "io/ktor#ktor-websocket-serialization-iosarm64/3.1.1": {
+   "module": "sha256-VPb392PogAswKF+4JMcILM2NZNadLKqfghNAYOmw5gg=",
+   "pom": "sha256-ldI2D2KdYX+YjvjgqoZnzmjiLQdZPfD6WTSRImQmDP8="
+  },
+  "io/ktor#ktor-websocket-serialization-iossimulatorarm64/3.1.1": {
+   "module": "sha256-qXavafuIIspjaXmx/Y3rq3D4mFqPejPI6RudmIKharw=",
+   "pom": "sha256-P7rHz7M7SJS3tAFGZqWn+B2/L/vt29gGmgd/belw7XU="
+  },
+  "io/ktor#ktor-websocket-serialization-jvm/3.1.1": {
+   "jar": "sha256-+zaNzbdiPHF4rKhjMiJknLFRBkaVS0m6NZxckm+Y/EE=",
+   "module": "sha256-SKFYB5qMwz5EBDrEkaVFtWNL5oMiY44INoclZIenLR0=",
+   "pom": "sha256-emkQogxJM7X00SJanW4uaE2RGvvxSVFiEO6YBbCyYXI="
+  },
+  "io/ktor#ktor-websocket-serialization/3.1.1": {
+   "module": "sha256-y6bmysD6XrDCG2n1ZfWaSSFPnEnc6Qrq8L/QWEyV7fQ=",
+   "pom": "sha256-GarQzpRZpleFsOJ5XY+87sf0o65DOfy9KrV8Y6zdQ6k="
+  },
+  "io/ktor#ktor-websockets-iosarm64/3.1.1": {
+   "module": "sha256-A7QmC+qHJuBX3JUBiY3vyhyiaNYrmwjm3/6d6JZZ7fc=",
+   "pom": "sha256-JzHj2o83qr4TQMHEmSUeRD1dfMPijtEdvQ+U3lylCjo="
+  },
+  "io/ktor#ktor-websockets-iossimulatorarm64/3.1.1": {
+   "module": "sha256-PpPlD3IJXlHXd/nF3TJnWbVTvMiZ3E2YU5VNd/uns+o=",
+   "pom": "sha256-S+CiEO/v/P/mUowLmVwcrfPu609nskkVR4OSizkp6r8="
+  },
+  "io/ktor#ktor-websockets-jvm/3.1.1": {
+   "jar": "sha256-INrwtfeSnXsLIH9WMN1SPUcYLSUdysUzqbGcqCQG69s=",
+   "module": "sha256-IIfo/BNzNDnJk6E0Cl7+ontaV2czRCONpcHr3uLMMAk=",
+   "pom": "sha256-grzt+ITD43sODDeuhHhiMxOpyTn3NTXoQuKqKwEE7Jw="
+  },
+  "io/ktor#ktor-websockets/3.1.1": {
+   "module": "sha256-NaXY4UALTUsTCqUHVhdEoG7u55c17bo/qrW+yVFUBPY=",
+   "pom": "sha256-UBJv8ak1FyiMAYseKTCfOozAfimsqU4WIpzV6LKjZNc="
+  },
+  "io/netty#netty-bom/4.1.86.Final": {
+   "pom": "sha256-EnFsH+ZM9b2qcETTfROq46iIIbkdR5hCDEanR2kXiv0="
+  },
+  "io/netty#netty-buffer/4.1.93.Final": {
+   "jar": "sha256-AHx9nDeN8C05BWfQ1931Qv/dsCG3MT2/UCOSET/6uwg=",
+   "pom": "sha256-g/vFTitzuG1Vsgj2GNGioVaRDsFG9+zldWUAe3UK3Xg="
+  },
+  "io/netty#netty-codec-http/4.1.93.Final": {
+   "jar": "sha256-2s94znirLSlXAyXbTNJFHqWJY5gH3pWIGg+nFVqea1U=",
+   "pom": "sha256-o9r/8HG20oToBj2WhD3iu4PPO4iergzJ4K22SlejG4I="
+  },
+  "io/netty#netty-codec-http2/4.1.93.Final": {
+   "jar": "sha256-2WzAkEWhNBxtR0lDUqomO4e3L7HS6p7KFhqnOCC/6Ls=",
+   "pom": "sha256-CEQztC1UH3rEtZKH3SUyhc/aOj1l3nLnNou37D02cnE="
+  },
+  "io/netty#netty-codec-socks/4.1.93.Final": {
+   "jar": "sha256-DqR7W6I8odqOuRRsj8dVwScUFGM7Hivizh33ZLoP/yo=",
+   "pom": "sha256-jNgW7ZkalGBBurTLJL2cjkHuBpJRJRHy2DzvU462Bdc="
+  },
+  "io/netty#netty-codec/4.1.93.Final": {
+   "jar": "sha256-mQw3gWjcY2TG/1aXAfTy8SL//omYs+GJ66TE2GjtEIQ=",
+   "pom": "sha256-Gc3tJnoHDf8avJ0Cm1UvrSYqzBq6XGxnsiePyhE6Jqs="
+  },
+  "io/netty#netty-common/4.1.93.Final": {
+   "jar": "sha256-RDuzFlmfsW47rrovtYiBgU1/8LevF2/nbjgHGm6G+MA=",
+   "pom": "sha256-QtiDsT6zjKv1SWFkYsXzMfUzO/DI/JIVdE+DwBgKT2s="
+  },
+  "io/netty#netty-handler-proxy/4.1.93.Final": {
+   "jar": "sha256-KsX3+++gtz73g4iQaTRNVRVQWhSyMDvmk8UALEht8rQ=",
+   "pom": "sha256-bcUNoOZ/WXgSh0+B6qRUBPfQdrgZnqkIiTKoXBthAkU="
+  },
+  "io/netty#netty-handler/4.1.93.Final": {
+   "jar": "sha256-Tl9WOuFO1xM4GBbVgvX8/QYVrvspIDSGzft4LYoAoCs=",
+   "pom": "sha256-hKFSXKwLR1nvrvKZekf+Gbm1ZC+Sc/oP1YoudsegWf4="
+  },
+  "io/netty#netty-parent/4.1.93.Final": {
+   "pom": "sha256-sQnLdvN1/tuKnvdaxYBjFw3rfqLd0CT0Zv723GXN/O4="
+  },
+  "io/netty#netty-resolver/4.1.93.Final": {
+   "jar": "sha256-5Zdwtm6Bgi5dERrE5UTX6wxUPgooX1JijlOUGs2O11k=",
+   "pom": "sha256-WzUMPJHp5V0py+aM/k7yEWzB8DKGd+v59hW6twgsefQ="
+  },
+  "io/netty#netty-transport-native-unix-common/4.1.93.Final": {
+   "jar": "sha256-d0FlocTbqssX+cGtZms1aaallxWugo58PUdwP0eaU+c=",
+   "pom": "sha256-Fbwltn/wpJJysnDvK4z/1iAFfKFssp3/etVmGtyirhI="
+  },
+  "io/netty#netty-transport/4.1.93.Final": {
+   "jar": "sha256-paeAGbwc1D28PHt83TgBkSyibR9Jj7VgUU/uSXhkupY=",
+   "pom": "sha256-DdYqDrPLHqABpNBCbk9cCN8ccNkmVnW/+lxYNhNCLUM="
+  },
+  "io/perfmark#perfmark-api/0.26.0": {
+   "jar": "sha256-t9I+k6NFN84zJwgmmg0UBHiKW14ZSegvVTX85Rs+qVs=",
+   "module": "sha256-MdgyMyR0zkgVD1uuADNDMZE28zav0QdqKJApMZ4+qXo=",
+   "pom": "sha256-ft7khhbhe2Epfq46gutIOoXlbSVnkpN4qkbzCpUDIto="
+  },
+  "io/perfmark#perfmark-api/0.27.0": {
+   "jar": "sha256-x7R4UD7FJOVd8ZtCTUbSfIporrgBZk+t1PBptx9S0PY=",
+   "module": "sha256-n2xOamK43v0UFzrNt9spPQhjU7Ikkj7vYpP1gWGJPMo=",
+   "pom": "sha256-IsF1wsGCNmdjDITnMiV2f1lwSS2ObL/7gaZXXbpHLSY="
+  },
+  "io/sentry#sentry-android-core/8.8.0": {
+   "module": "sha256-jbcCvRMVSXF4WlV76I/0maF4tYaqn0lchWV1CZc+FBw=",
+   "pom": "sha256-iKfBfWjKkRCF1r2vOtVu/BItvScWnwfP4F9IyvCBr0E="
+  },
+  "io/sentry#sentry-android-ndk/8.8.0": {
+   "module": "sha256-eQ8JNNraT5Jir/RzM/82HF14qJhqXyE2sNypyRf3DvE=",
+   "pom": "sha256-ktkaOog6skzcv2Pf3xgYWyofjejcRS0fD9wboHRu4II="
+  },
+  "io/sentry#sentry-android-replay/8.8.0": {
+   "module": "sha256-7NW/uwpNd4QrumJtV7wBYq57vz4UpKDYB29gl28unK0=",
+   "pom": "sha256-nzDqEgxP78aVb126hgU1Ua9Yf3wz9cAb+brdlmkTkEE="
+  },
+  "io/sentry#sentry-android/8.8.0": {
+   "module": "sha256-r0HfgTqFjBgfgL4tlkcan8xMH2I5uPSCkyy7fUuKu40=",
+   "pom": "sha256-ngns4+yoH0RB4rSWevFwrDWvfecE/rHcGVH87XklqFY="
+  },
+  "io/sentry#sentry-kotlin-multiplatform-android/0.12.0": {
+   "module": "sha256-s/ciiq33SK6Eei55LCGshOdOJONr3Q/SodxuMo9LKcU=",
+   "pom": "sha256-HeVNx19L+dvs9HYTEBNEBjcS30x4iL7X77N/o8/S7No="
+  },
+  "io/sentry#sentry-kotlin-multiplatform-iosarm64/0.12.0": {
+   "module": "sha256-Ts8JP0U3hBplkq0LBk8wdsmRVOi4u1gOcKyHWM1AHi0=",
+   "pom": "sha256-6sgAnNdrPmHBdjgM0/MAaScV9pXzvxvTqCsqqkGTlQk="
+  },
+  "io/sentry#sentry-kotlin-multiplatform-iossimulatorarm64/0.12.0": {
+   "module": "sha256-lA91SKJ+PZa82MGLKeBRYeDXe/Jq2bPLkALSl537Eeg=",
+   "pom": "sha256-Ubw0X/AGB8BKTxhPIPcbj7QMAfqWXoAq9WLPzXUNFJ0="
+  },
+  "io/sentry#sentry-kotlin-multiplatform-jvm/0.12.0": {
+   "jar": "sha256-O/z/1CG6XIIYrvjz/x+KBMBa3kaTt+8Yc7zWp8wOl8Y=",
+   "module": "sha256-uqQCJ82hcAuab1EtwgrXBDB7lVnptXtvu24CWL2W1jg=",
+   "pom": "sha256-/hEp7FMvE2lCHQnAWQtgdU8cUy3ycmFEfyfmxYNmSas="
+  },
+  "io/sentry#sentry-kotlin-multiplatform/0.12.0": {
+   "module": "sha256-N+fdfmhXBDIGLklwjxmDvWN8TOiyW1Gga8V6Tfwguss=",
+   "pom": "sha256-wkjtJf07NMXNPuk1ELsVVhgCcD+rjBZ+Chn0NBmttko="
+  },
+  "io/sentry#sentry/8.8.0": {
+   "jar": "sha256-FP6T2JRlBMFXy+haPC5QY77c7Jvq04TJP3mlFxTC0TI=",
+   "module": "sha256-upAHAYOH8B8RjPHCy0xgN+FKx1FR2sb7nSfG0akrwZw=",
+   "pom": "sha256-n5H3T5E9NMhWuml/lZ5cerZa2W7AjW1TY0688Irn4pc="
+  },
+  "jakarta/activation#jakarta.activation-api/1.2.1": {
+   "jar": "sha256-iwoPUvqLBcVDGSGgY+2GbvqkHa3y46fuPhlh8rDZZFs=",
+   "pom": "sha256-QlhcsH3afyOqBOteCUAGGUSiRqZ609FpQvvlaf8DzTE="
+  },
+  "jakarta/platform#jakarta.jakartaee-bom/9.0.0": {
+   "pom": "sha256-kZA9Ddh23sZ/i5I/EzK6cr8pWwa9OX0Y868ZMHzhos4="
+  },
+  "jakarta/platform#jakarta.jakartaee-bom/9.1.0": {
+   "pom": "sha256-35jgJmIZ/buCVigm15o6IHdqi6Aqp4fw8HZaU4ZUyKQ="
+  },
+  "jakarta/platform#jakartaee-api-parent/9.0.0": {
+   "pom": "sha256-9l3PFLbh2RSOGYo5D6/hVfrKCTJT3ekAMH8+DqgsrTs="
+  },
+  "jakarta/platform#jakartaee-api-parent/9.1.0": {
+   "pom": "sha256-p3AsSHAmgCeEtXl7YjMKi41lkr8PRzeyXGel6sgmWcA="
+  },
+  "jakarta/xml/bind#jakarta.xml.bind-api-parent/2.3.2": {
+   "pom": "sha256-FaVbfVN8n5lwrq0o0q+XwFn2X/YQL3a70p8SR92Kbfs="
+  },
+  "jakarta/xml/bind#jakarta.xml.bind-api/2.3.2": {
+   "jar": "sha256-aRVjBAeb3u2fwK47OTifGbPMS6REO8gFCJlTlOrXQuo=",
+   "pom": "sha256-tTeziNurTMBpC50vsMdBJNZyUxc0VnrPblMTDqsTGtY="
+  },
+  "javax/annotation#javax.annotation-api/1.3.2": {
+   "jar": "sha256-4EulGVvNVV3JVlD3zGFNFR5LzVLSmhC4qiGX86uJq5s=",
+   "pom": "sha256-RqSiUcpAbnjkhT16K66DKChEpJkoUUOe6aHyNxbwa5c="
+  },
+  "javax/inject#javax.inject/1": {
+   "jar": "sha256-kcdwRKUMSBY2wy2Rb9ickRinIZU5BFLIEGUID5V95/8=",
+   "pom": "sha256-lD4SsQBieARjj6KFgFoKt4imgCZlMeZQkh6/5GIai/o="
+  },
+  "junit#junit/4.13.2": {
+   "jar": "sha256-jklbY0Rp1k+4rPo0laBly6zIoP/1XOHjEAe+TBbcV9M=",
+   "pom": "sha256-Vptpd+5GA8llwcRsMFj6bpaSkbAWDraWTdCSzYnq3ZQ="
+  },
+  "net/bytebuddy#byte-buddy-agent/1.17.4": {
+   "jar": "sha256-4drn78VWLCmtO2JbkOaGQgjeabrVYyw/k6VH8XYirFE=",
+   "pom": "sha256-1ghCjJXnT6aXreYmDmCUE8O+oL+Wh72hvoe3BAPi/8k="
+  },
+  "net/bytebuddy#byte-buddy-parent/1.17.4": {
+   "pom": "sha256-4FQGL6bGDfvTnqmX8zgQZWTR7w3f5vu+qGeD+toDvak="
+  },
+  "net/bytebuddy#byte-buddy/1.17.4": {
+   "jar": "sha256-dHaHMSGaWy4MydKxyeIJLgYiJC5BsZJaa6c0bhYHMbw=",
+   "pom": "sha256-7sHUc2OcrqtenXbx+KSGRrCQZ7DFyYS3oL5TAoghg10="
+  },
+  "net/java#jvnet-parent/1": {
+   "pom": "sha256-KBRAgRJo5l2eJms8yJgpfiFOBPCXQNA4bO60qJI9Y78="
+  },
+  "net/java#jvnet-parent/3": {
+   "pom": "sha256-MPV4nvo53b+WCVqto/wSYMRWH68vcUaGcXyy3FBJR1o="
+  },
+  "net/java/dev/jna#jna-jpms/5.12.1": {
+   "jar": "sha256-Az6Kx6dCYkdIvyUWSPFQls9uFavgxMFfSnfKEIFqEyQ=",
+   "pom": "sha256-/oIEsE54gTuRM65GObdiwZauazmdQ9Z/olFXz7FSXS0="
+  },
+  "net/java/dev/jna#jna-platform-jpms/5.12.1": {
+   "jar": "sha256-1zvIB9SAk+9FzjVcZEb9/fO8DucEOysV+wM66hdhEQY=",
+   "pom": "sha256-CgHHSMhZdtcu2DfW/tp7Rk1DtjlV4JsYhH2FOPMmJc0="
+  },
+  "net/java/dev/jna#jna-platform/5.13.0": {
+   "jar": "sha256-R017iPbpcAm27B2YwwJN2VwjGHxl2r+8NTMbysPRc90=",
+   "pom": "sha256-Y7IMivBXyYGW+HieGiGm3d8Cqo84XmsEtLT58N8lcGY="
+  },
+  "net/java/dev/jna#jna-platform/5.15.0": {
+   "pom": "sha256-oNnHuB/tH6i+iLAv16dWDeGxrFlYOh4sWiGopdxs32c="
+  },
+  "net/java/dev/jna#jna-platform/5.17.0": {
+   "jar": "sha256-t+PUbIe60utAmw5wSRa82BIGFo41cxLf3dDiU2ec2eA=",
+   "pom": "sha256-CjC3l622giFH75jLJJ7z+/SiQ1QqqGv59C+tnmgwWkQ="
+  },
+  "net/java/dev/jna#jna-platform/5.6.0": {
+   "jar": "sha256-ns6ovysbOZY5OdGLcEZO72DFCP7Ygg+dyroMNVGOq/c=",
+   "pom": "sha256-G+s1y0GE5skGp+Murr2FLdPaCiY5YumRNKuUWDI5Tig="
+  },
+  "net/java/dev/jna#jna/5.13.0": {
+   "jar": "sha256-ZtT4GaBipRodVie//CP6xV0Wd/Dgof66FEqr3WcKZLs=",
+   "pom": "sha256-9RXCV4F49FJH7Mp6nh2xCVMbHELyQk4lPO6w9rjUI3Q="
+  },
+  "net/java/dev/jna#jna/5.15.0": {
+   "pom": "sha256-J2YC/zZ6TDkVXa7MHoy1T0eJ5dgN+Qo6i2YD8d61ngU="
+  },
+  "net/java/dev/jna#jna/5.17.0": {
+   "jar": "sha256-s6lAjnxR4I7w47/MCPRD9uwPYZG6jNfBjVPSsi5b28A=",
+   "pom": "sha256-UBoP8F2EpK0Q9t4lvpT0k5i3CjG+jzoO2fTGtE++/uQ="
+  },
+  "net/java/dev/jna#jna/5.6.0": {
+   "jar": "sha256-VVfiNaiqL5dm1dxgnWeUjyqIMsLXls6p7x1svgs7fq8=",
+   "pom": "sha256-X+gbAlWXjyRhbTexBgi3lJil8wc+HZsgONhzaoMfJgg="
+  },
+  "net/sf/jopt-simple#jopt-simple/4.9": {
+   "jar": "sha256-JsWFbpVLX4ZNt28TuGkZtZxu7Pn9kwuWuqiIRia68vU=",
+   "pom": "sha256-evfi2LJLR5jwTCt9okyfvRt1V7TgF8IFRIFWWRYHkJI="
+  },
+  "net/sf/kxml#kxml2/2.3.0": {
+   "jar": "sha256-8mTdn3mh/eEM5ezFMiHv8kvkyTMcgwt9UvLwintjPeI=",
+   "pom": "sha256-Mc5gb06VGJNimbsNJ8l4+mHhhf0d58mHT+lZpT40poU="
+  },
+  "org/apache#apache/13": {
+   "pom": "sha256-/1E9sDYf1BI3vvR4SWi8FarkeNTsCpSW+BEHLMrzhB0="
+  },
+  "org/apache#apache/18": {
+   "pom": "sha256-eDEwcoX9R1u8NrIK4454gvEcMVOx1ZMPhS1E7ajzPBc="
+  },
+  "org/apache#apache/21": {
+   "pom": "sha256-rxDBCNoBTxfK+se1KytLWjocGCZfoq+XoyXZFDU3s4A="
+  },
+  "org/apache#apache/23": {
+   "pom": "sha256-vBBiTgYj82V3+sVjnKKTbTJA7RUvttjVM6tNJwVDSRw="
+  },
+  "org/apache#apache/27": {
+   "pom": "sha256-srD8aeIqZQw4kvHDZtdwdvKVdcZzjfTHpwpEhESEzfk="
+  },
+  "org/apache#apache/31": {
+   "pom": "sha256-VV0MnqppwEKv+SSSe5OB6PgXQTbTVe6tRFIkRS5ikcw="
+  },
+  "org/apache#apache/33": {
+   "pom": "sha256-14vYUkxfg4ChkKZSVoZimpXf5RLfIRETg6bYwJI6RBU="
+  },
+  "org/apache/commons#commons-compress/1.21": {
+   "jar": "sha256-auz9VFlyillWAc+gcljRMZcv/Dm0kutIvdWWV3ovJEo=",
+   "pom": "sha256-Z1uwI8m+7d4yMpSZebl0Kl/qlGKApVobRi1Mp4AQiM0="
+  },
+  "org/apache/commons#commons-parent/34": {
+   "pom": "sha256-Oi5p0G1kHR87KTEm3J4uTqZWO/jDbIfgq2+kKS0Et5w="
+  },
+  "org/apache/commons#commons-parent/42": {
+   "pom": "sha256-zTE0lMZwtIPsJWlyrxaYszDlmPgHACNU63ZUefYEsJw="
+  },
+  "org/apache/commons#commons-parent/52": {
+   "pom": "sha256-ddvo806Y5MP/QtquSi+etMvNO18QR9VEYKzpBtu0UC4="
+  },
+  "org/apache/commons#commons-parent/69": {
+   "pom": "sha256-1Q2pw5vcqCPWGNG0oDtz8ZZJf8uGFv0NpyfIYjWSqbs="
+  },
+  "org/apache/groovy#groovy-bom/4.0.22": {
+   "module": "sha256-Ul0/SGvArfFvN+YAL9RlqygCpb2l9MZWf778copo5mY=",
+   "pom": "sha256-Hh9rQiKue/1jMgA+33AgGDWZDb1GEGsWzduopT4832U="
+  },
+  "org/apache/httpcomponents#httpclient/4.5.14": {
+   "jar": "sha256-yLx+HFGm1M5y9A0uu6vxxLaL/nbnMhBLBDgbSTR46dY=",
+   "pom": "sha256-8YNVr0z4CopO8E69dCpH6Qp+rwgMclsgldvE/F2977c="
+  },
+  "org/apache/httpcomponents#httpcomponents-client/4.5.14": {
+   "pom": "sha256-W60d5PEBRHZZ+J0ImGjMutZKaMxQPS1lQQtR9pBKoGE="
+  },
+  "org/apache/httpcomponents#httpcomponents-client/4.5.6": {
+   "pom": "sha256-sEK0HyOR7bANNff05Qmu0hI2SMHSRs5Y0Pe5Bcn+H3M="
+  },
+  "org/apache/httpcomponents#httpcomponents-core/4.4.16": {
+   "pom": "sha256-8tdaLC1COtGFOb8hZW1W+IpAkZRKZi/K8VnVrig9t/c="
+  },
+  "org/apache/httpcomponents#httpcomponents-parent/10": {
+   "pom": "sha256-yq+WfZSvshdT82CCxghiBr0fSIJf9ZaTLM66crZdOfo="
+  },
+  "org/apache/httpcomponents#httpcomponents-parent/11": {
+   "pom": "sha256-qQH4exFcVQcMfuQ+//Y+IOewLTCvJEOuKSvx9OUy06o="
+  },
+  "org/apache/httpcomponents#httpcore/4.4.16": {
+   "jar": "sha256-bJs90UKgncRo4jrTmq1vdaDyuFElEERp8CblKkdORk8=",
+   "pom": "sha256-PLrYSbNdrP5s7DGtraLGI8AmwyYRQbDSbux+OZxs1/o="
+  },
+  "org/apache/httpcomponents#httpmime/4.5.6": {
+   "jar": "sha256-CysRAsGNPH4Fp3IUubdQGm9gVhdK5WBODiVndu2nVT4=",
+   "pom": "sha256-37/W/+KnhMqYF8RjZap/ileDILgFveOdb1WgsJ2KqMo="
+  },
+  "org/apache/logging#logging-parent/11.3.0": {
+   "pom": "sha256-pcmFtW/hxYQzOTtQkabznlufeFGN2PySE0aQWZtk19A="
+  },
+  "org/apache/logging#logging-parent/7": {
+   "pom": "sha256-5YkR3J/GsXOhDlqp7bk8eZStBmAnBd0Gftz8bh6eFys="
+  },
+  "org/apache/logging/log4j#log4j-api/2.20.0": {
+   "jar": "sha256-L0PupnnqZvFMoPE/7CqGAKwST1pSMdy034OT7dy5dVA=",
+   "pom": "sha256-zUWDKj1s0hlENcDWPKAV8ZSWjy++pPKRVTv3r7hOFjc="
+  },
+  "org/apache/logging/log4j#log4j-api/2.24.2": {
+   "jar": "sha256-DKPsvUwxW91fLvavEncS33GMeDNMzlv2+3tKoX/asSY=",
+   "pom": "sha256-PvzSYUu/xZCVlJDx3FgXwUGRmYHZ6daaZSZKFzHhWKc="
+  },
+  "org/apache/logging/log4j#log4j-bom/2.20.0": {
+   "pom": "sha256-+LtpLpWmt72mAehxAJWOg9AGG38SMlC2gSiUOhlenaE="
+  },
+  "org/apache/logging/log4j#log4j-bom/2.24.2": {
+   "pom": "sha256-NQKIlCeybxfvStgWgCxJtJQ/DJOXJoYdEmPlenKiMEY="
+  },
+  "org/apache/logging/log4j#log4j-core/2.20.0": {
+   "jar": "sha256-YTffhIza7Z9NUHb3VRPGyF2oC5U/TnrMo4CYt3B2P1U=",
+   "pom": "sha256-3nGsEAVR9KB3rsrQd70VPnHfeqacMELXZRbMXM4Ice4="
+  },
+  "org/apache/logging/log4j#log4j-core/2.24.2": {
+   "jar": "sha256-enuQ24ZshqEJOz/edYyig5jrsqUz2g15owzAp4UGud8=",
+   "pom": "sha256-XA2/WcPDVRdm+NdukpIOd0gLFWuTR6L3Uuz+tN1kSxc="
+  },
+  "org/apache/logging/log4j#log4j-slf4j2-impl/2.20.0": {
+   "jar": "sha256-uN0+TqnP+hjbXzAc2MU5FYZi5pHv1HAaqHtNCZYb2LA=",
+   "pom": "sha256-twx2AextJIylCOojNyjIYqBi2lg0doIWdAcvq7OLkU4="
+  },
+  "org/apache/logging/log4j#log4j/2.20.0": {
+   "pom": "sha256-mje0qPZ+jUG8JHNxejAhYz1qPD8xBXnbmtC+PyRlnGk="
+  },
+  "org/apache/logging/log4j#log4j/2.24.2": {
+   "pom": "sha256-TY1YM2j0eTVGPhpnFQLVkBnHSvSki7sjoiOptI8B9Hk="
+  },
+  "org/bitbucket/b_c#jose4j/0.9.5": {
+   "jar": "sha256-gI+zFm8+Z9rZgRwzECmrFoEkL9Urc1vD8z8oEWf8xy4=",
+   "pom": "sha256-utAkGAobRpy9lOXy2xKEG8rFRD2VRWB/Zzz95nfB2HI="
+  },
+  "org/bouncycastle#bcpkix-jdk18on/1.79": {
+   "jar": "sha256-NjmiTd+bpLfroGWbRHcOkeuoFkIYiOVx8oWq3v5TLNY=",
+   "pom": "sha256-NeSfQTTeKsMmw6UKJXYsu021bzgC+j9zDMhbZTrQmHs="
+  },
+  "org/bouncycastle#bcprov-jdk18on/1.79": {
+   "jar": "sha256-DYHswxJFNrU5vOmqP+liG3+Eyc7jcbY1pbMceLeasdo=",
+   "pom": "sha256-2PGgaxSddG6dmN5U4veqmy62E/s1ymfYrjls6qxmHuQ="
+  },
+  "org/bouncycastle#bcutil-jdk18on/1.79": {
+   "jar": "sha256-xwuIraWJOMvC8AXUAykFQHi8+hFJ5v/APpJC62qyGDY=",
+   "pom": "sha256-4kwftM8WBUBaaYjp5NbksuH0OT/HOompRSrmJe4xHQI="
+  },
+  "org/checkerframework#checker-compat-qual/2.5.5": {
+   "jar": "sha256-EdE0skXpysxHRRTS1mtbhhj4A5oUZc3FW7wLNOAAi3o=",
+   "pom": "sha256-QvIevZGDvgSe5a/IIrNFQDpdp2QDeHVzSgObDW4DU74="
+  },
+  "org/checkerframework#checker-qual/2.5.8": {
+   "pom": "sha256-M6xqDxNBrpZkfH1EZfSqPST+l9Jpe87izq5vyLXvLDw="
+  },
+  "org/checkerframework#checker-qual/3.12.0": {
+   "module": "sha256-0EeUnBuBCRwsORN3H6wvMqL6VJuj1dVIzIwLbfpJN3c=",
+   "pom": "sha256-d1t6425iggs7htwao5rzfArEuF/0j3/khakionkPRrk="
+  },
+  "org/checkerframework#checker-qual/3.33.0": {
+   "jar": "sha256-4xYlW7/Nn+UNFlMUuFq7KzPLKmapPEkdtkjkmKgsLeE=",
+   "module": "sha256-6FIddWJdQScsdn0mKhU6wWPMUFtmZEou9wX6iUn/tOU=",
+   "pom": "sha256-9VqSICenj92LPqFaDYv+P+xqXOrDDIaqivpKW5sN9gM="
+  },
+  "org/checkerframework#checker-qual/3.42.0": {
+   "jar": "sha256-zK7dM68LeJTZ8vO2RPTRnkOSjjKQLmGsTRB3eDD1qsc=",
+   "module": "sha256-4PpiK33mPq4RBH726RtMKtDx8OE8uQP/UggKR/V6V0Y=",
+   "pom": "sha256-v1/KqycvVMvPG753w72WPIIcmrrSBYcIvwvtPIdUlMo="
+  },
+  "org/checkerframework#checker-qual/3.43.0": {
+   "module": "sha256-+BYzJyRauGJVMpSMcqkwVIzZfzTWw/6GD6auxaNNebQ=",
+   "pom": "sha256-kxO/U7Pv2KrKJm7qi5bjB5drZcCxZRDMbwIxn7rr7UM="
+  },
+  "org/codehaus/groovy#groovy-bom/3.0.14": {
+   "pom": "sha256-JODptzjecRjennNWD/0GA0u1zwfKE6fgNFnoi6nRric="
+  },
+  "org/codehaus/mojo#animal-sniffer-annotations/1.18": {
+   "pom": "sha256-rfUi9IOcNfUynql8QHrr6/qIB7ZEhS3E1c18l7em0uA="
+  },
+  "org/codehaus/mojo#animal-sniffer-annotations/1.23": {
+   "jar": "sha256-n/5Sa/Q6Y0jp2LM7nNb1gKf17tDPBVkTAH7aJj3pdNA=",
+   "pom": "sha256-VhDbBrczZBrLx6DEioDEAGnbYnutBD+MfI16+09qPSc="
+  },
+  "org/codehaus/mojo#animal-sniffer-annotations/1.24": {
+   "jar": "sha256-xyDm5by+ay9I3tdaR7zNt2Pu3nnRQzAQLg01Lj2J7ZI=",
+   "pom": "sha256-iEhPYKatQjipf+us8rMz6eCMF4uPGAoFo+2/9KOKg24="
+  },
+  "org/codehaus/mojo#animal-sniffer-parent/1.18": {
+   "pom": "sha256-Tp31RqR89jBKExfEaHAQCocm++oRsN0YMi+VfkBwlzw="
+  },
+  "org/codehaus/mojo#animal-sniffer-parent/1.23": {
+   "pom": "sha256-a38FSrhqh/jiWZ81gIsJiZIuhrbKsTmIAhzRJkCktAQ="
+  },
+  "org/codehaus/mojo#animal-sniffer-parent/1.24": {
+   "pom": "sha256-Sd2rQ8g2HcLvDB/4fLWQ+nIxcCq59i4m1RLcGKHxzQQ="
+  },
+  "org/codehaus/mojo#mojo-parent/50": {
+   "pom": "sha256-+BnK0bFbaneRyLYB6WveM3ZeRoE5WAfbRTfS8N7dSTs="
+  },
+  "org/codehaus/mojo#mojo-parent/74": {
+   "pom": "sha256-FHIyWhbwsb2r7SH6SDk3KWSURhApTOJoGyBZ7cZU8rM="
+  },
+  "org/codehaus/mojo#mojo-parent/84": {
+   "pom": "sha256-L+UQYYsvYPzV8vuCvEssLDRASNdPML5xn8uGgp7orDA="
+  },
+  "org/eclipse/ee4j#project/1.0.2": {
+   "pom": "sha256-dJWgenl+iOQ8O8GodCG9ix/FXjIpH6GOTjLYAx3chz8="
+  },
+  "org/eclipse/ee4j#project/1.0.5": {
+   "pom": "sha256-kWtHlNjYIgpZo/32pk2+eUrrIzleiIuBrjaptaLFkaY="
+  },
+  "org/eclipse/ee4j#project/1.0.6": {
+   "pom": "sha256-Tn2DKdjafc8wd52CQkG+FF8nEIky9aWiTrkHZ3vI1y0="
+  },
+  "org/eclipse/ee4j#project/1.0.7": {
+   "pom": "sha256-IFwDmkLLrjVW776wSkg+s6PPlVC9db+EJg3I8oIY8QU="
+  },
+  "org/eclipse/jetty#jetty-bom/9.4.50.v20221201": {
+   "pom": "sha256-TN5uUz1gHq+LZazulWt3BsGBkvJ1XQI9fo0Zu31bOUM="
+  },
+  "org/glassfish/jaxb#jaxb-bom/2.3.2": {
+   "pom": "sha256-oQGLtUZ47Z9ayy96QITjhf9RAgH06dv1913GpnX2a+c="
+  },
+  "org/glassfish/jaxb#jaxb-runtime/2.3.2": {
+   "jar": "sha256-5uCh6J+2/3hieeagCC1c71LcLr5nBT0EGABzdlK0/Rs=",
+   "pom": "sha256-lEilrX+mimCD375PQsjIPggrkgKhBUAfxo6UTCZUizQ="
+  },
+  "org/glassfish/jaxb#txw2/2.3.2": {
+   "jar": "sha256-SmqfSDOI1GG4GqmijGhbi3TAWXmTvxiEsE7dvKlfSP4=",
+   "pom": "sha256-p53QAvsDgYP/KGomNb4uaMEDuH4OZHF9jUS/0Bf9M+o="
+  },
+  "org/hamcrest#hamcrest-core/1.3": {
+   "jar": "sha256-Zv3vkelzk0jfeglqo4SlaF9Oh1WEzOiThqekclHE2Ok=",
+   "pom": "sha256-/eOGp5BRc6GxA95quCBydYS1DQ4yKC4nl3h8IKZP+pM="
+  },
+  "org/hamcrest#hamcrest-parent/1.3": {
+   "pom": "sha256-bVNflO+2Y722gsnyelAzU5RogAlkK6epZ3UEvBvkEps="
+  },
+  "org/jdom#jdom2/2.0.6": {
+   "jar": "sha256-E0XxG6YG0VYD1nQFUajCGUfAIVZAdw7GcnH+eL6pfPU=",
+   "pom": "sha256-R7I6ef4za3QbgkNMbgSdaBZSVuQF51wQkh/XL6imXY0="
+  },
+  "org/jetbrains#annotations/13.0": {
+   "jar": "sha256-rOKhDcji1f00kl7KwD5JiLLA+FFlDJS4zvSbob0RFHg=",
+   "pom": "sha256-llrrK+3/NpgZvd4b96CzuJuCR91pyIuGN112Fju4w5c="
+  },
+  "org/jetbrains#annotations/22.0.0": {
+   "pom": "sha256-pe8M4dxdO/1vYQD63AN3RVsc+wJRwsIX0yZqWkNYW7U="
+  },
+  "org/jetbrains#annotations/23.0.0": {
+   "jar": "sha256-ew8ZckCCy/y8ZuWr6iubySzwih6hHhkZM+1DgB6zzQU=",
+   "pom": "sha256-yUkPZVEyMo3yz7z990P1P8ORbWwdEENxdabKbjpndxw="
+  },
+  "org/jetbrains#annotations/26.0.1": {
+   "jar": "sha256-IDe+N4mA07qTM+l5VfOyzeOSqhJNBMpzzi7uZlcZkpc=",
+   "module": "sha256-x/njSbNN+LIRRw4imGJEnDzBPLweeMebKXo3Ryey5gU=",
+   "pom": "sha256-kEBuKDkHRCqz88ZftqO25RdILNb4Ywgep70sggENrFc="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-common/2.10.0-alpha01": {
+   "module": "sha256-NHRgKQ4D6dxNeuS32lIh+fv5KRAgmq8MDotPrIB1JsI=",
+   "pom": "sha256-LB3rSlGSF2hn58H8B1/HAqpgfbvrhh+LL4VWwhrg66Q="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-common/2.8.4": {
+   "module": "sha256-o7yb3i/+/IFT1Sr8WAQms4rWV2yuE0a7jIPbzFBvAPQ=",
+   "pom": "sha256-BjXG8hQBtELWxoStOF6vEfzeJDv7dZbGk62+tZPwobM="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-common/2.9.4": {
+   "module": "sha256-S/WE5uBMORPf6cIMGIKiKZ3N3gMgR9YxpqsAZSpRnTM=",
+   "pom": "sha256-DRDzDh37izhO+dnYN5kDd+pecAijEujpEINo++ZR67g="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose-desktop/2.10.0-alpha01": {
+   "jar": "sha256-McPEtt6jjweMRoKd7ixDq7or+HV7fuig9mDzEhc2SJg=",
+   "module": "sha256-YLxlyOiak1mwIyO2rEp8ZxXZVu6I/z86aUs2bO4hW4w=",
+   "pom": "sha256-yBjjKHLQNNPoSkPtN4wyL0fwTMRkzUt0QgCZL3CTXLU="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose-desktop/2.9.4": {
+   "jar": "sha256-oHi0QUV+wOEAB9zRY/+fLAQ3+bNfvJ7Gzq2C+OmFiU0=",
+   "module": "sha256-bzhY5UrLXgDNt5WBB1XNOo0YvhH5CA5Kq9NOW8fkAmk=",
+   "pom": "sha256-o4T7ZoTUHnwBpKhmOERe+s/bHJ2dzEwi5JIBV8T9Odc="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose-uikitarm64/2.10.0-alpha01": {
+   "module": "sha256-oQHFK4vqXlQBBnpsJZcicn1hRv5Oa4NpLRIIcN5AlMI=",
+   "pom": "sha256-7mDOab4R3OQwiYIMPhvTXvtfXwtucIMpKADdrc4vlr0="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose-uikitarm64/2.8.4": {
+   "module": "sha256-znxiSNBqKdli83V+T8EjzrAaRFArrpaCvzkrsZCo1FQ=",
+   "pom": "sha256-CBax5kg98XHEnUa7KEgzkgjR06blwRgeGmhQe55ny9k="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose-uikitarm64/2.9.4": {
+   "module": "sha256-I33fYlCUxX2xVUp/IYu/Eva+id75j9PDKxO6AUxHpCw=",
+   "pom": "sha256-c0a0O7IbDMnp9y6ojyhtBatFxh44Q/ICGcNkpBPYTIs="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose-uikitsimarm64/2.10.0-alpha01": {
+   "module": "sha256-muaNek/B3igmZqiWhEA0L8B+Q6gixoDyhQ+5AB+1MOk=",
+   "pom": "sha256-QkC+dc0Aoljt5dTk2MseEMOHfMw/H3sROZF9jeKvDQg="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose-uikitsimarm64/2.8.4": {
+   "module": "sha256-KLTMbw2TbsDsl7MmNN/8PTh8+FAH5HmleqblMMEoCgc=",
+   "pom": "sha256-4wIP/ijmcA/FVHbl6+63jxbjlBFR55TA4ygfQaCJBRU="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose-uikitsimarm64/2.9.4": {
+   "module": "sha256-4ALSJf25uAuei0GFl+JnSx2/bT9+L8rA4+IzQMKAwLE=",
+   "pom": "sha256-Flhuh1CfOTS/oF7hA/zt1gYb+Zm7MJYiz34yi3f9fyc="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose/2.10.0-alpha01": {
+   "module": "sha256-s1Er12vlhNDqZS28bUqCJR2+eIfqO+XgKaAHu6nHHkk=",
+   "pom": "sha256-xAm+35u3+5fm+jipMl6W9xf5skJm5saGrB2vozMK5dI="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose/2.8.4": {
+   "module": "sha256-Q7eeNCcX8sx9rQzddNUawtwxbEhmj3jfJsIc8GleED4=",
+   "pom": "sha256-UofDvv5hVYWLH9njHp2UwCQHN3i/fY1Bs4dasp70Gsc="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose/2.9.4": {
+   "module": "sha256-FOsoP3X55Qs7gDCWEi5xO7YX8LZkWntNkUYReBLzmzQ=",
+   "pom": "sha256-nTn31/uWEshmNaR9lkulaMrU+K6LD6JpwvNXUR4mC4E="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-runtime/2.10.0-alpha01": {
+   "module": "sha256-iS9RvoRE1KUjyre60I4s/a+cXAjjZHJIyMmik3syq3s=",
+   "pom": "sha256-qjXNap20CH6Bc5KAM6Uko61y3g27SPkBsD9UM6hiLwI="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-runtime/2.8.4": {
+   "module": "sha256-t/5oq5S4ncDF1wWltk3LDDyDpITimPNfA2x5cRZgHqQ=",
+   "pom": "sha256-DQ7wsV76yiXtdgT6FB0OjT+6iU0wl511DVBpZrZg0Dk="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-runtime/2.9.4": {
+   "module": "sha256-bu2+0UiG5BVzBDUROa1LtNTvkBxn3AKyJ+6Yvkr2EXs=",
+   "pom": "sha256-maX6xqZWgAhsFHQuww5ChGeEiEOVfgUhKzfW+qhbBaw="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel-compose-desktop/2.9.4": {
+   "jar": "sha256-LbmW6/laC7bi4FeOKKa6Ry6/7FntHV0y1RPvPsAd/Bs=",
+   "module": "sha256-XBUMJJ9s4Orw2dwFdOrjlgJ7UEqjtY+Xp17Jz9e4RWM=",
+   "pom": "sha256-8n/KWtmLHF1ytOs+GugKemX7+9+q2PBx/91smw8ZGPo="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel-compose-uikitarm64/2.9.4": {
+   "module": "sha256-xYl/m+Ov7p5EQNWq5S1YShHZ5TiUqD0diI98yYuYi6I=",
+   "pom": "sha256-NivXNpyUjEARUn3eIvoIicnySbykneCy0brSVmKVOvA="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel-compose-uikitsimarm64/2.9.4": {
+   "module": "sha256-KqKwj8z3yRBhF/nJeN5HlsPdGwdJk5MafLh8+ougwow=",
+   "pom": "sha256-1LxDR4pe0bUEXQbiOJYSFSk3huA9z6zFeedhZfnTVaU="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel-compose/2.9.4": {
+   "module": "sha256-GLcmEo6xjbJpVzVbF21ifBF9VL8CxwkPaawcbHPQR5M=",
+   "pom": "sha256-w1GFbJrUU8+yoNTx1Wd5RNOvl9GihRo4oj0igS6Vr34="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel-savedstate/2.10.0-alpha01": {
+   "module": "sha256-8j5tQbBIKBnnSRzKmTDwLZc1/e58yRSIRTDgs52hAP0=",
+   "pom": "sha256-IQjEZ7YVI5r7xuwH7tNB2N5rsMm+KQzEA0RqfV6eBDw="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel-savedstate/2.9.4": {
+   "module": "sha256-BenXVkAXdWgEeEwxXpZxqASZXa3EHaolt/8g3OWJm2Q=",
+   "pom": "sha256-7bq4xQVmwkGOjCZUXViG+sbkExhgn4Xarhd1t/jM9FQ="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel/2.10.0-alpha01": {
+   "module": "sha256-jysvPU2dwbAlMX3wuj8y5HWwFC3zv3voNhSJDmBd9F8=",
+   "pom": "sha256-D/lmoQGjmB8mcVvqgPH/1/YqV/2mn4R1yGZWcJk9SEI="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel/2.8.4": {
+   "module": "sha256-YdkxJsnivTyFp0+XrYFbxhi5A52bFIOz9OXp6Ayc+Bw=",
+   "pom": "sha256-7VnmgyoqJ4xsYcgDMqFxWJmewWE90Cvir6DZ/PMbvfY="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel/2.9.4": {
+   "module": "sha256-RQ5l1bXN5cWq6WwHPkOmA8k3xawekl2V1gX2zAmivoc=",
+   "pom": "sha256-jx+k87JIILrduKGJmb9NkMnF93g0BmL2lfYSrHOK09s="
+  },
+  "org/jetbrains/androidx/navigation#navigation-common-desktop/2.9.0": {
+   "jar": "sha256-CO+q0Iw6jJthHljWG9IWhKw4WBG9wY8/TAuvE7R+c0A=",
+   "module": "sha256-6r4u6c6m6xfLy7gHM6PjfS4YRWC0HAdk8orPfsLHapo=",
+   "pom": "sha256-+TkDliVIHUVP/Rz3Hgr2Zc4yi1/hwIW/3TtehC7l/V8="
+  },
+  "org/jetbrains/androidx/navigation#navigation-common-iosarm64/2.9.0": {
+   "module": "sha256-dlUZs3lHB/e0wYhrNOR6saLY5LQ1uPZu3phS5/Hpqyw=",
+   "pom": "sha256-2tEUZ7e+TXZ6kQNY7DHSjW01vTs0EsAA09KU/FP6jLE="
+  },
+  "org/jetbrains/androidx/navigation#navigation-common-iossimulatorarm64/2.9.0": {
+   "module": "sha256-nWZdAFP+N7xc64CknibBY5cDoeZvzR+9WMtrTHDKqPE=",
+   "pom": "sha256-uN+T6sgij+1WrbHLp0SWMdBcvM2R8oP/Z5WZBeo97Ng="
+  },
+  "org/jetbrains/androidx/navigation#navigation-common/2.9.0": {
+   "module": "sha256-txJRKtiw+V2ySPmXsg4nvHtO7IFlFgjGaVQdMuDEZsc=",
+   "pom": "sha256-ozn1LM6YjIRQ4Dn0O0lTuD+7sjYX+/ARXdAh182sQgY="
+  },
+  "org/jetbrains/androidx/navigation#navigation-compose-desktop/2.9.0": {
+   "jar": "sha256-IRoY+cw7JJZ/JR0dPIjslKmJL40EqctA1nW6HuGBkwk=",
+   "module": "sha256-WTQiZHWPurkbNBncsXQsy9SM7Cww/vmxeZ01lejx0xs=",
+   "pom": "sha256-3+sGcOd9jQhjUQunla8baxXoQMwdPK9/B4eTYWsosvg="
+  },
+  "org/jetbrains/androidx/navigation#navigation-compose-uikitarm64/2.9.0": {
+   "module": "sha256-lR/0YJ+cQofMCtIYjG4i4ytsd+V/yHAybPJQTDVZ1EE=",
+   "pom": "sha256-j/vt1/sfxEK9/2F8HqSwCWS05rQvoHys0vI719fDLQU="
+  },
+  "org/jetbrains/androidx/navigation#navigation-compose-uikitsimarm64/2.9.0": {
+   "module": "sha256-iOJpmzM9o/tqtLMuFhEHd6+LJJavjp6jMMZuqqZ9SPk=",
+   "pom": "sha256-PKWO2uN2UDsOieB1VsRt5eZvePbodNTTJF8wBUAMCcA="
+  },
+  "org/jetbrains/androidx/navigation#navigation-compose/2.9.0": {
+   "module": "sha256-nqrbjOIMVu4sPazJgKyceyLoXPnR4EZTTH5S4DVfqjc=",
+   "pom": "sha256-50hHlA0nXNZmETTd5nBrpWd39C8qfYhAjIPNZXmk+X4="
+  },
+  "org/jetbrains/androidx/navigation#navigation-runtime-desktop/2.9.0": {
+   "jar": "sha256-mDu8exKHi8eeGf5PqsVnKRzT5pLJHNyHJWI6xB2pFH0=",
+   "module": "sha256-tqb7PUDBscbAIXC+tkxmkCCKE+Pc1mAZEljSL3M1npo=",
+   "pom": "sha256-ZtugiQfPmYwwF5A2mSQXcMmHUgMvORbAcNzz42UqDp8="
+  },
+  "org/jetbrains/androidx/navigation#navigation-runtime-iosarm64/2.9.0": {
+   "module": "sha256-lARK1mMxjJqcfzgaeko2Q0YIVYu2rO/6vv1Q4UcJ7uQ=",
+   "pom": "sha256-DOnP2CxlPgw5mN/TBDl6zC6lL2jeeVxU/97mvQZr+L4="
+  },
+  "org/jetbrains/androidx/navigation#navigation-runtime-iossimulatorarm64/2.9.0": {
+   "module": "sha256-kkPwQlqzmGpg4UuRBG4axOoo3laUMU3ZIRS7lEkkZ5Y=",
+   "pom": "sha256-W4YxtGvmJi8uBmgvtlnXsB4ArgkGwn/JVRzBM4OfpXg="
+  },
+  "org/jetbrains/androidx/navigation#navigation-runtime/2.9.0": {
+   "module": "sha256-oWkN2zQoJSqjYiZB7RWj8U6xT8p5iMIRvtFklOHMVSw=",
+   "pom": "sha256-lJ6xfbCDW6AETqxWN+fffWePPJMMPAEFBvGtUyxLW5U="
+  },
+  "org/jetbrains/androidx/savedstate#savedstate-compose-desktop/1.3.4": {
+   "module": "sha256-HMfdieaRvibyXww3A/+4qDCwl6v6vFRakNf6JOKkRec=",
+   "pom": "sha256-NbzmQ7VvI5UgjooZhxZkW0vCkLz6yXlaWv/8j/k3BmM="
+  },
+  "org/jetbrains/androidx/savedstate#savedstate-compose-desktop/1.4.0-alpha01": {
+   "jar": "sha256-Dz0EXF/X4TAatsOM0HeAZ7BITPOaysEjO+cacjpqgHU=",
+   "module": "sha256-4vKHoF0Bkb7oZHVXv2X+DaHeEnW5PlgjogTdJ1DXMq0=",
+   "pom": "sha256-drF9uhEiK+vKCMqKqHUwA/bM6k/nGLK2eswcDg8zDHU="
+  },
+  "org/jetbrains/androidx/savedstate#savedstate-compose-uikitarm64/1.3.4": {
+   "module": "sha256-rQ8ztGkoWkmjiamfLLvaMWRLPxnk9rAHmgbfYakjMJk=",
+   "pom": "sha256-mNyjIn0v0nqX+CSFhn0MNSxXKO2KjdxnqFgFRqAIQhk="
+  },
+  "org/jetbrains/androidx/savedstate#savedstate-compose-uikitarm64/1.4.0-alpha01": {
+   "module": "sha256-5Y7SVQozveiLueTK6b651wdXjwTubKAsibc22xeXfsc=",
+   "pom": "sha256-XcYKh7NQLgGQBPZo1lnaXNaJ1URt7w+Lr0bBE8/93Aw="
+  },
+  "org/jetbrains/androidx/savedstate#savedstate-compose-uikitsimarm64/1.3.4": {
+   "module": "sha256-uEj1mld5vUXNA8c0+ddhYdLlHxSsLs/0M3Jt04TGvFo=",
+   "pom": "sha256-l7pKmV/SIEhyO+r4jpnpmUeqsr17JiRzAvQzWxcFS64="
+  },
+  "org/jetbrains/androidx/savedstate#savedstate-compose-uikitsimarm64/1.4.0-alpha01": {
+   "module": "sha256-6kv99OnnfXV4gS7+BDblkdDUL1j7M5GpAs+CexXaOrw=",
+   "pom": "sha256-tmM06ut7hGckYdnwwkjFP1NiPyLAJ1U+Ywl9ca7l5XQ="
+  },
+  "org/jetbrains/androidx/savedstate#savedstate-compose/1.3.4": {
+   "module": "sha256-A46PL+QVpysSdcURVYa94PKM445mUZqTaO2wvZMePTc=",
+   "pom": "sha256-WeXvwinjf4pQWaElb5mp1A1ayC2ms9YhQSNqyou8R50="
+  },
+  "org/jetbrains/androidx/savedstate#savedstate-compose/1.4.0-alpha01": {
+   "module": "sha256-CC+Bq+ywnpg46X7O8qG8nLpWCldn57+B3ZU49N59OLM=",
+   "pom": "sha256-6pyodoNNC3aa0W+qaUPpmIIVO2EDH2pfTP9sT7wsfqc="
+  },
+  "org/jetbrains/androidx/savedstate#savedstate/1.3.4": {
+   "module": "sha256-nx47jPrw+5xq1VqY6u7M/fO6p3lTj0JynWSeQGWLd5A=",
+   "pom": "sha256-31rG2m1h5s9MeWq3dLxDiMztC4h8B50q5VbpwZrcYgo="
+  },
+  "org/jetbrains/androidx/savedstate#savedstate/1.4.0-alpha01": {
+   "module": "sha256-O3u6xN1aGwAMMfXxvvLORtFtWYBKM0z+oNfyOmdHkik=",
+   "pom": "sha256-Sq5T5rBbH+zzLQuMpByzSu5p//PaYInPzSko3J2jbHc="
+  },
+  "org/jetbrains/androidx/window#window-core-desktop/1.4.0": {
+   "jar": "sha256-TgjOp9IXQRbCE2KL5oNIa94FEEGnduurTGJ7XOlkyS0=",
+   "module": "sha256-DgFhWE7Qt2Ym052p7PRU7GJSy3wvWRNQY+jjmuHO0Qc=",
+   "pom": "sha256-GpCJD45X6/XWmnePSLK8BEX0c8y448AC3aMUaoHrk64="
+  },
+  "org/jetbrains/androidx/window#window-core-desktop/1.5.0-alpha01": {
+   "jar": "sha256-5qLD1Oba5/aeRm2HXB6Kt4c0r5kawz4gdqmcd2Zd0zA=",
+   "module": "sha256-l4gP30BH2FGybwkHU8Y/CB+SOtipMDaCI0nntwFHOZA=",
+   "pom": "sha256-2/7/+GgypCr6aYPJDYD9xk+ai/kQHc1DvH0jHWSDNUM="
+  },
+  "org/jetbrains/androidx/window#window-core-iosarm64/1.4.0": {
+   "module": "sha256-zFiL9Ph3LfRYnWCsZr7xYgRenXfKyUJNe+kNI/0Qxys=",
+   "pom": "sha256-ppvwWAqO43DA1PiU/4ePTTvOZ26rfEK0HAq391qF+vM="
+  },
+  "org/jetbrains/androidx/window#window-core-iosarm64/1.5.0-alpha01": {
+   "module": "sha256-BKXrk/8vYobWLb9rQ5Vg+HNOZNY9ctG5XZJN0n+Q/A0=",
+   "pom": "sha256-ERNfvFkqr73hgGzA3AalNOI8ND6LTKjNLUn610sCA+A="
+  },
+  "org/jetbrains/androidx/window#window-core-iossimulatorarm64/1.4.0": {
+   "module": "sha256-pKwufrJcODa0unOkhw3kp+2NkjIoosWyc3Wj5/Skz3c=",
+   "pom": "sha256-eK2KihZqAlnaUN0OdW/WXyrHRBA/9Zbdw3Iuq5mzmu4="
+  },
+  "org/jetbrains/androidx/window#window-core-iossimulatorarm64/1.5.0-alpha01": {
+   "module": "sha256-JTY7E3ASftjKcplrBNDnIiyk1/T1CX3ZjcnUzTU+JxY=",
+   "pom": "sha256-ZJ/IyXkQf9I0IvpFFaE99GYKXls2r+dSqU5ZkUnRnxw="
+  },
+  "org/jetbrains/androidx/window#window-core/1.4.0": {
+   "module": "sha256-WkVPAYldrAq+84PcX6XuKXvYPbRZpRQghUuEHU3dxo0=",
+   "pom": "sha256-yR+VfolguTmNdpkJFOIqbKVKGrKewCuGbeBNC7mToKs="
+  },
+  "org/jetbrains/androidx/window#window-core/1.5.0-alpha01": {
+   "module": "sha256-BWy03kGoOXB4HSQXeI/h7eDKd2GmEzSZ9LK6MIOGgG8=",
+   "pom": "sha256-1TpBwrqBCrWU7V7/SnVDCpjKJ2r/97Fb/2W4d7o9gBw="
+  },
+  "org/jetbrains/compose#compose-gradle-plugin/1.9.0": {
+   "jar": "sha256-jdM5VeH80dQWLb5FPJA7/F/v9OgfrIQCpM+2mXxBop0=",
+   "module": "sha256-0XKYT4V8V3TAl8Odj54gbP61eFKT3/s7HodRnKs78VQ=",
+   "pom": "sha256-e3Mjwlrhz26+1oBOF1Ec83GXWRsjnsbim1bSYqpJL5c="
+  },
+  "org/jetbrains/compose#gradle-plugin-internal-jdk-version-probe/1.9.0": {
+   "jar": "sha256-kOjMnxmC+lmSX++vAJCvvBhpt0GLXqsoYoHxFOWSiVo=",
+   "module": "sha256-DTt3kyAyxkA/o0iOOHvWR1aH6uRrCz/kQQaik57d0N0=",
+   "pom": "sha256-+yKaC1liSBHiIYAO44s4JzuYNK0uM3+DF1qSqqx/lpE="
+  },
+  "org/jetbrains/compose#org.jetbrains.compose.gradle.plugin/1.9.0": {
+   "pom": "sha256-tSzYv0u2+WP18RWWztJfac+NsNKp41zv4l4OapDAvmI="
+  },
+  "org/jetbrains/compose/animation#animation-core-desktop/1.10.0-alpha01": {
+   "jar": "sha256-SBnZHTPHce9nUvSx/2T90cK5xts/W7i6/DffXCsDMd8=",
+   "module": "sha256-oXtfT8UqApji11YjS5T3LpKIN1nuJCOTTUIMdwUwRQc=",
+   "pom": "sha256-ylEtPUgfjjNe77kVCr+pIsKb7sqaOcd6Y6NYVu7gf+w="
+  },
+  "org/jetbrains/compose/animation#animation-core-desktop/1.7.1": {
+   "jar": "sha256-KzR6v2xIYmFToCtw7va74dPJUnUV1vn37OrqPDmFM7s=",
+   "module": "sha256-c7rYgJkZ/IbsKE5mCKv603DsBjPtbHWV9ptYNh9SAD8=",
+   "pom": "sha256-xqopawWzH+UZ3cIswgrd989vsdtV+anMYJ1TL/h/81w="
+  },
+  "org/jetbrains/compose/animation#animation-core-desktop/1.9.0": {
+   "module": "sha256-HDYyn4gq6yRHC8JYRVpXevjwVGV+OeWjDsocxR9wBkE=",
+   "pom": "sha256-0AS32FEkDFzOaTFu02dVyOzygw2YpC16jsrytm8GOYI="
+  },
+  "org/jetbrains/compose/animation#animation-core-uikitarm64/1.10.0-alpha01": {
+   "module": "sha256-h3OG1fW8sVzTZbgPFlWsgrm3P4wjkngj7qkKuHcPmKU=",
+   "pom": "sha256-rD1fWVqwWw5RR5XzvJOBpuM9cFYhn9caoOwryfx+dxI="
+  },
+  "org/jetbrains/compose/animation#animation-core-uikitarm64/1.7.1": {
+   "module": "sha256-lckXsTi8xsxXbYX3dcQTVxtuP1OD7t+kVSlyRJnlKLU=",
+   "pom": "sha256-C1z8znd/cZ68aOpx91R0dJK7qF9gva2YKiN8JqY1ZZA="
+  },
+  "org/jetbrains/compose/animation#animation-core-uikitsimarm64/1.10.0-alpha01": {
+   "module": "sha256-/nc5Ly+t+hPBaRlruZDwGLNDmkxrvNeuCdvv3AzNiSY=",
+   "pom": "sha256-MWnSE+aQeLPFatmeTMQ73ijt0gH04nTJA8Eg/ZKXkho="
+  },
+  "org/jetbrains/compose/animation#animation-core-uikitsimarm64/1.7.1": {
+   "module": "sha256-EYSIURuwEoeMuCr9PW95dUrC4kM1mPX7oHircEYI/dE=",
+   "pom": "sha256-GxeowL15CW5wK0JX0E3Hrmx7zWZzkCdY+bB+Fz5N3bU="
+  },
+  "org/jetbrains/compose/animation#animation-core/1.10.0-alpha01": {
+   "module": "sha256-eVCbmNfEP4Gt9ZH99RIcuZmMcPyCbND8vFhlsGxxEQU=",
+   "pom": "sha256-30jhXVrqlfciIMrZxi5MUcEvkZkPSj5l0vwesnWtc8s="
+  },
+  "org/jetbrains/compose/animation#animation-core/1.7.1": {
+   "module": "sha256-v4u73LKXNY9tN9inJOif8+kLp+VkA26ZA5X3OwxEjMo=",
+   "pom": "sha256-VdE9LN1WVa+tasG8Ou5rMU2ILf6Nj/UVVmsHj4AuKbw="
+  },
+  "org/jetbrains/compose/animation#animation-core/1.9.0": {
+   "module": "sha256-AyvygPprM79S8/PKNEQe2Ing2RdH+2ly4IgcEhagAu0=",
+   "pom": "sha256-QL8NFIA7IHhDz87+sllqcj1m35hwN3wNiQRjt2XRHns="
+  },
+  "org/jetbrains/compose/animation#animation-desktop/1.10.0-alpha01": {
+   "jar": "sha256-ouB+n9LqGv9a7Li0t97UpSzuI3GIy2SDC4RZfJ9K8yI=",
+   "module": "sha256-w7z86bTiI0ykBVtK+lVzViDGNcrr8q6R2Sx65sY5MsY=",
+   "pom": "sha256-DuvwfCN/gVXR0kCXrYfERWY0zOSAiOWUN7+q7vGdw/M="
+  },
+  "org/jetbrains/compose/animation#animation-desktop/1.7.1": {
+   "jar": "sha256-R05r0qasI2Ll2r14D5O4UnaGQKoWQDsPxQXaiBd/l7M=",
+   "module": "sha256-kw0qlickr+L6z9eYIQfYCmkGh4hHCl1VrcDZj3ijuwY=",
+   "pom": "sha256-j1SyEA/7lX0HPry7gxTwvEne5FWIH9eLvhKnBHnjFwU="
+  },
+  "org/jetbrains/compose/animation#animation-desktop/1.9.0": {
+   "module": "sha256-GZi9Zn+D8JNWo5xob3hS7RVvjCqNuJKVo6w56UYkukM=",
+   "pom": "sha256-cdJ8weEaTONaDDWYjPFMHqDlygRz9hm+3augjRl0v8Y="
+  },
+  "org/jetbrains/compose/animation#animation-uikitarm64/1.10.0-alpha01": {
+   "module": "sha256-2RNGAAnmcGQ7NfaeDOFyrwXHqKo8CNX2kqGLYVNPelI=",
+   "pom": "sha256-9R+2IxNyPJWDhSqi/eyoBL33kwr319X6qf+y6B+NT50="
+  },
+  "org/jetbrains/compose/animation#animation-uikitarm64/1.7.1": {
+   "module": "sha256-U7TPJHnw+a32SngRnUUdYytkiLj5ja3YbnLO1emQq2I=",
+   "pom": "sha256-+T53cNDZRXznY42YvSe8oQbgoeaFIRGXvAgl/vyx22o="
+  },
+  "org/jetbrains/compose/animation#animation-uikitarm64/1.9.0": {
+   "module": "sha256-iy2+CnbmLv1ntWD+fliffaK0ozO259ST6nKm5hWif+E=",
+   "pom": "sha256-/eb3n/Ch6I76xmqIrC1/wkRH3XXNieeyhjRavGFmoz0="
+  },
+  "org/jetbrains/compose/animation#animation-uikitsimarm64/1.10.0-alpha01": {
+   "module": "sha256-JjkDIBqPOO9emEeAKGm3m+lBs2epwhErINHNAIzzYLw=",
+   "pom": "sha256-4kZr7CZWAvIzWkwFIceSRZeibtyVuJCUY4sLYQFE7+s="
+  },
+  "org/jetbrains/compose/animation#animation-uikitsimarm64/1.7.1": {
+   "module": "sha256-vLikMuv+VnOA1/DX8huAdbNjrtniLzXHVYsMZOsgCCE=",
+   "pom": "sha256-bV7b0hauINOEmyZzaIHmq3+99Te6g+ouyxy1QKE2whg="
+  },
+  "org/jetbrains/compose/animation#animation-uikitsimarm64/1.9.0": {
+   "module": "sha256-idC/owQ27Mk4RRitnizWtuqy+90jmHNAwjbwiYp/6ko=",
+   "pom": "sha256-h0TjwVbI1x1iOIS8bG1abYWrkOT3h/mRP78nMYm1Ql4="
+  },
+  "org/jetbrains/compose/animation#animation/1.10.0-alpha01": {
+   "module": "sha256-0I7uj9/m3Jx3m2GGlpO6IkWQpQepHw0J/U7nQWm3txI=",
+   "pom": "sha256-9KG0qoUxyYGMYjv3x3gRacVYeRKOHaFIh6cDDOQoNKA="
+  },
+  "org/jetbrains/compose/animation#animation/1.7.1": {
+   "module": "sha256-leqNJuQAkoHcPo60WyBfj2ZrQmZmtRisSaapUwKiicM=",
+   "pom": "sha256-Q9zVYfPQZrMbAQsujbu8xvzr5dF61PBt1NR93+hF3SU="
+  },
+  "org/jetbrains/compose/animation#animation/1.9.0": {
+   "module": "sha256-RiS7LSOr9KRgyluQd1oG53UoTk2gnYOYl5hpjgVDM1g=",
+   "pom": "sha256-zNUgtBuPHxNkX8e2txcG0ochLUQ26E5L4ETRKGtKlIE="
+  },
+  "org/jetbrains/compose/annotation-internal#annotation/1.10.0-alpha01": {
+   "module": "sha256-+u74B7w53ktJpdIyTwkHll6HIOa+F/S0L8rKIUiQYy4=",
+   "pom": "sha256-GBDsOboUQDeZdagRa9QDhHDklrQVb/cjgq5bdkYt8BA="
+  },
+  "org/jetbrains/compose/annotation-internal#annotation/1.7.1": {
+   "module": "sha256-OBY3qiWg10JF0HpLhxPDjcUBtU+yWvnWHdwzMR9AFhk=",
+   "pom": "sha256-exANVYBe1I3wrGACFGbx1YcGM0wXJ9DQhRrNt302Ptk="
+  },
+  "org/jetbrains/compose/annotation-internal#annotation/1.9.0": {
+   "module": "sha256-wuNy4DRqo8B0a94IDEAFIb0zdicuXVTBc2pkuji8dZc=",
+   "pom": "sha256-hOGFqg90Z7GfToFxQY0FRr2MpJMIfhPFXoUWeHoq/V4="
+  },
+  "org/jetbrains/compose/collection-internal#collection/1.10.0-alpha01": {
+   "module": "sha256-l8ZZfDktQUy/r4gLxCx//wIhFEMqVZ5C9C/Y/NL23Kc=",
+   "pom": "sha256-oaPNKcwhjKLoTbfE83F2SgLRv0VkEStlmgXi1NGlVE4="
+  },
+  "org/jetbrains/compose/collection-internal#collection/1.7.1": {
+   "module": "sha256-gsd1JJvP3C1mEk95jcTrVf8PFYmBVwga9f3Qjq059dQ=",
+   "pom": "sha256-WI9ACx/5qa+QAnIiqNAo05Q1WC3JBkoxmlaL9vrzTgI="
+  },
+  "org/jetbrains/compose/collection-internal#collection/1.9.0": {
+   "module": "sha256-gDAK5xf3KEo4h5SKEX94kRnvukfy0fZIiwCv0Mt0rx8=",
+   "pom": "sha256-boJ19whECuea8VxYRdIUy2liiMRyyokyV3q7VsER5ic="
+  },
+  "org/jetbrains/compose/components#components-resources-android/1.9.0": {
+   "module": "sha256-PjU7tyxBUvxE9eBwngsoMuB3xoQLDQt9pFq8wc4NCT4=",
+   "pom": "sha256-C2imGeO52fHbjlCB/8ma9aTSnt9jtQVIlzV4BZEBgjo="
+  },
+  "org/jetbrains/compose/components#components-resources-desktop/1.9.0": {
+   "jar": "sha256-87jzMba7QxKnTtFte7NlRCfPpzcopYF63b/2TG533+w=",
+   "module": "sha256-OTHh694xwO+VJYKEJkOrT7yKQa3f8LMQN/y5HJnRjtE=",
+   "pom": "sha256-JiFTqaOp09D+2PS88PlLDk9Xzx31156V6JGGiUE3kA0="
+  },
+  "org/jetbrains/compose/components#components-resources-iosArm64/1.9.0": {
+   "module": "sha256-LVbw913nKXmxGnsypBT72GnLXm0qTa4yXYazkxn9EGA=",
+   "pom": "sha256-Kr3D3RTPhyIi9i0dg4WclIny/e77rT/dWTnu8Du25+s="
+  },
+  "org/jetbrains/compose/components#components-resources-iosSimulatorArm64/1.9.0": {
+   "module": "sha256-kPnQLV2u40w/D5WfYldQbF9NkfDgJq3XhKz0fc1cr2k=",
+   "pom": "sha256-WOgc5YXJx8yxeR4spN3qW1dRvw7+rTc73hoerK04I2Q="
+  },
+  "org/jetbrains/compose/components#components-resources/1.9.0": {
+   "module": "sha256-O/zJJv65jlZXAEXvnMLXKH+swiWJNEQlTENGSEM42P0=",
+   "pom": "sha256-4UJBU1Q55uEIKLERKX1Ot/9QIR+JR81kx0nKck4BmmE="
+  },
+  "org/jetbrains/compose/components#components-ui-tooling-preview-desktop/1.9.0": {
+   "jar": "sha256-yghX3N58//+O6jzOKUCihfIZ9nOCn3+aM4H3Z9Ik9BE=",
+   "module": "sha256-sogo7AE118wW0XINadnFxgXafm2qJm0vZLGk2d2B2zk=",
+   "pom": "sha256-c+hmbul87nb+xKUMDalRccu4SaMu+r5j4myQixyVk48="
+  },
+  "org/jetbrains/compose/components#components-ui-tooling-preview-iosArm64/1.9.0": {
+   "module": "sha256-a1uhJpr5A9H9wSV0SLY+GVmFMFXpSx7TwbZAyyEOab8=",
+   "pom": "sha256-6cbNc9hKH22zYxSXoEvNLYnWW5p/tolzwaUD12mlQRc="
+  },
+  "org/jetbrains/compose/components#components-ui-tooling-preview-iosSimulatorArm64/1.9.0": {
+   "module": "sha256-+ePSgJGBRYjtz/6L8ay8Hpm1z7ORDR/QvSEn3fCnQ3Y=",
+   "pom": "sha256-eFd59QfY4BYraFtNJE3V8YOsgtza8EiefdOTytLvBrY="
+  },
+  "org/jetbrains/compose/components#components-ui-tooling-preview/1.9.0": {
+   "module": "sha256-CNXYBJE7tQ73qS25o2IiTwwDkNHT1kcN+ruCuzxfKBM=",
+   "pom": "sha256-6BmBBX5cG2TYkzDL95ztBjzuBWEJFLbtK2XWIlMnttM="
+  },
+  "org/jetbrains/compose/desktop#desktop-jvm-linux-x64/1.9.0": {
+   "pom": "sha256-ikrzKPIGw40cwII7kzDaHHM/HAY2dIVgzPk8T6u9JcM="
+  },
+  "org/jetbrains/compose/desktop#desktop-jvm/1.9.0": {
+   "jar": "sha256-winFLJW0xNc5hMiPQPhHXAfRPSkI003wKeQktroambI=",
+   "module": "sha256-XZKFY3U+ZqsA1zpMgxAoYUt5SubNnt3BykvxdziQ2Eo=",
+   "pom": "sha256-Fa1qgZfJUB2LTvKsCnkU7SOK4KSU+Gq5dYdlaYjticc="
+  },
+  "org/jetbrains/compose/desktop#desktop/1.9.0": {
+   "module": "sha256-kiCLVt2h9QQPgOmufi3pZ9az1UY2gorrwFYVBa6weLk=",
+   "pom": "sha256-6pFZD1PxYbxeT/rjAVVXsG7zGcLme+lPiHuDPGEIPw8="
+  },
+  "org/jetbrains/compose/foundation#foundation-desktop/1.10.0-alpha01": {
+   "jar": "sha256-uA1HkwgmsvLWjdmKoyCTShJy94iC32AscH9zbji/Wg8=",
+   "module": "sha256-uvIJhZujFyZpLuKUj28ppgZhhVdMPOLNPqDYdWMlBYQ=",
+   "pom": "sha256-39tjEXr1Ihqs1n5HRxCM+JkB8liHbuzoRcMqI0CgnP0="
+  },
+  "org/jetbrains/compose/foundation#foundation-desktop/1.7.1": {
+   "jar": "sha256-UN84WzKKCtekeeaQz+WT+84IrTntV5FnR5MpVt7gfws=",
+   "module": "sha256-e0RnxpVJc6cG2nTOLI7Te4RlXSxSGWWXHWgCb5iBTJI=",
+   "pom": "sha256-aAvQ++JHgzK+3kUTK1VmVNpsK063CPiqVp0bvV3AZ9A="
+  },
+  "org/jetbrains/compose/foundation#foundation-desktop/1.9.0": {
+   "module": "sha256-vpZlZzRb+0wg8vNOWSVdBKRhvAXF4fia/qyOrD9kqro=",
+   "pom": "sha256-Dy5t7Bgcjq7IznOIHLJIaC+c9Z+rl/iuDFevTBkGyNY="
+  },
+  "org/jetbrains/compose/foundation#foundation-layout-desktop/1.10.0-alpha01": {
+   "jar": "sha256-zP7qm3UO71tCIK/bsQth7tB0BHql83fN6fq44R3Mqrg=",
+   "module": "sha256-2h6v79ct8JGkQE+9YBtNh1ojmwn2WS9VQZMQaZJuyGw=",
+   "pom": "sha256-kc+yhctD3FHqz0XSxz0ha1+9/zwjxPZFIs3KsCZf0ig="
+  },
+  "org/jetbrains/compose/foundation#foundation-layout-desktop/1.7.1": {
+   "jar": "sha256-0shnwT/2Yy+YgOZ9q6sukwAHsAi5silQ/CzAdQCOzrY=",
+   "module": "sha256-aeRUgNLR3M8Hdzyq5gwdkvTu9PxF3K7luOg2KFlzsBc=",
+   "pom": "sha256-G8KiSCB1lID95NL6BswigNBCOpXAohpoUdjOfoaxnN4="
+  },
+  "org/jetbrains/compose/foundation#foundation-layout-desktop/1.9.0": {
+   "module": "sha256-5wXUw8YaJQC9BmkMhIGkjjl/PzyEaPEVYX1p6szzcTs=",
+   "pom": "sha256-KxoFyZeJ69iDa5wc73P09K6FUqWN5SvNu0iDlLy2ASM="
+  },
+  "org/jetbrains/compose/foundation#foundation-layout-uikitarm64/1.10.0-alpha01": {
+   "module": "sha256-bN1Xy2TXOz9vpDkRYLGr9tzn31y1mkNn7bbQcq09mMY=",
+   "pom": "sha256-OJyp44VtvE1d13zUP4q5e8rGZQuAqWniebvprRVWR5Y="
+  },
+  "org/jetbrains/compose/foundation#foundation-layout-uikitarm64/1.7.1": {
+   "module": "sha256-vdURWJ6Ul42c8X6rGZx4xt7wVyd+aqlJpgbYdTJFKNw=",
+   "pom": "sha256-LFxgM8Ge710RxUrcTttiH5s4Y1k2aPGK5BD4aihbPc8="
+  },
+  "org/jetbrains/compose/foundation#foundation-layout-uikitsimarm64/1.10.0-alpha01": {
+   "module": "sha256-ERLxsvPv9MTPVrb5kd+F+oYPtHlql1llmvTCG0XImZY=",
+   "pom": "sha256-WJ6CojSRFzb+b69cKsxPiEqQrgY7YSdQUXvK/eIL4Nw="
+  },
+  "org/jetbrains/compose/foundation#foundation-layout-uikitsimarm64/1.7.1": {
+   "module": "sha256-pGVegmZYLYd42lKZ0tOmunZchc6VPSAoJ45ECliiNFs=",
+   "pom": "sha256-vxwsrGv2V1uG8bavMPNFrXnGez+HbDz3N/xib1lctjg="
+  },
+  "org/jetbrains/compose/foundation#foundation-layout/1.10.0-alpha01": {
+   "module": "sha256-8gZGA/QPDpgYCs2xwnrto5CjwWC7futStakG4DUpyjw=",
+   "pom": "sha256-6FWiqxGgEJGVsjfIxoioaGWlPHB1Hq01Zq57urTCXjM="
+  },
+  "org/jetbrains/compose/foundation#foundation-layout/1.7.1": {
+   "module": "sha256-U7+p+nvaWJ4NsTtyjjpWFPKMLJ5fvw8I862PKxT1hNE=",
+   "pom": "sha256-9+spSlpczBUbO2H9ot/tBcOpmErsNK3xp1VUS/2BN6s="
+  },
+  "org/jetbrains/compose/foundation#foundation-layout/1.9.0": {
+   "module": "sha256-YwrZaw97aT69sY9aXgKPZxaM4paL08yz8VflSqRjG7s=",
+   "pom": "sha256-Y0v0YLAjBNxJWl1pTxHeKYZeCdgHzZ7q1hPTxgXmkEc="
+  },
+  "org/jetbrains/compose/foundation#foundation-uikitarm64/1.10.0-alpha01": {
+   "module": "sha256-9gdPpS6w7ZpEs3kHv8E4mFQDaEfV7X7Yj1mPay0WdPI=",
+   "pom": "sha256-WTDNliTNmwb8TBlAzrQnRXVUHnvylE11R7EgvPQ1X80="
+  },
+  "org/jetbrains/compose/foundation#foundation-uikitarm64/1.7.1": {
+   "module": "sha256-H+nFZx7m9/B7Q3UDHKIjHp5crbzOM4ayyJ63AUmMmhc=",
+   "pom": "sha256-CYrrajPJDiWaxn+0SA3f338209iFMddHrVyZyDhGEQg="
+  },
+  "org/jetbrains/compose/foundation#foundation-uikitarm64/1.9.0": {
+   "module": "sha256-q1O6K7evNCwEqIpoaYnFLrv9Wd24iU7DNM4vrR8hVqQ=",
+   "pom": "sha256-z8eUPjzKjXILfVhAIWQE5traCr+lAEMYOH6hmEVXRaU="
+  },
+  "org/jetbrains/compose/foundation#foundation-uikitsimarm64/1.10.0-alpha01": {
+   "module": "sha256-mUOe0kHeE2qRZnzNtk1bi3+rRe7LyCD8N20Nvhu1JMg=",
+   "pom": "sha256-mZxgVrabxF6Db7jv3dk6M4W6kjZ3lqTy54peODOmL1c="
+  },
+  "org/jetbrains/compose/foundation#foundation-uikitsimarm64/1.7.1": {
+   "module": "sha256-igOO2RB4kcjtF5tQ1boTqWsbNEwZtxrRKrQeR9FUn4c=",
+   "pom": "sha256-PmuXGpUFeL3x3uYqUpZ+DndC8cX+FjVval17VsZ6Tiw="
+  },
+  "org/jetbrains/compose/foundation#foundation-uikitsimarm64/1.9.0": {
+   "module": "sha256-tpSJdvQncCuIOSRow4NThgCKjCoJFzJ2xy9wBF2bPiQ=",
+   "pom": "sha256-gtv6RkCMYdUu3gig2bO9z5hVII9mCEhOdLprypMjs/w="
+  },
+  "org/jetbrains/compose/foundation#foundation/1.10.0-alpha01": {
+   "module": "sha256-39LdGMG9GT1g5my/clqOZlovcAsQ7IvONPB4xtLKZfM=",
+   "pom": "sha256-9dnLpY6NH1A7vNw4yFzfN9qdAlLHdg9b37Ez/yLPGUc="
+  },
+  "org/jetbrains/compose/foundation#foundation/1.7.1": {
+   "module": "sha256-TudcyFcJEkmZZlCgo+Ag0MOoaHZtnB5ZdqySFMioscI=",
+   "pom": "sha256-js5Yc65fY4YFqEdPVZITMFGSkOcohMk6yJXSIN7/34Y="
+  },
+  "org/jetbrains/compose/foundation#foundation/1.9.0": {
+   "module": "sha256-/6+3yasG25hJJDhAlTja6o9Y3Bydh0TsSgMCn6b4Ky0=",
+   "pom": "sha256-KdYEVx22XMXYrruz8VeeiDBr1SxG2dh203PpYauoQW8="
+  },
+  "org/jetbrains/compose/material#material-desktop/1.9.0": {
+   "jar": "sha256-WgTR4pWWAj/dXK/e20UQpKb6ZRIuhBm1ogSlFtyJR4c=",
+   "module": "sha256-TJ2trYhGh+FTYScKxPLbbAjX+xZQBm/bEJa5gBELA+0=",
+   "pom": "sha256-0+IE86ZZdTxVipwLnVnHoP4t+PmWHJdnMps6sxyFRqw="
+  },
+  "org/jetbrains/compose/material#material-icons-core-desktop/1.7.1": {
+   "jar": "sha256-vPbIU7bbL/FI0tOq07en6lTZP8e0Lgr9hA622vGhxoE=",
+   "module": "sha256-dpqLgvJ7j5oIElPV7o/UittRBgrNnC6HsozvYMG28kQ=",
+   "pom": "sha256-AzQzIbHALCbkTVxBLTW1r1hIapEJ/YiUheHWf6+cdIc="
+  },
+  "org/jetbrains/compose/material#material-icons-core-desktop/1.7.3": {
+   "jar": "sha256-vPbIU7bbL/FI0tOq07en6lTZP8e0Lgr9hA622vGhxoE=",
+   "module": "sha256-e0EAWgTkVmrpU/c4diAmlt7sVBJ+ATzce8P7c0ZwNOM=",
+   "pom": "sha256-KPX/59+P3dmEwytjUP1xGPxkcPinV2ocaS8zZq72QKY="
+  },
+  "org/jetbrains/compose/material#material-icons-core-uikitarm64/1.7.1": {
+   "module": "sha256-bI0bkoFLHjYirpkZ+qEV/rRheEs7Y8il/obpiUwozX0=",
+   "pom": "sha256-93T2OmkNLQMRgKHNJNA5+RFI28e5KLuH4SxGo2vy/J8="
+  },
+  "org/jetbrains/compose/material#material-icons-core-uikitarm64/1.7.3": {
+   "module": "sha256-a1/41cuf+Duwt7K73CWzIgDni7buW1q3tk+bAwlS+BI=",
+   "pom": "sha256-3PFPi7ijO48bJSzRcbx5D8nyplqQrARlmz0kY16U5NM="
+  },
+  "org/jetbrains/compose/material#material-icons-core-uikitsimarm64/1.7.1": {
+   "module": "sha256-H26EHDyZIWkuni0xM9nXE07xHRY5w7q4xeJAqzwXEvM=",
+   "pom": "sha256-T4CRZDkZh2wea3Rvq4aswHoUEWDFbLAKNOz1t7+uaaM="
+  },
+  "org/jetbrains/compose/material#material-icons-core-uikitsimarm64/1.7.3": {
+   "module": "sha256-AEb4OtqlFrMqfXpA9LCFd+Bq29uw/M+BP5dM0Yio0Yk=",
+   "pom": "sha256-nlOTZFlRD0FKJO14qzfEVIA0gG/t9DGP/i5ScVtyMxA="
+  },
+  "org/jetbrains/compose/material#material-icons-core/1.7.1": {
+   "module": "sha256-B5vF4xG7NUubyRRi8TaEinU/3LQaox8NqNsYl657rOE=",
+   "pom": "sha256-4Y+gqZINr+qVp9YsZKGcgSLS1Bo9+JitPVSsMds9aqg="
+  },
+  "org/jetbrains/compose/material#material-icons-core/1.7.3": {
+   "module": "sha256-bzMObQpiopITWjDBxT6lGWrXrrBIZ5r2Hk/JKmYukHY=",
+   "pom": "sha256-wDviSkFlDR3YN/+tAA7Mf8y+y2EAoOj0gDmEcMQqhGo="
+  },
+  "org/jetbrains/compose/material#material-icons-extended-desktop/1.7.1": {
+   "jar": "sha256-3FXTg9yoJ541ORflxak9GSqV58pPkm7lXuC0Yn+Z2GA=",
+   "module": "sha256-ysKEishpAGbgJfbrPNMsDWqjBVLL8KTedb6NFo7TGY0=",
+   "pom": "sha256-Oncw3anS5QyIDaNSeoXSu/UZTjl52gtZakxq4BUWxCY="
+  },
+  "org/jetbrains/compose/material#material-icons-extended-desktop/1.7.3": {
+   "jar": "sha256-3FXTg9yoJ541ORflxak9GSqV58pPkm7lXuC0Yn+Z2GA=",
+   "module": "sha256-PYIoDQjwjMPjN58f/jiHBUovuDfknStj1JIumjf6ecU=",
+   "pom": "sha256-cD/QmE10zp88WXPXTsyyxD26VBml9VT91Ux0URHkfzY="
+  },
+  "org/jetbrains/compose/material#material-icons-extended-uikitarm64/1.7.1": {
+   "module": "sha256-/t7krZRttoCIl7wJoKty/Pn70I50YmcNFNkNcvx2+F8=",
+   "pom": "sha256-ndad4HHTaxyt49EqQP3dFv5Lk5mESvl9HSTyQqJVWsI="
+  },
+  "org/jetbrains/compose/material#material-icons-extended-uikitarm64/1.7.3": {
+   "module": "sha256-5KCiFxEPeVxfW1fJ9zWrhKYvO5FNehBZEt0qSuZjCPA=",
+   "pom": "sha256-9murSp5t63DCs4gxuZH+u9bV7YsU30eXTW7x46eiHZg="
+  },
+  "org/jetbrains/compose/material#material-icons-extended-uikitsimarm64/1.7.1": {
+   "module": "sha256-edjMDdgh0LuQdOnF+7Qmrxz71pFET+f6391C7l9GTac=",
+   "pom": "sha256-PleTIV3SO/B3Iq2RwH7lVEDOALBbp4+SJTAWf+ucvUc="
+  },
+  "org/jetbrains/compose/material#material-icons-extended-uikitsimarm64/1.7.3": {
+   "module": "sha256-b7hCeLiFoz4YXvg8+PcaEtwoU7YLDFvYTnWTzd7Rp+M=",
+   "pom": "sha256-u6icY88rtnAYkduqune6EygU+RZYay2xCbF8PGQWrVM="
+  },
+  "org/jetbrains/compose/material#material-icons-extended/1.7.1": {
+   "module": "sha256-3kM5Kc+XUZJrJ72xEbkNs2X4ZWozURLx0Tn5+sU+vyg=",
+   "pom": "sha256-fBBibxuyLO7dQpV6fheDlD4uYEIfWUTOJrnNCq6wYBg="
+  },
+  "org/jetbrains/compose/material#material-icons-extended/1.7.3": {
+   "module": "sha256-sfqa12veAdmGn5uwxxKc0rByeU8jfgTRXj73yKZqSHI=",
+   "pom": "sha256-3NyiJy7t6vlAZmO5s4zMl8cXnoWqHKeJMuxhIuVZlYw="
+  },
+  "org/jetbrains/compose/material#material-ripple-desktop/1.10.0-alpha01": {
+   "jar": "sha256-PFSyGNhg6CA0bIYQ6crA5MBiiNRP5FbdfXLZY6ElnSQ=",
+   "module": "sha256-Kj0ogsn9lQFJ/Lo/cxifl9pYhiK1buIkEmxo5Ql3gsA=",
+   "pom": "sha256-TJ5/1kvGeUAS6io7iy5bDhyFfFHwyNeSJUpo6ueU8Y4="
+  },
+  "org/jetbrains/compose/material#material-ripple-desktop/1.7.1": {
+   "jar": "sha256-xfa9+yKaF5SoOO0fMfcpmjtRYAS+/+GovMp1OqJovgk=",
+   "module": "sha256-476a8k7pZ20fYnKKt4BhaTS0Rqe4Z9wVVKqBaGpQE8g=",
+   "pom": "sha256-J3joa5k5b8ZfhR1C/BJ5Ku0hWYw4i8PCFlAIpRlOpfU="
+  },
+  "org/jetbrains/compose/material#material-ripple-uikitarm64/1.10.0-alpha01": {
+   "module": "sha256-ugR6uIPWjTO31n553PyxOz4FKwXlTNnyA7KONhCZVJg=",
+   "pom": "sha256-HCclS3F+nfwCvyNPrbQSWro+BgOIJwN9UGJgJqlu/is="
+  },
+  "org/jetbrains/compose/material#material-ripple-uikitarm64/1.7.1": {
+   "module": "sha256-0lZGmEMoIfcUeVYWDkzdjJTh+mac/diRnqAdgz5o2mk=",
+   "pom": "sha256-EzTYleo8CMyW4I0otlISFtuvy+YZp/jmhc5QAG+QHB4="
+  },
+  "org/jetbrains/compose/material#material-ripple-uikitsimarm64/1.10.0-alpha01": {
+   "module": "sha256-et2C3hAkkXjMrfAqN7AT/w5LoaKkvUq3SNeuWoEsl84=",
+   "pom": "sha256-NbBH/aSM27BjS69HeL9yXRH1vdSVi7hJ+r55WOZxgxg="
+  },
+  "org/jetbrains/compose/material#material-ripple-uikitsimarm64/1.7.1": {
+   "module": "sha256-tOPYCW+QDeILdjY4t1KrAiTMh1QkVbDCvLsK5j/fvbI=",
+   "pom": "sha256-wBVk8Td+FqtyIpA9Fp1gOJWiKtfboSXdjn4Vf/pspNE="
+  },
+  "org/jetbrains/compose/material#material-ripple/1.10.0-alpha01": {
+   "module": "sha256-3BWrD1i6qOimCWZ86+7LRNHV7B5Ju0UYRde+fuW6HbQ=",
+   "pom": "sha256-lMjpddaBTj9B7+H0Gtc9caNyT/20QfSkNkhr/UV9EOA="
+  },
+  "org/jetbrains/compose/material#material-ripple/1.7.1": {
+   "module": "sha256-0a8hV2+VfuVB6qCEckE116Sr0nNXTBJFUpWsXCFntBU=",
+   "pom": "sha256-8WQUEqPikyViaWeNGM41NQFS1fRNm4S0Dl64W/TvSdA="
+  },
+  "org/jetbrains/compose/material#material/1.9.0": {
+   "module": "sha256-UyLG9xJ+ZTOuU8dQ+TmDz7ww6kiJTOc72bKqUIzby/g=",
+   "pom": "sha256-4sNTk4f+GRpSKz4DesH+9UYn5T2gpkgHr6Xbd/+rCKc="
+  },
+  "org/jetbrains/compose/material3#material3-adaptive-navigation-suite-desktop/1.10.0-alpha01": {
+   "jar": "sha256-ySMoWG0sHwxRjotImzg5MZJy5Jj5xkYLBAP2UagyQT0=",
+   "module": "sha256-64Tv1SjGbNRv72KWcPw2AYRM/wncPqj7nGqlY/ollKY=",
+   "pom": "sha256-tuPqcUfMZTXF/ocOvJkoE6Y2jbjkAlfnGPLNOX0vA7U="
+  },
+  "org/jetbrains/compose/material3#material3-adaptive-navigation-suite-uikitarm64/1.10.0-alpha01": {
+   "module": "sha256-rpOqaoevpKORg2Rr6aHlVol3lRP8tZTNzEuKvEg2Aug=",
+   "pom": "sha256-fIUPa0AWB/HuTQ9JyCFwt8V1fheQp7s+mIadaDTY87M="
+  },
+  "org/jetbrains/compose/material3#material3-adaptive-navigation-suite-uikitsimarm64/1.10.0-alpha01": {
+   "module": "sha256-+QSDuD5SSR0oRcQhaHeZHH6uHhNawnBajpVhi4kgxUg=",
+   "pom": "sha256-Vz6wxDGOhAkdbUmLpKIjdlNf6zp99m7VYanb/5iemfU="
+  },
+  "org/jetbrains/compose/material3#material3-adaptive-navigation-suite/1.10.0-alpha01": {
+   "module": "sha256-dXrEjAYGMsmHRmMHaPQu9tQvEw2YIxOeslrkz2Zfe5s=",
+   "pom": "sha256-PfYGwp7Mgjt1hK6K+zIlAqQVpfYm2XTiqW0vHwmPwPM="
+  },
+  "org/jetbrains/compose/material3#material3-desktop/1.10.0-alpha01": {
+   "jar": "sha256-+Lf2j++CLTSyU5/G4wXorhSNDt7RaymlAKwdyx8wes4=",
+   "module": "sha256-l5KsE27DISOB+ZBZIleTmwCFQN0yHoLR+72nzLM4tsk=",
+   "pom": "sha256-sAiq4yLLe9W83Yvf1kAs/BjbmIEjl/W2Zt7y9jganRI="
+  },
+  "org/jetbrains/compose/material3#material3-desktop/1.7.1": {
+   "jar": "sha256-dkJDTX15vxSIby8NFzngouRCjv+opp5XyCsVQMGazhI=",
+   "module": "sha256-D7pIndXI/3UzMZZyGeKsH4smH3OQSr2MbxPS8la0yR4=",
+   "pom": "sha256-arivxNupMK+rpxWYkiOWE6LFoXelWo4oWCEn6Nv1mGk="
+  },
+  "org/jetbrains/compose/material3#material3-uikitarm64/1.10.0-alpha01": {
+   "module": "sha256-weaU8mywaQoBXGhVljQdDTyjbW2gmxZ/IXJrGcKb4Ok=",
+   "pom": "sha256-4HaZ0oYRJDYyVyI9FvjPVL3q6EKhQhgwWAvA5eipIqM="
+  },
+  "org/jetbrains/compose/material3#material3-uikitarm64/1.7.1": {
+   "module": "sha256-fH6lBmay9XRSX8fhZPc1Npy2PgKW9my3ol962yPtZ/g=",
+   "pom": "sha256-f68G0brLdYt/FA1RRl54FK9SwC0bPvisfiwA1hSMOK8="
+  },
+  "org/jetbrains/compose/material3#material3-uikitsimarm64/1.10.0-alpha01": {
+   "module": "sha256-/SC9ZMnO26UVCCGCVZ+suHEZReVg8bDNBrycSAZ0N/I=",
+   "pom": "sha256-/5xDqQwsbHzQCRA4Reff/M30iWBqKlIBKwWDJrpg8p0="
+  },
+  "org/jetbrains/compose/material3#material3-uikitsimarm64/1.7.1": {
+   "module": "sha256-Wq4rMJXyhbEG+TqnQ5kSja5gEDPEws7EOsGPVWaGSPA=",
+   "pom": "sha256-/nKsEGk8PhGcOue0xPyCbCrjuCbWUf0FSRJyscZEOmQ="
+  },
+  "org/jetbrains/compose/material3#material3/1.10.0-alpha01": {
+   "module": "sha256-aN22859ZHgC9DL8DDQRBDtEqMzPhNBKPbVsJt+2xckA=",
+   "pom": "sha256-mU620l3F0mnlfUvWR0j6bFjxFcD/KK+AMEFK4YwkL0I="
+  },
+  "org/jetbrains/compose/material3#material3/1.7.1": {
+   "module": "sha256-qvFQNGGrB7ehjYXFXdQEaSsRKu3l1XgOwYyDsPYNXUQ=",
+   "pom": "sha256-7I2Sz9gexvi8u5VGZiuphrZ5x1EwUjkCI4x1IVFfOBw="
+  },
+  "org/jetbrains/compose/material3/adaptive#adaptive-desktop/1.2.0-alpha06": {
+   "jar": "sha256-d2GlV0Ja70x9GAJ030pz/deqRyDvDRaZQ5zKqozGt90=",
+   "module": "sha256-5eZ3HvfcB1YZGbufcF0J2LUViacg9LMVbbWFDbxg0sI=",
+   "pom": "sha256-Qw4lD1jih5lg/2px+EjQCSWqXT1xE8U3U1LOdJg+4us="
+  },
+  "org/jetbrains/compose/material3/adaptive#adaptive-layout-desktop/1.2.0-alpha06": {
+   "jar": "sha256-3yeGAY9VWZTkmpxgMP/CFuzivsL2lSIF7qSWZidUW/c=",
+   "module": "sha256-3zcSxd9WISYwJpnnB4/59wTmMm2FIXdDjQzSJzmI8/s=",
+   "pom": "sha256-0LwkVfFIygfn1uudvqQ1xMOWZcKwGAFk0xMm/2ZUxDg="
+  },
+  "org/jetbrains/compose/material3/adaptive#adaptive-layout-uikitarm64/1.2.0-alpha06": {
+   "module": "sha256-8wcZMGz0Zn+RXuVIEmWoxvI3FIezuDLZmYJWb8CgDho=",
+   "pom": "sha256-IrfZ9X4tSkyOaiKb7shy22o+XCsy68loXHo32kScZQM="
+  },
+  "org/jetbrains/compose/material3/adaptive#adaptive-layout-uikitsimarm64/1.2.0-alpha06": {
+   "module": "sha256-pjyY5x9ncwAuOffVpFY4dP9WWcFce9d8jIWs4e78+f8=",
+   "pom": "sha256-1c0fPFBzUROUc/5mlbAkhM1Zifa9LetIlUWUSmmj0Go="
+  },
+  "org/jetbrains/compose/material3/adaptive#adaptive-layout/1.2.0-alpha06": {
+   "module": "sha256-EE1Fy03/SHwj+M2hP3u/3myo+MJIJyNyrm6gzbTpWuo=",
+   "pom": "sha256-b8gYIfCZ95rhtHwA5uoHa4yk4c2UVkY0uHikPwI+wsc="
+  },
+  "org/jetbrains/compose/material3/adaptive#adaptive-navigation-desktop/1.2.0-alpha06": {
+   "jar": "sha256-O1S+oNcAZGaCKYRCG8KHbgh/kAC4jG3LngFRAi92jvw=",
+   "module": "sha256-kH9pJa9rRGQ9puZK9OEp8iaEi3WmmFoh5JrrgNNJrpw=",
+   "pom": "sha256-hIdBsyClrc5l0A2OZkHs9wrIxuhqnHRdcscdVbmjTlk="
+  },
+  "org/jetbrains/compose/material3/adaptive#adaptive-navigation-uikitarm64/1.2.0-alpha06": {
+   "module": "sha256-SKbGKbxIP8Vou+faUeELXKk72jcZVfN60OAByymgoc8=",
+   "pom": "sha256-KUx9mdTvnw/Rr4eFFTSUsvs/p9YihNUsiw4sIxLJEc4="
+  },
+  "org/jetbrains/compose/material3/adaptive#adaptive-navigation-uikitsimarm64/1.2.0-alpha06": {
+   "module": "sha256-rRTBpQ6NhOPdj4AdkaEbukbZQcVXGnpHeifH9EQrGwU=",
+   "pom": "sha256-+2/BtRSSRJkthStounrxK0dysqAU6DwdTD6ppLAvosA="
+  },
+  "org/jetbrains/compose/material3/adaptive#adaptive-navigation/1.2.0-alpha06": {
+   "module": "sha256-kUv3rKq7CKxBmIBJxMprlPN36EM7PaYCEpaezB6Z9NI=",
+   "pom": "sha256-JEYxF+74hlWPyXVfK+SlKc0/Q3iAhtkHO/5zFFky4Pk="
+  },
+  "org/jetbrains/compose/material3/adaptive#adaptive-uikitarm64/1.2.0-alpha06": {
+   "module": "sha256-LjHXcYGf5CAJg0YstyUCRpDCFn4tg9hgh8alk5fAEoA=",
+   "pom": "sha256-s8dm05yRxigOHWrakK4MT/f9PPKyTtV29p4skJiPt2o="
+  },
+  "org/jetbrains/compose/material3/adaptive#adaptive-uikitsimarm64/1.2.0-alpha06": {
+   "module": "sha256-Ot+3DFQiT/vpdgzvkzb8UwcK2x57J1V3Iagsq+z35GU=",
+   "pom": "sha256-brNRKYUcjphoZTH42o295WwrKQpxbWg9MYMIFKwO5+I="
+  },
+  "org/jetbrains/compose/material3/adaptive#adaptive/1.2.0-alpha06": {
+   "module": "sha256-q3yNVhafM/fjKeGPjOYtbOrFqvMCvf1+jHwdLoXDqZo=",
+   "pom": "sha256-t2y/BsKiobOYgKeMVnrZlABWxs9h91WoO3bvHVGz/fg="
+  },
+  "org/jetbrains/compose/runtime#runtime-desktop/1.10.0-alpha01": {
+   "jar": "sha256-BfVXDAp+qK3db+lQenDyk++n8UUNi5sW3DyP7iHMYSc=",
+   "module": "sha256-FFaPofXTfnRkDfed3b/uN8fsQ/f/LaXirRRXa1erM68=",
+   "pom": "sha256-QXUcr3gWuaeMmk/IWPmzVX6Zxtkph7gNy8T+hI8HEkc="
+  },
+  "org/jetbrains/compose/runtime#runtime-desktop/1.7.1": {
+   "jar": "sha256-duMlBUe5yjyxpJwnKTOyXLO8y8m6Endd1hYaY9mqfPE=",
+   "module": "sha256-My6v5fATPpwP8mn+rhAMeJX+IkYo0FUZRYgfzKBhFsE=",
+   "pom": "sha256-01d42i+5MOce1u1rym8//gdcZOF24fuB1mMH1HHEseU="
+  },
+  "org/jetbrains/compose/runtime#runtime-desktop/1.9.0": {
+   "module": "sha256-kszIipLLMPWv1OBsHU/jkKBCEDbOzUD7jL6ntnEp8Pc=",
+   "pom": "sha256-hRQIp7xApYgt3rUY0HU/c42x0birWJP3U1mmYfmArSk="
+  },
+  "org/jetbrains/compose/runtime#runtime-saveable-desktop/1.10.0-alpha01": {
+   "jar": "sha256-63EytV3isJE3Nv3/RwUCKAPkVYEPAY7+zJ6zIwk2Ugo=",
+   "module": "sha256-GZUavL0WE7RNai1XJuku2WsTRL15w2xVVEo0EpOWM8Y=",
+   "pom": "sha256-F+KRhFmNmdhnHBcZbjk16iUmewadwrpE6MFz2VBXBVc="
+  },
+  "org/jetbrains/compose/runtime#runtime-saveable-desktop/1.7.1": {
+   "jar": "sha256-QwY2O+kOqr50uQDbTDLtHxXHVI5bMKcJPE7kDENrm4w=",
+   "module": "sha256-lbODl+J/sf4du5MfHL5qCZZReoWTQzLNRLT7OQ+PXLk=",
+   "pom": "sha256-YPjvLYLG1V2/Pn4LqLb41II06TEMpm8d+b9voLHoyLw="
+  },
+  "org/jetbrains/compose/runtime#runtime-saveable-desktop/1.8.2": {
+   "module": "sha256-P/OoOpzKK+Oz+2OEL/ghAJyrom1anJqs3i2U4LJgfGc=",
+   "pom": "sha256-457OQgbrcIObfFSWlwC6SLu9JtIxR9Nk0vmPgk1yR0k="
+  },
+  "org/jetbrains/compose/runtime#runtime-saveable-desktop/1.9.0": {
+   "module": "sha256-QT66RZ1ktkSR4mtYEPCXk5OX52278IvGKf2kYE+GR/w=",
+   "pom": "sha256-pIix1dT0+gTMEUVKX1YnmoDbgV5wv8poOu6gmovY0Wg="
+  },
+  "org/jetbrains/compose/runtime#runtime-saveable-uikitarm64/1.10.0-alpha01": {
+   "module": "sha256-WtbHYPZ6rHvfcw4E/kUc5cJ0RFTPIJT2EV78LQaCL1w=",
+   "pom": "sha256-PN15tzex2WW7wKKv2IcHrXQHnaybPuizyJn1kcGKyqk="
+  },
+  "org/jetbrains/compose/runtime#runtime-saveable-uikitarm64/1.7.1": {
+   "module": "sha256-RWBz1hMzkqxpnWLPsN64wCvaKATJ0DowDPUiSpH/LIg=",
+   "pom": "sha256-7woPdZv6dxVHNjyRKaa2PTUFds7PW4OZFTkQIcZoOgA="
+  },
+  "org/jetbrains/compose/runtime#runtime-saveable-uikitarm64/1.8.2": {
+   "module": "sha256-O942iQhum9QIocX9wOQx+NVAaLPAlHHSI1AoWonTdmw=",
+   "pom": "sha256-fPWcnAL/lQ0yt1nF7TCzyp/bAHRX1v0fywMEw2e/E6g="
+  },
+  "org/jetbrains/compose/runtime#runtime-saveable-uikitarm64/1.9.0": {
+   "module": "sha256-uNVM3vXgpbeDXLM4iBM0iSz7qz+SN3/lmBeiXXU+kbg=",
+   "pom": "sha256-HanDoPdPzxJ0SRyrHm7PfZ2C2iZnYCPoCQCldo+0uHs="
+  },
+  "org/jetbrains/compose/runtime#runtime-saveable-uikitsimarm64/1.10.0-alpha01": {
+   "module": "sha256-7lv9vaSZpK3cek0tm8KHCVUrTX59mHcigZ6X2A94GmI=",
+   "pom": "sha256-PeV86hjCN/hHe5dim6O7eFo2LHOE5D5t1LZKnUd7USE="
+  },
+  "org/jetbrains/compose/runtime#runtime-saveable-uikitsimarm64/1.7.1": {
+   "module": "sha256-OgEVWV6hCpJxUIVrUuPNsS4zRtVDcAd/+HKII0t043Q=",
+   "pom": "sha256-idSq3GUxiPxdCKVpbmH8HGq/IkpFNZUZ1MSNZDWG5n4="
+  },
+  "org/jetbrains/compose/runtime#runtime-saveable-uikitsimarm64/1.8.2": {
+   "module": "sha256-hkmLu/22k8LUHFfk9wYTdE+1oDbT08zxzBB8zV1KwGY=",
+   "pom": "sha256-wqhTeOdhVYu27PHODBBZBkAcH97ai3FDQmThhayWKQU="
+  },
+  "org/jetbrains/compose/runtime#runtime-saveable-uikitsimarm64/1.9.0": {
+   "module": "sha256-NgHdc32iO0hYHHvq25xG7bNLyR0HITAb2J5heheFy30=",
+   "pom": "sha256-mq9FKhMxH2vHDvqCZJma6dTV6EAOHJhoPDGDAgLM33M="
+  },
+  "org/jetbrains/compose/runtime#runtime-saveable/1.10.0-alpha01": {
+   "module": "sha256-NtIj/p5vNFliq+8ur5xPBKAXZBeUadOImixwOxvv5Tw=",
+   "pom": "sha256-lM7HFc70MuDDlXRnN+GD0UZZvHXTPxiyzcaHQtW8yTU="
+  },
+  "org/jetbrains/compose/runtime#runtime-saveable/1.7.1": {
+   "module": "sha256-yDUM3lAXvSoW+gL6d/sNpV0RcUyDqhGGy6NWcmrjq20=",
+   "pom": "sha256-to73YWrUYT9AYAPPCia71isXBq6XZ3uhM60QN9YGiyM="
+  },
+  "org/jetbrains/compose/runtime#runtime-saveable/1.8.2": {
+   "module": "sha256-tjnYq55mE/H7t10NXTxcy3eVJHcHl16mbLqfToNiV24=",
+   "pom": "sha256-OHs4L1azx/e/s6VyTt4ibrJ/ezcZDA7PRKQT0h9RHdA="
+  },
+  "org/jetbrains/compose/runtime#runtime-saveable/1.9.0": {
+   "module": "sha256-vND9YwqwZNKdv3HahqLATVX1lXiM+doOB8G+YZdAQlI=",
+   "pom": "sha256-0TBzcL6/xy7vRmUgeBvnPskoxvHzur2HfozlRl47Xb0="
+  },
+  "org/jetbrains/compose/runtime#runtime-uikitarm64/1.10.0-alpha01": {
+   "module": "sha256-HYcKd37Q4nU6sfFhUGeLLftK/p6KHbHax8fBcoPXfgc=",
+   "pom": "sha256-SB58iWeYG8lldMhe0xcYAwiKG4cRUy/Iw5NW/oktZ6s="
+  },
+  "org/jetbrains/compose/runtime#runtime-uikitarm64/1.7.1": {
+   "module": "sha256-2xIx1+scULW4+K2T/uR4pwCSC67mKxd5T/YfGP7W07U=",
+   "pom": "sha256-eXwHp6uQ546AGbHX19fC3CZ9gZSX5qBInZHRb4Inr+Y="
+  },
+  "org/jetbrains/compose/runtime#runtime-uikitarm64/1.9.0": {
+   "module": "sha256-s6eEGlp4LstMYFcqbZg/x5f3doSyJ3nbAXBscp3YLlc=",
+   "pom": "sha256-LPCYkSI9SdHA2O8o0bNGUYhIny4s3j8YsoIBRAPs3E0="
+  },
+  "org/jetbrains/compose/runtime#runtime-uikitsimarm64/1.10.0-alpha01": {
+   "module": "sha256-XsYilYpc+0KyJ++jtkf+DOjBmtYVftkDE2b8CtFvgUw=",
+   "pom": "sha256-Bt7KyCifPIjT7H6MfdYBXdOTMYw2JpSvNR7EEQ6xICw="
+  },
+  "org/jetbrains/compose/runtime#runtime-uikitsimarm64/1.7.1": {
+   "module": "sha256-O0aMQ/CcV3t6u0bw03WJYgXh0+nBAYJzNbgOnJzBoKM=",
+   "pom": "sha256-6pTYQJ+1cbbw25Pu+nHPjoQ6loLnuMOK+I57mCHPBbo="
+  },
+  "org/jetbrains/compose/runtime#runtime-uikitsimarm64/1.9.0": {
+   "module": "sha256-/lTyGVx0qPksYPSWyFCZ3fKy4MN3dF2YuYiYISyIAFU=",
+   "pom": "sha256-E4GhwPJ9QBNtqH2i5O8ZHUvo6LU4kkAATYEOqlWhZNs="
+  },
+  "org/jetbrains/compose/runtime#runtime/1.10.0-alpha01": {
+   "module": "sha256-IEotxyKzdEkGr9FqnvLnffmNAHEghNuy2RKNfG01zTY=",
+   "pom": "sha256-s5CHE1OaQYKuB5giOTPOMF7852XXDEpjSfmY2PRgg5w="
+  },
+  "org/jetbrains/compose/runtime#runtime/1.7.1": {
+   "module": "sha256-xSKUczzpqMZYOfVWCw4APbgWK37T2MqN6b+mLPAzTk8=",
+   "pom": "sha256-SBR/02A24kzaP9JYsYNJVAMA8ipOHXTeA9hWpMEakm4="
+  },
+  "org/jetbrains/compose/runtime#runtime/1.9.0": {
+   "module": "sha256-FuTMFfw9DaBRlitd4t2codlJqQ6TBF4nOCvdozGjiqM=",
+   "pom": "sha256-NYdEukMSFIl1/n0TqPnnQV1BRTdTSkFG2YDJSIBrSQA="
+  },
+  "org/jetbrains/compose/ui#ui-backhandler-desktop/1.10.0-alpha01": {
+   "jar": "sha256-1KnXIPGUBS/8xk4GERXN7mDZIhbshypLiK+wB7gn+W8=",
+   "module": "sha256-bNpF2IOfaj8BWBrGwqtz4tYco7C3ndT/Qd6qg4VyHM8=",
+   "pom": "sha256-0j2UPCxehcxkUWPq4U0zJ7OwKlVJb9n7Hp+Qut3KPXY="
+  },
+  "org/jetbrains/compose/ui#ui-backhandler-uikitarm64/1.10.0-alpha01": {
+   "module": "sha256-4AcYcEsRlwSPNFQPFeeUsQzuA8c/G1+COzrfzcRCQRc=",
+   "pom": "sha256-4fQ2bJQuRXlJnYb8y8DL7PlFldvaiYRwvNfbm+f+p7s="
+  },
+  "org/jetbrains/compose/ui#ui-backhandler-uikitsimarm64/1.10.0-alpha01": {
+   "module": "sha256-RSq9juEKIyWzr+rDEGrbjwbRnqkBWzZQ+o1EyHF+4+E=",
+   "pom": "sha256-zt+nSgG59Kuqo9Zq1wouvnFzIdPOj6kuEjyrIt7rjeA="
+  },
+  "org/jetbrains/compose/ui#ui-backhandler/1.10.0-alpha01": {
+   "module": "sha256-bQ+xXwB2qEiaF2LbB6Xgusts6DhKuKEp3tzeN0VMlhI=",
+   "pom": "sha256-tREFMifIDrp5Uxw79Yg8VUTXnlkdZXo4UITrJGvgQ6w="
+  },
+  "org/jetbrains/compose/ui#ui-backhandler/1.9.0": {
+   "module": "sha256-P4hjF2qDOYRO2IuAerY9e6T/sE5FHQ2z3vOl5rike1w=",
+   "pom": "sha256-vQddtSeMju4iD5jf0PWJ1MQfVm4hcPGAPFB1e9q12+k="
+  },
+  "org/jetbrains/compose/ui#ui-desktop/1.10.0-alpha01": {
+   "jar": "sha256-2GEvpuMFdAXGA3al2Cw/IZYVrEtTZqAVAH5iUMkH3cU=",
+   "module": "sha256-Xw66OXUYQxThoACt9uVjDjttkbtFczVg30nhd96nSPA=",
+   "pom": "sha256-hY7b2ptQcIdz/eA4Jps0/kCFxlodVSD75M+KXpC2U/U="
+  },
+  "org/jetbrains/compose/ui#ui-desktop/1.7.1": {
+   "jar": "sha256-QHKbljfqyR/Zup0QxM0usyi7MRb4CXpbnT8HGXHOoCI=",
+   "module": "sha256-pCdx2/0i3G4BxGwkWo4ZU0YwV7/tm2xzefgmcdxE/FQ=",
+   "pom": "sha256-/ZOsNR7uXLtUTfcLf3D+y1RhR2CW1uJG1gNklcXRiWE="
+  },
+  "org/jetbrains/compose/ui#ui-desktop/1.9.0": {
+   "module": "sha256-nShr23AMBOUQ6rfv8xcalPsS21In3UmIVjy2/JQAuCk=",
+   "pom": "sha256-N8qab9bThJ5l+UCCMjH05oycfYfAt19zSLSPIeU+NPw="
+  },
+  "org/jetbrains/compose/ui#ui-geometry-desktop/1.10.0-alpha01": {
+   "jar": "sha256-BEaJWwrfsGXIdOZ/UnIKMlU8NmRB13vnkoiQAp2vtXU=",
+   "module": "sha256-iOsu3FzajoJsMp2wRqfIMTAJ6BH0rhkLYqXP+H8ccjI=",
+   "pom": "sha256-ub5pD4eTLpVxIiL25KaiP5bGGGUXN1nLnenkfN8lVwY="
+  },
+  "org/jetbrains/compose/ui#ui-geometry-desktop/1.7.1": {
+   "jar": "sha256-S4bJYcC0vOeZUyn9V9Qznt4Ry3XX7JC8G5kTOWrdsw8=",
+   "module": "sha256-rxTJcKcEtuCHAB9jnE1r7dvuad5+FXKlunNjGV5e2+I=",
+   "pom": "sha256-3iEzIvQwizn+X73RZMCg+ApylT0E/AozXNqjsygGS84="
+  },
+  "org/jetbrains/compose/ui#ui-geometry-desktop/1.9.0": {
+   "module": "sha256-mZqXUb2oQ+LV/S6ZVq3Fd+FxVP5SrH6Q7LdaqTd+WUY=",
+   "pom": "sha256-ajUF56SiSisNnJqjxSFMQ5M0mQljcpLjvPjvjDR/9EM="
+  },
+  "org/jetbrains/compose/ui#ui-geometry-uikitarm64/1.10.0-alpha01": {
+   "module": "sha256-HhPLbpE+yHnBhXRjC3eoYAgVi/h1SNcOOIE8jc3oEUU=",
+   "pom": "sha256-DuETcpWNSBAnsO5J3QEwndOspd1pB9Ur5bgUuHuUTIc="
+  },
+  "org/jetbrains/compose/ui#ui-geometry-uikitarm64/1.7.1": {
+   "module": "sha256-K+XQZLXK+zXr0VN8xb/i51D2Dxt0pc1FCLDVKtxB6CY=",
+   "pom": "sha256-nkUZAy7jtV5TQlxjXTF+Xr3MBWUCpkriX5plEumy/MQ="
+  },
+  "org/jetbrains/compose/ui#ui-geometry-uikitarm64/1.9.0": {
+   "module": "sha256-yCiTGezgTCn+P8ubtWr3ihOkYGAI+bV/YUU0WBzPLDg=",
+   "pom": "sha256-uTYKA+aV2XQURpsoCJ14LRIO02Nxs47J6dY2cm9Jfwg="
+  },
+  "org/jetbrains/compose/ui#ui-geometry-uikitsimarm64/1.10.0-alpha01": {
+   "module": "sha256-eZMHP1YZwO57tqn1d48MCRwvMUnxhv+RWAIYiKhW65U=",
+   "pom": "sha256-iBawfMMQt/q+VZPBdiimMAL60xJ2gP5VXjfAh4iCyIM="
+  },
+  "org/jetbrains/compose/ui#ui-geometry-uikitsimarm64/1.7.1": {
+   "module": "sha256-WpFUbpZmpI/1vzM95va5UrBRUDa/fV0kujuPOgDliKY=",
+   "pom": "sha256-s8z7gF38Fb8arIYsuchHC7gs+ftIFXr53PZSj4c+sDc="
+  },
+  "org/jetbrains/compose/ui#ui-geometry-uikitsimarm64/1.9.0": {
+   "module": "sha256-PZWuOATm3ADtWWpqWgakZqd67Qo6QiFk+ji3XfwY+vA=",
+   "pom": "sha256-/c1M7t6Uh4IBL47JXJVC6HAZXJZ4U/kMxSb1gSgnh1A="
+  },
+  "org/jetbrains/compose/ui#ui-geometry/1.10.0-alpha01": {
+   "module": "sha256-Nn1aFzOUpTsxqw8KzxyWZEkJ9aaCmNTL+nXEmG4jdQM=",
+   "pom": "sha256-5TERYCEWAaEPdLeFDOxiKN6ebVdyxoolBMmlNexDD4U="
+  },
+  "org/jetbrains/compose/ui#ui-geometry/1.7.1": {
+   "module": "sha256-mkt+df1LWaMy2SRUTWUB9eDaVbIDwsxhs4fg14yTXJU=",
+   "pom": "sha256-93UQwBXgPlnocFWPdBdPZSRo9vhJOJaKxTjBKiGO3I8="
+  },
+  "org/jetbrains/compose/ui#ui-geometry/1.9.0": {
+   "module": "sha256-MrCoE8bMfwFQv+MYCKP9uAm4g7Xp+yODOZ2OCbxzAvQ=",
+   "pom": "sha256-6D3wiP53lSdwbdxB5T6g/o+aE0fLCZ79FGskisUtbEc="
+  },
+  "org/jetbrains/compose/ui#ui-graphics-desktop/1.10.0-alpha01": {
+   "jar": "sha256-JukabNi5Q0UdLowEA4b8BgRvD+gag+0FlSFWDjtKIWI=",
+   "module": "sha256-ht1BZR9hEALSs/MVbJOSjp1OCS9ng6YRFkOevwSgxWM=",
+   "pom": "sha256-+znYYezKMc0nRK5dlxyB9F+wtn0MJs/0Vmh8woBJh5M="
+  },
+  "org/jetbrains/compose/ui#ui-graphics-desktop/1.7.1": {
+   "jar": "sha256-kQnXfMJi+QQIFpscoLotFRNbYDTjd6gLvz7AI0lU6FI=",
+   "module": "sha256-DPP8FuwoupMp0UfnR54Rmyvbjr+lLyMn4yDlGQEUapE=",
+   "pom": "sha256-cIA44a4DMFFG1A/NcUNHlHGQ/yd8ZpysiH836iQ/M+Y="
+  },
+  "org/jetbrains/compose/ui#ui-graphics-desktop/1.9.0": {
+   "module": "sha256-zhOcM8R+fBaIL+Wg9x/ybsIgf0nbXkQs8dLsZjBYls8=",
+   "pom": "sha256-dnVmTZ/ahP6rPQ3AJn1nzNraBKiSlTzQsCY3BejgIsI="
+  },
+  "org/jetbrains/compose/ui#ui-graphics-uikitarm64/1.10.0-alpha01": {
+   "module": "sha256-Lw64/P/Fb6cFFXiWQO37EkTBRnxUq88lI+snaE4RCcI=",
+   "pom": "sha256-dDPrjoL1shItOVgxgyJXGOsTp+Lsw+ZG24qem4cs0lE="
+  },
+  "org/jetbrains/compose/ui#ui-graphics-uikitarm64/1.7.1": {
+   "module": "sha256-8PqSMYMBA80IUmPAhxjEl4g/YwChhxkBWSWgn+g3yOo=",
+   "pom": "sha256-q3/EUAXjdMDgd/5K9APkymXQ+stsHt30eXy3TYvGaU8="
+  },
+  "org/jetbrains/compose/ui#ui-graphics-uikitsimarm64/1.10.0-alpha01": {
+   "module": "sha256-Pv+xMc/Nvf7WpGlI6wh3uUiBbk7CVCV41uELz3Qbblc=",
+   "pom": "sha256-4XyvSSCPPJHZ3nXRHCTb+5ckuhcgc/8V20XAdJwkV+k="
+  },
+  "org/jetbrains/compose/ui#ui-graphics-uikitsimarm64/1.7.1": {
+   "module": "sha256-0ktuXlg6MiHPWCuY9scr7uUuleEcmyuLGN0qBsggCfw=",
+   "pom": "sha256-eIRplW2HMloqOUUZhbQzGFgWDG4hnSoRleeEqvgOjG4="
+  },
+  "org/jetbrains/compose/ui#ui-graphics/1.10.0-alpha01": {
+   "module": "sha256-iSd7Pvi9vbym0k/Cz1nG4PEZFfM39C6CjVBBJmWKqhQ=",
+   "pom": "sha256-0ObHcHHUVLIf9XQR4ak4GhuMZ7UOb1H8/gQeRBWyPLs="
+  },
+  "org/jetbrains/compose/ui#ui-graphics/1.7.1": {
+   "module": "sha256-Bpgc3L5OyqzDVxnptAOykEHl54Rps8L1zcfMUHX8DXs=",
+   "pom": "sha256-Sj2MCO2FYVWHeAGrzgWU3BxpiOVq7H0kSsfGwxpqX9I="
+  },
+  "org/jetbrains/compose/ui#ui-graphics/1.9.0": {
+   "module": "sha256-Dvn6KFk5rYTtwfdsWt5TDFFg8GdE1PVnrZeGRui5AEY=",
+   "pom": "sha256-WTraj4T62MMvpRVLwqHpDRcjycZMCNhuvTfBsg80tp4="
+  },
+  "org/jetbrains/compose/ui#ui-test-desktop/1.9.0": {
+   "jar": "sha256-8l4OW3eMbLZ8ZvW7tMMn8QPr3erG3fCab0i8kAV35nI=",
+   "module": "sha256-XNHxMxlX3a6gTboD8vF4FfgPD9Dvhk6xcntC10nZFPw=",
+   "pom": "sha256-N9ugtdfiz5lEP1uKiFxfRtY9elaOfoxlIX+nnkLq+PY="
+  },
+  "org/jetbrains/compose/ui#ui-test-junit4-desktop/1.9.0": {
+   "jar": "sha256-fRJEYYq/9goXugxZbLE63e/3RmSsyEANK3hbvY7ma1I=",
+   "module": "sha256-B/ad7G72U2H66JN8t0AKlR/qmy4mF0UDb9agW1CBqM8=",
+   "pom": "sha256-qJ/4Gi0n4kc4O74Xqjn2jZVvCztcgEZqS3ygsIbPcIE="
+  },
+  "org/jetbrains/compose/ui#ui-test-junit4/1.9.0": {
+   "module": "sha256-zTDv1RH4lrZJrTRMMNvCdUWtAq4JCDNBha7S8R1qcq8=",
+   "pom": "sha256-UJkWluLYqWYFwuvSqcRa+aENkwNE+C7CALtX8lyrcP0="
+  },
+  "org/jetbrains/compose/ui#ui-test/1.9.0": {
+   "module": "sha256-eRAuAeX9ZQNecX13BE1dRhnlrYn3rMeqS6TS0rBh6is=",
+   "pom": "sha256-rAJwNYvmIQrtgJFCnyITg7KjwhGIyTyCXfASBs0BKf0="
+  },
+  "org/jetbrains/compose/ui#ui-text-desktop/1.10.0-alpha01": {
+   "jar": "sha256-jZswqlxcoJtRtZiSNDyThybSuGBfp0jkGNS+rb7cFgs=",
+   "module": "sha256-aZbjmUbAC7dvrUa3nriiAmVowGNcfsHe72js+WQnvJ8=",
+   "pom": "sha256-MbgNyhgG57J7gEBo2efVRSE7tSC2Y5N+5Qzl9Zb+48k="
+  },
+  "org/jetbrains/compose/ui#ui-text-desktop/1.7.1": {
+   "jar": "sha256-gOB+TKc597YSL2PpoX5oU7lHIg7LEYD43K9BnQ5GiZY=",
+   "module": "sha256-PR7CKTU76v2v0awhS/VEkPv2nojwZ7/LgBaB07K2bqU=",
+   "pom": "sha256-UiwW5ZbJMrHloPPN+xqTRADodlj42JjBzery0Bgphoo="
+  },
+  "org/jetbrains/compose/ui#ui-text-uikitarm64/1.10.0-alpha01": {
+   "module": "sha256-hGFRtBTkpp29UayCw4QLvwnJBM5SeIrdF0aQDLwBgm8=",
+   "pom": "sha256-rRek/xVuHc22dDiBGT6Pg8I0NtlnwEQAzC8ylK1tja0="
+  },
+  "org/jetbrains/compose/ui#ui-text-uikitarm64/1.7.1": {
+   "module": "sha256-udB4XNhhjVx+uCNYmHz0MEwE5b7YnVDyNZy93nFWvc0=",
+   "pom": "sha256-KMiRBwqYjQTlvoNhdztU/INqlUfLpGEptUcrz8PG3LE="
+  },
+  "org/jetbrains/compose/ui#ui-text-uikitsimarm64/1.10.0-alpha01": {
+   "module": "sha256-qMQNGJOBi8BqmuG6wNN5oZb6ZGwYRV10uQTyQPfAh4M=",
+   "pom": "sha256-01m7Z/0Je7NqO/eIvE4TCj9z9K+iALkMGv8+FlFjwUY="
+  },
+  "org/jetbrains/compose/ui#ui-text-uikitsimarm64/1.7.1": {
+   "module": "sha256-Y7jLeOnueCdN+OoyXU6Omo+9Ky+Idb4tHrlxez7hVzk=",
+   "pom": "sha256-LLPi53tNZ4xDiKvgZDunlYJEZ20HbtP/JdF9lo576ek="
+  },
+  "org/jetbrains/compose/ui#ui-text/1.10.0-alpha01": {
+   "module": "sha256-wwKLmN/y2LSHvtJEKTvDLvcM5YY49FBniiDyEZlTdNU=",
+   "pom": "sha256-Chmweybl81KKP8uSwC9s/WOiqsq8YFeU0eRnxpthncM="
+  },
+  "org/jetbrains/compose/ui#ui-text/1.7.1": {
+   "module": "sha256-nYij0rkMF+a4Hs///a6dfEzsVMfWVXWYJbpJZ90vyGM=",
+   "pom": "sha256-huwdGGauW1x/4AUsJqB/8aphkz9Vf41PuePda2L8Jb4="
+  },
+  "org/jetbrains/compose/ui#ui-text/1.9.0": {
+   "module": "sha256-oLAwD3XZxrvIN6sNSuRpo3WqoZwV/ZhY03BVJmJOsEc=",
+   "pom": "sha256-0l2bn0ISu2Xoqx4KsQaltKLVxIky3AAzeZ015cS+hwQ="
+  },
+  "org/jetbrains/compose/ui#ui-tooling-preview-desktop/1.9.0": {
+   "jar": "sha256-qyghEVDLh8RtZzfiyGyb9E2sZCqV7SbbLCAKDi2vJQ0=",
+   "module": "sha256-4tbglF3zQSeXbYCB7PrQm8Rja5mpceQbd1Z5xZXaWR4=",
+   "pom": "sha256-WhRl70I5MpG2qcNZ97Hkl///onhZKPDkvS8PI10diI0="
+  },
+  "org/jetbrains/compose/ui#ui-tooling-preview/1.9.0": {
+   "module": "sha256-qLznna0FAdzZ4hCg0TrDGpiYtn0fDfJoNJuwP/RYgM0=",
+   "pom": "sha256-3Sx+EPRlVAIyJVl4J+n4B79+UEq30vkjp6C8pEffiD0="
+  },
+  "org/jetbrains/compose/ui#ui-uikit-uikitarm64/1.10.0-alpha01": {
+   "module": "sha256-W124ZcuM/6fglW+yFete7+JOnaDsfU1DYijWdoJi4E8=",
+   "pom": "sha256-1Rk49GvqQCGovkoHGyTmUZGXV85+RW2QC41Dhblxb4M="
+  },
+  "org/jetbrains/compose/ui#ui-uikit-uikitarm64/1.7.1": {
+   "module": "sha256-SqJDbH7n+mCGd2jt0T/wmzPmtWJeKLZc2apLiAdZQm8=",
+   "pom": "sha256-G02onwJP9FdD6hJ9Pd9wFBKr2d53o6cFDYDswd7GPk4="
+  },
+  "org/jetbrains/compose/ui#ui-uikit-uikitarm64/1.9.0": {
+   "module": "sha256-ctlR3SzPVFxAKFlUC6+dN3yZOl2q2CxPAcTL5/vA76A=",
+   "pom": "sha256-XFBoPTB9x75I89BiKQbDRNLD/JcguSZVzC2Mj51RTwo="
+  },
+  "org/jetbrains/compose/ui#ui-uikit-uikitsimarm64/1.10.0-alpha01": {
+   "module": "sha256-hPW+zou3W7zOgMce29hyf462oDX8sH1Qjmv2jHxny00=",
+   "pom": "sha256-X/aBBknDz7Xy5M+WG37rFSPTWVskn1pIzAwuaCKflEo="
+  },
+  "org/jetbrains/compose/ui#ui-uikit-uikitsimarm64/1.7.1": {
+   "module": "sha256-vsB4nkoD9Om2aSe02Su+Hg9jGQ68dynjHe7NvgWmyrk=",
+   "pom": "sha256-lTL9fOMfRJtGrHgqf/wHFGJKIEYGuNyw4ZKf7mhN6X0="
+  },
+  "org/jetbrains/compose/ui#ui-uikit-uikitsimarm64/1.9.0": {
+   "module": "sha256-S39/wqv3T9rveybON504oy68Jxej8WPNXD5ajzgJUXE=",
+   "pom": "sha256-8kQvWw5QrDx1R29HlYm05BE4Xt60D9siXjpDgmKRqmo="
+  },
+  "org/jetbrains/compose/ui#ui-uikit/1.10.0-alpha01": {
+   "module": "sha256-rrRrVTgdb5y8OHgxPqpHmhhUkcSRbhAr5LZsV4L+ho0=",
+   "pom": "sha256-+m5FswwFBPzLmUKXYXaoPyMUCQXZUO4pGjmUs+FXJD8="
+  },
+  "org/jetbrains/compose/ui#ui-uikit/1.7.1": {
+   "module": "sha256-66agOFmVMgDyTNkd0Wwup8msxWlSrEfigB0PTxTTS08=",
+   "pom": "sha256-CiPBf5+noaOPcCO+DrH2DhsiT38S1osXUXRvCAfIBVc="
+  },
+  "org/jetbrains/compose/ui#ui-uikit/1.9.0": {
+   "module": "sha256-ATt4MAvYWHe6Ew5Q7xtBwOOoZKzHKT7yjAloINwxxJs=",
+   "pom": "sha256-8htRQnT/u4kB26CSFTzgQNhUZvHWfqgzHYLtT9hSrO0="
+  },
+  "org/jetbrains/compose/ui#ui-uikitarm64/1.10.0-alpha01": {
+   "module": "sha256-nB1ocvQxTgt1KwuwFZbdOPHWyXRBPhYJa6DYFZe5tvI=",
+   "pom": "sha256-ksS0cNBfh02w7VQbeiUwEr91BUgRVIg+cSrDX+aFfGI="
+  },
+  "org/jetbrains/compose/ui#ui-uikitarm64/1.7.1": {
+   "module": "sha256-+tRfraDgGDzQbhJ5VQ+JLdHFmvJsjPe0rdpGGUAtb1Y=",
+   "pom": "sha256-4wCvrRhVF31xWv00UBvIr4CHnBsb3n3j3TrFHhUERwo="
+  },
+  "org/jetbrains/compose/ui#ui-uikitarm64/1.9.0": {
+   "module": "sha256-hAKm83t6ZdZ4wkTNKNbNXYG01UftNVBHG8IEfLTflSU=",
+   "pom": "sha256-tnl9qopmWdJoeLh09JCeHZRRHJSt2WgeqFCIGTNJqgM="
+  },
+  "org/jetbrains/compose/ui#ui-uikitsimarm64/1.10.0-alpha01": {
+   "module": "sha256-d284TBHyFUH4hvsoTRwS+AwoIJx7vIik53BYOCoMC90=",
+   "pom": "sha256-mfaFPtkcykjGSqjD6LkX9pRr3qNQx8AG4FoN6+YcW/E="
+  },
+  "org/jetbrains/compose/ui#ui-uikitsimarm64/1.7.1": {
+   "module": "sha256-nU8fMHfpRWR5RicEK/a20T7L98yJEIZKxBDDQU8Px0o=",
+   "pom": "sha256-Re4FU+05jNk/LSSlX3GcbAwQJNkp42/KsXtihTdUNsk="
+  },
+  "org/jetbrains/compose/ui#ui-uikitsimarm64/1.9.0": {
+   "module": "sha256-8pd2sKT9fxTRASZ0Zh4EyqNRtdyg7G3SAR5zPAdkZ6Y=",
+   "pom": "sha256-kPkBDBaP50ZHzxGr8K3GvcHlX0rGTnBhZb3tAF8hQB8="
+  },
+  "org/jetbrains/compose/ui#ui-unit-desktop/1.10.0-alpha01": {
+   "jar": "sha256-aJyC+qKlMqqS/lrAQBMCEl+lP0RkyA1rz9naq+d2CW0=",
+   "module": "sha256-baApD3M+DfhS579AmbNYH/Mm3pRKBW82JRdBJJXO/Is=",
+   "pom": "sha256-jtqpTK/67D+PgX/Iw4f7iLELDded55dF+wgkpEJxnzQ="
+  },
+  "org/jetbrains/compose/ui#ui-unit-desktop/1.7.1": {
+   "jar": "sha256-WYtS4lftZ0FFaUuXkKc4OpD+0uxxVLoJrOSqmDxlsaI=",
+   "module": "sha256-BacNXRO5Fhrn9YUkbrk97ly6K1XD8Ilf1mRekKPCPaU=",
+   "pom": "sha256-9R34TA7eKtHgHgf6R+9tSLoSy3ShfoXK6Nblz/Kc0Fk="
+  },
+  "org/jetbrains/compose/ui#ui-unit-desktop/1.9.0": {
+   "module": "sha256-9LjQy4GaPPqID16h6LxxPe4439uRa8P1vdjd1Cp2TmY=",
+   "pom": "sha256-CwR/GlukxA3i2aels9nBgZ6rNW9kvNxUAqr8dvsiUwE="
+  },
+  "org/jetbrains/compose/ui#ui-unit-uikitarm64/1.10.0-alpha01": {
+   "module": "sha256-Zeq710k3c8kk4o6pgydu74jM6PpOjSj25x7I7fNsYaw=",
+   "pom": "sha256-zc2cA69YZheTKr38rzo6SVVAm2ljN4edhls4Ssyqk1c="
+  },
+  "org/jetbrains/compose/ui#ui-unit-uikitarm64/1.7.1": {
+   "module": "sha256-aUNxUVeQMaJv/JTDaqi481k6yrqwLlm4q96RxX3oA8w=",
+   "pom": "sha256-h+Jlgnl3uYmw2TaDrsl2+Y/7m6oiNNOFoIMrPQq2ZE4="
+  },
+  "org/jetbrains/compose/ui#ui-unit-uikitarm64/1.9.0": {
+   "module": "sha256-cOQ+0u5KEH3YygE6hoSyEiARnKY7gb3vY3HRjLwMClk=",
+   "pom": "sha256-TGChrmtOEp7yKTWW5wVQhJytsGvMo/78BLOXHSsrM3w="
+  },
+  "org/jetbrains/compose/ui#ui-unit-uikitsimarm64/1.10.0-alpha01": {
+   "module": "sha256-rLjmR7LEY8SQWV93f6fQrSMl6jb+hXxBvIuRwptxwEo=",
+   "pom": "sha256-+nFDpvyM6eYiaC1unPzawoC9YuyEptZSwXeQzmytFNw="
+  },
+  "org/jetbrains/compose/ui#ui-unit-uikitsimarm64/1.7.1": {
+   "module": "sha256-LNJodZbuzqnUzI+wQwwZwdTkp52mqkV9YBLFQd5TVgs=",
+   "pom": "sha256-/bEAt4y7tcUQB1ki97WhV7eTbeazkeAjrns7VqCi5RE="
+  },
+  "org/jetbrains/compose/ui#ui-unit-uikitsimarm64/1.9.0": {
+   "module": "sha256-coIVhC4JS3DPjXDfvaVZ0PT/8LOiBL3An06v9EMtOTA=",
+   "pom": "sha256-WIpfflAvfoAy/A2u7E2PIJB1n8mopTxQxdSv+ebKCvY="
+  },
+  "org/jetbrains/compose/ui#ui-unit/1.10.0-alpha01": {
+   "module": "sha256-XTbAScasnbyYnAgG4zOpv74qlsPXJDc2wTLRzZEit6w=",
+   "pom": "sha256-ZzZ5hnvyBgVXBB9KdttdDfWpoLsZypXGSLwYcy0C0Jc="
+  },
+  "org/jetbrains/compose/ui#ui-unit/1.7.1": {
+   "module": "sha256-kDxEm48iI7uggivMWUuZLiqCv6rlwE/FCNKNq4hxfaA=",
+   "pom": "sha256-tq8XC59ySXOr8jPPEJFoqJIGqbFF1whpFbxlQOpdaHI="
+  },
+  "org/jetbrains/compose/ui#ui-unit/1.9.0": {
+   "module": "sha256-swHbwckV5ClwaGLg09Q7DrG+0xkkd1Vns+7t2SH0g84=",
+   "pom": "sha256-xE2RKziWVTv7+ZXmf+uJZtpP1QNGm4j048Ea/KyS3HU="
+  },
+  "org/jetbrains/compose/ui#ui-util-desktop/1.10.0-alpha01": {
+   "jar": "sha256-bARuOkFDfu9nhWpKKWTUFYQB8oSejlDvT5tuPm2DQ9U=",
+   "module": "sha256-bRiYwEJA6XPKsurC3YrvXL/fOLDIDplAq215S1CXtAA=",
+   "pom": "sha256-NzRhFhfbcDFx7YZ/x3J6WSpLRnk7O25W8EJhu/usdI0="
+  },
+  "org/jetbrains/compose/ui#ui-util-desktop/1.7.1": {
+   "jar": "sha256-Fh3Mc7kp2mHO5QBF6W+wLxYzw28You84tcLETDhga1I=",
+   "module": "sha256-35JU30uqHS7Q+ctR/BxgrUlqNqzEiYEUPF1PqHRpEXs=",
+   "pom": "sha256-AeJZ6hTRKWyvCAmzP5dAcXRDNJvrCJ7ketEOaEBYDvQ="
+  },
+  "org/jetbrains/compose/ui#ui-util-desktop/1.9.0": {
+   "module": "sha256-SUw37O+HE6n4UoBX6BbaPW3UD/kRcMZfygX7MlStozI=",
+   "pom": "sha256-6jmJnKSbL2BgJpcaZsbJcLNcpcyDNzWBssu7JcFaPtA="
+  },
+  "org/jetbrains/compose/ui#ui-util-uikitarm64/1.10.0-alpha01": {
+   "module": "sha256-44VxQW1TKx1zYKMZnQ/60rhMZc78qLOai372ZJbkIMg=",
+   "pom": "sha256-NTxP8R80cfCerUTOVF91uUG/4fj5Henw3f3FIGxCr4c="
+  },
+  "org/jetbrains/compose/ui#ui-util-uikitarm64/1.7.1": {
+   "module": "sha256-FbZDuR4VxlbR3kdPyyUBWPQ8WDL5IH//8yPOKD7y4E4=",
+   "pom": "sha256-XnoWek6cdf6YQYVEQY5uhQN2BuRjM8Y2T2l+bS+TVi8="
+  },
+  "org/jetbrains/compose/ui#ui-util-uikitarm64/1.9.0": {
+   "module": "sha256-qWko7b+wO7/NR+b00jTmNaidb4+0y3PKe3AtCDB3bQI=",
+   "pom": "sha256-oNrYE745kWfQrFRNo0uZI2wAfBINJRU6cf26BfoVAW0="
+  },
+  "org/jetbrains/compose/ui#ui-util-uikitsimarm64/1.10.0-alpha01": {
+   "module": "sha256-9F4kAhUWE1kLg24t3ixr5LjWNuE3tor3ZbrgWJyI5PE=",
+   "pom": "sha256-XFkfqLF//TVpI3DPL9Itz/7nRL6PKecHedJlPaEv5r0="
+  },
+  "org/jetbrains/compose/ui#ui-util-uikitsimarm64/1.7.1": {
+   "module": "sha256-5sh/hoODmNw0QdFCo2S020cCmIVGZNSX18/hZ8Gm3NA=",
+   "pom": "sha256-Aas8ZK2KiVPmCGJ2Ytpw9ObUlAhYZb+mrUpLBCAh0Tw="
+  },
+  "org/jetbrains/compose/ui#ui-util-uikitsimarm64/1.9.0": {
+   "module": "sha256-GIPk9C1LrU90T94X/V/gVh3xFIrMid+E5wPtbtX5UrU=",
+   "pom": "sha256-jQi7r3BYlDfXUhsJiDRbKCC0dnjs5oeUFnOkzuKC3D4="
+  },
+  "org/jetbrains/compose/ui#ui-util/1.10.0-alpha01": {
+   "module": "sha256-XngYNQpBwwXt9cKH5M0nFN+LJY+v27eBkAyNG0jbXbg=",
+   "pom": "sha256-Ybl9LiMA8bCkxPhns3WSb1cmfNjuLAgctlnVCJtnnLg="
+  },
+  "org/jetbrains/compose/ui#ui-util/1.7.1": {
+   "module": "sha256-razSdpfzafjF00aNb8ZySDHTP95e+5tvg9hdw6AXCw8=",
+   "pom": "sha256-7bcYbOSnYd3l8xMC3BRdWLw7/j5OT7x4YiiCP4zVSMw="
+  },
+  "org/jetbrains/compose/ui#ui-util/1.9.0": {
+   "module": "sha256-y6I6SuhwblUOxPj3BW225t4Q7oGB9ZEYtUGyzTWrP/g=",
+   "pom": "sha256-FXiSH0ZOLYUd47smQi7VTeiet5Tz/3Ufu4HmqbOxLW0="
+  },
+  "org/jetbrains/compose/ui#ui/1.10.0-alpha01": {
+   "module": "sha256-MQft4KGvh/lg5ew2BJR3br/YuyRDPXllGqqsVymgokM=",
+   "pom": "sha256-7WDjMN1fPF6K4v7umwYBXnVjNcmUfk1gez0bNszzFPs="
+  },
+  "org/jetbrains/compose/ui#ui/1.7.1": {
+   "module": "sha256-LpKRDBxZrLBjrmhWz5VWwlH9qMCtRsg6Tka/flenza4=",
+   "pom": "sha256-RWT33DQr7tal9G+RaxkLMe0rEgcK/ZfXXmNjSkQt9lc="
+  },
+  "org/jetbrains/compose/ui#ui/1.9.0": {
+   "module": "sha256-M6lOgXRyk5JvQ5FMDB0G1LFrSfTKwX1geTXHLjD8yEc=",
+   "pom": "sha256-Pd5Fl2AoE2rkmsrdr7O6oWT8wpTv6sGqjaoRI0EdPPI="
+  },
+  "org/jetbrains/intellij/deps#trove4j/1.0.20200330": {
+   "jar": "sha256-xf1yW/+rUYRr88d9sTg8YKquv+G3/i8A0j/ht98KQ50=",
+   "pom": "sha256-h3IcuqZaPJfYsbqdIHhA8WTJ/jh1n8nqEP/iZWX40+k="
+  },
+  "org/jetbrains/kotlin#abi-tools-api/2.2.20": {
+   "jar": "sha256-8chm6sXcCI8/0IEQCENAm/TxYSu7mY+6ofaFMlyuDVU=",
+   "pom": "sha256-HOL7NczYP8vJCuXFmN/bsilS0IVHgElEpbIfLEbKwL0="
+  },
+  "org/jetbrains/kotlin#compose-compiler-gradle-plugin/2.2.20": {
+   "module": "sha256-9AtjpzezeYShIZzH4Ioz6kHrl6Rx2vIvsTq05SoUe+Q=",
+   "pom": "sha256-UMpOe2tJz63xV3qOB1ady2eGowwlm/2lH3mHSuH1OME="
+  },
+  "org/jetbrains/kotlin#compose-compiler-gradle-plugin/2.2.20/gradle813": {
+   "jar": "sha256-ozhbipTPTwCVfqfaDiXqkwU8GsxkjkXfFos9g//C1HM="
+  },
+  "org/jetbrains/kotlin#fus-statistics-gradle-plugin/2.2.20": {
+   "module": "sha256-n+aVWzf+KQtlFiXPnGgea6IKjxLEZYzOUCblk1BaMSk=",
+   "pom": "sha256-P6gmRiy9hG0YAgLyLFGTQYy5zan2lcmUEjWpsbXBQdk="
+  },
+  "org/jetbrains/kotlin#fus-statistics-gradle-plugin/2.2.20/gradle813": {
+   "jar": "sha256-OmlZW2x1+/ktMgFodFxpj/cRS4YHhBBQ1ISYgjAG6HE="
+  },
+  "org/jetbrains/kotlin#kotlin-assignment-compiler-plugin-embeddable/2.0.21": {
+   "jar": "sha256-VNSBSyF3IXiP2GU5gSMImi/P91FQ17NdjnMKI34my9E=",
+   "pom": "sha256-rIU9chaJ+vEV8RiBCjU2/CcvE1to0CdFOqpW6eY79wc="
+  },
+  "org/jetbrains/kotlin#kotlin-bom/1.8.0": {
+   "pom": "sha256-aB+YeFSMChScZ4CS/YsfTMfFxBuhskOXEBwQc6bHbdo="
+  },
+  "org/jetbrains/kotlin#kotlin-build-common/2.0.21": {
+   "jar": "sha256-cLmHScMJc9O3YhCL37mROSB4swhzCKzTwa0zqg9GIV0=",
+   "pom": "sha256-qNP7huk2cgYkCh2+6LMBCteRP+oY+9Rtv2EB+Yvj4V0="
+  },
+  "org/jetbrains/kotlin#kotlin-build-statistics/2.2.20": {
+   "jar": "sha256-+2VKT1vFY2h1kXMSnfSRB60J3FtBcrAXda+z+nJXndU=",
+   "pom": "sha256-tdU2T1fSH/FBgiBei2lf1oZNnYqleApu3EIJWEBHwRU="
+  },
+  "org/jetbrains/kotlin#kotlin-build-tools-api/2.0.21": {
+   "jar": "sha256-j8orSvbEzyRWXZp/ZMMXhIlRjQSeEGmB22cY7yLK4Y4=",
+   "pom": "sha256-zL2XaTA2Y0gWKVGY5JRFNPr7c9d4+M1NQ588h7CQ9JQ="
+  },
+  "org/jetbrains/kotlin#kotlin-build-tools-api/2.2.20": {
+   "jar": "sha256-/ZlHs6F2Iahvq9lTr4fzS9K7f4sm2uksHte+dHL0TDs=",
+   "pom": "sha256-AtR9SHfsMktJbZMTMkXNTTSLZSMDzyfvpj44ry+zzyo="
+  },
+  "org/jetbrains/kotlin#kotlin-build-tools-impl/2.0.21": {
+   "jar": "sha256-um6iTa7URxf1AwcqkcWbDafpyvAAK9DsG+dzKUwSfcs=",
+   "pom": "sha256-epPI22tqqFtPyvD0jKcBa5qEzSOWoGUreumt52eaTkE="
+  },
+  "org/jetbrains/kotlin#kotlin-build-tools-impl/2.2.20": {
+   "jar": "sha256-ZHiafwBWWSfy8/LRCfIwV009kwjtXW6Gv8qEPaZIfPc=",
+   "pom": "sha256-4vQ157rwHeL/kNCoc3r4+b+X/BUuWVuGp2C6ZOjmnfY="
+  },
+  "org/jetbrains/kotlin#kotlin-compiler-embeddable/2.0.21": {
+   "jar": "sha256-n6jN0d4NzP/hVMmX1CPsa19TzW2Rd+OnepsN4D+xvIE=",
+   "pom": "sha256-vUZWpG7EGCUuW8Xhwg6yAp+yqODjzJTu3frH6HyM1bY="
+  },
+  "org/jetbrains/kotlin#kotlin-compiler-embeddable/2.2.20": {
+   "jar": "sha256-HGw/gQv+akGry8NLOi72OfHj9K7tOpU6Swl07qT0GIk=",
+   "pom": "sha256-Bf8CX3+wky+xH6HhzK71KPdgJ9lWaA+INdQ4VCdi4go="
+  },
+  "org/jetbrains/kotlin#kotlin-compiler-runner/2.0.21": {
+   "jar": "sha256-COYFvoEGD/YS0K65QFihm8SsmWJcNcRhxsCzAlYOkQQ=",
+   "pom": "sha256-+Wdq1JVBFLgc39CR6bW0J7xkkc+pRIRmjWU9TRkCPm0="
+  },
+  "org/jetbrains/kotlin#kotlin-compiler-runner/2.2.20": {
+   "jar": "sha256-+vloNPogBNeL2ORCD1go3j1CckJ9ZHR5gCTqbpz4XN0=",
+   "pom": "sha256-kbsVJI9OqUS2Mw8xA/HrVF0TvditSuxDe3R6WG57F6k="
+  },
+  "org/jetbrains/kotlin#kotlin-compose-compiler-plugin-embeddable/2.2.20": {
+   "jar": "sha256-Bimyp1YOqErUpnuq/Oxlzjim7OoEacUyks8HX8/FlIs=",
+   "pom": "sha256-WdmNoYr+XBvTIrWEsK1ks7jTRYsUYWcSgJEn1C9JfPI="
+  },
+  "org/jetbrains/kotlin#kotlin-daemon-client/2.0.21": {
+   "jar": "sha256-Nx6gjk8DaILMjgZP/PZEWZDfREKVuh7GiSjnzCtbwBU=",
+   "pom": "sha256-8oY4JGtQVSC/6TXxXz7POeS6VSb6RcjzKsfeejEjdAA="
+  },
+  "org/jetbrains/kotlin#kotlin-daemon-client/2.2.20": {
+   "jar": "sha256-cO983NwwEHe5s7ohqp6cVadq+z/73+9KtWKmd9GN+kw=",
+   "pom": "sha256-ihNtDxPrmDpr40/x4WPJznmFXkuiF09Fy0KqpnVT91Q="
+  },
+  "org/jetbrains/kotlin#kotlin-daemon-embeddable/2.0.21": {
+   "jar": "sha256-saCnPFAi+N0FpjjGt2sr1zYYGKHzhg/yZEEzsd0r2wM=",
+   "pom": "sha256-jbZ7QN1gJaLtBpKU8sm8+2uW2zFZz+927deEHCZq+/A="
+  },
+  "org/jetbrains/kotlin#kotlin-daemon-embeddable/2.2.20": {
+   "jar": "sha256-fFyM0vi+rdMoMjm7nKIZoMr6GvAmgrQHsYHhF5cY8vc=",
+   "pom": "sha256-9Yhmv7yYZ8bWR1ec/3DUKHeZctvd2N5MJXh5y0N0FIk="
+  },
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-annotations/2.2.20": {
+   "jar": "sha256-T8MqG+ZFynQE4hskRSCI+T6OmT6v/Sbza9Ndv3XGB1I=",
+   "pom": "sha256-sbbgEXktfKkv7K+/+sSlCPdvA5yfeuijI9GJKIgl9P4="
+  },
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-api/2.2.20": {
+   "jar": "sha256-dgfuXHoMpT+lku58VA7oCJYqe62P7p7Xj+Z0hBRj2V0=",
+   "module": "sha256-T8vx/H5Uzr/pC5peD7RpYv7Vwi03I52iNfXi37xtUog=",
+   "pom": "sha256-C5E9oNIYhCAmOpBLtApkD9s1pTWnLwWC/llkHjoMSi4="
+  },
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-api/2.2.20/gradle813": {
+   "jar": "sha256-dgfuXHoMpT+lku58VA7oCJYqe62P7p7Xj+Z0hBRj2V0="
+  },
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-idea-proto/2.2.20": {
+   "jar": "sha256-dtFu5ZzeHmpwVWtdQEhu+fEcFkOodJPBnE3zMWU4N9k=",
+   "pom": "sha256-xRuhScfyk1nSWk7RIS4otpNOGkdW9VLAAHvxFE0onB0="
+  },
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-idea/2.2.20": {
+   "jar": "sha256-7JacXwsJn4I4RiMiOPm9ZPPTdB5i6pBQrS5DL6150KA=",
+   "module": "sha256-/IW7KUlsw/X5DHjHonejkw7xFg8IQ/iu1ke3TGejtJQ=",
+   "pom": "sha256-NkQjJURfF7rCH1OGu0k4+D53K4NOWGBT1BRbGnXZ4oU="
+  },
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-model/2.2.20": {
+   "jar": "sha256-U6MhUoJjIGAYUgSaC291OMqLtX/QnYeszRGLxo1D+OQ=",
+   "module": "sha256-EZdKVPSOCCXpdxML9u9qyZp/216yr53iZa9iTHY2g+U=",
+   "pom": "sha256-3uDjB7pub1GQPH5DPehSZ10eMOfyLPJGWxglVSZR7fs="
+  },
+  "org/jetbrains/kotlin#kotlin-gradle-plugin/2.2.20": {
+   "module": "sha256-3CS/pH4EQigykOIfBpoFYUHR8IjWy57Kouqs4bR7a4w=",
+   "pom": "sha256-ucP9Lr1UhNYMX+DbeqEIeDA+7d/JP5Qvc1wHupmBh8w="
+  },
+  "org/jetbrains/kotlin#kotlin-gradle-plugin/2.2.20/gradle813": {
+   "jar": "sha256-XTJbXCxdS8i/RBRdJOtNS+sGDRPRHr5IiYk27VzRVk4="
+  },
+  "org/jetbrains/kotlin#kotlin-gradle-plugins-bom/2.2.20": {
+   "module": "sha256-P7tFda43xKd2rrhtj/k8aqEbDPLadXScUyDiWFCwIp4=",
+   "pom": "sha256-PG1GnpFfuzCWrEy4wvRsedAnw8WQ5lihBoihVx61eNg="
+  },
+  "org/jetbrains/kotlin#kotlin-klib-commonizer-api/2.2.20": {
+   "jar": "sha256-OYK+RbEpMOIYGbWJ2zcHyOhM4le/Ks5/xi/I3zaPWz4=",
+   "pom": "sha256-CzAJtJQmv6F3qtlLSBCbjKVMck6i5sUGgmo6lc9ZEOE="
+  },
+  "org/jetbrains/kotlin#kotlin-metadata-jvm/2.1.0": {
+   "jar": "sha256-uNOpJXS6HfxJvfIFJW0e3gZkFIyxUKti+qhyteG7RjI=",
+   "pom": "sha256-G8hTyAjj0o3D8Gf2Z/ZSSro0YWl6+VJu/et09Ulojdg="
+  },
+  "org/jetbrains/kotlin#kotlin-metadata-jvm/2.2.0": {
+   "jar": "sha256-UBIirn1jUn5V8uXmRfGNTv8sGQdMhbm8BVhm4+0rF78=",
+   "pom": "sha256-Vav6RtrO+hAxYMwE4MUeVgq6DKIyAD/bz7TtjN05m0U="
+  },
+  "org/jetbrains/kotlin#kotlin-native-utils/2.2.20": {
+   "jar": "sha256-UBd3SirqQf+HEhNxFs1NgAP+mroSAMEG5lcw/rW7dEI=",
+   "pom": "sha256-U+++4FpxIhiQYPXuXspodjnOr+KfXlmW3phiopxnJyU="
+  },
+  "org/jetbrains/kotlin#kotlin-parcelize-compiler/2.2.20": {
+   "jar": "sha256-LdtjfY0hDls08VoKrwHGZfR7SjmUHTvkDHDyNsOPIpw=",
+   "pom": "sha256-yD2Ol77ObfXhvmk1pTpGW9RK/jaGyMpEu2GVE2a7HJI="
+  },
+  "org/jetbrains/kotlin#kotlin-reflect/1.6.10": {
+   "jar": "sha256-MnesECrheq0QpVq+x1/1aWyNEJeQOWQ0tJbnUIeFQgM=",
+   "pom": "sha256-V5BVJCdKAK4CiqzMJyg/a8WSWpNKBGwcxdBsjuTW1ak="
+  },
+  "org/jetbrains/kotlin#kotlin-reflect/1.9.24": {
+   "jar": "sha256-plFmRFu4XvgWzeEnJ5/gAX0rfMQ5s7lyOQ4bc21k6Uw=",
+   "pom": "sha256-CghcMAUb1tSrdlrVoMUXnEE7NfdBjyiDFy+9m6GrzMk="
+  },
+  "org/jetbrains/kotlin#kotlin-reflect/2.0.10": {
+   "jar": "sha256-d/9bCll7ppfJdVbWYfaJkaAZynHUDEnozLaZH0+T4wg=",
+   "pom": "sha256-NmbNQR+B744nZL2XHhzx5bdiKmDINTATu1TJdZJV910="
+  },
+  "org/jetbrains/kotlin#kotlin-reflect/2.0.21": {
+   "jar": "sha256-OtL8rQwJ3cCSLeurRETWEhRLe0Zbdai7dYfiDd+v15k=",
+   "pom": "sha256-Aqt66rA8aPQBAwJuXpwnc2DLw2CBilsuNrmjqdjosEk="
+  },
+  "org/jetbrains/kotlin#kotlin-reflect/2.1.0": {
+   "jar": "sha256-tfYI7fqYqM+iNyzBLRitqXS+HFbBCT7/BswGH0/AiLI=",
+   "pom": "sha256-nNhLPU9xfJYjXkujtydolcz/1V3kEcfOCz97q1Yu/kI="
+  },
+  "org/jetbrains/kotlin#kotlin-sam-with-receiver-compiler-plugin-embeddable/2.0.21": {
+   "jar": "sha256-x88d6VXfIqFihyImvQZ3yaDItmMKLi1z0R0UfNDFO3M=",
+   "pom": "sha256-cWKsEOFFTpJ2c7FcrQMp2jgvt1jmVPWfy0AHRZ2eyEE="
+  },
+  "org/jetbrains/kotlin#kotlin-script-runtime/2.0.21": {
+   "jar": "sha256-nBEfjQit5FVWYnLVYZIa3CsstrekzO442YKcXjocpqM=",
+   "pom": "sha256-lbLpKa+hBxvZUv0Tey5+gdBP4bu4G3V+vtBrIW5aRSQ="
+  },
+  "org/jetbrains/kotlin#kotlin-script-runtime/2.2.20": {
+   "jar": "sha256-XIvV3Xrh6i7rJ3j9vqoZpWIYSXX2yrigu2d55BkHMa4=",
+   "pom": "sha256-IpOhQenagKfpjYXtKkkuldsMAWW86rC3Klzp4tkrCAc="
+  },
+  "org/jetbrains/kotlin#kotlin-scripting-common/2.0.21": {
+   "jar": "sha256-+H3rKxTQaPmcuhghfYCvhUgcApxzGthwRFjprdnKIPg=",
+   "pom": "sha256-hP6ezqjlV+/6iFbJAhMlrWPCHZ0TEh6q6xGZ9qZYZXU="
+  },
+  "org/jetbrains/kotlin#kotlin-scripting-common/2.2.20": {
+   "jar": "sha256-+5n/fwzZUtpo1UjT89ZErlB4sLlvybrwZewUZqKTuAU=",
+   "pom": "sha256-iTjGIFKXW7uW3OotqaeNS2sk2vLwnTWMGnqEHxaMtzo="
+  },
+  "org/jetbrains/kotlin#kotlin-scripting-compiler-embeddable/2.0.21": {
+   "jar": "sha256-JBPCMP3YzUfrvronPk35TPO0TLPsldLLNUcsk3aMnxw=",
+   "pom": "sha256-1Ch6fUD4+Birv3zJhH5/OSeC0Ufb7WqEQORzvE9r8ug="
+  },
+  "org/jetbrains/kotlin#kotlin-scripting-compiler-embeddable/2.2.20": {
+   "jar": "sha256-2GJhDAAzQuUIjKIcRAQix9ijcA4ZnWA/ehAnjESIR2E=",
+   "pom": "sha256-PW9vFZH6P3r14jFlxowu4BclFYZFQ09eMBdF5kfHVhE="
+  },
+  "org/jetbrains/kotlin#kotlin-scripting-compiler-impl-embeddable/2.0.21": {
+   "jar": "sha256-btD6W+slRmiDmJtWQfNoCUeSYLcBRTVQL9OHzmx7qDM=",
+   "pom": "sha256-0ysb8kupKaL6MqbjRDIPp7nnvgbON/z3bvOm3ITiNrE="
+  },
+  "org/jetbrains/kotlin#kotlin-scripting-compiler-impl-embeddable/2.2.20": {
+   "jar": "sha256-e3kSNZL//r81xhag/xBDMscc3mN6ZX4JrbXfbD+cA84=",
+   "pom": "sha256-+l+wJ+4qSbPb/zh3VBtC+3CuzMN7oC4dOthipcZyVLc="
+  },
+  "org/jetbrains/kotlin#kotlin-scripting-jvm/2.0.21": {
+   "jar": "sha256-iEJ/D3pMR4RfoiIdKfbg4NfL5zw+34vKMLTYs6M2p3w=",
+   "pom": "sha256-opCFi++0KZc09RtT7ZqUFaKU55um/CE8BMQnzch5nA0="
+  },
+  "org/jetbrains/kotlin#kotlin-scripting-jvm/2.2.20": {
+   "jar": "sha256-qR+5BJY0oyum09LpGgy5mD4KpOccDC4bKDg4qOBhYx8=",
+   "pom": "sha256-0df8RWSBne6v6OvdcfbyGBf/xVjr0U9HpW6NyTaW3Rk="
+  },
+  "org/jetbrains/kotlin#kotlin-serialization-compiler-plugin-embeddable/2.2.20": {
+   "jar": "sha256-jY+TYgGErIdsuo09/aF8JdQD+Q0kacqHrNfvox2EeZ8=",
+   "pom": "sha256-fJa3mogscA0BKBr1iT0dkuknZX2AOHkGjYMQsNV5G8E="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-common/1.9.10": {
+   "pom": "sha256-fUtwVHkQZ2s738iSWojztr+yRYLJeEVCgFVEzu9JCpI="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-common/1.9.24": {
+   "module": "sha256-6Y6oxE+zaCDQG7iwAxaOI6IhtAHLQyVtcjo/C3fWFsI=",
+   "pom": "sha256-XZfiDNWGLoR6aYF1uTno3Fxr11vtmZ1vPU6ghIESFsA="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-common/2.1.0": {
+   "module": "sha256-K5pa54X4UTqT+M7D9uXgf4sXZvhJezpIfzRBolHWdWM=",
+   "pom": "sha256-Sp2nqeUpW9VC1YY8rgNfevnKEB8iXEoIkcPS343CqA0="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-common/2.2.20": {
+   "module": "sha256-ND2ZRn/LRNPvsSorpwNmTKQ/Oj8m//k8jTGyJoOttX4=",
+   "pom": "sha256-/Xicsy4kEOzGg7hzn3t1AD0J2jMzDD+KZcJp22svbHU="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk7/1.8.21": {
+   "jar": "sha256-M9FI2w4R3r0NkGd9KCQrztkH+cd3MAAP1ZeGcIkDnYY=",
+   "pom": "sha256-m7EH1dXjkwvFl38AekPNILfSTZGxweUo6m7g8kjxTTY="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk7/1.8.22": {
+   "pom": "sha256-T5WKqZPVmE+PXr7UFGVipfOp9pW2BJyfKHOBN5ytqzM="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk7/1.9.10": {
+   "jar": "sha256-rGNhv5rR7TgsIQPZcSxHzewWYjK0kD7VluiHawaBybc=",
+   "pom": "sha256-x/pnx5YTILidhaPKWaLhjCxlhQhFWV3K5LRq9pRe3NU="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk7/2.1.0": {
+   "jar": "sha256-/epsQgNyT0Lo5kvvLwv3kSnM0d8e3xzP/cIt599JjHY=",
+   "pom": "sha256-BvvBTssUoK9HtaP400dj9JM9XLpaPSRQRb/i8r25Gx4="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk7/2.2.10": {
+   "jar": "sha256-z5XszGzHhN/0ed7guINPNYS5MpLMXZGXLoL117nhPjs=",
+   "pom": "sha256-vklJB+DhnHi7ghFUr6F3bVrXoFi0qzAJD3Q1Sw4TON4="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk8/1.8.21": {
+   "jar": "sha256-PbdSowB08G7mxXmEqm8n2kT00rvH9UQmUfaYjxyyt9c=",
+   "pom": "sha256-ODnXKNfDCaXDaLAnC0S08ceHj/XKXTKpogT6o0kUWdg="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk8/1.8.22": {
+   "pom": "sha256-ko8hhyF0djE8uBbUgHC8dlSqO5pa6B0/xfjCecyPjZ4="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk8/1.9.10": {
+   "jar": "sha256-pMdNlNZM4avlN2D+A4ndlB9vxVjQ2rNeR8CFoR7IDyg=",
+   "pom": "sha256-X0uU3TBlp3ZMN/oV3irW2B9A1Z+Msz8X0YHGOE+3py4="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk8/2.1.0": {
+   "jar": "sha256-I408fkkvEZtQ2hwiVG3XYkYuVfIkCWEfXlPdd2Jc1UQ=",
+   "pom": "sha256-52K4xFaQropqNd9YT1S+nJ2mWIXmGpBUJq6vylk34c4="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk8/2.1.21": {
+   "pom": "sha256-9KkWH2LpUq9Q/WKhomCB8413f+zWlH/YQD8UR/hmnao="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk8/2.2.10": {
+   "jar": "sha256-iXS/3Qix2BhD/o0R8HKatuWzwfiNZx6+DABjWBKc4Uk=",
+   "pom": "sha256-JWnPWpgHJPFAFXUB2zbf+rkZzQ1EPS4UtaNaL5b4T6w="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib/2.0.21": {
+   "jar": "sha256-8xzFPxBafkjAk2g7vVQ3Vh0SM5IFE3dLRwgFZBvtvAk=",
+   "module": "sha256-gf1tGBASSH7jJG7/TiustktYxG5bWqcpcaTd8b0VQe0=",
+   "pom": "sha256-/LraTNLp85ZYKTVw72E3UjMdtp/R2tHKuqYFSEA+F9o="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib/2.1.0": {
+   "jar": "sha256-1vkbew8wbMopn+x0+3w05IdNb17FuSWgtN4hkB4RnD8=",
+   "module": "sha256-3PvI6L8yzWen763ZHTEVK86YcJEdbsUIePT9tuA+cOI=",
+   "pom": "sha256-E05IwXeWwcECfsvmyfHHXHkvU1mHq4nh4d2kP4w2b14="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib/2.1.10": {
+   "jar": "sha256-XyrByo3Is3o/QxTnFtNpaevwInp1GB0yaZ0Kj2RbHCE=",
+   "module": "sha256-jSwdcXxzVG1WOC0TbIZQtZpxWZQBciY4GJNKzkTLBI0=",
+   "pom": "sha256-SSISHT8LxgzkB/Ny3kLQKgt+lOddDD0VCLaDVyHySe8="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib/2.2.0": {
+   "jar": "sha256-ZdEthaO4ZcFg25FHhRcSpksQ2t1osi7qIqlb+KhnDco=",
+   "module": "sha256-pbmP3NnbAX1ULhlyJdzuGNZYpW3h2yzEHhMZbWsXaaQ=",
+   "pom": "sha256-jDyCEAfBNBFVhzm589U4LrgVUds4lc/7iVYeVsD03BY="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib/2.2.20": {
+   "jar": "sha256-iDbM/9NYX63amQEkSyDUKQHS881YEFjYQ04v+rzzo+c=",
+   "module": "sha256-yRj1IU0CGnLjdn8nVul9EDpSbgTxQj2jZj79+1hH25U=",
+   "pom": "sha256-SosIbmQxvPYjY39Ssv8ZLhrbkTg4dC5cDupwqN7kKcQ="
+  },
+  "org/jetbrains/kotlin#kotlin-tooling-core/2.2.20": {
+   "jar": "sha256-dAFOxPPveM59p+Pmlk8sUmoxIdXFj++MopeeXzRFgvQ=",
+   "pom": "sha256-jvep2QYs59w/xlVxXdAoqZRLeElhPgEYR8XWs7mSgXE="
+  },
+  "org/jetbrains/kotlin#kotlin-util-io/2.2.20": {
+   "jar": "sha256-1DGva+puLcmInE/iawc84VfxEchgj+laGL/gi4F8/3Q=",
+   "pom": "sha256-xqXQGEjNBAz8j3uuYjLXktcFwpOi2nJmrmJszbNdagM="
+  },
+  "org/jetbrains/kotlin#kotlin-util-klib-metadata/2.2.20": {
+   "jar": "sha256-vuSQHKU6WiHA22RZAdKwcK/2gkAkF91XiODjWTZFcTs=",
+   "pom": "sha256-vtAGUSIGX65328DEb/xBRqaFy7GLijApq9XaO/qhECc="
+  },
+  "org/jetbrains/kotlin#kotlin-util-klib/2.2.20": {
+   "jar": "sha256-7XyAlrK75HetF8MXjeuoyDr1MourNr/iEJEL1bQZI0w=",
+   "pom": "sha256-2mwiR3qvQt2hbYWa2unj7Yq8khzLp/9RYTTMi9NZqpI="
+  },
+  "org/jetbrains/kotlin/native/cocoapods#org.jetbrains.kotlin.native.cocoapods.gradle.plugin/2.2.20": {
+   "pom": "sha256-nwvGGojFg6ps2H0WmJAVMgBL5unMJqSfveR9dFsamrE="
+  },
+  "org/jetbrains/kotlinx#atomicfu-gradle-plugin/0.27.0": {
+   "jar": "sha256-Ol911FKwg/txpx9fTjcvZH5kIguP1fXyk4pBDj4ESXc=",
+   "module": "sha256-HWkjLkplqQUDI3mHA4Gs0ns/IqI4dVPgK+vhpVMA5sA=",
+   "pom": "sha256-I1EtRWDRpL/Rm2h1wg9DE85ep20RhyUwI4yx58oxNDE="
+  },
+  "org/jetbrains/kotlinx#atomicfu-iosarm64/0.27.0": {
+   "module": "sha256-Wg9/yTr02WQEOAJINX6i5bctmaK312YB6XCMZrL9Az8=",
+   "pom": "sha256-5/+fpnuPakUQhAH5m+M7t/ZuvrhpeFnoS5f65skkH4A="
+  },
+  "org/jetbrains/kotlinx#atomicfu-iossimulatorarm64/0.27.0": {
+   "module": "sha256-VawiAXQlGELEFTWYok2VJLozw1C+7qke93+5KvIAkgY=",
+   "pom": "sha256-gQdN2+tLOEAxA/Lu+FMuovGVWumLll2NQer9NvLBZPA="
+  },
+  "org/jetbrains/kotlinx#atomicfu-jvm/0.27.0": {
+   "jar": "sha256-K2hGQXAHCosIXYpyJMfAAtvWXqFOH4uXqWBRFaJS9/s=",
+   "module": "sha256-zi6Gt1JxP/5nAUvdHhLvKQxwLom/rLh6sn+/3X4Tusk=",
+   "pom": "sha256-WyUzVczAbyUcuFKuBHKkLV+9TQKZWebXgj6dE56gPZk="
+  },
+  "org/jetbrains/kotlinx#atomicfu-transformer/0.27.0": {
+   "jar": "sha256-Mun9/FpwR6fnVEc4/YmRFLUnp6RiTfhXAnsehwIAeOw=",
+   "module": "sha256-eKfmR1/c4aDr+A62Mk5w0km24a/CgrdQPcw8pCk+yMg=",
+   "pom": "sha256-CiaCvpkn5FD+21SnYt9RxyUXW8f7A8ckPWDy8ckBQrk="
+  },
+  "org/jetbrains/kotlinx#atomicfu/0.27.0": {
+   "module": "sha256-umecB1fjmeaKmfl9c4QosvtwB3F93/Dx3uuoYrr0RpA=",
+   "pom": "sha256-e3Fbn9t9MTr8hRjV/Kv0LrSfzNbNf/RHNqEF6AmUBdg="
+  },
+  "org/jetbrains/kotlinx#kotlinx-collections-immutable-iosarm64/0.3.8": {
+   "module": "sha256-g8j4tu8QKfoUs/lqVDf20l3rg/yeLZsXeHed5B+zujI=",
+   "pom": "sha256-wr89Ny7FWFFI2gOFwnlVUmqYJTgUBZHijfIbHxJATP0="
+  },
+  "org/jetbrains/kotlinx#kotlinx-collections-immutable-iossimulatorarm64/0.3.8": {
+   "module": "sha256-vJyjlFYQpKDhXumYyxWx1HL4JWJVvieI6yHybwVukxw=",
+   "pom": "sha256-7HB+otLssbWiI7I761NWHNDZaakgUrInWawWXGqDnw8="
+  },
+  "org/jetbrains/kotlinx#kotlinx-collections-immutable-jvm/0.3.8": {
+   "jar": "sha256-cumpsAA+xSVLY4GG98oWdbCABr3eTJxMWJlwNCzNLnc=",
+   "module": "sha256-ak06jrdCIbQ7CP4hv5Vcq9aROJd9z3j4b9DvYiC3Efc=",
+   "pom": "sha256-LE3NVjaKtStQKwiwLC8dOMBpV5BC9ZeanMEGzkA7u78="
+  },
+  "org/jetbrains/kotlinx#kotlinx-collections-immutable/0.3.8": {
+   "module": "sha256-mO+84WKQhF+zCN6UK5GjA4ZYuhUzoNL3eIO5bsqRQAI=",
+   "pom": "sha256-3IVbPjOh9u/AP72/DZlRG3Swh+lplfAEUfvyyJrgpHc="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-android/1.10.2": {
+   "module": "sha256-CS/jgQPuxi6UVAygzWEDnvj32ORmlOwDO+H2Pw6iAT0=",
+   "pom": "sha256-uS02cuf56PTE4qsYfD4x/sxQZJY5b0pfJ+4clXpCsxk="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-android/1.7.3": {
+   "module": "sha256-SN/YE57e5UgbzIsl4k11hqymFfDR7SvrJC3HR47UzuA=",
+   "pom": "sha256-AgUVJG0Z4XbVYm6xGPgPl/eHbRrM2M7BWxpBWSV9UFQ="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-android/1.8.1": {
+   "module": "sha256-8Arwkgy33EYRIF/1ku7FqgBxvJWbN5cCar/kPPFL+tQ=",
+   "pom": "sha256-iOjH7eTSm4AnotpuqePOVQxVakITYz+PbeKLufsgHJA="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.10.1": {
+   "pom": "sha256-nL0EumPnOZhWdFcT4xLS8hYaHUTtpQbe1HyNVtr4Rh8="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.10.2": {
+   "pom": "sha256-+vDGU45T3cBJmmNmTY52PCFlgLLhjnIsy98bQxpq/iY="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.6.4": {
+   "pom": "sha256-qyYUhV+6ZqqKQlFNvj1aiEMV/+HtY/WTLnEKgAYkXOE="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.7.3": {
+   "pom": "sha256-Tl0ZAOY3nvP1lw0EqPMFKa3IL4WejMEHwhzoFJ72ZsQ="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.8.0": {
+   "pom": "sha256-Ejnp2+E5fNWXE0KVayURvDrOe2QYQuQ3KgiNz6i5rVU="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.8.1": {
+   "pom": "sha256-Vj5Kop+o/gmm4XRtCltRMI98fe3EaNxaDKgQpIWHcDA="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.9.0": {
+   "pom": "sha256-vqVRHpAB8sWTq1CA3xMbIZq14ghcxZec5YPqzUlG/Xg="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core-iosarm64/1.10.1": {
+   "module": "sha256-vz3DHLHJF2E4Jh8E6zXJMOboqoqOlvvx9Eoubbgm7CM=",
+   "pom": "sha256-CuARNTnEvUE+6zDC4zVzUm+5tbikVoKMxOq9hPZ/WfE="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core-iosarm64/1.10.2": {
+   "module": "sha256-P/PaA3R5jX6eV/ugT5zCTZpbUQxgTJoLPdMi1cXuHxg=",
+   "pom": "sha256-GHc8mVCsMAIPOmuE7xgPgHo0WIDe2Xohz691pPPmZV4="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core-iosarm64/1.8.0": {
+   "module": "sha256-IYnr/ki/tQBGr/gOgDTIua05Oj++uTCw+RISvOxMrYI=",
+   "pom": "sha256-LJqfNIgy/JYxpBY2m3FhaqA85ZPLICMKSCWEfV9yXyY="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core-iosarm64/1.8.1": {
+   "module": "sha256-mgDC7zIZ3CaW0hxLSEHqL6IumdUCRxSuNRzbc+sUQNI=",
+   "pom": "sha256-fiBXCqtPnIGPxSYfsWcK9UA4HI/IELQopbSQWa/bu7o="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core-iossimulatorarm64/1.10.1": {
+   "module": "sha256-XzkSC5DxTUKnScccEQxaLyczkhUEWo7+TVKBM3Xmnac=",
+   "pom": "sha256-aKKgD9MOxubByZa2kYvvl/fnTUtRFWHZRUMwUdUKEo0="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core-iossimulatorarm64/1.10.2": {
+   "module": "sha256-r8amerqj9JEgbAl/q8dU59ZS1aIaH2liX4taQegoAb8=",
+   "pom": "sha256-cECzNg9JBdQ7DA4idsp6SPpsR+2vPMdd20VVc00IsTc="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core-iossimulatorarm64/1.8.0": {
+   "module": "sha256-Crwhk2T+ysqXkwWlBgy4NWKZhRQqsNTqpnn9eoJ83Ag=",
+   "pom": "sha256-6IdPlLePWJ1EPjlAAglixa/iePPdBc5V443V2Mp02jI="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core-iossimulatorarm64/1.8.1": {
+   "module": "sha256-QvtlyVxpJ+8dBRp4i2QSSHvs+GHEWDrAl5gxGUZlYBs=",
+   "pom": "sha256-8/+zzTJj1EYfMGBxr1TG5rDcgATzMkhdknu59N2hiC4="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core-jvm/1.10.1": {
+   "jar": "sha256-BpxZiGMyMOB07A05Mh7DzapFR8SekLqTbGPY/JHIwA0=",
+   "module": "sha256-GN1lRl7IDQ5uXXGBi/EZLvSBfPXSASgrW5sbcTrHlpo=",
+   "pom": "sha256-f5AURlw6uheoNXqJZcqcnKjJ4aBEfHrqEXxkB4CKUtY="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core-jvm/1.10.2": {
+   "jar": "sha256-XKF1s43zMf1kFVs1zYyuElH6nuNpcJs21C4KKIzM4/0=",
+   "module": "sha256-6eSnS02/4PXr7tiNSfNUbD7DCJQZsg5SUEAxNcLGTFM=",
+   "pom": "sha256-ZY9Xa5bIMuc4JAatsZfWTY4ul94Q6W36NwDez6KmDe8="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core-jvm/1.6.4": {
+   "jar": "sha256-wkyLsnuzIMSpOHFQGn5eDGFgdjiQexl672dVE9TIIL4=",
+   "module": "sha256-DZTIpBSD58Jwfr1pPhsTV6hBUpmM6FVQ67xUykMho6c=",
+   "pom": "sha256-Cdlg+FkikDwuUuEmsX6fpQILQlxGnsYZRLPAGDVUciQ="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core-jvm/1.7.3": {
+   "module": "sha256-NNbumbdqwGK1FVW0pwvhg0n+VWbaeaGQYU8XHIC2U44=",
+   "pom": "sha256-dThYdT3su7I5c0PiuHHwYvaXgS6UIuQcnuRqZrk+7jA="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core-jvm/1.8.0": {
+   "jar": "sha256-mGCQahk3SQv187BtLw4Q70UeZblbJp8i2vaKPR9QZcU=",
+   "module": "sha256-/2oi2kAECTh1HbCuIRd+dlF9vxJqdnlvVCZye/dsEig=",
+   "pom": "sha256-pWM6vVNGfOuRYi2B8umCCAh3FF4LduG3V4hxVDSIXQs="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core-jvm/1.8.1": {
+   "jar": "sha256-89T13hw5G7zCDzs0Ncy6wBNSHna2kC19WWNewVwfeX4=",
+   "module": "sha256-CbgcnRHC3uvxM62HtweSfB8ECZy2Ee8AjHcls+swgyk=",
+   "pom": "sha256-R8alCxQVHo+vfzUKlSNcN9EqvDi/sFW2aJdCkxctryw="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core/1.10.1": {
+   "module": "sha256-y/1tFz4KXCmGr5U/ixzPKYAqrQnqympOkRQQj4rKyLE=",
+   "pom": "sha256-Ip7SIxgcPK8nt6wwHIFp3KLYYxkbcQ5hNVGlh5XANlU="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core/1.10.2": {
+   "module": "sha256-j+JUF35xGnzRijwG2CQvzpRfQcLMoT3BmzOuQqVDUBY=",
+   "pom": "sha256-UZ2lQACW80YqTa6AeDrQUEE9S8gex65T+udq7wzL7Uw="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core/1.7.3": {
+   "module": "sha256-f7FiOWWU7CjhtqRBG0V5SadnD14SAZF2d04f1rlHG78=",
+   "pom": "sha256-7W6wOYcXA14p8cHWCk4927iYWPPbnge1etdZ03Ta6Ck="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core/1.8.0": {
+   "module": "sha256-FE7s1TZd4+MNe0YibAWAUeOZVbXBieMfpMfP+5nWILo=",
+   "pom": "sha256-yglaS/iLR0+trOgzLBCXC3nLgBu/XfBHo5Ov4Ql28yE="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core/1.8.1": {
+   "module": "sha256-CMuvMyW1Tg+O+NqF5OtZb32Ub4Q+XRYAOFRj8yaKTvA=",
+   "pom": "sha256-+IkY2/qHh8TRcasCVToUrR3viqmwxcLCDMmUVdMkHiI="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-play-services/1.10.2": {
+   "jar": "sha256-qERp1oPP/EQnJwtxRMYgR9KnHs5wPgY6SIDI3MQsr3I=",
+   "module": "sha256-2iYsGjUinEbAsuBV6CQG3oYM4aQmWaOhf5MserOVUP8=",
+   "pom": "sha256-jTgFmv8j4bKsIW3trMsboV3H0UyAYVJE3gkcxhMyCWo="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-play-services/1.9.0": {
+   "module": "sha256-k9zumoMaL53NqVKLqyjXJOFeigv+xBlO+B1Ox+cwH/I=",
+   "pom": "sha256-BMklOqqrM6EDRGL//unXOkNiKpSBh/gDSLpcuXqydLE="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-slf4j/1.10.1": {
+   "jar": "sha256-5fpnTj2mpw/hGI/A1l+GcFN5rto0xZy9ML0VwORlts8=",
+   "module": "sha256-Z53VZCkanbzH7lbmZCzzqdB7BXGWj9lN5BachzJ/i8U=",
+   "pom": "sha256-UqJfb2ZMxFkJQmTVEDOeVYOqyQJ/DqqqPXA1XHVQkkY="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-slf4j/1.10.2": {
+   "jar": "sha256-1l3uPK+m97+u/ttJP8aLXGOr51BzT7ivkvrHoNMQFFc=",
+   "module": "sha256-B7xJACLGWAQpQfUrFxwPXOBkvWxjUikEMDmS5BegRbs=",
+   "pom": "sha256-xHdj+siNuwlDhJ0W4RucBdReYDhMfNExBe5xD7TdX7M="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-swing/1.10.2": {
+   "jar": "sha256-Ar24XyDsCABEKav2iH6NDkDzq2N9dGL4F/D4q759HrU=",
+   "module": "sha256-kFK7SUS5FqUGX2GNfUb+EqTAxonQIbyYQ1v4l3WIsWQ=",
+   "pom": "sha256-zt+0Miu5cVkXrmmCCeoS3ziKuliVy7rRxWcith6EQ8A="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-test-jvm/1.10.2": {
+   "jar": "sha256-WQpUn4wdtZDJ2YqKIEJKH1gaNBYqNp5qa9iEzn0209c=",
+   "module": "sha256-VrIIF8xRrYi9tZwBIWsJiXzU+mmNUXu0d9kqlyp6Gq8=",
+   "pom": "sha256-Y96yqGiry+JIjrzrqnXnMbLvIQQQO4FzjnY3/JolpfM="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-test-jvm/1.8.0": {
+   "module": "sha256-HS0Zc6L0GowMEmPmCyXneS9ji4xV18ocbQZztkvlfac=",
+   "pom": "sha256-BtHlPqNm5to7FxkwV1+RYnzxnkUqTnqfDeMNLwQdZFE="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-test-jvm/1.8.1": {
+   "jar": "sha256-xO8d6zG+P4HtguzyNyIMyViGhop+xSekGFmd//FZ3ts=",
+   "module": "sha256-+wj8JXyQBDPS35l71sKeBJzZ979UHAt3YYDgmYJB9XY=",
+   "pom": "sha256-4qht+xaCAWeYuVoPAGy0tdAQRsVaAS6hs2vSAjLcVXQ="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-test/1.10.2": {
+   "module": "sha256-QiByzuO2n2jVsVA7tmUb54lGsEw5KEocwCbM6L3x+AY=",
+   "pom": "sha256-vyXI3w7J8+rHu+5Tm2AbYBm36Z9fPzAR4ugXixQHUNs="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-test/1.8.0": {
+   "module": "sha256-DsPHX/2ZpqLfto8wfy8vcxQckz5Yt3sQTxyMrDr9U5Q=",
+   "pom": "sha256-NV8/pvBjDl6ZuHxywcQ4YgKin0lpFeOHWaOK3gsGkAQ="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-test/1.8.1": {
+   "module": "sha256-oc7i2rKWwTt47BwGDhj+QDNKRAyKB36QzKbeclJ9jN4=",
+   "pom": "sha256-TyiEIOjObP+RUgyfq9bK9o0C2GtkCp8hKPh6TkZtwlg="
+  },
+  "org/jetbrains/kotlinx#kotlinx-datetime-iosarm64/0.7.1": {
+   "module": "sha256-hnCJDOysumljc0ajuRnE9h6e3gNqKs8dTQGLX9d2abM=",
+   "pom": "sha256-cWeLdrfpvC30NmcE/F3aVaq6dm9nSNzaKEOlR5ol9MM="
+  },
+  "org/jetbrains/kotlinx#kotlinx-datetime-iossimulatorarm64/0.7.1": {
+   "module": "sha256-TLn4k7pp4au/jFflzXWi97y6rK2H3gs5bivH76Om3Yo=",
+   "pom": "sha256-dM+mya/1iJAN6yYLL+sQw0PP5moeMaLKiVB5rEqJpKs="
+  },
+  "org/jetbrains/kotlinx#kotlinx-datetime-jvm/0.7.1": {
+   "jar": "sha256-O4uYZXya/zvn9rS1denz+5o6H0UqgB2g9DiQFzSs2t4=",
+   "module": "sha256-2iG17aY2QqSURWXCqMhEzkj17+c0cDrFkYKglBusino=",
+   "pom": "sha256-inUEl+cFy/5Ljqu2IN1MG4woTs6taqjmMKWXefQ4l10="
+  },
+  "org/jetbrains/kotlinx#kotlinx-datetime/0.7.1": {
+   "module": "sha256-R0gD1qR3t8OV7otCw0zK52ZftdIx/bBa0I7TCFwk03o=",
+   "pom": "sha256-yiZ2PuBih00KtdOBzB0jBKjLm/VKUoI6wE7PA5oaMfw="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-bytestring-iosarm64/0.7.0": {
+   "module": "sha256-0gihZFkDfwYZ6uWRalfXTeA3k6CGJ0qokHWOVGEzjWQ=",
+   "pom": "sha256-XEMoAdQ5Igii/FmcMtqlOo9y7RCjes5DCWmOSZT4BCo="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-bytestring-iossimulatorarm64/0.7.0": {
+   "module": "sha256-5NHQI35Xb6KBf9DYi7Wk8C3hEPZpSNRk6zNVBR8VTjg=",
+   "pom": "sha256-/RE6RZErXHMgDczerWvlO2ne3g2p1ey6Ih8xjys0juI="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-bytestring-jvm/0.6.0": {
+   "jar": "sha256-uqd6eD1wpmr4jWiYodSXHkqoTmKyZBgFc3m98J+1uto=",
+   "module": "sha256-Tw2oHhXO+zujubirjmHoaoLtZd2N3S46cF2Euybr/Oo=",
+   "pom": "sha256-dQpt9xYR1MMAN+mCfSOVSSkKRuDBQBBoi4FM2ZZyG8c="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-bytestring-jvm/0.7.0": {
+   "jar": "sha256-6jimaw/0btgt3tnoHS3OcOX74DvWzFK0/IhpOB3qe30=",
+   "module": "sha256-D852CxW6wLkL7xvZDJfi0V+sQ6ZtwSCbSq7Jadk0Nv8=",
+   "pom": "sha256-mhfWfOIxynIhqWkS1WVtjRZ1gJ5FI/LDmupvs+o6bV8="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-bytestring/0.6.0": {
+   "module": "sha256-aO+bxmrpVPRzxZ9R679Ywdewb9b/9zNd0/s9JPipOQA=",
+   "pom": "sha256-I1NofPyzbJCaW8T08LUj0wv2WuXI34CsxW6enFJb528="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-bytestring/0.7.0": {
+   "module": "sha256-3NfGKkJ9279ezgt5jcEqD41VcSN/UScFEKUHIotjM3k=",
+   "pom": "sha256-b+eWaxTo7fC/rO+FfIiUpr9EtmFsbwK/7UoJMU7+0Zw="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-core-iosarm64/0.7.0": {
+   "module": "sha256-KTUswYUjrh7YpZZzQwPosQUOpj27f3i6Q73hUCriZec=",
+   "pom": "sha256-+DMgvQjJ56F2Dj4U6FsH6EYhk284oPmoNaSv7QxlafY="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-core-iossimulatorarm64/0.7.0": {
+   "module": "sha256-3XgOdT7y9YcfUHhuBb3Z8G+grMxFGVb+AEPiizPOvUE=",
+   "pom": "sha256-kdJqcjQarsY/3R4MZLmVllpNt/fydaNdFtUibBNh6FM="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-core-jvm/0.6.0": {
+   "jar": "sha256-QlI8gII9Me9Z+uQsklLvHTsRicqdPMOt/UAqKdBj5v8=",
+   "module": "sha256-tZuXjCxEJJpnRkGmlONaKs7LqBLah9NlpRZzQqjKU0c=",
+   "pom": "sha256-3DNkYsj1BEkGHNRdXLHI9oC+VEGqgQ6UQR/4GQmdT2s="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-core-jvm/0.7.0": {
+   "jar": "sha256-bt7cm+TYeK6oDH3WCfkb/Ef809NsyR/Q8/Mo+9ZlbI8=",
+   "module": "sha256-dDDspoloWorXVm2MgIIUpylQsdbwNjQd+MTYKah3Bsg=",
+   "pom": "sha256-I4nhfLeFp854BZ7v7yv5fpGCbCe4PMzhkbTkLtlfiBo="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-core/0.6.0": {
+   "module": "sha256-FIX7aljyQWnRr3PEFDAiUKx4u0axpD4Csa4hILKhJPA=",
+   "pom": "sha256-QIZ+EY9KW7uz291WZ3DY8Yu07w02MtyE+WyZ+2vD6oE="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-core/0.7.0": {
+   "module": "sha256-gTKXY+sZquO3OGcb7DFrkESEkcO/Unj24Q6kxwKS4iQ=",
+   "pom": "sha256-fu4E9DS9OmrRjhQFT0SH9DvKyQwDabBFA7FltzG+3Mo="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-okio-iosarm64/0.7.0": {
+   "module": "sha256-kS2HM274xYQdQ5oDFET/5On9G4mYSs7Gl/9VjMzntrc=",
+   "pom": "sha256-bR4mOACky4QWAKdVvDpSR451ijtiqo7y6h9gp8lUPQA="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-okio-iossimulatorarm64/0.7.0": {
+   "module": "sha256-/D1vFV5B9cWvXz0A+QJMt7KPs1hKbffRQpRdFoYGniI=",
+   "pom": "sha256-3kzXCa/HLtGFdUA3wSt7VMw77Mg8JeKIH8ETqXltSuA="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-okio/0.7.0": {
+   "module": "sha256-+IYKSiKGsCz9xSc60O/MVodgmnm27UuKZDcWJbjyvd0=",
+   "pom": "sha256-GYeuygPJBqwQIE3pwQO3DTqWU2wLfa/Xs/XXFxkDWGg="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-bom/1.6.2": {
+   "pom": "sha256-ew4dde6GIUmc+VQwyhL9qjL0p/kg1cMBv+lfoYfyczc="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-bom/1.6.3": {
+   "pom": "sha256-KdaYQrt9RJviqkreakp85qpVgn0KsT0Wh0X+bZVzkzI="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-bom/1.7.3": {
+   "pom": "sha256-QiakkcW1nOkJ9ztlqpiUQZHI3Kw4JWN8a+EGnmtYmkY="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-bom/1.8.0": {
+   "pom": "sha256-xD5IdSnM/RIJ66hlOrjolZggNGSq+/5fBEje2ZKHFQk="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-bom/1.8.1": {
+   "pom": "sha256-APNVWudiSFHGfbEsMIvJziauMnzw1yR2akAeW6AGCMc="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-bom/1.9.0": {
+   "pom": "sha256-bX/zZcDvHNN2+1SxoWyAoh7Vj+tGwz80ULbPIuKxNT0="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-core-iosarm64/1.6.2": {
+   "module": "sha256-y0gISQ5MJAg6b8JdVC4bTIY6UHWNhGjPGoO35U3/v5s=",
+   "pom": "sha256-wYwG9ZpsYtZ8iKQXTxi/bhpxQjwfHEc7FAwBgrsbVNg="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-core-iosarm64/1.7.3": {
+   "module": "sha256-r84AdN7+UrnQ5EV0ukIgP6PoYsuG+eir+Aiaq/JQ9Hg=",
+   "pom": "sha256-uYeKdnsxUI0DDq6rg8qhH/w3f3TNU6yUt5i6k9Q0RX8="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-core-iosarm64/1.9.0": {
+   "module": "sha256-7m11MLFSZqTuzza3KMnvyPIeUGbyn4ordnwwh5KMhBE=",
+   "pom": "sha256-V3i6vivmeKfxo3rr6BgKitBaDu2MlQqrm6dW9n0FrgE="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-core-iossimulatorarm64/1.6.2": {
+   "module": "sha256-p5KF5HcNDfueuUselXndDcE/RI6cHRNENeAeXyDEf70=",
+   "pom": "sha256-XKh3vU+YiwFFzTh0Jk+gZ4+KrHpyj3bhtcXfLw2SL1U="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-core-iossimulatorarm64/1.7.3": {
+   "module": "sha256-wFhgrsW2hdBc38MUucpWBGbgNXLrutUSm2+lzUQXQFw=",
+   "pom": "sha256-WiJOLFpEc700PE6adRPRDyNZfksq+oDagDw3itb4S14="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-core-iossimulatorarm64/1.9.0": {
+   "module": "sha256-ILLGilo6KEtMavjpfQtPux0mjMjrWHxgpYjKyRYyltc=",
+   "pom": "sha256-MRq3UNnQKYkvTNQcD0EHnKtLZfADj+ggQiqDfvg2xU0="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-core-jvm/1.6.3": {
+   "jar": "sha256-KcghqNTiXL/k8s6WzdRSb2H49OaaE1+WEqNKgdk7ZfE=",
+   "module": "sha256-MpEE29NOS96QVhHUJ8dYTlPD+MQRg2+59pmsnbpbqmw=",
+   "pom": "sha256-K0qolJn8AbMNHBB1lmmOCvQ0BBLVQBnFAdm6ayk7oro="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-core-jvm/1.7.3": {
+   "jar": "sha256-8K3eRYZBREdThc9Kp+C3/rJ/Yfz5RyZl7ZjMlxsGses=",
+   "module": "sha256-c7tMAnk/h8Ke9kvqS6AlgHb01Mlj/NpjPRJI7yS0tO8=",
+   "pom": "sha256-c09fdJII3QvvPZjKpZTPkiKv3w/uW2hDNHqP5k4kBCc="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-core-jvm/1.8.0": {
+   "jar": "sha256-08lOnYKbum4MTNOuR4pAhG3UnVR11nB4d76FOXav5BY=",
+   "module": "sha256-NzH80jhWGpCpdSs0hfHWNeAbRF5Kd4F9ewd/S50vQi0=",
+   "pom": "sha256-QVKRtvWbeTemcau136BLJyl811jLUQLNzHWUFJj5wDw="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-core-jvm/1.8.1": {
+   "jar": "sha256-NWW21NeJv3BoPEVWaUQof8HY3HXCPZi9h9AQWcx28rM=",
+   "module": "sha256-++GdWIrX1fZGZmaCA0/0Tglo0iBx/mzPn5ngPHpe+lc=",
+   "pom": "sha256-RGZV6NQ4KL+7OHzp0VGpNxowkrSLkJ6AYGtT/FiXnig="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-core-jvm/1.9.0": {
+   "jar": "sha256-Hwr6FyEQ5FpyMe8bRK6P2Eweuv+W8/w61o74xIEgtZw=",
+   "module": "sha256-cMh+MWGSq3cpqmOZIgKQ98jZ/dTZNC3J+cDkKFarNG0=",
+   "pom": "sha256-hxkNQ05icv7WBa8PztFfa8CC2KVQQMUZjm1LLWovysI="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-core/1.6.2": {
+   "module": "sha256-arz0gTrJTfA3AS4xZzaKNEUHD9+OqyHQjYhtTtnC+2c=",
+   "pom": "sha256-BibddZLIUwKToOPoHgiBltNRh3o422hHaTY3S6ZJ+S8="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-core/1.6.3": {
+   "module": "sha256-Nh6eMetylhdLdAhaxJ7dhKTzkAupQxpOQM0cI952oyg=",
+   "pom": "sha256-0tv2/BU2TIlp1qq24+zMdROZU/LMBXtzDjUmdGWztX4="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-core/1.7.3": {
+   "module": "sha256-OdCabgLfKzJVhECmTGKPnGBfroxPYJAyF5gzTIIXfmQ=",
+   "pom": "sha256-MdERd2ua93fKFnED8tYfvuqjLa5t1mNZBrdtgni6VzA="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-core/1.8.0": {
+   "module": "sha256-mE2aqabpvMONfoNuqNAAsThyCH/GZY0NjWIldjPzlfE=",
+   "pom": "sha256-nVbnQWLOQn4MSetsuXUSR0Mq3PwukTw4KWY+27qr7hM="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-core/1.8.1": {
+   "module": "sha256-eL3oMFSUrxs445ZrUleskINAFkk/i60hm4iGx/vbJdU=",
+   "pom": "sha256-Rz8Ko+Sheqt4YNykkNxC6rthJPHSlT5qmVoIcX5QxxQ="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-core/1.9.0": {
+   "module": "sha256-jNEYEwvyIIAgKeI5l0oz0nL00COlYQ9Vfs5rD4mV+J8=",
+   "pom": "sha256-lTt2Dcs2Ooqgz+X5GMPd0SRmh4XZGKw/QAsZGZasrJ0="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json-io-iosarm64/1.8.0": {
+   "module": "sha256-3AQOoS97Bl5c3g03PMhUFj00SVwOXQXO2Gpa313uo8E=",
+   "pom": "sha256-InliOIMiTBOSFahnLPYGB+qrpahDeNCpUhpe6OzbDds="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json-io-iosarm64/1.9.0": {
+   "module": "sha256-Z2QpbyHeL9ach+ii/lQheftFvAOSBAWbuI4pwVDHl90=",
+   "pom": "sha256-kj7Z3RWN689+p43P5VodYM8uDhAoOg3YaiZgNFJWvHk="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json-io-iossimulatorarm64/1.8.0": {
+   "module": "sha256-kNOUmfUcdg7hzY4bW0gSQYiGIo1f0EFSBZATtsJs33w=",
+   "pom": "sha256-nFUVaFQVoSzSZwQMm4ovhWWsPNEhzBQuXg1LX+n0Ebk="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json-io-iossimulatorarm64/1.9.0": {
+   "module": "sha256-RLUX8my9Hd7uIrgtPHlryER42VswON9207vD9YouhVE=",
+   "pom": "sha256-K/xjONYSF8K5TqiYIAO6j1+FKThPMrHOpPYnh1RWXbY="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json-io-jvm/1.8.0": {
+   "module": "sha256-/pQ5hti3/I7HoytonItHbDDM9KNbcKLEWxtffZ00BkM=",
+   "pom": "sha256-PbZlvwY1l3Inc9mKLQpqSps0FpeEFOnTYfICjTUc0yg="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json-io-jvm/1.9.0": {
+   "jar": "sha256-mKuxMrA+EbgDGNRTUOyeu7VFPSZQXoEzG/LupxQ7b74=",
+   "module": "sha256-Ulyljv7R1umPyqpU1SVREZDtF7uOVnP4TSiZnwi8Zbc=",
+   "pom": "sha256-s3U1BAhN78b0c6JYIz1gPtoTPEe40oYs/olDHNKcxfM="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json-io/1.8.0": {
+   "module": "sha256-+3LQaky980DBOnBPywfUsWJ66NnDCtZnEwb6x1UnB7Q=",
+   "pom": "sha256-xgC76woBPRA7cbGCa+t0Sbnv/5x4Knl0JKoOdV+Cw0Q="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json-io/1.9.0": {
+   "module": "sha256-vcVd2t2bARaFIanBk+KDkkGLOdZKalVdDbw163Jpltk=",
+   "pom": "sha256-qLTanfNROjgysRYUhPrwPiKCN05MsOWvy1LLqX1RhOE="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json-iosarm64/1.8.0": {
+   "module": "sha256-Fh+clqXZhkpugHnbAf0jnbX5J2v44aovakJN46M/AIg=",
+   "pom": "sha256-uGucPPyxOHoNij4QAEhIrafvPdAw4TDo0gudV0Th8NM="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json-iosarm64/1.9.0": {
+   "module": "sha256-dLiFAEuVV+TUkKhWq6vA6YvZ2B+fDRRB/7hAaO3GDpY=",
+   "pom": "sha256-B7G3RLTW1SXp1E/PS+cgRp8NkTkfOfwzGoBxLPnC5kQ="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json-iossimulatorarm64/1.8.0": {
+   "module": "sha256-+r+J6lX1wFD+A58jOWg7KLal4dTtLKvFQXdaiFc4I5k=",
+   "pom": "sha256-WwKMz/1MemHkCJFw5F/Eo3Lgagb/82QBrYTdVealdso="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json-iossimulatorarm64/1.9.0": {
+   "module": "sha256-kElAGLRhryXN9EjxhS/xRjjfaZH1eQNmtQdfw/QDSag=",
+   "pom": "sha256-SwiE+50GHOccOJssFyNoUpnPd4YbLif1vVIiAEUF2XA="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json-jvm/1.6.3": {
+   "jar": "sha256-0yNBebz/GIbVPWfBHspH9/PPe2PDSdFpZfbbUbfz3Zo=",
+   "module": "sha256-InoqmtOMAQsQe8gFjNYVF32lqqhts399WNSdnJt/l9A=",
+   "pom": "sha256-eN9n0GTTuq8a9Ohi6YFGl3YpfGyHi7e/G0Ljky9vr48="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json-jvm/1.8.1": {
+   "jar": "sha256-h2nlZHVX43AJGcMtUI9cXa1TxdgjTNEIRjVPvP8UqiQ=",
+   "module": "sha256-uZHLSTQAwdlgut+oYhcVjGN+XsqIgbIM0BJbtOz8+DE=",
+   "pom": "sha256-1mXWtB/gWPZmpvOGrS5JzBAe+P0u7+/vy8ER6R7oJDY="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json-jvm/1.9.0": {
+   "jar": "sha256-2UzDTK45JGoa90/aY/nEgSzhIhbvZB1fo7u7U5ppItg=",
+   "module": "sha256-u634x2urP82I/ORbO7tj37FIfzgCHhvdg7+5MQ735po=",
+   "pom": "sha256-azQzwqqesmYo26vxbJYzTKqzD24HcQ0Q7n+HkGznMN0="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json/1.6.3": {
+   "module": "sha256-gNHYf6CmO/+Dleo5EL2oDQnw9YNQTd6o7QB7x6hrTNQ=",
+   "pom": "sha256-KcIhdhjlMdfYMsyICupu0aj0B3PkN/WkHXC9FUaNPOM="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json/1.8.0": {
+   "module": "sha256-lK/eU8GRw+Hge5+AiqF3f4YryKlbxQtGYozQkhnVaFg=",
+   "pom": "sha256-WAgq+Zc0Ah1bjbKcQ1sR1FyhGxwP14bHhFIsnSxxeVg="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json/1.8.1": {
+   "module": "sha256-f33wBUM932BPUqq9avsh65YJMZfLS90Hk8SEydPEtnU=",
+   "pom": "sha256-x3AMmcg94CtGVBo9fktps4h0m3wPV9zrRU0UPyzYens="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json/1.9.0": {
+   "module": "sha256-T8E+xBK3uaIToX39qjNkV4Ab4W/BZa2GsLcxT9CW5ww=",
+   "pom": "sha256-mUGX39Wqub9VhVbCFW/eIoK6b8OtR/RmoIznk1zPR2Q="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-protobuf-iosarm64/1.9.0": {
+   "module": "sha256-zsH6xC77ae/AMDR/vQQzOBSs1RolQ0PAMcFuh0rFoBI=",
+   "pom": "sha256-xl6v8SVKyduKeu+6vECqj3lVr1xgMdfMoyR4SJybsQk="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-protobuf-iossimulatorarm64/1.9.0": {
+   "module": "sha256-JfZbntzt7FEH/UadJ+DeLBE0VUY6wOfK0WToK/XTdks=",
+   "pom": "sha256-P4J2pC3sntrncXxkNZkvjjs6IF7Pr9A8SPGCs1HUZM8="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-protobuf-jvm/1.9.0": {
+   "jar": "sha256-VVA1IFrRohJUtJ/Wtd2+atGrtce6uiRCWL11j4Boe8o=",
+   "module": "sha256-p/t741TYikH7SYLX67JhwMBVlnV1vihfqaZZIOcPw20=",
+   "pom": "sha256-fZIz7eXK8jgiBAVsevV7Bdfwc1qL7C49KwdMeeBzyGQ="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-protobuf/1.9.0": {
+   "module": "sha256-mwFJcOIvn6AaDZtp6Hnc08FDY7cZxIn/T4IV/wNAyk0=",
+   "pom": "sha256-fGITTg4BarB1VpjDWLOZAXsIikBFkj7K/rI9CL4yQEc="
+  },
+  "org/jetbrains/runtime#jbr-api/1.5.0": {
+   "jar": "sha256-ZX7efX+OF1yQmyPKoQ/NTUpREwT9k4qpzIRXtDeJUNU=",
+   "pom": "sha256-/jziiqT0Ga0GcErRyoIzTQ6HFmfKWxE8UVfnUXzhMh4="
+  },
+  "org/jetbrains/skiko#skiko-awt-runtime-linux-x64/0.9.22.2": {
+   "jar": "sha256-Szx19siqYLiDYsPf2Nc/hdkjc187Fb9nXEmBwm7+hdQ=",
+   "pom": "sha256-LmRnxRep8E1Z1YlRFkpMl/zMpRcs+/lXkNLF6AHzdt8="
+  },
+  "org/jetbrains/skiko#skiko-awt/0.8.18": {
+   "jar": "sha256-Y39d4aII8TaKxRtaKGpIJ87IKM1i3aMy3DQAuFQ+JD0=",
+   "module": "sha256-x9JON+j/js4Y7OdEg0Fxcnor1L7z6/hZBlN1in0Bbmo=",
+   "pom": "sha256-yrIp0lDLlzYK12MgQfCHFksKR+d75huz9VRaLWtAlJ8="
+  },
+  "org/jetbrains/skiko#skiko-awt/0.9.22.2": {
+   "module": "sha256-LeiBcFkeTTs4BM1Mdr2I5XUGBjUyOyHCiXGqw9dkBk4=",
+   "pom": "sha256-GIPhVQyTdcCV4177wr2N/A1iBPddDw+KSBiRQwkzjeg="
+  },
+  "org/jetbrains/skiko#skiko-awt/0.9.24": {
+   "jar": "sha256-Jz0g9h/gdbpDSyIMXziliv4rnx4MctKWt7rCNE1Jl2E=",
+   "module": "sha256-Zoand2Y8hMVGI61AXe2IxbEEleb3nL2plWrYgjw9Ots=",
+   "pom": "sha256-J2a/Cv//Ey4UbKy3RI0EblCjyA5F4XHFbViNhLD883E="
+  },
+  "org/jetbrains/skiko#skiko-iosarm64/0.8.18": {
+   "module": "sha256-cztsmPiKtVKOgV5C8FJa2hDBrLoo5JxBhCGlVokfmG0=",
+   "pom": "sha256-90WbyicHwTBIhFwN0r4DiLFPs0bKZoJpJomcQi2NI04="
+  },
+  "org/jetbrains/skiko#skiko-iosarm64/0.9.22.2": {
+   "module": "sha256-82bnLdyrzfTORS6rvaSA2G4XYaTldhJg0n34FifvLB4=",
+   "pom": "sha256-yTzb8zTkXzD1zrauWU2l3u4c8QunjyPR4kqKDeTaGf8="
+  },
+  "org/jetbrains/skiko#skiko-iosarm64/0.9.24": {
+   "module": "sha256-nTsDMHev8Iuz6cB6PJYeUSOphrkVzZEhUiwVDn7sI8Y=",
+   "pom": "sha256-iF0fOtlj/uqou2TT71FSq7b1i2ujnMbIHpQBnXmq7Zo="
+  },
+  "org/jetbrains/skiko#skiko-iossimulatorarm64/0.8.18": {
+   "module": "sha256-vxCbPYQ4WKf08fseUXCK6+r/+wD2hoYiuk2hzyk4QaA=",
+   "pom": "sha256-wq/VBTh8VUB2A2TORIKByY4HEC986WJypjSAW3jAOJY="
+  },
+  "org/jetbrains/skiko#skiko-iossimulatorarm64/0.9.22.2": {
+   "module": "sha256-fsEjCi14WrNdRIfmhTJ9zOuGZVnNI2cXNYf8kbntXts=",
+   "pom": "sha256-bpm6MOcBrAvik2EeXTDf3cS4HxS0GnDhoI/StPcQrBk="
+  },
+  "org/jetbrains/skiko#skiko-iossimulatorarm64/0.9.24": {
+   "module": "sha256-+sHzcMMdDSTTKS+jjSC+NVNVON57vv1DBmulmp1Fv/4=",
+   "pom": "sha256-OSEjjHB5t40C5SL6hyl9k4UQPY3ErmLaWERe4awK9ro="
+  },
+  "org/jetbrains/skiko#skiko/0.8.18": {
+   "module": "sha256-qbGDSU+EVPtX7B//+UyyqL7u3aG3PSjbbrS4+NwKU8s=",
+   "pom": "sha256-ac1xXT+/dr0QV571/D69q1RfiwxFm6iWzcbeoMETzAw="
+  },
+  "org/jetbrains/skiko#skiko/0.9.22.2": {
+   "module": "sha256-++zojoxrB/L+lPgSKs9AfjnTsMFUzHf+OLZoPfNn9Ks=",
+   "pom": "sha256-FVBgFtv1/RvtYYDWpVe7dyeX1N2woKzKLu0OVkf69fw="
+  },
+  "org/jetbrains/skiko#skiko/0.9.24": {
+   "module": "sha256-QzMQ1bCc736xK3QzSHPO3WhkOQaFFyDqorulB4JKnU0=",
+   "pom": "sha256-nSDhzuQGlPeEdheYnPn7Nz3fIwOJ3sDpqYQRsPLcR8Y="
+  },
+  "org/json#json/20231013": {
+   "jar": "sha256-DxgZLfKJEU4XqhoNCn+DcsyfXH5Pfjmtz4kG/nFPp9M=",
+   "pom": "sha256-xQBAI9OfVGNbNbvrQOIaKtVR/KDy41Cxzje9DnyypGY="
+  },
+  "org/jsoup#jsoup/1.18.1": {
+   "jar": "sha256-O7Ww7AKZir5FpR83185nwwaLTM1KtjyWWSnsUHTWTpE=",
+   "pom": "sha256-xN46hPu17vS9IpjW3pgcbNlyKHlQXINz4bZ/EdHK8n0="
+  },
+  "org/jspecify#jspecify/1.0.0": {
+   "jar": "sha256-H61ua+dVd4Hk0zcp1Jrhzcj92m/kd7sMxozjUer9+6s=",
+   "module": "sha256-0wfKd6VOGKwe8artTlu+AUvS9J8p4dL4E+R8J4KDGVs=",
+   "pom": "sha256-zauSmjuVIR9D0gkMXi0N/oRllg43i8MrNYQdqzJEM6Y="
+  },
+  "org/junit#junit-bom/5.10.2": {
+   "module": "sha256-3iOxFLPkEZqP5usXvtWjhSgWaYus5nBxV51tkn67CAo=",
+   "pom": "sha256-Fp3ZBKSw9lIM/+ZYzGIpK/6fPBSpifqSEgckzeQ6mWg="
+  },
+  "org/junit#junit-bom/5.10.3": {
+   "module": "sha256-qnlAydaDEuOdiaZShaqa9F8U2PQ02FDujZPbalbRZ7s=",
+   "pom": "sha256-EJN9RMQlmEy4c5Il00cS4aMUVkHKk6w/fvGG+iX2urw="
+  },
+  "org/junit#junit-bom/5.11.0": {
+   "module": "sha256-9+2+Z/IgQnCMQQq8VHQI5cR29An1ViNqEXkiEnSi7S0=",
+   "pom": "sha256-5nRZ1IgkJKxjdPQNscj0ouiJRrNAugcsgL6TKivkZE0="
+  },
+  "org/junit#junit-bom/5.9.1": {
+   "module": "sha256-kCbBZWaQ+hRa117Og2dCEaoSrYkwqRsQfC9c3s4vGxw=",
+   "pom": "sha256-sWPBz8j8H9WLRXoA1YbATEbphtdZBOnKVMA6l9ZbSWw="
+  },
+  "org/junit#junit-bom/5.9.2": {
+   "module": "sha256-qxN7pajjLJsGa/kSahx23VYUtyS6XAsCVJdyten0zx8=",
+   "pom": "sha256-LtB9ZYRRMfUzaoZHbJpAVrWdC1i5gVqzZ5uw82819wU="
+  },
+  "org/jvnet/staxex#stax-ex/1.8.1": {
+   "jar": "sha256-IFIlSQVunlCqNe8LRFouR6U9Br4LCpRn1wTiSD/7BJo=",
+   "pom": "sha256-j8hPNs5tps6MiTtlOBmaf2mmmgcG2bF6PuajoJRS7tY="
+  },
+  "org/mockito#mockito-bom/4.11.0": {
+   "pom": "sha256-2FMadGyYj39o7V8YjN6pRQBq6pk+xd+eUk4NJ9YUkdo="
+  },
+  "org/mozilla#rhino/1.7.10": {
+   "jar": "sha256-OOswAM9WuMdVnuVYhmp2juvL8lQXRSLWQEt/B491wtQ=",
+   "pom": "sha256-PHy6D12ldR1ipVZ2iXp64jaHx6Hi++HUdMW8Wka5+bM="
+  },
+  "org/openani/anitorrent#anitorrent-native-android-debug/0.2.0": {
+   "module": "sha256-dQdtpB0vxuAKZyV09MQKoDWcjUGDIuF7xHPc76P4NmA=",
+   "pom": "sha256-9CYwL2iKvy4iRtt36lElOIy4mwc5yNpfR3bc3D7jy3U="
+  },
+  "org/openani/anitorrent#anitorrent-native-android/0.2.0": {
+   "module": "sha256-TYv/a39E0zSOgeCQ1fxOCGr4XwR+T00RhArqTo79/OY=",
+   "pom": "sha256-zf0+6OBNRmOuYfA/U8neCRsuDe5eqanikBr65N8C7oY="
+  },
+  "org/openani/anitorrent#anitorrent-native-desktop-jni/0.2.0": {
+   "jar": "sha256-9LiZUNc3YshQre6bkCHh4zA9ZnTCaKBuNIK5Ju99qLI=",
+   "module": "sha256-c2G9Lw8t3ztqV1yTQmYOyymBpgy5Y9AAvoWJ+i6EVQA=",
+   "pom": "sha256-iGZteZ475N+d0tVVZ/iISHzIsXd8Tcc9ba93z5uW/Og="
+  },
+  "org/openani/anitorrent#anitorrent-native-desktop/0.2.0": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM=",
+   "module": "sha256-RZc7W63m6YC4b+7n2clkdwBN5SRb5FEVZ88X+3OOUsM=",
+   "pom": "sha256-hPy+1uzaX5/YloQvdcb+X7Ir3vV/hJD6aBmpY1slvb4="
+  },
+  "org/openani/anitorrent#anitorrent-native-desktop/0.2.0/linux-x64": {
+   "jar": "sha256-fExfhUPLpfnTcaElh9C8d3KjuDDvqUDNv/PJF2wbLKw="
+  },
+  "org/openani/anitorrent#anitorrent-native/0.2.0": {
+   "module": "sha256-ZWpbvwWi7WTW4Ej8hyxELlSDKv1+wZTUPYPY8LlzI8k=",
+   "pom": "sha256-fDLSHOpLWBoaqZy56RcVS3vr0x8L3FKQO+larWZSmYQ="
+  },
+  "org/openani/anitorrent#catalog/0.2.0": {
+   "module": "sha256-Fp+/oA0z4BUbxPomV8rnAyZ6xF6aQ92b7N7cSh1qyq4=",
+   "pom": "sha256-biSyM8rPd6AVOIxolBm3JV+kjGfQA4km2WE8pJPY3kI="
+  },
+  "org/openani/anitorrent/catalog/0.2.0/catalog-0.2.0": {
+   "toml": "sha256-3yKg8yGXTxBzOV2CstWaymNc11DvlO4E6h9zXzQZ9Nw="
+  },
+  "org/openani/jsystemthemedetector#jSystemThemeDetector/3.9": {
+   "jar": "sha256-ieTv4x81u+I+yjexpNrlMg3XX2c3w3O7X0B5Dm9jwvo=",
+   "module": "sha256-s+NvC4F8sW43udNc2Sf7pqQYPTpy6WYcDaEZtGe1U5Y=",
+   "pom": "sha256-EN0WnADat5JXw6z/58I2vqwkgfngp2xT620S9Mp1q2c="
+  },
+  "org/openani/mediamp#catalog/0.0.29": {
+   "module": "sha256-s6r4l6CUxAxXNrk0x4papHn7CT9Agn+VGhA5gde45/8=",
+   "pom": "sha256-E5GiqnTrK4imwFM7QBmAAhhxDKijBAIi/mwyH3FUuk4="
+  },
+  "org/openani/mediamp#mediamp-api-android-debug/0.0.29": {
+   "module": "sha256-jU1JEH7gsdNZqGDewGzwxm9RVbT/0cL0T4SsT1m/v/w=",
+   "pom": "sha256-ZRgAVnFvMsp3tirT+pxdzLl/UgaKwWLiJwix9zmo5hU="
+  },
+  "org/openani/mediamp#mediamp-api-android/0.0.29": {
+   "module": "sha256-A7Kf2AqX+9bds8WYtQnt7oRkoLXjXnk/3RnMiLcSCkw=",
+   "pom": "sha256-pyflDsXfp2uPi32gudBjcjjVfPjbwz2cV7Wnvclz7ME="
+  },
+  "org/openani/mediamp#mediamp-api-desktop/0.0.29": {
+   "jar": "sha256-k4Qsb20oECKLw2ZQ+QH7rCuKl9W3kM9nfJRWF0cTAlE=",
+   "module": "sha256-InxhvamLA6cAcu7JPORsd+NoK+eeTjlmg+kXHgUL8J8=",
+   "pom": "sha256-4yVSYeA9sIcF7x0W9IOSNEtURY10iC9gvsC00JZ6GmU="
+  },
+  "org/openani/mediamp#mediamp-api-iosarm64/0.0.29": {
+   "module": "sha256-pi4zPVts8iYT+Id6q3xRa5R9W9LQrCdYL3pKlLqVjV4=",
+   "pom": "sha256-FEuhDtbkSE07U1E8Q87TIB/v4YLFpLrOqZnpPchKilQ="
+  },
+  "org/openani/mediamp#mediamp-api-iossimulatorarm64/0.0.29": {
+   "module": "sha256-vX2BCljeCqNtJiV7jXlH8iQJDFiX5J7EaaCnaK9u1GQ=",
+   "pom": "sha256-a+yj2/YHppcgKiQ/pK5lEM5ndC2GoLxN/RfHloDC6nU="
+  },
+  "org/openani/mediamp#mediamp-api/0.0.29": {
+   "module": "sha256-5BiLU2hqMh9twBjyMkZymeltSP5Lvhqm+Ebram4FJxk=",
+   "pom": "sha256-bxPAiiGEC3XucMnl+KwnQfP1Q96RlQBpHw459rTU9os="
+  },
+  "org/openani/mediamp#mediamp-avkit-iosarm64/0.0.29": {
+   "module": "sha256-69NJ47GtvieicRl2jQwncgKUOdAg04krEMUkFanTD9E=",
+   "pom": "sha256-2ulgh0zZuf2Y3VB8HPEoeOoly57ZiuphZCxLt+O03PU="
+  },
+  "org/openani/mediamp#mediamp-avkit-iossimulatorarm64/0.0.29": {
+   "module": "sha256-NqOkI5Z9iakDOzLu9J/VdLA8s4k+RpyMHRUtpCsGQrw=",
+   "pom": "sha256-IPEcwTRk7xoDOwRIjOXcQ/xWneSRyfavPFoRQkKeYak="
+  },
+  "org/openani/mediamp#mediamp-avkit/0.0.29": {
+   "module": "sha256-3mZlCh9V5OHi74ETW/Z/7ElP12/rOxgDlHtfbcSmI5U=",
+   "pom": "sha256-BCn3TBi/kYcTE7qXYYJhAl+W7eXi5MPN6yodYYUi/18="
+  },
+  "org/openani/mediamp#mediamp-exoplayer/0.0.29": {
+   "module": "sha256-q3w8QTM4lgFZCCcKSH4/O8VASBVN/SxA7Kr6WBBjIpM=",
+   "pom": "sha256-aoJSOzxoqYK5oJThfGXanf6/kkRoji8PtCuBwui6vfE="
+  },
+  "org/openani/mediamp#mediamp-internal-utils-iosarm64/0.0.29": {
+   "module": "sha256-dM6tWX17zmoxefcPBq5k+cj/YVlU5AG3ItIN+G4uOZ8=",
+   "pom": "sha256-UVczUfnaJ0ap5maZ7b1KNPrEZksna+QfhHVFLbAbAeg="
+  },
+  "org/openani/mediamp#mediamp-internal-utils-iossimulatorarm64/0.0.29": {
+   "module": "sha256-imh0Vg3ZZcWinZeWPcN8ShBhgot2EJ4ZZrYdHrMlu/M=",
+   "pom": "sha256-q6DVnhuXEHqiLfk5X11RzePudY63ga1PhhiZg3fncWo="
+  },
+  "org/openani/mediamp#mediamp-internal-utils/0.0.29": {
+   "module": "sha256-sIGzzI9XNlRUYlXqou8iLMNqvgi+v6XIUYnjfA+pbeo=",
+   "pom": "sha256-s5DI6wAi4qSMP8bAPz4K/gOCLLDBSwNKk6m2CKsdtIY="
+  },
+  "org/openani/mediamp#mediamp-source-ktxio-android-debug/0.0.29": {
+   "module": "sha256-sUm1P7HhQUhOwDUR1uVAPvHfZO5xhgiWX7ePLYgKDDs=",
+   "pom": "sha256-/BJ4n949a/0FK/f8vMJ4LMyWDFYvb5PDL67YYZOzrMs="
+  },
+  "org/openani/mediamp#mediamp-source-ktxio-android/0.0.29": {
+   "module": "sha256-Qc/0FDWUS04Ss5F0BcpNAS5XJ6rTqVPhkHVXzaoFiRM=",
+   "pom": "sha256-tzinK8zk1fGrql2WXhwc7YgzDV6MnbnjIyT5KVzOqxw="
+  },
+  "org/openani/mediamp#mediamp-source-ktxio-desktop/0.0.29": {
+   "jar": "sha256-CmvsMdXJcrr1UcbNQVI8OyPqwxo9pLKYoa1ye5k0764=",
+   "module": "sha256-3ZMls4s+OGQgPoXLFBqB7WbyE1Qn2f84XoXw0pOdtUQ=",
+   "pom": "sha256-nN9HUn/RfKtPCOSNiD2URA+IBpkSwWWt0HZO8CZjtEE="
+  },
+  "org/openani/mediamp#mediamp-source-ktxio-iosarm64/0.0.29": {
+   "module": "sha256-s848sz/BVAOAd5ORpSuZ5Mngsco2qJdoVX/IVhPUU6Q=",
+   "pom": "sha256-M+BJJRgYRKhY02cEqQbeqOUC4HQpkrIaoGqfpfMf1G0="
+  },
+  "org/openani/mediamp#mediamp-source-ktxio-iossimulatorarm64/0.0.29": {
+   "module": "sha256-KodoKoQh4lb9t799R3O2ZhuX1fg57ULxCJ/xSL956hk=",
+   "pom": "sha256-RT9U7NnYMDnVCTWKnkvU4ZHtFVGM2+PON2JdB4hPwCs="
+  },
+  "org/openani/mediamp#mediamp-source-ktxio/0.0.29": {
+   "module": "sha256-As/GVZGSN4hAfby3KRxBzyMMUpuNmy24wVPlSQ4ABww=",
+   "pom": "sha256-Zd+xibJweb9/tUsvBKtkQm8REPIRs9JI/q6D4uGBDag="
+  },
+  "org/openani/mediamp#mediamp-vlc/0.0.29": {
+   "jar": "sha256-IipT5VaRSsRsF0+DOLb4ZEAVSVIVuSVMbydWzTgjN6I=",
+   "module": "sha256-3iXzV+GUgG26i6JGs+KuifxMAqw6n91hvFBnY4PhGH0=",
+   "pom": "sha256-hyzw9+4O0IBKsOBpmMYXFbYOFfhxlAXtvx5Zb2I2bU4="
+  },
+  "org/openani/mediamp/catalog/0.0.29/catalog-0.0.29": {
+   "toml": "sha256-wNPEmb14ugDo4NPEcf8lY0hRcCOGDFmsDGcHJqUSq5E="
+  },
+  "org/ow2#ow2/1.5.1": {
+   "pom": "sha256-Mh3bt+5v5PU96mtM1tt0FU1r+kI5HB92OzYbn0hazwU="
+  },
+  "org/ow2/asm#asm-analysis/9.7": {
+   "jar": "sha256-e8a8vCE3mUigyMRn+w+GQgbluBj2vAtUaHL1yflBVW8=",
+   "pom": "sha256-nDMIDry2Ma5Pd+ti7We/xAy4cujP0Fishj5EXB3Zc98="
+  },
+  "org/ow2/asm#asm-commons/9.7": {
+   "jar": "sha256-OJvCR5WOBJ/JoECNOYySxtNwwYA1EgOV1Muh2dkwS3o=",
+   "pom": "sha256-Ws7j7nJS7ZC4B0x1XQInh0malfr/+YrEpoUQfE2kCbQ="
+  },
+  "org/ow2/asm#asm-tree/9.7": {
+   "jar": "sha256-YvSzvENgRcGstcO6LY7FVuwzaQk9f10Gx0frBLVtUrE=",
+   "pom": "sha256-o06h4+QSjAEDjbQ8aXbojHec9a+EsFBdombf5pZWaOw="
+  },
+  "org/ow2/asm#asm-util/9.7": {
+   "jar": "sha256-N6ZBTTZkGXPxrxBJN8ldbZIbLdtNYSxmxanysT/BQhE=",
+   "pom": "sha256-XQFNjIcNSHGCW9LdtVZ7Ie9trI7Ei7uNu0ZbCzor9FI="
+  },
+  "org/ow2/asm#asm/9.7": {
+   "jar": "sha256-rfRtXjSUC98Ujs3Sap7o7qlElqcgNP9xQQZrPupcTp0=",
+   "pom": "sha256-3gARXx2E86Cy7jpLb2GS0Gb4bRhdZ7nRUi8sgP6sXwA="
+  },
+  "org/slf4j#slf4j-api/1.7.30": {
+   "pom": "sha256-fgdHdR6bZ+Gdy1IG8E6iLMA9JQxCJCZALq3QNRPywxQ="
+  },
+  "org/slf4j#slf4j-api/1.8.0-alpha2": {
+   "pom": "sha256-q7TTRvEsRpktok1TctybilWE2+hXbAlUkpId+iFpsEo="
+  },
+  "org/slf4j#slf4j-api/2.0.16": {
+   "jar": "sha256-oSV43eG6AL2bgW04iguHmSjQC6s8g8JA9wE79BlsV5o=",
+   "pom": "sha256-saAPWxxNvmK4BdZdI5Eab3cGOInXyx6G/oOJ1hkEc/c="
+  },
+  "org/slf4j#slf4j-bom/2.0.16": {
+   "pom": "sha256-BWYEjsglzfKHWGIK9k2eFK44qc2HSN1vr6bfSkGUwnk="
+  },
+  "org/slf4j#slf4j-parent/1.7.30": {
+   "pom": "sha256-EWR5VuSKDFv7OsM/bafoPzQQAraFfv0zWlBbaHvjS3U="
+  },
+  "org/slf4j#slf4j-parent/1.8.0-alpha2": {
+   "pom": "sha256-nWWHTIet1peG5j/+ncT025AuB86ODQmzlRqZ46ptLCg="
+  },
+  "org/slf4j#slf4j-parent/2.0.16": {
+   "pom": "sha256-CaC0zIFNcnRhbJsW1MD9mq8ezIEzNN5RMeVHJxsZguU="
+  },
+  "org/slf4j#slf4j-simple/1.8.0-alpha2": {
+   "jar": "sha256-ObJOKXTUdzen28wQKUiyzOcb0wNUEKnRb5gRhQhgtcI=",
+   "pom": "sha256-rqEymqts7JmjCCpSzd/IKFTxEyjspEEpGkhMHUCuNCQ="
+  },
+  "org/sonatype/oss#oss-parent/7": {
+   "pom": "sha256-tR+IZ8kranIkmVV/w6H96ne9+e9XRyL+kM5DailVlFQ="
+  },
+  "org/sonatype/oss#oss-parent/9": {
+   "pom": "sha256-+0AmX5glSCEv+C42LllzKyGH7G8NgBgohcFO8fmCgno="
+  },
+  "org/springframework#spring-framework-bom/5.3.24": {
+   "module": "sha256-GZbh9hfLA/p26hGFD+Kh4gsOMKEEa6bV2zvbv0QRP84=",
+   "pom": "sha256-U1ITVmu77+Jjag1OjdGnOt5hLiQwyP/TENzCo7O5ukE="
+  },
+  "org/springframework#spring-framework-bom/5.3.39": {
+   "module": "sha256-+ItA4qUDM7QLQvGB7uJyt17HXdhmbLFFvZCxW5fhg+M=",
+   "pom": "sha256-9tSBCT51dny6Gsfh2zj49pLL4+OHRGkzcada6yHGFIs="
+  },
+  "org/tensorflow#tensorflow-lite-metadata/0.2.0": {
+   "jar": "sha256-6fGLikHwF+kDPLDthciiuiMHKSzf4l6uNlkj56MdKnA=",
+   "pom": "sha256-D+MTJug7diLLzZx11GeykfAf/jzG4+dmUawFocHHo2A="
+  },
+  "org/xerial#sqlite-jdbc/3.41.2.2": {
+   "jar": "sha256-DNq0EJR+BLZ0Pfmc8VQyZ93RBzV9b3aUjRRb5ZD9SX0=",
+   "pom": "sha256-rhGjsR3LrBtkA2ieP9jYKyzupV6C2/xLsyrt7fjMrI4="
+  },
+  "org/xerial#sqlite-jdbc/3.46.1.0": {
+   "jar": "sha256-bcdGTjgDZI0/8YpzWbq2rfB5/NhJWxiZH29e3Lisbjs=",
+   "pom": "sha256-uNpEUuTj9LdaFygPBhD58xMH5BBKF1+uHSq+YkmHxIc="
+  },
+  "org/yaml#snakeyaml/2.2": {
+   "jar": "sha256-FGeTFEiggXaWrigFt7iyC/sIJlK/nE767VKJMNxJOJs=",
+   "pom": "sha256-6YLq3HiMac8uTeUKn2MrGCwx26UGEoMNNI/EtLqN19Y="
+  },
+  "tech/annexflow/compose#constraintlayout-compose-multiplatform-android/0.4.0": {
+   "module": "sha256-mpQ2XXEx1cRXTIRG7FRLJstKNiYBqx4Q9kbqbZx7NK0=",
+   "pom": "sha256-lu1aonPvftpDf9N7sju6qyPaj0yY1Pa7wO96kfw2tSs="
+  },
+  "tech/annexflow/compose#constraintlayout-compose-multiplatform-iosarm64/0.4.0": {
+   "module": "sha256-U4DNruCnvZsSAxNd3rZMPjBNO1cjW4Q35KzOlwoi/2I=",
+   "pom": "sha256-AwtjKPnG/TgtD5rdsSc5CjbSu1EQjTmYH/QH6vaVPNQ="
+  },
+  "tech/annexflow/compose#constraintlayout-compose-multiplatform-iossimulatorarm64/0.4.0": {
+   "module": "sha256-BBfumB+ZbvC9xRCBo+8J3VbgsyRNfG0E0i4GOddKgkc=",
+   "pom": "sha256-FkTtnox9EwIL7/BWSBZ17G0tLsARRE+CNn5a83MsbMc="
+  },
+  "tech/annexflow/compose#constraintlayout-compose-multiplatform-jvm/0.4.0": {
+   "jar": "sha256-xKVyQqdp1fCQB2UuS6gQcYmKZTInhQjD2TBn/0Ei6v0=",
+   "module": "sha256-TPx/6DMO+jmovVcqPHueF7WicqeBhBNKbvWbSnPRXgc=",
+   "pom": "sha256-nQULYmnCFV2QxFBxHWiJMIrPIvvW5yPnI4JZfoRfF9Y="
+  },
+  "tech/annexflow/compose#constraintlayout-compose-multiplatform/0.4.0": {
+   "module": "sha256-+Vs8lwmJ+y8cr2GN1AsbB4b1NC6hIESyTUH4TealwDY=",
+   "pom": "sha256-vb7fI+JUSZUrzLJYPx60FY9Dm9Zq2Wov9WJFoLdQvBE="
+  },
+  "uk/co/caprica#vlcj-natives/4.8.1": {
+   "jar": "sha256-9Hzvkd/fM1YRttEZRcnReU6FgRs4hMH9MfntdqsZ2lA=",
+   "pom": "sha256-pnZ3QHPk7j14LkcSlnmHf318CucundSwQCXVZnIpLtw="
+  },
+  "uk/co/caprica#vlcj/4.8.2": {
+   "jar": "sha256-ME1YXngL6HZbqk+oOzdsIZIHifnlcK7PiIkS1A7tq7U=",
+   "pom": "sha256-73L1ioRac36UiwFSE9tItp+cUTf3O1B8/ZeOVFxbIAk="
+  }
+ }
+}

--- a/pkgs/by-name/an/animeko/package.nix
+++ b/pkgs/by-name/an/animeko/package.nix
@@ -1,0 +1,242 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gradle,
+  autoPatchelfHook,
+  jetbrains, # Requird by upstream due to JCEF dependency
+  fontconfig,
+  libXinerama,
+  libXrandr,
+  file,
+  gtk3,
+  glib,
+  cups,
+  lcms2,
+  alsa-lib,
+  libvlc,
+  libidn,
+  pulseaudio,
+  ffmpeg,
+  libva,
+  libdvbpsi,
+  libogg,
+  chromaprint,
+  protobuf_21,
+  libgcrypt,
+  libdvdnav,
+  libsecret,
+  aribb24,
+  libavc1394,
+  libmpcdec,
+  libvorbis,
+  libebml,
+  faad2,
+  libjpeg8,
+  libkate,
+  librsvg,
+  xorg,
+  libsForQt5,
+  libupnp,
+  aalib,
+  libcaca,
+  libmatroska,
+  libopenmpt-modplug,
+  libsidplayfp,
+  shine,
+  libarchive,
+  gnupg,
+  srt,
+  libshout,
+  ffmpeg_6,
+  libmpeg2,
+  xcbutilkeysyms,
+  lirc,
+  lua5_2,
+  taglib,
+  libspatialaudio,
+  libmtp,
+  speexdsp,
+  libsamplerate,
+  sox,
+  libmad,
+  libnotify,
+  taglib_1,
+  zvbi,
+  libdc1394,
+  libcddb,
+  libbluray,
+  libdvdread,
+  libvncserver,
+  twolame,
+  samba,
+  libnfs,
+  flac,
+  writeShellScript,
+  nix-update,
+  libxml2,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "animeko";
+  version = "5.2.0";
+
+  src = fetchFromGitHub {
+    owner = "open-ani";
+    repo = "animeko";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-eP1v/o9qUk8qG+n1cJRmlgu2l06hFZLeUN/X06qAVpY=";
+    fetchSubmodules = true;
+  };
+
+  # CefLog.init(jcefConfig.cefSettings) is being comment out due to compile error
+  postPatch = ''
+    echo "kotlin.native.ignoreDisabledTargets=true" >> local.properties
+    sed -i "s/^version.name=.*/version.name=${finalAttrs.version}/" gradle.properties
+    sed -i "s/^package.version=.*/package.version=${finalAttrs.version}/" gradle.properties
+    substituteInPlace app/shared/app-platform/src/desktopMain/kotlin/platform/AniCefApp.kt \
+      --replace-fail 'CefLog.init(jcefConfig.cefSettings)' '//CefLog.init(jcefConfig.cefSettings)'
+  '';
+
+  gradleBuildTask = "createReleaseDistributable";
+
+  gradleUpdateTask = finalAttrs.gradleBuildTask;
+
+  mitmCache = gradle.fetchDeps {
+    inherit (finalAttrs) pname;
+    pkg = finalAttrs.finalPackage;
+    data = ./deps.json;
+    silent = false;
+    useBwrap = false;
+  };
+
+  env.JAVA_HOME = jetbrains.jdk;
+
+  gradleFlags = [
+    "-Dorg.gradle.java.home=${jetbrains.jdk}"
+  ];
+
+  nativeBuildInputs = [
+    gradle
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    fontconfig
+    libXinerama
+    libXrandr
+    file
+    shine
+    libmpeg2
+    gtk3
+    glib
+    cups
+    lcms2
+    alsa-lib
+    libidn
+    pulseaudio
+    ffmpeg
+    faad2
+    libjpeg8
+    libkate
+    librsvg
+    xorg.libXpm
+    libsForQt5.qt5.qtsvg
+    libsForQt5.qt5.qtbase
+    libsForQt5.qt5.qtx11extras
+    libupnp
+    aalib
+    libcaca
+    libva
+    libdvbpsi
+    libogg
+    chromaprint
+    protobuf_21
+    libgcrypt
+    libsecret
+    aribb24
+    twolame
+    libmpcdec
+    libvorbis
+    libebml
+    libmatroska
+    libopenmpt-modplug
+    libavc1394
+    libmtp
+    libsidplayfp
+    libarchive
+    gnupg
+    srt
+    libshout
+    ffmpeg_6
+    xcbutilkeysyms
+    lirc
+    lua5_2
+    taglib
+    libspatialaudio
+    speexdsp
+    libsamplerate
+    sox
+    libmad
+    libnotify
+    zvbi
+    libdc1394
+    libcddb
+    libbluray
+    libdvdread
+    libvncserver
+    samba
+    libnfs
+    taglib_1
+    libdvdnav
+    flac
+    libxml2
+  ];
+
+  dontWrapQtApps = true;
+
+  doCheck = false;
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r app/desktop/build/compose/binaries/main-release/app/Ani $out
+    chmod +x $out/lib/runtime/lib/jcef_helper
+    substituteInPlace app/desktop/appResources/linux-x64/animeko.desktop \
+      --replace-fail "icon" "animeko"
+    install -Dm644 app/desktop/appResources/linux-x64/animeko.desktop $out/share/applications/animeko.desktop
+    install -Dm644 app/desktop/appResources/linux-x64/icon.png $out/share/icons/hicolor/512x512/apps/animeko.png
+
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    # Remove prebuilt vlc and use NixOS version
+    rm -r $out/lib/app/resources/lib
+    ln -sf ${libvlc}/lib $out/lib/app/resources/
+  '';
+
+  ANDROID_SDK_HOME = "$(pwd)";
+
+  passthru.updateScript = writeShellScript "update-animeko" ''
+    ${lib.getExe nix-update} animeko
+    $(nix-build -A animeko.mitmCache.updateScript)
+  '';
+
+  meta = {
+    description = "One-stop platform for finding, following and watching anime";
+    homepage = "https://github.com/open-ani/animeko";
+    mainProgram = "Ani";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [
+      pokon548
+    ];
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryBytecode
+    ];
+    platforms = [
+      "x86_64-linux"
+    ];
+  };
+})

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -285,7 +285,6 @@ mapAliases {
   androidndkPkgs_24 = throw "androidndkPkgs_24 has been removed, as it is EOL"; # Added 2025-08-09
   androidndkPkgs_25 = throw "androidndkPkgs_25 has been removed, as it is EOL"; # Added 2025-08-09
   androidndkPkgs_26 = throw "androidndkPkgs_26 has been removed, as it is EOL"; # Added 2025-08-09
-  animeko = throw "'animeko' has been removed since it is unmaintained"; # Added 2025-08-20
   ansible-language-server = throw "ansible-language-server was removed, because it was unmaintained in nixpkgs."; # Added 2025-09-24
   ansible-later = throw "ansible-later has been discontinued. The author recommends switching to ansible-lint"; # Added 2025-08-24
   antlr4_8 = throw "antlr4_8 has been removed. Consider using a more recent version of antlr4"; # Added 2025-10-20


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
As the init `animeko` was dropped due to possible [ToS violation](https://github.com/NixOS/nixpkgs/pull/435204), I repackaged one without `dandanplay` api key by default to make it legally works without danmu function.

Feel free to override `postPatch` to provide your own api keys, so danmu will works like before.

Be aware: From > 5.0, `animeko` introduces advertisement (maybe NSFW) at `Recommendation` sections. I am not affiliated and / or endorsed with this, see [upstream declarant](https://github.com/open-ani/animeko/issues/2630) for details.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
