### PR TITLE
qui: init at 1.7.0

### DIFF
--- a/pkgs/by-name/qu/qui/package.nix
+++ b/pkgs/by-name/qu/qui/package.nix
@@ -1,0 +1,87 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  stdenvNoCC,
+  nix-update-script,
+  nodejs,
+  pnpm_9,
+  typescript,
+  versionCheckHook,
+}:
+buildGoModule (finalAttrs: {
+  pname = "qui";
+  version = "1.7.0";
+  src = fetchFromGitHub {
+    owner = "autobrr";
+    repo = "qui";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-CbPdngskDCAAhmsj5DPdnviZSWM0bO13Pbe7wRwaNaw=";
+  };
+
+  qui-web = stdenvNoCC.mkDerivation (finalAttrs': {
+    pname = "${finalAttrs.pname}-web";
+    inherit (finalAttrs) src version;
+
+    nativeBuildInputs = [
+      nodejs
+      pnpm_9.configHook
+      typescript
+    ];
+
+    sourceRoot = "${finalAttrs.src.name}/web";
+
+    pnpmDeps = pnpm_9.fetchDeps {
+      inherit (finalAttrs')
+        pname
+        version
+        src
+        sourceRoot
+        ;
+      fetcherVersion = 2;
+      hash = "sha256-WKoWts+/TGcGy/rFEJN3Qn/vq+gj+Mq+VcTYowEyvus=";
+    };
+
+    postBuild = ''
+      pnpm run build
+    '';
+
+    installPhase = ''
+      cp -r dist $out
+    '';
+  });
+
+  vendorHash = "sha256-rmUEFX8UzxEN7XaJ8Zj+kj3z1pwLkq3FTYzbPWnifW0=";
+
+  preBuild = ''
+    cp -r ${finalAttrs.qui-web}/* web/dist
+  '';
+
+  ldflags = [
+    "-X github.com/autobrr/qui/internal/buildinfo.Version=${finalAttrs.version}"
+    "-X main.PolarOrgID="
+  ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "version";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--subpackage"
+      "qui-web"
+    ];
+  };
+
+  meta = {
+    description = "Modern alternative webUI for qBittorrent, with multi-instance support";
+    license = lib.licenses.gpl2Plus;
+    homepage = "https://github.com/autobrr/qui";
+    changelog = "https://github.com/autobrr/qui/releases/tag/v${finalAttrs.version}";
+    maintainers = with lib.maintainers; [ pta2002 ];
+    mainProgram = "qui";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Initialize the qui package at version 1.7.0.

Package link: https://github.com/autobrr/qui

Package description:

> Modern alternative webUI for qBittorrent, with multi-instance support. Written in Go/React.

The derivation was based off the [one for autobrr](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/au/autobrr/package.nix), which is made by the same authors and has a very similar architecture.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
