### PR TITLE
supercollider: 3.13.1 -> 3.14.0

### DIFF
--- a/pkgs/development/interpreters/supercollider/default.nix
+++ b/pkgs/development/interpreters/supercollider/default.nix
@@ -1,8 +1,6 @@
 {
   lib,
   stdenv,
-  mkDerivation,
-  fetchpatch,
   fetchurl,
   cmake,
   runtimeShell,
@@ -13,7 +11,7 @@
   fftw,
   curl,
   gcc,
-  libsForQt5,
+  wrapQtAppsHook,
   libXt,
   qtbase,
   qttools,
@@ -30,28 +28,17 @@
   withWebengine ? false, # vulnerable, so disabled by default
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "supercollider";
-  version = "3.13.1";
+  version = "3.14.0";
 
   src = fetchurl {
     url = "https://github.com/supercollider/supercollider/releases/download/Version-${version}/SuperCollider-${version}-Source.tar.bz2";
-    sha256 = "sha256-aXnAFdqs/bVZMovoDV1P4mv2PtdFD2QuXHjnsnEyMSs=";
+    sha256 = "sha256-q3EOhDdvXAgskvzqdGW4XTdZNPPafe7Vg0V6CkiwqRg=";
   };
 
-  patches = [
-    # add support for SC_DATA_DIR and SC_PLUGIN_DIR env vars to override compile-time values
-    ./supercollider-3.12.0-env-dirs.patch
-
-    # Fixes the build with CMake 4
-    (fetchpatch {
-      url = "https://github.com/supercollider/supercollider/commit/7d1f3fbe54e122889489a2f60bbc6cd6bb3bce28.patch";
-      hash = "sha256-gyE0B2qTbj0ppbLlYTMa2ooY3FHzzIrdrpWYr81Hy1Y=";
-    })
-  ];
-
   postPatch = ''
-    substituteInPlace common/sc_popen.cpp --replace '/bin/sh' '${runtimeShell}'
+    substituteInPlace common/sc_popen.cpp --replace-fail '/bin/sh' '${runtimeShell}'
   '';
 
   strictDeps = true;
@@ -60,7 +47,7 @@ mkDerivation rec {
     cmake
     pkg-config
     qttools
-    libsForQt5.wrapQtAppsHook
+    wrapQtAppsHook
   ]
   ++ lib.optionals useSCEL [ emacs ];
 
@@ -125,3 +112,4 @@ mkDerivation rec {
     platforms = platforms.linux;
   };
 }
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5907,7 +5907,7 @@ with pkgs;
     spidermonkey_140
     ;
 
-  supercollider = libsForQt5.callPackage ../development/interpreters/supercollider {
+  supercollider = qt6Packages.callPackage ../development/interpreters/supercollider {
     fftw = fftwSinglePrec;
   };
 


### PR DESCRIPTION
enable qt6 for native wayland support


shall replace https://github.com/NixOS/nixpkgs/pull/462061#issuecomment-3537486359

Putting as draft  because on startup I get:

```


*** Welcome to SuperCollider 3.13.1. *** For help visit http://doc.sccode.org
ERROR: Message 'prSignalHandshakeCond' not understood.
RECEIVER:
class ScIDE (0x563172cfee00) {
  instance variables [19]
    name : Symbol 'ScIDE'
    nextclass : instance of Meta_Scale (0x563172e7c680, size=19, set=5)
    superclass : Symbol 'Object'
    subclasses : nil
    methods : nil
    instVarNames : nil
    classVarNames : instance of SymbolArray (0x563172cfef80, size=7, set=2)
    iprototype : nil
    cprototype : instance of Array (0x563172cff040, size=7, set=3)
    constNames : nil
    constValues : nil
    instanceFormat : Integer 0
    instanceFlags : Integer 0
    classIndex : Integer 439
    classFlags : Integer 0
    maxSubclassIndex : Integer 439
    filenameSymbol : Symbol '/nix/store/blc6k3qy343f6pg8qzwckj1sdccbl2sc-supercollider-3.13.1/share/SuperCollider/SCClassLibrary/scide_scqt/ScIDE.sc'
    charPos : Integer 0
    classVarIndex : Integer 35
}
ARGS:
CALL STACK:
	DoesNotUnderstandError:reportError
		arg this = <instance of DoesNotUnderstandError>
	Nil:handleError
		arg this = nil
		arg error = <instance of DoesNotUnderstandError>
	Thread:handleError
		arg this = <instance of Thread>
		arg error = <instance of DoesNotUnderstandError>
	Object:throw
		arg this = <instance of DoesNotUnderstandError>
	Object:doesNotUnderstand
		arg this = <instance of Meta_ScIDE>
		arg selector = 'prSignalHandshakeCond'
		arg args = [*0]
	Process:interpretCmdLine
		arg this = <instance of Main>
^^ ERROR: Message 'prSignalHandshakeCond' not understood.
RECEIVER: ScIDE



```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
