### PR TITLE
{spidermonkey_128,spidermonkey_140}: Pass stdenv.{build,host}Platform.rust.rustcTarget

### DIFF
--- a/pkgs/development/interpreters/spidermonkey/add-rust-triplet-options.patch
+++ b/pkgs/development/interpreters/spidermonkey/add-rust-triplet-options.patch
@@ -1,0 +1,121 @@
+diff '--color=auto' -ruN a/build/moz.configure/rust.configure b/build/moz.configure/rust.configure
+--- a/build/moz.configure/rust.configure	2025-08-11 19:07:15.000000000 +0200
++++ b/build/moz.configure/rust.configure	2025-11-17 14:26:13.259267375 +0100
+@@ -280,6 +280,7 @@
+     return data
+ 
+ 
++@imports(_from="textwrap", _import="dedent")
+ def detect_rustc_target(
+     host_or_target, compiler_info, arm_target, rust_supported_targets
+ ):
+@@ -414,7 +415,19 @@
+     rustc_target = find_candidate(candidates)
+ 
+     if rustc_target is None:
+-        die("Don't know how to translate {} for rustc".format(host_or_target.alias))
++        log.warning(
++            dedent(
++                """
++        Don't know how to translate {} for rustc.
++
++        If the triplet is not understood by LLVM, try passing --rust-host-triplet and --rust-target-triplet.
++
++        If you passed those, and the later triplet check doesn't fail, then ignore this warning.
++                """.format(host_or_target.alias)
++            )
++        )
++        # Functionality of this triplet is asserted later, and user-specified triplet may override this
++        rustc_target = host_or_target.alias
+ 
+     return rustc_target
+ 
+@@ -481,7 +494,7 @@
+     arm_target,
+     when=rust_compiler,
+ )
+-@checking("for rust host triplet")
++@checking("for rust host triplet (default)")
+ @imports(_from="textwrap", _import="dedent")
+ def rust_host_triple(
+     rustc, host, compiler_info, rustc_host, rust_supported_targets, arm_target
+@@ -489,48 +502,52 @@
+     rustc_target = detect_rustc_target(
+         host, compiler_info, arm_target, rust_supported_targets
+     )
+-    if rustc_target != rustc_host:
+-        if host.alias == rustc_target:
+-            configure_host = host.alias
+-        else:
+-            configure_host = "{}/{}".format(host.alias, rustc_target)
+-        die(
+-            dedent(
+-                """\
+-        The rust compiler host ({rustc}) is not suitable for the configure host ({configure}).
+-
+-        You can solve this by:
+-        * Set your configure host to match the rust compiler host by editing your
+-        mozconfig and adding "ac_add_options --host={rustc}".
+-        * Or, install the rust toolchain for {configure}, if supported, by running
+-        "rustup default stable-{rustc_target}"
+-        """.format(
+-                    rustc=rustc_host,
+-                    configure=configure_host,
+-                    rustc_target=rustc_target,
+-                )
+-            )
+-        )
+-    assert_rust_compile(host, rustc_target, rustc)
+     return rustc_target
+ 
+ 
+ @depends(
+     rustc, target, c_compiler, rust_supported_targets, arm_target, when=rust_compiler
+ )
+-@checking("for rust target triplet")
++@checking("for rust target triplet (default)")
+ def rust_target_triple(
+     rustc, target, compiler_info, rust_supported_targets, arm_target
+ ):
+     rustc_target = detect_rustc_target(
+         target, compiler_info, arm_target, rust_supported_targets
+     )
+-    assert_rust_compile(target, rustc_target, rustc)
+     return rustc_target
+ 
+ 
+-set_config("RUST_TARGET", rust_target_triple)
+-set_config("RUST_HOST_TARGET", rust_host_triple)
++option(
++    "--rust-target-triplet",
++    nargs=1,
++    default=rust_target_triple,
++    help="Rust target triplet"
++)
++
++option(
++    "--rust-host-triplet",
++    nargs=1,
++    default=rust_host_triple,
++    help="Rust host triplet"
++)
++
++
++@depends(target, rustc, "--rust-target-triplet")
++@checking("for rust target triplet")
++def checked_rust_target_triplet(target, rustc, triplet):
++    assert_rust_compile(target, triplet[0], rustc)
++    return triplet[0]
++
++@depends(target, rustc, "--rust-host-triplet")
++@checking("for rust host triplet")
++def checked_rust_host_triplet(target, rustc, triplet):
++    assert_rust_compile(target, triplet[0], rustc)
++    return triplet[0]
++
++
++set_config("RUST_TARGET", checked_rust_target_triplet)
++set_config("RUST_HOST_TARGET", checked_rust_host_triplet)
+ 
+ 
+ # This is used for putting source info into symbol files.

--- a/pkgs/development/interpreters/spidermonkey/common.nix
+++ b/pkgs/development/interpreters/spidermonkey/common.nix
@@ -52,6 +52,9 @@ stdenv.mkDerivation (finalAttrs: {
     # use pkg-config for all systems
     ./always-check-for-pkg-config-128.patch
     ./allow-system-s-nspr-and-icu-on-bootstrapped-sysroot-128.patch
+
+    # Add support for --rust-{host,target}-triplet
+    ./add-rust-triplet-options.patch
   ]
   ++ lib.optionals (stdenv.hostPlatform.system == "i686-linux") [
     # Fixes i686 build, https://bugzilla.mozilla.org/show_bug.cgi?id=1729459
@@ -129,8 +132,11 @@ stdenv.mkDerivation (finalAttrs: {
     "--disable-tests"
     # Spidermonkey seems to use different host/build terminology for cross
     # compilation here.
+    # Rust also uses slightly different triplets in some cases.
     "--host=${stdenv.buildPlatform.config}"
     "--target=${stdenv.hostPlatform.config}"
+    "--rust-host-triplet=${stdenv.buildPlatform.rust.rustcTarget}"
+    "--rust-target-triplet=${stdenv.hostPlatform.rust.rustcTarget}"
   ];
 
   # mkDerivation by default appends --build/--host to configureFlags when cross compiling


### PR DESCRIPTION
Spidermonkey tries to figure out an appropriate triplet for Rust based on the C compiler host & target triplets we give it. This fails when our triplets cannot be understood as-is by LLVM (gnuabielfv{1,2} on POWER).

We already have a mechanism to convert our triplets for Rust usage, so tell Spidermonkey to use the converted triplets.

---

Due to LLVM not knowing about the POWER ELF ABI version suffix: #493090

Can be tested via cross: `pkgsCross.ppc64-elfv1.spidermonkey_{128,140}`

Result of the above command before this PR:
```
spidermonkey> checking for rust target triplet... 
spidermonkey> ERROR: Don't know how to translate powerpc64-unknown-linux-gnuabielfv1 for rustc
```

(`pkgsCross.ppc64-elfv2.spidermonkey_{128,140}` would require #493084)

Not sure if this is acceptable for upstream.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] powerpc64-linux (ELFv1; native & cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

(predates the AI policy, but I assure you that I don't use LLMs)

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
