### PR TITLE
[release-25.05]: netron 8.3.3 -> 8.7.3

### DIFF
--- a/pkgs/by-name/ne/netron/package.nix
+++ b/pkgs/by-name/ne/netron/package.nix
@@ -16,16 +16,16 @@ let
 in
 buildNpmPackage (finalAttrs: {
   pname = "netron";
-  version = "8.3.5";
+  version = "8.3.8";
 
   src = fetchFromGitHub {
     owner = "lutzroeder";
     repo = "netron";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-YxvUUn8VWv5M6FvIHJCaXQl7PRGcZ8qSgrZ7K0+8iME=";
+    hash = "sha256-BHV51d5X8uXnqjCkpVnZX40dAuF2HCNk/6A5cKr9nZE=";
   };
 
-  npmDepsHash = "sha256-fsF40qUKUNXeqvdM1m/IEgnxRZrnGW/aOYS3oZKQNpk=";
+  npmDepsHash = "sha256-E4jqaDJqgvOvV+67jtMzt/4YkhQ4GmKati0wuVMC8yI=";
 
   nativeBuildInputs = [ jq ];
 

--- a/pkgs/by-name/ne/netron/package.nix
+++ b/pkgs/by-name/ne/netron/package.nix
@@ -16,16 +16,16 @@ let
 in
 buildNpmPackage (finalAttrs: {
   pname = "netron";
-  version = "8.3.4";
+  version = "8.3.5";
 
   src = fetchFromGitHub {
     owner = "lutzroeder";
     repo = "netron";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-P7lv0pnhrdU9zFwCzQYwYilq6qJ1UUaYgVDMiRZP5M8=";
+    hash = "sha256-YxvUUn8VWv5M6FvIHJCaXQl7PRGcZ8qSgrZ7K0+8iME=";
   };
 
-  npmDepsHash = "sha256-gPRxgf4XTxIZIKTZbr07zzEJW1n0Waas+zms6Ap6RAY=";
+  npmDepsHash = "sha256-fsF40qUKUNXeqvdM1m/IEgnxRZrnGW/aOYS3oZKQNpk=";
 
   nativeBuildInputs = [ jq ];
 

--- a/pkgs/by-name/ne/netron/package.nix
+++ b/pkgs/by-name/ne/netron/package.nix
@@ -16,16 +16,16 @@ let
 in
 buildNpmPackage (finalAttrs: {
   pname = "netron";
-  version = "8.3.8";
+  version = "8.3.9";
 
   src = fetchFromGitHub {
     owner = "lutzroeder";
     repo = "netron";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-BHV51d5X8uXnqjCkpVnZX40dAuF2HCNk/6A5cKr9nZE=";
+    hash = "sha256-4AnbhdZVkPhpzNxmjhRNcUTiWrxXNWqVrUxR8pO+ULo=";
   };
 
-  npmDepsHash = "sha256-E4jqaDJqgvOvV+67jtMzt/4YkhQ4GmKati0wuVMC8yI=";
+  npmDepsHash = "sha256-71O2cMr44tLv4m/iM/pOE126k1Z2DTRDKI7o7aWUePg=";
 
   nativeBuildInputs = [ jq ];
 

--- a/pkgs/by-name/ne/netron/package.nix
+++ b/pkgs/by-name/ne/netron/package.nix
@@ -2,30 +2,30 @@
   lib,
   stdenv,
   buildNpmPackage,
-  electron_36,
+  electron_39,
   fetchFromGitHub,
   jq,
   makeDesktopItem,
 }:
 
 let
-  electron = electron_36;
+  electron = electron_39;
   description = "Visualizer for neural network, deep learning and machine learning models";
   icon = "netron";
 
 in
 buildNpmPackage (finalAttrs: {
   pname = "netron";
-  version = "8.3.9";
+  version = "8.7.3";
 
   src = fetchFromGitHub {
     owner = "lutzroeder";
     repo = "netron";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-4AnbhdZVkPhpzNxmjhRNcUTiWrxXNWqVrUxR8pO+ULo=";
+    hash = "sha256-4ATVEPOOju2nz7vsl+qCwG4A6F1HRx3/1MkFSUKPD2Q=";
   };
 
-  npmDepsHash = "sha256-71O2cMr44tLv4m/iM/pOE126k1Z2DTRDKI7o7aWUePg=";
+  npmDepsHash = "sha256-TTAemrFZoXKlkPSHjQWZh0zree+s5ZWYXT0cy8xUBA0=";
 
   nativeBuildInputs = [ jq ];
 

--- a/pkgs/by-name/ne/netron/package.nix
+++ b/pkgs/by-name/ne/netron/package.nix
@@ -16,16 +16,16 @@ let
 in
 buildNpmPackage (finalAttrs: {
   pname = "netron";
-  version = "8.3.3";
+  version = "8.3.4";
 
   src = fetchFromGitHub {
     owner = "lutzroeder";
     repo = "netron";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-7OdHg0nLVz7xno1FTE+fr6FZkzkI+6KjX3EsDzyZbOM=";
+    hash = "sha256-P7lv0pnhrdU9zFwCzQYwYilq6qJ1UUaYgVDMiRZP5M8=";
   };
 
-  npmDepsHash = "sha256-oOGHo/KCc/qlJRdIyUmoRayV1i+e0mEqMr7TTCo5YKA=";
+  npmDepsHash = "sha256-gPRxgf4XTxIZIKTZbr07zzEJW1n0Waas+zms6Ap6RAY=";
 
   nativeBuildInputs = [ jq ];
 


### PR DESCRIPTION
Motivation: https://github.com/NixOS/nixpkgs/pull/461995

Manual backport of the corresponding PRs.

Currently blockend on having `electron_39` in stable.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
