### PR TITLE
ceccomp: init at 3.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22441,6 +22441,13 @@
     githubId = 26892280;
     name = "Robert Walter";
   };
+  RocketDev = {
+    email = "ma2014119@outlook.com";
+    github = "RocketMaDev";
+    githubId = 48864431;
+    keys = [ { fingerprint = "A7AC CC38 6C15 E3C5 54D3  4B3E AB08 F980 92A4 56BB"; } ];
+    name = "Rocket Ma";
+  };
   roconnor = {
     email = "roconnor@r6.ca";
     github = "roconnor";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25814,6 +25814,12 @@
     githubId = 26417242;
     name = "Mikolaj Galkowski";
   };
+  tesuji = {
+    email = "taolzu@gmail.com";
+    github = "tesuji";
+    githubId = 15225902;
+    name = "Lzu Tao";
+  };
   TethysSvensson = {
     email = "freaken@freaken.dk";
     github = "TethysSvensson";

--- a/pkgs/by-name/ce/ceccomp/package.nix
+++ b/pkgs/by-name/ce/ceccomp/package.nix
@@ -1,0 +1,71 @@
+{
+  withLocales ? true,
+  withDocs ? true,
+
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  libseccomp,
+  python3,
+  flock,
+  asciidoctor,
+  gettext,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ceccomp";
+  version = "3.5";
+
+  src = fetchFromGitHub {
+    owner = "dbgbgtf1";
+    repo = "Ceccomp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-TVRYWRkrXlSgGXL2KtFsFx26ncf77QE+edZvv2HtVkg=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    libseccomp
+    python3
+    flock
+  ]
+  ++ lib.optionals withDocs [
+    asciidoctor
+  ]
+  ++ lib.optionals withLocales [
+    gettext
+  ];
+
+  configureFlags = [
+    "--prefix=$out"
+    "--packager=Nix"
+  ]
+  ++ lib.optionals (!withDocs) [ "--without-doc" ]
+  ++ lib.optionals (!withLocales) [ "--without-i18n" ];
+
+  configurePhase = ''
+    runHook preConfigure
+
+    python ./configure ${lib.concatStringsSep " " finalAttrs.configureFlags}
+
+    runHook postConfigure
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "A tool to analyze seccomp filters like `seccomp-tools` but in C";
+    homepage = "https://github.com/dbgbgtf1/Ceccomp";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      tesuji
+      RocketDev
+    ];
+    platforms = lib.platforms.linux;
+    mainProgram = "ceccomp";
+  };
+})


### PR DESCRIPTION
Ceccomp is a tool to analyze `seccomp` filters like [`seccomp-tools`][1], written in C.

The alternative program [`seccomp-tools`][1] is written in Ruby. ~~At the moment [it is broken][2] at least with nix ruby/gem of the unstable channel~~[^3].

GitHub URL: https://github.com/dbgbgtf1/Ceccomp

**Edit**: Added `@RocketDev` (program author) as another maintainer.

[1]: https://github.com/david942j/seccomp-tools
[2]: https://github.com/david942j/seccomp-tools/issues/264
[^3]: Fixed via https://github.com/david942j/seccomp-tools/pull/312

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
