### PR TITLE
nixos/tests/acl: init

### DIFF
--- a/nixos/tests/acl.nix
+++ b/nixos/tests/acl.nix
@@ -1,0 +1,33 @@
+{
+  vmTools,
+  perl,
+  coreutils,
+  acl,
+}:
+# Can't run this within a VM because tests require root access
+# Can't easily use a standard VM test because we need to have access to intermediate build results
+vmTools.runInLinuxVM (
+  acl.overrideAttrs (old: {
+    postPatch = old.postPatch or "" + ''
+      # The runwrapper uses LD_PRELOAD to override available user/groups
+      substituteInPlace Makefile.in --replace-fail \
+        'TEST_LOG_COMPILER = $(srcdir)/test/runwrapper' \
+        'TEST_LOG_COMPILER = $(srcdir)/test/run'
+    '';
+    nativeCheckInputs = old.nativeCheckInputs or [ ] ++ [
+      perl
+      # By default `ls` would come from bootstrap tools,
+      # which doesn't support showing ACLs, which the tests rely on
+      coreutils
+    ];
+    preCheck = ''
+      cp test/test.passwd /etc/passwd
+      cp test/test.group /etc/group
+    '';
+    doCheck = true;
+    outputs = [ "out" ];
+    installPhase = ''
+      touch $out
+    '';
+  })
+)

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -188,6 +188,7 @@ in
   # keep-sorted start case=no numeric=no block=yes
   _3proxy = runTest ./3proxy.nix;
   aaaaxy = runTest ./aaaaxy.nix;
+  acl = pkgs.callPackage ./acl.nix { };
   acme = import ./acme/default.nix {
     inherit runTest;
     inherit (pkgs) lib;


### PR DESCRIPTION
Adds a NixOS test for the acl package check phase, because they depend on ACLs and users, which are not available in the sandbox.

I also tried associating this test with `acl.passthru.tests`, but it doesn't work by default due to some bootstrapping issues, so I'm leaving that out for now.

Ping @trofi

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
