### PR TITLE
commitlint: fix executable, add version check

### DIFF
--- a/pkgs/by-name/co/commitlint/package.nix
+++ b/pkgs/by-name/co/commitlint/package.nix
@@ -5,6 +5,7 @@
   fetchYarnDeps,
   yarnConfigHook,
   nodejs,
+  makeBinaryWrapper,
   nix-update-script,
 }:
 
@@ -27,6 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     yarnConfigHook
     nodejs
+    makeBinaryWrapper
   ];
 
   buildPhase = ''
@@ -50,7 +52,10 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/bin
     mkdir -p $out/lib/node_modules/@commitlint/root
     mv * $out/lib/node_modules/@commitlint/root/
-    ln -s $out/lib/node_modules/@commitlint/root/@commitlint/cli/cli.js $out/bin/commitlint
+
+    makeBinaryWrapper ${lib.getExe nodejs} $out/bin/commitlint \
+      --add-flags "$out/lib/node_modules/@commitlint/root/@commitlint/cli/cli.js" \
+      --set NODE_PATH "$out/lib/node_modules/@commitlint/root/node_modules"
 
     runHook postInstall
   '';

--- a/pkgs/by-name/co/commitlint/package.nix
+++ b/pkgs/by-name/co/commitlint/package.nix
@@ -6,6 +6,7 @@
   yarnConfigHook,
   nodejs,
   makeBinaryWrapper,
+  versionCheckHook,
   nix-update-script,
 }:
 
@@ -83,6 +84,11 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/co/commitlint/package.nix
+++ b/pkgs/by-name/co/commitlint/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
           "resolve-extends" "execute-rule" "load" "read" "types" "cli")
     for p in "''${pkgs[@]}" ; do
       cd @commitlint/$p/
-      yarn run tsc --build --force
+      yarn run --offline tsc --build --force
       cd ../..
     done
 

--- a/pkgs/by-name/co/commitlint/package.nix
+++ b/pkgs/by-name/co/commitlint/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "conventional-changelog";
     repo = "commitlint";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-o8AnIewSmg8vRjs8LU6QwRyl2hMQ2iK5W7WL137treU=";
   };
 
@@ -87,7 +87,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    changelog = "https://github.com/conventional-changelog/commitlint/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/conventional-changelog/commitlint/releases/tag/${finalAttrs.src.tag}";
     description = "Lint your commit messages";
     homepage = "https://commitlint.js.org/";
     license = lib.licenses.mit;

--- a/pkgs/by-name/co/commitlint/package.nix
+++ b/pkgs/by-name/co/commitlint/package.nix
@@ -34,9 +34,33 @@ stdenv.mkDerivation (finalAttrs: {
   buildPhase = ''
     runHook preBuild
 
-    pkgs=("config-validator" "rules" "parse" "is-ignored" "lint"
-          "resolve-extends" "execute-rule" "load" "read" "types" "cli")
+    # Remove test files to avoid dependency on commitlint test packages
+    rm -rf @commitlint/**/*.test.{js,ts}
+
+    # See https://github.com/conventional-changelog/commitlint/blob/20.1.0/Dockerfile.ci
+    # Excludes `config-nx-scopes` which is a plain JavaScript package
+    pkgs=(
+      "config-validator"
+      "rules"
+      "parse"
+      "is-ignored"
+      "lint"
+      "resolve-extends"
+      "execute-rule"
+      "load"
+      "read"
+      "types"
+      "cli"
+      "config-conventional"
+      "config-pnpm-scopes"
+      "ensure"
+      "format"
+      "message"
+      "to-lines"
+      "top-level"
+    )
     for p in "''${pkgs[@]}" ; do
+      echo "Building package: @commitlint/$p"
       cd @commitlint/$p/
       yarn run --offline tsc --build --force
       cd ../..


### PR DESCRIPTION
In its current state, the commitlint executable fails to run due to node missing and certain subpackages not being built in the derivation (e.g. try running `echo 'lint me' | commitlint -o`). This PR

- Creates the executable based on `node` and correctly sets `NODE_PATH`
- Builds the additionally required packages in `buildPhase`
- Adds a version check via `versionCheckHook` to verify basic functionality of the executable

See the commit messages for more details.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
