### PR TITLE
ripe-atlas-software-probe: init at 5120

### DIFF
--- a/pkgs/by-name/ri/ripe-atlas-software-probe/package.nix
+++ b/pkgs/by-name/ri/ripe-atlas-software-probe/package.nix
@@ -1,0 +1,54 @@
+{
+  autoreconfHook,
+  fetchFromGitHub,
+  lib,
+  openssl,
+  python3,
+  stdenv,
+}:
+
+let
+  pname = "ripe-atlas-software-probe";
+  version = "5120";
+in
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "RIPE-NCC";
+    repo = pname;
+    rev = "${version}";
+    hash = "sha256-rjhLLeUj6US76/joRVBmYeqKsPVE5KzZGdE4eEilEKI=";
+  };
+
+  configureFlags = [
+    "--with-probe-type=generic"
+    "--disable-chown"
+    "--disable-systemd"
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+
+  buildInputs = [
+    openssl
+    python3
+  ];
+
+  hardeningDisable = [ "format" ];
+
+  meta = {
+    description = ''
+      RIPE Atlas is a global network of probes that measure Internet connectivity and
+      reachability, providing an unprecedented understanding of the state of the
+      Internet in real time.
+
+      This project contains the probe code that powers software probes.
+    '';
+    homepage = "https://github.com/RIPE-NCC/ripe-atlas-software-probe";
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ ananthb ];
+  };
+}


### PR DESCRIPTION
[RIPE Atlas](https://atlas.ripe.net/) is a global network of probes that measure Internet connectivity and reachability, providing an unprecedented understanding of the state of the Internet in real time.

This project contains the probe code that powers software probes.

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
