### PR TITLE
nixos/music-assistant: fix yt-dlp challenge solving for YouTube Music

### DIFF
--- a/nixos/modules/services/audio/music-assistant.nix
+++ b/nixos/modules/services/audio/music-assistant.nix
@@ -26,6 +26,9 @@ let
   finalPackage = cfg.package.override {
     inherit (cfg) providers;
   };
+
+  # YouTube Music needs deno with JIT to solve yt-dlp challenges
+  useYTMusic = lib.elem "ytmusic" cfg.providers;
 in
 
 {
@@ -89,6 +92,10 @@ in
         ]
         ++ lib.optionals (lib.elem "snapcast" cfg.providers) [
           snapcast
+        ]
+        ++ lib.optionals useYTMusic [
+          deno
+          ffmpeg
         ];
 
       serviceConfig = {
@@ -104,7 +111,7 @@ in
         CapabilityBoundingSet = [ "" ];
         DevicePolicy = "closed";
         LockPersonality = true;
-        MemoryDenyWriteExecute = true;
+        MemoryDenyWriteExecute = !useYTMusic;
         ProcSubset = "pid";
         ProtectClock = true;
         ProtectControlGroups = true;
@@ -125,6 +132,9 @@ in
         SystemCallFilter = [
           "@system-service"
           "~@privileged @resources"
+        ]
+        ++ lib.optionals useYTMusic [
+          "@pkey"
         ];
         RestrictSUIDSGID = true;
         UMask = "0077";


### PR DESCRIPTION
The YouTube Music provider uses `yt-dlp`, which in turn wants `ffmpeg` and `deno` in the `$PATH`. Additionally, `deno` uses JIT for which we have to relax our unit sandboxing.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
