### PR TITLE
magika-cli: init at 1.0.1

### DIFF
--- a/pkgs/by-name/ma/magika-cli/package.nix
+++ b/pkgs/by-name/ma/magika-cli/package.nix
@@ -1,0 +1,95 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  openssl,
+  onnxruntime,
+  versionCheckHook,
+  runCommand,
+  writeText,
+  testers,
+  nix-update-script,
+  magika-cli,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "magika-cli";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "magika";
+    tag = "cli/v${finalAttrs.version}";
+    hash = "sha256-g/fnSdh2jpOHOLTuR4DUPB1kbC0eKADHLKcfB1q08XI=";
+  };
+
+  cargoHash = "sha256-uqnTyedry9nWyO2518r0D3hk6oWb4wQE/Ku0cOkSjBA=";
+
+  cargoRoot = "rust/cli";
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+    onnxruntime
+  ];
+
+  env = {
+    OPENSSL_NO_VENDOR = "true";
+  };
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--version";
+
+  passthru = {
+    tests = {
+      mime = testers.testEqualContents {
+        assertion = "magika detects the correct language from content even when the file extension is wrong";
+
+        # Magika does not support Nix files yet: https://github.com/google/magika/issues/1247
+        expected = writeText "expected" ''
+          application/x-rust
+        '';
+        actual =
+          runCommand "actual"
+            {
+              nativeBuildInputs = [
+                magika-cli
+              ];
+            }
+            ''
+              magika --format '%m' '${./test.md}' >>"$out"
+            '';
+      };
+    };
+
+    updateScript = nix-update-script {
+      extraArgs = [ "--version-regex=^cli/v([0-9.]+)$" ];
+    };
+  };
+
+  meta = {
+    description = "Determines file content types using AI";
+    homepage = "https://securityresearch.google/magika/";
+    downloadPage = "https://github.com/google/magika";
+    changelog = "https://github.com/google/magika/releases/tag/cli/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      kachick
+    ];
+    mainProgram = "magika";
+    platforms = with lib.platforms; unix ++ windows;
+
+    # The package test fails on Darwin with this error, even though the build succeeds:
+    # libc++abi: terminating due to uncaught exception of type std::__1::system_error: mutex lock failed: Invalid argument
+    broken = stdenv.hostPlatform.isDarwin;
+  };
+})

--- a/pkgs/by-name/ma/magika-cli/test.md
+++ b/pkgs/by-name/ma/magika-cli/test.md
@@ -1,0 +1,3 @@
+fn main() {
+    println!("This is a code example");
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

ref: https://github.com/NixOS/nixpkgs/issues/289843

Introduce magika-cli.

This is the CLI for the [Magika](https://github.com/google/magika) project. The Python version of Magika is [already in](https://github.com/NixOS/nixpkgs/pull/291462) Nixpkgs.

It is useful for text files when the `file` or `xdg-mime` command can't correctly detect the language.

For example, a rust file saved with a wrong extension like `.md`.

```rust
fn main() {
    println!("This is a code example");
}
```

```console
> nix run nixpkgs/nixos-25.05#file -- pkgs/by-name/ma/magika-cli/test.md
pkgs/by-name/ma/magika-cli/test.md: C source, ASCII text

> xdg-mime query filetype pkgs/by-name/ma/magika-cli/test.md
text/markdown

> nix run .#magika-cli -- pkgs/by-name/ma/magika-cli/test.md
pkgs/by-name/ma/magika-cli/test.md: Rust source (code)
```

Since we require the runtime dependency `onnxruntime`, I added a simple package test to check actual behavior.

```console
> nix-build --attr pkgs.magika-cli.passthru.tests
/nix/store/j2xxxf6700w28f6f42sqqrkv58mcpqpy-equal-contents-magika-detects-the-correct-language-from-content-even-when-the-file-extension-is-wrong
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
