### PR TITLE
Revert "nixos/postfix-tlspol: make tlsrpt depend on tlsrpt service"

### DIFF
--- a/nixos/modules/services/mail/postfix-tlspol.nix
+++ b/nixos/modules/services/mail/postfix-tlspol.nix
@@ -142,7 +142,7 @@ in
               else
                 "inet:${cfg.settings.server.address}";
           in
-          [ "socketmap:${address}:${if config.services.tlsrpt.enable then "QUERYwithTLSRPT" else "QUERY"}" ];
+          [ "socketmap:${address}:QUERYwithTLSRPT" ];
       };
 
       systemd.services.postfix = {


### PR DESCRIPTION
This reverts commit 9ccec77537e72c1f7e792e838e99c1f0d7692850.

Per the author of postfix-tlspol in
https://github.com/NixOS/nixpkgs/pull/456728#issuecomment-3536706358

> QUERYwithTLSRPT should be used when the installed Postfix version is
> 3.10 or newer, regardless of the state of the TLSRPT option in the
> Postfix configuration. Especially Postfix 3.10.5 and later use the
> additional data provided by postfix-tlspol to find the correct MX
> domains to connect to MTA-STS-protected mail destinations.
>
> If you use QUERY with Postfix 3.10.5+, Postfix will use the legacy
> way of DNS MX lookup for the domain, which theoretically can differ
> from the hosts provided by the MTA-STS policy (but usually should be
> the same).
>
> The user can still disable TLSRPT in the Postfix configuration without
> side-effects.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
