### PR TITLE
conventional-changelog-cli: wrap with nodejs

### DIFF
--- a/pkgs/by-name/co/conventional-changelog-cli/package.nix
+++ b/pkgs/by-name/co/conventional-changelog-cli/package.nix
@@ -5,6 +5,7 @@
   nodejs,
   pnpm,
   makeBinaryWrapper,
+  versionCheckHook,
   nix-update-script,
 }:
 
@@ -57,6 +58,12 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace $out/lib/node_modules/conventional-changelog/packages/*/package.json \
       --replace-warn '"exports": "./src/index.ts"' '"exports": "./dist/index.js"'
   '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
 
   passthru.updateScript = nix-update-script {
     extraArgs = [

--- a/pkgs/by-name/co/conventional-changelog-cli/package.nix
+++ b/pkgs/by-name/co/conventional-changelog-cli/package.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    changelog = "https://github.com/conventional-changelog/conventional-changelog/releases/tag/conventional-changelog-v${finalAttrs.version}";
+    changelog = "https://github.com/conventional-changelog/conventional-changelog/releases/tag/${finalAttrs.src.tag}";
     description = "Generate a CHANGELOG from git metadata";
     homepage = "https://github.com/conventional-changelog/conventional-changelog";
     license = lib.licenses.isc;

--- a/pkgs/by-name/co/conventional-changelog-cli/package.nix
+++ b/pkgs/by-name/co/conventional-changelog-cli/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   nodejs,
   pnpm,
+  makeBinaryWrapper,
   nix-update-script,
 }:
 
@@ -27,6 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     nodejs
     pnpm.configHook
+    makeBinaryWrapper
   ];
 
   buildPhase = ''
@@ -43,9 +45,10 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/lib/node_modules/conventional-changelog/
     mkdir $out/bin
     mv * $out/lib/node_modules/conventional-changelog/
-    chmod +x $out/lib/node_modules/conventional-changelog/packages/conventional-changelog/dist/cli/index.js
-    ln -s $out/lib/node_modules/conventional-changelog/packages/conventional-changelog/dist/cli/index.js $out/bin/conventional-changelog
-    patchShebangs $out/bin/conventional-changelog
+
+    makeBinaryWrapper ${lib.getExe nodejs} $out/bin/conventional-changelog \
+      --add-flags "$out/lib/node_modules/conventional-changelog/packages/conventional-changelog/dist/cli/index.js" \
+      --set NODE_PATH "$out/lib/node_modules/conventional-changelog/node_modules"
 
     runHook postInstall
   '';


### PR DESCRIPTION
In its current state, the conventional-changelog-cli executable fails to run because node is missing.

This PR introduces a wrapper for the CLI entrypoint that calls `node` and adds a version check via `versionCheckHook` to verify basic functionality of the executable.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
