### PR TITLE
yaml-shellcheck: init at 1.8.0

### DIFF
--- a/pkgs/by-name/ya/yaml-shellcheck/package.nix
+++ b/pkgs/by-name/ya/yaml-shellcheck/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  shellcheck,
+  makeWrapper,
+  nix-update-script,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "yaml-shellcheck";
+  version = "1.8.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mschuett";
+    repo = "yaml-shellcheck";
+    tag = "v${version}";
+    hash = "sha256-I+HkpUV1OCXau+i/ni0WX2bzTPFI705hrmVL9W9Co+8=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail '"ruamel.yaml" = "0.18.15"' '"ruamel.yaml" = "0.18.16"'
+  '';
+
+  build-system = [
+    python3Packages.poetry-core
+  ];
+
+  dependencies = with python3Packages; [
+    ruamel-yaml
+  ];
+
+  pythonImportsCheck = [
+    "yaml_shellcheck"
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram  $out/bin/${meta.mainProgram} --prefix PATH : "${lib.makeBinPath [ shellcheck ]}"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Wrapper script to run shellcheck on YAML CI-config files";
+    homepage = "https://github.com/mschuett/yaml-shellcheck";
+    changelog = "https://github.com/mschuett/yaml-shellcheck/releases/tag/v${version}";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ kpbaks ];
+    mainProgram = "yaml_shellcheck";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add program [yaml-shellcheck](https://github.com/mschuett/yaml-shellcheck). The release at version `1.8.0` sets a hard constraint on the [`ruamel-yaml == 0.18.5`](https://github.com/mschuett/yaml-shellcheck/blob/c5f49b745cc1e881a415712f57760fbbc4d2cabe/pyproject.toml#L10). Currently version `0.18.6` is available in nixpkgs-unstable. I substitute the patch number to 16, and program still works as expected.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
