### PR TITLE
Revert "curl: enable c-ares"

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2514,7 +2514,6 @@ with pkgs;
       pslSupport = true;
       zstdSupport = true;
       http3Support = true;
-      c-aresSupport = true;
     }
     // lib.optionalAttrs (!stdenv.hostPlatform.isStatic) {
       brotliSupport = true;


### PR DESCRIPTION
Reverts NixOS/nixpkgs#451579

Fixes https://github.com/NixOS/nixpkgs/issues/462625
