### PR TITLE
ndi: add ffmpeg to rpath and fixup patchelf script

### DIFF
--- a/pkgs/by-name/nd/ndi-6/package.nix
+++ b/pkgs/by-name/nd/ndi-6/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   avahi,
+  ffmpeg_7,
   obs-studio-plugins,
 }:
 
@@ -29,8 +30,6 @@ stdenv.mkDerivation rec {
     hash = versionJSON.hash;
   };
 
-  buildInputs = [ avahi ];
-
   unpackPhase = ''
     unpackFile $src
     echo y | ./${installerName}.sh
@@ -38,27 +37,28 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    mkdir $out
+    mkdir -p $out $out/share/doc/ndi-6
     mv bin/${ndiPlatform} $out/bin
-    for i in $out/bin/*; do
-      if [ -L "$i" ]; then continue; fi
-      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$i"
-    done
-    patchelf --set-rpath "${avahi}/lib:${stdenv.cc.libc}/lib" $out/bin/ndi-record
-    patchelf --set-rpath "${avahi}/lib:${stdenv.cc.libc}/lib" $out/bin/ndi-free-audio
     mv lib/${ndiPlatform} $out/lib
-    for i in $out/lib/*; do
-      if [ -L "$i" ]; then continue; fi
-      patchelf --set-rpath "${avahi}/lib:${stdenv.cc.libc}/lib" "$i"
-    done
-    rm $out/bin/libndi.so.${majorVersion}
-    ln -s $out/lib/libndi.so $out/bin/libndi.so.${majorVersion}
     # Fake ndi version 5 for compatibility with DistroAV (obs plugin using NDI)
     ln -s $out/lib/libndi.so $out/bin/libndi.so.5
     mv include examples $out/
-    mkdir -p $out/share/doc/ndi-6
     mv licenses $out/share/doc/ndi-6/licenses
     mv documentation/* $out/share/doc/ndi-6/
+  '';
+
+  dontPatchELF = true;
+
+  fixupPhase = ''
+    for i in $out/bin/*; do
+      if [ -L "$i" ]; then continue; fi
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$i"
+      patchelf --set-rpath "${avahi}/lib:${ffmpeg_7.lib}/lib:${stdenv.cc.libc}/lib" "$i"
+    done
+    for i in $out/lib/*; do
+      if [ -L "$i" ]; then continue; fi
+      patchelf --set-rpath "${avahi}/lib:${ffmpeg_7.lib}/lib:${stdenv.cc.libc}/lib" "$i"
+    done
   '';
 
   # Stripping breaks ndi-record.

--- a/pkgs/by-name/nd/ndi-6/package.nix
+++ b/pkgs/by-name/nd/ndi-6/package.nix
@@ -81,6 +81,9 @@ stdenv.mkDerivation rec {
     ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [ globule655 ];
+    maintainers = with lib.maintainers; [
+      globule655
+      ChaosAttractor
+    ];
   };
 }

--- a/pkgs/by-name/nd/ndi/package.nix
+++ b/pkgs/by-name/nd/ndi/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   avahi,
+  ffmpeg_4,
   obs-studio-plugins,
 }:
 
@@ -32,8 +33,6 @@ stdenv.mkDerivation rec {
     hash = versionJSON.hash;
   };
 
-  buildInputs = [ avahi ];
-
   unpackPhase = ''
     unpackFile $src
     echo y | ./${installerName}.sh
@@ -41,24 +40,26 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    mkdir $out
+    mkdir -p $out $out/share/doc/${pname}-${version}
     mv bin/${ndiPlatform} $out/bin
+    mv lib/${ndiPlatform} $out/lib
+    mv include examples $out/
+    mv licenses $out/share/doc/${pname}-${version}/licenses
+    mv documentation/* $out/share/doc/${pname}-${version}/
+  '';
+
+  dontPatchELF = true;
+
+  fixupPhase = ''
     for i in $out/bin/*; do
       if [ -L "$i" ]; then continue; fi
       patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$i"
+      patchelf --set-rpath "${avahi}/lib:${ffmpeg_4.lib}/lib:${stdenv.cc.libc}/lib" "$i"
     done
-    patchelf --set-rpath "${avahi}/lib:${stdenv.cc.libc}/lib" $out/bin/ndi-record
-    mv lib/${ndiPlatform} $out/lib
     for i in $out/lib/*; do
       if [ -L "$i" ]; then continue; fi
-      patchelf --set-rpath "${avahi}/lib:${stdenv.cc.libc}/lib" "$i"
+      patchelf --set-rpath "${avahi}/lib:${ffmpeg_4.lib}/lib:${stdenv.cc.libc}/lib" "$i"
     done
-    rm $out/bin/libndi.so.${majorVersion}
-    ln -s $out/lib/libndi.so.${version} $out/bin/libndi.so.${majorVersion}
-    mv include examples $out/
-    mkdir -p $out/share/doc/${pname}-${version}
-    mv licenses $out/share/doc/${pname}-${version}/licenses
-    mv documentation/* $out/share/doc/${pname}-${version}/
   '';
 
   # Stripping breaks ndi-record.

--- a/pkgs/by-name/nd/ndi/package.nix
+++ b/pkgs/by-name/nd/ndi/package.nix
@@ -79,6 +79,7 @@ stdenv.mkDerivation rec {
       "aarch64-linux"
       "armv7l-linux"
     ];
+    maintainers = with lib.maintainers; [ ChaosAttractor ];
     hydraPlatforms = [ ];
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
NDI use dlopen to load ffmpeg for decoding, without ffmpeg in rpath, NDI will just broken like this.
<img width="1273" height="620" alt="image" src="https://github.com/user-attachments/assets/b73cd595-d785-499d-b546-2dea00d06e32" />
This only seems to happen without Nvidia GPU Installed.
You can determine the required ffmpeg version as follows, the wrong version will not solve the problem.
```bash
lostattractor@CADesktop ~> strings /nix/store/hja06xa4i0r14f82q7y4bnj1jbavh6z2-ndi-6-6.2.1.0/lib/libndi.so.6.2.1 | grep libav
libavcodec.so.61
libavcodec-ndi.so.61
libavutil.so.59
libavutil-ndi.so.59
libavahi-common.so.3
libavahi-client.so.3
```
For this case, libavcodec.so.61 is specificed, and it's ffmpeg 7.
It looks like not only me have this issue. https://github.com/DistroAV/DistroAV/issues/964

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
