### PR TITLE
matrix-tuwunel: drop reference to rustc

### DIFF
--- a/pkgs/by-name/ma/matrix-tuwunel/dont-record-compilation-flags.patch
+++ b/pkgs/by-name/ma/matrix-tuwunel/dont-record-compilation-flags.patch
@@ -1,0 +1,21 @@
+commit be2b9e1992f5a7048fe011f4d48591dfcec927a8
+Author: Guillaume Girol <symphorien+git@xlumurb.eu>
+Date:   Mon Nov 17 12:00:00 2025 +0000
+
+    make the macro recording conpilation flags a noop
+    
+    it records references to rustc which increases the size of the closure of tuwunel by 1.5 GB.
+
+diff --git a/src/macros/mod.rs b/src/macros/mod.rs
+index b5c5b67d..86f4755b 100644
+--- a/src/macros/mod.rs
++++ b/src/macros/mod.rs
+@@ -39,7 +39,7 @@ pub fn recursion_depth(args: TokenStream, input: TokenStream) -> TokenStream {
+ }
+ 
+ #[proc_macro]
+-pub fn rustc_flags_capture(args: TokenStream) -> TokenStream { rustc::flags_capture(args) }
++pub fn rustc_flags_capture(_args: TokenStream) -> TokenStream { TokenStream::default() }
+ 
+ #[proc_macro]
+ pub fn rustc_version(args: TokenStream) -> TokenStream { rustc::version(args) }

--- a/pkgs/by-name/ma/matrix-tuwunel/package.nix
+++ b/pkgs/by-name/ma/matrix-tuwunel/package.nix
@@ -19,6 +19,7 @@
   liburing,
   nixosTests,
   writeTextFile,
+  rustc-unwrapped,
 }:
 let
   rust-jemalloc-sys' = rust-jemalloc-sys.override {
@@ -103,6 +104,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
     rustPlatform.bindgenHook
   ];
 
+  patches = [
+    # reduce closure size by not storing a reference to rustc-unwrapped
+    # alternative to https://github.com/NixOS/nixpkgs/pull/462394
+    ./dont-record-compilation-flags.patch
+  ];
+
   buildInputs = [
     bzip2
     zstd
@@ -171,6 +178,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
       inherit (nixosTests) matrix-tuwunel;
     };
   };
+
+  disallowedReferences = [ rustc-unwrapped ];
 
   meta = {
     description = "Matrix homeserver written in Rust, official successor to conduwuit";


### PR DESCRIPTION
Alternative to the below PR

Closes: https://github.com/NixOS/nixpkgs/pull/462394


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
