### PR TITLE
treewide: switch to channels.nixos.org

### DIFF
--- a/maintainers/scripts/update-channel-branches.sh
+++ b/maintainers/scripts/update-channel-branches.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-: ${NIXOS_CHANNELS:=https://nixos.org/channels/}
+: ${NIXOS_CHANNELS:=https://channels.nixos.org/}
 : ${CHANNELS_NAMESPACE:=refs/heads/channels/}
 
 # List all channels which are currently in the repository which we would

--- a/nixos/doc/manual/development/replace-modules.section.md
+++ b/nixos/doc/manual/development/replace-modules.section.md
@@ -37,7 +37,7 @@ nixos-unstable unless explicitly configured to do so.
 
   imports = [
     # Use postgresql service from nixos-unstable channel.
-    # sudo nix-channel --add https://nixos.org/channels/nixos-unstable nixos-unstable
+    # sudo nix-channel --add https://channels.nixos.org/nixos-unstable nixos-unstable
     <nixos-unstable/nixos/modules/services/databases/postgresql.nix>
   ];
 

--- a/nixos/doc/manual/installation/installing-from-other-distro.section.md
+++ b/nixos/doc/manual/installation/installing-from-other-distro.section.md
@@ -35,14 +35,14 @@ The first steps to all these are the same:
 
     ```ShellSession
     $ nix-channel --list
-    nixpkgs https://nixos.org/channels/nixpkgs-unstable
+    nixpkgs https://channels.nixos.org/nixpkgs-unstable
     ```
 
     As that channel gets released without running the NixOS tests, it
     will be safer to use the `nixos-*` channels instead:
 
     ```ShellSession
-    $ nix-channel --add https://nixos.org/channels/nixos-<version> nixpkgs
+    $ nix-channel --add https://channels.nixos.org/nixos-<version> nixpkgs
     ```
 
     Where `<version>` corresponds to the latest version available on [channels.nixos.org](https://channels.nixos.org/).

--- a/nixos/doc/manual/release-notes/rl-1809.section.md
+++ b/nixos/doc/manual/release-notes/rl-1809.section.md
@@ -39,7 +39,7 @@ Notable changes and additions for 18.09 include:
   For example
 
   ```ShellSession
-  $ nix-channel --add https://nixos.org/channels/nixpkgs-unstable nixpkgsunstable
+  $ nix-channel --add https://channels.nixos.org/nixpkgs-unstable nixpkgsunstable
   $ nix-channel --update
   $ nix-build '<nixpkgsunstable>' -A gitFull
   $ nix run -f '<nixpkgsunstable>' gitFull

--- a/nixos/modules/services/continuous-integration/gitlab-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitlab-runner.nix
@@ -318,7 +318,7 @@ in
 
               ''${pkgs.nix}/bin/nix-env -i ''${concatStringsSep " " (with pkgs; [ nix cacert git openssh ])}
 
-              ''${pkgs.nix}/bin/nix-channel --add https://nixos.org/channels/nixpkgs-unstable
+              ''${pkgs.nix}/bin/nix-channel --add https://channels.nixos.org/nixpkgs-unstable
               ''${pkgs.nix}/bin/nix-channel --update nixpkgs
             ''';
             environmentVariables = {

--- a/nixos/modules/tasks/auto-upgrade.nix
+++ b/nixos/modules/tasks/auto-upgrade.nix
@@ -52,7 +52,7 @@ in
       channel = lib.mkOption {
         type = lib.types.nullOr lib.types.str;
         default = null;
-        example = "https://nixos.org/channels/nixos-14.12-small";
+        example = "https://channels.nixos.org/nixos-14.12-small";
         description = ''
           The URI of the NixOS channel to use for automatic
           upgrades. By default, this is the channel set using

--- a/nixos/tests/activation/nix-channel.nix
+++ b/nixos/tests/activation/nix-channel.nix
@@ -17,7 +17,7 @@
 
       assert machine.succeed("cat /root/.nix-channels") == "${nodes.machine.system.defaultChannel} nixos\n"
 
-      nixpkgs_unstable_channel = "https://nixos.org/channels/nixpkgs-unstable nixpkgs"
+      nixpkgs_unstable_channel = "https://channels.nixos.org/nixpkgs-unstable nixpkgs"
       machine.succeed(f"echo '{nixpkgs_unstable_channel}' > /root/.nix-channels")
 
       machine.reboot()

--- a/nixos/tests/ec2.nix
+++ b/nixos/tests/ec2.nix
@@ -123,7 +123,7 @@ in
     inherit image;
     sshPublicKey = snakeOilPublicKey;
 
-    # ### https://nixos.org/channels/nixos-unstable nixos
+    # ### https://channels.nixos.org/nixos-unstable nixos
     userData = ''
       { pkgs, ... }:
 


### PR DESCRIPTION
This is a follow-up for #460057 to completely remove all mentions of nixos.org/channels/.

The following command was used to generate this change:

```
find . -type f -exec sed -i 's|nixos.org/channels/|channels.nixos.org/|g' {} +
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
