### PR TITLE
chromium,chromedriver: 142.0.7444.162 -> 142.0.7444.175

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,10 +1,10 @@
 {
   "chromium": {
-    "version": "142.0.7444.162",
+    "version": "142.0.7444.175",
     "chromedriver": {
-      "version": "142.0.7444.162",
-      "hash_darwin": "sha256-5IjkO18e8WiruQjTPZ4WXybbbDOwcSEbI+AnDEwNR3I=",
-      "hash_darwin_aarch64": "sha256-xDsFiFdeDmZyceDRhe6Kl5KndDgVzkwFtvB4qdzUt0E="
+      "version": "142.0.7444.176",
+      "hash_darwin": "sha256-VG4+tQbZ8r3i8NZpia/9tRC0sqzbH5auTHbBsPbkqpc=",
+      "hash_darwin_aarch64": "sha256-A1xHznjElisrEQY0UIbjizGpCbxlCa7wnvTK6rlMH2w="
     },
     "deps": {
       "depot_tools": {
@@ -21,8 +21,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "c076baf266c3ed5efb225de664cfa7b183668ad6",
-        "hash": "sha256-HdVZl4Zvspgm/9wy+WtDc1UiSM1VrszfwpITQchYoSc=",
+        "rev": "302067f14a4ea3f42001580e6101fa25ed343445",
+        "hash": "sha256-2x1IpfD0BXDaPKwdBO4+t8Dw7dYLM7oQDlrXY57tFIw=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -807,8 +807,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "9210361d0a26fa4afefad8c5e60c85e59c5e2c8e",
-        "hash": "sha256-otYRT8scmJ9boG2PKXRacL0C5FFwOVctKK/Dh7WG0tU="
+        "rev": "baea8d627b70725fb777ebc1074f8ec4110ef6cb",
+        "hash": "sha256-jECAfgeAgdkhbI/8BgT9TakR9Ylha2zPznjZzibPQbE="
       }
     }
   },


### PR DESCRIPTION
https://chromereleases.googleblog.com/2025/11/stable-channel-update-for-desktop_17.html

This update includes 2 security fixes. Google is aware that an exploit for CVE-2025-13223 exists in the wild.

CVEs:
CVE-2025-13223 CVE-2025-13224

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
