### PR TITLE
pw3270, lib3270, libv3270: 5.4 -> 5.5.0

### DIFF
--- a/pkgs/by-name/li/lib3270/package.nix
+++ b/pkgs/by-name/li/lib3270/package.nix
@@ -2,33 +2,29 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  which,
   pkg-config,
-  autoconf,
-  automake,
-  libtool,
   gettext,
   openssl,
   curl,
+  meson,
+  ninja,
 }:
 
 stdenv.mkDerivation rec {
   pname = "lib3270";
-  version = "5.4";
+  version = "5.5.0";
 
   src = fetchFromGitHub {
     owner = "PerryWerneck";
     repo = "lib3270";
     rev = version;
-    hash = "sha256-w6Bg+TvSDAuZwtu/nyAIuq6pgheM5nXtfuryECfnKng=";
+    hash = "sha256-AGS7RkMeVKe2Ed5Aj3oHdbiGMoYGmq2Wlkcd4wSm4J8=";
   };
 
   nativeBuildInputs = [
-    which
     pkg-config
-    autoconf
-    automake
-    libtool
+    meson
+    ninja
   ];
 
   buildInputs = [
@@ -36,15 +32,6 @@ stdenv.mkDerivation rec {
     openssl
     curl
   ];
-
-  postPatch = ''
-    # Patch the required version.
-    sed -i -e "s/20211118/19800101/" src/core/session.c
-  '';
-
-  preConfigure = ''
-    NOCONFIGURE=1 sh autogen.sh
-  '';
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/li/lib3270/package.nix
+++ b/pkgs/by-name/li/lib3270/package.nix
@@ -1,45 +1,46 @@
 {
   lib,
   stdenv,
-  fetchFromGitHub,
-  pkg-config,
-  gettext,
-  openssl,
   curl,
+  fetchFromGitHub,
+  gettext,
   meson,
   ninja,
+  openssl,
+  pkg-config,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "lib3270";
   version = "5.5.0";
 
   src = fetchFromGitHub {
     owner = "PerryWerneck";
     repo = "lib3270";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-AGS7RkMeVKe2Ed5Aj3oHdbiGMoYGmq2Wlkcd4wSm4J8=";
   };
 
   nativeBuildInputs = [
-    pkg-config
     meson
     ninja
+    pkg-config
   ];
 
   buildInputs = [
+    curl
     gettext
     openssl
-    curl
   ];
 
   enableParallelBuilding = true;
 
-  meta = with lib; {
+  meta = {
     description = "TN3270 client Library";
     homepage = "https://github.com/PerryWerneck/lib3270";
-    license = licenses.lgpl3Plus;
-    maintainers = [ maintainers.vifino ];
+    changelog = "https://github.com/PerryWerneck/lib3270/blob/${finalAttrs.version}/CHANGELOG";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ vifino ];
     broken = stdenv.hostPlatform.isDarwin;
   };
-}
+})

--- a/pkgs/by-name/li/libv3270/package.nix
+++ b/pkgs/by-name/li/libv3270/package.nix
@@ -9,14 +9,14 @@
   ninja,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libv3270";
   version = "5.5.0";
 
   src = fetchFromGitHub {
     owner = "PerryWerneck";
     repo = "libv3270";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-Cn/to1/7mH1Ygjcx12mMf52PTcz4smy/+bwWH1mbT9s=";
   };
 
@@ -40,11 +40,11 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = with lib; {
+  meta = {
     description = "3270 Virtual Terminal for GTK";
     homepage = "https://github.com/PerryWerneck/libv3270";
     changelog = "https://github.com/PerryWerneck/libv3270/blob/master/CHANGELOG";
-    license = licenses.lgpl3Plus;
-    maintainers = [ maintainers.vifino ];
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ vifino ];
   };
-}
+})

--- a/pkgs/by-name/li/libv3270/package.nix
+++ b/pkgs/by-name/li/libv3270/package.nix
@@ -2,32 +2,28 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  autoconf,
-  automake,
-  libtool,
-  which,
   pkg-config,
   gtk3,
   lib3270,
+  meson,
+  ninja,
 }:
 
 stdenv.mkDerivation rec {
   pname = "libv3270";
-  version = "5.4";
+  version = "5.5.0";
 
   src = fetchFromGitHub {
     owner = "PerryWerneck";
     repo = "libv3270";
     rev = version;
-    hash = "sha256-Z3FvxPa1pfeECxfB5ZL6gwhkbTKFpfO3D/zLVLF+uiI=";
+    hash = "sha256-Cn/to1/7mH1Ygjcx12mMf52PTcz4smy/+bwWH1mbT9s=";
   };
 
   nativeBuildInputs = [
-    which
     pkg-config
-    autoconf
-    automake
-    libtool
+    meson
+    ninja
   ];
 
   buildInputs = [
@@ -40,12 +36,6 @@ stdenv.mkDerivation rec {
     for f in $(find . -type f -iname "*.c"); do
       sed -i -e "s@lib3270_build_data_filename(@g_build_filename(\"$out/share/pw3270\", @" "$f"
     done
-  '';
-
-  preConfigure = ''
-    mkdir -p scripts
-    touch scripts/config.rpath
-    NOCONFIGURE=1 sh ./autogen.sh
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/pw/pw3270/package.nix
+++ b/pkgs/by-name/pw/pw3270/package.nix
@@ -2,11 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  which,
   pkg-config,
-  automake,
-  autoconf,
-  libtool,
   gtk3,
   libv3270,
   lib3270,
@@ -14,27 +10,29 @@
   gettext,
   desktop-file-utils,
   wrapGAppsHook3,
+  meson,
+  scour,
+  ninja,
 }:
 
 stdenv.mkDerivation rec {
   pname = "pw3270";
-  version = "5.4";
+  version = "5.5.0";
 
   src = fetchFromGitHub {
     owner = "PerryWerneck";
     repo = "pw3270";
     rev = version;
-    hash = "sha256-Nk/OUqrWngKgb1D1Wi8q5ygKtvuRKUPhPQaLvWi1Z4g=";
+    hash = "sha256-thvurPyAsbcCRcanV6PwObO26LCmphdNrYYKhHDKnzE=";
   };
 
   nativeBuildInputs = [
-    which
     pkg-config
-    autoconf
-    automake
-    libtool
     desktop-file-utils
     wrapGAppsHook3
+    meson
+    scour
+    ninja
   ];
 
   buildInputs = [
@@ -52,14 +50,11 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  preConfigure = ''
-    NOCONFIGURE=1 sh autogen.sh
-  '';
-
   postFixup = ''
     # Schemas get installed to wrong directory.
     mkdir -p $out/share/glib-2.0
     mv $out/share/gsettings-schemas/pw3270-${version}/glib-2.0/schemas $out/share/glib-2.0/
+    glib-compile-schemas $out/share/glib-2.0/schemas
     rm -rf $out/share/gsettings-schemas
   '';
 

--- a/pkgs/by-name/pw/pw3270/package.nix
+++ b/pkgs/by-name/pw/pw3270/package.nix
@@ -15,14 +15,14 @@
   ninja,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "pw3270";
   version = "5.5.0";
 
   src = fetchFromGitHub {
     owner = "PerryWerneck";
     repo = "pw3270";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-thvurPyAsbcCRcanV6PwObO26LCmphdNrYYKhHDKnzE=";
   };
 
@@ -53,18 +53,19 @@ stdenv.mkDerivation rec {
   postFixup = ''
     # Schemas get installed to wrong directory.
     mkdir -p $out/share/glib-2.0
-    mv $out/share/gsettings-schemas/pw3270-${version}/glib-2.0/schemas $out/share/glib-2.0/
+    mv $out/share/gsettings-schemas/pw3270-${finalAttrs.version}/glib-2.0/schemas $out/share/glib-2.0/
     glib-compile-schemas $out/share/glib-2.0/schemas
     rm -rf $out/share/gsettings-schemas
   '';
 
   enableParallelBuilding = true;
 
-  meta = with lib; {
+  meta = {
     description = "3270 Emulator for gtk";
     homepage = "https://softwarepublico.gov.br/social/pw3270/";
-    license = licenses.lgpl3Plus;
-    maintainers = [ maintainers.vifino ];
+    changelog = "https://github.com/PerryWerneck/pw3270/blob/${finalAttrs.version}/CHANGELOG";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ vifino ];
     mainProgram = "pw3270";
   };
-}
+})


### PR DESCRIPTION
### Update of `pw3270`, `lib3270` and `libv3270`

- All three of these packages fail to build on [Hydra](https://hydra.nixos.org/eval/1820250?filter=3270&compare=1820245&full=).
- The update from version 5.4 to 5.5.0 makes these packages work again.

#### `pw3270`
Release: https://github.com/PerryWerneck/pw3270/releases/tag/5.5.0
Diff: https://github.com/PerryWerneck/pw3270/compare/5.4...5.5.0

#### `lib3270`
Release: https://github.com/PerryWerneck/lib3270/releases/tag/5.5.0
Diff: https://github.com/PerryWerneck/lib3270/compare/5.4...5.5.0

#### `libv3270`
Release: https://github.com/PerryWerneck/libv3270/releases/tag/5.5.0
Diff: https://github.com/PerryWerneck/libv3270/compare/5.4...5.5.0

**Tracking:**  #457852

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
