### PR TITLE
nix-prefetch-pijul: always output “state” (Pijul’s stable reference)

### DIFF
--- a/pkgs/build-support/fetchpijul/nix-prefetch-pijul
+++ b/pkgs/build-support/fetchpijul/nix-prefetch-pijul
@@ -100,6 +100,11 @@ if [ -z "$final_path" ]; then
 
 	cd "$tmp_clone"
 	pijul clone $clone_args "$remote" "$name"
+	# State is a stable reference is a stable reference for the patchset that
+	# doesn't depend on patch order. As a result, it will always be included.
+	if [ -z "$state" ]; then
+		state="$(pijul log --repository "$tmp_clone/$name" --state --limit 1 | awk '/^State:/ {printf $2}')"
+	fi
 	rm -rf "$tmp_clone/$name/.pijul"
 
 	hash="$(nix-hash --type "$hash_algo" "$hash_format" "$tmp_clone/$name")"
@@ -125,10 +130,8 @@ EOF
 if [ -n "$change" ]; then cat <<EOF
 	"change": $(json_escape "$change"),
 EOF
-elif [ -n "$state" ]; then cat <<EOF
-	"state": $(json_escape "$state"),
-EOF
 fi; cat <<EOF
+	"state": $(json_escape "$state"),
 	"path": "$final_path",
 	$(json_escape "$hash_algo"): $(json_escape "$hash"),
 	"hash": "$(nix-hash --to-sri --type "$hash_algo" "$hash")"

--- a/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
+++ b/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
@@ -83,6 +83,7 @@ rec {
     subversion
   ];
   nix-prefetch-pijul = mkPrefetchScript "pijul" ../../../build-support/fetchpijul/nix-prefetch-pijul [
+    gawk
     pijul
     cacert
     jq


### PR DESCRIPTION
State can be an input to the prefetcher, but if state wasn’t used, it will be useful in the JSON output for downstream scripts.

This is an extension of discussions from https://github.com/Thaigersprint/thaigersprint-2025/issues/2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
