### PR TITLE
nixos/packet: init module

### DIFF
--- a/nixos/modules/programs/packet.nix
+++ b/nixos/modules/programs/packet.nix
@@ -1,0 +1,63 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.programs.packet;
+in
+{
+  options = {
+    programs.packet = {
+      enable = lib.mkEnableOption "packet, a Quick Share client for Linux";
+
+      package = lib.mkPackageOption pkgs "packet" { };
+
+      port = lib.mkOption {
+        type = lib.types.oneOf [
+          lib.types.port
+          (lib.types.enum [ "dynamic" ])
+        ];
+        default = 9300;
+        description = ''
+          The port used by packet. Setting to `"dynamic"` will disable
+          static network port, and will not work with {option}`programs.packet.openFirewall`.
+        '';
+      };
+
+      openFirewall = lib.mkEnableOption "open firewall port for packet" // {
+        default = true;
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.openFirewall -> (cfg.port != "dynamic");
+        message = "Cannot open firewall for packet with dynamic port.";
+      }
+    ];
+
+    environment.systemPackages = [ cfg.package ];
+
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.port ];
+    };
+
+    programs.dconf.profiles.user.databases = [
+      {
+        settings."io/github/nozwock/Packet" = {
+          enable-static-port = cfg.port != "dynamic";
+        }
+        // (lib.optionalAttrs (cfg.port != "dynamic") {
+          static-port-number = lib.gvariant.mkInt32 cfg.port;
+        });
+      }
+    ];
+  };
+
+  meta.maintainers = with lib.maintainers; [ aleksana ];
+}

--- a/pkgs/by-name/pa/packet/package.nix
+++ b/pkgs/by-name/pa/packet/package.nix
@@ -73,6 +73,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Quick Share client for Linux";
+    longDescription = ''
+      Packet requires opening firewall port to transfer files.
+      On NixOS, you can use {option}`programs.packet.enable` option.
+      On non-NixOS, you can either disable firewall, or enable
+      "Static Network Port" in Preferences and allow TCP port for
+      corresponding "Port Number" in your firewall settings.
+    '';
     homepage = "https://github.com/nozwock/packet";
     changelog = "https://github.com/nozwock/packet/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl3Plus;


### PR DESCRIPTION
Related: https://github.com/nozwock/packet/issues/87 https://github.com/nozwock/packet/issues/35

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
