### PR TITLE
tealdeer: fix tests on darwin

### DIFF
--- a/pkgs/by-name/te/tealdeer/package.nix
+++ b/pkgs/by-name/te/tealdeer/package.nix
@@ -28,17 +28,9 @@ rustPlatform.buildRustPackage rec {
   '';
 
   # Disable tests that require Internet access:
-  checkFlags = [
-    "--skip test_autoupdate_cache"
-    "--skip test_create_cache_directory_path"
-    "--skip test_pager_flag_enable"
-    "--skip test_quiet_cache"
-    "--skip test_quiet_failures"
-    "--skip test_quiet_old_cache"
-    "--skip test_spaces_find_command"
-    "--skip test_update_cache"
-    "--skip test_update_language_arg"
-  ];
+  checkFeatures = [ "ignore-online-tests" ];
+  # tealdeer requires --test-threads=1
+  dontUseCargoParallelTests = true;
 
   meta = with lib; {
     description = "Very fast implementation of tldr in Rust";


### PR DESCRIPTION
Resolves #462177.

tealdeer 1.8.x now requires run tests with `--test-threads 1`: https://github.com/tealdeer-rs/tealdeer/blob/v1.8.1/.github/workflows/ci.yml#L46-L47

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
