### PR TITLE
greetd: only define legacy passthrus on `allowAliases`

### DIFF
--- a/pkgs/by-name/gr/greetd/package.nix
+++ b/pkgs/by-name/gr/greetd/package.nix
@@ -1,6 +1,7 @@
 {
   rustPlatform,
   lib,
+  config,
   fetchFromSourcehut,
   pam,
   scdoc,
@@ -49,17 +50,19 @@ rustPlatform.buildRustPackage (finalAttrs: {
     let
       warnPassthru = name: lib.warnOnInstantiate "`greetd.${name}` was renamed to `${name}`";
     in
-    lib.mapAttrs warnPassthru {
-      inherit
-        gtkgreet
-        qtgreet
-        regreet
-        tuigreet
-        wlgreet
-        ;
-    }
+    lib.mapAttrs warnPassthru (
+      lib.optionalAttrs config.allowAliases {
+        inherit
+          gtkgreet
+          qtgreet
+          regreet
+          tuigreet
+          wlgreet
+          ;
+        greetd = finalAttrs.finalPackage;
+      }
+    )
     // {
-      greetd = warnPassthru "greetd" finalAttrs.finalPackage;
       updateScript = nix-update-script { };
     };
 


### PR DESCRIPTION
just realised i forgot to do it in #427540 🙈 

~~> [!CAUTION]~~
~~> not at my PC, can't test rn~~
just tested, works perfectly:
```console
> (import ./. {config.allowAliases = true;}).greetd.passthru
{
evaluation warning: `greetd.greetd` was renamed to `greetd`
«derivation /nix/store/rqh6bwdi6mbx6imdjaxva1kkvr68pcax-greetd-0.10.3.drv»;
evaluation warning: `greetd.gtkgreet` was renamed to `gtkgreet`
«derivation /nix/store/n33wpj95h9farrkqdk60qcyhy2hkwyxx-gtkgreet-0.8.drv»;
evaluation warning: `greetd.qtgreet` was renamed to `qtgreet`
«derivation /nix/store/dsbvp5xwzr347wa3av6carygqbqr25m0-qtgreet-2.0.4.drv»;
evaluation warning: `greetd.regreet` was renamed to `regreet`
«derivation /nix/store/a2yzis7pfy5sw1n4mlg3kmr9jgnm35l7-regreet-0.2.0.drv»;
evaluation warning: `greetd.tuigreet` was renamed to `tuigreet`
«derivation /nix/store/nkn4h7x7nh0q7pvib6sjx3qnvbzdk1s0-tuigreet-0.9.1.drv»;
  updateScript = [ ... ];
evaluation warning: `greetd.wlgreet` was renamed to `wlgreet`
«derivation /nix/store/h5m2c5bdj3ch213dmw5l3a17lvy3ql67-wlgreet-0.5.0.drv»;
}

> (import ./. {config.allowAliases = false;}).greetd.passthru
{
  updateScript = [ ... ];
}
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
