### PR TITLE
aws-shell: fix build

### DIFF
--- a/pkgs/by-name/aw/aws-shell/package.nix
+++ b/pkgs/by-name/aw/aws-shell/package.nix
@@ -2,6 +2,7 @@
   python3Packages,
   lib,
   fetchFromGitHub,
+  fetchPypi,
   awscli,
   writableTmpDirAsHomeHook,
 }:
@@ -29,12 +30,16 @@ python3Packages.buildPythonApplication rec {
     configobj
     awscli
     (prompt-toolkit.overrideAttrs (old: {
-      src = fetchFromGitHub {
-        owner = "prompt-toolkit";
-        repo = "python-prompt-toolkit";
-        rev = "refs/tags/1.0.18"; # Need >=1.0.0,<1.1.0
-        hash = "sha256-mt/fIubkpeVc7vhAaTk0pXZXI8JzB7n2MzXqgqK0wE4=";
+      src = fetchPypi {
+        pname = "prompt_toolkit";
+        version = "1.0.18";
+        hash = "sha256-3U/KAsgGlJetkxotCZFMaw0bUBUc6Ha8Fb3kx0cJASY=";
       };
+      postPatch = null;
+      propagatedBuildInputs = old.propagatedBuildInputs ++ [
+        wcwidth
+        six
+      ];
     }))
   ];
 


### PR DESCRIPTION
Fix https://hydra.nixos.org/build/313300678

Tracking: https://github.com/NixOS/nixpkgs/issues/457852

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
