### PR TITLE
Revert "ci/github-script/labels: close empty PRs"

### DIFF
--- a/ci/github-script/bot.js
+++ b/ci/github-script/bot.js
@@ -167,49 +167,6 @@ module.exports = async ({ github, context, core, dry }) => {
       getUser,
     })
 
-    // When the same change has already been merged to the target branch, a PR will still be
-    // open and display the same changes - but will not actually have any effect. This causes
-    // strange CI behavior, because the diff of the merge-commit is empty, no rebuilds will
-    // be detected, no maintainers pinged.
-    // We can just check the temporary merge commit, and if it's empty the PR can safely be
-    // closed - there are no further changes.
-    // We only do this for PRs, which are non-empty to start with. This avoids closing PRs
-    // which have been created with an empty commit for notification purposes, for example
-    // the yearly election notification for voters.
-    if (pull_request.merge_commit_sha && pull_request.changed_files > 0) {
-      const commit = (
-        await github.rest.repos.getCommit({
-          ...context.repo,
-          ref: pull_request.merge_commit_sha,
-        })
-      ).data
-
-      if (commit.files.length === 0) {
-        const body = [
-          `The diff for the temporary merge commit ${pull_request.merge_commit_sha} is empty.`,
-          'The changes in this PR have almost certainly already been merged to the target branch.',
-        ].join('\n')
-
-        core.info(`PR #${item.number}: closed`)
-
-        if (!dry) {
-          await github.rest.issues.createComment({
-            ...context.repo,
-            issue_number: pull_number,
-            body,
-          })
-
-          await github.rest.pulls.update({
-            ...context.repo,
-            pull_number,
-            state: 'closed',
-          })
-        }
-
-        return {}
-      }
-    }
-
     // Check for any human reviews other than the PR author, GitHub actions and other GitHub apps.
     // Accounts could be deleted as well, so don't count them.
     const reviews = (


### PR DESCRIPTION
This reverts commit 402b41c1257ffc7cb88f2876b5fa20ab3ffe4f95.

GitHub' API repeatedly returns wrong data which causes closed PRs when the changes had not been merged, yet.

We have closed a bit more than 100 PRs overall, most of them initially - the feature is not really that important overall.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
