### PR TITLE
atlantis: drop maintainer

### DIFF
--- a/pkgs/by-name/at/atlantis/package.nix
+++ b/pkgs/by-name/at/atlantis/package.nix
@@ -35,6 +35,6 @@ buildGoModule (finalAttrs: {
     description = "Terraform Pull Request Automation";
     mainProgram = "atlantis";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ jpotier ];
+    maintainers = [ ];
   };
 })


### PR DESCRIPTION
not using atlantis anymore, and too little time to correctly take maintenance ownership for this software