### PR TITLE
models-dev: 0-unstable-2025-11-14 -> 0-unstable-2025-11-17

### DIFF
--- a/pkgs/by-name/mo/models-dev/package.nix
+++ b/pkgs/by-name/mo/models-dev/package.nix
@@ -8,12 +8,12 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "models-dev";
-  version = "0-unstable-2025-11-14";
+  version = "0-unstable-2025-11-17";
   src = fetchFromGitHub {
     owner = "sst";
     repo = "models.dev";
-    rev = "83a038148a44242ab39430d41d88e862f782e796";
-    hash = "sha256-dRHnDRMVObcE26MrD8DCdkdMrxhHYIBF+ZGJTfsrxNs=";
+    rev = "0cb3e3498ba712bd31528926d2efdd26e925267b";
+    hash = "sha256-ICMR59DaqriZZmO7260iuyMjuIRJ9AYtWlzVZY0KFXw=";
   };
 
   node_modules = stdenvNoCC.mkDerivation {


### PR DESCRIPTION
Automatic update generated by [nixpkgs-update-gha](https://github.com/delafthi/nixpkgs-update-gha). This update was made based on information from `passthru.updateScript`.

meta.description for models-dev is: Comprehensive open-source database of AI model specifications, pricing, and capabilities

meta.homepage for models-dev is: https://github.com/sst/models-dev

meta.changelog for models-dev is: 

###### Updates performed

- Ran `passthru.updateScript`

###### To inspect upstream changes

https://github.com/sst/models-dev

###### Impact

<b>Checks done</b>

---

- built on NixOS
- found 0-unstable-2025-11-17 in filename of file in /nix/store/xxaj8xlgkb4mbir3rc87qvjphnw4lds4-models-dev-0-unstable-2025-11-17
- nixpkgs-review-gha triggered for multi-platform testing ([view workflow runs](https://github.com/delafthi/nixpkgs-review-gha/actions))

---

<details>
<summary>
<b>Rebuild report</b> (if merged into master) (click to expand)
</summary>

```
Build logs: https://github.com/delafthi/nixpkgs-update-gha/actions/runs/19452875897
```

</details>

### Pre-merge build results

We have automatically built all packages that will get rebuilt due to
this change.

This gives evidence on whether the upgrade will break dependent packages.
Note sometimes packages show up as _failed to build_ independent of the
change, simply because they are already broken on the target branch.

## `nixpkgs-review` result

### `x86_64-linux`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>models-dev</li>
    <li>opencode</li>
  </ul>
</details>

###### Maintainer pings

cc @delafthi for [testing](https://github.com/ryantm/nixpkgs-update/blob/main/doc/nixpkgs-maintainer-faq.md#r-ryantm-opened-a-pr-for-my-package-what-do-i-do).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.com/blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
