### PR TITLE
rod: init at 0.1.13

### DIFF
--- a/pkgs/by-name/ro/rod/package.nix
+++ b/pkgs/by-name/ro/rod/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rod";
+  version = "0.1.13";
+
+  src = fetchFromGitHub {
+    owner = "leiserfg";
+    repo = "rod";
+    tag = finalAttrs.version;
+    hash = "sha256-LwksGhz55CVY6D0IqNHA9OYNB6261xWxwxXxlYN5NQA=";
+  };
+
+  cargoHash = "sha256-vpZOS8PY9fSOVeMGQf8uYZtpUnc3D6a+ZenLmBCfPFg=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Tool for detecting the lightness of the terminal background";
+    homepage = "https://github.com/leiserfg/rod";
+    changelog = "https://github.com/leiserfg/rod/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      leiserfg
+      nekowinston
+    ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
CLI to query whether the terminal is using dark or light appearance.

Glad to be able to add upstream author @leiserfg as maintainer :)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
