### PR TITLE
python3packages.countryinfo: init at 1.0.0

### DIFF
--- a/pkgs/development/python-modules/countryinfo/default.nix
+++ b/pkgs/development/python-modules/countryinfo/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+  pydantic,
+  typer,
+  pytestCheckHook,
+}:
+buildPythonPackage rec {
+  pname = "countryinfo";
+  version = "1.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "porimol";
+    repo = "countryinfo";
+    tag = "v${version}";
+    hash = "sha256-Y4nJnjXg8raJx2f00DFMktdcWoLO09wqTFK6Fc8RKSI=";
+  };
+
+  build-system = [ poetry-core ];
+
+  patches = [ ./fix-pyproject-file.patch ];
+
+  dependencies = [
+    pydantic
+    typer
+  ];
+
+  pythonRelaxDeps = [ "typer" ];
+
+  pythonImportsCheck = [ "countryinfo" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  meta = {
+    homepage = "https://github.com/porimol/countryinfo";
+    description = "Data about countries, ISO info and states/provinces within them";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      cizniarova
+    ];
+  };
+}

--- a/pkgs/development/python-modules/countryinfo/fix-pyproject-file.patch
+++ b/pkgs/development/python-modules/countryinfo/fix-pyproject-file.patch
@@ -1,0 +1,11 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index f31c9e3..31fa9c8 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,3 +1,6 @@
++[project]
++name = "countryinfo"
++
+ [tool.poetry]
+ name = "countryinfo"
+ version = "1.0.0"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3073,6 +3073,8 @@ self: super: with self; {
 
   countryguess = callPackage ../development/python-modules/countryguess { };
 
+  countryinfo = callPackage ../development/python-modules/countryinfo { };
+
   courlan = callPackage ../development/python-modules/courlan { };
 
   coverage = callPackage ../development/python-modules/coverage { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
## Things done
Add a derivation for countryinfo python packages
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
