### PR TITLE
kotatogram-desktop: fix build with GLib 2.86

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
@@ -60,6 +60,7 @@ telegram-desktop.override {
 
     patches = [
       ./macos-qt5.patch
+      ./glib-2.86.patch
       (fetchpatch {
         url = "https://gitlab.com/mnauw/cppgir/-/commit/c8bb1c6017a6f7f2e47bd10543aea6b3ec69a966.patch";
         stripLen = 1;

--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/glib-2.86.patch
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/glib-2.86.patch
@@ -1,0 +1,37 @@
+Submodule Telegram/lib_base contains modified content
+diff --git a/Telegram/lib_base/base/platform/linux/base_url_scheme_linux.cpp b/Telegram/lib_base/base/platform/linux/base_url_scheme_linux.cpp
+index 4197367..f79d2fa 100644
+--- a/Telegram/lib_base/base/platform/linux/base_url_scheme_linux.cpp
++++ b/Telegram/lib_base/base/platform/linux/base_url_scheme_linux.cpp
+@@ -15,7 +15,7 @@
+ #include <kshell.h>
+ #include <ksandbox.h>
+ 
+-#include <gio/gio.hpp>
++#include <giounix/giounix.hpp>
+ #include <snapcraft/snapcraft.hpp>
+ 
+ namespace base::Platform {
+@@ -125,7 +125,7 @@ void RegisterUrlScheme(const UrlSchemeDescriptor &descriptor) {
+ 
+     const auto appId = QGuiApplication::desktopFileName().toStdString();
+     if (!appId.empty()) {
+-        Gio::AppInfo appInfo = Gio::DesktopAppInfo::new_(appId + ".desktop");
++        Gio::AppInfo appInfo = GioUnix::DesktopAppInfo::new_(appId + ".desktop");
+         if (appInfo) {
+             if (appInfo.get_commandline() == commandlineForCreator + " %u") {
+                 appInfo.set_as_default_for_type(handlerType);
+Submodule cmake contains modified content
+diff --git a/cmake/external/glib/CMakeLists.txt b/cmake/external/glib/CMakeLists.txt
+index 3c6fe4b..6f73dc5 100644
+--- a/cmake/external/glib/CMakeLists.txt
++++ b/cmake/external/glib/CMakeLists.txt
+@@ -16,7 +16,7 @@ endfunction()
+ add_cppgir()
+ 
+ include(generate_cppgir.cmake)
+-generate_cppgir(external_glib Gio-2.0)
++generate_cppgir(external_glib GioUnix-2.0)
+ 
+ find_package(PkgConfig REQUIRED)
+ pkg_check_modules(GLIB2 REQUIRED IMPORTED_TARGET glib-2.0 gobject-2.0 gio-2.0 gio-unix-2.0)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
