### PR TITLE
nixos/temporal: tests: Lower `temporal` command timeout to 1 minute

### DIFF
--- a/nixos/tests/temporal.nix
+++ b/nixos/tests/temporal.nix
@@ -274,32 +274,32 @@
       )
 
       import json
-      cluster_list_json = json.loads(temporal.wait_until_succeeds("temporal operator cluster list --output json"))
+      cluster_list_json = json.loads(temporal.wait_until_succeeds("temporal operator cluster list --output json", timeout=60))
       assert cluster_list_json[0]['clusterName'] == "active"
 
-      cluster_describe_json = json.loads(temporal.wait_until_succeeds("temporal operator cluster describe --output json"))
+      cluster_describe_json = json.loads(temporal.wait_until_succeeds("temporal operator cluster describe --output json", timeout=60))
       assert cluster_describe_json['serverVersion'] in "${pkgs.temporal.version}"
 
-      temporal.log(temporal.wait_until_succeeds("temporal operator namespace create --namespace default"))
+      temporal.log(temporal.wait_until_succeeds("temporal operator namespace create --namespace default", timeout=60))
 
       temporal.wait_until_succeeds(
         "journalctl -o cat -u temporal.service | grep 'Register namespace succeeded'"
       )
 
-      namespace_list_json = json.loads(temporal.wait_until_succeeds("temporal operator namespace list --output json"))
+      namespace_list_json = json.loads(temporal.wait_until_succeeds("temporal operator namespace list --output json", timeout=60))
       assert len(namespace_list_json) == 2
 
-      namespace_describe_json = json.loads(temporal.wait_until_succeeds("temporal operator namespace describe --output json --namespace default"))
+      namespace_describe_json = json.loads(temporal.wait_until_succeeds("temporal operator namespace describe --output json --namespace default", timeout=60))
       assert namespace_describe_json['namespaceInfo']['name'] == "default"
       assert namespace_describe_json['namespaceInfo']['state'] == "NAMESPACE_STATE_REGISTERED"
 
-      workflow_json = json.loads(temporal.wait_until_succeeds("temporal workflow list --output json"))
+      workflow_json = json.loads(temporal.wait_until_succeeds("temporal workflow list --output json", timeout=60))
       assert len(workflow_json) == 0
 
-      out = temporal.wait_until_succeeds("temporal-hello-workflow.py")
+      out = temporal.wait_until_succeeds("temporal-hello-workflow.py", timeout=60)
       assert "Result: Hello, World!" in out
 
-      workflow_json = json.loads(temporal.wait_until_succeeds("temporal workflow list --output json"))
+      workflow_json = json.loads(temporal.wait_until_succeeds("temporal workflow list --output json", timeout=60))
       assert workflow_json[0]['execution']['workflowId'] == "hello-activity-workflow-id"
       assert workflow_json[0]['status'] == "WORKFLOW_EXECUTION_STATUS_COMPLETED"
 

--- a/nixos/tests/temporal.nix
+++ b/nixos/tests/temporal.nix
@@ -9,6 +9,8 @@
       temporal =
         { config, pkgs, ... }:
         {
+          virtualisation.cores = 2;
+
           networking.firewall.allowedTCPPorts = [ 7233 ];
 
           environment.systemPackages = [

--- a/nixos/tests/temporal.nix
+++ b/nixos/tests/temporal.nix
@@ -95,6 +95,7 @@
                     asyncio.run(main())
               ''
             )
+            pkgs.grpc-health-probe
             pkgs.temporal-cli
           ];
 
@@ -266,6 +267,18 @@
       temporal.wait_for_open_port(7233)
       temporal.wait_for_open_port(7234)
       temporal.wait_for_open_port(7235)
+
+      temporal.wait_until_succeeds(
+        "grpc-health-probe -addr=localhost:7233 -service=temporal.api.workflowservice.v1.WorkflowService"
+      )
+
+      temporal.wait_until_succeeds(
+        "grpc-health-probe -addr=localhost:7234 -service=temporal.api.workflowservice.v1.HistoryService"
+      )
+
+      temporal.wait_until_succeeds(
+        "grpc-health-probe -addr=localhost:7235 -service=temporal.api.workflowservice.v1.MatchingService"
+      )
 
       temporal.wait_until_succeeds(
         "journalctl -o cat -u temporal.service | grep 'server-version' | grep '${pkgs.temporal.version}'"

--- a/nixos/tests/temporal.nix
+++ b/nixos/tests/temporal.nix
@@ -11,6 +11,7 @@
         {
           virtualisation.cores = 2;
 
+          networking.useDHCP = false;
           networking.firewall.allowedTCPPorts = [ 7233 ];
 
           environment.systemPackages = [


### PR DESCRIPTION
Bail out the commands quickly when [they weirdly timeout](https://github.com/temporalio/cli/issues/847) to stop them from clogging up Hydra

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
