### PR TITLE
python3Packages.blackjax: 1.2.5 -> 1.3

### DIFF
--- a/pkgs/development/python-modules/blackjax/default.nix
+++ b/pkgs/development/python-modules/blackjax/default.nix
@@ -17,24 +17,25 @@
   # checks
   pytestCheckHook,
   pytest-xdist,
-
-  stdenv,
 }:
 
 buildPythonPackage rec {
   pname = "blackjax";
-  version = "1.2.5";
+  version = "1.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "blackjax-devs";
     repo = "blackjax";
     tag = version;
-    hash = "sha256-2GTjKjLIWFaluTjdWdUF9Iim973y81xv715xspghRZI=";
+    hash = "sha256-ystvPfIsnMFYkC+LNtcRQsI19i/y/905SnPSApM8v4E=";
   };
 
   build-system = [ setuptools-scm ];
 
+  pythonRelaxDeps = [
+    "jaxopt"
+  ];
   dependencies = [
     fastprogress
     jax
@@ -75,13 +76,6 @@ buildPythonPackage rec {
     "test_nuts__without_device"
     "test_nuts__without_jit"
     "test_smc_waste_free__with_jit"
-
-    # Numerical test (AssertionError)
-    # First report, when the failure was only happening on aarch64-linux:
-    # https://github.com/blackjax-devs/blackjax/issues/668
-    # Second report, when the test started happening on x86_64-linux too after Jax was updated to 0.7.0
-    # https://github.com/blackjax-devs/blackjax/issues/795
-    "test_chees_adaptation"
   ];
 
   pythonImportsCheck = [ "blackjax" ];


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/blackjax-devs/blackjax/compare/1.2.5...1.3
Changelog: https://github.com/blackjax-devs/blackjax/releases/tag/1.3

cc @bcdarwin

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc