### PR TITLE
hypr{launcher,pwcenter,toolkit,wire}: update to latest versions

### DIFF
--- a/pkgs/by-name/hy/hyprlauncher/package.nix
+++ b/pkgs/by-name/hy/hyprlauncher/package.nix
@@ -19,13 +19,13 @@
 
 gcc15Stdenv.mkDerivation (finalAttrs: {
   pname = "hyprlauncher";
-  version = "0.1.0";
+  version = "0.1.3";
 
   src = fetchFromGitHub {
     owner = "hyprwm";
     repo = "hyprlauncher";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-6JVor77g1LR/22lZYCArUm/geIXE0aGJZ4DHIlgSOj4=";
+    hash = "sha256-KMqHEAuRfO4ep40jxsGW6mnJSeWM41qv63KbWcLBfuw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/hy/hyprpwcenter/package.nix
+++ b/pkgs/by-name/hy/hyprpwcenter/package.nix
@@ -16,13 +16,13 @@
 
 gcc15Stdenv.mkDerivation (finalAttrs: {
   pname = "hyprpwcenter";
-  version = "0.1.0";
+  version = "0.1.1";
 
   src = fetchFromGitHub {
     owner = "hyprwm";
     repo = "hyprpwcenter";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-/kE3VlkJjpFxjbgdKCFumg/Oxn4n7Z//5atAObpPiRY=";
+    hash = "sha256-Hxv5Xjlnv70Q/MGLZ4eTlhW8jYhx4gzhn3YL4oc4hN0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/hy/hyprtoolkit/package.nix
+++ b/pkgs/by-name/hy/hyprtoolkit/package.nix
@@ -8,6 +8,7 @@
   wayland-scanner,
   aquamarine,
   cairo,
+  gtest,
   hyprgraphics,
   hyprlang,
   hyprutils,
@@ -24,13 +25,13 @@
 
 gcc15Stdenv.mkDerivation (finalAttrs: {
   pname = "hyprtoolkit";
-  version = "0.1.1";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "hyprwm";
     repo = "hyprtoolkit";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-SjZAlFpZ/ZpYXj59toamF4qx5rC8RP0U/yEsPVniyI8=";
+    hash = "sha256-M+mlYKvzqW+TSoJ4MH9U+HcFoUmWc1etiXehyLEVB2M=";
   };
 
   nativeBuildInputs = [
@@ -43,6 +44,7 @@ gcc15Stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     aquamarine
     cairo
+    gtest
     hyprgraphics
     hyprlang
     hyprutils

--- a/pkgs/by-name/hy/hyprwire/package.nix
+++ b/pkgs/by-name/hy/hyprwire/package.nix
@@ -11,13 +11,13 @@
 
 gcc15Stdenv.mkDerivation (finalAttrs: {
   pname = "hyprwire";
-  version = "0.1.0";
+  version = "0.1.1";
 
   src = fetchFromGitHub {
     owner = "hyprwm";
     repo = "hyprwire";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-84KqFPakU1Pv7axkwbSi1D5XssSHIW8B2xduOUq5Mw4=";
+    hash = "sha256-EoLyrxFJVr7igDhhVNRk2rRpEEOJllRWvYg5XZ3J5y0=";
   };
 
   nativeBuildInputs = [
@@ -26,9 +26,9 @@ gcc15Stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    pugixml
     hyprutils
     libffi
+    pugixml
   ];
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/hyprwm/hyprlauncher/releases/tag/v0.1.3
https://github.com/hyprwm/hyprpwcenter/releases/tag/v0.1.1
https://github.com/hyprwm/hyprtoolkit/releases/tag/v0.3.0
https://github.com/hyprwm/hyprwire/releases/tag/v0.1.1

Hey, I've updated hyprtoolkit and all packages that depend on it.
Otherwise hyprlauncher and hyprpwcenter would break.

hyprlauncher finds more applications now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
