### PR TITLE
cowsay: cowthink fix #462638

### DIFF
--- a/pkgs/by-name/co/cowsay/package.nix
+++ b/pkgs/by-name/co/cowsay/package.nix
@@ -33,6 +33,17 @@ stdenv.mkDerivation (finalAttrs: {
   postInstall = ''
     wrapProgram $out/bin/cowsay \
       --suffix COWPATH : $out/share/cowsay/cows
+
+    # Replace the cowthink symlink with a Perl wrapper that sets $0 correctly
+    # This is necessary because exec -a doesn't work for Perl scripts
+    rm $out/bin/cowthink
+    cat > $out/bin/cowthink << EOF
+    #!/usr/bin/env perl
+    \$0 = "cowthink";
+    \$ENV{COWPATH} = "\$ENV{COWPATH}" . (\$ENV{COWPATH} ? ":" : "") . "$out/share/cowsay/cows";
+    do "$out/bin/.cowsay-wrapped";
+    EOF
+    chmod +x $out/bin/cowthink
   '';
 
   passthru = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
The cowthink command incorrectly shows speech bubbles < > instead of thought bubbles ( ) because the cowsay Perl script determines bubble type by checking if $0 contains "think", but nixpkgs wrapping breaks this detection since the upstream symlink points to unwrapped cowsay and exec -a doesn't work with Perl scripts. This fix replaces the symlink with a Perl wrapper that sets $0 = "cowthink" before executing the wrapped cowsay script using do, preserving the original detection logic while ensuring proper COWPATH configuration.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
