### PR TITLE
zoho-mail-desktop: init at 1.7.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22458,6 +22458,12 @@
     githubId = 17805516;
     name = "Rohan Rao";
   };
+  rohi-devs = {
+    email = "rohi.devs@gmail.com";
+    github = "rohi-devs";
+    githubId = 129837916;
+    name = "Rohith S";
+  };
   rolfschr = {
     email = "rolf.schr@posteo.de";
     github = "rolfschr";

--- a/pkgs/by-name/zo/zoho-mail-desktop/package.nix
+++ b/pkgs/by-name/zo/zoho-mail-desktop/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  appimageTools,
+  fetchurl,
+}:
+
+let
+  pname = "zoho-mail-desktop";
+  version = "1.7.1";
+
+  src = fetchurl {
+    url = "https://downloads.zohocdn.com/zmail-desktop/linux/zoho-mail-desktop-lite-x64-v${version}.AppImage";
+    hash = "sha256-KLDJl91vfTdDtUQ5maDuCBU1HJQf4V0VEnplAc4ytZM=";
+  };
+
+  appimageContents = appimageTools.extract {
+    inherit pname version src;
+  };
+
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraInstallCommands = ''
+    install -Dm444 ${appimageContents}/zoho-mail-desktop.desktop \
+      $out/share/applications/zoho-mail-desktop.desktop
+
+    install -Dm444 ${appimageContents}/usr/share/icons/hicolor/1024x1024/apps/zoho-mail-desktop.png \
+      $out/share/icons/hicolor/1024x1024/apps/zoho-mail-desktop.png
+
+    substituteInPlace $out/share/applications/zoho-mail-desktop.desktop \
+      --replace-fail 'Exec=AppRun' 'Exec=${pname}'
+  '';
+
+  meta = {
+    description = "Desktop client for Zoho Mail";
+    homepage = "https://www.zoho.com/mail/desktop/";
+    license = lib.licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ rohi-devs ];
+    mainProgram = "zoho-mail-desktop";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
Adds the desktop client for Zoho Mail, distributed as an AppImage.
Includes `.desktop` entry and icons.

Upstream license is proprietary so meta.license = licenses.unfree.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

- Tested, as applicable:
  - [ ] NixOS tests in nixos/tests.
  - [ ] Package tests at passthru.tests.
  - [ ] Tests in lib/tests or pkgs/test.

- [x] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files, usually in ./result/bin/.

- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.

- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.

- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.
