### PR TITLE
ci/github-script/prepare: fix with missing release- branch

### DIFF
--- a/ci/github-script/prepare.js
+++ b/ci/github-script/prepare.js
@@ -128,10 +128,7 @@ module.exports = async ({ github, context, core, dry }) => {
       )
 
       // Make sure that we always check the current target as well, even if its a WIP branch.
-      // If it's not a WIP branch, it was already included in either releases or secondary.
-      if (classify(base.ref).type.includes('wip')) {
-        secondary.push(classify(base.ref))
-      }
+      secondary.push(classify(base.ref))
 
       for (const branch of secondary) {
         const nextCandidate = await mergeBase(branch)


### PR DESCRIPTION
The prepare script is currently failing for staging-25.11 PR's, because it assumes that a release-25.11 exists respectively. This is not the case in the transition phase before branch-off.

We can fix this by always including the current target branch in the branches to check for, even if it's not a WIP branch. This means we might check some branches twice, but that's better than erroring out entirely when the branch is in fact correct.

One example of this failing is https://github.com/NixOS/nixpkgs/pull/462514#pullrequestreview-3471476223.

## Things done

- [x] Tested locally.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
