### PR TITLE
python3Packages.pypaperless: 5.1.0 -> 5.2.0

### DIFF
--- a/pkgs/development/python-modules/pypaperless/default.nix
+++ b/pkgs/development/python-modules/pypaperless/default.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage rec {
   pname = "pypaperless";
-  version = "5.1.0";
+  version = "5.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tb1337";
     repo = "paperless-api";
     tag = "v${version}";
-    hash = "sha256-J2YAUVgiXcb9jM0yDkBkg3X7k8B7hT3dxeEI5Tn2QLY=";
+    hash = "sha256-QZQtANLiOs7Yl/8AAD65LFG5x8CIZHCgSusR55KmgFk=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Diff: https://github.com/tb1337/paperless-api/compare/v5.1.0...v5.2.0

Changelog: https://github.com/tb1337/paperless-api/releases/tag/v5.2.0

I'm confused why `pythonImportsCheck` fails with
```
Check whether the following modules can be imported: pypaperless
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import sys; import importlib; list(map(lambda mod: importlib.import_module(mod), sys.argv[1:]))
                                  ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<string>", line 1, in <lambda>
    import sys; import importlib; list(map(lambda mod: importlib.import_module(mod), sys.argv[1:]))
                                                       ~~~~~~~~~~~~~~~~~~~~~~~^^^^^
  File "/nix/store/7gl4khq26h625mpqzkiiqsify3hclar1-python3-3.13.9/lib/python3.13/importlib/__init__.py", line 88, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 1027, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/nix/store/q37w2li0r5mjyvliprpvg2b8vx8m4vcf-python3.13-pypaperless-5.2.0/lib/python3.13/site-packages/pypaperless/__init__.py", line 3, in <module>
    from .api import Paperless
  File "/nix/store/q37w2li0r5mjyvliprpvg2b8vx8m4vcf-python3.13-pypaperless-5.2.0/lib/python3.13/site-packages/pypaperless/api.py", line 13, in <module>
    from . import helpers
  File "/nix/store/q37w2li0r5mjyvliprpvg2b8vx8m4vcf-python3.13-pypaperless-5.2.0/lib/python3.13/site-packages/pypaperless/helpers.py", line 5, in <module>
    from .models.base import HelperBase  # noqa: F401
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/q37w2li0r5mjyvliprpvg2b8vx8m4vcf-python3.13-pypaperless-5.2.0/lib/python3.13/site-packages/pypaperless/models/__init__.py", line 3, in <module>
    from .classifiers import (
    ...<8 lines>...
    )
  File "/nix/store/q37w2li0r5mjyvliprpvg2b8vx8m4vcf-python3.13-pypaperless-5.2.0/lib/python3.13/site-packages/pypaperless/models/classifiers.py", line 158, in <module>
    class Tag(
    ...<24 lines>...
            self._api_path = self._api_path.format(pk=data.get("id"))
  File "/nix/store/q37w2li0r5mjyvliprpvg2b8vx8m4vcf-python3.13-pypaperless-5.2.0/lib/python3.13/site-packages/pypaperless/models/classifiers.py", line 177, in Tag
    children: list[Tag] | None = None  # noqa: F821
                   ^^^
NameError: name 'Tag' is not defined
```
even though upstream's tests pass.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
