### PR TITLE
nixos/send: Add `environmentFile` option for securely passing secrets

### DIFF
--- a/nixos/modules/services/web-servers/send.nix
+++ b/nixos/modules/services/web-servers/send.nix
@@ -46,6 +46,22 @@ in
         };
       };
 
+      environmentFile = mkOption {
+        default = null;
+        description = ''
+          Environment file (see {manpage}`systemd.exec(5)` "EnvironmentFile="
+          section for the syntax) passed to the service. This option is the
+          recommended way to pass secrets to Send.
+
+          This is especially important for users using a cloud storage backend.
+
+          A list of environment variables recognized by Send can be found here:
+          <https://github.com/timvisee/send/blob/master/docs/docker.md>
+        '';
+        example = "/run/secrets/send";
+        type = with types; nullOr path;
+      };
+
       dataDir = lib.mkOption {
         type = types.path;
         readOnly = true;
@@ -159,6 +175,7 @@ in
         LoadCredential = lib.optionalString (
           cfg.redis.passwordFile != null
         ) "redis-password:${cfg.redis.passwordFile}";
+        EnvironmentFile = cfg.environmentFile;
 
         # Hardening
         RestrictAddressFamilies = [


### PR DESCRIPTION
Currently, NixOS's module for Send (fka. Firefox Send) lacks a way to securely configure the cloud storage backends supported upstream.  While it is technically possible to use these backends by passing credentials using the `environment` option, this creates a well known security risk by exposing credentials in the Nix store.

This change adds an `environmentFile` option, which accepts a path that is subsequently passed to the `serviceConfig.EnvironmentFile` systemd setting, thereby allowing users to use agenix or other secure secret passing schemes of their chosing.

Module maintainer: @moraxyc (hi again!)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
