### PR TITLE
jpegli: init at 0-unstable-2025-02-11

### DIFF
--- a/pkgs/by-name/jp/jpegli/package.nix
+++ b/pkgs/by-name/jp/jpegli/package.nix
@@ -1,0 +1,90 @@
+{
+  stdenv,
+  lib,
+  asciidoc,
+  brotli,
+  cmake,
+  fetchFromGitHub,
+  giflib,
+  gtest,
+  lcms2,
+  libjpeg,
+  libhwy,
+  libpng,
+  ninja,
+  openexr,
+  pkg-config,
+  python3Minimal,
+  unstableGitUpdater,
+}:
+stdenv.mkDerivation {
+  pname = "jpegli";
+  version = "0-unstable-2025-02-11";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "jpegli";
+    rev = "bc19ca2393f79bfe0a4a9518f77e4ad33ce1ab7a";
+    hash = "sha256-8th+QHLOoAIbSJwFyaBxUXoCXwj7K7rgg/cCK7LgOb0=";
+    fetchSubmodules = true;
+  };
+
+  outputs = [
+    "out"
+    "man"
+  ];
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    asciidoc
+    cmake
+    ninja
+    pkg-config
+    python3Minimal
+  ];
+
+  buildInputs = [
+    brotli
+    giflib
+    gtest
+    lcms2
+    libhwy
+    libjpeg
+    libpng
+    openexr
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "JPEGXL_ENABLE_JPEGLI_LIBJPEG" false)
+    (lib.cmakeBool "JPEGXL_BUNDLE_LIBPNG" false)
+    (lib.cmakeBool "JPEGXL_FORCE_SYSTEM_BROTLI" true)
+    (lib.cmakeBool "JPEGXL_FORCE_SYSTEM_GTEST" true)
+    (lib.cmakeBool "JPEGXL_FORCE_SYSTEM_LCMS2" true)
+    (lib.cmakeBool "JPEGXL_FORCE_SYSTEM_HWY" true)
+    # Enable hardware-dependent optimizations
+    (lib.cmakeBool "JPEGXL_ENABLE_SIZELESS_VECTORS" true)
+    (lib.cmakeBool "JPEGXL_ENABLE_AVX512" true)
+    (lib.cmakeBool "JPEGXL_ENABLE_AVX512_SPR" true)
+    (lib.cmakeBool "JPEGXL_ENABLE_AVX512_ZEN4" true)
+    (lib.cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "3.5")
+  ];
+
+  doCheck = true;
+
+  passthru = {
+    updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
+  };
+
+  meta = {
+    description = "Improved JPEG encoder and decoder implementation";
+    homepage = "https://github.com/google/jpegli";
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [
+      jwillikers
+      leiserfg
+    ];
+    mainProgram = "cjpegli";
+  };
+}


### PR DESCRIPTION
[jpegli](https://github.com/google/jpegli) is an improved JPEG encoder and decoder implementation.

Fixes https://github.com/NixOS/nixpkgs/issues/361872
closes #413118
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
