### PR TITLE
cross: Fix shebang of installed python scripts

### DIFF
--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -138,6 +138,7 @@ in
           propagatedBuildInputs = [ installer ];
           substitutions = {
             inherit pythonInterpreter pythonSitePackages;
+            python = python.interpreter;
           };
         } ./pypa-install-hook.sh
       )

--- a/pkgs/development/interpreters/python/hooks/pypa-install-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pypa-install-hook.sh
@@ -8,7 +8,7 @@ pypaInstallPhase() {
     pushd dist >/dev/null
 
     for wheel in *.whl; do
-        @pythonInterpreter@ -m installer --prefix "$out" "$wheel"
+        @pythonInterpreter@ -m installer --prefix "$out" --executable "@python@" "$wheel"
         echo "Successfully installed $wheel"
     done
 

--- a/pkgs/development/python-modules/installer/cross.patch
+++ b/pkgs/development/python-modules/installer/cross.patch
@@ -1,0 +1,67 @@
+diff --git a/src/installer/__main__.py b/src/installer/__main__.py
+index 51014b9..45682d0 100644
+--- a/src/installer/__main__.py
++++ b/src/installer/__main__.py
+@@ -30,6 +30,13 @@ def _get_main_parser() -> argparse.ArgumentParser:
+         type=str,
+         help="override prefix to install packages to",
+     )
++    parser.add_argument(
++        "--executable",
++        metavar="path",
++        default=sys.executable,
++        type=str,
++        help="#! executable to install scripts with (default=sys.executable)",
++    )
+     parser.add_argument(
+         "--compile-bytecode",
+         action="append",
+@@ -86,7 +93,7 @@ def _main(cli_args: Sequence[str], program: Optional[str] = None) -> None:
+     with WheelFile.open(args.wheel) as source:
+         destination = SchemeDictionaryDestination(
+             scheme_dict=_get_scheme_dict(source.distribution, prefix=args.prefix),
+-            interpreter=sys.executable,
++            interpreter=args.executable,
+             script_kind=get_launcher_kind(),
+             bytecode_optimization_levels=bytecode_levels,
+             destdir=args.destdir,
+@@ -94,5 +101,6 @@ def _main(cli_args: Sequence[str], program: Optional[str] = None) -> None:
+         installer.install(source, destination, {})
+ 
+ 
++
+ if __name__ == "__main__":  # pragma: no cover
+     _main(sys.argv[1:], "python -m installer")
+diff --git a/tests/test_main.py b/tests/test_main.py
+index 391a13d..d7b4192 100644
+--- a/tests/test_main.py
++++ b/tests/test_main.py
+@@ -53,6 +53,28 @@ def test_main_prefix(fancy_wheel, tmp_path):
+     }
+ 
+ 
++def test_main_executable(fancy_wheel, tmp_path):
++    destdir = tmp_path / "dest"
++
++    main(
++        [
++            str(fancy_wheel),
++            "-d",
++            str(destdir),
++            "--executable",
++            "/monty/python3.x",
++        ],
++        "python -m installer",
++    )
++
++    installed_scripts = destdir.rglob("bin/*")
++
++    for f in installed_scripts:
++        with f.open("rb") as fp:
++            shebang = fp.readline()
++            assert shebang == b"#!/monty/python3.x\n"
++
++
+ def test_main_no_pyc(fancy_wheel, tmp_path):
+     destdir = tmp_path / "dest"
+ 

--- a/pkgs/development/python-modules/installer/default.nix
+++ b/pkgs/development/python-modules/installer/default.nix
@@ -21,11 +21,17 @@ buildPythonPackage rec {
     hash = "sha256-thHghU+1Alpay5r9Dc3v7ATRFfYKV8l9qR0nbGOOX/A=";
   };
 
-  patches = lib.optionals (pythonAtLeast "3.13") [
-    # Fix compatibility with Python 3.13
-    # https://github.com/pypa/installer/pull/201
-    ./python313-compat.patch
-  ];
+  patches =
+    lib.optionals (pythonAtLeast "3.13") [
+      # Fix compatibility with Python 3.13
+      # https://github.com/pypa/installer/pull/201
+      ./python313-compat.patch
+    ]
+    ++ [
+      # Add -m flag to installer to correctly support cross
+      # https://github.com/pypa/installer/pull/258
+      ./cross.patch
+    ];
 
   nativeBuildInputs = [ flit-core ];
 


### PR DESCRIPTION
An alternative to the below PR

Closes: https://github.com/NixOS/nixpkgs/pull/449340
Fixes: https://github.com/NixOS/nixpkgs/issues/449325

It uses a patch to `installer` that was accepted upstream, then reverted because it was too much functionality and if somebody wants it they should implement a different frontend to the `installer` command using `installer` as a library. For now we just need one more CLI flag so the burden of carrying this patch is lower to the one of copy pasting the CLI part of `installer` with the patch.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
