### PR TITLE
[25.05] breitbandmessung: 3.9.0 -> 3.10.0, update to electron_38

### DIFF
--- a/pkgs/by-name/br/breitbandmessung/package.nix
+++ b/pkgs/by-name/br/breitbandmessung/package.nix
@@ -4,7 +4,7 @@
   fetchurl,
   asar,
   dpkg,
-  electron_36,
+  electron_38,
   makeWrapper,
   nixosTests,
   undmg,
@@ -13,7 +13,7 @@
 let
   inherit (stdenv.hostPlatform) system;
 
-  electron = electron_36;
+  electron = electron_38;
 
   sources = import ./sources.nix;
 

--- a/pkgs/by-name/br/breitbandmessung/package.nix
+++ b/pkgs/by-name/br/breitbandmessung/package.nix
@@ -64,6 +64,9 @@ let
 
         sourceRoot = "Breitbandmessung.app";
 
+        dontFixup = true;
+        dontStrip = true;
+
         installPhase = ''
           runHook preInstall
           mkdir -p $out/Applications/Breitbandmessung.app

--- a/pkgs/by-name/br/breitbandmessung/package.nix
+++ b/pkgs/by-name/br/breitbandmessung/package.nix
@@ -62,6 +62,8 @@ let
 
         nativeBuildInputs = [ undmg ];
 
+        sourceRoot = "Breitbandmessung.app";
+
         installPhase = ''
           runHook preInstall
           mkdir -p $out/Applications/Breitbandmessung.app

--- a/pkgs/by-name/br/breitbandmessung/sources.nix
+++ b/pkgs/by-name/br/breitbandmessung/sources.nix
@@ -1,11 +1,11 @@
 {
-  version = "3.9.0";
+  version = "3.9.1";
   x86_64-linux = {
-    url = "https://download.breitbandmessung.de/bbm/Breitbandmessung-3.9.0-linux.deb";
-    sha256 = "sha256-OG+oZr5UHIjrQOxPmLs/DzGJuUAd5pAyvLuTOvhC+20=";
+    url = "https://download.breitbandmessung.de/bbm/Breitbandmessung-3.9.1-linux.deb";
+    sha256 = "sha256-BKfvV9oCzmIS/B1xoPmDELyT8MPLnGCoZ2sXk2aMh5A=";
   };
   x86_64-darwin = {
-    url = "https://download.breitbandmessung.de/bbm/Breitbandmessung-3.9.0-mac.dmg";
-    sha256 = "sha256-Tvb2Cum/Bavu+VAVS/1O7pxSIVLdP2XzTG27fhgIh9E=";
+    url = "https://download.breitbandmessung.de/bbm/Breitbandmessung-3.9.1-mac.dmg";
+    sha256 = "sha256-NzxNOkncfZkaEaHqmrS4Xz0R5yly7yOff6+/czYgmB0=";
   };
 }

--- a/pkgs/by-name/br/breitbandmessung/sources.nix
+++ b/pkgs/by-name/br/breitbandmessung/sources.nix
@@ -1,11 +1,11 @@
 {
-  version = "3.9.1";
+  version = "3.10.0";
   x86_64-linux = {
-    url = "https://download.breitbandmessung.de/bbm/Breitbandmessung-3.9.1-linux.deb";
-    sha256 = "sha256-BKfvV9oCzmIS/B1xoPmDELyT8MPLnGCoZ2sXk2aMh5A=";
+    url = "https://download.breitbandmessung.de/bbm/Breitbandmessung-3.10.0-linux.deb";
+    sha256 = "sha256-Lh1bVV7hp1XvQoeToxkOtT5Tdq7ayUDzR6D/VgDSIWQ=";
   };
   x86_64-darwin = {
-    url = "https://download.breitbandmessung.de/bbm/Breitbandmessung-3.9.1-mac.dmg";
-    sha256 = "sha256-NzxNOkncfZkaEaHqmrS4Xz0R5yly7yOff6+/czYgmB0=";
+    url = "https://download.breitbandmessung.de/bbm/Breitbandmessung-3.10.0-mac.dmg";
+    sha256 = "sha256-sdBOcjc4q3LUKwCz+gHisMtg4aH1I21R6/5T5IZ/ah8=";
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Backport of:
- https://github.com/NixOS/nixpkgs/pull/421973
- https://github.com/NixOS/nixpkgs/pull/430640
- https://github.com/NixOS/nixpkgs/pull/440314
- https://github.com/NixOS/nixpkgs/pull/458505

Related to `electron_36` EOL: https://github.com/NixOS/nixpkgs/pull/461995

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
