### PR TITLE
distrobox: ensure grep is in the PATH

### DIFF
--- a/pkgs/by-name/di/distrobox/package.nix
+++ b/pkgs/by-name/di/distrobox/package.nix
@@ -5,6 +5,8 @@
   makeWrapper,
   wget,
   gnugrep,
+  nix-update-script,
+  testers,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -14,7 +16,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "89luca89";
     repo = "distrobox";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-uwJD7HsWoQ/LxYL0mSSxMni676qqEnMHndpL01M5ySE=";
   };
 
@@ -48,7 +50,14 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     echo 'container_additional_volumes="/nix:/nix"' > $out/share/distrobox/distrobox.conf
   '';
 
-  meta = with lib; {
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+    };
+  };
+
+  meta = {
     description = "Wrapper around podman or docker to create and start containers";
     longDescription = ''
       Use any linux distribution inside your terminal. Enable both backward and
@@ -56,9 +65,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       you’re more comfortable with
     '';
     homepage = "https://distrobox.it/";
-    license = licenses.gpl3Only;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ atila ];
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ atila ];
     mainProgram = "distrobox";
   };
 })

--- a/pkgs/by-name/di/distrobox/package.nix
+++ b/pkgs/by-name/di/distrobox/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   makeWrapper,
   wget,
+  gnugrep,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -40,6 +41,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     wrapProgram "$out/bin/distrobox-generate-entry" \
       --prefix PATH ":" ${lib.makeBinPath [ wget ]}
 
+    wrapProgram "$out/bin/${finalAttrs.meta.mainProgram}" \
+      --prefix PATH ":" ${lib.makeBinPath [ gnugrep ]}
+
     mkdir -p $out/share/distrobox
     echo 'container_additional_volumes="/nix:/nix"' > $out/share/distrobox/distrobox.conf
   '';
@@ -55,5 +59,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     license = licenses.gpl3Only;
     platforms = platforms.linux;
     maintainers = with maintainers; [ atila ];
+    mainProgram = "distrobox";
   };
 })


### PR DESCRIPTION
Resolves #462947

cc @eclairevoyant for testing

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
