### PR TITLE
blender: 4.5.4 -> 5.0.0

### DIFF
--- a/pkgs/by-name/bl/blender/fix-hip-path.patch
+++ b/pkgs/by-name/bl/blender/fix-hip-path.patch
@@ -1,0 +1,25 @@
+commit 0c7159ed66e28b4da4275cd79e01b2d0669808a3 (HEAD -> fix-hip-path-syntax-error, amarshall/fix-hip-path-syntax-error)
+Author: Andrew Marshall <andrew@johnandrewmarshall.com>
+Date:   Thu Nov 20 20:24:20 2025 -0500
+
+    Fix: Incorrect HIP load path on Linux
+    
+    Missing comma meant the following line was concatenated with this one,
+    causing the path to be
+    "/opt/rocm/hip/lib/libamdhip64.so.6libamdhip64.so.7".
+    
+    Broken in 14bd7a531feddb81a0e522b7db76288639f1ad05.
+
+diff --git a/extern/hipew/src/hipew.c b/extern/hipew/src/hipew.c
+index 3ce13ef7c32..e72ccde69ef 100644
+--- a/extern/hipew/src/hipew.c
++++ b/extern/hipew/src/hipew.c
+@@ -244,7 +244,7 @@ static int hipewHipInit(void) {
+   const char* hip_paths[] = { "libamdhip64.so",
+                             "libamdhip64.so.6",
+                             "/opt/rocm/lib/libamdhip64.so.6",
+-                            "/opt/rocm/hip/lib/libamdhip64.so.6"
++                            "/opt/rocm/hip/lib/libamdhip64.so.6",
+                             "libamdhip64.so.7",
+                             "/opt/rocm/lib/libamdhip64.so.7",
+                             "/opt/rocm/hip/lib/libamdhip64.so.7",

--- a/pkgs/by-name/bl/blender/package.nix
+++ b/pkgs/by-name/bl/blender/package.nix
@@ -69,6 +69,7 @@
   pugixml,
   python3Packages, # must use instead of python3.pkgs, see https://github.com/NixOS/nixpkgs/issues/211340
   rocmPackages, # comes with a significantly larger closure size
+  rubberband,
   runCommand,
   shaderc,
   spaceNavSupport ? stdenv.hostPlatform.isLinux,
@@ -116,13 +117,17 @@ in
 
 stdenv'.mkDerivation (finalAttrs: {
   pname = "blender";
-  version = "4.5.4";
+  version = "5.0.0";
 
   src = fetchzip {
     name = "source";
     url = "https://download.blender.org/source/blender-${finalAttrs.version}.tar.xz";
-    hash = "sha256-/cYMCWgojkO1mqzJ4BZwbwXPuBmg66T+gzpEuLiOskY=";
+    hash = "sha256-UUHsylDmMWRcr1gGiXuYnno7D6uMjLqTYd9ak4FnZis=";
   };
+
+  patches = [
+    ./fix-hip-path.patch # https://projects.blender.org/blender/blender/pulls/150321
+  ];
 
   postPatch =
     (lib.optionalString stdenv.hostPlatform.isDarwin ''
@@ -263,6 +268,7 @@ stdenv'.mkDerivation (finalAttrs: {
     pugixml
     python3
     python3Packages.materialx
+    rubberband
     zlib
     zstd
   ]


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Built and tested CUDA render.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `62b927a3095ec9065e2bbc838ecb635ba5e513e4`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 3 packages built:</summary>
  <ul>
    <li>blender</li>
    <li>blender-hip</li>
    <li>blendfarm</li>
  </ul>
</details>


[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
