### PR TITLE
goldendict-ng: 25.05.0 -> 25.10.2

### DIFF
--- a/pkgs/applications/misc/goldendict-ng/default.nix
+++ b/pkgs/applications/misc/goldendict-ng/default.nix
@@ -28,16 +28,18 @@
   wrapGAppsHook3,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "goldendict-ng";
   version = "25.10.2";
 
   src = fetchFromGitHub {
     owner = "xiaoyifang";
     repo = "goldendict-ng";
-    tag = "v25.10.2-Release.673d1b90";
+    tag = "v${finalAttrs.version}-Release.673d1b90";
     hash = "sha256-afzMUko09vGmQvu6sob8jYfVUvQECoUdAmIbLIoh1Dw=";
   };
+
+  strictDeps = true;
 
   nativeBuildInputs = [
     pkg-config
@@ -45,6 +47,7 @@ stdenv.mkDerivation {
     wrapQtAppsHook
     wrapGAppsHook3
   ];
+
   buildInputs = [
     qtbase
     qtsvg
@@ -68,7 +71,7 @@ stdenv.mkDerivation {
     libzim
   ];
 
-  # to prevent double wrapping of wrapQtApps and wrapGApps
+  # Prevent double wrapping of wrapQtApps and wrapGApps
   dontWrapGApps = true;
 
   preFixup = ''
@@ -84,16 +87,16 @@ stdenv.mkDerivation {
     "-DUSE_SYSTEM_TOML=ON"
   ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://xiaoyifang.github.io/goldendict-ng/";
     description = "Advanced multi-dictionary lookup program";
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "goldendict";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       slbtty
       michojel
       linsui
     ];
-    license = licenses.gpl3Plus;
+    license = lib.licenses.gpl3Plus;
   };
-}
+})

--- a/pkgs/applications/misc/goldendict-ng/default.nix
+++ b/pkgs/applications/misc/goldendict-ng/default.nix
@@ -30,13 +30,13 @@
 
 stdenv.mkDerivation {
   pname = "goldendict-ng";
-  version = "25.05.0";
+  version = "25.10.2";
 
   src = fetchFromGitHub {
     owner = "xiaoyifang";
     repo = "goldendict-ng";
-    tag = "v25.05.0-Release.2a2b0e16";
-    hash = "sha256-PBqkVac867xE4ZcvwTysAK6rQSoEZelKrV9USvFsaLk=";
+    tag = "v25.10.2-Release.673d1b90";
+    hash = "sha256-afzMUko09vGmQvu6sob8jYfVUvQECoUdAmIbLIoh1Dw=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Resolves #463000

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
