### PR TITLE
libxml2: fetch patch fixing CVE-2025-12863 in xmlSetTreeDoc

### DIFF
--- a/pkgs/development/libraries/libxml2/CVE-2025-12863.patch
+++ b/pkgs/development/libraries/libxml2/CVE-2025-12863.patch
@@ -1,0 +1,49 @@
+From 0bdccc7ea453df4030787da073f55f2d7b10803a Mon Sep 17 00:00:00 2001
+From: Ahmed Lekssays <lekssaysahmed@gmail.com>
+Date: Thu, 6 Nov 2025 11:22:01 +0300
+Subject: [PATCH] Fix UAF in xmlSetTreeDoc() - Issue #1012
+
+---
+ tree.c | 16 +++++++++++++++-
+ 1 file changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/tree.c b/tree.c
+index e4fd0d6e5..bd345ae25 100644
+--- a/tree.c
++++ b/tree.c
+@@ -2586,10 +2586,12 @@ xmlNodeSetDoc(xmlNodePtr node, xmlDocPtr doc) {
+ int
+ xmlSetTreeDoc(xmlNode *tree, xmlDoc *doc) {
+     int ret = 0;
++    xmlDocPtr oldDoc;
+ 
+     if ((tree == NULL) || (tree->type == XML_NAMESPACE_DECL))
+ 	return(0);
+-    if (tree->doc == doc)
++    oldDoc = tree->doc;
++    if (oldDoc == doc)
+         return(0);
+ 
+     if (tree->type == XML_ELEMENT_NODE) {
+@@ -2617,6 +2619,18 @@ xmlSetTreeDoc(xmlNode *tree, xmlDoc *doc) {
+     if (xmlNodeSetDoc(tree, doc) < 0)
+         ret = -1;
+ 
++    /*
++     * Reconcile namespaces when moving between documents.
++     * This prevents use-after-free when namespaces from the old
++     * document are accessed after the old document is freed.
++     */
++    if ((ret == 0) && (oldDoc != doc) && (tree->type == XML_ELEMENT_NODE)) {
++        if (xmlReconciliateNs(doc, tree) < 0) {
++            /* Reconciliation failed, but document was already changed */
++            ret = -1;
++        }
++    }
++
+     return(ret);
+ }
+ 
+-- 
+GitLab
+

--- a/pkgs/development/libraries/libxml2/common.nix
+++ b/pkgs/development/libraries/libxml2/common.nix
@@ -49,7 +49,12 @@ stdenv'.mkDerivation (finalAttrs: {
   ++ lib.optional (enableStatic && enableShared) "static";
   outputMan = "bin";
 
-  patches = [ ] ++ extraPatches;
+  patches = [
+    # https://gitlab.gnome.org/GNOME/libxml2/-/merge_requests/349
+    # debian already uses this patch, despite it not being merged upstream
+    ./CVE-2025-12863.patch
+  ]
+  ++ extraPatches;
 
   strictDeps = true;
 


### PR DESCRIPTION
Patch source: https://gitlab.gnome.org/GNOME/libxml2/-/merge_requests/349

Debian already uses this patch despite it not being merged upstream yet [1]. We should too.

Fixes CVE-2025-12863

[1] https://salsa.debian.org/xml-sgml-team/libxml2/-/commit/66caa6af18f3e03680b27fa11c3fc0e27e314b2e

cc @LeSuisse who brought up this CVE over on matrix


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
