### PR TITLE
megacmd-bin: init at 2.4.0

### DIFF
--- a/pkgs/by-name/le/legends-of-equestria/package.nix
+++ b/pkgs/by-name/le/legends-of-equestria/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   runCommand,
-  megacmd,
+  megacmd-bin,
   unzip,
   makeWrapper,
   autoPatchelfHook,
@@ -101,7 +101,7 @@ stdenv.mkDerivation {
           pname = "${pname}-source";
           inherit version;
           nativeBuildInputs = [
-            megacmd
+            megacmd-bin
             unzip
           ];
           outputHashAlgo = "sha256";

--- a/pkgs/by-name/me/megacmd-bin/package.nix
+++ b/pkgs/by-name/me/megacmd-bin/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  versionCheckHook,
+  dpkg,
+  gcc-unwrapped,
+  fuse,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "megacmd";
+  version = "2.4.0";
+
+  src =
+    let
+      base_url = "https://mega.nz/linux/repo/xUbuntu_25.10/";
+    in
+    {
+      x86_64-linux = fetchurl {
+        url = "${base_url}/amd64/megacmd_${version}-1.1_amd64.deb";
+        hash = "sha256-rcgjZHfWyCtC1JU6kdonVa2uRpXIBG6lp4XD+cKB9VE=";
+      };
+      aarch64-linux = fetchurl {
+        url = "${base_url}/arm64/megacmd_${version}-1.1_arm64.deb";
+        hash = "sha256-laNWyQpF3Xy40FLjeqY9RmUOR7ewHwlMUtGaEurJZdQ=";
+      };
+    }
+    .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  sourceRoot = "megacmd";
+  unpackCmd = "dpkg -x $src ./${sourceRoot}";
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+  ];
+
+  buildInputs = [
+    gcc-unwrapped
+    fuse
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+
+    cp -r usr/{bin,share} $out/
+    cp -r opt/megacmd/lib $out/lib
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/mega-exec";
+  versionCheckProgramArg = "version";
+
+  meta = {
+    description = "MEGA Command Line Interactive and Scriptable Application";
+    homepage = "https://mega.io/cmd";
+    license = with lib.licenses; [
+      bsd2
+      gpl3Only
+    ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      lunik1
+      ulysseszhan
+    ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

WIP binary replacement for `megacmd` since we can't build any versions since 2.0.0 #380258 

Fixes #459126

@UlyssesZh I currently only fetch the linux binaries and can't easily test on mac. Would you be able to add darwin support?

Not sure if we can redistribute these binaries too, so maybe we need to mark this as unfree/don't build on hydra?

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
