### PR TITLE
eb-garamond: disable ttfautohint's GUI

### DIFF
--- a/pkgs/by-name/eb/eb-garamond/package.nix
+++ b/pkgs/by-name/eb/eb-garamond/package.nix
@@ -5,14 +5,14 @@
   python3,
   ttfautohint-nox,
 }:
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "eb-garamond";
   version = "0.016";
 
   src = fetchFromGitHub {
     owner = "georgd";
     repo = "EB-Garamond";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-ajieKhTeH6yv2qiE2xqnHFoMS65//4ZKiccAlC2PXGQ=";
   };
 
@@ -42,15 +42,15 @@ stdenvNoCC.mkDerivation rec {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "http://www.georgduffner.at/ebgaramond/";
     description = "Digitization of the Garamond shown on the Egenolff-Berner specimen";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       bengsparks
       relrod
       rycee
     ];
-    license = licenses.ofl;
-    platforms = platforms.all;
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/eb/eb-garamond/package.nix
+++ b/pkgs/by-name/eb/eb-garamond/package.nix
@@ -3,7 +3,7 @@
   stdenvNoCC,
   fetchFromGitHub,
   python3,
-  ttfautohint,
+  ttfautohint-nox,
 }:
 stdenvNoCC.mkDerivation rec {
   pname = "eb-garamond";
@@ -18,7 +18,7 @@ stdenvNoCC.mkDerivation rec {
 
   nativeBuildInputs = [
     (python3.withPackages (p: [ p.fontforge ]))
-    ttfautohint
+    ttfautohint-nox
   ];
 
   postPatch = ''


### PR DESCRIPTION
The darwin build will likely continue working once staging(-next) has been merged into master again.
This simply remove the GUI dependencies from the package's closure.

```console
ben at BenjaminsLaptop in ~/coding/nixpkgs (master) 
$ nom-build -A eb-garamond --system aarch64-linux
warning: Nix search path entry '/nix/var/nix/profiles/per-user/root/channels' does not exist, ignoring
Finished at 23:29:22 after 1s
/nix/store/dplp9520hvsh0kkv4c1p4r9106fzb2zz-eb-garamond-0.016
```

```console
ben at BenjaminsLaptop in ~/coding/nixpkgs (master) 
$ nom-build -A eb-garamond --system x86_64-linux 
warning: Nix search path entry '/nix/var/nix/profiles/per-user/root/channels' does not exist, ignoring
this path will be fetched (2.24 MiB download, 5.69 MiB unpacked):
  /nix/store/xbvwwz2yva8vnc122xq42zzqxrf5zp0j-eb-garamond-0.016
copying path '/nix/store/xbvwwz2yva8vnc122xq42zzqxrf5zp0j-eb-garamond-0.016' from 'https://cache.nixos.org'
┏━━━ Downloads       │ Host                         
┃        │     │     │ localhost                    
┃        │ ↓ 1 │     │ https://cache.nixos.org      
┗━ ∑ ↓ 0 │ ↓ 1 │ ⏸ 0 │ Finished at 23:29:32 after 6s
/nix/store/xbvwwz2yva8vnc122xq42zzqxrf5zp0j-eb-garamond-0.016
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
