### PR TITLE
blender-hip: remove in favor of config.rocmSupport = true

### DIFF
--- a/pkgs/by-name/bl/blender/package.nix
+++ b/pkgs/by-name/bl/blender/package.nix
@@ -95,8 +95,9 @@ let
     (!stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isLinux) || stdenv.hostPlatform.isDarwin;
   vulkanSupport = !stdenv.hostPlatform.isDarwin;
 
-  python3 = python311Packages.python;
-  pyPkgsOpenusd = python311Packages.openusd.override (old: {
+  python3Packages = python311Packages;
+  python3 = python3Packages.python;
+  pyPkgsOpenusd = python3Packages.openusd.override (old: {
     opensubdiv = old.opensubdiv.override { inherit cudaSupport; };
     withOsl = false;
   });
@@ -131,7 +132,7 @@ stdenv'.mkDerivation (finalAttrs: {
       substituteInPlace source/creator/CMakeLists.txt \
         --replace-fail '${"$"}{LIBDIR}/python' \
                   '${python3}' \
-        --replace-fail '${"$"}{LIBDIR}/materialx/' '${python311Packages.materialx}/'
+        --replace-fail '${"$"}{LIBDIR}/materialx/' '${python3Packages.materialx}/'
       substituteInPlace build_files/cmake/platform/platform_apple.cmake \
         --replace-fail '${"$"}{LIBDIR}/brotli/lib/libbrotlicommon-static.a' \
                   '${lib.getLib brotli}/lib/libbrotlicommon.dylib' \
@@ -149,12 +150,12 @@ stdenv'.mkDerivation (finalAttrs: {
   cmakeFlags = [
     "-C../build_files/cmake/config/blender_release.cmake"
 
-    (lib.cmakeFeature "MaterialX_DIR" "${python311Packages.materialx}/lib/cmake/MaterialX")
+    (lib.cmakeFeature "MaterialX_DIR" "${python3Packages.materialx}/lib/cmake/MaterialX")
     (lib.cmakeFeature "PYTHON_INCLUDE_DIR" "${python3}/include/${python3.libPrefix}")
     (lib.cmakeFeature "PYTHON_LIBPATH" "${python3}/lib")
     (lib.cmakeFeature "PYTHON_LIBRARY" "${python3.libPrefix}")
-    (lib.cmakeFeature "PYTHON_NUMPY_INCLUDE_DIRS" "${python311Packages.numpy_1}/${python3.sitePackages}/numpy/core/include")
-    (lib.cmakeFeature "PYTHON_NUMPY_PATH" "${python311Packages.numpy_1}/${python3.sitePackages}")
+    (lib.cmakeFeature "PYTHON_NUMPY_INCLUDE_DIRS" "${python3Packages.numpy_1}/${python3.sitePackages}/numpy/core/include")
+    (lib.cmakeFeature "PYTHON_NUMPY_PATH" "${python3Packages.numpy_1}/${python3.sitePackages}")
     (lib.cmakeFeature "PYTHON_VERSION" "${python3.pythonVersion}")
 
     (lib.cmakeBool "WITH_BUILDINFO" false)
@@ -221,7 +222,7 @@ stdenv'.mkDerivation (finalAttrs: {
     cmake
     llvmPackages.llvm.dev
     makeWrapper
-    python311Packages.wrapPython
+    python3Packages.wrapPython
   ]
   ++ lib.optionals cudaSupport [
     addDriverRunpath
@@ -263,7 +264,7 @@ stdenv'.mkDerivation (finalAttrs: {
     potrace
     pugixml
     python3
-    python311Packages.materialx
+    python3Packages.materialx
     rubberband
     zlib
     zstd
@@ -316,7 +317,7 @@ stdenv'.mkDerivation (finalAttrs: {
 
   pythonPath =
     let
-      ps = python311Packages;
+      ps = python3Packages;
     in
     [
       ps.materialx
@@ -362,13 +363,13 @@ stdenv'.mkDerivation (finalAttrs: {
 
   passthru = {
     python = python3;
-    pythonPackages = python311Packages;
+    pythonPackages = python3Packages;
 
     withPackages =
       f:
       (callPackage ./wrapper.nix { }).override {
         blender = finalAttrs.finalPackage;
-        extraModules = (f python311Packages);
+        extraModules = (f python3Packages);
       };
 
     tests = {

--- a/pkgs/development/rocm-modules/6/release-attrPaths.json
+++ b/pkgs/development/rocm-modules/6/release-attrPaths.json
@@ -18,6 +18,7 @@
     "audiobookshelf",
     "babeldoc",
     "backgroundremover",
+    "blender",
     "btop",
     "btop-cuda",
     "c3d",

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -364,6 +364,7 @@ mapAliases {
   bitwarden_rs-sqlite = throw "'bitwarden_rs-sqlite' has been renamed to/replaced by 'vaultwarden-sqlite'"; # Converted to throw 2025-10-27
   bitwarden_rs-vault = throw "'bitwarden_rs-vault' has been renamed to/replaced by 'vaultwarden-vault'"; # Converted to throw 2025-10-27
   blas-reference = throw "blas-reference has been removed since it has been discontinued as free-standing package. It is now contained within lapack-reference."; # Added 2025-10-21
+  blender-hip = throw "blender-hip has been removed in favor of setting `config.rocmSupport = true` or using `pkgsRocm.blender`"; # Added 2026-01-04
   blender-with-packages = throw "blender-with-packages is deprecated in in favor of blender.withPackages, e.g. `blender.withPackages(ps: [ ps.foobar ])`"; # Converted to throw 2025-10-26
   blockbench-electron = throw "'blockbench-electron' has been renamed to/replaced by 'blockbench'"; # Converted to throw 2025-10-27
   bloomeetunes = throw "bloomeetunes is unmaintained and has been removed"; # Added 2025-08-26

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10367,8 +10367,6 @@ with pkgs;
     pinentry = pinentry-curses;
   };
 
-  blender-hip = blender.override { hipSupport = true; };
-
   blucontrol = callPackage ../applications/misc/blucontrol/wrapper.nix {
     inherit (haskellPackages) ghcWithPackages;
   };


### PR DESCRIPTION
Prior to e720baecf0371b0c92b6c1bddebe9f21ce2fd050 (Nov 2023), there was no global config.rocmSupport, and Blender’s hipSupport param predates that. Since the global config now exists, defer to that instead.

The closure size of various ROCm packages has also been reduced recently in 32d957e0cd38f83fd7a40f9a3fe1dd04f5fd7f0f.

Add to rocm release attrs so Hydra will build it.

See individual commits for details.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
