### PR TITLE
antigravity: 1.11.3-6583016683339776 -> 1.11.3

### DIFF
--- a/pkgs/by-name/an/antigravity/package.nix
+++ b/pkgs/by-name/an/antigravity/package.nix
@@ -15,7 +15,7 @@ let
     (lib.importJSON ./sources.json)."${hostPlatform.system}"
       or (throw "antigravity: unsupported system ${hostPlatform.system}");
 
-  version = "1.11.3-6583016683339776";
+  version = "1.11.3";
   vscodeVersion = "1.104.0";
 in
 callPackage vscode-generic {

--- a/pkgs/by-name/an/antigravity/package.nix
+++ b/pkgs/by-name/an/antigravity/package.nix
@@ -57,6 +57,9 @@ callPackage vscode-generic {
       "x86_64-darwin"
       "aarch64-darwin"
     ];
-    maintainers = with lib.maintainers; [ Zaczero ];
+    maintainers = with lib.maintainers; [
+      xiaoxiangmoe
+      Zaczero
+    ];
   };
 }

--- a/pkgs/by-name/an/antigravity/package.nix
+++ b/pkgs/by-name/an/antigravity/package.nix
@@ -43,6 +43,8 @@ callPackage vscode-generic {
   tests = { };
   updateScript = ./update.sh;
 
+  dontFixup = hostPlatform.isDarwin;
+
   meta = {
     mainProgram = "antigravity";
     description = "Agentic development platform, evolving the IDE into the agent-first era";

--- a/pkgs/by-name/an/antigravity/update.sh
+++ b/pkgs/by-name/an/antigravity/update.sh
@@ -23,7 +23,7 @@ linux_x86_64_url=$(
 # Extract version and check for update
 version=$(
   printf '%s\n' "$linux_x86_64_url" \
-    | sed -n 's#.*/stable/\([^/]*\)/linux-x64/Antigravity.tar.gz#\1#p'
+    | sed -n 's#.*/stable/\([^-]*\)-[0-9]*/linux-x64/Antigravity.tar.gz#\1#p'
 )
 echo "Version: $version"
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
