### PR TITLE
nexusmods-app: 0.20.2 → 0.21.1

### DIFF
--- a/pkgs/by-name/ne/nexusmods-app/deps.json
+++ b/pkgs/by-name/ne/nexusmods-app/deps.json
@@ -5,6 +5,11 @@
     "hash": "sha256-YCv5pEi5JJRJlyncpqO1eTzMi5jYeecWdj5YphUOgpY="
   },
   {
+    "pname": "Argon",
+    "version": "0.32.0",
+    "hash": "sha256-V8qLTM0OwqBMd6Ok1Pv3+z8V4TP/rb6JtKCVcAtKWnE="
+  },
+  {
     "pname": "AutoFixture",
     "version": "4.18.1",
     "hash": "sha256-reP+aoYiPcIj4GbCIhjd5/OhuWVLCtD4hKuLPHe2EXI="
@@ -255,6 +260,11 @@
     "hash": "sha256-JkkAUk7dwYYLz1TwO5T34aZf+VW+uTKuYF/hmRcxBuo="
   },
   {
+    "pname": "DiffEngine",
+    "version": "16.8.0",
+    "hash": "sha256-rMlVrtTu9cSTQLEG5nOltf8SqqSAsuihN6IWbhJm2l0="
+  },
+  {
     "pname": "DiffPlex",
     "version": "1.7.2",
     "hash": "sha256-Vsn81duAmPIPkR40h5bEz7hgtF5Kt5nAAGhQZrQbqxE="
@@ -293,6 +303,11 @@
     "pname": "EmptyFiles",
     "version": "8.11.1",
     "hash": "sha256-1rmycQh9HW08BtLk+lu90MSNuy+O7JPrE+NbupPnZ2I="
+  },
+  {
+    "pname": "EmptyFiles",
+    "version": "8.15.0",
+    "hash": "sha256-RUlzWyHtkiRdiiBjmUNeSR6CRc0G/F0TwqnYUcQeNUE="
   },
   {
     "pname": "EnumerableAsyncProcessor",
@@ -1085,6 +1100,11 @@
     "hash": "sha256-Zk2nRqnBMWdn5FHexMOGxFiqX95sJkYdLVd3T8TMPT8="
   },
   {
+    "pname": "Microsoft.DiaSymReader",
+    "version": "2.0.0",
+    "hash": "sha256-8hotZmh8Rb6Q6oD9Meb74SvAdbDo39Y/1m8h43HHjjw="
+  },
+  {
     "pname": "Microsoft.DotNet.PlatformAbstractions",
     "version": "3.1.6",
     "hash": "sha256-RfM2qXiqdiamPkXr4IDkNc0IZSF9iTZv4uou/E7zNS0="
@@ -1298,6 +1318,11 @@
     "pname": "Microsoft.Extensions.DependencyInjection.AutoActivation",
     "version": "9.8.0",
     "hash": "sha256-hIoJx/VgT1K8tsQRWI90vjLsWI68T2kwc93od5z/xaw="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyModel",
+    "version": "6.0.2",
+    "hash": "sha256-WVM/gshGie1J9q5l3YWRzrPWYlVvX6ISI+SiVMoPp5o="
   },
   {
     "pname": "Microsoft.Extensions.Diagnostics",
@@ -1760,24 +1785,34 @@
     "hash": "sha256-hNTkpKdCLY5kIuOmznD1mY+pRdJ0PKu2HypyXog9vb0="
   },
   {
+    "pname": "Microsoft.Testing.Extensions.CodeCoverage",
+    "version": "18.1.0",
+    "hash": "sha256-sw6HGpoJ51ldPedpP516gpYxZS7Wi9/08LFYVvI5xgk="
+  },
+  {
+    "pname": "Microsoft.Testing.Extensions.TrxReport",
+    "version": "2.0.1",
+    "hash": "sha256-I4gtv5iVnqL9yMW1J75CBP3rXyXrmLkav4B+BkFhuGM="
+  },
+  {
     "pname": "Microsoft.Testing.Extensions.TrxReport.Abstractions",
-    "version": "1.8.3",
-    "hash": "sha256-4lbrLFfNAqGP4Y1kdC7kxxCOVEL2dczLV0Jj0qt2RBc="
+    "version": "2.0.1",
+    "hash": "sha256-iSrQLohQTpbNtXmag8b3N9/Dqfh25/f0zb7xO7xqVe0="
   },
   {
     "pname": "Microsoft.Testing.Platform",
-    "version": "1.4.3",
-    "hash": "sha256-KqB3+uBGl0edpaGl6Qykubb3OrVTs6IcPWc59UQ/Iww="
+    "version": "2.0.0",
+    "hash": "sha256-YXhxULoi2mrpVHhrf/hu3lSOREU6hueFzDDb1YAlGs4="
   },
   {
     "pname": "Microsoft.Testing.Platform",
-    "version": "1.8.3",
-    "hash": "sha256-e/84lOkoTz90bux7D9mq6WSrRBPh4uFLUVuxLgHUddM="
+    "version": "2.0.1",
+    "hash": "sha256-0acL8DGgQ5rtvJi/lGQah7xa6+IoeVb4HS+NaYsl90Q="
   },
   {
     "pname": "Microsoft.Testing.Platform.MSBuild",
-    "version": "1.4.3",
-    "hash": "sha256-289hhblU55kDvzbiSQAFSxOyht1MlXT4e+bEQyQqils="
+    "version": "2.0.1",
+    "hash": "sha256-pft4O5U5WtPirj24xMdVcd6t0byGY7z/uJSUYkrCXKE="
   },
   {
     "pname": "Microsoft.TestPlatform.ObjectModel",
@@ -2971,6 +3006,11 @@
   },
   {
     "pname": "System.Memory",
+    "version": "4.5.4",
+    "hash": "sha256-3sCEfzO4gj5CYGctl9ZXQRRhwAraMQfse7yzKoRe65E="
+  },
+  {
+    "pname": "System.Memory",
     "version": "4.5.5",
     "hash": "sha256-EPQ9o1Kin7KzGI5O3U3PUQAZTItSbk9h/i4rViN3WiI="
   },
@@ -3306,8 +3346,18 @@
   },
   {
     "pname": "System.Text.Encodings.Web",
+    "version": "6.0.1",
+    "hash": "sha256-l3oKwZStjew/ClSrDaVLyHDAExoP6Iwm6uqJSdI9YJo="
+  },
+  {
+    "pname": "System.Text.Encodings.Web",
     "version": "8.0.0",
     "hash": "sha256-IUQkQkV9po1LC0QsqrilqwNzPvnc+4eVvq+hCvq8fvE="
+  },
+  {
+    "pname": "System.Text.Json",
+    "version": "6.0.11",
+    "hash": "sha256-KsgOU3RvSN/Kc+my45K0eua4owQPZar81LVF2Kzupf0="
   },
   {
     "pname": "System.Text.Json",
@@ -3338,11 +3388,6 @@
     "pname": "System.Threading.Channels",
     "version": "7.0.0",
     "hash": "sha256-Cu0gjQsLIR8Yvh0B4cOPJSYVq10a+3F9pVz/C43CNeM="
-  },
-  {
-    "pname": "System.Threading.Channels",
-    "version": "9.0.0",
-    "hash": "sha256-depIorJqzjyWew0+aBRgbGh88KWivbp9RrtWZHFr+pI="
   },
   {
     "pname": "System.Threading.RateLimiting",
@@ -3383,6 +3428,11 @@
     "pname": "System.Threading.Timer",
     "version": "4.3.0",
     "hash": "sha256-pmhslmhQhP32TWbBzoITLZ4BoORBqYk25OWbru04p9s="
+  },
+  {
+    "pname": "System.ValueTuple",
+    "version": "4.6.1",
+    "hash": "sha256-Hb87MPcNdHQRlREDzFEKU8ZqtKN26bjyAiimJmm6LWI="
   },
   {
     "pname": "System.Windows.Extensions",
@@ -3451,23 +3501,28 @@
   },
   {
     "pname": "TUnit",
-    "version": "0.57.24",
-    "hash": "sha256-19XQGB9UbhPqTeubaMo4Vq/MwNfhdEajmsqegQiJib0="
+    "version": "0.86.5",
+    "hash": "sha256-XQ0ByaufvRy5Vwxj5HEeCDkm7oiwVyoURc7Nz924Pdk="
   },
   {
     "pname": "TUnit.Assertions",
-    "version": "0.57.24",
-    "hash": "sha256-yRSwh/BMUR4eOiNWVFK7IXZITKq5nYnsgVR6ws4ABfs="
+    "version": "0.86.5",
+    "hash": "sha256-pnfw4mRwFwi999iWwd0zkw/S5zy0dxF4lnBTzTnZygM="
   },
   {
     "pname": "TUnit.Core",
-    "version": "0.57.24",
-    "hash": "sha256-dpTSlAhcZbMzUil9OOnQNgLWrtJMykUKCSHQclQzNjY="
+    "version": "0.86.5",
+    "hash": "sha256-wmxyJjA7W6+jrvlOIHJGMinXCnE28dxY62NxENwinpw="
+  },
+  {
+    "pname": "TUnit.Core",
+    "version": "0.87.8",
+    "hash": "sha256-3g5K6et+5j4dZQ9+QLNZLEuxv+08XwOywtnHAy0mTjI="
   },
   {
     "pname": "TUnit.Engine",
-    "version": "0.57.24",
-    "hash": "sha256-jbtRa1lMhtQW99sYDM33F89e7dCmqaH72vQJBAc1jog="
+    "version": "0.86.5",
+    "hash": "sha256-zVvBfu74t8qc0TySg2o56QckmpRWjWOYlAfcaxamycA="
   },
   {
     "pname": "Validation",
@@ -3505,6 +3560,11 @@
     "hash": "sha256-ET3tUBfryHi17VYavmA0n/U0vPWxO7Am1imPs6MYcYk="
   },
   {
+    "pname": "Verify",
+    "version": "31.4.1",
+    "hash": "sha256-vUQvTnyKkcCBwUNMldQWIaD/2JntWpSvfn/4TWNHvLU="
+  },
+  {
     "pname": "Verify.ImageMagick",
     "version": "3.7.3",
     "hash": "sha256-cbKQC4eruazFxlv6UtQodurCoE2h/pNXmNWvWC+xsGI="
@@ -3516,8 +3576,8 @@
   },
   {
     "pname": "Verify.TUnit",
-    "version": "30.11.0",
-    "hash": "sha256-xuP2oetSNIBhCzt7go3S2Icy8wy3pBseq4XcEMMrDV8="
+    "version": "31.4.1",
+    "hash": "sha256-aZ0/tGsdRYiJLS45ghhEEWPx9bQfZGHdgddGqTlP9nM="
   },
   {
     "pname": "Verify.Xunit",

--- a/pkgs/by-name/ne/nexusmods-app/package.nix
+++ b/pkgs/by-name/ne/nexusmods-app/package.nix
@@ -22,13 +22,13 @@ let
 in
 buildDotnetModule (finalAttrs: {
   inherit pname;
-  version = "0.20.2";
+  version = "0.21.1";
 
   src = fetchFromGitHub {
     owner = "Nexus-Mods";
     repo = "NexusMods.App";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-hpsrHHh0Bk+9Z4Qp5aTqH5i8KnqCLQdseYGrbr4sh1k=";
+    hash = "sha256-RTQ3EwfA7hRfnCJoRubWtaqFVHhRdbWfLTBORVc+kss=";
     fetchSubmodules = true;
   };
 
@@ -137,6 +137,9 @@ buildDotnetModule (finalAttrs: {
     "--environment=USER=nobody"
     "--property:Version=${finalAttrs.version}"
     "--property:DefineConstants=${lib.strings.concatStringsSep "%3B" constants}"
+
+    # Disable native apphosts for tests; they fail in checkPhase as the wrapper env (DOTNET_ROOT, libs) isn't applied
+    "--property:UseAppHost=false"
   ];
 
   testFilters = [

--- a/pkgs/by-name/ne/nexusmods-app/vendored/games.json
+++ b/pkgs/by-name/ne/nexusmods-app/vendored/games.json
@@ -6,12 +6,12 @@
     "forum_url": "https://forums.nexusmods.com/games/19-stardew-valley/",
     "nexusmods_url": "https://www.nexusmods.com/stardewvalley",
     "genre": "Simulation",
-    "file_count": 144372,
-    "downloads": 635510946,
+    "file_count": 145440,
+    "downloads": 642501970,
     "domain_name": "stardewvalley",
     "approved_date": 1457432329,
-    "mods": 26187,
-    "collections": 1990
+    "mods": 26417,
+    "collections": 1958
   },
   {
     "id": 1704,
@@ -20,12 +20,12 @@
     "forum_url": "https://forums.nexusmods.com/games/6-skyrim/",
     "nexusmods_url": "https://www.nexusmods.com/skyrimspecialedition",
     "genre": "RPG",
-    "file_count": 667120,
-    "downloads": 9346275237,
+    "file_count": 671705,
+    "downloads": 9497429062,
     "domain_name": "skyrimspecialedition",
     "approved_date": 1477480498,
-    "mods": 119859,
-    "collections": 4876
+    "mods": 120722,
+    "collections": 4886
   },
   {
     "id": 3174,
@@ -34,11 +34,11 @@
     "forum_url": "https://forums.nexusmods.com/games/9-mount-blade-ii-bannerlord/",
     "nexusmods_url": "https://www.nexusmods.com/mountandblade2bannerlord",
     "genre": "Strategy",
-    "file_count": 50960,
-    "downloads": 117558949,
+    "file_count": 51310,
+    "downloads": 118459993,
     "domain_name": "mountandblade2bannerlord",
     "approved_date": 1582898627,
-    "mods": 6397,
+    "mods": 6455,
     "collections": 294
   },
   {
@@ -48,12 +48,12 @@
     "forum_url": "https://forums.nexusmods.com/games/1-cyberpunk-2077/",
     "nexusmods_url": "https://www.nexusmods.com/cyberpunk2077",
     "genre": "Action",
-    "file_count": 126752,
-    "downloads": 958960285,
+    "file_count": 127687,
+    "downloads": 981788054,
     "domain_name": "cyberpunk2077",
     "approved_date": 1607433331,
-    "mods": 18283,
-    "collections": 1597
+    "mods": 18464,
+    "collections": 1613
   },
   {
     "id": 3474,
@@ -62,11 +62,11 @@
     "forum_url": "https://forums.nexusmods.com/games/2-baldurs-gate-3/",
     "nexusmods_url": "https://www.nexusmods.com/baldursgate3",
     "genre": "RPG",
-    "file_count": 106755,
-    "downloads": 359737700,
+    "file_count": 107598,
+    "downloads": 366648874,
     "domain_name": "baldursgate3",
     "approved_date": 1602863114,
-    "mods": 15196,
-    "collections": 1740
+    "mods": 15345,
+    "collections": 1725
   }
 ]


### PR DESCRIPTION
Changelog: https://github.com/Nexus-Mods/NexusMods.App/releases/tag/v0.21.1

Upstream upgraded `Microsoft.Testing.Platform` from 1.x → 2.x, which now builds native "apphost" test executables by default. These fail in `checkPhase` because the wrapper environment (`DOTNET_ROOT`, library paths, etc.) isn’t applied. \
Disable apphost generation for tests by adding `UseAppHost=false` to `dotnetTestFlags`. The main app is unaffected.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
    - `nix-build -A nexusmods-app.tests`
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - Tested the GUI opens correctly when running `result/bin/NexusMods.App`
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
