### PR TITLE
ocamlPackages.{color,cpu,cpuid,dssi}: small cleaning

### DIFF
--- a/pkgs/development/ocaml-modules/color/default.nix
+++ b/pkgs/development/ocaml-modules/color/default.nix
@@ -5,26 +5,23 @@
   gg,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "color";
   version = "0.2.0";
 
-  useDune2 = true;
-  minimalOCamlVersion = "4.05";
-
   src = fetchurl {
-    url = "https://github.com/anuragsoni/color/releases/download/${version}/color-${version}.tbz";
-    sha256 = "0wg3a36i1a7fnz5pf57qzbdghwr6dzp7nnxyrz9m9765lxsn65ph";
+    url = "https://github.com/anuragsoni/color/releases/download/${finalAttrs.version}/color-${finalAttrs.version}.tbz";
+    hash = "sha256-8BZjdafFnFTTz75be+5vJnP42vr4FHfLt+6oEM1Q43E=";
   };
 
   propagatedBuildInputs = [
     gg
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Converts between different color formats";
-    license = licenses.mit;
-    maintainers = with maintainers; [ fgaz ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fgaz ];
     homepage = "https://github.com/anuragsoni/color";
   };
-}
+})

--- a/pkgs/development/ocaml-modules/cpu/default.nix
+++ b/pkgs/development/ocaml-modules/cpu/default.nix
@@ -6,17 +6,15 @@
   autoconf,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "cpu";
   version = "2.0.0";
 
-  useDune2 = true;
-
   src = fetchFromGitHub {
     owner = "UnixJunkie";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "1vir6gh1bhvxgj2fcn69c38yhw3jgk7dyikmw789m5ld2csnyjiv";
+    repo = "cpu";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-O0pvNRONlprQ4XVG3858cnDo0WDJWOaEfH3DFeAzOe4=";
   };
 
   preConfigure = ''
@@ -28,10 +26,10 @@ buildDunePackage rec {
 
   hardeningDisable = lib.optional stdenv.hostPlatform.isDarwin "strictoverflow";
 
-  meta = with lib; {
-    inherit (src.meta) homepage;
+  meta = {
+    homepage = "https://github.com/UnixJunkie/cpu";
     description = "Core pinning library";
-    maintainers = [ maintainers.bcdarwin ];
-    license = licenses.lgpl2;
+    maintainers = [ lib.maintainers.bcdarwin ];
+    license = lib.licenses.lgpl2;
   };
-}
+})

--- a/pkgs/development/ocaml-modules/cpuid/default.nix
+++ b/pkgs/development/ocaml-modules/cpuid/default.nix
@@ -4,17 +4,13 @@
   buildDunePackage,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "cpuid";
   version = "0.1.2";
 
-  useDune2 = true;
-
-  minimalOCamlVersion = "4.03";
-
   src = fetchurl {
-    url = "https://github.com/pqwy/cpuid/releases/download/v${version}/cpuid-v${version}.tbz";
-    sha256 = "08ng4mva6qblb5ipkrxbr0my7ndkc4qwcbswkqgbgir864s74m93";
+    url = "https://github.com/pqwy/cpuid/releases/download/v${finalAttrs.version}/cpuid-v${finalAttrs.version}.tbz";
+    hash = "sha256-I1VyNDEox7cenlwvxjFhs9njK8ir53ljWXRho3YlzyI=";
   };
 
   meta = {
@@ -23,4 +19,4 @@ buildDunePackage rec {
     license = lib.licenses.isc;
     maintainers = [ lib.maintainers.vbgl ];
   };
-}
+})

--- a/pkgs/development/ocaml-modules/dssi/default.nix
+++ b/pkgs/development/ocaml-modules/dssi/default.nix
@@ -7,17 +7,15 @@
   alsa-lib,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "dssi";
   version = "0.1.5";
-
-  useDune2 = true;
 
   src = fetchFromGitHub {
     owner = "savonet";
     repo = "ocaml-dssi";
-    rev = "v${version}";
-    sha256 = "1frbmx1aznwp60r6bkx1whqyr6mkflvd9ysmjg7s7b80mh0s4ix6";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-pkeiAawAraPPk1X71DZ1s5rsMeShz2UyMJfbr0KvK7s=";
   };
 
   buildInputs = [ dune-configurator ];
@@ -26,10 +24,10 @@ buildDunePackage rec {
     alsa-lib
   ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/savonet/ocaml-dssi";
     description = "Bindings for the DSSI API which provides audio synthesizers";
-    license = licenses.gpl2Only;
-    maintainers = with maintainers; [ dandellion ];
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ dandellion ];
   };
-}
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
