### PR TITLE
virtualisation/rosetta: Perserve ArgvZero to fix python virtualenv creation

### DIFF
--- a/nixos/modules/virtualisation/rosetta.nix
+++ b/nixos/modules/virtualisation/rosetta.nix
@@ -76,7 +76,7 @@ in
       mask = ''\xff\xff\xff\xff\xff\xfe\xfe\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff'';
       fixBinary = true;
       matchCredentials = true;
-      preserveArgvZero = false;
+      preserveArgvZero = true;
 
       # Remove the shell wrapper and call the runtime directly
       wrapInterpreterInShell = false;


### PR DESCRIPTION
Preserving ArgvZero is supported from MacOS 14 Sonoma forward, which is the current minimum supported version of nixpkgs. See https://developer.apple.com/documentation/virtualization/running-intel-binaries-in-linux-vms-with-rosetta#Mount-the-Shared-Directory-and-Register-Rosetta

The necessity of this fix came up with python virtual environments, because python uses the path of the executable (argv zero) to determine if it should load a virtual environment or not. In the past this was overriden with NIX_PYTHONEXECUTABLE, NIX_PYTHONPATH and NIX_PYTHONPREFIX, but we stopped doing that for the python interpreter so it works more like a normal python interpreter in nix.

Without those variables, in the rosetta emulated case, python was no longer able to determine where it was called from, and thus could not correctly activate virtual environments in that case.

Investigation and this suggestion for the fix happened here. #461884 

This is related to, but not the same issue as was observed here: #461406

This problem was introduced here https://github.com/NixOS/nixpkgs/pull/442540 where virtual env creation was changed so the interpreter was special cased and no longer sets the above mentioned variables.

I'd like to ping some of the people that helped debug this: @qbisi @9999years @eclairevoyant @winterqt 

Some open questions: should this be targeting [NixOS:staging](https://github.com/NixOS/nixpkgs/tree/staging) instead of master like https://github.com/NixOS/nixpkgs/pull/462090?


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
