### PR TITLE
wl-clicker: 0.3.1 -> 0.4

### DIFF
--- a/pkgs/by-name/wl/wl-clicker/package.nix
+++ b/pkgs/by-name/wl/wl-clicker/package.nix
@@ -5,6 +5,7 @@
   wayland-scanner,
   wlr-protocols,
   wayland,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -20,22 +21,28 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "phoneticalb";
     repo = "wl-clicker";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-+k3iZOv12WbqpeYbYjIXBIB4mO2DrY1pl+MJn2B+cZA=";
   };
+
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/bin
-    install build/wl-clicker $out/bin/wl-clicker
+    install -D build/wl-clicker --target-directory="$out"/bin
 
     runHook postInstall
   '';
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Wayland autoclicker";
-    longDescription = "Script for auto clicking at incredibly high speeds - user must be a part of `input` group to run.";
+    longDescription = ''
+      Script for auto clicking at incredibly high speeds - user must
+      be a part of `input` group to run.
+    '';
     homepage = "https://github.com/phoneticalb/wl-clicker";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.Flameopathic ];

--- a/pkgs/by-name/wl/wl-clicker/package.nix
+++ b/pkgs/by-name/wl/wl-clicker/package.nix
@@ -9,7 +9,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "wl-clicker";
-  version = "0.3.1";
+  version = "0.4";
 
   nativeBuildInputs = [ wayland-scanner ];
   buildInputs = [
@@ -18,15 +18,11 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   src = fetchFromGitHub {
-    owner = "phonetic112";
+    owner = "phoneticalb";
     repo = "wl-clicker";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-HuUK1kkqIdB5SdcewJ1J8elzqrFaFWC3BRV3GgcasTU=";
+    hash = "sha256-+k3iZOv12WbqpeYbYjIXBIB4mO2DrY1pl+MJn2B+cZA=";
   };
-
-  postPatch = ''
-    sed -i 's|/usr|${wlr-protocols}|g' Makefile
-  '';
 
   installPhase = ''
     runHook preInstall
@@ -40,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Wayland autoclicker";
     longDescription = "Script for auto clicking at incredibly high speeds - user must be a part of `input` group to run.";
-    homepage = "https://github.com/phonetic112/wl-clicker";
+    homepage = "https://github.com/phoneticalb/wl-clicker";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.Flameopathic ];
     mainProgram = "wl-clicker";


### PR DESCRIPTION
Resolves #463040

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
