### PR TITLE
prek: 0.2.11 -> 0.2.17

### DIFF
--- a/pkgs/by-name/pr/prek/package.nix
+++ b/pkgs/by-name/pr/prek/package.nix
@@ -9,16 +9,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "prek";
-  version = "0.2.11";
+  version = "0.2.17";
 
   src = fetchFromGitHub {
     owner = "j178";
     repo = "prek";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-wzbvofNOAtqbjO5//ECu1FeZrS0FyDvFZPKxC0fOJnE=";
+    sha256 = "sha256-7GTp1UBAnxLVEQFTQbBxGiKSvZwEVVMA7oa3Iz5Ifzk=";
   };
 
-  cargoHash = "sha256-KVGdAPyUlPCgcx1DpZbfNRNmALdJvzOcsv3WQy3Q7OI=";
+  cargoHash = "sha256-i09ZcG3xUt+qFZge/8MiZ5yKxIeBd3l0BYlY5OFf3l8=";
 
   preBuild = ''
     version312_str=$(${python312}/bin/python -c 'import sys; print(sys.version_info[:3])')
@@ -66,6 +66,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "script"
     "check_useless_excludes_remote"
     "run_worktree"
+    "try_repo_relative_path"
+    "languages::tests::test_native_tls"
     # "meta_hooks"
     "reuse_env"
     "docker::docker"
@@ -86,6 +88,17 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "python::can_not_download"
     "python::hook_stderr"
     "python::language_version"
+    "ruby::additional_gem_dependencies"
+    "ruby::environment_isolation"
+    "ruby::gemspec_workflow"
+    "ruby::language_version_default"
+    "ruby::local_hook_with_gemspec"
+    "ruby::native_gem_dependency"
+    "ruby::native_gem_dependency"
+    "ruby::process_files"
+    "ruby::specific_ruby_available"
+    "ruby::specific_ruby_unavailable"
+    "ruby::system_ruby"
     # can't checkout pre-commit-hooks
     "cjk_hook_name"
     "fail_fast"
@@ -116,6 +129,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "no_commit_to_branch_hook"
     "no_commit_to_branch_hook_with_custom_branches"
     "no_commit_to_branch_hook_with_patterns"
+    "check_executables_have_shebangs_various_cases"
+    "check_executables_have_shebangs_hook"
     # does not properly use TMP
     "hook_impl"
     # problems with environment


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
