### PR TITLE
sylk: 3.0.1 -> 3.7.0; add ngi team

### DIFF
--- a/pkgs/by-name/sy/sylk/package.nix
+++ b/pkgs/by-name/sy/sylk/package.nix
@@ -2,16 +2,31 @@
   appimageTools,
   fetchurl,
   lib,
+  xorg,
 }:
 
 appimageTools.wrapType2 rec {
   pname = "sylk";
-  version = "3.0.1";
+  version = "3.7.0";
 
   src = fetchurl {
-    url = "http://download.ag-projects.com/Sylk/Sylk-${version}-x86_64.AppImage";
-    hash = "sha256-VgepO7LHFmNKq/H0RFcIkafgtiVGt8K/LdiCO5Dw2s4=";
+    url = "https://download.ag-projects.com/Sylk/Sylk-${version}-x86_64.AppImage";
+    hash = "sha256-3lWWc3aSn+aKM/gX4v2suVbj5sZPKl1r36eQP3a2pNg=";
   };
+
+  extraPkgs = pkgs: [
+    xorg.libxshmfence
+  ];
+
+  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+
+  extraInstallCommands = ''
+    install -Dm444 ${appimageContents}/sylk-electron.desktop -t $out/share/applications/
+    install -Dm444 ${appimageContents}/sylk-electron.png -t $out/share/icons/hicolor/512x512/apps/
+
+    substituteInPlace $out/share/applications/sylk-electron.desktop \
+      --replace-fail 'Exec=AppRun --no-sandbox' 'Exec=${pname}'
+  '';
 
   profile = ''
     export LC_ALL=C.UTF-8
@@ -21,8 +36,9 @@ appimageTools.wrapType2 rec {
     description = "Desktop client for SylkServer, a multiparty conferencing tool";
     homepage = "https://sylkserver.com/";
     license = lib.licenses.agpl3Plus;
-    mainProgram = "Sylk";
+    mainProgram = "sylk";
     maintainers = with lib.maintainers; [ zimbatm ];
+    teams = with lib.teams; [ ngi ];
     platforms = [
       "i386-linux"
       "x86_64-linux"


### PR DESCRIPTION
Closes https://github.com/ngi-nix/projects/issues/1591

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
