### PR TITLE
vscode-extensions.eamodio.gitlens: fix build, disable minification

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/eamodio.gitlens/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/eamodio.gitlens/default.nix
@@ -22,6 +22,10 @@ let
       hash = "sha256-9XEv50WIG1BJenY9MswES6d72Ead2VqW5dgBr7Eu8ek=";
     };
 
+    patches = [
+      ./gitlens-disable-swc-minification.patch
+    ];
+
     pnpmDeps = pnpm.fetchDeps {
       inherit (finalAttrs) pname version src;
       fetcherVersion = 2;

--- a/pkgs/applications/editors/vscode/extensions/eamodio.gitlens/gitlens-disable-swc-minification.patch
+++ b/pkgs/applications/editors/vscode/extensions/eamodio.gitlens/gitlens-disable-swc-minification.patch
@@ -1,0 +1,91 @@
+diff --git a/webpack.config.mjs b/webpack.config.mjs
+index 9d3de47..926fb40 100644
+--- a/webpack.config.mjs
++++ b/webpack.config.mjs
+@@ -259,31 +259,7 @@ function getExtensionConfig(target, mode, env) {
+ 			path: target === 'webworker' ? path.join(__dirname, 'dist', 'browser') : path.join(__dirname, 'dist'),
+ 		},
+ 		optimization: {
+-			minimizer: [
+-				new TerserPlugin({
+-					minify: TerserPlugin.swcMinify,
+-					extractComments: false,
+-					parallel: true,
+-					terserOptions: {
+-						compress: {
+-							drop_debugger: true,
+-							drop_console: true,
+-							ecma: 2020,
+-							// Keep the class names otherwise @log won't provide a useful name
+-							keep_classnames: true,
+-							module: true,
+-						},
+-						format: {
+-							comments: false,
+-							ecma: 2020,
+-						},
+-						mangle: {
+-							// Keep the class names otherwise @log won't provide a useful name
+-							keep_classnames: true,
+-						},
+-					},
+-				}),
+-			],
++			minimizer: [],
+ 			splitChunks:
+ 				target === 'webworker'
+ 					? false
+@@ -576,52 +552,7 @@ function getWebviewConfig(webviews, overrides, mode, env) {
+ 			outputModule: true,
+ 		},
+ 		optimization: {
+-			minimizer:
+-				mode === 'production'
+-					? [
+-							new TerserPlugin({
+-								minify: TerserPlugin.swcMinify,
+-								extractComments: false,
+-								parallel: true,
+-								terserOptions: {
+-									compress: {
+-										drop_debugger: true,
+-										drop_console: true,
+-										ecma: 2020,
+-										// Keep the class names otherwise @log won't provide a useful name
+-										keep_classnames: true,
+-										module: true,
+-									},
+-									format: {
+-										comments: false,
+-										ecma: 2020,
+-									},
+-									mangle: {
+-										// Keep the class names otherwise @log won't provide a useful name
+-										keep_classnames: true,
+-									},
+-								},
+-							}),
+-							new ImageMinimizerPlugin({
+-								deleteOriginalAssets: true,
+-								generator: [imageGeneratorConfig],
+-							}),
+-							new CssMinimizerPlugin({
+-								minimizerOptions: {
+-									preset: [
+-										'cssnano-preset-advanced',
+-										{
+-											autoprefixer: false,
+-											discardUnused: false,
+-											mergeIdents: false,
+-											reduceIdents: false,
+-											zindex: false,
+-										},
+-									],
+-								},
+-							}),
+-						]
+-					: [],
++			minimizer: [],
+ 			splitChunks: {
+ 				// Disable all non-async code splitting
+ 				// chunks: () => false,


### PR DESCRIPTION
Closes #462082

The failing step is the minification, which uses the Terser plugin configured with `@swc/core` (a Rust-based native module). 

The native bindings can't load in the Nix sandbox, causing the build to fail. 
This patch disables minification from webpack's config. 

Note: not sure this is the best solution, but it's quick win that restores the extension to its working state and gives us time to investigate the issue.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
