### PR TITLE
rtl8192su: rename, set sourceProvenance, modernize

### DIFF
--- a/pkgs/by-name/rt/rtl8192su-firmware/package.nix
+++ b/pkgs/by-name/rt/rtl8192su-firmware/package.nix
@@ -30,11 +30,12 @@ stdenvNoCC.mkDerivation {
     done
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Firmware for Realtek RTL8188SU/RTL8191SU/RTL8192SU";
     homepage = "https://github.com/chunkeey/rtl8192su";
-    license = licenses.unfreeRedistributableFirmware;
-    maintainers = with maintainers; [ mic92 ];
-    platforms = with platforms; linux;
+    license = lib.licenses.unfreeRedistributableFirmware;
+    maintainers = with lib.maintainers; [ mic92 ];
+    platforms = lib.platforms.linux;
+    sourceProvenance = with lib.sourceTypes; [ binaryFirmware ];
   };
 }

--- a/pkgs/by-name/rt/rtl8192su-firmware/package.nix
+++ b/pkgs/by-name/rt/rtl8192su-firmware/package.nix
@@ -11,7 +11,7 @@ stdenvNoCC.mkDerivation {
     owner = "chunkeey";
     repo = "rtl8192su";
     rev = "c00112c9a14133290fe30bd3b44e45196994cb1c";
-    sha256 = "0j3c35paapq1icmxq0mg7pm2xa2m69q7bkfmwgq99d682yr2cb5l";
+    hash = "sha256-tCwmshfItJTw49XNdXAyVagu6j2vAtwriwFfpW4ZbEg=";
   };
 
   dontBuild = true;

--- a/pkgs/by-name/rt/rtl8192su-firmware/package.nix
+++ b/pkgs/by-name/rt/rtl8192su-firmware/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
 }:
 stdenvNoCC.mkDerivation {
-  pname = "rtl8192su";
+  pname = "rtl8192su-firmware";
   version = "0-unstable-2016-10-05";
 
   src = fetchFromGitHub {


### PR DESCRIPTION
The rename was added to reduce confusion related to the different by-name path / attribute name.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
