### PR TITLE
rt5677-firmware: 995de6c -> 4.16-10, modernize, set sourceProvenance

### DIFF
--- a/pkgs/by-name/rt/rt5677-firmware/package.nix
+++ b/pkgs/by-name/rt/rt5677-firmware/package.nix
@@ -4,14 +4,15 @@
   fetchFromGitHub,
 }:
 
-stdenvNoCC.mkDerivation {
-  name = "rt5677-firmware";
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "rt5677-firmware";
+  version = "4.16-10";
 
   src = fetchFromGitHub {
     owner = "raphael";
     repo = "linux-samus";
-    rev = "995de6c2093797905fbcd79f1a3625dd3f50be37";
-    sha256 = "sha256-PjPFpz4qJLC+vTomV31dA3AKGjfYjKB2ZYfUpnj61Cg=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-fghU20fqKDhmisXI42t23omWYCRs0HAyzCp4c2GMZc0";
   };
 
   installPhase = ''
@@ -19,10 +20,11 @@ stdenvNoCC.mkDerivation {
     cp ./firmware/rt5677_elf_vad $out/lib/firmware
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Firmware for Realtek rt5677 device";
-    license = licenses.unfreeRedistributableFirmware;
-    maintainers = [ maintainers.zohl ];
-    platforms = platforms.linux;
+    license = lib.licenses.unfreeRedistributableFirmware;
+    maintainers = with lib.maintainers; [ zohl ];
+    platforms = lib.platforms.linux;
+    sourceProvenance = with lib.sourceTypes; [ binaryFirmware ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
