### PR TITLE
zig: disable libcxx hardening flags

### DIFF
--- a/pkgs/development/compilers/zig/cc.nix
+++ b/pkgs/development/compilers/zig/cc.nix
@@ -20,6 +20,10 @@ runCommand "zig-cc-${zig.version}"
     passthru = {
       isZig = true;
       inherit targetPrefix;
+      hardeningUnsupportedFlags = [
+        "libcxxhardeningfast"
+        "libcxxhardeningextensive"
+      ];
     };
 
     inherit zig;


### PR DESCRIPTION
The libcxxhardeningfast and libcxxhardeingextensive hardening flags introduced by #442945 add _LIBCPP_HARDENING_MODE definitions to compiler invocations, but zig already sets it automatically. This causes macro redefinition warnings (or errors if -Werror is enabled) when compiling C++ projects with zigStdenv.

https://github.com/ziglang/zig/blob/4ea472808437c932f6240c0df5e4d5912d282052/src/libs/libcxx.zig#L542-L544

Repro:

```bash
nix build -L --impure --expr 'with builtins.getFlake "git+file:///home/ddosolitary/nixpkgs"; with legacyPackages.x86_64-linux; (hello-cpp.override { stdenv = zigStdenv; }).overrideAttrs { cmakeFlags = [ "-DCMAKE_CXX_LINKER_DEPFILE_SUPPORTED=OFF" ]; env.CXXFLAGS = "-Werror"; }'
```

```plain
hello-cpp> Running phase: unpackPhase
hello-cpp> unpacking source archive /nix/store/icxd577v8wc16sankg0di3wg5dpa6zdq-src
hello-cpp> source root is src
hello-cpp> Running phase: patchPhase
hello-cpp> Running phase: updateAutotoolsGnuConfigScriptsPhase
hello-cpp> Running phase: configurePhase
hello-cpp> cmake flags: -GNinja -DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF -DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DCMAKE_INSTALL_LOCALEDIR=/nix/store/276rwjs6xcxr2xaz8agm4mldi2ni40fl-hello-cpp/share/locale -DCMAKE_INSTALL_LIBEXECDIR=/nix/store/276rwjs6xcxr2xaz8agm4mldi2ni40fl-hello-cpp/libexec -DCMAKE_INSTALL_LIBDIR=/nix/store/276rwjs6xcxr2xaz8agm4mldi2ni40fl-hello-cpp/lib -DCMAKE_INSTALL_DOCDIR=/nix/store/276rwjs6xcxr2xaz8agm4mldi2ni40fl-hello-cpp/share/doc/hello-cpp -DCMAKE_INSTALL_INFODIR=/nix/store/276rwjs6xcxr2xaz8agm4mldi2ni40fl-hello-cpp/share/info -DCMAKE_INSTALL_MANDIR=/nix/store/276rwjs6xcxr2xaz8agm4mldi2ni40fl-hello-cpp/share/man -DCMAKE_INSTALL_INCLUDEDIR=/nix/store/276rwjs6xcxr2xaz8agm4mldi2ni40fl-hello-cpp/include -DCMAKE_INSTALL_SBINDIR=/nix/store/276rwjs6xcxr2xaz8agm4mldi2ni40fl-hello-cpp/sbin -DCMAKE_INSTALL_BINDIR=/nix/store/276rwjs6xcxr2xaz8agm4mldi2ni40fl-hello-cpp/bin -DCMAKE_INSTALL_NAME_DIR=/nix/store/276rwjs6xcxr2xaz8agm4mldi2ni40fl-hello-cpp/lib -DCMAKE_STRIP= -DCMAKE_RANLIB=/nix/store/yyfy4mihm2nvb3in1zw5fvjrgnwhgwkf-zig-cc-wrapper-0.15.2/bin/ranlib -DCMAKE_AR=/nix/store/yyfy4mihm2nvb3in1zw5fvjrgnwhgwkf-zig-cc-wrapper-0.15.2/bin/ar -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_INSTALL_PREFIX=/nix/store/276rwjs6xcxr2xaz8agm4mldi2ni40fl-hello-cpp -DCMAKE_CXX_LINKER_DEPFILE_SUPPORTED=OFF
hello-cpp> -- The C compiler identification is Clang 20.1.8
hello-cpp> -- The CXX compiler identification is Clang 20.1.8
hello-cpp> -- Detecting C compiler ABI info
hello-cpp> -- Detecting C compiler ABI info - done
hello-cpp> -- Check for working C compiler: /nix/store/yyfy4mihm2nvb3in1zw5fvjrgnwhgwkf-zig-cc-wrapper-0.15.2/bin/clang - skipped
hello-cpp> -- Detecting C compile features
hello-cpp> -- Detecting C compile features - done
hello-cpp> -- Detecting CXX compiler ABI info
hello-cpp> -- Detecting CXX compiler ABI info - done
hello-cpp> -- Check for working CXX compiler: /nix/store/yyfy4mihm2nvb3in1zw5fvjrgnwhgwkf-zig-cc-wrapper-0.15.2/bin/clang++ - skipped
hello-cpp> -- Detecting CXX compile features
hello-cpp> -- Detecting CXX compile features - done
hello-cpp> -- Configuring done (9.7s)
hello-cpp> -- Generating done (0.0s)
hello-cpp> CMake Warning:
hello-cpp>   Manually-specified variables were not used by the project:
hello-cpp> 
hello-cpp>     BUILD_TESTING
hello-cpp>     CMAKE_EXPORT_NO_PACKAGE_REGISTRY
hello-cpp>     CMAKE_FIND_USE_PACKAGE_REGISTRY
hello-cpp>     CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY
hello-cpp>     CMAKE_INSTALL_DOCDIR
hello-cpp>     CMAKE_INSTALL_INCLUDEDIR
hello-cpp>     CMAKE_INSTALL_INFODIR
hello-cpp>     CMAKE_INSTALL_LIBDIR
hello-cpp>     CMAKE_INSTALL_LIBEXECDIR
hello-cpp>     CMAKE_INSTALL_LOCALEDIR
hello-cpp>     CMAKE_INSTALL_MANDIR
hello-cpp>     CMAKE_INSTALL_SBINDIR
hello-cpp> 
hello-cpp> 
hello-cpp> -- Build files have been written to: /build/src/build
hello-cpp> cmake: enabled parallel building
hello-cpp> cmake: enabled parallel installing
hello-cpp> Running phase: buildPhase
hello-cpp> build flags: -j24
hello-cpp> [1/2] Building CXX object CMakeFiles/hello-cpp.dir/main.cpp.o
hello-cpp> FAILED: [code=1] CMakeFiles/hello-cpp.dir/main.cpp.o
hello-cpp> /nix/store/yyfy4mihm2nvb3in1zw5fvjrgnwhgwkf-zig-cc-wrapper-0.15.2/bin/clang++   -Werror -O3 -DNDEBUG -MD -MT CMakeFiles/hello-cpp.dir/main.cpp.o -MF CMakeFiles/hello-cpp.dir/main.cpp.o.d -o CMakeFiles/hello-cpp.dir/main.cpp.o -c /build/src/main.cpp
hello-cpp> In file included from <built-in>:478:
hello-cpp> <command line>:23:9: error: '_LIBCPP_HARDENING_MODE' macro redefined [-Werror,-Wmacro-redefined]
hello-cpp>    23 | #define _LIBCPP_HARDENING_MODE _LIBCPP_HARDENING_MODE_EXTENSIVE
hello-cpp>       |         ^
hello-cpp> <command line>:20:9: note: previous definition is here
hello-cpp>    20 | #define _LIBCPP_HARDENING_MODE _LIBCPP_HARDENING_MODE_NONE
hello-cpp>       |         ^
hello-cpp> 1 error generated.
hello-cpp> ninja: build stopped: subcommand failed.
error: builder for '/nix/store/si1ag79a442k2vg0615jbvfkcw8ygz2m-hello-cpp.drv' failed with exit code 1;
       last 25 log lines:
       >     CMAKE_INSTALL_INFODIR
       >     CMAKE_INSTALL_LIBDIR
       >     CMAKE_INSTALL_LIBEXECDIR
       >     CMAKE_INSTALL_LOCALEDIR
       >     CMAKE_INSTALL_MANDIR
       >     CMAKE_INSTALL_SBINDIR
       >
       > 
       > -- Build files have been written to: /build/src/build
       > cmake: enabled parallel building
       > cmake: enabled parallel installing
       > Running phase: buildPhase
       > build flags: -j24
       > [1/2] Building CXX object CMakeFiles/hello-cpp.dir/main.cpp.o
       > FAILED: [code=1] CMakeFiles/hello-cpp.dir/main.cpp.o
       > /nix/store/yyfy4mihm2nvb3in1zw5fvjrgnwhgwkf-zig-cc-wrapper-0.15.2/bin/clang++   -Werror -O3 -DNDEBUG -MD -MT CMakeFiles/hello-cpp.dir/main.cpp.o -MF CMakeFiles/hello-cpp.dir/main.cpp.o.d -o CMakeFiles/hello-cpp.dir/main.cpp.o -c /build/src/main.cpp
       > In file included from <built-in>:478:
       > <command line>:23:9: error: '_LIBCPP_HARDENING_MODE' macro redefined [-Werror,-Wmacro-redefined]
       >    23 | #define _LIBCPP_HARDENING_MODE _LIBCPP_HARDENING_MODE_EXTENSIVE
       >       |         ^
       > <command line>:20:9: note: previous definition is here
       >    20 | #define _LIBCPP_HARDENING_MODE _LIBCPP_HARDENING_MODE_NONE
       >       |         ^
       > 1 error generated.
       > ninja: build stopped: subcommand failed.
       For full logs, run 'nix log /nix/store/si1ag79a442k2vg0615jbvfkcw8ygz2m-hello-cpp.drv'.
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
