### PR TITLE
gnome-secrets: 10.4 -> 12.0

### DIFF
--- a/pkgs/development/python-modules/pyhibp/default.nix
+++ b/pkgs/development/python-modules/pyhibp/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitLab,
+  setuptools,
+  requests,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "pyhibp";
+  version = "4.2.0";
+  pyproject = true;
+
+  src = fetchFromGitLab {
+    group = "kitsunix";
+    owner = "pyHIBP";
+    repo = "pyHIBP";
+    tag = "v${version}";
+    hash = "sha256-2LJA989hpG5X6o+zCTSU0RRd0Z4zd29RAtp/jBW8Clo=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ requests ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTests = [
+    # All require internet access
+    "TestIsPasswordBreached"
+    "TestSuffixSearch"
+    "TestGetAllBreaches"
+    "TestGetSingleBreach"
+    "TestGetDataClasses"
+  ];
+
+  pythonImportsCheck = [ "pyhibp" ];
+
+  meta = {
+    description = "Python interface to Troy Hunt's 'Have I Been Pwned?' public API";
+    homepage = "https://gitlab.com/kitsunix/pyHIBP/pyHIBP";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ aleksana ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13362,6 +13362,8 @@ self: super: with self; {
 
   pyhepmc = callPackage ../development/python-modules/pyhepmc { };
 
+  pyhibp = callPackage ../development/python-modules/pyhibp { };
+
   pyhidra = callPackage ../development/python-modules/pyhidra { };
 
   pyhik = callPackage ../development/python-modules/pyhik { };


### PR DESCRIPTION
I hope someone can test smartcard integration. Other than that it should be okay.

Closes https://github.com/NixOS/nixpkgs/pull/397715

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
