### PR TITLE
nixos/send: change type of passwordFile to str

### DIFF
--- a/nixos/modules/services/web-servers/send.nix
+++ b/nixos/modules/services/web-servers/send.nix
@@ -116,7 +116,7 @@ in
           default = null;
           example = "/run/agenix/send-redis-password";
           description = ''
-            The path to the file containing the Redis password.
+            The full path to the file containing the Redis password.
 
             If {option}`services.send.redis.createLocally` is set to true,
             the content of this file will be used as the password for the locally created Redis instance.
@@ -158,7 +158,7 @@ in
         ReadWritePaths = cfg.dataDir;
         LoadCredential = lib.optionalString (
           cfg.redis.passwordFile != null
-        ) "redis-password:${cfg.redis.passwordFile}";
+        ) "redis-password:${toString cfg.redis.passwordFile}"; # Avoid path being included in the store
 
         # Hardening
         RestrictAddressFamilies = [


### PR DESCRIPTION
Thanks @Frontear for pointing this out.

>  If redis.password is a path type (raw path type, not a string), then interpolation will force a store copy, making credentials world-readable.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
