### PR TITLE
terraform: 1.13.5 -> 1.14.0

### DIFF
--- a/pkgs/applications/networking/cluster/terraform/default.nix
+++ b/pkgs/applications/networking/cluster/terraform/default.nix
@@ -194,9 +194,9 @@ rec {
   mkTerraform = attrs: pluggable (generic attrs);
 
   terraform_1 = mkTerraform {
-    version = "1.13.5";
-    hash = "sha256-F8fpTI6kPrjOM+4N67uBCpsxMLQUR6sXzTr1SYFI9Ww=";
-    vendorHash = "sha256-3skDvOcDlTOv8okiGmaB0bvkoMrQjutGdvpxcradqUk=";
+    version = "1.14.0";
+    hash = "sha256-G9GyrwELOuzQqTMimC+z2GJUjq+c5YJDoE313JSsX5w=";
+    vendorHash = "sha256-T6baxFk5lrmhyeJgcn7s5cF+utaogSQOD9S5omEKTZg=";
     patches = [ ./provider-path-0_15.patch ];
     passthru = {
       inherit plugins;

--- a/pkgs/applications/networking/cluster/terraform/provider-path-0_15.patch
+++ b/pkgs/applications/networking/cluster/terraform/provider-path-0_15.patch
@@ -1,18 +1,19 @@
-diff -Naur terraform.old/internal/command/init.go terraform.new/internal/command/init.go
---- terraform.old/internal/command/init.go
-+++ terraform.new/internal/command/init.go
-@@ -7,6 +7,7 @@
- 	"context"
+diff -Naur terraform.old/internal/command/init_run.go terraform.new/internal/command/init_run.go
+--- terraform.old/internal/command/init_run.go
++++ terraform.new/internal/command/init_run.go
+@@ -6,6 +6,7 @@
+ import (
  	"errors"
  	"fmt"
 +	"os"
- 	"log"
- 	"reflect"
- 	"sort"
-@@ -79,6 +80,11 @@
+ 	"strings"
+ 
+ 	"github.com/hashicorp/hcl/v2"
+@@ -76,6 +77,11 @@
+ 	if c.forceInitCopy {
  		c.migrateState = true
  	}
-
+ 
 +	val, ok := os.LookupEnv("NIX_TERRAFORM_PLUGIN_DIR")
 +	if ok {
 +		initArgs.PluginPath = append(initArgs.PluginPath, val)


### PR DESCRIPTION
https://github.com/hashicorp/terraform/releases/tag/v1.14.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
