### PR TITLE
amule,amule-daemon,amule-gui,amule-web: refactor, migrate overrides

### DIFF
--- a/pkgs/by-name/am/amule-daemon/package.nix
+++ b/pkgs/by-name/am/amule-daemon/package.nix
@@ -1,0 +1,8 @@
+{
+  amule,
+}:
+
+amule.override {
+  monolithic = false;
+  enableDaemon = true;
+}

--- a/pkgs/by-name/am/amule-gui/package.nix
+++ b/pkgs/by-name/am/amule-gui/package.nix
@@ -1,0 +1,8 @@
+{
+  amule,
+}:
+
+amule.override {
+  monolithic = false;
+  client = true;
+}

--- a/pkgs/by-name/am/amule-web/package.nix
+++ b/pkgs/by-name/am/amule-web/package.nix
@@ -1,0 +1,8 @@
+{
+  amule,
+}:
+
+amule.override {
+  monolithic = false;
+  httpServer = true;
+}

--- a/pkgs/by-name/am/amule/package.nix
+++ b/pkgs/by-name/am/amule/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "amule-project";
     repo = "amule";
     tag = finalAttrs.version;
-    sha256 = "1nm4vxgmisn1b6l3drmz0q04x067j2i8lw5rnf0acaapwlp8qwvi";
+    hash = "sha256-cXOMLuVXKaaAs7lwiqKQx4BOAAa/5jaoWcHqWF/fpNo=";
   };
 
   patches = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1404,24 +1404,6 @@ with pkgs;
 
   crystfel-headless = callPackage ../applications/science/physics/crystfel { withGui = false; };
 
-  amule-daemon = amule.override {
-    monolithic = false;
-    enableDaemon = true;
-    mainProgram = "amuled";
-  };
-
-  amule-gui = amule.override {
-    monolithic = false;
-    client = true;
-    mainProgram = "amulegui";
-  };
-
-  amule-web = amule.override {
-    monolithic = false;
-    httpServer = true;
-    mainProgram = "amuleweb";
-  };
-
   inherit (callPackages ../tools/security/bitwarden-directory-connector { })
     bitwarden-directory-connector-cli
     bitwarden-directory-connector


### PR DESCRIPTION
- Refactor amule package to use finalAttrs pattern
- Update hash format from sha256 to modern hash attribute
- Move amule variants (amule-daemon, amule-gui, amule-web) to pkgs/by-name structure
- Remove variant definitions from all-packages.nix in favor of pkgs/by-name

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
