### PR TITLE
antigravity-fhs: support auto-discovery of google-chrome/chromium

### DIFF
--- a/pkgs/by-name/an/antigravity/package.nix
+++ b/pkgs/by-name/an/antigravity/package.nix
@@ -4,6 +4,9 @@
   callPackage,
   vscode-generic,
   fetchurl,
+  buildFHSEnv,
+  writeShellScript,
+  coreutils,
   commandLineArgs ? "",
   useVSCodeRipgrep ? stdenv.hostPlatform.isDarwin,
 }:
@@ -39,6 +42,29 @@ callPackage vscode-generic {
   };
 
   sourceRoot = if hostPlatform.isDarwin then "Antigravity.app" else "Antigravity";
+
+  # When running inside an FHS environment, try linking Google Chrome or Chromium
+  # to the hardcoded Playwright search path: /opt/google/chrome/chrome
+  buildFHSEnv =
+    args:
+    buildFHSEnv (
+      args
+      // {
+        extraBuildCommands = (args.extraBuildCommands or "") + ''
+          mkdir -p "$out/opt/google/chrome"
+        '';
+        extraBwrapArgs = (args.extraBwrapArgs or [ ]) ++ [ "--tmpfs /opt/google/chrome" ];
+        runScript = writeShellScript "antigravity-wrapper" ''
+          for candidate in google-chrome-stable google-chrome chromium-browser chromium; do
+            if target=$(command -v "$candidate"); then
+              ${coreutils}/bin/ln -sf "$target" /opt/google/chrome/chrome
+              break
+            fi
+          done
+          exec ${args.runScript} "$@"
+        '';
+      }
+    );
 
   tests = { };
   updateScript = ./update.sh;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This change allows the antigravity-fhs variant to automatically discover Google Chrome/Chromium installations on the user's system. This feature is exclusive to the -fhs variant because it uses the bubblewrap sandbox to populate the hardcoded search path, `/opt/google/chrome/chrome`. This is a nice convenience improvement.

Previously, or when using the non-fhs variant, users were required to manually specify the Google Chrome/Chromium location, such as by setting it to the path determined by `which chromium`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
