### PR TITLE
verapdf: pin component versions

### DIFF
--- a/pkgs/by-name/ve/verapdf/package.nix
+++ b/pkgs/by-name/ve/verapdf/package.nix
@@ -12,7 +12,17 @@ maven.buildMavenPackage rec {
   pname = "verapdf";
   version = "1.28.2";
 
-  mvnParameters = "-pl '!installer' -Dverapdf.timestamp=1980-01-01T00:00:02Z -Dproject.build.outputTimestamp=1980-01-01T00:00:02Z";
+  mvnParameters =
+    "-pl '!installer' -Dverapdf.timestamp=1980-01-01T00:00:02Z -Dproject.build.outputTimestamp=1980-01-01T00:00:02Z "
+    +
+      # By default, veraPDF uses version ranges for some components.
+      # These versions are pinned to the package version in order to avoid
+      # non-reproducibility of the maven dependencies.
+      lib.concatMapStringsSep " " (id: "-Dverapdf.${id}.version=${version}") [
+        "library"
+        "pdfbox.validation"
+        "validation"
+      ];
 
   src = fetchFromGitHub {
     owner = "veraPDF";
@@ -23,8 +33,7 @@ maven.buildMavenPackage rec {
 
   patches = [ ./stable-maven-plugins.patch ];
 
-  # FIXME: this hash keeps changing over time??
-  mvnHash = "sha256-+4ccnv0S7K/S2T7KryBJHJBEFrMZSFC7cNf3Kg/wN20=";
+  mvnHash = "sha256-CrpiomKsAyD7SyVzwbjVXy8BoVnkejQVcim+kwVP5Ng=";
 
   nativeBuildInputs = [
     makeWrapper


### PR DESCRIPTION
By default, veraPDF uses version ranges for some components.
These versions are pinned to the package version in order to avoid non-reproducibility of the maven dependencies.

#457852

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `581aa8d8cbfde441e52e609f62c3bc638e51bb47`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>verapdf</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc