### PR TITLE
nitchrevived: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9607,6 +9607,12 @@
     github = "gmacon";
     githubId = 238853;
   };
+  gnuvalerie = {
+    email = "git@val.8shield.net";
+    name = "Valerie";
+    githubId = 240524768;
+    github = "gnuvalerie";
+  };
   gnxlxnxx = {
     email = "gnxlxnxx@web.de";
     github = "gnxlxnxx";

--- a/pkgs/by-name/ni/nitchrevived/package.nix
+++ b/pkgs/by-name/ni/nitchrevived/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nimble,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "nitchrevived";
+  version = "0.1.7.5";
+
+  src = fetchFromGitHub {
+    owner = "gnuvalerie";
+    repo = "nitchrevived";
+    tag = "${version}";
+    sha256 = "sha256-R0grP4QcQeTvUAvSYCAxwD0Nw3fEXPWP3ImE60lK3QA=";
+  };
+
+  nativeBuildInputs = [ nimble ];
+
+  buildPhase = ''
+    export HOME=$TMPDIR
+    cd src
+    nimble build -d:release -d:danger --opt:speed --passC:-march=native --passC:-O3 --passL:-s
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp nitchrevived $out/bin/
+  '';
+
+  meta = with lib; {
+    description = "Incredibly fast system fetch written in Nim";
+    homepage = "https://github.com/gnuvalerie/nitchrevived";
+    license = licenses.mit;
+    maintainers = [ maintainers.gnuvalerie ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
This adds a new package `nitchrevived`, an incredibly fast system fetch written in Nim.  
Homepage: https://github.com/gnuvalerie/nitchrevived

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
---

Add a :+1: [reaction] to [pull requests you find important].
