### PR TITLE
prismlauncher{,-unwrapped}: add missing licenses

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -172,6 +172,11 @@ lib.mapAttrs mkLicense (
       fullName = "Baekmuk License";
     };
 
+    batchLicense = {
+      fullName = "Batch Icons License";
+      url = "https://github.com/rivermont/batch/blob/master/License.txt";
+    };
+
     bitstreamCharter = {
       spdxId = "Bitstream-Charter";
       fullName = "Bitstream Charter Font License";

--- a/pkgs/by-name/pr/prismlauncher-unwrapped/package.nix
+++ b/pkgs/by-name/pr/prismlauncher-unwrapped/package.nix
@@ -109,7 +109,33 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://prismlauncher.org/";
     changelog = "https://github.com/PrismLauncher/PrismLauncher/releases/tag/${finalAttrs.version}";
-    license = lib.licenses.gpl3Only;
+    # License list sources:
+    # https://github.com/PrismLauncher/PrismLauncher/tree/develop/libraries
+    # https://github.com/PrismLauncher/PrismLauncher/blob/develop/COPYING.md
+    license = with lib.licenses; [
+      # Prism Launcher's license
+      gpl3Only
+      # Original MultiMC license
+      asl20
+      # Prism Launcher assets
+      cc-by-sa-40
+      # LibNBT++, Oxygen Icons
+      lgpl3Plus
+      # rainbow
+      lgpl2Plus
+      # qdcss
+      lgpl3Only
+      # Material Design Icons
+      ofl
+      # lionshead
+      mit
+      # LocalPeer
+      bsd3
+      # Batch Icons
+      batchLicense
+      # murmur2
+      publicDomain
+    ];
     maintainers = with lib.maintainers; [
       minion3665
       Scrumplex


### PR DESCRIPTION
Did not specify MultiMC's original ASL20 license, or the cc-by-sa 4.0 license for the assets.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
