### PR TITLE
earthly: move to earthbuild 0.8.17

### DIFF
--- a/pkgs/by-name/ea/earthbuild/package.nix
+++ b/pkgs/by-name/ea/earthbuild/package.nix
@@ -4,21 +4,20 @@
   fetchFromGitHub,
   stdenv,
   testers,
-  earthly,
 }:
 
 buildGoModule (finalAttrs: {
-  pname = "earthly";
-  version = "0.8.16";
+  pname = "earthbuild";
+  version = "0.8.17";
 
   src = fetchFromGitHub {
-    owner = "earthly";
-    repo = "earthly";
+    owner = "EarthBuild";
+    repo = "earthbuild";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-2+Ya5i6V2QDzHsYR+Ro14u0VWR3wrQJHZRXBatGC8BA=";
+    hash = "sha256-ATdNA9KjAXsxMiez3AF6TxK7OujNDABY8jB6hXeSNpc=";
   };
 
-  vendorHash = "sha256-kEgg7zrT69X4yrsGtLyvnrGQ7+sXaEzdqd4Fz7rpFyg=";
+  vendorHash = "sha256-49FWzLHEbgwWOXT1uPshdY5risFHInA541Mfhu7v08A=";
   subPackages = [
     "cmd/earthly"
     "cmd/debugger"
@@ -30,9 +29,8 @@ buildGoModule (finalAttrs: {
     "-s"
     "-w"
     "-X main.Version=v${finalAttrs.version}"
-    "-X main.DefaultBuildkitdImage=docker.io/earthly/buildkitd:v${finalAttrs.version}"
+    "-X main.DefaultBuildkitdImage=docker.io/earthbuild/buildkitd:v${finalAttrs.version}"
     "-X main.GitSha=v${finalAttrs.version}"
-    "-X main.DefaultInstallationName=earthly"
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     "-extldflags '-static'"
@@ -48,19 +46,22 @@ buildGoModule (finalAttrs: {
 
   postInstall = ''
     mv $out/bin/debugger $out/bin/earthly-debugger
+    ln -s $out/bin/earthly-debugger $out/bin/earth-debugger
+    ln -s $out/bin/earthly $out/bin/earth
   '';
 
   passthru = {
     tests.version = testers.testVersion {
-      package = earthly;
+      package = finalAttrs.finalPackage;
       version = "v${finalAttrs.version}";
     };
   };
 
   meta = {
     description = "Build automation for the container era";
-    homepage = "https://earthly.dev/";
-    changelog = "https://github.com/earthly/earthly/releases/tag/v${finalAttrs.version}";
+    mainProgram = "earth";
+    homepage = "https://earthbuild.dev/";
+    changelog = "https://github.com/EarthBuild/earthbuild/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mpl20;
     maintainers = with lib.maintainers; [
       zoedsoupe

--- a/pkgs/by-name/ea/earthbuild/package.nix
+++ b/pkgs/by-name/ea/earthbuild/package.nix
@@ -4,21 +4,22 @@
   fetchFromGitHub,
   stdenv,
   testers,
-  earthly,
 }:
 
 buildGoModule (finalAttrs: {
-  pname = "earthly";
-  version = "0.8.16";
+  pname = "earthbuild";
+  version = "0.8.17";
 
   src = fetchFromGitHub {
-    owner = "earthly";
-    repo = "earthly";
+    owner = "EarthBuild";
+    repo = "earthbuild";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-2+Ya5i6V2QDzHsYR+Ro14u0VWR3wrQJHZRXBatGC8BA=";
+    hash = "sha256-ATdNA9KjAXsxMiez3AF6TxK7OujNDABY8jB6hXeSNpc=";
   };
 
-  vendorHash = "sha256-kEgg7zrT69X4yrsGtLyvnrGQ7+sXaEzdqd4Fz7rpFyg=";
+  vendorHash = "sha256-49FWzLHEbgwWOXT1uPshdY5risFHInA541Mfhu7v08A=";
+
+  __structuredAttrs = true;
   subPackages = [
     "cmd/earthly"
     "cmd/debugger"
@@ -30,9 +31,8 @@ buildGoModule (finalAttrs: {
     "-s"
     "-w"
     "-X main.Version=v${finalAttrs.version}"
-    "-X main.DefaultBuildkitdImage=docker.io/earthly/buildkitd:v${finalAttrs.version}"
+    "-X main.DefaultBuildkitdImage=docker.io/earthbuild/buildkitd:v${finalAttrs.version}"
     "-X main.GitSha=v${finalAttrs.version}"
-    "-X main.DefaultInstallationName=earthly"
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     "-extldflags '-static'"
@@ -48,19 +48,22 @@ buildGoModule (finalAttrs: {
 
   postInstall = ''
     mv $out/bin/debugger $out/bin/earthly-debugger
+    ln -s $out/bin/earthly-debugger $out/bin/earth-debugger
+    ln -s $out/bin/earthly $out/bin/earth
   '';
 
   passthru = {
     tests.version = testers.testVersion {
-      package = earthly;
+      package = finalAttrs.finalPackage;
       version = "v${finalAttrs.version}";
     };
   };
 
   meta = {
     description = "Build automation for the container era";
-    homepage = "https://earthly.dev/";
-    changelog = "https://github.com/earthly/earthly/releases/tag/v${finalAttrs.version}";
+    mainProgram = "earth";
+    homepage = "https://earthbuild.dev/";
+    changelog = "https://github.com/EarthBuild/earthbuild/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mpl20;
     maintainers = with lib.maintainers; [
       zoedsoupe

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -616,6 +616,7 @@ mapAliases {
   dump1090 = throw "'dump1090' has been renamed to/replaced by 'dump1090-fa'"; # Converted to throw 2025-10-27
   dune_1 = throw "'dune_1' has been removed"; # Added 2025-11-13
   e17gtk = throw "'e17gtk' has been removed because it was archived upstream."; # Added 2026-01-15
+  earthly = throw "'earthly' has been discontinued. It is replaced by a community fork 'earthbuild'"; # Added 2025-11-19
   eask = throw "'eask' has been renamed to/replaced by 'eask-cli'"; # Converted to throw 2025-10-27
   easyloggingpp = throw "easyloggingpp has been removed, as it is deprecated upstream and does not build with CMake 4"; # Added 2025-09-17
   EBTKS = throw "'EBTKS' has been renamed to/replaced by 'ebtks'"; # Converted to throw 2025-10-27

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -695,6 +695,7 @@ mapAliases {
   e17gtk = throw "'e17gtk' has been removed because it was archived upstream."; # Added 2026-01-15
   e-search = throw "'e-search' has been removed due to outdated KF5 dependencies"; # Added 2026-05-01
   eagle = throw "'eagle' has been removed because official support ends 2026-06-07. It depended on qt5 webengine, which was removed for its numerous security issues. For more details, see the autodesk announcement at https://www.autodesk.com/support/technical/article/caas/sfdcarticles/sfdcarticles/Autodesk-EAGLE-Announcement-Next-steps-and-FAQ.html"; # Added 2026-04-26
+  earthly = warnAlias "'earthly' has been discontinued. It is replaced by a community fork 'earthbuild'" earthbuild; # Added 2025-11-19
   eask = throw "'eask' has been renamed to/replaced by 'eask-cli'"; # Converted to throw 2025-10-27
   easyloggingpp = throw "easyloggingpp has been removed, as it is deprecated upstream and does not build with CMake 4"; # Added 2025-09-17
   ebpf-verifier = warnAlias "'ebpf-verifier' has been renamed to 'prevail'" prevail; # Added 2026-04-01


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Earthly has been discontinued. Community fork is called EarthBuild.

Version bumped to v0.8.17 from v0.8.16.

New binaries are: `earth`, `earth-debugger`. Links to `earthly` and `earthly-debugged` provided for compatibility.

See this post: https://earthly.dev/blog/shutting-down-earthfiles-cloud/
and this issue: https://github.com/EarthBuild/earthbuild/issues/158

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
