### PR TITLE
redumper: 657 -> 664, fix include headers

### DIFF
--- a/pkgs/by-name/re/redumper/package.nix
+++ b/pkgs/by-name/re/redumper/package.nix
@@ -9,13 +9,13 @@
 # redumper is using C++ modules, this requires latest C++20 compiler and build tools
 llvmPackages.libcxxStdenv.mkDerivation (finalAttrs: {
   pname = "redumper";
-  version = "657";
+  version = "664";
 
   src = fetchFromGitHub {
     owner = "superg";
     repo = "redumper";
     tag = "b${finalAttrs.version}";
-    hash = "sha256-dkdG00nbnHSC8xC6540KJmTDnEohLQfHpvYzc5dS6tk=";
+    hash = "sha256-fc3M6Pim+x/UwHOWZDp3yjLx7ajcNaIfYgamskwPDSA=";
   };
 
   nativeBuildInputs = [
@@ -23,6 +23,8 @@ llvmPackages.libcxxStdenv.mkDerivation (finalAttrs: {
     ninja
     llvmPackages.clang-tools
   ];
+
+  env.NIX_CFLAGS_COMPILE = "-isystem ${llvmPackages.libcxx.dev}/include/c++/v1";
 
   # https://github.com/superg/redumper/blob/main/.github/workflows/cmake.yml
   cmakeFlags = [


### PR DESCRIPTION


- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
