### PR TITLE
teleport_18: 18.3.2 -> 18.6.1; teleport_17: 17.7.9 -> 17.7.12

### DIFF
--- a/pkgs/by-name/te/teleport_17/package.nix
+++ b/pkgs/by-name/te/teleport_17/package.nix
@@ -7,11 +7,11 @@
 }:
 
 buildTeleport {
-  version = "17.7.9";
-  hash = "sha256-qS0QWSbhyhBEJTEcJGEbomhsH4hkcLYJlvsaQeBIH7A=";
-  vendorHash = "sha256-ZxJPzqvSGjc4AS5CPuSKCLWVvqcpqlMUUMtSqWn37o0=";
+  version = "17.7.12";
+  hash = "sha256-o4bepzHmPx9TfDBz0QsqQ9nd8o/WV1UTRDBnT1wM2yE=";
+  vendorHash = "sha256-m4oeFuH+60UFBkK6BHil4X8BSHwCVrCJ0i0b5eNJLYE=";
   cargoHash = "sha256-qz8gkooQTuBlPWC4lHtvBQpKkd+nEZ0Hl7AVg9JkPqs=";
-  pnpmHash = "sha256-+240TF1+wHw2HIt4GrhnknL3yxLqQbO+atNUkf/vh6Q=";
+  pnpmHash = "sha256-I+uNfC9aAuFuCqRFdp442pW25F1G7rZwl+1s00i/wq0=";
 
   wasm-bindgen-cli = wasm-bindgen-cli_0_2_95;
   inherit buildGoModule withRdpClient extPatches;

--- a/pkgs/by-name/te/teleport_18/package.nix
+++ b/pkgs/by-name/te/teleport_18/package.nix
@@ -7,10 +7,10 @@
 }:
 
 buildTeleport {
-  version = "18.3.2";
-  hash = "sha256-BeYn/uq81t9aL3xfxc7TJlNhvqJ2MDzN2Cue2XeG7g8=";
-  vendorHash = "sha256-FSG/54vVFVWiJmlUYqS+3l2EoqxM9tUH91/Nap1p8nk=";
-  pnpmHash = "sha256-6sThtwACNEdV0fleaQf3iMmFxPsd0AshYeYZUatFMcg=";
+  version = "18.6.1";
+  hash = "sha256-Jtjy2qmlm7zsl0a8o4/4jWdnse1yFR++oq3FcDuQOJo=";
+  vendorHash = "sha256-PW8UP1YuUssw//1qb3oUN/FrbLUwt6D+c4q6jrm09Xk=";
+  pnpmHash = "sha256-xjAqyReWRdty67LWaNX1jG4/uCeQtUMH/BKLIHUx6+0=";
   cargoHash = "sha256-ia4We4IfIkqz82aFMVvXdzjDXw0w+OJSPVdutfau6PA=";
 
   wasm-bindgen-cli = wasm-bindgen-cli_0_2_99;


### PR DESCRIPTION
Changelogs: https://github.com/gravitational/teleport/releases/tag/v18.4.0 https://github.com/gravitational/teleport/releases/tag/v18.4.1 https://github.com/gravitational/teleport/releases/tag/v18.4.2 https://github.com/gravitational/teleport/releases/tag/v18.5.0 https://github.com/gravitational/teleport/releases/tag/v18.6.0 https://github.com/gravitational/teleport/releases/tag/v18.6.1
Diff: https://github.com/gravitational/teleport/compare/v18.3.2...v18.6.1

Changelogs: https://github.com/gravitational/teleport/releases/tag/v17.7.10 https://github.com/gravitational/teleport/releases/tag/v17.7.11 https://github.com/gravitational/teleport/releases/tag/v17.7.12
Diff: https://github.com/gravitational/teleport/compare/v17.7.9...v17.7.12

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
