### PR TITLE
cacert: Improve sourcing

### DIFF
--- a/pkgs/by-name/ca/cacert/update.sh
+++ b/pkgs/by-name/ca/cacert/update.sh
@@ -25,7 +25,7 @@ BASEDIR="$(dirname "$0")/../../../.."
 
 
 CURRENT_PATH=$(nix-build --no-out-link -A cacert.out)
-PATCHED_PATH=$(nix-build --no-out-link -E "with import $BASEDIR {}; (cacert.override { nssOverride = nss_latest; }).out")
+PATCHED_PATH=$(nix-build --no-out-link -E "with import $BASEDIR {}; (cacert.overrideAttrs { src = nss_latest.src + \"/lib/ckfw/builtins/certdata.txt\"; }).out")
 
 # Check the hash of the etc subfolder
 # We can't check the entire output as that contains the nix-support folder
@@ -35,5 +35,5 @@ PATCHED_HASH=$(nix-hash "$PATCHED_PATH/etc")
 
 if [[ "$CURRENT_HASH" !=  "$PATCHED_HASH" ]]; then
     NSS_VERSION=$(nix-instantiate --json --eval -E "with import $BASEDIR {}; nss_latest.version" | jq -r .)
-    update-source-version --version-key=srcVersion cacert.src "$NSS_VERSION"
+    update-source-version cacert "$NSS_VERSION"
 fi


### PR DESCRIPTION
Switch to fetching only certdata.txt directly from the upstream repository, because:

- While it's possible to deduct that github/nss-dev is an NSS-project-owned mirror repository, it's not trivial:
  - Go to the homepage: https://firefox-source-docs.mozilla.org/security/nss/index.html
  - Navigate to the source, e.g. https://phabricator.services.mozilla.com/source/nss/
  - Check the readme.md, which mentions github.com/nss-dev/nss
- GitHub is a mirror of the Mercurial repository, and while I was able to confirm that the latest version does match, it leaves more room for a malicious actor:
  - It's unknown who owns the nss-dev GitHub organisation, there's no public members and no contact information
  - The mirroring automation from Mercurial to GitHub is not documented
  - Git hashes by necessity don't match Mercurial hashes, so it's not easy to verify that they match
- Previously the build and update script were more complicated and slow by depending on the entire source, when we really only need a single file.

Furthermore, update the meta.homepage to point to the actual page that mentions the root certificates, because the old one pointed to a curl page which we don't even use anymore (if we ever even did, Git history is inconclusive)

The cacert build was verified to be unchanged

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
