### PR TITLE
python314Packages.libcst: fix build

### DIFF
--- a/pkgs/development/python-modules/libcst/default.nix
+++ b/pkgs/development/python-modules/libcst/default.nix
@@ -3,14 +3,12 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  callPackage,
   cargo,
   hypothesmith,
+  isPy313,
   libcst,
   libiconv,
   pytestCheckHook,
-  python,
-  pythonOlder,
   pyyaml,
   pyyaml-ft,
   rustPlatform,
@@ -58,7 +56,7 @@ buildPythonPackage rec {
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
 
   dependencies = [
-    (if pythonOlder "3.13" then pyyaml else pyyaml-ft)
+    (if isPy313 then pyyaml-ft else pyyaml)
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
Broken on v3.14 because it expects normal pyyaml and not pyyaml-ft.

Fixes:
```
libcst> Checking runtime dependencies for libcst-1.8.6-cp314-cp314-linux_x86_64.whl
libcst>   - pyyaml not installed
```

See also: https://github.com/Instagram/LibCST/blob/v1.8.6/pyproject.toml

Tested by building for Python 3.12, 3.13, and 3.14 on both x86_64-linux and aarch64-linux, both at HEAD and based atop python-updates and 12aea66d5e2fa9d27b5190e5e732d9cf29e753a8. For the latter, I've also tested all 3 versions' passthru.tests on aarch64-linux.

I've set the merge-base such that this can be merged to any of `python-updates`, `staging`, `staging-next`, and `master`, so feel free to change the base branch before merging if you like. But note that (at least currently) python-updates doesn't have 12aea66d5e2fa9d27b5190e5e732d9cf29e753a8, which this needs.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
