### PR TITLE
[25.05] vscode-extensions.github.copilot-chat: 0.27.1 -> 0.33.1

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/github.copilot-chat/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/github.copilot-chat/default.nix
@@ -7,8 +7,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     publisher = "github";
     name = "copilot-chat";
-    version = "0.31.3";
-    hash = "sha256-Kvg5gmvAcz+K6mWBzWoNnkqEWAPRgC+w0idUC6RzM0g=";
+    version = "0.31.5";
+    hash = "sha256-D7k+hA786w7IZHVI+Og6vHGAAohpfpuOmmCcDUU0WsY=";
   };
 
   meta = {

--- a/pkgs/applications/editors/vscode/extensions/github.copilot-chat/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/github.copilot-chat/default.nix
@@ -7,8 +7,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     publisher = "github";
     name = "copilot-chat";
-    version = "0.28.2";
-    hash = "sha256-o6h9AOeBMRqVkhSgHUE2/vmsmJCXciY21mIQD7SUHOU=";
+    version = "0.28.5";
+    hash = "sha256-sxbikIUxaIVT0ySaicUIZIiHuy0kzz5xyYcKYds6+XE=";
   };
 
   meta = {

--- a/pkgs/applications/editors/vscode/extensions/github.copilot-chat/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/github.copilot-chat/default.nix
@@ -7,8 +7,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     publisher = "github";
     name = "copilot-chat";
-    version = "0.31.5";
-    hash = "sha256-D7k+hA786w7IZHVI+Og6vHGAAohpfpuOmmCcDUU0WsY=";
+    version = "0.33.1";
+    hash = "sha256-qiWuoxd/CXTxYtlOcj1Aww16wLvTZbQ7qJYhPPEndqk=";
   };
 
   meta = {

--- a/pkgs/applications/editors/vscode/extensions/github.copilot-chat/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/github.copilot-chat/default.nix
@@ -7,8 +7,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     publisher = "github";
     name = "copilot-chat";
-    version = "0.27.3";
-    hash = "sha256-b7zvbDzwJcHAp9tn2ibtyeErrH2KNbgqT4Ir7aqLMQg=";
+    version = "0.28.0";
+    hash = "sha256-Pc04vtCSPlXALPnFtgQcEVa+exzfkYqFh/b8K3bUBJg=";
   };
 
   meta = {

--- a/pkgs/applications/editors/vscode/extensions/github.copilot-chat/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/github.copilot-chat/default.nix
@@ -7,8 +7,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     publisher = "github";
     name = "copilot-chat";
-    version = "0.30.1";
-    hash = "sha256-itANvwMSzFBPnU4B6erEXO/x3SNlqHygXlTE6jLc+0U=";
+    version = "0.31.0";
+    hash = "sha256-jMy6mjPUxz3p1dvrveZ/9tyn+KZ6rBLJinZMBUUb9QY=";
   };
 
   meta = {

--- a/pkgs/applications/editors/vscode/extensions/github.copilot-chat/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/github.copilot-chat/default.nix
@@ -7,8 +7,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     publisher = "github";
     name = "copilot-chat";
-    version = "0.28.5";
-    hash = "sha256-sxbikIUxaIVT0ySaicUIZIiHuy0kzz5xyYcKYds6+XE=";
+    version = "0.29.1";
+    hash = "sha256-v9PP+3psOOMCrIgIaVqrwOUZ9tqTXiSjUUuOcCrEie4=";
   };
 
   meta = {

--- a/pkgs/applications/editors/vscode/extensions/github.copilot-chat/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/github.copilot-chat/default.nix
@@ -7,8 +7,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     publisher = "github";
     name = "copilot-chat";
-    version = "0.27.2";
-    hash = "sha256-nwBDQNs5qrA0TxQZVtuXRiOy0iBNOCFpIim0x2k37YA=";
+    version = "0.27.3";
+    hash = "sha256-b7zvbDzwJcHAp9tn2ibtyeErrH2KNbgqT4Ir7aqLMQg=";
   };
 
   meta = {

--- a/pkgs/applications/editors/vscode/extensions/github.copilot-chat/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/github.copilot-chat/default.nix
@@ -7,8 +7,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     publisher = "github";
     name = "copilot-chat";
-    version = "0.31.0";
-    hash = "sha256-jMy6mjPUxz3p1dvrveZ/9tyn+KZ6rBLJinZMBUUb9QY=";
+    version = "0.31.3";
+    hash = "sha256-Kvg5gmvAcz+K6mWBzWoNnkqEWAPRgC+w0idUC6RzM0g=";
   };
 
   meta = {

--- a/pkgs/applications/editors/vscode/extensions/github.copilot-chat/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/github.copilot-chat/default.nix
@@ -7,8 +7,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     publisher = "github";
     name = "copilot-chat";
-    version = "0.28.0";
-    hash = "sha256-Pc04vtCSPlXALPnFtgQcEVa+exzfkYqFh/b8K3bUBJg=";
+    version = "0.28.2";
+    hash = "sha256-o6h9AOeBMRqVkhSgHUE2/vmsmJCXciY21mIQD7SUHOU=";
   };
 
   meta = {

--- a/pkgs/applications/editors/vscode/extensions/github.copilot-chat/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/github.copilot-chat/default.nix
@@ -7,8 +7,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     publisher = "github";
     name = "copilot-chat";
-    version = "0.29.1";
-    hash = "sha256-v9PP+3psOOMCrIgIaVqrwOUZ9tqTXiSjUUuOcCrEie4=";
+    version = "0.30.1";
+    hash = "sha256-itANvwMSzFBPnU4B6erEXO/x3SNlqHygXlTE6jLc+0U=";
   };
 
   meta = {

--- a/pkgs/applications/editors/vscode/extensions/github.copilot-chat/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/github.copilot-chat/default.nix
@@ -15,7 +15,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
     description = "GitHub Copilot Chat is a companion extension to GitHub Copilot that houses experimental chat features";
     downloadPage = "https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-chat";
     homepage = "https://github.com/features/copilot";
-    license = lib.licenses.unfree;
+    license = lib.licenses.mit;
     maintainers = [ lib.maintainers.laurent-f1z1 ];
   };
 }

--- a/pkgs/applications/editors/vscode/extensions/github.copilot-chat/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/github.copilot-chat/default.nix
@@ -7,8 +7,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     publisher = "github";
     name = "copilot-chat";
-    version = "0.27.1";
-    hash = "sha256-HXzPI8B4wISly2SQNdbFO6CEREfhey+SH4HhutxH7Mg=";
+    version = "0.27.2";
+    hash = "sha256-nwBDQNs5qrA0TxQZVtuXRiOy0iBNOCFpIim0x2k37YA=";
   };
 
   meta = {


### PR DESCRIPTION
Backport version update commits of this extension from master. Currently 0.27.1 is incompatible with the latest Visual Studio Code version; this backport fixes that on 25.05.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
