### PR TITLE
viskores: 1.0.0 -> 1.1.0

### DIFF
--- a/pkgs/by-name/vi/viskores/package.nix
+++ b/pkgs/by-name/vi/viskores/package.nix
@@ -13,22 +13,14 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "viskores";
-  version = "1.0.0";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "viskores";
     repo = "viskores";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-jKuDM/NPfbMIfNpDNsDpmXdKuVobsr3s9+iht1zBLvI=";
+    hash = "sha256-s399ZkUlKB1xvow+VcA3FQxd+GVlCJyx6KWLtl2Z3RY=";
   };
-
-  patches = [
-    # https://github.com/Viskores/viskores/pull/137
-    (fetchpatch2 {
-      url = "https://github.com/Viskores/viskores/commit/36bf609511adb5530e6952bc14daefeafdf4ab11.patch?full_index=1";
-      hash = "sha256-SKmgVZhkCk1/X17dLXZ8ceF9Pq1Kkc2sXuFdrvotsdo=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
changelog: https://github.com/Viskores/viskores/releases/tag/v1.1.0

currently only used by vtk in nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
