### PR TITLE
gitlogue: init at 0.3.0

### DIFF
--- a/pkgs/by-name/gi/gitlogue/package.nix
+++ b/pkgs/by-name/gi/gitlogue/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  libgit2,
+  libssh2,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "gitlogue";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "unhappychoice";
+    repo = "gitlogue";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-IKCjv33I6bM5PSp1IBXEArHgNF1hV9J+Zko0uV2OPZA=";
+  };
+
+  cargoHash = "sha256-j8h+EI+vOf8nN69ROFiwuUBRi84T/QdhbdMpAMupkoM=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    openssl
+    libgit2
+    libssh2
+  ];
+
+  env = {
+    OPENSSL_NO_VENDOR = 1;
+    LIBGIT2_NO_VENDOR = 1;
+    LIBSSH2_SYS_USE_PKG_CONFIG = 1;
+  };
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Cinematic Git commit replay tool for the terminal";
+    longDescription = ''
+      A cinematic Git commit replay tool for the terminal, turning your Git history into a living, animated story.
+    '';
+    homepage = "https://github.com/unhappychoice/gitlogue";
+    changelog = "https://github.com/unhappychoice/gitlogue/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ chillcicada ];
+    mainProgram = "gitlogue";
+  };
+})


### PR DESCRIPTION
init [gitlogue](https://github.com/unhappychoice/gitlogue) at 0.3.0, which is a terminal cinematic Git commit replay tool.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
