### PR TITLE
nixos/ollama: add `syncModels` to remove models not defined in `loadModels`

### DIFF
--- a/nixos/modules/services/misc/ollama.nix
+++ b/nixos/modules/services/misc/ollama.nix
@@ -152,7 +152,15 @@ in
       };
       loadModels = lib.mkOption {
         type = types.listOf types.str;
+        apply = builtins.filter (model: model != "");
         default = [ ];
+        example = [
+          "dolphin3"
+          "gemma3"
+          "gemma3:27b"
+          "deepseek-r1:latest"
+          "deepseek-r1:1.5b"
+        ];
         description = ''
           Download these models using `ollama pull` as soon as `ollama.service` has started.
 
@@ -287,30 +295,20 @@ in
         RestartSteps = "10";
       };
 
-      script = ''
-        total=${toString (builtins.length cfg.loadModels)}
-        failed=0
-
-        for model in ${lib.escapeShellArgs cfg.loadModels}; do
-          '${lib.getExe ollamaPackage}' pull "$model" &
-        done
-
-        for job in $(jobs -p); do
-          set +e
-          wait $job
-          exit_code=$?
-          set -e
-
-          if [ $exit_code != 0 ]; then
-            failed=$((failed + 1))
-          fi
-        done
-
-        if [ $failed != 0 ]; then
-          echo "error: $failed out of $total attempted model downloads failed" >&2
-          exit 1
-        fi
-      '';
+      script =
+        let
+          binaryInputs = lib.mapAttrs (_: lib.getExe) {
+            ollama = ollamaPackage;
+            parallel = pkgs.parallel;
+          };
+          inherit (binaryInputs)
+            ollama
+            parallel
+            ;
+        in
+        ''
+          '${parallel}' --tag '${ollama}' pull ::: ${lib.escapeShellArgs cfg.loadModels}
+        '';
     };
 
     networking.firewall = lib.mkIf cfg.openFirewall { allowedTCPPorts = [ cfg.port ]; };

--- a/nixos/modules/services/misc/ollama.nix
+++ b/nixos/modules/services/misc/ollama.nix
@@ -165,8 +165,17 @@ in
           Download these models using `ollama pull` as soon as `ollama.service` has started.
 
           This creates a systemd unit `ollama-model-loader.service`.
+          Use `services.ollama.syncModels` to automatically remove any models not currently declared here.
 
           Search for models of your choice from: <https://ollama.com/library>
+        '';
+      };
+      syncModels = lib.mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Synchronize all currently installed models with those declared in `services.ollama.loadModels`,
+          removing any models that are installed but not currently declared there.
         '';
       };
       openFirewall = lib.mkOption {
@@ -272,7 +281,7 @@ in
         };
     };
 
-    systemd.services.ollama-model-loader = lib.mkIf (cfg.loadModels != [ ]) {
+    systemd.services.ollama-model-loader = lib.mkIf (cfg.loadModels != [ ] || cfg.syncModels) {
       description = "Download ollama models in the background";
       wantedBy = [
         "multi-user.target"
@@ -300,13 +309,44 @@ in
           binaryInputs = lib.mapAttrs (_: lib.getExe) {
             ollama = ollamaPackage;
             parallel = pkgs.parallel;
+            awk = pkgs.gawk;
+            sed = pkgs.gnused;
           };
           inherit (binaryInputs)
             ollama
             parallel
+            awk
+            sed
             ;
+
+          declaredModelsRegex = lib.pipe cfg.loadModels [
+            (map lib.escapeRegex)
+            (lib.concatStringsSep "|")
+            (lib.escape [ "/" ])
+            lib.escapeShellArg
+          ];
         in
         ''
+          ${lib.optionalString cfg.syncModels ''
+            installed=$('${ollama}' list | '${awk}' 'NR > 1 {print $1}')
+            ${
+              # if `declaredModelsRegex` is empty, sed will err
+              if (cfg.loadModels != [ ]) then
+                ''
+                  echo declared models regex: ${declaredModelsRegex}
+                  undeclared=$(echo "$installed" | '${sed}' -E /${declaredModelsRegex}/d)
+                ''
+              else
+                ''
+                  undeclared="$installed"
+                ''
+            }
+            if [ -n "$undeclared" ]; then
+              echo removing: $undeclared
+              '${ollama}' rm $undeclared
+            fi
+          ''}
+
           '${parallel}' --tag '${ollama}' pull ::: ${lib.escapeShellArgs cfg.loadModels}
         '';
     };


### PR DESCRIPTION
Add an option to strictly synchronize the list of models declared in `services.ollama.loadModels`, deleting any models that are currently installed but aren't currently specified there. This is opt-in (off by default), both for backward compatibility and because this behavior may be surprising/undesirable to many people.

Resolves #462585


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
