### PR TITLE
mew: init at 1.0-unstable-2025-06-20

### DIFF
--- a/pkgs/by-name/me/mew/package.nix
+++ b/pkgs/by-name/me/mew/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitea,
+
+  # nativeBuildInputs
+  pkg-config,
+
+  # buildInputs
+  fcft,
+  libxkbcommon,
+  pixman,
+  wayland,
+  wayland-protocols,
+  wayland-scanner,
+}:
+stdenv.mkDerivation {
+  pname = "mew";
+  version = "1.0-unstable-2025-06-20";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "sewn";
+    repo = "mew";
+    rev = "af6440da8fe6683cf0b873e0a98c293bf02c3447";
+    hash = "sha256-NbpYITHO81fnaDY0dtolaUBdRqQNKwHQz/lBQMOHM5c=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    fcft
+    libxkbcommon
+    pixman
+    wayland
+    wayland-protocols
+    wayland-scanner
+  ];
+
+  makeFlags = [
+    # The PREFIX var is hardcoded in the makefile.
+    "PREFIX=$(out)"
+  ];
+
+  postFixup = ''
+    substituteInPlace $out/bin/mew-run \
+      --replace-fail \
+        'path | mew -e "$@"' \
+        'path | ${placeholder "out"}/bin/mew -e "$@"'
+  '';
+
+  meta = {
+    description = "Efficient dynamic menu for Wayland, an effective port of dmenu to Wayland";
+    homepage = "https://codeberg.org/sewn/mew";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ Notarin ];
+    platforms = lib.platforms.linux;
+    mainProgram = "mew";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
