### PR TITLE
inko: 0.18.1 -> 0.19.1

### DIFF
--- a/pkgs/by-name/in/inko/package.nix
+++ b/pkgs/by-name/in/inko/package.nix
@@ -15,16 +15,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "inko";
-  version = "0.18.1";
+  version = "0.19.1";
 
   src = fetchFromGitHub {
     owner = "inko-lang";
     repo = "inko";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-jVfAfR02R2RaTtzFSBoLuq/wdPaaI/eochrZaRVdmHY=";
+    hash = "sha256-ZHVOwYvNRL2ObZt2PvayoqvS64MumN4oXQOgeCWbEUM=";
   };
 
-  cargoHash = "sha256-IOMhwcZHB5jVYDM65zifxCjVHWl1EBbxNA3WVmarWcs=";
+  cargoHash = "sha256-BHrbqPMQnhw8pjN8e0/qW1rPe/fMhs2iUbRVPt5ATrg=";
 
   buildInputs = [
     libffi

--- a/pkgs/by-name/in/inko/test.nix
+++ b/pkgs/by-name/in/inko/test.nix
@@ -7,26 +7,30 @@
 
 let
   source =
+    # https://docs.inko-lang.org/manual/v0.19.1/getting-started/hello-concurrency/#channels
     writeText "hello.inko" # inko
       ''
         import std.process (sleep)
-        import std.stdio (STDOUT)
+        import std.stdio (Stdout)
+        import std.sync (Channel)
         import std.time (Duration)
 
-        class async Printer {
-          fn async print(message: String, channel: Channel[Nil]) {
-            let _ = STDOUT.new.print(message)
+        type async Printer {
+          fn async print(message: String, channel: uni Channel[Nil]) {
+            let _ = Stdout.new.print(message)
 
             channel.send(nil)
           }
         }
 
-        class async Main {
+        type async Main {
           fn async main {
-            let channel = Channel.new(size: 2)
+            let channel = Channel.new
 
-            Printer().print('Hello', channel)
-            Printer().print('world', channel)
+            Printer().print('Hello', recover channel.clone)
+            Printer().print('world', recover channel.clone)
+
+            sleep(Duration.from_millis(500))
 
             channel.receive
             channel.receive


### PR DESCRIPTION
Also updated the tests since there are breaking changes.

Supersedes https://github.com/NixOS/nixpkgs/pull/463302

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
