### PR TITLE
ocamlPackages.{earley,gnuplot,wtf8,xmlplaylist}: small cleaning

### DIFF
--- a/pkgs/development/ocaml-modules/earley/default.nix
+++ b/pkgs/development/ocaml-modules/earley/default.nix
@@ -5,18 +5,15 @@
   stdlib-shims,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   version = "3.0.0";
   pname = "earley";
   src = fetchFromGitHub {
     owner = "rlepigre";
     repo = "ocaml-earley";
-    rev = version;
-    sha256 = "1vi58zdxchpw6ai0bz9h2ggcmg8kv57yk6qbx82lh47s5wb3mz5y";
+    tag = finalAttrs.version;
+    hash = "sha256-vvw6Fi/6EEgF6gub6U/ZE73K3hMw/QWiMvxC1ttHJe4=";
   };
-
-  minimalOCamlVersion = "4.07";
-  useDune2 = true;
 
   buildInputs = [ stdlib-shims ];
 
@@ -29,4 +26,4 @@ buildDunePackage rec {
     maintainers = [ lib.maintainers.vbgl ];
     mainProgram = "pa_ocaml";
   };
-}
+})

--- a/pkgs/development/ocaml-modules/gnuplot/default.nix
+++ b/pkgs/development/ocaml-modules/gnuplot/default.nix
@@ -6,19 +6,15 @@
   iso8601,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "gnuplot";
   version = "0.7";
 
-  useDune2 = true;
-
-  minimalOCamlVersion = "4.03";
-
   src = fetchFromGitHub {
     owner = "c-cube";
-    repo = "ocaml-${pname}";
-    rev = "v${version}";
-    sha256 = "02pzi3lb57ysrdsba743s3vmnapjbxgq8ynlzpxbbs6cn1jj6ch9";
+    repo = "ocaml-gnuplot";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-CTIjZbDM6LX6/dR6hF9f8ipb99CDHLV0y9qfsuiI/wo=";
   };
 
   propagatedBuildInputs = [
@@ -26,10 +22,10 @@ buildDunePackage rec {
     iso8601
   ];
 
-  meta = with lib; {
-    inherit (src.meta) homepage;
-    description = "Ocaml bindings to Gnuplot";
-    maintainers = [ maintainers.bcdarwin ];
-    license = licenses.lgpl21;
+  meta = {
+    homepage = "https://github.com/c-cube/ocaml-gnuplot";
+    description = "OCaml bindings to Gnuplot";
+    maintainers = [ lib.maintainers.bcdarwin ];
+    license = lib.licenses.lgpl21;
   };
-}
+})

--- a/pkgs/development/ocaml-modules/wtf8/default.nix
+++ b/pkgs/development/ocaml-modules/wtf8/default.nix
@@ -4,23 +4,19 @@
   buildDunePackage,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "wtf8";
   version = "1.0.2";
 
-  useDune2 = true;
-
-  minimalOCamlVersion = "4.02";
-
   src = fetchurl {
-    url = "https://github.com/flowtype/ocaml-${pname}/releases/download/v${version}/${pname}-v${version}.tbz";
-    sha256 = "09ygcxxd5warkdzz17rgpidrd0pg14cy2svvnvy1hna080lzg7vp";
+    url = "https://github.com/flowtype/ocaml-wtf8/releases/download/v${finalAttrs.version}/wtf8-v${finalAttrs.version}.tbz";
+    hash = "sha256-d5/3KUBAWRj8tntr4RkJ74KWW7wvn/B/m1nx0npnzyc=";
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/flowtype/ocaml-wtf8";
     description = "WTF-8 is a superset of UTF-8 that allows unpaired surrogates";
-    license = licenses.mit;
-    maintainers = [ maintainers.eqyiel ];
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.eqyiel ];
   };
-}
+})

--- a/pkgs/development/ocaml-modules/xmlplaylist/default.nix
+++ b/pkgs/development/ocaml-modules/xmlplaylist/default.nix
@@ -6,26 +6,24 @@
   xmlm,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "xmlplaylist";
   version = "0.1.5";
-
-  useDune2 = true;
 
   src = fetchFromGitHub {
     owner = "savonet";
     repo = "ocaml-xmlplaylist";
-    rev = "v${version}";
-    sha256 = "1x5lbwkr2ip00x8vyfbl8936yy79j138vx8a16ix7g9p2j5qsfcq";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-mDmNixQ3vdOjCQr1jUaQ6XhvRkJ0Ob9RB+BGkSdftPQ=";
   };
 
   buildInputs = [ dune-configurator ];
   propagatedBuildInputs = [ xmlm ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/savonet/ocaml-xmlplaylist";
     description = "Module to parse various RSS playlist formats";
-    license = licenses.lgpl21Only;
-    maintainers = with maintainers; [ dandellion ];
+    license = lib.licenses.lgpl21Only;
+    maintainers = with lib.maintainers; [ dandellion ];
   };
-}
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
