### PR TITLE
vatprism: 0.3.5 -> 0.3.6

### DIFF
--- a/pkgs/by-name/ma/maven/build-maven-package.nix
+++ b/pkgs/by-name/ma/maven/build-maven-package.nix
@@ -4,7 +4,6 @@
   jdk,
   jre-generate-cacerts,
   maven,
-  perl,
   writers,
 }:
 
@@ -13,7 +12,9 @@
   sourceRoot ? null,
   buildOffline ? false,
   doCheck ? true,
+  prePatch ? null,
   patches ? [ ],
+  postPatch ? null,
   pname,
   version,
   mvnJdk ? jdk,
@@ -40,7 +41,9 @@ let
       inherit
         src
         sourceRoot
+        prePatch
         patches
+        postPatch
         version
         ;
 


### PR DESCRIPTION
https://github.com/marvk/vatprism/compare/refs/tags/v0.3.5...refs/tags/v0.3.6
https://github.com/marvk/vatprism/raw/refs/tags/v0.3.6/CHANGELOG.md
https://github.com/marvk/vatprism/releases/tag/v0.3.6

This also enables proper inheritance of the patch phase hooks for `maven.buildMavenPackage`.
It has been verified that this does not affect `mvnHash` for the following packages:
+ apgdiff
+ dependency-track
+ filius
+ global-platform-pro
+ jol
+ jugglinglab
+ openrefine
+ scenebuilder
+ sqlline

#457852

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 463418`
Commit: `aa39bb3bf8813ed97314564dba10c8feb23481b9`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>vatprism</li>
  </ul>
</details>

---
### `aarch64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>vatprism</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc