### PR TITLE
polari: 46.0 -> 49.0

### DIFF
--- a/pkgs/by-name/po/polari/0001-joinDialog-Fix-detecting-pointer-devices.patch
+++ b/pkgs/by-name/po/polari/0001-joinDialog-Fix-detecting-pointer-devices.patch
@@ -1,0 +1,50 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ball=C3=B3=20Gy=C3=B6rgy?= <ballogyor@gmail.com>
+Date: Fri, 30 Aug 2024 16:44:15 +0000
+Subject: [PATCH] joinDialog: Fix detecting pointer devices
+
+Gtk.get_current_event_device() is not available in GTK4.
+
+Closes: https://gitlab.gnome.org/GNOME/polari/-/issues/209
+---
+ src/serverRoomManager.js | 13 ++++++++++---
+ 1 file changed, 10 insertions(+), 3 deletions(-)
+
+diff --git a/src/serverRoomManager.js b/src/serverRoomManager.js
+index 88753648388d..3122a09500d9 100644
+--- a/src/serverRoomManager.js
++++ b/src/serverRoomManager.js
+@@ -3,7 +3,6 @@
+ //
+ // SPDX-License-Identifier: GPL-2.0-or-later
+ 
+-import Gdk from 'gi://Gdk';
+ import Gio from 'gi://Gio';
+ import GLib from 'gi://GLib';
+ import GObject from 'gi://GObject';
+@@ -179,15 +178,23 @@ class ServerRoomList extends Gtk.Box {
+                 this._toggleChecked(this._list.model.get_path(iter));
+         });
+ 
++        let pointerDeviceEvent = false;
++        const clickController = new Gtk.GestureClick();
++        clickController.connect('pressed', (_controller, _nPress, _x, _y) => {
++            pointerDeviceEvent = true;
++        });
++        this._list.add_controller(clickController);
++
+         this._list.connect('row-activated', (view, path, _column) => {
+             this._toggleChecked(path);
++            pointerDeviceEvent = false;
+         });
+ 
+         this._toggleRenderer.connect('toggled', (cell, pathStr) => {
+             // For pointer devices, ::row-activated is emitted as well
+-            const dev = Gtk.get_current_event_device();
+-            if (dev && dev.input_source === Gdk.InputSource.KEYBOARD)
++            if (!pointerDeviceEvent)
+                 this._toggleChecked(Gtk.TreePath.new_from_string(pathStr));
++            pointerDeviceEvent = false;
+         });
+ 
+         this._manager = ServerRoomManager.getDefault();

--- a/pkgs/by-name/po/polari/0002-mainWindow-Disconnect-event-handler-on-destroy.patch
+++ b/pkgs/by-name/po/polari/0002-mainWindow-Disconnect-event-handler-on-destroy.patch
@@ -1,0 +1,87 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ball=C3=B3=20Gy=C3=B6rgy?= <ballogyor@gmail.com>
+Date: Wed, 13 Nov 2024 13:39:36 +0100
+Subject: [PATCH] mainWindow: Disconnect event handler on destroy
+
+Without this, it remains active when the main window is closed and
+reopened, causing a crash.
+
+Closes: https://gitlab.gnome.org/GNOME/polari/-/issues/233
+---
+ src/mainWindow.js | 23 +++++++++++++----------
+ 1 file changed, 13 insertions(+), 10 deletions(-)
+
+diff --git a/src/mainWindow.js b/src/mainWindow.js
+index dfb2ea07dd16..7d813a881106 100644
+--- a/src/mainWindow.js
++++ b/src/mainWindow.js
+@@ -96,49 +96,50 @@ class MainWindow extends Adw.ApplicationWindow {
+             }
+         });
+ 
+-        const app = this.application;
+-        if (app.isTestInstance)
++        this._app = this.application;
++        if (this._app.isTestInstance)
+             this.add_css_class('test-instance');
+         if (GLib.get_application_name().toLowerCase().includes('snapshot'))
+             this.add_css_class('snapshot');
+ 
+         const actions = [{
+             name: 'search',
+             handler: () => this._searchButton.activate(),
+         }];
+         actions.forEach(a => {
+-            app.lookup_action(a.name).connect('activate', a.handler);
++            this._app.lookup_action(a.name).connect('activate', a.handler);
+         });
+ 
+         this._roomStack.connect('notify::view-height',
+             () => this.notify('view-height'));
+ 
+         this._accountsMonitor = AccountsMonitor.getDefault();
+         this._accountsChangedId = this._accountsMonitor.connect(
+             'accounts-changed', this._onAccountsChanged.bind(this));
+         this._onAccountsChanged(this._accountsMonitor);
+ 
+         this._accountReachableId = this._accountsMonitor.connect(
+             'account-reachable-changed', this._onAccountsReachableChanged.bind(this));
+         this._onAccountsReachableChanged();
+ 
+         this._roomManager = RoomManager.getDefault();
+         this._roomsLoadedId = this._roomManager.connect('rooms-loaded',
+             this._onRoomsLoaded.bind(this));
+         this._roomRemovedId = this._roomManager.connect('room-removed',
+             this._onRoomRemoved.bind(this));
+         this._onRoomsLoaded();
+ 
+         this._updateUserListLabel();
+ 
+-        this._userListAction = app.lookup_action('user-list');
++        this._userListAction = this._app.lookup_action('user-list');
+ 
+-        app.connect('action-state-changed::user-list', (group, name, value) => {
+-            if (value.get_boolean())
+-                this._userListPopover.popup();
+-            else
+-                this._userListPopover.popdown();
+-        });
++        this._userListActionStateChangedId =
++            this._app.connect('action-state-changed::user-list', (group, name, value) => {
++                if (value.get_boolean())
++                    this._userListPopover.popup();
++                else
++                    this._userListPopover.popdown();
++            });
+         this._userListPopover.connect('notify::visible', () => {
+             if (!this._userListPopover.visible)
+                 this._userListAction.change_state(GLib.Variant.new('b', false));
+@@ -207,6 +208,8 @@ class MainWindow extends Adw.ApplicationWindow {
+ 
+         this._roomManager.disconnect(this._roomsLoadedId);
+         this._roomManager.disconnect(this._roomRemovedId);
++
++        this._app.disconnect(this._userListActionStateChangedId);
+     }
+ 
+     _onAccountsChanged() {

--- a/pkgs/by-name/po/polari/0003-Add-option-to-disable-URL-preview-feature.patch
+++ b/pkgs/by-name/po/polari/0003-Add-option-to-disable-URL-preview-feature.patch
@@ -1,0 +1,73 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ball=C3=B3=20Gy=C3=B6rgy?= <ballogyor@gmail.com>
+Date: Wed, 13 Nov 2024 14:13:28 +0100
+Subject: [PATCH] Add option to disable URL preview feature
+
+It has security and privacy concerns.
+
+Closes: https://gitlab.gnome.org/GNOME/polari/-/issues/133
+---
+ data/org.gnome.Polari.gschema.xml | 5 +++++
+ data/ui/main-window.ui            | 4 ++++
+ src/application.js                | 2 ++
+ src/chatView.js                   | 3 ++-
+ 4 files changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/data/org.gnome.Polari.gschema.xml b/data/org.gnome.Polari.gschema.xml
+index bfc3de08ab26..a97603976f40 100644
+--- a/data/org.gnome.Polari.gschema.xml
++++ b/data/org.gnome.Polari.gschema.xml
+@@ -36,6 +36,11 @@ SPDX-FileCopyrightText: 2015 Florian Müllner <fmuellner@gnome.or>
+       <summary>Last active channel</summary>
+       <description>Last active (selected) channel</description>
+     </key>
++    <key type="b" name="url-preview">
++      <default>false</default>
++      <summary>URL Preview</summary>
++      <description>Show preview for URLs.</description>
++    </key>
+   </schema>
+ 
+   <schema id="org.gnome.Polari.Account">
+diff --git a/data/ui/main-window.ui b/data/ui/main-window.ui
+index 0756a5e24f7d..021a71e3c0ef 100644
+--- a/data/ui/main-window.ui
++++ b/data/ui/main-window.ui
+@@ -21,6 +21,10 @@ SPDX-License-Identifier: GPL-2.0-or-later
+         <attribute name="action">app.run-in-background</attribute>
+         <attribute name="label" translatable="yes">Run in Background</attribute>
+       </item>
++      <item>
++        <attribute name="action">app.url-preview</attribute>
++        <attribute name="label" translatable="yes">URL Preview</attribute>
++      </item>
+     </section>
+     <section>
+       <item>
+diff --git a/src/application.js b/src/application.js
+index 6a297646e39f..9a06fbd1081b 100644
+--- a/src/application.js
++++ b/src/application.js
+@@ -361,6 +361,8 @@ class Application extends Adw.Application {
+         this._settings = new Gio.Settings({schema_id: 'org.gnome.Polari'});
+         let action = this._settings.create_action('run-in-background');
+         this.add_action(action);
++        action = this._settings.create_action('url-preview');
++        this.add_action(action);
+ 
+         action = this.lookup_action('user-list');
+         action.connect('notify::enabled', () => {
+diff --git a/src/chatView.js b/src/chatView.js
+index fcb373687327..de13a80e2e44 100644
+--- a/src/chatView.js
++++ b/src/chatView.js
+@@ -1305,7 +1305,8 @@ class ChatView extends Gtk.ScrolledWindow {
+             this._insertWithTags(iter,
+                 url.name, tags.concat(this._lookupTag('url'), tag));
+ 
+-            if (GLib.uri_parse_scheme(url.url).startsWith('http'))
++            if (this._app._settings.get_boolean('url-preview') &&
++                GLib.uri_parse_scheme(url.url).startsWith('http'))
+                 previews.push(new URLPreview({uri: url.url}));
+ 
+             pos = url.pos + url.name.length;

--- a/pkgs/by-name/po/polari/check_dbus_unconditionally.patch
+++ b/pkgs/by-name/po/polari/check_dbus_unconditionally.patch
@@ -1,0 +1,14 @@
+diff --git a/src/application.js b/src/application.js
+index 6a29764..a14cd1a 100644
+--- a/src/application.js
++++ b/src/application.js
+@@ -222,9 +222,6 @@ class Application extends Adw.Application {
+     }
+ 
+     vfunc_dbus_register(conn, _path) {
+-        if (!Utils.isFlatpakSandbox())
+-            return true;
+-
+         GLib.setenv('IDLE_PERSIST', '1', false);
+         this._ensureService(conn,
+             Tp.ACCOUNT_MANAGER_BUS_NAME,

--- a/pkgs/by-name/po/polari/fix_sparql_database_race.patch
+++ b/pkgs/by-name/po/polari/fix_sparql_database_race.patch
@@ -1,0 +1,63 @@
+diff --git a/src/utils.js b/src/utils.js
+index 3a9863d..6314f39 100644
+--- a/src/utils.js
++++ b/src/utils.js
+@@ -547,29 +547,40 @@ export function formatDateTime(date) {
+ }
+ 
+ /**
+- * @returns {Tracker.SparqlConnection}
++ * @returns {Promise<Tracker.SparqlConnection>}
+  */
+ export async function getSparqlStore() {
+-    await _sparqlStorePromise;
++    if (_sparqlStorePromise)
++        return _sparqlStorePromise;
+ 
+-    if (_sparqlStore)
+-        return _sparqlStore;
+-
+-    const {promise, resolve} = Promise.withResolvers();
++    const { promise, resolve, reject } = Promise.withResolvers();
+     _sparqlStorePromise = promise;
+ 
+-    const path = GLib.build_filenamev(
+-        [GLib.get_user_data_dir(), 'polari', 'chatlogs.v1']);
+-    const dir = Gio.File.new_for_path(path);
+-    const ontology = Gio.File.new_for_uri(
+-        'resource:///org/gnome/Polari/ontologies/');
+-
+-    _sparqlStore = await Tracker.SparqlConnection.new_async(
+-        Tracker.SparqlConnectionFlags.FTS_ENABLE_STEMMER |
+-        Tracker.SparqlConnectionFlags.FTS_ENABLE_UNACCENT,
+-        dir, ontology, null);
++    (async () => {
++        try {
++            if (_sparqlStore) {
++                resolve(_sparqlStore);
++                return;
++            }
+ 
+-    resolve();
++            const path = GLib.build_filenamev(
++                [GLib.get_user_data_dir(), 'polari', 'chatlogs.v1']);
++            const dir = Gio.File.new_for_path(path);
++            const ontology = Gio.File.new_for_uri(
++                'resource:///org/gnome/Polari/ontologies/');
++
++            const store = await Tracker.SparqlConnection.new_async(
++                Tracker.SparqlConnectionFlags.FTS_ENABLE_STEMMER |
++                Tracker.SparqlConnectionFlags.FTS_ENABLE_UNACCENT,
++                dir, ontology, null
++            );
++
++            _sparqlStore = store;
++            resolve(store);
++        } catch (e) {
++            reject(e);
++        }
++    })();
+ 
+-    return _sparqlStore;
++    return promise;
+ }

--- a/pkgs/by-name/po/polari/package.nix
+++ b/pkgs/by-name/po/polari/package.nix
@@ -3,14 +3,14 @@
   lib,
   itstool,
   fetchurl,
-  fetchpatch,
   gdk-pixbuf,
   telepathy-glib,
+  telepathy-idle,
+  telepathy-mission-control,
   gjs,
   meson,
   ninja,
   gettext,
-  telepathy-idle,
   libxml2,
   desktop-file-utils,
   pkg-config,
@@ -19,6 +19,7 @@
   libadwaita,
   gtk3,
   glib,
+  glib-networking,
   libsecret,
   libsoup_3,
   webkitgtk_4_1,
@@ -29,13 +30,13 @@
   gsettings-desktop-schemas,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "polari";
-  version = "46.0";
+  version = "49.0";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/polari/${lib.versions.major version}/polari-${version}.tar.xz";
-    hash = "sha256-0rFwnjeRiSlPU9TvFfA/i8u76MUvD0FeYvfV8Aw2CjE=";
+    url = "mirror://gnome/sources/polari/${lib.versions.major finalAttrs.version}/polari-${finalAttrs.version}.tar.xz";
+    hash = "sha256-UmJv3jkJkhrFhsxMwQ8w8SOq9hVaF374hhyg5V1t6FA=";
   };
 
   patches = [
@@ -44,15 +45,32 @@ stdenv.mkDerivation rec {
     # Let’s change the code to run the script directly by making it executable and having gjs in shebang.
     ./make-thumbnailer-wrappable.patch
 
-    # Switch to girepository-2.0
-    # https://gitlab.gnome.org/GNOME/polari/-/merge_requests/356
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/polari/-/commit/d7946c7fe39f112cd3f751bb95b170446022980d.patch";
-      hash = "sha256-naRzZ5Iple11HJ+d8DL9oJy3C4VKLkz+FdMuhO7sc7k=";
-    })
+    # fix TypeError: (intermediate value).get_current_event_device is not a function
+    # https://gitlab.gnome.org/GNOME/polari/-/merge_requests/320
+    ./0001-joinDialog-Fix-detecting-pointer-devices.patch
+
+    # https://gitlab.gnome.org/GNOME/polari/-/merge_requests/329
+    ./0002-mainWindow-Disconnect-event-handler-on-destroy.patch
+
+    # https://gitlab.gnome.org/GNOME/polari/-/merge_requests/330
+    ./0003-Add-option-to-disable-URL-preview-feature.patch
+
+    # This also helps us to distribute the app as a single package
+    # without enabling telepathy-{idle,mission-control} services
+    ./check_dbus_unconditionally.patch
+
+    # This fixes Tracker.SparqlError: table Resource already exists
+    # and chat history spinning forever on second launch.
+    # Fixes the race condition by ensuring all callers wait on the
+    # same shared initialization promise
+    ./fix_sparql_database_race.patch
   ];
 
-  propagatedUserEnvPkgs = [ telepathy-idle ];
+  postPatch = ''
+    substituteInPlace src/application.js \
+      --replace-fail "/app/libexec/mission-control-5" "${lib.getLib telepathy-mission-control}/libexec/mission-control-5" \
+      --replace-fail "/app/libexec/telepathy-idle" "${telepathy-idle}/libexec/telepathy-idle"
+  '';
 
   nativeBuildInputs = [
     meson
@@ -72,6 +90,7 @@ stdenv.mkDerivation rec {
     libadwaita
     gtk3 # for thumbnailer
     glib
+    glib-networking
     gsettings-desktop-schemas
     telepathy-glib
     gjs
@@ -90,15 +109,15 @@ stdenv.mkDerivation rec {
     updateScript = gnome.updateScript { packageName = "polari"; };
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://apps.gnome.org/Polari/";
     description = "IRC chat client designed to integrate with the GNOME desktop";
     mainProgram = "polari";
     teams = [
-      teams.gnome
-      teams.gnome-circle
+      lib.teams.gnome
+      lib.teams.gnome-circle
     ];
-    license = licenses.gpl2Plus;
-    platforms = platforms.linux;
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/te/telepathy-idle/package.nix
+++ b/pkgs/by-name/te/telepathy-idle/package.nix
@@ -7,6 +7,7 @@
   pkg-config,
   dbus-glib,
   telepathy-glib,
+  glib-networking,
   python3,
   libxslt,
   makeWrapper,
@@ -28,6 +29,7 @@ stdenv.mkDerivation rec {
   ];
   buildInputs = [
     glib
+    glib-networking
     telepathy-glib
     dbus-glib
     libxslt
@@ -36,7 +38,12 @@ stdenv.mkDerivation rec {
 
   preFixup = ''
     wrapProgram "$out/libexec/telepathy-idle" \
-      --prefix GIO_EXTRA_MODULES : "${lib.getLib dconf}/lib/gio/modules"
+      --prefix GIO_EXTRA_MODULES : "${
+        lib.makeSearchPath "lib/gio/modules" [
+          (lib.getLib dconf)
+          glib-networking
+        ]
+      }"
   '';
 
   meta = {


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/149685

All the issues fixed now, and polari can launch as a standalone app without telepathy service (and use the service if exists)!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
