### PR TITLE
cstop: init at 1.0.1

### DIFF
--- a/pkgs/by-name/cs/cstop/package.nix
+++ b/pkgs/by-name/cs/cstop/package.nix
@@ -1,0 +1,139 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  fetchpatch,
+  nix-update-script,
+  cmake,
+  pkg-config,
+  libx11,
+  libxrandr,
+  libxinerama,
+  libxext,
+  libxcursor,
+  freetype,
+  fontconfig,
+  expat,
+  alsa-lib,
+  juce,
+
+  buildStandalone ? true,
+  buildVST3 ? true,
+  buildCLAP ? true,
+}:
+
+let
+  chowdsp_utils = fetchFromGitHub {
+    owner = "Chowdhury-DSP";
+    repo = "chowdsp_utils";
+    tag = "v2.3.0";
+    hash = "sha256-/RCbCQ302lsXDgyQ4AmQJqPmky+CvvjZbj6NdboNPbM=";
+  };
+
+  clap-juce-extensions = fetchFromGitHub {
+    owner = "free-audio";
+    repo = "clap-juce-extensions";
+    rev = "645ed2fd0949d36639e3d63333f26136df6df769";
+    hash = "sha256-Lx88nyEFjPLA5yh8rrqBdyZIxe/j0FgIHoyKcbjuuI4=";
+    fetchSubmodules = true;
+  };
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  name = "cstop";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "calgoheen";
+    repo = "cStop";
+    tag = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-TzXsT1rKHu62O+NB6xvTLsoBwP3B8UmCOQaH+kqSQDI=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    libx11
+    libxcursor
+    libxrandr
+    libxinerama
+    libxext
+    freetype
+    fontconfig
+    expat
+    alsa-lib
+  ];
+
+  # Needed for standalone
+  NIX_LDFLAGS = [
+    "-lX11"
+  ];
+
+  patches = [
+    # Adds CMake BUILD_* options
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/calgoheen/cStop/pull/5.patch";
+      hash = "sha256-jkjOLVEVA3n1xOcFmgy5FIICaLOSU5VNvyIASZzklkc=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "juce::juce_recommended_lto_flags" "# Not forcing LTO"
+
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "COPY_PLUGIN_AFTER_BUILD TRUE" "COPY_PLUGIN_AFTER_BUILD FALSE"
+  '';
+
+  cmakeFlags = [
+    (lib.cmakeFeature "CMAKE_AR" (lib.getExe' stdenv.cc.cc "gcc-ar"))
+    (lib.cmakeFeature "CMAKE_RANLIB" (lib.getExe' stdenv.cc.cc "gcc-ranlib"))
+
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_JUCE" "${juce.src}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_CLAP-JUCE-EXTENSIONS" "${clap-juce-extensions}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_CHOWDSP_UTILS" "${chowdsp_utils}")
+
+    (lib.cmakeBool "BUILD_STANDALONE" buildStandalone)
+    (lib.cmakeBool "BUILD_VST3" buildVST3)
+    (lib.cmakeBool "BUILD_CLAP" buildCLAP)
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    pushd cStop_artefacts/Release
+      ${lib.optionalString buildStandalone ''
+        install -Dm755 Standalone/cStop -t $out/bin
+      ''}
+
+      ${lib.optionalString buildVST3 ''
+        mkdir -p $out/lib/vst3
+        cp -r VST3/cStop.vst3 $out/lib/vst3
+      ''}
+
+      ${lib.optionalString buildCLAP ''
+        mkdir -p $out/lib/clap
+        cp CLAP/cStop.clap $out/lib/clap
+      ''}
+    popd
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Tape stop audio effect plugin";
+    homepage = "https://github.com/calgoheen/cStop";
+    platforms = lib.platforms.linux;
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.mrtnvgr ];
+  }
+  // lib.optionalAttrs buildStandalone {
+    mainProgram = "cStop";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
