### PR TITLE
python313Packages.optype: 0.14.0 -> 0.14.0-unstable-2025-11-10

### DIFF
--- a/pkgs/development/python-modules/numpy-typing-compat/default.nix
+++ b/pkgs/development/python-modules/numpy-typing-compat/default.nix
@@ -17,6 +17,11 @@ buildPythonPackage rec {
     hash = "sha256-cug9U1tjXWaLpzFeQ66AvhRppvrqb8ltMSUW85s9j6U=";
   };
 
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail '"uv_build>=0.8.11,<0.9.0"' '"uv_build>=0.8.11"'
+  '';
+
   build-system = [
     uv-build
   ];

--- a/pkgs/development/python-modules/optype/default.nix
+++ b/pkgs/development/python-modules/optype/default.nix
@@ -11,16 +11,16 @@
   pythonOlder,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "optype";
-  version = "0.14.0";
+  version = "0.14.0-unstable-2025-11-10";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jorenham";
     repo = "optype";
-    tag = "v${version}";
-    hash = "sha256-0CE6dU4Vt3UP8ZfNcmP2Th7ixceCa0ItYUmNcEU7mgw=";
+    rev = "5f16def3546222caf81a3411a27b007a00819172";
+    hash = "sha256-52cY+u0wjhJFQDLsjND/h6cfln4rCTtcy+HqaoH/re0=";
   };
 
   disabled = pythonOlder "3.11";


### PR DESCRIPTION
https://github.com/jorenham/optype/compare/v0.14.0...5f16def3546222caf81a3411a27b007a00819172

Updating to an unstable commit of optype as upstream already updated uv-build on `master`. This is not the case for numpy-typing-compat, so we patch.

Hydra: https://hydra.nixos.org/build/312511601/nixlog/3
ZHF: #457852

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
