### PR TITLE
b43-firmware: update source, set sourceProvenance, modernize

### DIFF
--- a/pkgs/os-specific/linux/firmware/b43-firmware/5.1.138.nix
+++ b/pkgs/os-specific/linux/firmware/b43-firmware/5.1.138.nix
@@ -4,17 +4,12 @@
   fetchurl,
   b43FirmwareCutter,
 }:
-
-let
-  version = "5.100.138";
-in
-
-stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "b43-firmware";
-  inherit version;
+  version = "5.100.138";
 
   src = fetchurl {
-    url = "http://www.lwfinger.com/b43-firmware/broadcom-wl-${version}.tar.bz2";
+    url = "https://github.com/minios-linux/b43-firmware/releases/download/b43-firmware/broadcom-wl-${finalAttrs.version}.tar.bz2";
     hash = "sha256-8ecGeqxbYrZ7i25MUXmQJ3gEM5rBYGXrE8cx/5Ca5G8=";
   };
 
@@ -29,5 +24,6 @@ stdenvNoCC.mkDerivation {
     description = "Firmware for cards supported by the b43 kernel module";
     homepage = "https://wireless.wiki.kernel.org/en/users/drivers/b43";
     license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryFirmware ];
   };
-}
+})

--- a/pkgs/os-specific/linux/firmware/b43-firmware/5.1.138.nix
+++ b/pkgs/os-specific/linux/firmware/b43-firmware/5.1.138.nix
@@ -15,7 +15,7 @@ stdenvNoCC.mkDerivation {
 
   src = fetchurl {
     url = "http://www.lwfinger.com/b43-firmware/broadcom-wl-${version}.tar.bz2";
-    sha256 = "0vz4ka8gycf72gmnaq61k8rh8y17j1wm2k3fidxvcqjvmix0drzi";
+    hash = "sha256-8ecGeqxbYrZ7i25MUXmQJ3gEM5rBYGXrE8cx/5Ca5G8=";
   };
 
   nativeBuildInputs = [ b43FirmwareCutter ];

--- a/pkgs/os-specific/linux/firmware/b43-firmware/6.30.163.46.nix
+++ b/pkgs/os-specific/linux/firmware/b43-firmware/6.30.163.46.nix
@@ -4,13 +4,12 @@
   fetchurl,
   b43FirmwareCutter,
 }:
-
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "b43-firmware";
   version = "6.30.163.46";
 
   src = fetchurl {
-    url = "http://www.lwfinger.com/b43-firmware/broadcom-wl-${version}.tar.bz2";
+    url = "https://github.com/minios-linux/b43-firmware/releases/download/b43-firmware/broadcom-wl-${finalAttrs.version}.tar.bz2";
     hash = "sha256-oHw7ayd4M8fb5h2qUR+QjNZsXidj63oIWavDbNkzXC0=";
   };
 
@@ -28,5 +27,6 @@ stdenvNoCC.mkDerivation rec {
     homepage = "https://wireless.wiki.kernel.org/en/users/drivers/b43";
     downloadPage = "http://www.lwfinger.com/b43-firmware";
     license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryFirmware ];
   };
-}
+})

--- a/pkgs/os-specific/linux/firmware/b43-firmware/6.30.163.46.nix
+++ b/pkgs/os-specific/linux/firmware/b43-firmware/6.30.163.46.nix
@@ -11,7 +11,7 @@ stdenvNoCC.mkDerivation rec {
 
   src = fetchurl {
     url = "http://www.lwfinger.com/b43-firmware/broadcom-wl-${version}.tar.bz2";
-    sha256 = "0baw6gcnrhxbb447msv34xg6rmlcj0gm3ahxwvdwfcvq4xmknz50";
+    hash = "sha256-oHw7ayd4M8fb5h2qUR+QjNZsXidj63oIWavDbNkzXC0=";
   };
 
   nativeBuildInputs = [ b43FirmwareCutter ];


### PR DESCRIPTION
The previous url redirects to some gambling website; the new url provides the same tarballs

I have verified the new hashes by first using `lib.fakeHash` to force a fresh download and the files indeed have the same hash as before.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
