### PR TITLE
buildEnv: relax constraints about readdir contents

### DIFF
--- a/pkgs/build-support/buildenv/builder.pl
+++ b/pkgs/build-support/buildenv/builder.pl
@@ -74,7 +74,7 @@ sub findFiles;
 
 sub findFilesInDir($relName, $target, $ignoreCollisions, $checkCollisionContents, $priority, $ignoreSingleFileOutputs) {
     opendir DIR, "$target" or die "cannot open `$target': $!";
-    my @names = readdir DIR or die;
+    my @names = readdir DIR;
     closedir DIR;
 
     foreach my $name (@names) {


### PR DESCRIPTION
We were wondering why nix builds were failing, where the nix store is located on a virtual filesystem / fuse. In our case it is a store located on a lazy pulling enabled OCI image. We use estargz / zstd:chunked images, where fuse is used to start the container right away (and pulling the rest of the image in the background)

```
# nix profile upgrade runtime 
error: Cannot build '/nix/store/nccvdkcbvrl9y35f7ngw9x8qpcvbp7kp-devtools.drv'.
       Reason: builder failed with exit code 2.
       Output paths:
         /nix/store/2sj7yjv2756y16nz5f1azszgms4vix8z-devtools
       Last 1 log lines:
       > pkgs.buildEnv error: Died at /nix/store/4z0grds97rmripxps6b0kby1fr3g35cp-builder.pl line 77.
       For full logs, run:
         nix log /nix/store/nccvdkcbvrl9y35f7ngw9x8qpcvbp7kp-devtools.drv
error: build of '/nix/store/nccvdkcbvrl9y35f7ngw9x8qpcvbp7kp-devtools.drv^out' failed
```

This boils down to the POSIX standard, where "." and ".." are optional and SHALL get displayed (not MUST).

see https://pubs.opengroup.org/onlinepubs/9799919799/functions/readdir.html

The nixpkgs code has an assumption that empty directories at least have the result "." and "..", but this is not valid for all FS.

https://perldoc.perl.org/functions/readdir

> Returns the next directory entry for a directory opened by [opendir](https://perldoc.perl.org/functions/opendir).

The nixpkgs code should work in a more relaxed mode, since opendir already checks that the directory is valid and readable. We would appreciate a backport to 25.11. staging as well (I can not set the tags)

```
# ls -lsa /nix/store/5r2skpf8xr3wjkgix63993cnp99nngsl-file-5.45-man/share/man/
total 0
0 dr-xr-xr-x 2 root root 0 Jan  1  1970 man1
0 dr-xr-xr-x 2 root root 0 Jan  1  1970 man3
0 dr-xr-xr-x 2 root root 0 Jan  1  1970 man4
0 dr-xr-xr-x 2 root root 0 Jan  1  1970 man5
# ls -lsa /nix/store/5r2skpf8xr3wjkgix63993cnp99nngsl-file-5.45-man/share/man/man5
total 0
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
