### PR TITLE
Cinnamon updates 2025-11-20

### DIFF
--- a/pkgs/by-name/li/lightdm-slick-greeter/package.nix
+++ b/pkgs/by-name/li/lightdm-slick-greeter/package.nix
@@ -18,17 +18,18 @@
   linkFarm,
   lightdm-slick-greeter,
   numlockx,
+  xapp-symbolic-icons,
 }:
 
 stdenv.mkDerivation rec {
   pname = "lightdm-slick-greeter";
-  version = "2.2.2";
+  version = "2.2.3";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "slick-greeter";
     rev = version;
-    hash = "sha256-32H2Q/JdT5v0xrdsZfSJobJ4Dxx63LPgbiB9OKIyc1U=";
+    hash = "sha256-htyFH1Q8RFyvkW75NMpjajNJDzv/87k/Dr8+R5beT2w=";
   };
 
   nativeBuildInputs = [
@@ -85,6 +86,7 @@ stdenv.mkDerivation rec {
     buildPythonPath "$out $pythonPath"
     gappsWrapperArgs+=(
       --prefix PYTHONPATH : "$program_PYTHONPATH"
+      --prefix XDG_DATA_DIRS : "${lib.makeSearchPath "share" [ xapp-symbolic-icons ]}"
     )
   '';
 

--- a/pkgs/by-name/pi/pix/package.nix
+++ b/pkgs/by-name/pi/pix/package.nix
@@ -30,17 +30,18 @@
   desktop-file-utils,
   itstool,
   xapp,
+  xapp-symbolic-icons,
 }:
 
 stdenv.mkDerivation rec {
   pname = "pix";
-  version = "3.4.7";
+  version = "3.4.8";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "pix";
     rev = version;
-    hash = "sha256-Z8JGss5DA4Lsj7fhjRztF6Y+zYjZuIbmYRo7wvwxB8k=";
+    hash = "sha256-zK02qhTGuYgZWHkJ6c3EVinUcojNEWwecvPjblECLkw=";
   };
 
   nativeBuildInputs = [
@@ -85,7 +86,6 @@ stdenv.mkDerivation rec {
 
     patchShebangs data/gschemas/make-enums.py \
       pix/make-pix-h.py \
-      po/make-potfiles-in.py \
       postinstall.py \
       pix/make-authors-tab.py
   '';
@@ -95,7 +95,12 @@ stdenv.mkDerivation rec {
   mesonFlags = [ "-Dwebservices=false" ];
 
   preFixup = ''
-    gappsWrapperArgs+=(--prefix XDG_DATA_DIRS : "${shared-mime-info}/share")
+    gappsWrapperArgs+=(--prefix XDG_DATA_DIRS : "${
+      lib.makeSearchPath "share" [
+        shared-mime-info
+        xapp-symbolic-icons
+      ]
+    }")
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/st/sticky/package.nix
+++ b/pkgs/by-name/st/sticky/package.nix
@@ -11,18 +11,19 @@
   glib,
   gspell,
   gtk3,
+  xapp-symbolic-icons,
   gitUpdater,
 }:
 
 stdenv.mkDerivation rec {
   pname = "sticky";
-  version = "1.27";
+  version = "1.28";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "sticky";
     rev = version;
-    hash = "sha256-IuYRcvoUyY03aEclkiOmamjb/c/JaYYIoqKdcwDSY8Q=";
+    hash = "sha256-6CRkeJ2xuUs3viyYxnrgGFUIakK7ANyVpPZuwU486NM=";
   };
 
   postPatch = ''
@@ -51,14 +52,13 @@ stdenv.mkDerivation rec {
     python-xapp
   ];
 
-  dontWrapGApps = true;
-
   preFixup = ''
     buildPythonPath "$out $pythonPath"
 
-    wrapProgram $out/bin/sticky \
-      --prefix PYTHONPATH : "$program_PYTHONPATH" \
-      ''${gappsWrapperArgs[@]}
+    gappsWrapperArgs+=(
+      --prefix PYTHONPATH : "$program_PYTHONPATH"
+      --prefix XDG_DATA_DIRS : "${lib.makeSearchPath "share" [ xapp-symbolic-icons ]}"
+    )
   '';
 
   passthru = {

--- a/pkgs/by-name/xa/xapp-symbolic-icons/package.nix
+++ b/pkgs/by-name/xa/xapp-symbolic-icons/package.nix
@@ -9,13 +9,13 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "xapp-symbolic-icons";
-  version = "1.0.1";
+  version = "1.0.2";
 
   src = fetchFromGitHub {
     owner = "xapp-project";
     repo = "xapp-symbolic-icons";
     tag = finalAttrs.version;
-    hash = "sha256-TOSbEcxYXuUtc0RC1Seva8uqF5qveVRq2dpG0BZmCK0=";
+    hash = "sha256-Z5edMCjw1/LO0+Ms5KCfFJ/iAANO2MihVZmLcJd5d3A=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--

pix: 3.4.7 -> 3.4.8
lightdm-slick-greeter: 2.2.2 -> 2.2.3
sticky: 1.27 -> 1.28
xapp-symbolic-icons: 1.0.1 -> 1.0.2


-->


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

