### PR TITLE
knot-resolver{,-manager}_6: init at 6.0.16 and nixos/knot-resolver: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -10,7 +10,7 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- Create the first release note entry in this section!
+- [knot-resolver](https://www.knot-resolver.cz/) in version 6. Available as `services.knot-resolver`. A module for knot-resolver 5 was already available as `services.kresd`.
 
 ## Backward Incompatibilities {#sec-release-26.05-incompatibilities}
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1231,6 +1231,7 @@
   ./services/networking/keepalived/default.nix
   ./services/networking/keybase.nix
   ./services/networking/kismet.nix
+  ./services/networking/knot-resolver.nix
   ./services/networking/knot.nix
   ./services/networking/kresd.nix
   ./services/networking/lambdabot.nix

--- a/nixos/modules/services/networking/knot-resolver.nix
+++ b/nixos/modules/services/networking/knot-resolver.nix
@@ -1,0 +1,153 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.knot-resolver;
+  # pkgs.writers.yaml_1_1.generate with additional kresctl validate
+  configFile =
+    pkgs.runCommandLocal "knot-resolver.yaml"
+      {
+        nativeBuildInputs = [ pkgs.remarshal_0_17 ];
+        value = builtins.toJSON cfg.settings;
+        passAsFile = [ "value" ];
+      }
+      ''
+        json2yaml "$valuePath" "$out"
+        ${cfg.managerPackage}/bin/kresctl validate "$out"
+      '';
+in
+{
+  meta.maintainers = [
+    lib.maintainers.vcunat # upstream developer
+  ]
+  ++ lib.teams.flyingcircus.members;
+
+  ###### interface
+  options.services.knot-resolver = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to enable knot-resolver (version 6) domain name server.
+        DNSSEC validation is turned on by default.
+        If you want to use knot-resolver 5, please use services.kresd.
+      '';
+    };
+    package = lib.mkPackageOption pkgs "knot-resolver_6" {
+      example = "knot-resolver_6.override { extraFeatures = true; }";
+    };
+    managerPackage = lib.mkPackageOption pkgs "knot-resolver-manager_6" { };
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = (pkgs.formats.yaml { }).type;
+        options = {
+          network.listen = lib.mkOption {
+            type = lib.types.listOf (
+              lib.types.submodule {
+                freeformType = (pkgs.formats.yaml { }).type;
+              }
+            );
+            description = "List of interfaces to listen to and its configuration.";
+            default = [
+              {
+                interface = [ "127.0.0.1" ];
+                kind = "dns";
+                freebind = false;
+              }
+            ]
+            ++ lib.optionals config.networking.enableIPv6 [
+              {
+                interface = [ "::1" ];
+                kind = "dns";
+                freebind = false;
+              }
+            ];
+            defaultText = lib.literalExpression ''
+              [
+                {
+                  interface = [ "127.0.0.1" ];
+                  kind = "dns";
+                  freebind = false;
+                }
+              ]
+              ++ lib.optionals config.networking.enableIPv6 [
+                {
+                  interface = [ "::1" ];
+                  kind = "dns";
+                  freebind = false;
+                }
+               ];
+            '';
+          };
+          workers = lib.mkOption {
+            type = lib.types.oneOf [
+              (lib.types.enum [ "auto" ])
+              lib.types.ints.unsigned
+            ];
+            default = 1;
+            description = ''
+              The number of running kresd (Knot Resolver daemon) workers. If set to 'auto', it is equal to number of CPUs available.
+            '';
+          };
+        };
+      };
+      default = { };
+      description = ''
+        Nix-based (RFC 42) configuration for Knot Resolver.
+        For configuration reference (described as YAML) see
+        <https://www.knot-resolver.cz/documentation/latest/config-overview.html>
+      '';
+    };
+  };
+
+  ###### implementation
+  config = lib.mkIf cfg.enable {
+    users.users.knot-resolver = {
+      isSystemUser = true;
+      group = "knot-resolver";
+      description = "Knot-resolver daemon user";
+    };
+    users.groups.knot-resolver = { };
+    networking.resolvconf.useLocalResolver = lib.mkDefault true;
+    assertions = lib.optionals (lib.versions.major cfg.package.version == 5) [
+      "services.knot-resolver only works with knot-resolver 6 or later. Please use services.kresd for knot-resolver 5."
+    ];
+
+    environment = {
+      etc."knot-resolver/config.yaml".source = configFile;
+      systemPackages = [
+        # We just avoid including the other binaries, e.g. supervisorctl.
+        (pkgs.runCommandLocal "knot-resolver-cmds" { } ''
+          mkdir -p "$out/bin"
+          ln -s '${cfg.managerPackage}/bin/kresctl' "$out/bin/"
+        '')
+      ];
+    };
+
+    systemd.packages = [ cfg.package ]; # the unit gets patched a bit just below
+    systemd.services."knot-resolver" = {
+      wantedBy = [ "multi-user.target" ];
+      path = [ (lib.getBin cfg.package) ];
+      stopIfChanged = false;
+      reloadTriggers = [
+        configFile
+      ];
+      serviceConfig = {
+        ExecStart = "${cfg.managerPackage}/bin/knot-resolver";
+        ExecReload = "${cfg.managerPackage}/bin/kresctl reload";
+
+        StateDirectory = "knot-resolver";
+        StateDirectoryMode = "0770";
+
+        RuntimeDirectory = "knot-resolver";
+        RuntimeDirectoryMode = "0770";
+
+        CacheDirectory = "knot-resolver";
+        CacheDirectoryMode = "0770";
+      };
+    };
+  };
+}

--- a/nixos/modules/services/networking/kresd.nix
+++ b/nixos/modules/services/networking/kresd.nix
@@ -66,9 +66,10 @@ in
       type = lib.types.bool;
       default = false;
       description = ''
-        Whether to enable knot-resolver domain name server.
+        Whether to enable knot-resolver (version 5) domain name server.
         DNSSEC validation is turned on by default.
         You can run `kresd-cli 1` and give commands interactively to kresd@1.service.
+        If you want to user knot-resolver 6, please use services.knot-resolver.
       '';
     };
     package = lib.mkPackageOption pkgs "knot-resolver_5" {
@@ -134,6 +135,9 @@ in
 
   ###### implementation
   config = lib.mkIf cfg.enable {
+    assertions = lib.optionals (lib.versions.major cfg.package.version > 5) [
+      "services.kresd only works with knot-resolver 5. Please use services.knot-resolver for knot-resolver 6 and newer."
+    ];
     environment = {
       etc."knot-resolver/kresd.conf".source = configFile; # not required
       systemPackages = [

--- a/nixos/modules/services/networking/kresd.nix
+++ b/nixos/modules/services/networking/kresd.nix
@@ -71,8 +71,8 @@ in
         You can run `kresd-cli 1` and give commands interactively to kresd@1.service.
       '';
     };
-    package = lib.mkPackageOption pkgs "knot-resolver" {
-      example = "knot-resolver.override { extraFeatures = true; }";
+    package = lib.mkPackageOption pkgs "knot-resolver_5" {
+      example = "knot-resolver_5.override { extraFeatures = true; }";
     };
     extraConfig = lib.mkOption {
       type = lib.types.lines;

--- a/pkgs/by-name/kn/knot-dns/package.nix
+++ b/pkgs/by-name/kn/knot-dns/package.nix
@@ -26,7 +26,7 @@
   sphinx,
   autoreconfHook,
   nixosTests,
-  knot-resolver,
+  knot-resolver_5,
   knot-dns,
   runCommandLocal,
 }:
@@ -113,7 +113,7 @@ stdenv.mkDerivation rec {
   '';
 
   passthru.tests = {
-    inherit knot-resolver;
+    inherit knot-resolver_5;
   }
   // lib.optionalAttrs stdenv.hostPlatform.isLinux {
     inherit (nixosTests) knot kea;

--- a/pkgs/by-name/kn/knot-resolver-manager_6/package.nix
+++ b/pkgs/by-name/kn/knot-resolver-manager_6/package.nix
@@ -1,0 +1,56 @@
+{
+  knot-resolver_6,
+  writeText,
+  python3Packages,
+}:
+
+python3Packages.buildPythonPackage {
+  pname = "knot-resolver-manager_6";
+  inherit (knot-resolver_6) version src;
+  pyproject = true;
+
+  patches = [
+    # Rewrap the two supervisor's binaries, so that they obtain access to python modules
+    # defined in the manager.  Those are then used as extensions of supervisord.
+    # Manager needs this fixed bin/supervisord on its $PATH.
+    ./rewrap-supervisor.patch
+  ];
+
+  # Propagate meson config from the C part to the python part.
+  # But the install-time etc differs from a sensible run-time etc.
+  postPatch = ''
+    substitute '${knot-resolver_6.config_py}'/knot_resolver/constants.py ./python/knot_resolver/constants.py \
+      --replace-fail '${knot-resolver_6.out}/etc' '/etc'
+  '';
+
+  build-system = with python3Packages; [
+    poetry-core
+    setuptools
+  ];
+
+  # Deps can be seen in ${src}/pyproject.toml
+  propagatedBuildInputs = with python3Packages; [
+    aiohttp
+    jinja2
+    pyyaml
+    prometheus-client
+    supervisor
+    typing-extensions
+  ];
+
+  doCheck = false; # FIXME
+  checkInputs = with python3Packages; [
+    python3Packages.augeas
+    dnspython
+    lief
+    pytestCheckHook
+    pytest-asyncio
+    pyroute2
+    pyparsing
+    toml
+  ];
+
+  meta = knot-resolver_6.meta // {
+    mainProgram = "knot-resolver";
+  };
+}

--- a/pkgs/by-name/kn/knot-resolver-manager_6/rewrap-supervisor.patch
+++ b/pkgs/by-name/kn/knot-resolver-manager_6/rewrap-supervisor.patch
@@ -1,0 +1,14 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 22d6ca5b0d..15acfb3c6c 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -71,6 +71,9 @@
+ [tool.poetry.scripts]
+ kresctl = 'knot_resolver.client.main:main'
+ knot-resolver = 'knot_resolver.manager.main:main'
++supervisord = 'supervisor.supervisord:main'
++supervisorctl = 'supervisor.supervisorctl:main'
++
+
+ [tool.poe.tasks]
+ # tasks runed through scripts located in 'scripts/poe-tasks/'

--- a/pkgs/by-name/kn/knot-resolver_5/package.nix
+++ b/pkgs/by-name/kn/knot-resolver_5/package.nix
@@ -33,12 +33,12 @@ let
   inherit (lib) optional optionals optionalString;
   lua = luajitPackages;
 
-  unwrapped = stdenv.mkDerivation rec {
+  unwrapped = stdenv.mkDerivation (finalAttrs: {
     pname = "knot-resolver_5";
     version = "5.7.6";
 
     src = fetchurl {
-      url = "https://secure.nic.cz/files/knot-resolver/${pname}-${version}.tar.xz";
+      url = "https://secure.nic.cz/files/knot-resolver/knot-resolver-${finalAttrs.version}.tar.xz";
       sha256 = "500ccd3a560300e547b8dc5aaff322f7c8e2e7d6f0d7ef5f36e59cb60504d674";
     };
 
@@ -69,7 +69,7 @@ let
       done
     ''
     # some tests have issues with network sandboxing, apparently
-    + optionalString doInstallCheck ''
+    + optionalString finalAttrs.doInstallCheck ''
       echo 'os.exit(77)' > daemon/lua/trust_anchors.test/bootstrap.test.lua
       sed -E '/^[[:blank:]]*test_(dstaddr|headers),?$/d' -i \
         tests/config/doh2.test.lua modules/http/http_doh.test.lua
@@ -116,8 +116,8 @@ let
       "-Dmalloc=jemalloc"
       "--default-library=static" # not used by anyone
     ]
-    ++ optional doInstallCheck "-Dunit_tests=enabled"
-    ++ optional doInstallCheck "-Dconfig_tests=enabled"
+    ++ optional finalAttrs.doInstallCheck "-Dunit_tests=enabled"
+    ++ optional finalAttrs.doInstallCheck "-Dconfig_tests=enabled"
     ++ optional stdenv.hostPlatform.isLinux "-Dsystemd_files=enabled" # used by NixOS service
     #"-Dextra_tests=enabled" # not suitable as in-distro tests; many deps, too.
     ;
@@ -153,7 +153,7 @@ let
       ];
       mainProgram = "kresd";
     };
-  };
+  });
 
   wrapped-full =
     runCommand unwrapped.name

--- a/pkgs/by-name/kn/knot-resolver_5/package.nix
+++ b/pkgs/by-name/kn/knot-resolver_5/package.nix
@@ -15,7 +15,7 @@
   gnutls,
   lmdb,
   jemalloc,
-  systemd,
+  systemdMinimal,
   libcap_ng,
   dns-root-data,
   nghttp2, # optionals, in principle
@@ -34,7 +34,7 @@ let
   lua = luajitPackages;
 
   unwrapped = stdenv.mkDerivation rec {
-    pname = "knot-resolver";
+    pname = "knot-resolver_5";
     version = "5.7.6";
 
     src = fetchurl {
@@ -96,7 +96,7 @@ let
     ## the rest are optional dependencies
     ++ optionals stdenv.hostPlatform.isLinux [
       # lib
-      systemd
+      systemdMinimal
       libcap_ng
     ]
     ++ [

--- a/pkgs/by-name/kn/knot-resolver_6/package.nix
+++ b/pkgs/by-name/kn/knot-resolver_6/package.nix
@@ -146,6 +146,7 @@ let
       maintainers = [
         maintainers.vcunat # upstream developer
       ];
+      teams = [ teams.flyingcircus ];
       mainProgram = "kresd";
     };
   });

--- a/pkgs/by-name/kn/knot-resolver_6/package.nix
+++ b/pkgs/by-name/kn/knot-resolver_6/package.nix
@@ -1,0 +1,188 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  # native deps.
+  runCommand,
+  pkg-config,
+  meson,
+  ninja,
+  makeWrapper,
+  # build+runtime deps.
+  knot-dns,
+  luajitPackages,
+  libuv,
+  gnutls,
+  lmdb,
+  jemalloc,
+  systemdMinimal,
+  libcap_ng,
+  dns-root-data,
+  nghttp2, # optionals, in principle
+  fstrm,
+  protobufc, # more optionals
+  # test-only deps.
+  cmocka,
+  which,
+  cacert,
+  extraFeatures ? false, # catch-all if defaults aren't enough
+}:
+let
+  result = if extraFeatures then wrapped-full else unwrapped;
+
+  inherit (lib) optional optionals optionalString;
+  lua = luajitPackages;
+
+  unwrapped = stdenv.mkDerivation (finalAttrs: {
+    pname = "knot-resolver_6";
+    version = "6.0.17";
+
+    src = fetchurl {
+      url = "https://secure.nic.cz/files/knot-resolver/knot-resolver-${finalAttrs.version}.tar.xz";
+      hash = "sha256-E9RJbvh66y+9OwBX4iEdRYUgUkHlCaDNQ0Hb5ejLXBw=";
+    };
+
+    outputs = [
+      "out"
+      "dev"
+      "config_py"
+    ];
+
+    # Path fixups for the NixOS service.
+    # systemd Exec* options are difficult to override in NixOS *if present*, so we drop them.
+    postPatch = ''
+      patch meson.build <<EOF
+      @@ -50,2 +50,3 @@
+      -systemd_work_dir = prefix / get_option('localstatedir') / 'lib' / 'knot-resolver'
+      -systemd_cache_dir = prefix / get_option('localstatedir') / 'cache' / 'knot-resolver'
+      +systemd_work_dir  = '/var/lib/knot-resolver'
+      +systemd_cache_dir = '/var/cache/knot-resolver'
+      +run_dir = '/run/knot-resolver'
+      EOF
+
+      sed -e '/^ExecStart=/d' -e '/^ExecReload=/d' \
+        -i systemd/knot-resolver.service.in
+    ''
+    # some tests have issues with network sandboxing, apparently
+    + optionalString finalAttrs.doInstallCheck ''
+      echo 'os.exit(77)' > daemon/lua/trust_anchors.test/bootstrap.test.lua
+      sed -E '/^[[:blank:]]*test_(dstaddr|headers),?$/d' -i \
+        tests/config/doh2.test.lua modules/http/http_doh.test.lua
+    '';
+
+    preConfigure = ''
+      patchShebangs scripts/
+    '';
+
+    nativeBuildInputs = [
+      pkg-config
+      meson
+      ninja
+    ];
+
+    # http://knot-resolver.readthedocs.io/en/latest/build.html#requirements
+    buildInputs = [
+      knot-dns
+      lua.lua
+      libuv
+      gnutls
+      lmdb
+    ]
+    ## the rest are optional dependencies
+    ++ optionals stdenv.hostPlatform.isLinux [
+      # lib
+      systemdMinimal
+      libcap_ng
+    ]
+    ++ [
+      jemalloc
+      nghttp2
+    ]
+    ++ [
+      fstrm
+      protobufc
+    ] # dnstap support
+    ;
+
+    mesonFlags = [
+      "-Dkeyfile_default=${dns-root-data}/root.ds"
+      "-Droot_hints=${dns-root-data}/root.hints"
+      "-Dinstall_kresd_conf=disabled" # not really useful; examples are inside share/doc/
+      "-Dmalloc=jemalloc"
+      "--default-library=static" # not used by anyone
+    ]
+    ++ optional finalAttrs.doInstallCheck "-Dunit_tests=enabled"
+    ++ optional finalAttrs.doInstallCheck "-Dconfig_tests=enabled"
+    ++ optional stdenv.hostPlatform.isLinux "-Dsystemd_files=enabled" # used by NixOS service
+    #"-Dextra_tests=enabled" # not suitable as in-distro tests; many deps, too.
+    ;
+
+    postInstall = ''
+      cp -r ./python "$config_py"
+      rm "$out"/lib/libkres.a
+    ''
+    + optionalString stdenv.hostPlatform.isLinux ''
+      rm -r "$out"/lib/sysusers.d/ # ATM more likely to harm than help
+    '';
+
+    doInstallCheck = with stdenv; hostPlatform == buildPlatform;
+    nativeInstallCheckInputs = [
+      cmocka
+      which
+      cacert
+      lua.cqueues
+      lua.basexx
+      lua.http
+    ];
+    installCheckPhase = ''
+      meson test --print-errorlogs --no-suite snowflake
+    '';
+
+    meta = with lib; {
+      description = "Caching validating DNS resolver, from .cz domain registry";
+      homepage = "https://knot-resolver.cz";
+      license = licenses.gpl3Plus;
+      platforms = platforms.unix;
+      maintainers = [
+        maintainers.vcunat # upstream developer
+      ];
+      mainProgram = "kresd";
+    };
+  });
+
+  wrapped-full =
+    runCommand unwrapped.name
+      {
+        nativeBuildInputs = [ makeWrapper ];
+        buildInputs = with luajitPackages; [
+          # For http module, prefill module, trust anchor bootstrap.
+          # It brings lots of deps; some are useful elsewhere (e.g. cqueues).
+          http
+          # used by policy.slice_randomize_psl()
+          psl
+        ];
+        preferLocalBuild = true;
+        allowSubstitutes = false;
+        inherit (unwrapped) meta;
+      }
+      (
+        ''
+          mkdir -p "$out"/bin
+          makeWrapper '${unwrapped}/bin/kresd' "$out"/bin/kresd \
+            --set LUA_PATH  "$LUA_PATH" \
+            --set LUA_CPATH "$LUA_CPATH"
+
+          ln -sr '${unwrapped}/bin/kres-cache-gc' "$out"/bin/
+          ln -sr '${unwrapped}/share' "$out"/
+          ln -sr '${unwrapped}/lib'   "$out"/ # useful in NixOS service
+          ln -sr "$out"/{bin,sbin}
+        ''
+        + lib.optionalString unwrapped.doInstallCheck ''
+          echo "Checking that 'http' module loads, i.e. lua search paths work:"
+          echo "modules.load('http')" > test-http.lua
+          echo -e 'quit()' | env -i "$out"/bin/kresd -a 127.0.0.1#53535 -c test-http.lua
+        ''
+      );
+
+in
+result

--- a/pkgs/by-name/li/libuv/package.nix
+++ b/pkgs/by-name/li/libuv/package.nix
@@ -12,7 +12,7 @@
   # for passthru.tests
   bind,
   cmake,
-  knot-resolver,
+  knot-resolver_5,
   sbclPackages,
   luajitPackages,
   mosquitto,
@@ -181,7 +181,7 @@ stdenv.mkDerivation (finalAttrs: {
     inherit
       bind
       cmake
-      knot-resolver
+      knot-resolver_5
       mosquitto
       neovim
       nodejs

--- a/pkgs/development/libraries/gnutls/default.nix
+++ b/pkgs/development/libraries/gnutls/default.nix
@@ -32,7 +32,7 @@
   emacs,
   ffmpeg,
   haskellPackages,
-  knot-resolver,
+  knot-resolver_5,
   ngtcp2-gnutls,
   ocamlPackages,
   pkgsStatic,
@@ -203,7 +203,7 @@ stdenv.mkDerivation rec {
       ffmpeg
       emacs
       qemu
-      knot-resolver
+      knot-resolver_5
       samba
       openconnect
       ;

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -781,6 +781,7 @@ mapAliases {
   kgx = throw "'kgx' has been renamed to/replaced by 'gnome-console'"; # Converted to throw 2025-10-27
   khoj = throw "khoj has been removed because it has been marked as broken since at least November 2024."; # Added 2025-10-11
   kmplayer = throw "'kmplayer' has been removed, as it is unmaintained upstream"; # Added 2025-08-30
+  knot-resolver = warnAlias "'knot-resolver' is currently aliased to 'knot-resolver_5'. This will change with the knot-resolver 6 being declared as stable. Please explicitly use the 'knot-resolver_5' or 'knot-resolver_6' package until then." knot-resolver_5; # Added 2025-11-30
   kodiGBM = throw "'kodiGBM' has been renamed to/replaced by 'kodi-gbm'"; # Converted to throw 2025-10-27
   kodiPlain = throw "'kodiPlain' has been renamed to/replaced by 'kodi'"; # Converted to throw 2025-10-27
   kodiPlainWayland = throw "'kodiPlainWayland' has been renamed to/replaced by 'kodi-wayland'"; # Converted to throw 2025-10-27

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9225,10 +9225,6 @@ with pkgs;
     kanidmWithSecretProvisioning_1_8
     ;
 
-  knot-resolver = callPackage ../servers/dns/knot-resolver {
-    systemd = systemdMinimal; # in closure already anyway
-  };
-
   leafnode = callPackage ../servers/news/leafnode { };
 
   leafnode1 = callPackage ../servers/news/leafnode/1.nix { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
