### PR TITLE
nh,nh-unwrapped: split into two packages

### DIFF
--- a/pkgs/by-name/nh/nh-unwrapped/package.nix
+++ b/pkgs/by-name/nh/nh-unwrapped/package.nix
@@ -1,0 +1,62 @@
+{
+  stdenv,
+  lib,
+  rustPlatform,
+  installShellFiles,
+  fetchFromGitHub,
+  nix-update-script,
+  buildPackages,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "nh-unwrapped";
+  version = "4.2.0";
+
+  src = fetchFromGitHub {
+    owner = "nix-community";
+    repo = "nh";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6n5SVO8zsdVTD691lri7ZcO4zpqYFU8GIvjI6dbxkA8=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
+    let
+      emulator = stdenv.hostPlatform.emulator buildPackages;
+    in
+    ''
+      mkdir completions
+
+      for shell in bash zsh fish; do
+        NH_NO_CHECKS=1 ${emulator} $out/bin/nh completions $shell > completions/nh.$shell
+      done
+
+      installShellCompletion completions/*
+
+      cargo xtask man --out-dir gen
+      installManPage gen/nh.1
+    ''
+  );
+
+  cargoHash = "sha256-cxZsePgraYevuYQSi3hTU2EsiDyn1epSIcvGi183fIU=";
+
+  passthru.updateScript = nix-update-script { };
+
+  env.NH_REV = finalAttrs.src.tag;
+
+  meta = {
+    changelog = "https://github.com/nix-community/nh/blob/${finalAttrs.version}/CHANGELOG.md";
+    description = "Yet another nix cli helper";
+    homepage = "https://github.com/nix-community/nh";
+    license = lib.licenses.eupl12;
+    mainProgram = "nh";
+    maintainers = with lib.maintainers; [
+      NotAShelf
+      viperML
+    ];
+  };
+})

--- a/pkgs/by-name/nh/nh/package.nix
+++ b/pkgs/by-name/nh/nh/package.nix
@@ -1,75 +1,30 @@
 {
-  stdenv,
   lib,
-  rustPlatform,
-  installShellFiles,
+  symlinkJoin,
   makeBinaryWrapper,
-  fetchFromGitHub,
-  nix-update-script,
+  nh-unwrapped,
   nix-output-monitor,
-  buildPackages,
 }:
 let
+  unwrapped = nh-unwrapped;
   runtimeDeps = [
     nix-output-monitor
   ];
 in
-rustPlatform.buildRustPackage (finalAttrs: {
+symlinkJoin {
   pname = "nh";
-  version = "4.2.0";
+  inherit (unwrapped) version meta;
 
-  src = fetchFromGitHub {
-    owner = "nix-community";
-    repo = "nh";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-6n5SVO8zsdVTD691lri7ZcO4zpqYFU8GIvjI6dbxkA8=";
-  };
-
-  strictDeps = true;
+  paths = [
+    unwrapped
+  ];
 
   nativeBuildInputs = [
-    installShellFiles
     makeBinaryWrapper
   ];
 
-  postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
-    let
-      emulator = stdenv.hostPlatform.emulator buildPackages;
-    in
-    ''
-      mkdir completions
-
-      for shell in bash zsh fish; do
-        NH_NO_CHECKS=1 ${emulator} $out/bin/nh completions $shell > completions/nh.$shell
-      done
-
-      installShellCompletion completions/*
-
-      cargo xtask man --out-dir gen
-      installManPage gen/nh.1
-    ''
-  );
-
-  postFixup = ''
+  postBuild = ''
     wrapProgram $out/bin/nh \
       --prefix PATH : ${lib.makeBinPath runtimeDeps}
   '';
-
-  cargoHash = "sha256-cxZsePgraYevuYQSi3hTU2EsiDyn1epSIcvGi183fIU=";
-
-  passthru.updateScript = nix-update-script { };
-
-  env.NH_REV = finalAttrs.src.tag;
-
-  meta = {
-    changelog = "https://github.com/nix-community/nh/blob/${finalAttrs.version}/CHANGELOG.md";
-    description = "Yet another nix cli helper";
-    homepage = "https://github.com/nix-community/nh";
-    license = lib.licenses.eupl12;
-    mainProgram = "nh";
-    maintainers = with lib.maintainers; [
-      NotAShelf
-      viperML
-    ];
-  };
-})
+}


### PR DESCRIPTION
In my NixOS configuration I override `nix-output-monitor` with its latest git revision, and it is kinda annoying to have to rebuild the entirety of `nh` each time just to prefix its `PATH` with the newer `nix-output-monitor`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
