### PR TITLE
python3Packages.wagtail: fix missing static files

### DIFF
--- a/pkgs/development/python-modules/wagtail/default.nix
+++ b/pkgs/development/python-modules/wagtail/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
+  fetchPypi,
 
   # build-system
   setuptools,
@@ -35,11 +35,12 @@ buildPythonPackage rec {
   version = "7.2";
   pyproject = true;
 
-  src = fetchFromGitHub {
-    owner = "wagtail";
-    repo = "wagtail";
-    tag = "v${version}";
-    hash = "sha256-o/4jn32ffR3BPVNwtFKJ6PowXYi7SpjBqghdeZIl5tM=";
+  # The GitHub source requires some assets to be compiled, which in turn
+  # requires fixing the upstream package lock. We need to use the PyPI release
+  # until https://github.com/wagtail/wagtail/pull/13136 gets merged.
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-ijnfkIvWSrAp4IvxkfR19UzJFPhKpB6a55tBv0HVXsM=";
   };
 
   build-system = [


### PR DESCRIPTION
Switch to PyPI source to fix missing admin CSS/JS. GitHub source requires uncompiled static assets.

Fixes: #463463


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
## Problem
After commit 6a2cb5059ac72716d95a4d73c3697106a6c4ea3d, wagtail package is missing admin static files because GitHub source requires static asset compilation that isn't performed in the Nix build.

This breaks:
- Wagtail admin interface (no CSS/JS)
- collectstatic command
- Development and production usage

## Solution
Revert to PyPI source which includes pre-built static files.

## Testing
- Built package locally: ✅
- Verified static files exist: ✅
- Tested with Django project: ✅

> [!NOTE]
>**Note:** Test failure is expected due to missing test dependencies, not related to our changes.
>Main functionality works correctly - static files are now present.

```console
error: Cannot build '/nix/store/mj4rl4w4aw1p74qfdrfq9zzghm1ql3qr-python3.13-wagtail-tests-7.2.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/vh89l7gjincnrj4qc2dmz9izqxb12ncd-python3.13-wagtail-tests-7.2
                > ======================================================================
       > ERROR: wagtail.embeds.tests.test_embeds (unittest.loader._FailedTest.wagtail.embeds.tests.test_embeds)
       > ----------------------------------------------------------------------
       > ImportError: Failed to import test module: wagtail.embeds.tests.test_embeds
       > Traceback (most recent call last):
       >   File "/nix/store/7gl4khq26h625mpqzkiiqsify3hclar1-python3-3.13.9/lib/python3.13/unittest/loader.py", line 396, in _find_test_path
       >     module = self._get_module_from_name(name)
       >   File "/nix/store/7gl4khq26h625mpqzkiiqsify3hclar1-python3-3.13.9/lib/python3.13/unittest/loader.py", line 339, in _get_module_from_name
       >     __import__(name)
       >     ~~~~~~~~~~^^^^^^
       >   File "/build/wagtail-7.2/wagtail/embeds/tests/test_embeds.py", line 8, in <module>
       >     import responses
       > ModuleNotFoundError: No module named 'responses'
         
```

CC: @sephi


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
