### PR TITLE
maintainers: remove sheenobu due to inactivity

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23849,12 +23849,6 @@
     githubId = 6292;
     name = "Andrey Petrov";
   };
-  sheenobu = {
-    email = "sheena.artrip@gmail.com";
-    github = "sheenobu";
-    githubId = 1443459;
-    name = "Sheena Artrip";
-  };
   sheepforce = {
     email = "phillip.seeber@googlemail.com";
     github = "sheepforce";

--- a/pkgs/by-name/fr/freeradius/package.nix
+++ b/pkgs/by-name/fr/freeradius/package.nix
@@ -105,9 +105,7 @@ stdenv.mkDerivation rec {
     homepage = "https://freeradius.org/";
     description = "Modular, high performance free RADIUS suite";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [
-      sheenobu
-    ];
+    maintainers = [ ];
     platforms = with platforms; linux;
   };
 }

--- a/pkgs/by-name/li/libcollectdclient/package.nix
+++ b/pkgs/by-name/li/libcollectdclient/package.nix
@@ -18,9 +18,6 @@ collectd.overrideAttrs (prevAttrs: {
     homepage = "https://collectd.org";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [
-      sheenobu
-      bjornfor
-    ];
+    maintainers = with lib.maintainers; [ bjornfor ];
   };
 })

--- a/pkgs/by-name/si/sipsak/package.nix
+++ b/pkgs/by-name/si/sipsak/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/sipwise/sipsak";
     description = "SIP Swiss army knife";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ sheenobu ];
+    maintainers = [ ];
     platforms = with lib.platforms; unix;
     mainProgram = "sipsak";
   };

--- a/pkgs/by-name/sp/spotify/linux.nix
+++ b/pkgs/by-name/sp/spotify/linux.nix
@@ -232,7 +232,6 @@ stdenv.mkDerivation (finalAttrs: {
   meta = meta // {
     maintainers = with lib.maintainers; [
       ftrvxmtrx
-      sheenobu
       timokau
       ma27
     ];

--- a/pkgs/development/tools/minizinc/default.nix
+++ b/pkgs/development/tools/minizinc/default.nix
@@ -80,6 +80,6 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = licenses.mpl20;
     platforms = platforms.unix;
-    maintainers = [ maintainers.sheenobu ];
+    maintainers = [ ];
   };
 })


### PR DESCRIPTION
No PRs since July 2021 and does not appear to be part of the NixOS GitHub organization anymore.

cc @sheenobu

Review would also be appreciated on https://github.com/NixOS/nixpkgs/pull/449965, PR updating package maintained by sheenobu.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
