### PR TITLE
sentry-cli: 2.58.0 -> 2.58.2, enable tests, modernize

### DIFF
--- a/pkgs/by-name/se/sentry-cli/package.nix
+++ b/pkgs/by-name/se/sentry-cli/package.nix
@@ -25,10 +25,8 @@ rustPlatform.buildRustPackage rec {
   # Needed to get openssl-sys to use pkgconfig.
   OPENSSL_NO_VENDOR = 1;
 
-  patches = [
-    (replaceVars ./fix-swift-lib-path.patch {
-      swiftLib = lib.getLib swift;
-    })
+  patches = lib.optionals stdenv.hostPlatform.isDarwin [
+    (replaceVars ./fix-swift-lib-path.patch { swiftLib = lib.getLib swift; })
   ];
 
   buildInputs = [ openssl ];

--- a/pkgs/by-name/se/sentry-cli/package.nix
+++ b/pkgs/by-name/se/sentry-cli/package.nix
@@ -9,6 +9,7 @@
   swift,
   swiftpm,
   replaceVars,
+  gitMinimal,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -21,7 +22,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     tag = finalAttrs.version;
     hash = "sha256-8fz8bSQxqylTQ7mD/QbQ6gc8qlEdx/SDCjaB3uqFnGA=";
   };
-  doCheck = false;
 
   # Needed to get openssl-sys to use pkgconfig.
   OPENSSL_NO_VENDOR = 1;
@@ -31,6 +31,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   buildInputs = [ openssl ];
+
   nativeBuildInputs = [
     installShellFiles
     pkg-config
@@ -40,8 +41,18 @@ rustPlatform.buildRustPackage (finalAttrs: {
     swiftpm
   ]);
 
+  nativeCheckInputs = [ gitMinimal ];
+
+  checkFlags = [
+    "--skip=integration::send_metric::command_send_metric"
+    "--skip=integration::update::command_update"
+  ];
+
   # By default including `swiftpm` in `nativeBuildInputs` will take over `buildPhase`
   dontUseSwiftpmBuild = true;
+  dontUseSwiftpmCheck = true;
+
+  __darwinAllowLocalNetworking = true;
 
   cargoHash = "sha256-3I0uKHpD4SpSeLSIAEjBxxAFfyS4WIvb76x7QAy53HM=";
 

--- a/pkgs/by-name/se/sentry-cli/package.nix
+++ b/pkgs/by-name/se/sentry-cli/package.nix
@@ -10,6 +10,7 @@
   swiftpm,
   replaceVars,
   gitMinimal,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -62,6 +63,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
         --fish <($out/bin/sentry-cli completions fish) \
         --zsh <($out/bin/sentry-cli completions zsh)
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://docs.sentry.io/cli/";

--- a/pkgs/by-name/se/sentry-cli/package.nix
+++ b/pkgs/by-name/se/sentry-cli/package.nix
@@ -10,6 +10,7 @@
   swiftpm,
   replaceVars,
   gitMinimal,
+  versionCheckHook,
   nix-update-script,
 }:
 
@@ -63,6 +64,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
         --fish <($out/bin/sentry-cli completions fish) \
         --zsh <($out/bin/sentry-cli completions zsh)
   '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/se/sentry-cli/package.nix
+++ b/pkgs/by-name/se/sentry-cli/package.nix
@@ -25,30 +25,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-8fz8bSQxqylTQ7mD/QbQ6gc8qlEdx/SDCjaB3uqFnGA=";
   };
 
-  # Needed to get openssl-sys to use pkgconfig.
-  OPENSSL_NO_VENDOR = 1;
-
   patches = lib.optionals stdenv.hostPlatform.isDarwin [
     (replaceVars ./fix-swift-lib-path.patch { swiftLib = lib.getLib swift; })
   ];
 
-  buildInputs = [ openssl ];
+  cargoHash = "sha256-3I0uKHpD4SpSeLSIAEjBxxAFfyS4WIvb76x7QAy53HM=";
 
-  nativeBuildInputs = [
-    installShellFiles
-    pkg-config
-  ]
-  ++ (lib.optionals stdenv.hostPlatform.isDarwin [
-    swift
-    swiftpm
-  ]);
-
-  nativeCheckInputs = [ gitMinimal ];
-
-  checkFlags = [
-    "--skip=integration::send_metric::command_send_metric"
-    "--skip=integration::update::command_update"
-  ];
+  # Needed to get openssl-sys to use pkgconfig.
+  env.OPENSSL_NO_VENDOR = 1;
 
   # By default including `swiftpm` in `nativeBuildInputs` will take over `buildPhase`
   dontUseSwiftpmBuild = true;
@@ -56,7 +40,23 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   __darwinAllowLocalNetworking = true;
 
-  cargoHash = "sha256-3I0uKHpD4SpSeLSIAEjBxxAFfyS4WIvb76x7QAy53HM=";
+  nativeBuildInputs = [
+    installShellFiles
+    pkg-config
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    swift
+    swiftpm
+  ];
+
+  buildInputs = [ openssl ];
+
+  nativeCheckInputs = [ gitMinimal ];
+
+  checkFlags = [
+    "--skip=integration::send_metric::command_send_metric"
+    "--skip=integration::update::command_update"
+  ];
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd sentry-cli \

--- a/pkgs/by-name/se/sentry-cli/package.nix
+++ b/pkgs/by-name/se/sentry-cli/package.nix
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "getsentry";
     repo = "sentry-cli";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-8fz8bSQxqylTQ7mD/QbQ6gc8qlEdx/SDCjaB3uqFnGA=";
   };
   doCheck = false;

--- a/pkgs/by-name/se/sentry-cli/package.nix
+++ b/pkgs/by-name/se/sentry-cli/package.nix
@@ -10,14 +10,15 @@
   swiftpm,
   replaceVars,
 }:
-rustPlatform.buildRustPackage rec {
+
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "sentry-cli";
   version = "2.58.0";
 
   src = fetchFromGitHub {
     owner = "getsentry";
     repo = "sentry-cli";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-8fz8bSQxqylTQ7mD/QbQ6gc8qlEdx/SDCjaB3uqFnGA=";
   };
   doCheck = false;
@@ -56,7 +57,7 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.bsd3;
     description = "Command line utility to work with Sentry";
     mainProgram = "sentry-cli";
-    changelog = "https://github.com/getsentry/sentry-cli/raw/${version}/CHANGELOG.md";
+    changelog = "https://github.com/getsentry/sentry-cli/raw/${finalAttrs.version}/CHANGELOG.md";
     maintainers = with lib.maintainers; [ rizary ];
   };
-}
+})

--- a/pkgs/by-name/se/sentry-cli/package.nix
+++ b/pkgs/by-name/se/sentry-cli/package.nix
@@ -16,20 +16,20 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "sentry-cli";
-  version = "2.58.0";
+  version = "2.58.2";
 
   src = fetchFromGitHub {
     owner = "getsentry";
     repo = "sentry-cli";
     tag = finalAttrs.version;
-    hash = "sha256-8fz8bSQxqylTQ7mD/QbQ6gc8qlEdx/SDCjaB3uqFnGA=";
+    hash = "sha256-2dxnAwxIdmeA53PETUyDUgi1T4ZH9faBvPCMdRPUDxw=";
   };
 
   patches = lib.optionals stdenv.hostPlatform.isDarwin [
     (replaceVars ./fix-swift-lib-path.patch { swiftLib = lib.getLib swift; })
   ];
 
-  cargoHash = "sha256-3I0uKHpD4SpSeLSIAEjBxxAFfyS4WIvb76x7QAy53HM=";
+  cargoHash = "sha256-CwULTOZN2TTpB8heLuegID38ub6J3XoiY7l7UW1VcGo=";
 
   # Needed to get openssl-sys to use pkgconfig.
   env.OPENSSL_NO_VENDOR = 1;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
