### PR TITLE
nixos/vte: restore lightweight shell integration, build without app; nixos/gdm: generate users

### DIFF
--- a/nixos/modules/config/vte.nix
+++ b/nixos/modules/config/vte.nix
@@ -9,7 +9,12 @@ let
   vteInitSnippet = ''
     # Show current working directory in VTE terminals window title.
     # Supports both bash and zsh, requires interactive shell.
-    . ${pkgs.vte.override { gtkVersion = null; }}/etc/profile.d/vte.sh
+    . ${
+      pkgs.vte.override {
+        withApp = false;
+        gtkVersion = null;
+      }
+    }/etc/profile.d/vte.sh
   '';
 
 in

--- a/nixos/modules/config/vte.nix
+++ b/nixos/modules/config/vte.nix
@@ -9,7 +9,7 @@ let
   vteInitSnippet = ''
     # Show current working directory in VTE terminals window title.
     # Supports both bash and zsh, requires interactive shell.
-    . ${pkgs.vte-gtk4}/etc/profile.d/vte.sh
+    . ${pkgs.vte.override { gtkVersion = null; }}/etc/profile.d/vte.sh
   '';
 
 in

--- a/nixos/modules/services/display-managers/gdm.nix
+++ b/nixos/modules/services/display-managers/gdm.nix
@@ -179,47 +179,33 @@ in
 
     services.xserver.displayManager.lightdm.enable = false;
 
-    users.users.gdm = {
-      name = "gdm";
-      uid = config.ids.uids.gdm;
-      group = "gdm";
-      description = "GDM user";
-    };
+    users.users = lib.mkMerge [
+      {
+        gdm = {
+          name = "gdm";
+          uid = config.ids.uids.gdm;
+          group = "gdm";
+          description = "GDM user";
+        };
 
-    users.users.gdm-greeter = {
-      isSystemUser = true;
-      uid = 60578;
-      group = "gdm";
-      home = "/run/gdm";
-    };
+        gdm-greeter = {
+          isSystemUser = true;
+          uid = 60578;
+          group = "gdm";
+          home = "/run/gdm";
+        };
+      }
 
-    users.users.gdm-greeter-1 = {
-      isSystemUser = true;
-      uid = 60579;
-      group = "gdm";
-      home = "/run/gdm-1";
-    };
-
-    users.users.gdm-greeter-2 = {
-      isSystemUser = true;
-      uid = 60580;
-      group = "gdm";
-      home = "/run/gdm-2";
-    };
-
-    users.users.gdm-greeter-3 = {
-      isSystemUser = true;
-      uid = 60581;
-      group = "gdm";
-      home = "/run/gdm-3";
-    };
-
-    users.users.gdm-greeter-4 = {
-      isSystemUser = true;
-      uid = 60582;
-      group = "gdm";
-      home = "/run/gdm-4";
-    };
+      (lib.genAttrs' [ 1 2 3 4 ] (
+        i:
+        lib.nameValuePair "gdm-greeter-${toString i}" {
+          isSystemUser = true;
+          uid = 60578 + i;
+          group = "gdm";
+          home = "/run/gdm-${toString i}";
+        }
+      ))
+    ];
 
     users.groups.gdm.gid = config.ids.gids.gdm;
 

--- a/pkgs/by-name/vt/vte/package.nix
+++ b/pkgs/by-name/vt/vte/package.nix
@@ -34,6 +34,7 @@
   nixosTests,
   blackbox-terminal,
   darwinMinVersionHook,
+  withApp ? true,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -70,6 +71,12 @@ stdenv.mkDerivation (finalAttrs: {
     (fetchpatch {
       url = "https://gitlab.gnome.org/GNOME/vte/-/commit/f672ed15a88dd3e25c33aa0a5ef6f6d291a6d5c7.patch";
       hash = "sha256-JdLDild5j7marvR5n2heW9YD00+bwzJIoxDlzO5r/6w=";
+    })
+
+    # Add option to not build the vte application
+    (fetchpatch {
+      url = "https://github.com/GNOME/vte/commit/6b7a6a7df9df99368b7ce5ac5903bd2578167567.patch";
+      hash = "sha256-s3HigfTZLtGmsZS6dfD3YE95ZdBjB4WOWDvuoatOu3o=";
     })
   ];
 
@@ -118,6 +125,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   mesonFlags = [
     "-Ddocs=true"
+    (lib.mesonBool "app" withApp)
     (lib.mesonBool "gtk3" (gtkVersion == "3"))
     (lib.mesonBool "gtk4" (gtkVersion == "4"))
     (lib.mesonBool "_systemd" (!systemdSupport))

--- a/pkgs/by-name/vt/vte/package.nix
+++ b/pkgs/by-name/vt/vte/package.nix
@@ -120,9 +120,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-Ddocs=true"
     (lib.mesonBool "gtk3" (gtkVersion == "3"))
     (lib.mesonBool "gtk4" (gtkVersion == "4"))
-  ]
-  ++ lib.optionals (!systemdSupport) [
-    "-D_systemd=false"
+    (lib.mesonBool "_systemd" (!systemdSupport))
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # -Bsymbolic-functions is not supported on darwin
@@ -136,11 +134,11 @@ stdenv.mkDerivation (finalAttrs: {
   );
 
   postPatch = ''
-    patchShebangs perf/*
-    patchShebangs src/app/meson_desktopfile.py
-    patchShebangs src/parser-seq.py
-    patchShebangs src/minifont-coverage.py
-    patchShebangs src/modes.py
+    patchShebangs perf/* \
+      src/app/meson_desktopfile.py \
+      src/parser-seq.py \
+      src/minifont-coverage.py \
+      src/modes.py
   '';
 
   postFixup = ''

--- a/pkgs/by-name/vt/vte/package.nix
+++ b/pkgs/by-name/vt/vte/package.nix
@@ -60,6 +60,17 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://git.alpinelinux.org/aports/plain/community/vte3/fix-W_EXITCODE.patch?id=4d35c076ce77bfac7655f60c4c3e4c86933ab7dd";
       hash = "sha256-FkVyhsM0mRUzZmS2Gh172oqwcfXv6PyD6IEgjBhy2uU=";
     })
+
+    # Skip test depending on gdk when building without gtk3 and gtk4
+    (fetchpatch {
+      url = "https://github.com/GNOME/vte/commit/f946e5bacf97305453d731c507885c52d4c34171.patch";
+      hash = "sha256-axi16Fpt4d32akFYeAR+SuUIwzRhjhK2oHp/yAXVRgk=";
+    })
+    # https://gitlab.gnome.org/GNOME/vte/-/merge_requests/11
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/vte/-/commit/f672ed15a88dd3e25c33aa0a5ef6f6d291a6d5c7.patch";
+      hash = "sha256-JdLDild5j7marvR5n2heW9YD00+bwzJIoxDlzO5r/6w=";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
