### PR TITLE
metadata: 0.1.10 -> 0.1.12

### DIFF
--- a/pkgs/by-name/me/metadata/package.nix
+++ b/pkgs/by-name/me/metadata/package.nix
@@ -11,16 +11,16 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "metadata";
-  version = "0.1.10";
+  version = "0.1.12";
 
   src = fetchFromGitHub {
     owner = "zmwangx";
     repo = "metadata";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-wZ1wLygPFBFZsSYJGxNzYV+mXtbN68GY3nMYDFHPZHo=";
+    hash = "sha256-gDOYqPwrWUfUTCx+p+ZpwsP8XxUufDCGem/WzW5cQPc=";
   };
 
-  cargoHash = "sha256-pWekXsjAhK4wyjf95nZO+Wj9PcH87D8vYsRFAE/w/sw=";
+  cargoHash = "sha256-tUVaseaavm746sxaA2A3ua4ZxzoKSnRQ4rJRBeO9t1U=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
Diff: https://github.com/zmwangx/metadata/compare/v0.1.10...v0.1.12

Updated ffmpeg-next dependency in [v0.1.11](https://github.com/zmwangx/metadata/commit/1bf3a96e6054d4c6375ebab99f7c555a66f0e309)

ZHF: https://github.com/NixOS/nixpkgs/issues/457852

```console
> hydra-check metadata
Build Status for nixpkgs.metadata.x86_64-linux on jobset nixos/trunk-combined
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.metadata.x86_64-linux
✖ (Failed)     metadata-0.1.10  2025-11-14  https://hydra.nixos.org/build/313187618
✔              metadata-0.1.10  2025-10-21  https://hydra.nixos.org/build/310416782

> nix eval 'nixpkgs/9da7f1cf7f8a6e2a7cb3001b048546c92a8258b4#ffmpeg.version'
"7.1.1"

> nix eval 'nixpkgs/c5ae371f1a6a7fd27823bc500d9390b38c05fa55#ffmpeg.version'
"8.0"
```

Returned value for https://github.com/zmwangx/metadata/blob/11537051e650c519ccf604e1121b1a8032ab2d34/tests/data/h264_mp4/h264.mp4

```console
> build-metadata-unbreak-metadata-X64-Linux/result/bin/metadata ./h264.mp4
Filename:               h264.mp4
File size:              2892 (2.90KB, 2.83KiB)
Container format:       MPEG-4 Part 14 (MP4)
Duration:               00:00:02.00
Pixel dimensions:       128x72
Sample aspect ratio:    1:1
Display aspect ratio:   16:9
Scan type:              Progressive scan
Frame rate:             25 fps
Bit rate:               12 kb/s
Streams:
    #0: Video, H.264 (High Profile level 1), yuv420p, 128x72 (SAR 1:1, DAR 16:9), 25 fps, 6 kb/s
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
