### PR TITLE
ryzen-smu: 0.1.5-unstable-2025-06-04 -> 0.1.7-unstable-2025-10-22

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3747,6 +3747,13 @@
     githubId = 4621;
     name = "Brad Ediger";
   };
+  bradleyjones = {
+    email = "jones.bradley@me.com";
+    github = "bradleyjones";
+    githubId = 2159185;
+    name = "Bradley Jones";
+    keys = [ { fingerprint = "FE6E 9D7A 6ECC C6E7 8F7B  F166 3A0E 7022 EBAD D1AA"; } ];
+  };
   brahyerr = {
     name = "Bryant Pham";
     email = "bp@1829847@gmail.com";

--- a/pkgs/os-specific/linux/ryzen-smu/default.nix
+++ b/pkgs/os-specific/linux/ryzen-smu/default.nix
@@ -4,9 +4,8 @@
   fetchFromGitHub,
   kernel,
 }:
-
 let
-  version = "0.1.5-unstable-2025-06-04";
+  version = "0.1.7-unstable-2025-10-22";
 
   ## Upstream has not been merging PRs.
   ## Nixpkgs maintainers are providing a
@@ -15,8 +14,8 @@ let
   src = fetchFromGitHub {
     owner = "amkillam";
     repo = "ryzen_smu";
-    rev = "9f9569f889935f7c7294cc32c1467e5a4081701a";
-    hash = "sha256-i8T0+kUYsFMzYO3h6ffUXP1fgGOXymC4Ml2dArQLOdk=";
+    rev = "21c1e2c51832dccfac64981b345745ce0cccf524";
+    hash = "sha256-JA7dH958IceuBvHTp4lPlHolzLN9bXDt9hmhxITvvJA=";
   };
 
   monitor-cpu = stdenv.mkDerivation {
@@ -35,7 +34,6 @@ let
       runHook postInstall
     '';
   };
-
 in
 stdenv.mkDerivation {
   pname = "ryzen-smu-${kernel.version}";
@@ -67,6 +65,7 @@ stdenv.mkDerivation {
       Cryolitia
       phdyellow
       aleksana
+      bradleyjones
     ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "monitor_cpu";


### PR DESCRIPTION
Updated to the latest commit in the ryzen-smu fork which adds support for Strix Halo CPUs

https://github.com/amkillam/ryzen_smu/commit/21c1e2c51832dccfac64981b345745ce0cccf524

Changed the version to 0.1.7 and the date of the latest commit, this reflects the version the module outputs:
```
❯ sudo cat /sys/kernel/ryzen_smu_drv/drv_version
0.1.7
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
