### PR TITLE
open-webui: patch imports for langchain v1

### DIFF
--- a/pkgs/by-name/op/open-webui/langchain-v1.patch
+++ b/pkgs/by-name/op/open-webui/langchain-v1.patch
@@ -1,0 +1,27 @@
+diff --git a/backend/open_webui/retrieval/utils.py b/backend/open_webui/retrieval/utils.py
+index da570330b..6ea16e249 100644
+--- a/backend/open_webui/retrieval/utils.py
++++ b/backend/open_webui/retrieval/utils.py
+@@ -10,7 +10,7 @@ import re
+ 
+ from urllib.parse import quote
+ from huggingface_hub import snapshot_download
+-from langchain.retrievers import ContextualCompressionRetriever, EnsembleRetriever
++from langchain_classic.retrievers import ContextualCompressionRetriever, EnsembleRetriever
+ from langchain_community.retrievers import BM25Retriever
+ from langchain_core.documents import Document
+ 
+diff --git a/backend/open_webui/routers/retrieval.py b/backend/open_webui/routers/retrieval.py
+index f8147372f..363bb4706 100644
+--- a/backend/open_webui/routers/retrieval.py
++++ b/backend/open_webui/routers/retrieval.py
+@@ -28,8 +28,7 @@ from pydantic import BaseModel
+ import tiktoken
+ 
+ 
+-from langchain.text_splitter import RecursiveCharacterTextSplitter, TokenTextSplitter
+-from langchain_text_splitters import MarkdownHeaderTextSplitter
++from langchain_text_splitters import MarkdownHeaderTextSplitter, RecursiveCharacterTextSplitter, TokenTextSplitter
+ from langchain_core.documents import Document
+ 
+ from open_webui.models.files import FileModel, Files

--- a/pkgs/by-name/op/open-webui/package.nix
+++ b/pkgs/by-name/op/open-webui/package.nix
@@ -75,6 +75,8 @@ python3Packages.buildPythonApplication rec {
 
   build-system = with python3Packages; [ hatchling ];
 
+  patches = [ ./langchain-v1.patch ];
+
   # Not force-including the frontend build directory as frontend is managed by the `frontend` derivation above.
   postPatch = ''
     substituteInPlace pyproject.toml \
@@ -128,6 +130,7 @@ python3Packages.buildPythonApplication rec {
       iso-639
       itsdangerous
       langchain
+      langchain-classic
       langchain-community
       langdetect
       ldap3


### PR DESCRIPTION
open-webui currently crashes at startup due to [import errors](https://github.com/NixOS/nixpkgs/issues/461605#issuecomment-3555225122). This is because the `langchain-*` packages that we package have recently been updated to their LangChain v1-compatible versions (typically 1.x or 0.4.x; see #455030, #461021). The corresponding changes in the LangChain ecosystem require consumers to update their imports in some cases. open-webui is affected by this because upstream [still pins the old versions `langchain==0.3.27` and `langchain-community==0.3.29`](https://github.com/open-webui/open-webui/blob/v0.6.36/pyproject.toml#L57C1-L58C35) and imports some of the moved members.

This PR patches the affected `langchain_*` imports of open-webui to make them compatible with the newer (v1) generation of LangChain dependencies (that we package).

The crash at startup can be reproduced by building/running `open-webui.passthru.tests` (or the equivalent `nixosTests.open-webui`).

If you are a regular user of this package, I'd highly appreciate if you could test that this doesn't break any important functionality.

cc @sarahec

Fixes https://github.com/NixOS/nixpkgs/issues/461605#issuecomment-3555225122

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
