### PR TITLE
nixos/qemu-vm: Allow 9p cache to be configured

### DIFF
--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -917,6 +917,23 @@ in
       '';
     };
 
+    virtualisation.nixStore9pCache = mkOption {
+      type = types.enum [
+        "loose"
+        "none"
+        "fscache"
+      ];
+      default = "loose";
+      description = ''
+        Type of 9p cache to use when mounting host nix store. "none" provides
+        no caching. "loose" enables Linux's local VFS cache. "fscache" uses Linux's
+        fscache subsystem.
+
+        This option is only respected when {option}`virtualisation.mountHostNixStore`
+        is enabled.
+      '';
+    };
+
     virtualisation.directBoot = {
       enable = mkOption {
         type = types.bool;
@@ -1369,7 +1386,7 @@ in
             "msize=${toString cfg.msize}"
             "x-systemd.requires=modprobe@9pnet_virtio.service"
           ]
-          ++ lib.optional (tag == "nix-store") "cache=loose";
+          ++ lib.optional (tag == "nix-store") "cache=${cfg.nixStore9pCache}";
         };
       in
       lib.mkMerge [


### PR DESCRIPTION
Allows user configuration of the type of 9p cache.

Under high contention store paths seem to be improperly cached inside of the VM when cache=loose is set. Generally this will manifest with null bytes or garbage appearing in the affected files. This change allows for users to set cache=none if they want slower but more correct tests or to use cache=fscache. Haven't tested fscache, but it is a valid 9p cache.

## Things done

default is kept as-is, so this should not be a breaking change