### PR TITLE
ccextractor: fix build with FFmpeg 7

### DIFF
--- a/pkgs/by-name/cc/ccextractor/fix-avcodec-close.patch
+++ b/pkgs/by-name/cc/ccextractor/fix-avcodec-close.patch
@@ -1,0 +1,13 @@
+diff --git a/src/lib_ccx/hardsubx.c b/src/lib_ccx/hardsubx.c
+index 20b4388..fa6b5fa 100644
+--- a/src/lib_ccx/hardsubx.c
++++ b/src/lib_ccx/hardsubx.c
+@@ -125,7 +125,7 @@ int hardsubx_process_data(struct lib_hardsubx_ctx *ctx, struct lib_ccx_ctx *ctx_
+ 	if (ctx->frame)
+ 		av_frame_free(&ctx->frame);
+ 	if (ctx->rgb_frame)
+ 		av_frame_free(&ctx->rgb_frame);
+-	avcodec_close(ctx->codec_ctx);
++	avcodec_free_context(&ctx->codec_ctx);
+ 	avformat_close_input(&ctx->format_ctx);
+ }

--- a/pkgs/by-name/cc/ccextractor/package.nix
+++ b/pkgs/by-name/cc/ccextractor/package.nix
@@ -42,6 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     ./remove-default-commit-hash.patch
     ./remove-vendored-libraries.patch
+    ./fix-avcodec-close.patch
   ]
   ++ finalAttrs.cargoDeps.vendorStaging.patches;
 


### PR DESCRIPTION
The avcodec_close function was deprecated and removed in FFmpeg 7. Replace it with avcodec_free_context, following the same pattern used in other nixpkgs packages (loudgain, musly, oven-media-engine).

Fixes #463432


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
