### PR TITLE
valent: 1.0.0.alpha.48 -> 1.0.0.alpha.49

### DIFF
--- a/pkgs/by-name/va/valent/package.nix
+++ b/pkgs/by-name/va/valent/package.nix
@@ -23,6 +23,7 @@
   pipewire,
   pulseaudio,
   tinysparql,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -36,6 +37,8 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-dVV/rqd3DktI67DPo0qTs3VP7yZIAy7Ew5TSYsE6ZTA=";
     fetchSubmodules = true;
   };
+
+  strictDeps = true;
 
   nativeBuildInputs = [
     desktop-file-utils
@@ -69,6 +72,8 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonBool "plugin_bluez" true)
   ];
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Implementation of the KDE Connect protocol, built on GNOME platform libraries";
     mainProgram = "valent";
@@ -90,7 +95,7 @@ stdenv.mkDerivation (finalAttrs: {
       ```
     '';
     homepage = "https://valent.andyholmes.ca";
-    changelog = "https://github.com/andyholmes/valent/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/andyholmes/valent/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = with lib.licenses; [
       gpl3Plus
       cc0

--- a/pkgs/by-name/va/valent/package.nix
+++ b/pkgs/by-name/va/valent/package.nix
@@ -27,13 +27,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "valent";
-  version = "1.0.0.alpha.48";
+  version = "1.0.0.alpha.49";
 
   src = fetchFromGitHub {
     owner = "andyholmes";
     repo = "valent";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-CB3Jb7N8vcNTLCWXKoDh/wQkPW1CH6WRlwXg4efU3GY=";
+    hash = "sha256-dVV/rqd3DktI67DPo0qTs3VP7yZIAy7Ew5TSYsE6ZTA=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
Resolves #463193

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
