### PR TITLE
mesa: fix build for musl

### DIFF
--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -150,6 +150,7 @@ stdenv.mkDerivation {
 
   patches = [
     ./opencl.patch
+    ./musl.patch
   ];
 
   postPatch = ''

--- a/pkgs/development/libraries/mesa/musl.patch
+++ b/pkgs/development/libraries/mesa/musl.patch
@@ -1,0 +1,39 @@
+From 571dedac8881649cd94c59488413b835cbcf0498 Mon Sep 17 00:00:00 2001
+From: Alyssa Ross <hi@alyssa.is>
+Date: Thu, 20 Nov 2025 23:16:47 +0100
+Subject: [PATCH] rocket: fix building for musl
+
+musl follows POSIX and provides ioctl as int ioctl(int, int, ...).
+
+Fixes: 5b829658f74 ("rocket: Initial commit of a driver for Rockchip's NPU")
+Signed-off-by: Alyssa Ross <hi@alyssa.is>
+Link: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/38561
+---
+ src/gallium/drivers/rocket/intercept.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/src/gallium/drivers/rocket/intercept.c b/src/gallium/drivers/rocket/intercept.c
+index 6ffb8647d61f5..88e55893d9520 100644
+--- a/src/gallium/drivers/rocket/intercept.c
++++ b/src/gallium/drivers/rocket/intercept.c
+@@ -294,9 +294,15 @@ handle_action(struct rknpu_action *args)
+    }
+ }
+ 
+-typedef int (*real_ioctl_t)(int fd, unsigned long request, ...);
++#ifdef __GLIBC__
++typedef unsigned long ioctl_req;
++#else
++typedef int ioctl_req; // per POSIX
++#endif
++
++typedef int (*real_ioctl_t)(int fd, ioctl_req request, ...);
+ int
+-ioctl(int fd, unsigned long request, ...)
++ioctl(int fd, ioctl_req request, ...)
+ {
+    int ret;
+    uint32_t output_address = 0;
+-- 
+GitLab
+


### PR DESCRIPTION
Fixes: ae921d60d393 ("mesa: 25.2.6 -> 25.3.0")


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
