### PR TITLE
openloco: 25.08 -> 25.11

### DIFF
--- a/pkgs/games/openloco/default.nix
+++ b/pkgs/games/openloco/default.nix
@@ -17,31 +17,31 @@ let
   sfl-src = fetchFromGitHub {
     owner = "slavenf";
     repo = "sfl-library";
-    tag = "1.9.2";
-    hash = "sha256-/3++CtSuZJ5Sdg8U8mJ/gT+FTatKhBx8QeYjUVQCDWA=";
+    tag = "2.0.2";
+    hash = "sha256-C8BRl77fryD1aNW6ASD/orb8+hrAKBqmXjr2Z4JqX94=";
   };
 
   openloco-objects = fetchurl {
-    url = "https://github.com/OpenLoco/OpenGraphics/releases/download/v0.1.3/objects.zip";
-    sha256 = "c08937691b9d7a956305864b535c6e4537a84b81a9dc5d4c9016edff83dcceb6";
+    url = "https://github.com/OpenLoco/OpenGraphics/releases/download/v0.1.5/objects.zip";
+    sha256 = "fe8943fabad8eb07cebab5354589abd7e798a705f7993bb4d9dab2122b4fe96e";
   };
 
 in
 stdenv.mkDerivation rec {
   pname = "openloco";
-  version = "25.08";
+  version = "25.11";
 
   src = fetchFromGitHub {
     owner = "OpenLoco";
     repo = "OpenLoco";
     tag = "v${version}";
-    hash = "sha256-f4GZxLibQM/od0tJoszaG94FkRH5vb9qwQ7OqVdt1cU=";
+    hash = "sha256-ohHTa5ow6wiq0GajqLcOwL9mnjocw+Od93SEaxCR2C0=";
   };
 
   postPatch = ''
     # the upstream build process determines the version tag from git; since we
     # are not using a git checkout, we patch it manually
-    sed -i '/#define NAME "OpenLoco"/a#define OPENLOCO_VERSION_TAG "${version}"' src/OpenLoco/src/Version.cpp
+    sed -i '/#define OPENLOCO_NAME "OpenLoco"/a#define OPENLOCO_VERSION_TAG "${version}"' src/OpenLoco/src/Version.cpp
 
     # prefetch sfl header sources
     grep -q 'GIT_TAG \+${sfl-src.tag}' thirdparty/CMakeLists.txt


### PR DESCRIPTION
openloco: 25.08 -> 25.11

https://openloco.io/news/2025/11/openloco-v25.11.html


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
