### PR TITLE
hmat-oss: fix build on darwin

### DIFF
--- a/pkgs/by-name/hm/hmat-oss/package.nix
+++ b/pkgs/by-name/hm/hmat-oss/package.nix
@@ -20,22 +20,21 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cmakeFlags = [
-    "-DHMAT_GIT_VERSION=OFF"
+    (lib.cmakeBool "HMAT_GIT_VERSION" false)
+    # Find BLAS/LAPACK via pkg-config to avoid linking against Accelerate on Darwin.
+    (lib.cmakeBool "BLA_PREFER_PKGCONFIG" true)
+    (lib.cmakeFeature "CBLAS_INCLUDE_DIR" "${lib.getDev blas}/include")
   ];
 
   nativeBuildInputs = [
     cmake
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    pkg-config # used to find the LAPACK
+    pkg-config
   ];
 
   buildInputs = [
     blas
     lapack
   ];
-
-  enableParallelBuilding = true;
 
   meta = {
     description = "Hierarchical matrix C/C++ library";


### PR DESCRIPTION
cmake build system find cblas.h in apple-sdk rather than provided blas, hence the build failed.

finding blas/lapack is always a problem in darwin platform, it's recommended to use BLA_PREFER_PKGCONFIG.

cc @NixOS/darwin-core , how can we respect blas/lapack in buildInputs rather than adding magic BLA_PREFER_PKGCONFIG/CBLAS_INCLUDE_DIR

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
