### PR TITLE
uv: 0.9.10 -> 0.9.11

### DIFF
--- a/pkgs/by-name/uv/uv/package.nix
+++ b/pkgs/by-name/uv/uv/package.nix
@@ -18,16 +18,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "uv";
-  version = "0.9.10";
+  version = "0.9.11";
 
   src = fetchFromGitHub {
     owner = "astral-sh";
     repo = "uv";
     tag = finalAttrs.version;
-    hash = "sha256-XpWBgFxBflyqsla0K83j/3aBgq5ccedQTa5PoaYs9f0=";
+    hash = "sha256-X3jTJxT8aZ7/yuCVBhIG6UCmrB4/y2sbD3z2dGBApzg=";
   };
 
-  cargoHash = "sha256-9SEUnud2gu64+trX87GhpXzTlBaB/DLrXLjoZbGL0f4=";
+  cargoHash = "sha256-4Zp+d74Auc/rQ2yJvg7ZdQB4NGqBpMSO5NmgDwsDzf0=";
 
   buildInputs = [
     rust-jemalloc-sys


### PR DESCRIPTION
Release notes: https://github.com/astral-sh/uv/releases/tag/0.9.11
Changelog: https://github.com/astral-sh/uv/blob/0.9.11/CHANGELOG.md#0911

Cherry picked the commit to master and built on x86_64-linux:
```
/nix/store/r884vp58mickc90cyn8vx5xaphi79p6f-uv-0.9.11
/nix/store/mwjyidfs8pvhdha5mj75llr749mqp4ls-python3.13-uv-0.9.11
/nix/store/5kln09vhwn19hh3cmsiyp29wg67ixli3-python3.13-uv-build-0.9.11
```

Despite this, uv-build will not be updated on staging because of https://github.com/NixOS/nixpkgs/pull/457247.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
