### PR TITLE
valent: replace gdk-pixbuf with libglycin, remove now default flag

### DIFF
--- a/pkgs/by-name/va/valent/package.nix
+++ b/pkgs/by-name/va/valent/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   desktop-file-utils,
+  glycin-loaders,
   gobject-introspection,
   meson,
   ninja,
@@ -10,13 +11,13 @@
   wrapGAppsHook4,
   vala,
   evolution-data-server-gtk4,
-  gdk-pixbuf,
   glib,
   glib-networking,
   gnutls,
   gst_all_1,
   json-glib,
   libadwaita,
+  libglycin,
   libpeas2,
   libphonenumber,
   libportal-gtk4,
@@ -52,7 +53,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     evolution-data-server-gtk4
-    gdk-pixbuf
     glib
     glib-networking
     gnutls
@@ -60,6 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
     gst_all_1.gst-plugins-base
     json-glib
     libadwaita
+    libglycin
     libpeas2
     libphonenumber
     libportal-gtk4
@@ -68,9 +69,11 @@ stdenv.mkDerivation (finalAttrs: {
     tinysparql
   ];
 
-  mesonFlags = [
-    (lib.mesonBool "plugin_bluez" true)
-  ];
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix XDG_DATA_DIRS : "${glycin-loaders}/share"
+    )
+  '';
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
Followup https://github.com/NixOS/nixpkgs/pull/463558

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
