### PR TITLE
c-ascii-render: init at 0-unstable-2025-11-18

### DIFF
--- a/pkgs/by-name/c-/c-ascii-render/package.nix
+++ b/pkgs/by-name/c-/c-ascii-render/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation {
+  pname = "c-ascii-render";
+  version = "0-unstable-2025-11-18";
+
+  src = fetchFromGitHub {
+    owner = "Lallapallooza";
+    repo = "c_ascii_render";
+    rev = "c1894b50488c6ba75e33734d6b3d4a3397ac1fb5";
+    hash = "sha256-sqGKUbv8OCWAs7Rxe2H6+xHQJivBkGM7K13GdNuPVd8=";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail "CC = gcc" "CC = ${stdenv.cc.targetPrefix}cc" \
+      --replace-fail '/usr/local' '${placeholder "out"}'
+  '';
+
+  env.NIX_CFLAGS_COMPILE =
+    "-Wno-error"
+    # otherwise does not find SIGWINCH
+    + lib.optionalString stdenv.hostPlatform.isDarwin " -D_DARWIN_C_SOURCE";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Simple ASCII Render using Pure C";
+    homepage = "https://github.com/Lallapallooza/c_ascii_render";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "c-ascii-render";
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
