### PR TITLE
ipmiview: 2.21.0 -> 2.23.0; enable TLSv1 for older hosts

### DIFF
--- a/pkgs/by-name/ip/ipmiview/package.nix
+++ b/pkgs/by-name/ip/ipmiview/package.nix
@@ -16,12 +16,12 @@
 
 stdenv.mkDerivation rec {
   pname = "IPMIView";
-  version = "2.21.0";
-  buildVersion = "221118";
+  version = "2.23.0";
+  buildVersion = "250519";
 
   src = fetchurl {
-    url = "https://www.supermicro.com/wftp/utility/IPMIView/Linux/IPMIView_${version}_build.${buildVersion}_bundleJRE_Linux_x64.tar.gz";
-    hash = "sha256-ZN0vadGbjGj9U2wPqvHLjS9fsk3DNCbXoNvzUfnn8IM=";
+    url = "https://www.supermicro.com/Bios/sw_download/960/IPMIView_${version}_build.${buildVersion}_bundleJRE_Linux_x64.tar.gz";
+    hash = "sha256-MpgBReek891jBgbX7HvNAKzBqwKMO2qdkuqrEV90oI0=";
   };
 
   nativeBuildInputs = [
@@ -54,6 +54,10 @@ stdenv.mkDerivation rec {
       patchelf --set-rpath "${lib.makeLibraryPath [ freetype ]}" ./jre/lib/libfontmanager.so
       patchelf --set-rpath "${gcc.cc}/lib:$out/jre/lib/jli" --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" ./jre/bin/java
       patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" ./BMCSecurity/${stunnelBinary}
+
+      # Enable TLSv1 to connect to older hosts
+      substituteInPlace jre/conf/security/java.security \
+        --replace-fail "SSLv3, TLSv1, TLSv1.1," "SSLv3,"
 
       runHook postBuild
     '';
@@ -101,7 +105,10 @@ stdenv.mkDerivation rec {
       binaryNativeCode
     ];
     license = licenses.unfree;
-    maintainers = with maintainers; [ vlaci ];
+    maintainers = with maintainers; [
+      vlaci
+      xddxdd
+    ];
     platforms = [
       "x86_64-linux"
       "i686-linux"


### PR DESCRIPTION
Update `ipmiview` package to latest version, and also fix hash mismatch in the process.

Also enable TLSv1 in `ipmiview`'s Java config to connect to older hosts. IMO `ipmiview` is mostly used for older IPMI with older SSL config, as newer IPMIs come with HTML5 console and do not need `ipmiview` to connect.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
