### PR TITLE
python3Packages.django-typer: init at 3.3.2

### DIFF
--- a/pkgs/development/python-modules/django-typer/default.nix
+++ b/pkgs/development/python-modules/django-typer/default.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  django,
+  click,
+  typer-slim,
+  shellingham,
+  typing-extensions,
+
+  # optional-dependencies
+  rich,
+
+  # tests
+  pytest,
+  pytest-django,
+}:
+
+buildPythonPackage rec {
+  pname = "django-typer";
+  version = "3.3.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "django-commons";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-W5mR5YiLWwpLkZxkXvF6QWVynIlwxCzEu7lzWgN53e0=";
+  };
+
+  nativeBuildInputs = [
+    hatchling
+  ];
+
+  dependencies = [
+    django
+    click
+    typer-slim
+    shellingham
+    typing-extensions
+  ];
+
+  optional-dependencies = {
+    rich = [
+      rich
+    ];
+  };
+
+  nativeCheckInputs = [
+    pytest
+    pytest-django
+  ];
+
+  pythonImportsCheck = [
+    "django_typer"
+  ];
+
+  meta = with lib; {
+    description = "Use Typer to define the CLI for your Django management commands.";
+    homepage = "https://django-typer.readthedocs.io";
+    license = licenses.mit;
+    maintainers = with maintainers; [ MOIS3Y ];
+  };
+}

--- a/pkgs/development/python-modules/django-typer/default.nix
+++ b/pkgs/development/python-modules/django-typer/default.nix
@@ -64,6 +64,6 @@ buildPythonPackage rec {
     description = "Use Typer to define the CLI for your Django management commands.";
     homepage = "https://django-typer.readthedocs.io";
     license = licenses.mit;
-    maintainers = with maintainers; [ MOIS3Y ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4239,6 +4239,8 @@ self: super: with self; {
 
   django-two-factor-auth = callPackage ../development/python-modules/django-two-factor-auth { };
 
+  django-typer = callPackage ../development/python-modules/django-typer { };
+
   django-types = callPackage ../development/python-modules/django-types { };
 
   django-versatileimagefield =


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
`django-typer`: A Django integration for `Typer` that allows using static typing to define CLI interfaces for Django management commands. Provides a `TyperCommand` class that maps Typer's interface onto Django's familiar class-based command system,
serving as a drop-in replacement for `BaseCommand`.

Homepage: [django-typer](https://django-typer.readthedocs.io/)


#### Additional testing performed:

- [x]  Code formatting applied: nix fmt
- [x]  Package builds successfully: `nix-build -A python3Packages.django-typer --check`
- [x]  Python module imports correctly and version matches: `python3Packages.django-typer v3.3.2`

```console
nix-shell -I nixpkgs=. -p python3Packages.django-typer --run "python -c '
import django_typer
print(\"Package:\", django_typer.__name__)
print(\"Version:\", getattr(django_typer, \"__version__\", \"not specified\"))
print(\"File:\", django_typer.__file__)
'"
Package: django_typer
Version: 3.3.2
File: /nix/store/gcgibbfzfyq6ma2rq9apa7660vn6ks8v-python3.13-django-typer-3.3.2/lib/python3.13/site-packages/django_typer/__init__.py
```



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
