### PR TITLE
spectralsuite: init at 2.2.0

### DIFF
--- a/pkgs/by-name/sp/spectralsuite/package.nix
+++ b/pkgs/by-name/sp/spectralsuite/package.nix
@@ -1,0 +1,87 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  cmake,
+  ninja,
+  pkg-config,
+  libx11,
+  libxrandr,
+  libxinerama,
+  libxext,
+  libxcursor,
+  freetype,
+  fontconfig,
+  expat,
+  alsa-lib,
+  juce,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "spectralsuite";
+  version = "2.2.0";
+
+  # don't forget to update plugin list in installPhase
+  src = fetchFromGitHub {
+    owner = "andrewreeman";
+    repo = "SpectralSuite";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-CqnmF+i7JoAaKQHVx9SwgA566TV0M5BdjibE8ik9AHk=";
+  };
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "juce::juce_recommended_lto_flags" "# no lto"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    libx11
+    libxcursor
+    libxrandr
+    libxinerama
+    libxext
+    freetype
+    fontconfig
+    expat
+    alsa-lib
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_JUCE" "${juce.src}")
+  ];
+
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-Wno-error=float-equal"
+    "-Wno-error=overloaded-virtual="
+    "-Wno-error=shadow"
+    "-Wno-error=catch-value="
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/vst3
+    for plugin in BinScrambler FrequencyMagnet FrequencyShift Morph PhaseLock SinusoidalShapedFilter SpectralGate; do
+      cp -r $plugin/*_artefacts/Release/VST3/*.vst3 $out/lib/vst3
+    done
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Collection of audio plugins for spectral manipulation";
+    longDescription = "Collection of audio plugins that utilise the FFT algorithm to manipulate the spectral components of the input audio";
+    homepage = "https://github.com/andrewreeman/spectralsuite";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    license = [ lib.licenses.unlicense ];
+    maintainers = [ lib.maintainers.mrtnvgr ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
