### PR TITLE
nixos/sylkserver: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -145,6 +145,8 @@
 
 - [SuiteNumérique Docs](https://github.com/suitenumerique/docs), a collaborative note taking, wiki and documentation web platform and alternative to Notion or Outline. Available as [services.lasuite-docs](#opt-services.lasuite-docs.enable).
 
+- [sylkserver](https://github.com/AGProjects/sylkserver), a SIP/XMPP/WebRTC Application Server. Available as [services.sylkserver](#opt-services.sylkserver.enable).
+
 - [dwl](https://codeberg.org/dwl/dwl), a compact, hackable compositor for Wayland based on wlroots. Available as [programs.dwl](#opt-programs.dwl.enable).
 
 - [nebula-lighthouse-service](https://github.com/manuels/nebula-lighthouse-service), a public Nebula VPN lighthouse service. Available as [services.nebula-lighthouse-service](#opt-services.nebula-lighthouse-service.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1374,6 +1374,7 @@
   ./services/networking/supplicant.nix
   ./services/networking/supybot.nix
   ./services/networking/suricata/default.nix
+  ./services/networking/sylkserver
   ./services/networking/syncplay.nix
   ./services/networking/syncthing-relay.nix
   ./services/networking/syncthing.nix

--- a/nixos/modules/services/networking/sylkserver/config-modules/conference.nix
+++ b/nixos/modules/services/networking/sylkserver/config-modules/conference.nix
@@ -1,0 +1,31 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.services.sylkserver;
+  settingsFormat = pkgs.formats.ini { };
+in
+
+{
+  freeformType = settingsFormat.type;
+  options = {
+    Conference = {
+      file_transfer_dir = lib.mkOption {
+        type = lib.types.path;
+        default = cfg.stateDir;
+        defaultText = lib.literalExpression "config.services.sylkserver.stateDir";
+        description = "Directory for storing files transferred to rooms.";
+      };
+      screensharing_images_dir = lib.mkOption {
+        type = lib.types.path;
+        default = "${cfg.stateDir}/conference/screensharing";
+        defaultText = lib.literalExpression "\"\${config.services.sylkserver.stateDir}/conference/screensharing\"";
+        description = "Directory where images used by the Screen Sharing functionality will be stored.";
+      };
+    };
+  };
+}

--- a/nixos/modules/services/networking/sylkserver/config-modules/config.nix
+++ b/nixos/modules/services/networking/sylkserver/config-modules/config.nix
@@ -1,0 +1,89 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.services.sylkserver;
+  settingsFormat = pkgs.formats.ini { };
+in
+
+{
+  freeformType = settingsFormat.type;
+  options = {
+    Server = {
+      spool_dir = lib.mkOption {
+        type = lib.types.path;
+        default = cfg.stateDir;
+        defaultText = lib.literalExpression "config.services.sylkserver.stateDir";
+        description = "Directory for files created by the server, excluding logs.";
+      };
+      trace_dir = lib.mkOption {
+        type = lib.types.path;
+        default = "/var/log/sylkserver";
+        description = "Directory for trace logs.";
+      };
+      log_level = lib.mkOption {
+        type = lib.types.enum [
+          "debug"
+          "info"
+          "warning"
+          "error"
+          "critical"
+        ];
+        default = "info";
+        description = "Log level.";
+      };
+      ca_file = lib.mkOption {
+        type = lib.types.path;
+        default = "${cfg.package}/share/sylkserver/tls/ca.crt";
+        defaultText = lib.literalExpression "\"\${config.services.sylkserver.package}/share/sylkserver/tls/ca.crt\"";
+        description = "Path to the Certificate Authority file for TLS.";
+      };
+      certificate = lib.mkOption {
+        type = lib.types.path;
+        default = "${cfg.package}/share/sylkserver/tls/default.crt";
+        defaultText = lib.literalExpression "\"\${config.services.sylkserver.package}/share/sylkserver/tls/default.crt\"";
+        description = "Path to the server certificate file for TLS.";
+      };
+    };
+    SIP = {
+      local_ip = lib.mkOption {
+        type = lib.types.str;
+        default = "127.0.0.1";
+        description = "Local IP address for SIP.";
+      };
+      local_udp_port = lib.mkOption {
+        type = lib.types.port;
+        default = 5060;
+        description = "UDP port for SIP.";
+      };
+      local_tcp_port = lib.mkOption {
+        type = lib.types.port;
+        default = 5060;
+        description = "TCP port for SIP.";
+      };
+      local_tls_port = lib.mkOption {
+        type = lib.types.port;
+        default = 5061;
+        description = "TLS port for SIP.";
+      };
+    };
+    RTP = {
+      port_range = lib.mkOption {
+        type = lib.types.str;
+        default = "50000:50500";
+        description = "Port range for RTP.";
+      };
+    };
+    WebServer = {
+      local_port = lib.mkOption {
+        type = lib.types.port;
+        default = 10888;
+        description = "Port for the web server.";
+      };
+    };
+  };
+}

--- a/nixos/modules/services/networking/sylkserver/config-modules/xmppgateway.nix
+++ b/nixos/modules/services/networking/sylkserver/config-modules/xmppgateway.nix
@@ -1,0 +1,36 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.services.sylkserver;
+  settingsFormat = pkgs.formats.ini { };
+in
+
+{
+  freeformType = settingsFormat.type;
+  options = {
+    general = {
+      local_port = lib.mkOption {
+        type = lib.types.port;
+        default = 5269;
+        description = "Port for XMPP.";
+      };
+      ca_file = lib.mkOption {
+        type = lib.types.path;
+        default = "${cfg.package}/share/sylkserver/tls/ca.crt";
+        defaultText = lib.literalExpression "\"\${config.services.sylkserver.package}/share/sylkserver/tls/ca.crt\"";
+        description = "Path to the Certificate Authority file for TLS.";
+      };
+      certificate = lib.mkOption {
+        type = lib.types.path;
+        default = "${cfg.package}/share/sylkserver/tls/default.crt";
+        defaultText = lib.literalExpression "\"\${config.services.sylkserver.package}/share/sylkserver/tls/default.crt\"";
+        description = "Path to the server certificate file for TLS.";
+      };
+    };
+  };
+}

--- a/nixos/modules/services/networking/sylkserver/default.nix
+++ b/nixos/modules/services/networking/sylkserver/default.nix
@@ -1,0 +1,188 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}@args:
+
+let
+  cfg = config.services.sylkserver;
+  settingsFormat = pkgs.formats.ini { };
+in
+
+{
+  options = {
+    services.sylkserver = {
+      enable = lib.mkEnableOption "the SylkServer SIP/XMPP/WebRTC Application Server";
+      package = lib.mkPackageOption pkgs "sylkserver" { };
+      debug = lib.mkEnableOption "verbose logging";
+
+      openFirewall = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Whether to open ports in the firewall for SylkServer.";
+      };
+
+      user = lib.mkOption {
+        type = lib.types.nonEmptyStr;
+        default = "sylkserver";
+        description = "User account under which SylkServer runs.";
+      };
+
+      group = lib.mkOption {
+        type = lib.types.nonEmptyStr;
+        default = "sylkserver";
+        description = "Group under which SylkServer runs.";
+      };
+
+      stateDir = lib.mkOption {
+        type = lib.types.path;
+        default = "/var/lib/sylkserver";
+        description = "Directory to store SylkServer data and configuration.";
+      };
+
+      # See configuration samples for options
+      # e.g. https://github.com/AGProjects/sylkserver/blob/master/config.ini.sample
+      settings = lib.mkOption {
+        type = lib.types.submodule {
+          options = {
+            config = lib.mkOption {
+              type = lib.types.submodule (import ./config-modules/config.nix args);
+              default = { };
+              description = "Main SylkServer configuration.";
+            };
+            conference = lib.mkOption {
+              type = lib.types.submodule (import ./config-modules/conference.nix args);
+              default = { };
+              description = "Conference application configuration.";
+            };
+            auth = lib.mkOption {
+              type = lib.types.submodule {
+                freeformType = settingsFormat.type;
+                options = { };
+              };
+              default = { };
+              description = "Authentication configuration.";
+            };
+            playback = lib.mkOption {
+              type = lib.types.submodule {
+                freeformType = settingsFormat.type;
+                options = { };
+              };
+              default = { };
+              description = "Playback application configuration.";
+            };
+            webrtcgateway = lib.mkOption {
+              type = lib.types.submodule {
+                freeformType = settingsFormat.type;
+                options = { };
+              };
+              default = { };
+              description = "WebRTC gateway configuration.";
+            };
+            xmppgateway = lib.mkOption {
+              type = lib.types.submodule (import ./config-modules/xmppgateway.nix args);
+              default = { };
+              description = "XMPP gateway configuration.";
+            };
+            ircconference = lib.mkOption {
+              type = lib.types.submodule {
+                freeformType = settingsFormat.type;
+                options = { };
+              };
+              default = { };
+              description = "IRC conference configuration.";
+            };
+          };
+        };
+        default = { };
+        description = "SylkServer configuration files.";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # TODO: dynamic user?
+    # there were some issues with using a dynamic user (tied to uid and gid)
+    # that may warrant patching the software
+    users.groups.${cfg.group} = { };
+    users.users.${cfg.user} = {
+      description = "SylkServer service user";
+      home = cfg.stateDir;
+      createHome = true;
+      isSystemUser = true;
+      group = cfg.group;
+    };
+
+    # TODO: the server requies `/var/spool/sylkserver` to exist despite
+    # changing `spool_dir` to something else. find out why this happens and
+    # remove the hardcoded value
+    systemd.tmpfiles.settings = {
+      "10-sylkserver"."/var/spool/sylkserver".d = {
+        group = cfg.group;
+        user = cfg.user;
+        mode = "075";
+      };
+    };
+
+    systemd.services.sylkserver = {
+      description = "SylkServer SIP/XMPP/WebRTC Application Server";
+      wantedBy = [
+        "multi-user.target"
+      ];
+      after = [
+        "network.target"
+        "systemd-tmpfiles-setup.service"
+      ];
+      requires = [
+        "systemd-tmpfiles-setup.service"
+      ];
+
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+
+        ExecStart = toString [
+          (lib.getExe' cfg.package "sylk-server")
+          (lib.optionalString cfg.debug "--debug")
+          "--no-fork"
+          "--config-dir $STATE_DIRECTORY"
+        ];
+
+        LogsDirectory = "sylkserver";
+        RuntimeDirectory = "sylkserver";
+        StateDirectory = "sylkserver";
+        WorkingDirectory = cfg.stateDir;
+
+        Restart = "on-failure";
+        RestartSec = 5;
+      };
+
+      unitConfig = {
+        StartLimitBurst = 5;
+        StartLimitInterval = 100;
+      };
+
+      preStart = ''
+        # create config files
+        ${lib.concatMapStringsSep "\n" (name: ''
+          cat > $STATE_DIRECTORY/${name}.ini <<EOF
+          ${lib.generators.toINI { } cfg.settings.${name}}
+          EOF
+        '') (lib.attrNames cfg.settings)}
+      '';
+    };
+
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts = [
+        cfg.settings.config.SIP.local_tcp_port
+        cfg.settings.config.SIP.local_tls_port
+        cfg.settings.config.WebServer.local_port
+        cfg.settings.xmppgateway.general.local_port
+      ];
+      allowedUDPPorts = [
+        cfg.settings.config.SIP.local_udp_port
+      ];
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1446,6 +1446,7 @@ in
   swayfx = runTest ./swayfx.nix;
   switchTest = runTest ./switch-test.nix;
   sx = runTest ./sx.nix;
+  sylkserver = runTest ./sylkserver.nix;
   sympa = runTest ./sympa.nix;
   syncthing = runTest ./syncthing/main.nix;
   syncthing-folders = runTest ./syncthing/folders.nix;

--- a/nixos/tests/sylkserver.nix
+++ b/nixos/tests/sylkserver.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  ...
+}:
+
+let
+  ports = {
+    sip = 5060;
+    xmpp = 5269;
+    web = 10888;
+  };
+in
+
+{
+  name = "sylkserver";
+  meta.maintainers = lib.teams.ngi.members;
+
+  nodes.machine =
+    { config, ... }:
+    {
+      services.sylkserver.enable = true;
+
+      services.sylkserver.settings.config.SIP.local_tcp_port = ports.sip;
+      services.sylkserver.settings.config.WebServer.public_port = ports.web;
+      services.sylkserver.settings.xmppgateway.general.local_port = ports.xmpp;
+
+      services.sylkserver.settings.config.SIP.local_ip = "0.0.0.0";
+      services.sylkserver.settings.config.WebServer.hostname = "0.0.0.0";
+      services.sylkserver.settings.xmppgateway.general.local_ip = "0.0.0.0";
+    };
+
+  testScript =
+    { nodes, ... }:
+    # python
+    ''
+      machine.start()
+      machine.wait_for_unit("sylkserver.service")
+      machine.wait_for_open_port(${toString ports.sip})
+
+      machine.wait_for_console_text("Web server listening for requests")
+      machine.succeed("""
+        curl http://0.0.0.0:${toString ports.web} \
+          --fail \
+          --connect-timeout 2
+      """)
+    '';
+
+  # for debugging
+  interactive.sshBackdoor.enable = true;
+  interactive.nodes = {
+    machine =
+      { pkgs, lib, ... }:
+      {
+        imports = [
+          # enable graphical session + users (alice, bob)
+          ./common/x11.nix
+          ./common/user-account.nix
+        ];
+
+        # forward ports from VM to host
+        virtualisation.forwardPorts = lib.mapAttrsToList (_: port: {
+          from = "host";
+          host = { inherit port; };
+          guest = { inherit port; };
+        }) ports;
+
+        services.xserver.enable = true;
+        test-support.displayManager.auto.user = "alice";
+
+        networking.firewall.enable = false;
+
+        # TODO: connect client to server
+        environment.systemPackages = with pkgs; [
+          sylk
+          freetalk
+          pidgin
+        ];
+      };
+  };
+}

--- a/pkgs/by-name/sy/sylkserver/package.nix
+++ b/pkgs/by-name/sy/sylkserver/package.nix
@@ -34,6 +34,7 @@ python3Packages.buildPythonApplication rec {
     dnspython
     klein
     lxml
+    lxml-html-clean
     msrplib
     python3-eventlib
     python3-gnutls
@@ -49,6 +50,13 @@ python3Packages.buildPythonApplication rec {
   nativeCheckInputs = [ versionCheckHook ];
   versionCheckProgram = "${placeholder "out"}/bin/sylk-server";
   versionCheckProgramArg = "--version";
+
+  # copy config file examples
+  postInstall = ''
+    for file in *.ini.sample; do
+      install -Dm0644 $file $out/share/sylkserver/examples/''${file%.*}
+    done
+  '';
 
   meta = {
     description = "SIP/XMPP/WebRTC Application Server";

--- a/pkgs/by-name/sy/sylkserver/package.nix
+++ b/pkgs/by-name/sy/sylkserver/package.nix
@@ -4,6 +4,7 @@
   python3Packages,
   versionCheckHook,
   fetchpatch2,
+  nixosTests,
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -25,6 +26,14 @@ python3Packages.buildPythonApplication rec {
       hash = "sha256-U0a8mRbt8c4lUcN2xYDfvXTt/sWcvi7F3/Vw5sIQPrU=";
     })
   ];
+
+  postPatch = ''
+    # "value must be a string"
+    substituteInPlace \
+      sylk/configuration/__init__.py \
+      sylk/applications/xmppgateway/configuration.py \
+        --replace-fail "host.default_ip" "host.default_ip or '127.0.0.1'"
+  '';
 
   build-system = [ python3Packages.setuptools ];
 
@@ -57,6 +66,10 @@ python3Packages.buildPythonApplication rec {
       install -Dm0644 $file $out/share/sylkserver/examples/''${file%.*}
     done
   '';
+
+  passthru = {
+    tests = nixosTests.sylkserver;
+  };
 
   meta = {
     description = "SIP/XMPP/WebRTC Application Server";


### PR DESCRIPTION
Work done as part of the [Nix@NGI packaging effort](https://nixos.org/community/teams/ngi/) of Sylk (tracked in https://github.com/ngi-nix/projects/issues/109)

Closes https://github.com/ngi-nix/projects/issues/1778
Closes https://github.com/ngi-nix/projects/issues/1776

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc