### PR TITLE
wf-recorder: 0.5.0 -> 0.6.0

### DIFF
--- a/pkgs/by-name/wf/wf-recorder/package.nix
+++ b/pkgs/by-name/wf/wf-recorder/package.nix
@@ -14,27 +14,18 @@
   libpulseaudio,
   pipewire,
   libgbm,
-  fetchpatch,
 }:
 
 stdenv.mkDerivation rec {
   pname = "wf-recorder";
-  version = "0.5.0";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "ammen99";
     repo = "wf-recorder";
     rev = "v${version}";
-    hash = "sha256-7/fQOkfAw5v3irD5blJOdq88j0VBrPVQQufdt9wsACk=";
+    hash = "sha256-CY0pci2LNeQiojyeES5323tN3cYfS3m4pECK85fpn5I=";
   };
-
-  patches = [
-    # compile fixes from upstream, remove when they stop applying
-    (fetchpatch {
-      url = "https://github.com/ammen99/wf-recorder/commit/560bb92d3ddaeb31d7af77d22d01b0050b45bebe.diff";
-      sha256 = "sha256-7jbX5k8dh4dWfolMkZXiERuM72zVrkarsamXnd+1YoI=";
-    })
-  ];
 
   nativeBuildInputs = [
     meson

--- a/pkgs/by-name/wf/wf-recorder/package.nix
+++ b/pkgs/by-name/wf/wf-recorder/package.nix
@@ -14,6 +14,7 @@
   libpulseaudio,
   pipewire,
   libgbm,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -43,6 +44,8 @@ stdenv.mkDerivation rec {
     pipewire
     libgbm
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Utility program for screen recording of wlroots-based compositors";


### PR DESCRIPTION
Removed the patch since that's in 0.6.0 already.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
