### PR TITLE
ocamlPackages.{bheap,bigarray-compat,cairo2}: small cleaning

### DIFF
--- a/pkgs/development/ocaml-modules/bheap/default.nix
+++ b/pkgs/development/ocaml-modules/bheap/default.nix
@@ -5,26 +5,24 @@
   stdlib-shims,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "bheap";
   version = "2.0.0";
 
   src = fetchurl {
-    url = "https://github.com/backtracking/${pname}/releases/download/${version}/${pname}-${version}.tbz";
-    sha256 = "0dpnpla20lgiicrxl2432m2fcr6y68msw3pnjxqb11xw6yrdfhsz";
+    url = "https://github.com/backtracking/bheap/releases/download/${finalAttrs.version}/bheap-${finalAttrs.version}.tbz";
+    hash = "sha256-X0PXsje8h7Bwl/YOrisy3mTmRBWDCNozi/FRIBS99jY=";
   };
-
-  useDune2 = true;
 
   doCheck = true;
   checkInputs = [
     stdlib-shims
   ];
 
-  meta = with lib; {
-    description = "OCaml binary heap implementation by Jean-Christophe Filliatre";
-    license = licenses.lgpl21Only;
-    maintainers = [ maintainers.sternenseemann ];
+  meta = {
+    description = "OCaml binary heap implementation by Jean-Christophe Filliâtre";
+    license = lib.licenses.lgpl21Only;
+    maintainers = [ lib.maintainers.sternenseemann ];
     homepage = "https://github.com/backtracking/bheap";
   };
-}
+})

--- a/pkgs/development/ocaml-modules/bigarray-compat/default.nix
+++ b/pkgs/development/ocaml-modules/bigarray-compat/default.nix
@@ -1,28 +1,22 @@
 {
   lib,
   buildDunePackage,
-  fetchFromGitHub,
+  fetchurl,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "bigarray-compat";
   version = "1.1.0";
 
-  useDune2 = true;
-
-  minimalOCamlVersion = "4.02";
-
-  src = fetchFromGitHub {
-    owner = "mirage";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-2JVopggK2JuXWEPu8qn12F1jQIJ9OV89XY1rHtUqLkI=";
+  src = fetchurl {
+    url = "https://github.com/mirage/bigarray-compat/releases/download/v${finalAttrs.version}/bigarray-compat-${finalAttrs.version}.tbz";
+    hash = "sha256-Q0RppI1chOgNYhsT2V6wZ/gTjBZQof1a5gCaGbk3GNU=";
   };
 
   meta = {
     description = "Compatibility library to use Stdlib.Bigarray when possible";
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/mirage/bigarray-compat";
     license = lib.licenses.isc;
     maintainers = [ lib.maintainers.vbgl ];
   };
-}
+})

--- a/pkgs/development/ocaml-modules/cairo2/default.nix
+++ b/pkgs/development/ocaml-modules/cairo2/default.nix
@@ -9,17 +9,14 @@
   cairo,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "cairo2";
   version = "0.6.5";
 
   src = fetchurl {
-    url = "https://github.com/Chris00/ocaml-cairo/releases/download/${version}/cairo2-${version}.tbz";
-    sha256 = "sha256-JdxByUNtmrz1bKrZoQWUT/c0YEG4zGoqZUq4hItlc3I=";
+    url = "https://github.com/Chris00/ocaml-cairo/releases/download/${finalAttrs.version}/cairo2-${finalAttrs.version}.tbz";
+    hash = "sha256-JdxByUNtmrz1bKrZoQWUT/c0YEG4zGoqZUq4hItlc3I=";
   };
-
-  minimalOCamlVersion = "4.02";
-  useDune2 = true;
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
@@ -34,7 +31,7 @@ buildDunePackage rec {
       || lib.versionAtLeast ocaml.version "4.10"
     );
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/Chris00/ocaml-cairo";
     description = "Binding to Cairo, a 2D Vector Graphics Library";
     longDescription = ''
@@ -43,10 +40,10 @@ buildDunePackage rec {
       the X Window System, Quartz, Win32, image buffers, PostScript, PDF,
       and SVG file output.
     '';
-    license = licenses.lgpl3;
-    maintainers = with maintainers; [
+    license = lib.licenses.lgpl3;
+    maintainers = with lib.maintainers; [
       jirkamarsik
       vbgl
     ];
   };
-}
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
