### PR TITLE
kdePackages.breeze: put the menus back on a diet

### DIFF
--- a/pkgs/kde/plasma/breeze/default.nix
+++ b/pkgs/kde/plasma/breeze/default.nix
@@ -3,9 +3,23 @@
   qtbase,
   qtsvg,
   libsForQt5,
+  fetchpatch,
 }:
 mkKdeDerivation {
   pname = "breeze";
+
+  # Fix extra thicc padding on menu items
+  # FIXME: remove in next update
+  patches = [
+    (fetchpatch {
+      url = "https://invent.kde.org/plasma/breeze/-/commit/4a8a46aba6b9e39bfb02c7f46933079b5a50eff5.diff";
+      hash = "sha256-ZzRMMwz3OihChywzQWBNv9rPcZI+IcXNVzoRuXTWt9c=";
+    })
+    (fetchpatch {
+      url = "https://invent.kde.org/plasma/breeze/-/commit/2cd5b37dad8f213aab4029b6d3b80ca7f159ea50.diff";
+      hash = "sha256-3pOJEH1H3o+U40K/mtKnruPsoA+vy+HrAa8vU5Oza6c=";
+    })
+  ];
 
   outputs = [
     "out"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
