### PR TITLE
python3Packages.model-hosting-container-standards: init at 0.1.9

### DIFF
--- a/pkgs/development/python-modules/model-hosting-container-standards/default.nix
+++ b/pkgs/development/python-modules/model-hosting-container-standards/default.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  poetry-core,
+
+  # dependencies
+  fastapi,
+  httpx,
+  jmespath,
+  pydantic,
+  starlette,
+  supervisor,
+
+  # tests
+  pytest-asyncio,
+  pytestCheckHook,
+  writableTmpDirAsHomeHook,
+}:
+
+buildPythonPackage rec {
+  pname = "model-hosting-container-standards";
+  version = "0.1.9";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "aws";
+    repo = "model-hosting-container-standards";
+    tag = "v${version}";
+    hash = "sha256-iy7lPtMM2J/zC1TUB5Eydtesy4JsjWTjACNlDhfSPA8=";
+  };
+
+  sourceRoot = "${src.name}/python";
+
+  build-system = [
+    poetry-core
+  ];
+
+  pythonRelaxDeps = [
+    "starlette"
+  ];
+  pythonRemoveDeps = [
+    # Declared as a runtime dependency, but not used in practice
+    "setuptools"
+  ];
+  dependencies = [
+    fastapi
+    httpx
+    jmespath
+    pydantic
+    starlette
+    supervisor
+  ];
+
+  pythonImportsCheck = [ "model_hosting_container_standards" ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
+    writableTmpDirAsHomeHook
+  ];
+
+  disabledTests = [
+    # AssertionError: Server should have created restart log
+    "test_continuous_restart_behavior"
+    "test_startup_retry_limit"
+  ];
+
+  meta = {
+    description = "Standardized Python framework for seamless integration between ML frameworks (TensorRT-LLM, vLLM) and Amazon SageMaker hosting";
+    homepage = "https://github.com/aws/model-hosting-container-standards/tree/main/python";
+    changelog = "https://github.com/aws/model-hosting-container-standards/blob/${src.tag}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9717,6 +9717,10 @@ self: super: with self; {
 
   model-checker = callPackage ../development/python-modules/model-checker { };
 
+  model-hosting-container-standards =
+    callPackage ../development/python-modules/model-hosting-container-standards
+      { };
+
   model-signing = callPackage ../development/python-modules/model-signing { };
 
   modelcif = callPackage ../development/python-modules/modelcif { };


### PR DESCRIPTION
## Things done

Add [model-hosting-container-standards](https://github.com/aws/model-hosting-container-standards/tree/main/python).

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
