### PR TITLE
image/repart: add image.repart.imageSize for --size

### DIFF
--- a/nixos/modules/image/repart-image.nix
+++ b/nixos/modules/image/repart-image.nix
@@ -37,6 +37,7 @@
   split,
   seed,
   definitionsDirectory,
+  imageSize ? "auto",
   sectorSize,
   mkfsEnv ? { },
   createEmpty ? true,
@@ -170,7 +171,7 @@ stdenvNoCC.mkDerivation (
     systemdRepartFlags = [
       "--architecture=${systemdArch}"
       "--dry-run=no"
-      "--size=auto"
+      "--size=${imageSize}"
       "--definitions=${finalAttrs.finalRepartDefinitions}"
       "--split=${lib.boolToString split}"
       "--json=pretty"

--- a/nixos/modules/image/repart.nix
+++ b/nixos/modules/image/repart.nix
@@ -201,6 +201,14 @@ in
       '';
     };
 
+    imageSize = lib.mkOption {
+      type = lib.types.strMatching "^([0-9]+[KMGTP]?|auto)$";
+      default = "auto";
+      example = "512G";
+      description = "Size of the produced image in bytes with optional K, M, G, T suffix,
+        or 'auto' to determine the minimal size automatically";
+    };
+
     package = lib.mkPackageOption pkgs "systemd-repart" {
       # We use buildPackages so that repart images are built with the build
       # platform's systemd, allowing for cross-compiled systems to work.
@@ -415,6 +423,7 @@ in
             compression
             split
             seed
+            imageSize
             sectorSize
             finalPartitions
             ;


### PR DESCRIPTION
This allows users to specify their desired total size of the generated disk image. This is useful to e.g. match the size of a target medium to have a appropriately sized filesystems even before first boot.

It's a noop for the default value of "auto".


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
