### PR TITLE
gitlab-runner: apply patch for file variable handling

### DIFF
--- a/pkgs/by-name/gi/gitlab-runner/package.nix
+++ b/pkgs/by-name/gi/gitlab-runner/package.nix
@@ -4,6 +4,7 @@
   bash,
   buildGoModule,
   fetchFromGitLab,
+  fetchpatch,
   nix-update-script,
   versionCheckHook,
 }:
@@ -27,6 +28,12 @@ buildGoModule (finalAttrs: {
   patches = [
     ./fix-shell-path.patch
     ./remove-bash-test.patch
+    # fix regression. remove with next release.
+    (fetchpatch {
+      name = "fix-shell-executor-not-working-with-variables-that-use-file-variables.patch";
+      url = "https://gitlab.com/gitlab-org/gitlab-runner/-/commit/6318fe8e38ca9774eb0f52fa2c68555cdad3ab44.patch";
+      hash = "sha256-GTdBo+7kHHpNs6JywjOII4NBcHjFYEZ3xhdGTcGKov4=";
+    })
   ];
 
   prePatch = ''


### PR DESCRIPTION
Upstream introduced this regression in the 18.6.0 release, there's currently no fix release, so introduce the patch.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
