### PR TITLE
progress-tracker: 1.6 -> 1.7.2

### DIFF
--- a/pkgs/by-name/pr/progress-tracker/package.nix
+++ b/pkgs/by-name/pr/progress-tracker/package.nix
@@ -10,22 +10,27 @@
   stdenv,
   tinyxml-2,
   wrapGAppsHook4,
+  gettext,
+  libuuid,
+  spdlog,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "progress-tracker";
-  version = "1.6";
+  version = "1.7.2";
 
   src = fetchFromGitHub {
     owner = "smolBlackCat";
     repo = "progress-tracker";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-uUw3+BJWRoCT1VH27SZBEBRsEbbpaP4IahKonfSOyeM=";
+    fetchSubmodules = true;
+    hash = "sha256-RIguUto0ADAT9OJ+gBf/JBpAiDn1DX9NBuGmDJYJn+Q=";
   };
 
   nativeBuildInputs = [
     cmake
     pkg-config
     wrapGAppsHook4
+    gettext
   ];
 
   buildInputs = [
@@ -34,18 +39,14 @@ stdenv.mkDerivation (finalAttrs: {
     libadwaita
     pcre2
     tinyxml-2
+    spdlog
+    libuuid
   ];
 
-  postPatch = ''
-    substituteInPlace src/CMakeLists.txt \
-      --replace-fail "/usr/bin/" "${placeholder "out"}/bin/"
-
-    substituteInPlace po/CMakeLists.txt \
-      --replace-fail "/usr/share/" "${placeholder "out"}/share/"
-
-    substituteInPlace data/CMakeLists.txt \
-      --replace-fail "/usr/share/" "${placeholder "out"}/share/"
-  '';
+  cmakeFlags = [
+    "-DDEVELOPMENT=OFF"
+    "-DBUILD_APP=ON"
+  ];
 
   meta = {
     description = "Simple kanban-style task organiser";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This updates `progress-tracker` from 1.6 to 1.7.2 to match the latest upstream release and align the build with the upstream Linux build instructions.

Changes:

- Bump `progress-tracker` from **1.6 → 1.7.2**
- Switch `src` to `fetchSubmodules = true;` so the `subprojects/crossguid` submodule is fetched and builds correctly
- Add `gettext`, `libuuid`, and `spdlog` to match upstream’s documented build dependencies
- Add CMake flags `-DDEVELOPMENT=OFF` and `-DBUILD_APP=ON` to build the release application without tests
- Drop the old `postPatch` that rewrote `/usr/bin` and `/usr/share` paths, which is no longer needed for 1.7.2 and failed against the updated CMakeLists

Upstream:

- Repo: https://github.com/smolBlackCat/progress-tracker
- Release: https://github.com/smolBlackCat/progress-tracker/releases/tag/v1.7.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test