### PR TITLE
nfs-ganesha: 6.5 -> 9.2

### DIFF
--- a/pkgs/by-name/nf/nfs-ganesha/package.nix
+++ b/pkgs/by-name/nf/nfs-ganesha/package.nix
@@ -16,6 +16,7 @@
   flex,
   nfs-utils,
   acl,
+  prometheus-cpp-lite,
   useCeph ? false,
   ceph,
   useDbus ? true,
@@ -24,7 +25,7 @@
 
 stdenv.mkDerivation rec {
   pname = "nfs-ganesha";
-  version = "6.5";
+  version = "9.2";
 
   outputs = [
     "out"
@@ -35,13 +36,15 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "nfs-ganesha";
     repo = "nfs-ganesha";
-    rev = "V${version}";
-    hash = "sha256-OHGmEzHu8y/TPQ70E2sicaLtNgvlf/bRq8JRs6S1tpY=";
+    tag = "V${version}";
+    hash = "sha256-2EAkr+zu7Jc2j/8BrJ/+Skv/D3rTSbh4A5JTRhWafEk=";
   };
 
   patches = lib.optional useDbus ./allow-bypassing-dbus-pkg-config-test.patch;
 
   preConfigure = "cd src";
+
+  env.NIX_CFLAGS_COMPILE = "-Wno-redundant-move";
 
   cmakeFlags = [
     "-DUSE_SYSTEM_NTIRPC=ON"
@@ -50,6 +53,7 @@ stdenv.mkDerivation rec {
     "-DUSE_ACL_MAPPING=ON"
     "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON"
     "-DUSE_MAN_PAGE=ON"
+    "-DUSE_MONITORING=ON"
   ]
   ++ lib.optionals useCeph [
     "-DUSE_RADOS_RECOV=ON"
@@ -85,14 +89,11 @@ stdenv.mkDerivation rec {
     ntirpc
     liburcu
     nfs-utils
+    prometheus-cpp-lite
   ]
   ++ lib.optional useCeph ceph;
 
   postPatch = ''
-    substituteInPlace src/CMakeLists.txt --replace-fail \
-      "cmake_minimum_required(VERSION 2.6.3)" \
-      "cmake_minimum_required(VERSION 3.10)"
-
     substituteInPlace src/tools/mount.9P --replace-fail "/bin/mount" "/usr/bin/env mount"
   '';
 

--- a/pkgs/by-name/nt/ntirpc/package.nix
+++ b/pkgs/by-name/nt/ntirpc/package.nix
@@ -7,17 +7,18 @@
   liburcu,
   libtirpc,
   libnsl,
+  prometheus-cpp-lite,
 }:
 
 stdenv.mkDerivation rec {
   pname = "ntirpc";
-  version = "6.3";
+  version = "7.2";
 
   src = fetchFromGitHub {
     owner = "nfs-ganesha";
     repo = "ntirpc";
     rev = "v${version}";
-    sha256 = "sha256-e4eF09xwX2Qf/y9YfOGy7p6yhDFnKGI5cnrQy3o8c98=";
+    hash = "sha256-4E6wDAwinCNn7arRgBulg7e0x9S/steh+mjwNY4X3Vc=";
   };
 
   outputs = [
@@ -38,6 +39,11 @@ stdenv.mkDerivation rec {
     krb5
     liburcu
     libnsl
+    prometheus-cpp-lite
+  ];
+
+  cmakeFlags = [
+    "-DUSE_MONITORING=ON"
   ];
 
   postInstall = ''

--- a/pkgs/by-name/pr/prometheus-cpp-lite/missing_includes.patch
+++ b/pkgs/by-name/pr/prometheus-cpp-lite/missing_includes.patch
@@ -1,0 +1,11 @@
+diff --git a/core/include/prometheus/family.h b/core/include/prometheus/family.h
+index 1c625c1..a3d0e85 100644
+--- a/core/include/prometheus/family.h
++++ b/core/include/prometheus/family.h
+@@ -1,5 +1,6 @@
+ #pragma once
+ 
++#include <stdexcept>
+ #include <cstddef>
+ #include <map>
+ #include <memory>

--- a/pkgs/by-name/pr/prometheus-cpp-lite/package.nix
+++ b/pkgs/by-name/pr/prometheus-cpp-lite/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "prometheus-cpp-lite";
+  version = "1.0-unstable-2023-08-13";
+
+  src = fetchFromGitHub {
+    owner = "biaks";
+    repo = "prometheus-cpp-lite";
+    rev = "48d09c45ee6deb90e02579b03037740e1c01fd27";
+    hash = "sha256-XplbP4wHxK9z8Q5fOnaiL7vzXBaZTJyo/tmXUJN/mb4=";
+  };
+
+  patches = [
+    ./missing_includes.patch
+  ];
+
+  postPatch = ''
+    for dir in . core simpleapi; do
+    substituteInPlace $dir/CMakeLists.txt --replace-fail \
+      'cmake_minimum_required(VERSION 3.2)' \
+      'cmake_minimum_required(VERSION 3.10)'
+    done
+
+    substituteInPlace 3rdpatry/http-client-lite/CMakeLists.txt --replace-fail \
+      'cmake_minimum_required(VERSION 3.3 FATAL_ERROR)' \
+      'cmake_minimum_required(VERSION 3.10)' \
+  '';
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/include/prometheus $out/lib
+
+    cp ../core/include/prometheus/* $out/include/prometheus
+    cp ../simpleapi/include/prometheus/* $out/include/prometheus
+    cp simpleapi/libprometheus-cpp-simpleapi.* $out/lib/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "C++ Header-only Prometheus client library";
+    homepage = "https://github.com/biaks/prometheus-cpp-lite";
+    maintainers = [ lib.maintainers.markuskowa ];
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Changelog: https://github.com/nfs-ganesha/nfs-ganesha/tags

## Things done
* Update NTIRPC
* Add `prometheus-cpp-lite`, which is need now (building without monitoring is broken since nfs-ganesha V7.0).
* Tested against an external NixOS test.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
