### PR TITLE
stdenv: make inputDerivation never require system features

### DIFF
--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -214,6 +214,9 @@ let
       shellDryRun = "${stdenv.shell} -n -O extglob";
 
       tests = {
+        inputDerivationRequiredSystemFeatures = import ../tests/inputDerivationRequiredSystemFeatures.nix {
+          inherit lib stdenv;
+        };
         succeedOnFailure = import ../tests/succeedOnFailure.nix { inherit stdenv; };
       };
       passthru.tests = lib.warn "Use `stdenv.tests` instead. `passthru` is a `mkDerivation` detail." stdenv.tests;

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -882,6 +882,9 @@ let
             name = derivationArg.name or "inputDerivation";
             # This always only has one output
             outputs = [ "out" ];
+            # This doesn’t require any system features even if the original
+            # derivation did.
+            requiredSystemFeatures = [ ];
 
             # Propagate the original builder and arguments, since we override
             # them and they might contain references to build inputs

--- a/pkgs/stdenv/tests/inputDerivationRequiredSystemFeatures.nix
+++ b/pkgs/stdenv/tests/inputDerivationRequiredSystemFeatures.nix
@@ -1,0 +1,40 @@
+{ lib, stdenv }:
+let
+  impossibleToBuildPackage = stdenv.mkDerivation {
+    name = "impossible-to-build-package";
+    # According to the Nix manual, the "apple-virt" system feature is
+    # Darwin-only and the "kvm" system feature is Linux-only [1].
+    #
+    # [1]: <https://nix.dev/manual/nix/2.32/command-ref/conf-file.html#conf-system-features>
+    requiredSystemFeatures = if stdenv.buildPlatform.isLinux then "apple-virt" else "kvm";
+
+    buildCommand = ''
+      echo ERROR: It’s supposed to be impossible to start building this package. >&2
+      exit 1
+    '';
+  };
+in
+stdenv.mkDerivation {
+  name = "stdenv-test-inputDerivationRequiredSystemFeatures";
+
+  impossibleToBuildPackageInputDerivation = impossibleToBuildPackage.inputDerivation;
+  buildCommand = ''
+    ln --symbolic "$impossibleToBuildPackageInputDerivation" "$out"
+  '';
+
+  meta = {
+    longDescription = ''
+      In previous versions of Nixpkgs,
+      `<originalDerivation>.inputDerivation.requiredSystemFeatures` would
+      always be the same as `<originalDerivation>.requiredSystemFeatures`. This
+      meant that if a builder wasn’t able to build `<originalDerivation>` due
+      to a lack of system features, then that builder would also not be able to
+      build `<originalDerivation>.inputDerivation`.
+
+      That was an aribtrary (and probably accidental) limitation. Building
+      input derivations never requires any system features. This test checks to
+      make sure that that limitation no longer exists.
+    '';
+    maintainers = [ lib.maintainers.jayman2000 ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This pull request removes a limitation with `inputDerivation`s. See the commit message and `stdenv.tests.inputDerivationRequiredSystemFeatures.meta.longDescription` for details.

This pull requests also adds a test to make sure that the limitation no longer exists. I added a `meta.maintainers` value to the test since that’s what gets done for NixOS tests as well as other derivations, but I’m not sure if that’s the right thing to do for an `stdenv` test.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `5a8ae559a2f94ac306fd0065b6a4065de05ff03f`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>tests.stdenv.test-inputDerivation</li>
    <li>tests.stdenv.test-inputDerivation-fixed-output</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
