### PR TITLE
tclPackages.*: refactor to modern conventions

### DIFF
--- a/pkgs/development/tcl-modules/by-name/ex/expect/package.nix
+++ b/pkgs/development/tcl-modules/by-name/ex/expect/package.nix
@@ -67,12 +67,12 @@ tcl.mkTclDerivation rec {
     "dev"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Tool for automating interactive applications";
     homepage = "https://expect.sourceforge.net/";
-    license = licenses.publicDomain;
-    platforms = platforms.unix;
+    license = lib.licenses.publicDomain;
+    platforms = lib.platforms.unix;
     mainProgram = "expect";
-    maintainers = with maintainers; [ SuperSandro2000 ];
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
   };
 }

--- a/pkgs/development/tcl-modules/by-name/in/incrtcl/package.nix
+++ b/pkgs/development/tcl-modules/by-name/in/incrtcl/package.nix
@@ -13,13 +13,13 @@ mkTclDerivation rec {
 
   src = fetchurl {
     url = "mirror://sourceforge/incrtcl/%5BIncr%20Tcl_Tk%5D-source/3.4/itcl${version}.tar.gz";
-    sha256 = "sha256-idOs2GXP3ZY7ECtF+K9hg5REyK6sQ0qk+666gUQPjCY=";
+    hash = "sha256-idOs2GXP3ZY7ECtF+K9hg5REyK6sQ0qk+666gUQPjCY=";
   };
 
   enableParallelBuilding = true;
 
   patchPhase = ''
-    substituteInPlace configure --replace "\''${TCL_SRC_DIR}/generic" "${tcl}/include"
+    substituteInPlace configure --replace-fail "\''${TCL_SRC_DIR}/generic" "${tcl}/include"
   '';
 
   postInstall = ''
@@ -40,11 +40,11 @@ mkTclDerivation rec {
     "man"
   ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://incrtcl.sourceforge.net/";
     description = "Object Oriented Enhancements for Tcl/Tk";
-    license = licenses.tcltk;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ thoughtpolice ];
+    license = lib.licenses.tcltk;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ thoughtpolice ];
   };
 }

--- a/pkgs/development/tcl-modules/by-name/it/itktcl/package.nix
+++ b/pkgs/development/tcl-modules/by-name/it/itktcl/package.nix
@@ -13,7 +13,7 @@ mkTclDerivation rec {
 
   src = fetchurl {
     url = "mirror://sourceforge/incrtcl/%5BIncr%20Tcl_Tk%5D-source/3.4/itk${version}.tar.gz";
-    sha256 = "1iy964jfgsfnc1agk1w6bbm44x18ily8d4wmr7cc9z9f4acn2r6s";
+    hash = "sha256-2mRhmSIu/cTYyZWThjyNKHRC6lqGh/lUYNbp5yQxycc=";
   };
 
   buildInputs = [
@@ -42,11 +42,11 @@ mkTclDerivation rec {
     "man"
   ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://incrtcl.sourceforge.net/";
     description = "Mega-widget toolkit for incr Tk";
-    license = licenses.tcltk;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ thoughtpolice ];
+    license = lib.licenses.tcltk;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ thoughtpolice ];
   };
 }

--- a/pkgs/development/tcl-modules/by-name/mu/mustache-tcl/package.nix
+++ b/pkgs/development/tcl-modules/by-name/mu/mustache-tcl/package.nix
@@ -12,8 +12,8 @@ mkTclDerivation rec {
   src = fetchFromGitHub {
     owner = "ianka";
     repo = "mustache.tcl";
-    rev = "v${version}";
-    sha256 = "sha256-apM57LEZ0Y9hXcEPWrKYOoTVtP5QSqiaQrjTHQc3pc4=";
+    tag = "v${version}";
+    hash = "sha256-apM57LEZ0Y9hXcEPWrKYOoTVtP5QSqiaQrjTHQc3pc4=";
   };
 
   buildInputs = [
@@ -26,11 +26,11 @@ mkTclDerivation rec {
     cp $src/pkgIndex.tcl $out/lib/mustache-tcl/pkgIndex.tcl
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/ianka/mustache.tcl";
     description = "Tcl implementation of the mustache templating language";
-    license = licenses.bsd2;
-    platforms = platforms.all;
-    maintainers = with maintainers; [ nat-418 ];
+    license = lib.licenses.bsd2;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ nat-418 ];
   };
 }

--- a/pkgs/development/tcl-modules/by-name/tc/tcl-fcgi/package.nix
+++ b/pkgs/development/tcl-modules/by-name/tc/tcl-fcgi/package.nix
@@ -13,7 +13,7 @@ mkTclDerivation {
     owner = "mpcjanssen";
     repo = "tcl-fcgi";
     rev = "62452dbf3177ba9458fbb42457834ca77bdf5a82";
-    sha256 = "sha256-RLuV4ARmGWCJTmhs7DbMWENQGj3d5ZXWb821WrgG0qA=";
+    hash = "sha256-RLuV4ARmGWCJTmhs7DbMWENQGj3d5ZXWb821WrgG0qA=";
   };
 
   buildInputs = [
@@ -25,11 +25,11 @@ mkTclDerivation {
     cp -r $src/tcl-src/* $out/lib/tcl-fcgi/
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/mpcjanssen/tcl-fcgi";
     description = "Tcl interface for the FastCGI protocol";
-    license = licenses.bsd2;
+    license = lib.licenses.bsd2;
     platforms = tclx.meta.platforms;
-    maintainers = with maintainers; [ nat-418 ];
+    maintainers = with lib.maintainers; [ nat-418 ];
   };
 }

--- a/pkgs/development/tcl-modules/by-name/tc/tclreadline/package.nix
+++ b/pkgs/development/tcl-modules/by-name/tc/tclreadline/package.nix
@@ -17,8 +17,8 @@ mkTclDerivation rec {
   src = fetchFromGitHub {
     owner = "flightaware";
     repo = "tclreadline";
-    rev = "v${version}";
-    sha256 = "sha256-6FIQJsAm28jPIfNG+7xsMlCJSLw9JStOVzDemw2P+EI=";
+    tag = "v${version}";
+    hash = "sha256-6FIQJsAm28jPIfNG+7xsMlCJSLw9JStOVzDemw2P+EI=";
   };
 
   nativeBuildInputs = [
@@ -58,11 +58,11 @@ mkTclDerivation rec {
     done
   '';
 
-  meta = with lib; {
+  meta = {
     description = "GNU readline for interactive tcl shells";
     homepage = "https://github.com/flightaware/tclreadline";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ fgaz ];
-    platforms = platforms.all;
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ fgaz ];
+    platforms = lib.platforms.all;
   };
 }

--- a/pkgs/development/tcl-modules/by-name/ti/tix/package.nix
+++ b/pkgs/development/tcl-modules/by-name/ti/tix/package.nix
@@ -11,13 +11,13 @@ tcl.mkTclDerivation {
   pname = "tix";
   src = fetchurl {
     url = "mirror://sourceforge/tix/tix/8.4.3/Tix8.4.3-src.tar.gz";
-    sha256 = "1jq3dkyk9mqkj4cg7mdk5r0cclqsby9l2b7wrysi0zk5yw7h8bsn";
+    hash = "sha256-Vi8ED/dlfhC1z/wsQZNfGlPGQC6z1fMYkRPXNP1sA8s=";
   };
   patches = [
     (fetchpatch {
       name = "tix-8.4.3-tcl8.5.patch";
       url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/dev-tcltk/tix/files/tix-8.4.3-tcl8.5.patch?id=56bd759df1d0c750a065b8c845e93d5dfa6b549d";
-      sha256 = "0wzqmcxxq0rqpnjgxz10spw92yhfygnlwv0h8pcx2ycnqiljz6vj";
+      hash = "sha256-cpsvacSWedHZRRBsTu3zDnqR+NUg/P6kvTgD3Dur+HM=";
     })
     # Remove duplicated definition of XLowerWindow
     ./duplicated-xlowerwindow.patch
@@ -28,7 +28,7 @@ tcl.mkTclDerivation {
   ++ lib.optional (tcl.release == "8.6") (fetchpatch {
     name = "tix-8.4.3-tcl8.6.patch";
     url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/dev-tcltk/tix/files/tix-8.4.3-tcl8.6.patch?id=56bd759df1d0c750a065b8c845e93d5dfa6b549d";
-    sha256 = "1jaz0l22xj7x1k4rb9ia6i1psnbwk4pblgq4gfvya7gg7fbb7r36";
+    hash = "sha256-ZuSzljvvHeW3ewQ/ui6ZfFl9QzQqppXJDP3ILgQFX8k=";
   });
   buildInputs = [ tk ];
   # the configure script expects to find the location of the sources of
@@ -52,11 +52,11 @@ tcl.mkTclDerivation {
     "--libdir=\${prefix}/lib"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Widget library for Tcl/Tk";
     homepage = "https://tix.sourceforge.net/";
-    platforms = platforms.all;
-    license = with licenses; [
+    platforms = lib.platforms.all;
+    license = with lib.licenses; [
       bsd2 # tix
       gpl2 # patches from portage
     ];

--- a/pkgs/development/tcl-modules/by-name/wa/wapp/package.nix
+++ b/pkgs/development/tcl-modules/by-name/wa/wapp/package.nix
@@ -27,10 +27,10 @@ mkTclDerivation {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://wapp.tcl-lang.org/home/doc/trunk/README.md";
     description = "Framework for writing web applications in Tcl";
-    license = licenses.bsd2;
-    maintainers = with maintainers; [ nat-418 ];
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ nat-418 ];
   };
 }

--- a/pkgs/development/tcl-modules/critcl/default.nix
+++ b/pkgs/development/tcl-modules/critcl/default.nix
@@ -13,7 +13,7 @@ mkTclDerivation rec {
   src = fetchFromGitHub {
     owner = "andreas-kupries";
     repo = "critcl";
-    rev = version;
+    tag = version;
     hash = "sha256-LBTAuwTrvwj42vo/TXVSUK8euxHgvSLai23e1jmhMso=";
   };
 
@@ -37,12 +37,12 @@ mkTclDerivation rec {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Easily embed C code in Tcl";
     homepage = "https://andreas-kupries.github.io/critcl/";
-    license = licenses.tcltk;
+    license = lib.licenses.tcltk;
     mainProgram = "critcl";
-    maintainers = with maintainers; [ fgaz ];
-    platforms = platforms.all;
+    maintainers = with lib.maintainers; [ fgaz ];
+    platforms = lib.platforms.all;
   };
 }


### PR DESCRIPTION
  - Remove 'with lib;' from meta blocks and use qualified lib attributes
  - Replace deprecated 'sha256' with 'hash' for fetchurl and fetchFromGitHub
  - Replace 'rev' with 'tag' when using version tags in fetchFromGitHub
  - Update substituteInPlace to use --replace-fail for better error detection


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
