### PR TITLE
nixos/xdg.portal.wlr: fix screensharing chooser_cmd example

### DIFF
--- a/nixos/modules/config/xdg/portals/wlr.nix
+++ b/nixos/modules/config/xdg/portals/wlr.nix
@@ -47,7 +47,7 @@ in
             exec_before = "disable_notifications.sh";
             exec_after = "enable_notifications.sh";
             chooser_type = "simple";
-            chooser_cmd = "''${pkgs.slurp}/bin/slurp -f %o -or";
+            chooser_cmd = "''${pkgs.slurp}/bin/slurp -f 'Monitor: %o' -or";
           };
         }
       '';


### PR DESCRIPTION
Without this change, screensharing on e.g. `sway` with `xdg-desktop-portal-wlr` 0.8.0 will fail with:

```
xdg-desktop-portal-wlr[13010]: 2025/11/21 12:34:11 [ERROR] - wlroots: chooser /nix/store/yxm4cyg5b4m5l65gsa15ymw4sx1dbfnx-slurp-1.5.0/bin/slurp -f %o -or selected unknown target: HDMI-A-1
xdg-desktop-portal-wlr[13010]: 2025/11/21 12:34:11 [ERROR] - wlroots: no output found
```

Upstream sets this as the default when `chooser_cmd` is unset:
https://github.com/emersion/xdg-desktop-portal-wlr/blob/v0.8.0/src/screencast/chooser.c#L212

See: https://github.com/emersion/xdg-desktop-portal-wlr/issues/350
Related PR which updated `xdg-desktop-portal-wlr`: https://github.com/NixOS/nixpkgs/pull/454287

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
