### PR TITLE
python3Packages.pyiceberg: update dependencies

### DIFF
--- a/pkgs/development/python-modules/pyiceberg/default.nix
+++ b/pkgs/development/python-modules/pyiceberg/default.nix
@@ -13,12 +13,10 @@
   cachetools,
   click,
   fsspec,
-  google-auth,
   mmh3,
   pydantic,
   pyparsing,
   pyroaring,
-  ray,
   requests,
   rich,
   sortedcontainers,
@@ -31,17 +29,20 @@
   google-cloud-bigquery,
   # bodo,
   # daft,
+  datafusion,
   duckdb,
   pyarrow,
-  pyiceberg-core,
   boto3,
-  huggingface-hub,
+  google-auth,
   gcsfs,
+  huggingface-hub,
   thrift,
   kerberos,
   # thrift-sasl,
   pandas,
-  # pyiceberg-core,
+  polars,
+  pyiceberg-core,
+  ray,
   s3fs,
   python-snappy,
   psycopg2-binary,
@@ -50,7 +51,6 @@
   # tests
   azure-core,
   azure-storage-blob,
-  datafusion,
   fastavro,
   moto,
   pyspark,
@@ -100,12 +100,10 @@ buildPythonPackage rec {
     cachetools
     click
     fsspec
-    google-auth
     mmh3
     pydantic
     pyparsing
     pyroaring
-    ray
     requests
     rich
     sortedcontainers
@@ -127,6 +125,9 @@ buildPythonPackage rec {
     daft = [
       # daft
     ];
+    datafusion = [
+      datafusion
+    ];
     duckdb = [
       duckdb
       pyarrow
@@ -134,14 +135,17 @@ buildPythonPackage rec {
     dynamodb = [
       boto3
     ];
-    hf = [
-      huggingface-hub
+    gcp-auth = [
+      google-auth
     ];
     gcsfs = [
       gcsfs
     ];
     glue = [
       boto3
+    ];
+    hf = [
+      huggingface-hub
     ];
     hive = [
       thrift
@@ -155,14 +159,23 @@ buildPythonPackage rec {
       pandas
       pyarrow
     ];
+    polars = [
+      polars
+    ];
     pyarrow = [
       pyarrow
+      pyiceberg-core
+    ];
+    pyiceberg-core = [
       pyiceberg-core
     ];
     ray = [
       pandas
       pyarrow
       ray
+    ];
+    rest-sigv4 = [
+      boto3
     ];
     s3fs = [
       s3fs


### PR DESCRIPTION
Update dependencies to be in line with upstream:
* https://github.com/apache/iceberg-python/blob/pyiceberg-0.10.0/pyproject.toml#L52-L91
* https://github.com/apache/iceberg-python/blob/pyiceberg-0.10.0/pyproject.toml#L308-L332

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin — dependency broken
  - [ ] aarch64-darwin — dependency broken
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
