### PR TITLE
adios2: 2.10.2 -> 2.11.0

### DIFF
--- a/pkgs/by-name/ad/adios2/package.nix
+++ b/pkgs/by-name/ad/adios2/package.nix
@@ -64,6 +64,11 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     chmod +x cmake/install/post/adios2-config.pre.sh.in
     patchShebangs cmake/install/post/{generate-adios2-config,adios2-config.pre}.sh.in
+
+    # use upstream GoogleTest.cmake
+    # see https://github.com/ornladios/ADIOS2/issues/4659
+    substituteInPlace cmake/GoogleTest.cmake \
+      --replace-fail 'CMAKE_VERSION VERSION_LESS 4' 'TRUE'
   '';
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ad/adios2/package.nix
+++ b/pkgs/by-name/ad/adios2/package.nix
@@ -181,10 +181,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelChecking = false;
 
-  enabledTestPaths = [
-    "../testing/adios2/python/Test*.py"
-  ];
-
   __darwinAllowLocalNetworking = finalAttrs.finalPackage.doCheck && mpiSupport;
 
   nativeCheckInputs = [

--- a/pkgs/by-name/ad/adios2/package.nix
+++ b/pkgs/by-name/ad/adios2/package.nix
@@ -64,11 +64,6 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     chmod +x cmake/install/post/adios2-config.pre.sh.in
     patchShebangs cmake/install/post/{generate-adios2-config,adios2-config.pre}.sh.in
-  ''
-  # Dynamic cast to nullptr on darwin platform, switch to unsafe reinterpret cast.
-  + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    substituteInPlace bindings/Python/py11{Attribute,Engine,Variable}.cpp \
-      --replace-fail "dynamic_cast" "reinterpret_cast"
   '';
 
   nativeBuildInputs = [

--- a/pkgs/by-name/do/dolfinx/package.nix
+++ b/pkgs/by-name/do/dolfinx/package.nix
@@ -12,7 +12,6 @@
   kahip,
   adios2,
   python3Packages,
-  darwinMinVersionHook,
   catch2_3,
   withParmetis ? false,
 }:
@@ -26,19 +25,15 @@ let
   );
 in
 stdenv.mkDerivation (finalAttrs: {
-  version = "0.10.0.post3";
+  version = "0.10.0.post4";
   pname = "dolfinx";
 
   src = fetchFromGitHub {
     owner = "fenics";
     repo = "dolfinx";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-YsFya92lz9Twc1PsSLGj6tJNvKb+MQfpmN/qOFxbe34=";
+    hash = "sha256-vzP5vBZpUR4HW6yJw1wFtbo/TiZ/k02TXV2Zk42b5aQ=";
   };
-
-  preConfigure = ''
-    cd cpp
-  '';
 
   nativeBuildInputs = [
     cmake
@@ -49,7 +44,6 @@ stdenv.mkDerivation (finalAttrs: {
     dolfinxPackages.kahip
     dolfinxPackages.scotch
   ]
-  ++ lib.optional stdenv.hostPlatform.isDarwin (darwinMinVersionHook "13.3")
   ++ lib.optional withParmetis dolfinxPackages.parmetis;
 
   propagatedBuildInputs = [
@@ -63,6 +57,8 @@ stdenv.mkDerivation (finalAttrs: {
     python3Packages.fenics-basix
     python3Packages.fenics-ffcx
   ];
+
+  cmakeDir = "../cpp";
 
   cmakeFlags = [
     (lib.cmakeBool "DOLFINX_ENABLE_ADIOS2" true)
@@ -81,9 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
       pname = "${finalAttrs.pname}-unittests";
       inherit (finalAttrs) version src;
 
-      preConfigure = ''
-        cd cpp/test
-      '';
+      cmakeDir = "../cpp/test";
 
       nativeBuildInputs = [
         cmake


### PR DESCRIPTION
some cleanup before upgrading adios2

1. propagate openmp by zfp (moved to https://github.com/NixOS/nixpkgs/pull/464852)
2. remove patch with clang19 (patch for darwin platform was needed with clang19, no longer needed with clang21, pytest looks good on darwin.)
3. force use upstream GoogleTest.cmake that fix test failure with cmake4, see https://github.com/ornladios/ADIOS2/issues/4659

dolfinx upgrade: 0.10.0.post3 -> 0.10.0.post.4

fix build with adios2 v2.11, see changelog https://github.com/FEniCS/dolfinx/releases/tag/v0.10.0.post4.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

adios2.tests.withCheck passed on x86_64-linux, wait for aarch64-darwin

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
