### PR TITLE
fftwMpi: link explicitly against -lmpi

### DIFF
--- a/pkgs/by-name/ff/fftw/package.nix
+++ b/pkgs/by-name/ff/fftw/package.nix
@@ -69,7 +69,15 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional (
     stdenv.hostPlatform.isx86_64 && (precision == "single" || precision == "double")
   ) "--enable-sse2 --enable-avx --enable-avx2 --enable-avx512 --enable-avx128-fma"
-  ++ lib.optional enableMpi "--enable-mpi"
+  ++ lib.optionals enableMpi [
+    "--enable-mpi"
+    # link libfftw3_mpi explicitly with -lmpi
+    # linker on darwin requires all symbols to be resolvable at link time
+    # see
+    #   https://github.com/FFTW/fftw3/issues/274
+    #   https://github.com/spack/spack/pull/29279
+    "MPILIBS=-lmpi"
+  ]
   # doc generation causes Fortran wrapper generation which hard-codes gcc
   ++ lib.optional (!withDoc) "--disable-doc";
 


### PR DESCRIPTION
fix build failue of fftwMpi on darwin platform.

library libfftw3_mpi.dylib need to resolve all its symbol at link time, hence we link it explicitly against -lmpi

see also
 https://github.com/FFTW/fftw3/issues/274
https://github.com/spack/spack/pull/29279

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
