### PR TITLE
[25.05] reposilite: 3.5.24 -> 3.5.26

### DIFF
--- a/pkgs/by-name/re/reposilite/package.nix
+++ b/pkgs/by-name/re/reposilite/package.nix
@@ -18,11 +18,11 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "Reposilite";
-  version = "3.5.25";
+  version = "3.5.26";
 
   src = fetchurl {
     url = "https://maven.reposilite.com/releases/com/reposilite/reposilite/${finalAttrs.version}/reposilite-${finalAttrs.version}-all.jar";
-    hash = "sha256-g1a+9TGRqRK4qcJW2ZACsiew5f27T4qkm/A+c7sVxHI=";
+    hash = "sha256-JSvp4Ka/98AkeExrSA2WCNoqMQAmpCllIRNyHzhkzqM=";
   };
 
   dontUnpack = true;

--- a/pkgs/by-name/re/reposilite/package.nix
+++ b/pkgs/by-name/re/reposilite/package.nix
@@ -18,11 +18,11 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "Reposilite";
-  version = "3.5.24";
+  version = "3.5.25";
 
   src = fetchurl {
     url = "https://maven.reposilite.com/releases/com/reposilite/reposilite/${finalAttrs.version}/reposilite-${finalAttrs.version}-all.jar";
-    hash = "sha256-HyA59f4Og3bGTe5hEShkAt0jl9rLUBzGAGxUKgJV9Y0=";
+    hash = "sha256-g1a+9TGRqRK4qcJW2ZACsiew5f27T4qkm/A+c7sVxHI=";
   };
 
   dontUnpack = true;

--- a/pkgs/by-name/re/reposilite/plugins.json
+++ b/pkgs/by-name/re/reposilite/plugins.json
@@ -1,7 +1,7 @@
 {
-  "checksum": "sha256-XaFqu3ln73XLDSbHO7PUalwOLdtBfQ1pOGttcbM50To=",
-  "groovy": "sha256-sDHaaWdcx8kAnjoalizxVkMALljlrzvBLf0EjtZWsB0=",
-  "migration": "sha256-TAnaun2V8dVZeMWAWsThZcBD+DDgGj+7qMt4LTDkYpE=",
-  "prometheus": "sha256-yVs53YX8vIxjhojVYGK1xstw/8wZNE7C9DG01rdFpSc=",
-  "swagger": "sha256-gSiJeS0NLvVWlKg/CNkwpBD3fNZUWyBwrD53NWuY1Ug="
+  "checksum": "sha256-NAB69EvfAP/2EegqR9ni5bdk5MtYd/Rzn40nUqfivfY=",
+  "groovy": "sha256-WjQy9nUz3LWv/AaTyZFfD/55ukt/FaXrGF3h7tc8KJg=",
+  "migration": "sha256-djEeQIwfNxgaMmPAmQQT+KC1qwP58sjEbQI6nqqTKNo=",
+  "prometheus": "sha256-avwHOdv0kj9TrK9fxhGTNzyFTn0Rjr70PTNDeyUz4cw=",
+  "swagger": "sha256-8Zit1SWYVJv+hn+VR38QBTSMuyucnaNfZePNPN6LhI8="
 }

--- a/pkgs/by-name/re/reposilite/plugins.json
+++ b/pkgs/by-name/re/reposilite/plugins.json
@@ -1,7 +1,7 @@
 {
-  "checksum": "sha256-NAB69EvfAP/2EegqR9ni5bdk5MtYd/Rzn40nUqfivfY=",
-  "groovy": "sha256-WjQy9nUz3LWv/AaTyZFfD/55ukt/FaXrGF3h7tc8KJg=",
-  "migration": "sha256-djEeQIwfNxgaMmPAmQQT+KC1qwP58sjEbQI6nqqTKNo=",
-  "prometheus": "sha256-avwHOdv0kj9TrK9fxhGTNzyFTn0Rjr70PTNDeyUz4cw=",
-  "swagger": "sha256-8Zit1SWYVJv+hn+VR38QBTSMuyucnaNfZePNPN6LhI8="
+  "checksum": "sha256-MSQMx4bD59cTnKb6u5tV2twFkOwSNPs5i5boknuXzbU=",
+  "groovy": "sha256-3/YRKsAsPhghxacLGQp/GvNJ6RHqGhmVwx3iPn5epgw=",
+  "migration": "sha256-HxWKemXxeuhNgfFtj8ztKu8hZVhN8suI2KnS94Qg8G0=",
+  "prometheus": "sha256-Y+d+HudqEgLR5a5u9kq66w6Y0sYhjBDIYBsBUAYl06w=",
+  "swagger": "sha256-a3yoOWxIhXb/pHlstPTBE1DnLBjchKxbIU1G/5kB6Mc="
 }


### PR DESCRIPTION
Backport of #422815 and #445048

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
