### PR TITLE
php84: enable reproducible phars

### DIFF
--- a/pkgs/development/interpreters/php/file-order-phar-pack.patch
+++ b/pkgs/development/interpreters/php/file-order-phar-pack.patch
@@ -1,0 +1,12 @@
+diff --git a/ext/phar/Makefile.frag b/ext/phar/Makefile.frag
+--- a/ext/phar/Makefile.frag
++++ b/ext/phar/Makefile.frag
+@@ -45,7 +45,7 @@
+ 	if [ "$(TEST_PHP_EXECUTABLE_RES)" != 1 ]; then \
+ 		rm -f $(builddir)/phar.phar; \
+ 		rm -f $(srcdir)/phar.phar; \
+-		$(PHP_PHARCMD_EXECUTABLE) $(PHP_PHARCMD_SETTINGS) $(builddir)/phar.php pack -f $(builddir)/phar.phar -a pharcommand -c auto -p 0 -s $(srcdir)/phar/phar.php -h sha1 -b "$(PHP_PHARCMD_BANG)"  $(srcdir)/phar/; \
++		$(PHP_PHARCMD_EXECUTABLE) $(PHP_PHARCMD_SETTINGS) $(builddir)/phar.php pack -f $(builddir)/phar.phar -a pharcommand -c auto -p 0 -s $(srcdir)/phar/phar.php -h sha1 -b "$(PHP_PHARCMD_BANG)" -l 5 `ls -A $(srcdir)/phar/*`; \
+ 		chmod +x $(builddir)/phar.phar; \
+ 	else \
+ 		echo "Skipping phar.phar generating during cross compilation"; \

--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -10,6 +10,7 @@ let
       nixosTests,
       tests,
       fetchurl,
+      fetchpatch,
       makeBinaryWrapper,
       symlinkJoin,
       writeText,
@@ -356,6 +357,12 @@ let
             ]
             ++ lib.optionals (lib.versionAtLeast version "8.4") [
               ./fix-paths-php84.patch
+              # Make sure that Phar files are reproducible by removing timestamps (1/2)
+              # Patch source: https://codeberg.org/stagex/stagex/src/branch/staging/packages/core/php-zts
+              ./remove-timestamps-from-phar.patch
+              # Make sure that Phar files are reproducible by having deterministic sorting order (2/2)
+              # Patch source: https://codeberg.org/stagex/stagex/src/branch/staging/packages/core/php-zts
+              ./file-order-phar-pack.patch
             ]
             ++ extraPatches;
 

--- a/pkgs/development/interpreters/php/remove-timestamps-from-phar.patch
+++ b/pkgs/development/interpreters/php/remove-timestamps-from-phar.patch
@@ -1,0 +1,82 @@
+diff --git a/ext/phar/tar.c b/ext/phar/tar.c
+--- a/ext/phar/tar.c
++++ b/ext/phar/tar.c
+@@ -972,7 +972,7 @@
+ 	char *buf, *signature, sigbuf[8];
+
+ 	entry.flags = PHAR_ENT_PERM_DEF_FILE;
+-	entry.timestamp = time(NULL);
++	entry.timestamp = source_date_epoch_time(NULL);
+ 	entry.is_modified = 1;
+ 	entry.is_crc_checked = 1;
+ 	entry.is_tar = 1;
+diff --git a/ext/phar/zip.c b/ext/phar/zip.c
+--- a/ext/phar/zip.c
++++ b/ext/phar/zip.c
+@@ -158,7 +158,7 @@
+ 	struct tm *tm, tmbuf;
+ 	time_t now;
+
+-	now = time(NULL);
++	now = source_date_epoch_time(NULL);
+ 	tm = php_localtime_r(&now, &tmbuf);
+
+ 	tm->tm_year = ((ddate>>9)&127) + 1980 - 1900;
+@@ -1271,7 +1271,7 @@
+
+ 	pass.error = &temperr;
+ 	entry.flags = PHAR_ENT_PERM_DEF_FILE;
+-	entry.timestamp = time(NULL);
++	entry.timestamp = source_date_epoch_time(NULL);
+ 	entry.is_modified = 1;
+ 	entry.is_zip = true;
+ 	entry.phar = phar;
+diff --git a/ext/phar/phar.c b/ext/phar/phar.c
+--- a/ext/phar/phar.c
++++ b/ext/phar/phar.c
+@@ -2965,7 +2965,7 @@
+ 			4: metadata-len
+ 			+: metadata
+ 		*/
+-		mytime = time(NULL);
++		mytime = source_date_epoch_time(NULL);
+ 		phar_set_32(entry_buffer, entry->uncompressed_filesize);
+ 		phar_set_32(entry_buffer+4, mytime);
+ 		phar_set_32(entry_buffer+8, entry->compressed_filesize);
+diff --git a/ext/phar/stream.c b/ext/phar/stream.c
+--- a/ext/phar/stream.c
++++ b/ext/phar/stream.c
+@@ -474,7 +474,7 @@
+ 	phar_entry_data *data = (phar_entry_data *) stream->abstract;
+
+ 	if (data->internal_file->is_modified) {
+-		data->internal_file->timestamp = time(0);
++		data->internal_file->timestamp = source_date_epoch_time(0);
+ 		phar_flush(data->phar, &error);
+ 		if (error) {
+ 			php_stream_wrapper_log_error(stream->wrapper, REPORT_ERRORS, "%s", error);
+diff --git a/ext/phar/phar_internal.h b/ext/phar/phar_internal.h
+--- a/ext/phar/phar_internal.h
++++ b/ext/phar/phar_internal.h
+@@ -323,6 +323,21 @@
+ 	return PHAR_G(cached_fp)[entry->phar->phar_pos].manifest[entry->manifest_pos].fp_type;
+ }
+
++static inline time_t source_date_epoch_time(time_t *tloc)
++{
++	const char *sde;
++	time_t ts;
++
++	tsrm_env_lock();
++	sde = getenv("SOURCE_DATE_EPOCH");
++	ts = (sde) ? strtoul(sde, NULL, 10) : time(0);
++	tsrm_env_unlock();
++	if (tloc) {
++		*tloc = ts;
++	}
++	return ts;
++}
++
+ #define PHAR_MIME_PHP '\0'
+ #define PHAR_MIME_PHPS '\1'
+ #define PHAR_MIME_OTHER '\2'

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -30,7 +30,6 @@
   nix-update-script,
   oniguruma,
   openldap,
-  openssl_1_1,
   openssl,
   pam,
   pcre2,

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -587,10 +587,10 @@ lib.makeScope pkgs.newScope (
               buildInputs = [
                 pcre2
               ]
-              ++ lib.optional (
+              ++ lib.optionals (
                 !stdenv.hostPlatform.isDarwin && lib.meta.availableOn stdenv.hostPlatform valgrind
-              ) valgrind.dev;
-              configureFlags = lib.optional php.ztsSupport "--disable-opcache-jit";
+              ) [ valgrind.dev ];
+              configureFlags = lib.optionals php.ztsSupport [ "--disable-opcache-jit" ];
               zendExtension = true;
               postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
                 # Tests are flaky on darwin


### PR DESCRIPTION
I recently discovered the project https://stagex.tools and out of curiosity I checked how the PHP package (https://codeberg.org/stagex/stagex/src/branch/staging/packages/core/php-zts) was built (credits to @zeroware). This is how I discovered those two interesting patches that could easily be upstreamed in the PHP distribution (perhaps @ndossche). 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
