### PR TITLE
unzip: inline patch files from dead sources

### DIFF
--- a/pkgs/by-name/un/unzip/06-initialize-the-symlink-flag.patch
+++ b/pkgs/by-name/un/unzip/06-initialize-the-symlink-flag.patch
@@ -1,0 +1,20 @@
+From: Andreas Schwab <schwab@linux-m68k.org>
+Subject: Initialize the symlink flag
+Bug-Debian: https://bugs.debian.org/717029
+X-Debian-version: 6.0-10
+
+--- a/process.c
++++ b/process.c
+@@ -1758,6 +1758,12 @@
+         = (G.crec.general_purpose_bit_flag & (1 << 11)) == (1 << 11);
+ #endif
+ 
++#ifdef SYMLINKS
++    /* Initialize the symlink flag, may be set by the platform-specific
++       mapattr function.  */
++    G.pInfo->symlink = 0;
++#endif
++
+     return PK_COOL;
+ 
+ } /* end function process_cdir_file_hdr() */

--- a/pkgs/by-name/un/unzip/28-cve-2022-0529-and-cve-2022-0530.patch
+++ b/pkgs/by-name/un/unzip/28-cve-2022-0529-and-cve-2022-0530.patch
@@ -1,0 +1,173 @@
+From: Steven M. Schweda <sms@antinode.info>
+Subject: Fix for CVE-2022-0529 and CVE-2022-0530
+Bug-Debian: https://bugs.debian.org/1010355
+X-Debian-version: 6.0-27
+
+--- a/fileio.c
++++ b/fileio.c
+@@ -171,8 +171,10 @@
+ static ZCONST char Far FilenameTooLongTrunc[] =
+   "warning:  filename too long--truncating.\n";
+ #ifdef UNICODE_SUPPORT
++   static ZCONST char Far UFilenameCorrupt[] =
++     "error: Unicode filename corrupt.\n";
+    static ZCONST char Far UFilenameTooLongTrunc[] =
+-     "warning:  Converted unicode filename too long--truncating.\n";
++     "warning:  Converted Unicode filename too long--truncating.\n";
+ #endif
+ static ZCONST char Far ExtraFieldTooLong[] =
+   "warning:  extra field too long (%d).  Ignoring...\n";
+@@ -2361,16 +2363,30 @@
+                   /* convert UTF-8 to local character set */
+                   fn = utf8_to_local_string(G.unipath_filename,
+                                             G.unicode_escape_all);
+-                  /* make sure filename is short enough */
+-                  if (strlen(fn) >= FILNAMSIZ) {
+-                    fn[FILNAMSIZ - 1] = '\0';
++
++                  /* 2022-07-22 SMS, et al.  CVE-2022-0530
++                   * Detect conversion failure, emit message.
++                   * Continue with unconverted name.
++                   */
++                  if (fn == NULL)
++                  {
+                     Info(slide, 0x401, ((char *)slide,
+-                      LoadFarString(UFilenameTooLongTrunc)));
+-                    error = PK_WARN;
++                     LoadFarString(UFilenameCorrupt)));
++                    error = PK_ERR;
++                  }
++                  else
++                  {
++                    /* make sure filename is short enough */
++                    if (strlen(fn) >= FILNAMSIZ) {
++                      fn[FILNAMSIZ - 1] = '\0';
++                      Info(slide, 0x401, ((char *)slide,
++                        LoadFarString(UFilenameTooLongTrunc)));
++                      error = PK_WARN;
++                    }
++                    /* replace filename with converted UTF-8 */
++                    strcpy(G.filename, fn);
++                    free(fn);
+                   }
+-                  /* replace filename with converted UTF-8 */
+-                  strcpy(G.filename, fn);
+-                  free(fn);
+                 }
+ # endif /* UNICODE_WCHAR */
+                 if (G.unipath_filename != G.filename_full)
+--- a/process.c
++++ b/process.c
+@@ -222,6 +222,8 @@
+      "\nwarning:  Unicode Path version > 1\n";
+    static ZCONST char Far UnicodeMismatchError[] =
+      "\nwarning:  Unicode Path checksum invalid\n";
++   static ZCONST char Far UFilenameTooLongTrunc[] =
++     "warning:  filename too long (P1) -- truncating.\n";
+ #endif
+ 
+ 
+@@ -1915,7 +1917,7 @@
+     Sets both local header and central header fields.  Not terribly clever,
+     but it means that this procedure is only called in one place.
+ 
+-    2014-12-05 SMS.
++    2014-12-05 SMS.  (oCERT.org report.)  CVE-2014-8141.
+     Added checks to ensure that enough data are available before calling
+     makeint64() or makelong().  Replaced various sizeof() values with
+     simple ("4" or "8") constants.  (The Zip64 structures do not depend
+@@ -1947,9 +1949,10 @@
+               ef_len - EB_HEADSIZE));
+             break;
+         }
++
+         if (eb_id == EF_PKSZ64)
+         {
+-          int offset = EB_HEADSIZE;
++          unsigned offset = EB_HEADSIZE;
+ 
+           if ((G.crec.ucsize == Z64FLGL) || (G.lrec.ucsize == Z64FLGL))
+           {
+@@ -2046,7 +2049,7 @@
+         }
+         if (eb_id == EF_UNIPATH) {
+ 
+-          int offset = EB_HEADSIZE;
++          unsigned offset = EB_HEADSIZE;
+           ush ULen = eb_len - 5;
+           ulg chksum = CRCVAL_INITIAL;
+ 
+@@ -2504,16 +2507,17 @@
+   int state_dependent;
+   int wsize = 0;
+   int max_bytes = MB_CUR_MAX;
+-  char buf[9];
++  char buf[ MB_CUR_MAX+ 1];             /* ("+1" not really needed?) */
+   char *buffer = NULL;
+   char *local_string = NULL;
++  size_t buffer_size;                   /* CVE-2022-0529 */
+ 
+   for (wsize = 0; wide_string[wsize]; wsize++) ;
+ 
+   if (max_bytes < MAX_ESCAPE_BYTES)
+     max_bytes = MAX_ESCAPE_BYTES;
+-
+-  if ((buffer = (char *)malloc(wsize * max_bytes + 1)) == NULL) {
++  buffer_size = wsize * max_bytes + 1;          /* Reused below. */
++  if ((buffer = (char *)malloc( buffer_size)) == NULL) {
+     return NULL;
+   }
+ 
+@@ -2551,8 +2555,28 @@
+     } else {
+       /* no MB for this wide */
+         /* use escape for wide character */
+-        char *escape_string = wide_to_escape_string(wide_string[i]);
+-        strcat(buffer, escape_string);
++        size_t buffer_len;
++        size_t escape_string_len;
++        char *escape_string;
++        int err_msg = 0;
++
++        escape_string = wide_to_escape_string(wide_string[i]);
++        buffer_len = strlen( buffer);
++        escape_string_len = strlen( escape_string);
++
++        /* Append escape string, as space allows. */
++        /* 2022-07-18 SMS, et al.  CVE-2022-0529 */
++        if (escape_string_len > buffer_size- buffer_len- 1)
++        {
++            escape_string_len = buffer_size- buffer_len- 1;
++            if (err_msg == 0)
++            {
++                err_msg = 1;
++                Info(slide, 0x401, ((char *)slide,
++                 LoadFarString( UFilenameTooLongTrunc)));
++            }
++        }
++        strncat( buffer, escape_string, escape_string_len);
+         free(escape_string);
+     }
+   }
+@@ -2604,9 +2628,18 @@
+   ZCONST char *utf8_string;
+   int escape_all;
+ {
+-  zwchar *wide = utf8_to_wide_string(utf8_string);
+-  char *loc = wide_to_local_string(wide, escape_all);
+-  free(wide);
++  zwchar *wide;
++  char *loc = NULL;
++
++  wide = utf8_to_wide_string( utf8_string);
++
++  /* 2022-07-25 SMS, et al.  CVE-2022-0530 */
++  if (wide != NULL)
++  {
++    loc = wide_to_local_string( wide, escape_all);
++    free( wide);
++  }
++
+   return loc;
+ }
+ 

--- a/pkgs/by-name/un/unzip/package.nix
+++ b/pkgs/by-name/un/unzip/package.nix
@@ -52,24 +52,8 @@ stdenv.mkDerivation rec {
       name = "CVE-2019-13232-3.patch";
       sha256 = "1jvs7dkdqs97qnsqc6hk088alhv8j4c638k65dbib9chh40jd7pf";
     })
-    (fetchurl {
-      urls = [
-        # original link (will be dead eventually):
-        "https://sources.debian.org/data/main/u/unzip/6.0-26%2Bdeb11u1/debian/patches/06-initialize-the-symlink-flag.patch"
-
-        "https://gist.github.com/veprbl/41261bb781571e2246ea42d3f37795f5/raw/d8533d8c6223150f76b0f31aec03e185fcde3579/06-initialize-the-symlink-flag.patch"
-      ];
-      sha256 = "1h00djdvgjhwfb60wl4qrxbyfsbbnn1qw6l2hkldnif4m8f8r1zj";
-    })
-    (fetchurl {
-      urls = [
-        # original link (will be dead eventually):
-        "https://sources.debian.org/data/main/u/unzip/6.0-27/debian/patches/28-cve-2022-0529-and-cve-2022-0530.patch"
-
-        "https://web.archive.org/web/20230106200319/https://sources.debian.org/data/main/u/unzip/6.0-27/debian/patches/28-cve-2022-0529-and-cve-2022-0530.patch"
-      ];
-      sha256 = "sha256-on79jElQ+z2ULWAq14RpluAqr9d6itHiZwDkKubBzTc=";
-    })
+    ./06-initialize-the-symlink-flag.patch
+    ./28-cve-2022-0529-and-cve-2022-0530.patch
     # Clang 16 makes implicit declarations an error by default for C99 and newer, causing the
     # configure script to fail to detect errno and the directory libraries on Darwin.
     ./implicit-declarations-fix.patch


### PR DESCRIPTION
Of all the patches listed in unzip, these two stand out as depending on dubious or unreliable sources. Concretely, the Internet Archive was down yesterday (Nov 20, 2025) and caused build failures for the unzip package. I also can't imagine that the IA folks want to be a hard dependency for this.

There is prior art for inlining unzip patches into the repository and these two are quite small.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
