### PR TITLE
 python3Packages.sphinxcontrib-mermaid: init at 1.0.0, python3Packages.apeye: init at 1.4.1, python3Packages.autodocsumm: init at 0.2.14, python3Packages.dict2css: init at 0.3.0.post1, python3Packages.sphinx-jinja2-compat: init at 0.4.1, python3Packages.sphinx-toolbox: init at 4.0.0

### DIFF
--- a/pkgs/development/python-modules/apeye/default.nix
+++ b/pkgs/development/python-modules/apeye/default.nix
@@ -1,0 +1,39 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  flit-core,
+  apeye-core,
+  domdf-python-tools,
+  platformdirs,
+  requests,
+  lib,
+}:
+buildPythonPackage rec {
+  pname = "apeye";
+  version = "1.4.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit version;
+    pname = "apeye";
+    hash = "sha256-FOpUL61onjv9vaIYmjVKSQjpCu5L+EwVq3XWhFPXajY=";
+  };
+
+  build-system = [ flit-core ];
+
+  dependencies = [
+    apeye-core
+    domdf-python-tools
+    platformdirs
+    requests
+  ];
+
+  pythonImportsCheck = [ "apeye" ];
+
+  meta = {
+    description = "Handy tools for working with URLs and APIs";
+    homepage = "https://github.com/domdfcoding/apeye";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/development/python-modules/autodocsumm/default.nix
+++ b/pkgs/development/python-modules/autodocsumm/default.nix
@@ -1,0 +1,35 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  versioneer,
+  sphinx,
+  lib,
+}:
+buildPythonPackage rec {
+  pname = "autodocsumm";
+  version = "0.2.14";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit version;
+    pname = "autodocsumm";
+    hash = "sha256-KDmp1PrMPE7M0wbAhpVUCREEK0bur83DID5tC6tAvHc=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    versioneer
+    sphinx
+  ];
+
+  pythonImportsCheck = [ "autodocsumm" ];
+
+  meta = {
+    description = "Extended sphinx autodoc including automatic autosummaries";
+    homepage = "https://github.com/Chilipp/autodocsumm";
+    license = lib.licenses.asl20;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/development/python-modules/dict2css/default.nix
+++ b/pkgs/development/python-modules/dict2css/default.nix
@@ -1,0 +1,31 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  whey,
+  cssutils,
+  lib,
+}:
+buildPythonPackage rec {
+  pname = "dict2css";
+  version = "0.3.0.post1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit version;
+    pname = "dict2css";
+    hash = "sha256-icVEwhxMp0csP/+50309km9gYymv23Udwd5npBG3Bxk=";
+  };
+
+  build-system = [ whey ];
+
+  dependencies = [ cssutils ];
+
+  pythonImportsCheck = [ "dict2css" ];
+
+  meta = {
+    description = "μ-library for constructing cascading style sheets from Python dictionaries";
+    homepage = "https://github.com/sphinx-toolbox/dict2css";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/development/python-modules/sphinx-jinja2-compat/default.nix
+++ b/pkgs/development/python-modules/sphinx-jinja2-compat/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     hash = "sha256-AYjwgC1Cw9pymXUztVoAgVZZp40/gdS0dHsfsVpXKOY=";
   };
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace \
       requirements.txt PKG-INFO pyproject.toml \
       --replace-fail "standard-imghdr==3.10.14" "standard-imghdr"

--- a/pkgs/development/python-modules/sphinx-jinja2-compat/default.nix
+++ b/pkgs/development/python-modules/sphinx-jinja2-compat/default.nix
@@ -1,0 +1,47 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  whey,
+  whey-pth,
+  jinja2,
+  markupsafe,
+  standard-imghdr,
+  lib,
+}:
+buildPythonPackage rec {
+  pname = "sphinx-jinja2-compat";
+  version = "0.4.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit version;
+    pname = "sphinx_jinja2_compat";
+    hash = "sha256-AYjwgC1Cw9pymXUztVoAgVZZp40/gdS0dHsfsVpXKOY=";
+  };
+
+  patchPhase = ''
+    substituteInPlace \
+      requirements.txt PKG-INFO pyproject.toml \
+      --replace-fail "standard-imghdr==3.10.14" "standard-imghdr"
+  '';
+
+  build-system = [
+    whey
+    whey-pth
+  ];
+
+  dependencies = [
+    jinja2
+    markupsafe
+    standard-imghdr
+  ];
+
+  pythonImportsCheck = [ "sphinx_jinja2_compat" ];
+
+  meta = {
+    description = "Patches Jinja2 v3 to restore compatibility with earlier Sphinx versions";
+    homepage = "https://github.com/sphinx-toolbox/sphinx-jinja2-compat";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/development/python-modules/sphinx-toolbox/default.nix
+++ b/pkgs/development/python-modules/sphinx-toolbox/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
     hash = "sha256-SMMUUdsuLYxxwDk55yoZ73vJLKeFCmLbY/x7uDlbZ4U=";
   };
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace \
       requirements.txt PKG-INFO pyproject.toml \
       --replace-fail "sphinx-tabs<3.4.7,>=1.2.1" "sphinx-tabs<=3.4.7,>=1.2.1"

--- a/pkgs/development/python-modules/sphinx-toolbox/default.nix
+++ b/pkgs/development/python-modules/sphinx-toolbox/default.nix
@@ -1,0 +1,69 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  lib,
+  whey,
+  sphinx,
+  apeye,
+  autodocsumm,
+  beautifulsoup4,
+  cachecontrol,
+  dict2css,
+  filelock,
+  html5lib,
+  ruamel-yaml,
+  sphinx-autodoc-typehints,
+  sphinx-jinja2-compat,
+  sphinx-prompt,
+  sphinx-tabs,
+  tabulate,
+  python,
+}:
+buildPythonPackage rec {
+  pname = "sphinx-toolbox";
+  version = "4.0.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit version;
+    pname = "sphinx_toolbox";
+    hash = "sha256-SMMUUdsuLYxxwDk55yoZ73vJLKeFCmLbY/x7uDlbZ4U=";
+  };
+
+  patchPhase = ''
+    substituteInPlace \
+      requirements.txt PKG-INFO pyproject.toml \
+      --replace-fail "sphinx-tabs<3.4.7,>=1.2.1" "sphinx-tabs<=3.4.7,>=1.2.1"
+  '';
+
+  build-system = [ whey ];
+
+  dependencies = [
+    sphinx
+    apeye
+    autodocsumm
+    beautifulsoup4
+    cachecontrol
+    dict2css
+    filelock
+    html5lib
+    ruamel-yaml
+    sphinx-autodoc-typehints
+    sphinx-jinja2-compat
+    sphinx-prompt
+    sphinx-tabs
+    tabulate
+  ];
+
+  # Not PEP420 compliant, some variables are imported from within the package.
+  postFixup = ''
+    echo '__version__: str = "${version}"' > $out/${python.sitePackages}/sphinx_toolbox/__init__.py
+  '';
+
+  meta = {
+    description = "Box of handy tools for Sphinx";
+    homepage = "https://github.com/sphinx-toolbox/sphinx-toolbox";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/development/python-modules/sphinxcontrib-mermaid/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-mermaid/default.nix
@@ -1,0 +1,37 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  sphinx,
+  pyyaml,
+  rst2pdf,
+  lib,
+}:
+buildPythonPackage rec {
+  pname = "sphinxcontrib-mermaid";
+  version = "1.0.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit version;
+    pname = "sphinxcontrib_mermaid";
+    hash = "sha256-Loq2fT4eKBZmP5NH0Cao3uSoWKzdStMt0cgIiT24gUY=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    sphinx
+    pyyaml
+    rst2pdf
+  ];
+
+  pythonImportsCheck = [ "sphinxcontrib.mermaid" ];
+
+  meta = {
+    description = "Mermaid diagrams in yours sphinx powered docs";
+    homepage = "https://github.com/mgaitan/sphinxcontrib-mermaid";
+    license = lib.licenses.bsd2;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17627,6 +17627,8 @@ self: super: with self; {
 
   sphinxcontrib-log-cabinet = callPackage ../development/python-modules/sphinxcontrib-log-cabinet { };
 
+  sphinxcontrib-mermaid = callPackage ../development/python-modules/sphinxcontrib-mermaid { };
+
   sphinxcontrib-moderncmakedomain =
     callPackage ../development/python-modules/sphinxcontrib-moderncmakedomain
       { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17587,6 +17587,8 @@ self: super: with self; {
 
   sphinx-togglebutton = callPackage ../development/python-modules/sphinx-togglebutton { };
 
+  sphinx-toolbox = callPackage ../development/python-modules/sphinx-toolbox { };
+
   sphinx-version-warning = callPackage ../development/python-modules/sphinx-version-warning { };
 
   sphinx-versions = callPackage ../development/python-modules/sphinx-versions { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1180,6 +1180,8 @@ self: super: with self; {
 
   autocommand = callPackage ../development/python-modules/autocommand { };
 
+  autodocsumm = callPackage ../development/python-modules/autodocsumm { };
+
   autofaiss = callPackage ../development/python-modules/autofaiss { };
 
   autoflake = callPackage ../development/python-modules/autoflake { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -778,6 +778,8 @@ self: super: with self; {
 
   apcaccess = callPackage ../development/python-modules/apcaccess { };
 
+  apeye = callPackage ../development/python-modules/apeye { };
+
   apeye-core = callPackage ../development/python-modules/apeye-core { };
 
   apipkg = callPackage ../development/python-modules/apipkg { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17535,6 +17535,8 @@ self: super: with self; {
 
   sphinx-jinja = callPackage ../development/python-modules/sphinx-jinja { };
 
+  sphinx-jinja2-compat = callPackage ../development/python-modules/sphinx-jinja2-compat { };
+
   sphinx-jupyterbook-latex = callPackage ../development/python-modules/sphinx-jupyterbook-latex { };
 
   sphinx-last-updated-by-git =

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3745,6 +3745,8 @@ self: super: with self; {
 
   dicomweb-client = callPackage ../development/python-modules/dicomweb-client { };
 
+  dict2css = callPackage ../development/python-modules/dict2css { };
+
   dict2xml = callPackage ../development/python-modules/dict2xml { };
 
   dictdiffer = callPackage ../development/python-modules/dictdiffer { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Various python packages needed to build the Nextcloud documentation. This has been extracted from https://github.com/NixOS/nixpkgs/pull/442910 to make it smaller.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
