### PR TITLE
python3Packages.georss-client: 0.18 -> 0.19

### DIFF
--- a/pkgs/development/python-modules/georss-client/default.nix
+++ b/pkgs/development/python-modules/georss-client/default.nix
@@ -7,32 +7,31 @@
   setuptools,
 
   # dependencies
-  dateparser,
   haversine,
+  python-dateutil,
   requests,
   xmltodict,
 
-  # tests
+  # testing
   pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "georss-client";
-  version = "0.18";
+  version = "0.19";
   pyproject = true;
-
   src = fetchFromGitHub {
     owner = "exxamalte";
     repo = "python-georss-client";
     tag = "v${version}";
-    hash = "sha256-KtndXsNvmjSGwqfKqkGAimHbapIC3I0yi4JuDh6cMzs=";
+    hash = "sha256-+CmauNb+5mDbZXQCd8ZxZCz6FSfEPAnktkMjvQueiO0=";
   };
 
   build-system = [ setuptools ];
 
   dependencies = [
-    dateparser
     haversine
+    python-dateutil
     requests
     xmltodict
   ];
@@ -42,7 +41,6 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "georss_client" ];
 
   meta = {
-    broken = lib.versionAtLeast xmltodict.version "1";
     description = "Python library for accessing GeoRSS feeds";
     homepage = "https://github.com/exxamalte/python-georss-client";
     changelog = "https://github.com/exxamalte/python-georss-client/releases/tag/${src.tag}";

--- a/pkgs/development/python-modules/georss-client/default.nix
+++ b/pkgs/development/python-modules/georss-client/default.nix
@@ -1,22 +1,25 @@
 {
   lib,
   buildPythonPackage,
-  dateparser,
   fetchFromGitHub,
-  haversine,
-  pytestCheckHook,
-  pythonOlder,
-  requests,
+
+  # build-system
   setuptools,
+
+  # dependencies
+  dateparser,
+  haversine,
+  requests,
   xmltodict,
+
+  # tests
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "georss-client";
   version = "0.18";
   pyproject = true;
-
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "exxamalte";
@@ -25,25 +28,25 @@ buildPythonPackage rec {
     hash = "sha256-KtndXsNvmjSGwqfKqkGAimHbapIC3I0yi4JuDh6cMzs=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [
-    haversine
-    xmltodict
-    requests
+  dependencies = [
     dateparser
+    haversine
+    requests
+    xmltodict
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "georss_client" ];
 
-  meta = with lib; {
+  meta = {
     broken = lib.versionAtLeast xmltodict.version "1";
     description = "Python library for accessing GeoRSS feeds";
     homepage = "https://github.com/exxamalte/python-georss-client";
     changelog = "https://github.com/exxamalte/python-georss-client/releases/tag/${src.tag}";
-    license = with licenses; [ asl20 ];
-    maintainers = with maintainers; [ fab ];
+    license = with lib.licenses; [ asl20 ];
+    maintainers = with lib.maintainers; [ fab ];
   };
 }

--- a/pkgs/development/python-modules/georss-ign-sismologia-client/default.nix
+++ b/pkgs/development/python-modules/georss-ign-sismologia-client/default.nix
@@ -5,7 +5,6 @@
   fetchFromGitHub,
   georss-client,
   pytestCheckHook,
-  pythonOlder,
   setuptools,
 }:
 
@@ -14,8 +13,6 @@ buildPythonPackage rec {
   version = "0.8";
   pyproject = true;
 
-  disabled = pythonOlder "3.8";
-
   src = fetchFromGitHub {
     owner = "exxamalte";
     repo = "python-georss-ign-sismologia-client";
@@ -23,9 +20,9 @@ buildPythonPackage rec {
     hash = "sha256-geIxF4GumxRoetJ6mIZCzI3pAvWjJJoY66aQYd2Mzik=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     dateparser
     georss-client
   ];
@@ -34,11 +31,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "georss_ign_sismologia_client" ];
 
-  meta = with lib; {
+  meta = {
     description = "Python library for accessing the IGN Sismologia GeoRSS feed";
     homepage = "https://github.com/exxamalte/python-georss-ign-sismologia-client";
-    changelog = "https://github.com/exxamalte/python-georss-ign-sismologia-client/blob/v0.6/CHANGELOG.md";
-    license = with licenses; [ asl20 ];
-    maintainers = with maintainers; [ fab ];
+    changelog = "https://github.com/exxamalte/python-georss-ign-sismologia-client/blob/${src.tag}/CHANGELOG.md";
+    license = with lib.licenses; [ asl20 ];
+    maintainers = with lib.maintainers; [ fab ];
   };
 }

--- a/pkgs/development/python-modules/georss-ingv-centro-nazionale-terremoti-client/default.nix
+++ b/pkgs/development/python-modules/georss-ingv-centro-nazionale-terremoti-client/default.nix
@@ -36,5 +36,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/exxamalte/python-georss-ingv-centro-nazionale-terremoti-client/releases/tag/v${version}";
     license = with licenses; [ asl20 ];
     maintainers = with maintainers; [ fab ];
+    broken = true; # Sends a dict to georss_client.xml_parser which expects a string or character stream
   };
 }


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/313483760

Hydra fails in a test due to API changes in dependent packages:
```sh
FAILED tests/test_feed.py::test_update_ok_feed_3 - AttributeError: 'dict' object has no attribute 'split'
```

1. Modernize `georss-client`. (FYI @fabaff)
   Supersedes #461859
2. Bump `python3Packages.georss-client` to 0.1.9. This fixes the Hydra failure.
3. `python3Packages.georss-ign-sismologia-client: modernize` as it was triggering a spurious `georss-client` package imports check failure (`xmltodict` version). `propagatedBuildInputs` -> `dependencies` fixed that.
4. Mark `python3Packages.georss-ingv-centro-nazionale-terremoti-client` as broken as it passes a dict to `georss_client.xml_parser` which expects a string or character stream.

ZHF: #457852

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
