### PR TITLE
eudic: fix incompatible Qt plugins version

### DIFF
--- a/pkgs/by-name/eu/eudic/package.nix
+++ b/pkgs/by-name/eu/eudic/package.nix
@@ -74,7 +74,8 @@ stdenv.mkDerivation (finalAttrs: {
     cp -r usr/share $out/share
     makeWrapper $out/share/eusoft-eudic/eudic $out/bin/eudic \
       --inherit-argv0 \
-      --set GST_PLUGIN_PATH $out/share/eusoft-eudic/gstreamer-1.0
+      --set GST_PLUGIN_PATH $out/share/eusoft-eudic/gstreamer-1.0 \
+      --set QT_PLUGIN_PATH $out/share/eusoft-eudic/plugins
 
     runHook postInstall
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This package behaves inconsistently on the unstable channel. My `QT_PLUGIN_PATH` includes several directories with Qt 5.15.18 plugins, and when I run it, I get errors about incompatible Qt versions as below:

```
$ env | grep QT_
QT_PLUGIN_PATH=/nix/store/kii6isijgs3pmw3rvr86zffz5psiiz0f-fcitx5-with-addons-5.1.16/lib/qt-6/plugins:/etc/profiles/per-user/xin/lib/qt-5.15.18/plugins:/etc/profiles/per-user/xin/lib/qt-6/plugins:/home/xin/.local/share/flatpak/exports/lib/qt-5.15.18/plugins:/home/xin/.local/share/flatpak/exports/lib/qt-6/plugins:/var/lib/flatpak/exports/lib/qt-5.15.18/plugins:/var/lib/flatpak/exports/lib/qt-6/plugins:/home/xin/.nix-profile/lib/qt-5.15.18/plugins:/home/xin/.nix-profile/lib/qt-6/plugins:/nix/profile/lib/qt-5.15.18/plugins:/nix/profile/lib/qt-6/plugins:/home/xin/.local/state/nix/profile/lib/qt-5.15.18/plugins:/home/xin/.local/state/nix/profile/lib/qt-6/plugins:/etc/profiles/per-user/xin/lib/qt-5.15.18/plugins:/etc/profiles/per-user/xin/lib/qt-6/plugins:/nix/var/nix/profiles/default/lib/qt-5.15.18/plugins:/nix/var/nix/profiles/default/lib/qt-6/plugins:/run/current-system/sw/lib/qt-5.15.18/plugins:/run/current-system/sw/lib/qt-6/plugins

$ eudic                                                                                                      
Cannot mix incompatible Qt library (5.15.18) with this library (5.15.2)
```

I've pointed QT_PLUGIN_PATH to the one included in the package through wrapper, and this fixes the problem.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
