### PR TITLE
nixos/gonic: fix writeability of paths from config

### DIFF
--- a/nixos/modules/services/audio/gonic.nix
+++ b/nixos/modules/services/audio/gonic.nix
@@ -65,7 +65,6 @@ in
             ) cfg.settings;
           in
           "${lib.getExe cfg.package} -config-path ${settingsFormat.generate "gonic" filteredSettings}";
-        DynamicUser = true;
         StateDirectory = "gonic";
         CacheDirectory = "gonic";
         WorkingDirectory = "/var/lib/gonic";

--- a/nixos/modules/services/audio/gonic.nix
+++ b/nixos/modules/services/audio/gonic.nix
@@ -21,6 +21,8 @@ in
 
       enable = lib.mkEnableOption "Gonic music server";
 
+      package = lib.mkPackageOption pkgs "gonic" { };
+
       settings = lib.mkOption rec {
         type = settingsFormat.type;
         apply = lib.recursiveUpdate default;
@@ -62,7 +64,7 @@ in
               n: v: !((n == "tls-cert" || n == "tls-key") && v == null)
             ) cfg.settings;
           in
-          "${pkgs.gonic}/bin/gonic -config-path ${settingsFormat.generate "gonic" filteredSettings}";
+          "${lib.getExe cfg.package} -config-path ${settingsFormat.generate "gonic" filteredSettings}";
         DynamicUser = true;
         StateDirectory = "gonic";
         CacheDirectory = "gonic";

--- a/nixos/tests/gonic.nix
+++ b/nixos/tests/gonic.nix
@@ -1,6 +1,7 @@
 { lib, pkgs, ... }:
 {
   name = "gonic";
+  meta.maintainers = pkgs.gonic.meta.maintainers;
 
   nodes.default_cache_dir =
     { config, ... }:

--- a/nixos/tests/gonic.nix
+++ b/nixos/tests/gonic.nix
@@ -1,19 +1,33 @@
-{ pkgs, ... }:
+{ lib, pkgs, ... }:
 {
   name = "gonic";
 
-  nodes.machine =
-    { ... }:
+  nodes.default_cache_dir =
+    { config, ... }:
     {
       systemd.tmpfiles.settings = {
         "10-gonic" = {
           "/tmp/music"."d" = { };
           "/tmp/podcast"."d" = { };
           "/tmp/playlists"."d" = { };
+          "/tmp/secrets"."d" = { };
         };
       };
       services.gonic = {
         enable = true;
+        # Wrap gonic to check that the required paths are writable.
+        # This isn't necessarily checked by successful service startup.
+        package = pkgs.writeShellApplication {
+          name = "gonic-test-wrapper";
+          runtimeInputs = [ pkgs.gonic ];
+          text = ''
+            touch ${config.services.gonic.settings.cache-path}/foo && echo "cache dir writeable" >&2
+            touch /tmp/podcast/foo && echo "podcast dir writeable" >&2
+            touch /tmp/playlists/foo && echo "playlists dir writeable" >&2
+            touch /tmp/secrets/foo && echo "shouldn't be able to write /tmp/secrets" >&2 && exit 1
+            exec ${lib.getExe pkgs.gonic} "$@"
+          '';
+        };
         settings = {
           music-path = [ "/tmp/music" ];
           podcast-path = "/tmp/podcast";
@@ -22,8 +36,33 @@
       };
     };
 
+  nodes.custom_cache_dir =
+    { ... }:
+    {
+      systemd.tmpfiles.settings = {
+        "10-gonic" = {
+          "/tmp/music"."d" = { };
+          "/tmp/podcast"."d" = { };
+          "/tmp/playlists"."d" = { };
+          "/tmp/cache"."d" = { };
+        };
+      };
+      services.gonic = {
+        enable = true;
+        settings = {
+          music-path = [ "/tmp/music" ];
+          podcast-path = "/tmp/podcast";
+          playlists-path = "/tmp/playlists";
+          cache-path = "/tmp/cache";
+        };
+      };
+    };
+
   testScript = ''
-    machine.wait_for_unit("gonic")
-    machine.wait_for_open_port(4747)
+    default_cache_dir.wait_for_unit("gonic")
+    default_cache_dir.wait_for_open_port(4747)
+
+    custom_cache_dir.wait_for_unit("gonic")
+    custom_cache_dir.wait_for_open_port(4747)
   '';
 }


### PR DESCRIPTION
Not sure this is even possible with DynamicUser. Even if we BindPath the directories the dynamic service user isn't allowed to write them, they are root owned. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
