### PR TITLE
xine-lib: 1.2.13-unstable-2024-06-29 -> 1.2.13-unstable-2025-11-03

### DIFF
--- a/pkgs/by-name/xi/xine-lib/package.nix
+++ b/pkgs/by-name/xi/xine-lib/package.nix
@@ -32,12 +32,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xine-lib";
-  version = "1.2.13-unstable-2024-06-29";
+  version = "1.2.13-unstable-2025-11-03";
 
   src = fetchhg {
     url = "http://hg.code.sf.net/p/xine/xine-lib-1.2";
-    rev = "53845e2f6b1f3b69328de5c030c0ab27eb8f043d";
-    hash = "sha256-O5lIYmNC2TpoY4QbPMsDWxNOoxdw61967Q4QG9d/+Bg=";
+    rev = "405a16a848927ed9861d6ac177c7e9624ecf58d1";
+    hash = "sha256-Q+PcpVMgV2b+htEhTlUK63ZpuJ9Vz+dlmBhNiO8PC2A=";
   };
 
   outputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

~~Fixes build of `xine-lib` by pinning `ffmpeg` to `ffmpeg_7`. It looks like significant upstream changes may be necessary to support `ffmpeg_8`.~~

Updating to latest unstable version to address `ffmpeg` 8 compatibility.

Last failed Hydra build: https://hydra.nixos.org/build/313278840

ZHF: #457852

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
