### PR TITLE
python3Packages.mkdocs: fix build with click 8.3.1

### DIFF
--- a/pkgs/development/python-modules/mkdocs/click-8.3.0-compat.patch
+++ b/pkgs/development/python-modules/mkdocs/click-8.3.0-compat.patch
@@ -1,0 +1,25 @@
+diff --git a/mkdocs/__main__.py b/mkdocs/__main__.py
+index c8d40969..3432ff40 100644
+--- a/mkdocs/__main__.py
++++ b/mkdocs/__main__.py
+@@ -253,8 +253,8 @@ def cli():
+ @cli.command(name="serve")
+ @click.option('-a', '--dev-addr', help=dev_addr_help, metavar='<IP:PORT>')
+ @click.option('-o', '--open', 'open_in_browser', help=serve_open_help, is_flag=True)
+-@click.option('--no-livereload', 'livereload', flag_value=False, help=no_reload_help)
+-@click.option('--livereload', 'livereload', flag_value=True, default=True, hidden=True)
++@click.option('--no-livereload', is_flag=True, help=no_reload_help)
++@click.option('--livereload', is_flag=True, hidden=True)
+ @click.option('--dirtyreload', 'build_type', flag_value='dirty', hidden=True)
+ @click.option('--dirty', 'build_type', flag_value='dirty', help=serve_dirty_help)
+ @click.option('-c', '--clean', 'build_type', flag_value='clean', help=serve_clean_help)
+@@ -268,6 +268,9 @@ def serve_command(**kwargs):
+     """Run the builtin development server."""
+     from mkdocs.commands import serve
+ 
++    kwargs['livereload'] = kwargs['livereload'] or not kwargs['no_livereload']
++    del kwargs['no_livereload']
++
+     _enable_warnings()
+     serve.serve(**kwargs)
+ 

--- a/pkgs/development/python-modules/mkdocs/default.nix
+++ b/pkgs/development/python-modules/mkdocs/default.nix
@@ -48,6 +48,11 @@ buildPythonPackage rec {
     hash = "sha256-JQSOgV12iYE6FubxdoJpWy9EHKFxyKoxrm/7arCn9Ak=";
   };
 
+  patches = [
+    # https://github.com/mkdocs/mkdocs/pull/4065
+    ./click-8.3.0-compat.patch
+  ];
+
   build-system = [
     hatchling
     # babel, setuptools required as "build hooks"


### PR DESCRIPTION
This applies https://github.com/mkdocs/mkdocs/pull/4065 in order to fix https://github.com/NixOS/nixpkgs/pull/454434#issuecomment-3564024069.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
