### PR TITLE
yaziPlugins: update on 2025-11-21

### DIFF
--- a/pkgs/by-name/ya/yazi/plugins/git/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/git/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "git.yazi";
-  version = "25.5.31-unstable-2025-07-05";
+  version = "25.5.31-unstable-2025-11-19";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "cbc4450a6c238114362e3c2fbca355166c2a2202";
-    hash = "sha256-otD7zmm/Juh68D2czRhtU7CZFIaMgADxuo8p68cS7fk=";
+    rev = "2301ff803a033cd16d16e62697474d6cb9a94711";
+    hash = "sha256-+lirIBXv3EvztE/1b3zHnQ9r5N3VWBCUuH3gZR52fE0=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/mediainfo/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mediainfo/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mediainfo.yazi";
-  version = "25.5.31-unstable-2025-11-04";
+  version = "25.5.31-unstable-2025-11-15";
 
   src = fetchFromGitHub {
     owner = "boydaihungst";
     repo = "mediainfo.yazi";
-    rev = "7543154138ffb2bb0c738419af6ff4595152a809";
-    hash = "sha256-qWh/2WA1pBhze+g5aDSl4gHk2zJSgnl4WZr74FfNA74=";
+    rev = "1099409ca956282efe49dea8ab53f8be95feb72a";
+    hash = "sha256-K2SHIzmNtICgVchSPB1mtTboyvDPIq+hN3GEOR20hpk=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/recycle-bin/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/recycle-bin/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "recycle-bin.yazi";
-  version = "0-unstable-2025-11-03";
+  version = "0-unstable-2025-11-11";
 
   src = fetchFromGitHub {
     owner = "uhs-robert";
     repo = "recycle-bin.yazi";
-    rev = "bce0eb110e2447544fd619f30ff82bfee51a6347";
-    hash = "sha256-dj/lKod8I6Fs1Vp2e6AOEmUVSwT12Ck7zT5e4Qsmzt0=";
+    rev = "1762676a032e0de6d4712ae06d14973670621f61";
+    hash = "sha256-LzqFBLqaclRgjyLKL0OxlAao+MMivh4Ww7UZf2gcOUM=";
   };
 
   meta = {


### PR DESCRIPTION
- git: 25.5.31-unstable-2025-07-05 → 25.5.31-unstable-2025-11-19
- mediainfo: 25.5.31-unstable-2025-11-04 → 25.5.31-unstable-2025-11-15
- recycle-bin: 0-unstable-2025-11-03 → 0-unstable-2025-11-11


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
