### PR TITLE
fetchurl, fetchgit: converge hash attributes and reference from `finalAttrs.hash`

### DIFF
--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -214,8 +214,8 @@ lib.extendMkDerivation {
           }
         else if cacert != null then
           {
-            outputHashAlgo = "sha256";
-            outputHash = "";
+            outputHashAlgo = null;
+            outputHash = lib.fakeHash;
           }
         else
           throw "fetchurl requires a hash for fixed-output derivation: ${lib.generators.toPretty { } urls_}";

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -64,7 +64,6 @@ lib.extendMkDerivation {
     "derivationArgs"
 
     # Hash attributes will be map to the corresponding outputHash*
-    "hash"
     "sha1"
     "sha256"
     "sha512"
@@ -220,6 +219,9 @@ lib.extendMkDerivation {
         else
           throw "fetchurl requires a hash for fixed-output derivation: ${lib.generators.toPretty { } urls_}";
 
+      finalHashHasColon = lib.hasInfix ":" finalAttrs.hash;
+      finalHashColonMatch = lib.match "([^:]+)[:](.*)" finalAttrs.hash;
+
       resolvedUrl =
         let
           mirrorSplit = lib.match "mirror://([[:alpha:]]+)/(.+)" url;
@@ -259,7 +261,23 @@ lib.extendMkDerivation {
       preferHashedMirrors = false;
 
       # New-style output content requirements.
-      inherit (hash_) outputHashAlgo outputHash;
+      hash =
+        if
+          hash_.outputHashAlgo == null
+          || hash_.outputHash == ""
+          || lib.hasPrefix hash_.outputHashAlgo hash_.outputHash
+        then
+          hash_.outputHash
+        else
+          "${hash_.outputHashAlgo}:${hash_.outputHash}";
+      outputHashAlgo = if finalHashHasColon then lib.head finalHashColonMatch else null;
+      outputHash =
+        if finalAttrs.hash == "" then
+          lib.fakeHash
+        else if finalHashHasColon then
+          lib.elemAt finalHashColonMatch 1
+        else
+          finalAttrs.hash;
 
       # Disable TLS verification only when we know the hash and no credentials are
       # needed to access the resource

--- a/pkgs/test/overriding.nix
+++ b/pkgs/test/overriding.nix
@@ -5,7 +5,13 @@
 }:
 
 let
-  tests = tests-stdenv // test-extendMkDerivation // tests-fetchhg // tests-go // tests-python;
+  tests =
+    tests-stdenv
+    // test-extendMkDerivation
+    // tests-fetchhg
+    // tests-fetchurl
+    // tests-go
+    // tests-python;
 
   tests-stdenv =
     let
@@ -128,6 +134,52 @@ let
       extendMkDerivation-helloLocal-specialArg = {
         expr = hiLocal.greeting;
         expected = "Hi!";
+      };
+    };
+
+  tests-fetchurl =
+    let
+      src-with-sha256 = pkgs.fetchurl {
+        url = "https://example.com/source.tar.gz";
+        sha256 = lib.fakeSha256;
+      };
+    in
+    {
+      test-fetchurl-hash-compat = {
+        expr = {
+          inherit (src-with-sha256)
+            outputHash
+            outputHashAlgo
+            ;
+        };
+        expected = {
+          outputHash = lib.fakeSha256;
+          outputHashAlgo = "sha256";
+        };
+      };
+      test-fetchurl-overrideAttrs-hash = {
+        expr = {
+          inherit (src-with-sha256.overrideAttrs { hash = pkgs.hello.src.hash; })
+            outputHash
+            outputHashAlgo
+            ;
+        };
+        expected = {
+          outputHash = pkgs.hello.src.hash;
+          outputHashAlgo = null;
+        };
+      };
+      test-fetchurl-overrideAttrs-hash-empty = {
+        expr = {
+          inherit (src-with-sha256.overrideAttrs { hash = ""; })
+            outputHash
+            outputHashAlgo
+            ;
+        };
+        expected = {
+          outputHash = lib.fakeHash;
+          outputHashAlgo = null;
+        };
       };
     };
 

--- a/pkgs/test/overriding.nix
+++ b/pkgs/test/overriding.nix
@@ -137,6 +137,52 @@ let
       };
     };
 
+  tests-fetchgit =
+    let
+      src-with-sha256 = pkgs.fetchgit {
+        url = "https://example.com/source.git";
+        sha256 = lib.fakeSha256;
+      };
+    in
+    {
+      test-fetchgit-hash-compat = {
+        expr = {
+          inherit (src-with-sha256)
+            outputHash
+            outputHashAlgo
+            ;
+        };
+        expected = {
+          outputHash = lib.fakeSha256;
+          outputHashAlgo = "sha256";
+        };
+      };
+      test-fetchgit-overrideAttrs-hash = {
+        expr = {
+          inherit (src-with-sha256.overrideAttrs { hash = pkgs.nix.src.hash; })
+            outputHash
+            outputHashAlgo
+            ;
+        };
+        expected = {
+          outputHash = pkgs.nix.src.hash;
+          outputHashAlgo = null;
+        };
+      };
+      test-fetchurl-overrideAttrs-hash-empty = {
+        expr = {
+          inherit (src-with-sha256.overrideAttrs { hash = ""; })
+            outputHash
+            outputHashAlgo
+            ;
+        };
+        expected = {
+          outputHash = lib.fakeHash;
+          outputHashAlgo = null;
+        };
+      };
+    };
+
   tests-fetchurl =
     let
       src-with-sha256 = pkgs.fetchurl {


### PR DESCRIPTION
This PR makes the `hash`, passed from `fetchurl` to `stdenvNoCC.mkDerivation`, overridable via `<pkg>.overrideAttrs`. If applied, both `outputHash` and `outputHashAlgo` are determined by `finalAttrs.hash` and `lib.fakeHash`. This follows the consensus in issue #459651

To keep full backward compatibility, this PR exploits the obsolete but still supported hash format `<algorithm>:<body>` (the "colon hash") as the `finalAttrs.hash` representation for the legacy `outputHashAlgo` and `outputHash` pair. This preserves the previous `outputHash` and `outputHashAlgo` behaviour in most cases, with the only exception when `outputHash` is specified with a colon-hash.

Since [`nix-prefetch`](https://github.com/msteen/nix-prefetch) is probably the only tool that uses the colon-hash, and that `{ outputHash = "<algo>:<body>"; outputHashAlgo = null; }`, `{ outputHash = "<algo>:<body>"; outputHashAlgo = "<algo>"; }` and `{ outputHash = "<body>"; outputHashAlgo = "<algo>"; }` are all hash-equivalent, this change should be backward compatible.

Competing PR:
- #459487 (That PR makes all `sha1`, `sha256`, `sha512`, and `hash` overridable with `<pkg>.overrideAttrs`)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
