### PR TITLE
home-assistant: 2025.11.2 -> 2025.11.3

### DIFF
--- a/pkgs/development/python-modules/aioautomower/default.nix
+++ b/pkgs/development/python-modules/aioautomower/default.nix
@@ -23,7 +23,7 @@
 
 buildPythonPackage rec {
   pname = "aioautomower";
-  version = "2.7.0";
+  version = "2.7.1";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -32,7 +32,7 @@ buildPythonPackage rec {
     owner = "Thomas55555";
     repo = "aioautomower";
     tag = "v${version}";
-    hash = "sha256-qhjfnneLJjdDDP4XrecSI/psqEqKGP5ziaPd/iRiZfM=";
+    hash = "sha256-+OzCs+yNU7ni+Lua2gAhaqYdb8dQz3lhtEdhdDgvMxo=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/aiounifi/default.nix
+++ b/pkgs/development/python-modules/aiounifi/default.nix
@@ -17,7 +17,7 @@
 
 buildPythonPackage rec {
   pname = "aiounifi";
-  version = "87";
+  version = "88";
   pyproject = true;
 
   disabled = pythonOlder "3.13";
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     owner = "Kane610";
     repo = "aiounifi";
     tag = "v${version}";
-    hash = "sha256-+aObnX82erFXAdQ5hdj/ebMj9Xm5ZCooprt+UensDpM=";
+    hash = "sha256-nMx2mygHn27Y1LbTZR30lQ5p4LmEt5FxOAKr6rF82JI=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/go2rtc-client/default.nix
+++ b/pkgs/development/python-modules/go2rtc-client/default.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "go2rtc-client";
-  version = "0.2.1";
+  version = "0.3.0";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "home-assistant-libs";
     repo = "python-go2rtc-client";
     tag = version;
-    hash = "sha256-d5N9IEmxCDKqDv4lD9tYyTPWtR6d86iCZzucx3Pbx7Y=";
+    hash = "sha256-TJl4797z1q4fbjTX7d+KyWJukn6SwMwGUsNzuQg8hmc=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/ohme/default.nix
+++ b/pkgs/development/python-modules/ohme/default.nix
@@ -9,7 +9,7 @@
 
 buildPythonPackage rec {
   pname = "ohme";
-  version = "1.5.2";
+  version = "1.6.0";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     owner = "dan-r";
     repo = "ohmepy";
     tag = "v${version}";
-    hash = "sha256-r3pu+HAQc8hXF2aMuWuE151Lz4rbrVti8YBrm4CS8z4=";
+    hash = "sha256-nMYtlJzSy7ymQeNKHR0d6gBfx3vBMk8nf6sJk2/FQLE=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/ohme/default.nix
+++ b/pkgs/development/python-modules/ohme/default.nix
@@ -3,7 +3,6 @@
   aiohttp,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonOlder,
   setuptools,
 }:
 
@@ -11,8 +10,6 @@ buildPythonPackage rec {
   pname = "ohme";
   version = "1.6.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "dan-r";
@@ -33,7 +30,7 @@ buildPythonPackage rec {
   meta = {
     description = "Module for interacting with the Ohme API";
     homepage = "https://github.com/dan-r/ohmepy";
-    changelog = "https://github.com/dan-r/ohmepy/releases/tag/v${version}";
+    changelog = "https://github.com/dan-r/ohmepy/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/onedrive-personal-sdk/default.nix
+++ b/pkgs/development/python-modules/onedrive-personal-sdk/default.nix
@@ -9,14 +9,14 @@
 
 buildPythonPackage rec {
   pname = "onedrive-personal-sdk";
-  version = "0.0.16";
+  version = "0.0.17";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "zweckj";
     repo = "onedrive-personal-sdk";
     tag = "v${version}";
-    hash = "sha256-zGzJtfgOuEfAaL+26jnEZzhKJLhRpBTYPBWzIHqwtXw=";
+    hash = "sha256-dJ8cFZKnSN8sQxe2wMqwPXf7CaFKUP6TZbS/J4Z0qa0=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/python-awair/default.nix
+++ b/pkgs/development/python-modules/python-awair/default.nix
@@ -4,6 +4,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   poetry-core,
+  pytest-asyncio,
   pytest-aiohttp,
   pytestCheckHook,
   pythonOlder,
@@ -13,39 +14,37 @@
 
 buildPythonPackage rec {
   pname = "python-awair";
-  version = "0.2.4";
-  format = "pyproject";
-  disabled = pythonOlder "3.6";
+  version = "0.2.5";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ahayworth";
     repo = "python_awair";
-    rev = version;
-    hash = "sha256-zdZyA6adM4bfEYupdZl7CzMjwyfRkQBrntNh0MusynE=";
+    tag = version;
+    hash = "sha256-ZET24T6MeCPPL1V84538U6Fb/ZVGv1hwcdTQi3Q+yMY=";
   };
 
-  nativeBuildInputs = [ poetry-core ];
+  build-system = [ poetry-core ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     aiohttp
     voluptuous
   ];
 
-  # Failed: async def functions are not natively supported.
-  doCheck = false;
-
   nativeCheckInputs = [
     pytest-aiohttp
+    pytest-asyncio
     pytestCheckHook
     vcrpy
   ];
 
   pythonImportsCheck = [ "python_awair" ];
 
-  meta = with lib; {
+  meta = {
+    changelog = "https://github.com/ahayworth/python_awair/releases/tag/${src.tag}";
     description = "Python library for the Awair API";
     homepage = "https://github.com/ahayworth/python_awair";
-    license = with licenses; [ mit ];
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
   };
 }

--- a/pkgs/development/python-modules/tplink-omada-client/default.nix
+++ b/pkgs/development/python-modules/tplink-omada-client/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "tplink-omada-client";
-  version = "1.4.4";
+  version = "1.5.3";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "tplink_omada_client";
     inherit version;
-    hash = "sha256-6MiPgseHrqgD+DGth5rJ03HK+0YfBpmDPXybzrTDeeA=";
+    hash = "sha256-JcH39WqEk0HNQIQ6jiN2Ml3PEX+mNLBVSaRENiut29A=";
   };
 
   build-system = [ hatchling ];

--- a/pkgs/development/python-modules/universal-silabs-flasher/default.nix
+++ b/pkgs/development/python-modules/universal-silabs-flasher/default.nix
@@ -28,14 +28,14 @@
 
 buildPythonPackage rec {
   pname = "universal-silabs-flasher";
-  version = "0.0.37";
+  version = "0.1.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "NabuCasa";
     repo = "universal-silabs-flasher";
     tag = "v${version}";
-    hash = "sha256-XvDzv39at+6h1Q2tmiYiNsLpcMTx+sOd958K+PB0WSc=";
+    hash = "sha256-Qeudh75PzIxI4vr3H4nBULhM2X8WSPF8hrT2uMWopHQ=";
   };
 
   postPatch = ''

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2025.11.2";
+  version = "2025.11.3";
   components = {
     "3_day_blinds" =
       ps: with ps; [

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -305,7 +305,7 @@ let
   extraBuildInputs = extraPackages python.pkgs;
 
   # Don't forget to run update-component-packages.py after updating
-  hassVersion = "2025.11.2";
+  hassVersion = "2025.11.3";
 
 in
 python.pkgs.buildPythonApplication rec {
@@ -326,13 +326,13 @@ python.pkgs.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     tag = version;
-    hash = "sha256-o4rpdnO/TslJWRj7HwTyWOS0NBVOfAeDfWiYvlx/jhw=";
+    hash = "sha256-Wd+q2ooNguJMKnQ1uzLJtglAyBFXjBSj5hjEgY4bgzY=";
   };
 
   # Secondary source is pypi sdist for translations
   sdist = fetchPypi {
     inherit pname version;
-    hash = "sha256-j10a2GSnFau6KYMpFrFCrCTqsmy/D5p6BwQMvlOEe+w=";
+    hash = "sha256-KxpjOPlusEHT+bRtgs/9EsIksTd4pRMKsXb7e5q+b2Q=";
   };
 
   build-system = with python.pkgs; [

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -8,7 +8,7 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20251105.0";
+  version = "20251105.1";
   format = "wheel";
 
   src = fetchPypi {
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     pname = "home_assistant_frontend";
     dist = "py3";
     python = "py3";
-    hash = "sha256-sQp23ibdVQHEuP016pA1E1xxXB275YNPvDqEFfI15nk=";
+    hash = "sha256-keqQTQyo06xMUsZLf920n1eyu/iPrI2cNkXYMThhGFI=";
   };
 
   # there is nothing to strip in this package

--- a/pkgs/servers/home-assistant/stubs.nix
+++ b/pkgs/servers/home-assistant/stubs.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "homeassistant-stubs";
-  version = "2025.11.2";
+  version = "2025.11.3";
   pyproject = true;
 
   disabled = python.version != home-assistant.python.version;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "KapJI";
     repo = "homeassistant-stubs";
     tag = version;
-    hash = "sha256-xsFbgrXPWwA9c764Jp7fjsUjaG+C03zpdot/+mRAKgA=";
+    hash = "sha256-Cl5wRdYGVGtDTsnlU5poHJA3F8wxh1e3Rb1Zhmfc2CI=";
   };
 
   build-system = [


### PR DESCRIPTION
Diff: https://github.com/home-assistant/core/compare/2025.11.2...2025.11.3

Changelog: https://github.com/home-assistant/core/releases/tag/2025.11.3

closes https://github.com/NixOS/nixpkgs/pull/462132
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
