### PR TITLE
stdenv: Fix inputDerivation for __structuredAttrs (again?)

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -878,8 +878,7 @@ let
         inputDerivation = derivation (
           deleteFixedOutputRelatedAttrs derivationArg
           // {
-            # Add a name in case the original drv didn't have one
-            name = derivationArg.name or "inputDerivation";
+            name = "inputDerivation${lib.optionalString (derivationArg ? name) "-${derivationArg.name}"}";
             # This always only has one output
             outputs = [ "out" ];
 

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -912,23 +912,20 @@ let
             ];
           }
           // (
-            let
-              sharedOutputChecks = {
-                # inputDerivation produces the inputs; not the outputs, so any
-                # restrictions on what used to be the outputs don't serve a purpose
-                # anymore.
+            # inputDerivation produces the inputs; not the outputs, so any
+            # restrictions on what used to be the outputs don't serve a purpose
+            # anymore.
+            if __structuredAttrs then
+              {
+                outputChecks = { };
+              }
+            else
+              {
                 allowedReferences = null;
                 allowedRequisites = null;
                 disallowedReferences = [ ];
                 disallowedRequisites = [ ];
-              };
-            in
-            if __structuredAttrs then
-              {
-                outputChecks.out = sharedOutputChecks;
               }
-            else
-              sharedOutputChecks
           )
         );
 

--- a/pkgs/test/stdenv/default.nix
+++ b/pkgs/test/stdenv/default.nix
@@ -355,6 +355,10 @@ in
         touch $out
       '';
 
+  test-inputDerivation-structured = (stdenv.mkDerivation {
+    __structuredAttrs = true;
+  }).inputDerivation;
+
   test-prepend-append-to-var = testPrependAndAppendToVar {
     name = "test-prepend-append-to-var";
     stdenv' = bootStdenv;


### PR DESCRIPTION
Supposedly https://github.com/NixOS/nixpkgs/pull/368226 fixed it, but either nobody actually tested it or older Nix versions were fine, but all currently available Nix versions, including 2.24 and 2.32 complain about it:

    building '/nix/store/9n4hwzk8s74n6cq8dlxa4qas9jchsbgc-inputDerivation.drv'...
    error: output '/nix/store/l3gmc01pwa42rzq9riv8wm3skzkm144r-inputDerivation' is not allowed to refer to the following paths:
             /nix/store/k5z8rkvj1fn1nrf05l5a86aflc5s1p6m-stdenv-linux
             /nix/store/l3gmc01pwa42rzq9riv8wm3skzkm144r-inputDerivation
             /nix/store/l622p70vy8k5sh7y5wizi5f2mic6ynpg-source-stdenv.sh
             /nix/store/qsydfxm1vq6q9jac2kq3r8kn0xdmsldf-bash-5.3p3
             /nix/store/shkw4qm9qcw5sc5n1k5jznc83ny02r39-default-builder.sh

This commit fixes it (again?) and adds a regression test

Ping @ShamrockLee 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
