### PR TITLE
esphome: 2025.10.5 -> 2025.11.0

### DIFF
--- a/pkgs/by-name/es/esphome/package.nix
+++ b/pkgs/by-name/es/esphome/package.nix
@@ -33,14 +33,14 @@ let
 in
 python.pkgs.buildPythonApplication rec {
   pname = "esphome";
-  version = "2025.10.5";
+  version = "2025.11.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "esphome";
     repo = "esphome";
     tag = version;
-    hash = "sha256-o40zMoqgjBpkn80dUvr7mJQ/EtmIHEI/cf/E+wbBPOw=";
+    hash = "sha256-ezyuV9PcZ5SsJc5viyV+8n+pW8k0SV2bXr+JPVkOdus=";
   };
 
   patches = [
@@ -64,10 +64,6 @@ python.pkgs.buildPythonApplication rec {
   pythonRemoveDeps = [
     "esptool"
     "platformio"
-    # esp-idf v5.1 uses esp-idf-kconfig instead:
-    # https://github.com/espressif/esp-idf/blob/release/v5.1/tools/requirements/requirements.core.txt#L15
-    # Can be removed once this pr is released: https://github.com/esphome/esphome/pull/11210
-    "kconfiglib"
   ];
 
   postPatch = ''
@@ -82,6 +78,7 @@ python.pkgs.buildPythonApplication rec {
   dependencies = with python.pkgs; [
     aioesphomeapi
     argcomplete
+    bleak
     cairosvg
     click
     colorama
@@ -137,7 +134,10 @@ python.pkgs.buildPythonApplication rec {
       pytest-mock
       pytestCheckHook
     ]
-    ++ [ versionCheckHook ];
+    ++ [
+      git
+      versionCheckHook
+    ];
 
   disabledTestPaths = [
     # platformio builds; requires networking for dependency resolution
@@ -172,6 +172,9 @@ python.pkgs.buildPythonApplication rec {
     "test_upload_using_esptool_with_file_path"
     # AssertionError: Expected 'run_external_command' to have been called once. Called 0 times.
     "test_run_platformio_cli_sets_environment_variables"
+    # Expects a full git clone
+    "test_clang_tidy_mode_full_scan"
+    "test_clang_tidy_mode_targeted_scan"
   ];
 
   versionCheckProgramArg = "--version";


### PR DESCRIPTION
https://github.com/esphome/esphome/releases/tag/2025.11.0

Still debugging the following, which happens for ESP32 devices

```
idf_tools.py installation failed (rc=1). Tail:
Traceback (most recent call last):
  File "/home/hexa/.platformio/packages/tool-esp_install/tools/idf_tools.py", line 93, in <module>
    from platformio.project.config import ProjectConfig
ModuleNotFoundError: No module named 'platformio'
error: /home/hexa/.platformio/packages/tool-esptoolpy does not appear to be a Python project, as neither `pyproject.toml` nor `setup.py` are present in the directory
Warning: Failed to install esptool from /home/hexa/.platformio/packages/tool-esptoolpy (exit 2)
[...]
Linking .pioenvs/esphome-766d10/bootloader.elf
Building .pioenvs/esphome-766d10/bootloader.bin
sh: line 1: /home/hexa/.platformio/penv/bin/esptool: No such file or directory
*** [.pioenvs/esphome-766d10/bootloader.bin] Error 127
```

That's this script: https://github.com/pioarduino/esp_install/blob/main/tools/idf_tools.py

vs on 2025.10.5

```
Tool Manager: Installing https://github.com/pioarduino/registry/releases/download/0.0.1/esptoolpy-v5.0.2.zip
Unpacking  [####################################]  100%
Tool Manager: tool-esptoolpy@5.0.2 has been installed!
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
