### PR TITLE
stdenv/darwin: remove workarounds and do cleanup

### DIFF
--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -1144,8 +1144,6 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
               cctools
               cctools.libtool
               coreutils
-              darwin.binutils
-              darwin.binutils.bintools
               diffutils
               ed
               file
@@ -1185,6 +1183,8 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
           ]
           ++ lib.optionals localSystem.isx86_64 [ prevStage.darwin.Csu ]
           ++ (with prevStage.darwin; [
+            binutils
+            binutils.bintools
             libcxx
             libiconv.out
             libresolv.out
@@ -1194,13 +1194,13 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
           ])
           ++ (with prevStage."llvmPackages_${llvmVersion}"; [
             bintools-unwrapped
-            clang-unwrapped
-            (lib.getLib clang-unwrapped)
             compiler-rt
             compiler-rt.dev
+            libclang
+            libclang.lib
+            libllvm
+            libllvm.lib
             lld
-            llvm
-            llvm.lib
           ]);
 
         __stdenvImpureHostDeps = commonImpureHostDeps;

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -312,13 +312,10 @@ let
   llvmLibrariesDeps = _: { };
 
   llvmToolsPackages = prevStage: {
-      clang-unwrapped
     inherit (prevStage."llvmPackages_${llvmVersion}")
       libclang
       libllvm
       lld
-      llvm
-      llvm-manpages
       ;
   };
 
@@ -381,9 +378,10 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
         sigtool = null;
       };
 
-        clang-unwrapped = null;
+      clang = null;
       "llvmPackages_${llvmVersion}" = {
         compiler-rt = null;
+        libclang = null;
         libcxx = null;
         libllvm = null;
       };

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -657,7 +657,9 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
         xar = super.xarMinimal;
 
         darwin = super.darwin.overrideScope (
-          selfDarwin: superDarwin: {
+          selfDarwin: superDarwin:
+          llvmLibrariesDarwinDepsNoCC prevStage
+          // {
             signingUtils = prevStage.darwin.signingUtils.override { inherit (selfDarwin) sigtool; };
 
             # Rewrap binutils with the real libSystem
@@ -820,6 +822,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
             darwin = super.darwin.overrideScope (
               selfDarwin: superDarwin:
               darwinPackages prevStage
+              // llvmLibrariesDarwinDepsNoCC prevStage
               // {
                 inherit (prevStage.darwin) binutils-unwrapped;
                 # Rewrap binutils so it uses the rebuilt Libsystem.
@@ -903,6 +906,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
               selfDarwin: superDarwin:
               darwinPackages prevStage
               // sdkDarwinPackages prevStage
+              // llvmLibrariesDarwinDepsNoCC prevStage
               # Rebuild darwin.binutils with the new LLVM, so only inherit libSystem from the previous stage.
               // {
                 inherit (prevStage.darwin) libSystem;
@@ -977,6 +981,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
             darwin = super.darwin.overrideScope (
               _: superDarwin:
               sdkDarwinPackages prevStage
+              // llvmLibrariesDarwinDepsNoCC prevStage
               // {
                 inherit (prevStage.darwin) binutils-unwrapped libSystem;
                 binutils = superDarwin.binutils.override {
@@ -1217,6 +1222,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
               darwin = super.darwin.overrideScope (
                 _: _:
                 sdkDarwinPackages prevStage
+                // llvmLibrariesDarwinDepsNoCC prevStage
                 // {
                   inherit (prevStage.darwin) libSystem locale sigtool;
                 }

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -673,9 +673,8 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
 
             # Rewrap binutils with the real libSystem
             binutils = superDarwin.binutils.override {
-              inherit (self) coreutils;
+              inherit (self) coreutils libc;
               bintools = selfDarwin.binutils-unwrapped;
-              libc = selfDarwin.libSystem;
             };
 
             # Avoid building unnecessary Python dependencies due to building LLVM manpages.
@@ -837,7 +836,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
                 # Rewrap binutils so it uses the rebuilt Libsystem.
                 binutils = superDarwin.binutils.override {
                   inherit (prevStage) expand-response-params;
-                  libc = selfDarwin.libSystem;
+                  inherit (self) libc;
                 };
               }
             );
@@ -1125,7 +1124,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
 
         extraAttrs = {
           inherit bootstrapTools;
-          libc = prevStage.darwin.libSystem;
+          inherit (prevStage) libc;
           shellPackage = prevStage.bashNonInteractive;
         };
 

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -789,12 +789,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
 
             "llvmPackages_${llvmVersion}" =
               (super."llvmPackages_${llvmVersion}".overrideScope (
-                _: _:
-                llvmToolsPackages prevStage
-                // llvmLibrariesPackages prevStage
-                // {
-                  inherit (prevStage."llvmPackages_${llvmVersion}") clangNoCompilerRtWithLibc;
-                }
+                _: _: llvmToolsPackages prevStage // llvmLibrariesPackages prevStage
               ))
               // {
                 inherit (super."llvmPackages_${llvmVersion}") override;

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -415,6 +415,16 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
         gnugrep = bootstrapTools;
         pbzx = bootstrapTools;
 
+        # Build expand-response-params with an unwrapped clang. This works because the SDK has headers and stubs,
+        # which is all that’s needed.
+        expand-response-params = super.expand-response-params.overrideAttrs (old: {
+          buildPhase = ''
+            CC=${bootstrapTools}/bin/clang
+            export SDKROOT=${self.apple-sdk.sdkroot}
+          ''
+          + old.buildPhase;
+        });
+
         jq = bootstrapTools;
 
         cctools = bootstrapTools // {

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -383,6 +383,9 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
 
         darwin = super.darwin.overrideScope (
           selfDarwin: superDarwin: {
+            # The bootstrap tools provide a libc++ that is definitely compatible with the Clang in the bootstrap tools.
+            # Otherwise, it is possible for the bootstrap tools Clang to be too old for the system libc++ headers.
+            inherit (self.llvmPackages) libcxx;
 
             binutils-unwrapped =
               (superDarwin.binutils-unwrapped.override { enableManpages = false; }).overrideAttrs
@@ -608,6 +611,10 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
           selfDarwin: superDarwin:
           llvmLibrariesDarwinDepsNoCC prevStage
           // {
+            # The bootstrap tools provide a libc++ that is definitely compatible with the Clang in the bootstrap tools.
+            # Otherwise, it is possible for the bootstrap tools Clang to be too old for the system libc++ headers.
+            inherit (self.llvmPackages) libcxx;
+
             signingUtils = prevStage.darwin.signingUtils.override { inherit (selfDarwin) sigtool; };
 
             # Rewrap binutils with the real libSystem

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -467,7 +467,6 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
                 '';
                 passthru.isFromBootstrapFiles = true;
               };
-              llvm-manpages = self.llvmPackages.libllvm;
               lld = self.stdenv.mkDerivation {
                 name = "bootstrap-stage0-lld";
                 buildCommand = "";


### PR DESCRIPTION
This is a follow up to https://github.com/NixOS/nixpkgs/pull/445668. Many thanks to @LunNova for her work on that PR and to @RossComputerGuy for the initial work in https://github.com/NixOS/nixpkgs/pull/436350. Even though there are not as many deletions as I’d have liked, it has still allowed for a lot of cruft to be removed from the Darwin bootstrap.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
