### PR TITLE
winchecksec: init at 3.1.0

### DIFF
--- a/pkgs/by-name/wi/winchecksec/package.nix
+++ b/pkgs/by-name/wi/winchecksec/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pe-parse,
+  uthenticode,
+  openssl,
+  gtest,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "winchecksec";
+  version = "3.1.0";
+
+  src = fetchFromGitHub {
+    owner = "trailofbits";
+    repo = "winchecksec";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-KK0mQiPY/LNCcY4z1smpRjzyLhVcpm/k2ReCUB2hq1Y=";
+  };
+
+  checkInputs = [ gtest ];
+
+  buildInputs = [
+    cmake
+    openssl
+
+    pe-parse
+    uthenticode
+  ];
+
+  patchPhase = ''
+    substituteInPlace CMakeLists.txt \
+      --replace 'if (BUILD_TESTS)' $'find_package(GTest CONFIG REQUIRED)\nadd_subdirectory(test)\nif (FALSE)'
+  '';
+
+  doCheck = true;
+  checkPhase = "test/winchecksec_test";
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm555 winchecksec $out/bin/winchecksec
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://trailofbits.github.io/winchecksec/";
+    description = "Check security features of Windows executables";
+    mainProgram = "winchecksec";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ feyorsh ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

cc @arcz

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
