### PR TITLE
circt: 1.131.0 -> 1.138.0

### DIFF
--- a/pkgs/by-name/ci/circt/circt-llvm.nix
+++ b/pkgs/by-name/ci/circt/circt-llvm.nix
@@ -6,6 +6,7 @@
   circt,
   llvm,
   python3,
+  zstd,
 }:
 stdenv.mkDerivation {
   pname = circt.pname + "-llvm";
@@ -19,21 +20,27 @@ stdenv.mkDerivation {
     python3
   ];
 
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+    # This is needed for darwin builds
+    zstd
+  ];
+
   preConfigure = ''
     cd llvm/llvm
   '';
 
   cmakeFlags = [
-    "-DBUILD_SHARED_LIBS=ON"
-    "-DLLVM_ENABLE_BINDINGS=OFF"
-    "-DLLVM_ENABLE_OCAMLDOC=OFF"
-    "-DLLVM_BUILD_EXAMPLES=OFF"
-    "-DLLVM_OPTIMIZED_TABLEGEN=ON"
-    "-DLLVM_ENABLE_PROJECTS=mlir"
-    "-DLLVM_TARGETS_TO_BUILD=Native"
-
-    # This option is needed to install llvm-config
-    "-DLLVM_INSTALL_UTILS=ON"
+    # Based on utils/build-llvm.sh
+    (lib.cmakeBool "BUILD_SHARED_LIBS" true)
+    (lib.cmakeBool "LLVM_BUILD_EXAMPLES" false)
+    (lib.cmakeBool "LLVM_ENABLE_ASSERTIONS" true)
+    (lib.cmakeBool "LLVM_ENABLE_BINDINGS" false)
+    (lib.cmakeBool "LLVM_ENABLE_OCAMLDOC" false)
+    (lib.cmakeFeature "LLVM_ENABLE_PROJECTS" "mlir")
+    (lib.cmakeBool "LLVM_INSTALL_UTILS" true)
+    (lib.cmakeBool "LLVM_INSTALL_GTEST" true)
+    (lib.cmakeBool "LLVM_OPTIMIZED_TABLEGEN" true)
+    (lib.cmakeFeature "LLVM_TARGETS_TO_BUILD" "host")
   ];
 
   outputs = [


### PR DESCRIPTION
This commit does a few things.
- Updates circt to the latest version
- Updates the llvm and circt build options to match the official release
- Adds enable_slang_frontend feature flag that is enabled by default
- Updates the check targets
- Adds versionCheckHook
- ~~Applies patch to fix build failures on some platforms (This should be removed on the next release)~~ Edit: updated to 1.38.0 which already includes the patch.

There was PR made by the bot (#447296) but it was failing on some platforms, such as github actions and OfBorg. The applied patch should fix this (https://github.com/llvm/circt/pull/9254). Since it has already been merged upstream, the patch should be removed in the next release.



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
