### PR TITLE
umu-launcher-unwrapped: 1.2.9 -> 1.3.0

### DIFF
--- a/pkgs/by-name/um/umu-launcher-unwrapped/package.nix
+++ b/pkgs/by-name/um/umu-launcher-unwrapped/package.nix
@@ -3,13 +3,14 @@
   cargo,
   fetchFromGitHub,
   lib,
-  nix-update-script,
   python3Packages,
   rustPlatform,
   scdoc,
   writableTmpDirAsHomeHook,
   withTruststore ? true,
   withDeltaUpdates ? true,
+  versionCheckHook,
+  nix-update-script,
 }:
 python3Packages.buildPythonPackage rec {
   pname = "umu-launcher-unwrapped";
@@ -34,13 +35,15 @@ python3Packages.buildPythonPackage rec {
 
   nativeBuildInputs = [
     cargo
-    python3Packages.build
-    python3Packages.installer
-    python3Packages.hatchling
-    python3Packages.hatch-vcs
     rustPlatform.cargoSetupHook
     scdoc
-  ];
+  ]
+  ++ (with python3Packages; [
+    build
+    hatchling
+    hatch-vcs
+    installer
+  ]);
 
   pythonPath =
     with python3Packages;
@@ -83,6 +86,9 @@ python3Packages.buildPythonPackage rec {
     # Fails with AssertionError: SystemExit not raised
     "test_parse_args_noopts"
   ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/um/umu-launcher-unwrapped/package.nix
+++ b/pkgs/by-name/um/umu-launcher-unwrapped/package.nix
@@ -13,13 +13,13 @@
 }:
 python3Packages.buildPythonPackage rec {
   pname = "umu-launcher-unwrapped";
-  version = "1.2.9";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "Open-Wine-Components";
     repo = "umu-launcher";
     tag = version;
-    hash = "sha256-nqI2XmMS28dvYrgD9kh7Xc510CvG7ifIybj+HlrU3qI=";
+    hash = "sha256-ELFOffP3KabvyOu4Fl7Z4zvPhamZrmhuuqz1aTYdbnE=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {


### PR DESCRIPTION
Resolves #463884

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
