### PR TITLE
[staging-next] mlt: 7.32.0 -> 7.34.1

### DIFF
--- a/pkgs/by-name/ml/mlt/package.nix
+++ b/pkgs/by-name/ml/mlt/package.nix
@@ -25,6 +25,7 @@
   cudaSupport ? config.cudaSupport,
   cudaPackages ? { },
   enableJackrack ? stdenv.hostPlatform.isLinux,
+  gdk-pixbuf,
   glib,
   ladspa-sdk,
   ladspaPlugins,
@@ -40,13 +41,13 @@
 
 stdenv.mkDerivation rec {
   pname = "mlt";
-  version = "7.32.0";
+  version = "7.34.1";
 
   src = fetchFromGitHub {
     owner = "mltframework";
     repo = "mlt";
     tag = "v${version}";
-    hash = "sha256-8T5FXXGs7SxL6nD+R1Q/0Forsdp5Xux4S3VLvgqXzw8=";
+    hash = "sha256-zdfjl4ZrdmX445hYx2CoKj1NuXQslQpTC5m96zPrZes=";
     # The submodule contains glaxnimate code, since MLT uses internally some functions defined in glaxnimate.
     # Since glaxnimate is not available as a library upstream, we cannot remove for now this dependency on
     # submodules until upstream exports glaxnimate as a library: https://gitlab.com/mattbas/glaxnimate/-/issues/545
@@ -71,6 +72,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
+    gdk-pixbuf
     (opencv4.override { inherit ffmpeg; })
     ffmpeg
     fftw
@@ -118,9 +120,18 @@ stdenv.mkDerivation rec {
   ++ lib.optionals enablePython [
     "-DSWIG_PYTHON=ON"
   ]
-  ++ lib.optionals (qt != null) [
-    "-DMOD_QT${lib.versions.major qt.qtbase.version}=ON"
-    "-DMOD_GLAXNIMATE${if lib.versions.major qt.qtbase.version == "5" then "" else "_QT6"}=ON"
+  ++ lib.optionals (qt == null) [
+    "-DMOD_QT6=OFF"
+  ]
+  ++ lib.optionals (qt != null && lib.versions.major qt.qtbase.version == "5") [
+    "-DMOD_QT=ON"
+    "-DMOD_QT6=OFF"
+    "-DMOD_GLAXNIMATE=ON"
+  ]
+  ++ lib.optionals (qt != null && lib.versions.major qt.qtbase.version == "6") [
+    "-DMOD_QT6=ON"
+    "-DMOD_QT=OFF"
+    "-DMOD_GLAXNIMATE_QT6=ON"
   ];
 
   preFixup = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes build with latest ffmpeg.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
