### PR TITLE
unicode-paracode: use unicode-character-database for UnicodeData.txt

### DIFF
--- a/pkgs/by-name/un/unicode-paracode/package.nix
+++ b/pkgs/by-name/un/unicode-paracode/package.nix
@@ -5,6 +5,7 @@
   python3Packages,
   installShellFiles,
   gitUpdater,
+  unicode-character-database,
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -27,18 +28,13 @@ python3Packages.buildPythonApplication rec {
     })
   ];
 
-  ucdtxt = fetchurl {
-    url = "https://www.unicode.org/Public/16.0.0/ucd/UnicodeData.txt";
-    sha256 = "sha256-/1jlgjvQlRZlZKAG5H0RETCBPc+L8jTvefpRqHDttI8=";
-  };
-
   nativeBuildInputs = [ installShellFiles ];
 
   build-system = with python3Packages; [ setuptools ];
 
   postFixup = ''
     substituteInPlace "$out/bin/.unicode-wrapped" \
-      --replace-fail "/usr/share/unicode/UnicodeData.txt" "$ucdtxt"
+      --replace-fail "/usr/share/unicode/UnicodeData.txt" "${unicode-character-database}/share/unicode/UnicodeData.txt"
   '';
 
   postInstall = ''


### PR DESCRIPTION
Right now, unicode-paracode uses UnicodeData.txt from Unicode 16, which is out of date. We have that file packaged already – let's reuse it!

Before:

```console
$ unicode -s 🫪 --terse
🫪 U+1FAEA  - No such unicode character name in database
```

After:

```console
$ unicode --s 🫪 --terse
🫪 U+1FAEA DISTORTED FACE
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
