### PR TITLE
Add cloudflare ddns to module list

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1123,6 +1123,7 @@
   ./services/networking/chisel-server.nix
   ./services/networking/cjdns.nix
   ./services/networking/clatd.nix
+  ./services/networking/cloudflare-ddns.nix
   ./services/networking/cloudflare-dyndns.nix
   ./services/networking/cloudflare-warp.nix
   ./services/networking/cloudflared.nix

--- a/nixos/modules/services/networking/cloudflare-ddns.nix
+++ b/nixos/modules/services/networking/cloudflare-ddns.nix
@@ -22,9 +22,8 @@ in
       description = ''
         Path to a file containing the Cloudflare API authentication token.
         The file content should be in the format `CLOUDFLARE_API_TOKEN=YOUR_SECRET_TOKEN`.
-        The service user `${cfg.user}` needs read access to this file.
+        The service user needs read access to this file.
         Ensure permissions are secure (e.g., `0400` or `0440`) and ownership is appropriate
-        (e.g., `owner = root`, `group = ${cfg.group}`).
         Using `CLOUDFLARE_API_TOKEN` is preferred over the deprecated `CF_API_TOKEN`.
       '';
       example = "/run/secrets/cloudflare-ddns-token";

--- a/nixos/modules/services/networking/cloudflare-ddns.nix
+++ b/nixos/modules/services/networking/cloudflare-ddns.nix
@@ -324,4 +324,7 @@ in
       };
     };
   };
+  meta.maintainers = with lib.maintainers; [
+    shokerplz
+  ];
 }

--- a/pkgs/by-name/cl/cloudflare-ddns/package.nix
+++ b/pkgs/by-name/cl/cloudflare-ddns/package.nix
@@ -29,7 +29,7 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/favonia/cloudflare-ddns";
     mainProgram = "ddns";
     license = licenses.asl20;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ shokerplz ];
     platforms = platforms.unix ++ platforms.darwin;
   };
 })


### PR DESCRIPTION
Added myself as a maintainer to both cloudflare-ddns package and module.
Added cloudflare-ddns module to module-list.nix
Fixed description for the cloudflare-ddns module

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
  - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
