### PR TITLE
detect: init at 0.3.0

### DIFF
--- a/pkgs/by-name/de/detect/package.nix
+++ b/pkgs/by-name/de/detect/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "detect";
+  version = "0.3.0";
+
+  # if we use fetchCrate the tests fail, because the fixtures weren't included in the published crate
+  src = fetchFromGitHub {
+    owner = "inanna-malick";
+    repo = "detect";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-8aLvHBt4HPpVb4676l7V1bZ3YJQ5W3/LZZU5oRCk+K4=";
+  };
+
+  cargoHash = "sha256-hAjFnpOgb31yQWVFFNGP0E8kT6G6OhB90kfkJsQtaWg=";
+
+  meta = {
+    description = "Expression-based file search combining name, content, metadata, and structured data predicates";
+    homepage = "https://github.com/inanna-malick/detect/";
+    changelog = "https://github.com/inanna-malick/detect/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = with lib.licenses; [
+      mit # or
+      asl20
+    ];
+    maintainers = with lib.maintainers; [ lilyball ];
+    mainProgram = "detect";
+  };
+})


### PR DESCRIPTION
`detect` is a replacement for find/grep using an expression language.

https://github.com/inanna-malick/detect/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
