### PR TITLE
haskell.compiler.ghc9141: init at 9.14.1

### DIFF
--- a/pkgs/development/compilers/ghc/9.14.1.nix
+++ b/pkgs/development/compilers/ghc/9.14.1.nix
@@ -1,0 +1,4 @@
+import ./common-hadrian.nix {
+  version = "9.14.1";
+  sha256 = "2a83779c9af86554a3289f2787a38d6aa83d00d136aa9f920361dd693c101e77";
+}

--- a/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
@@ -1,0 +1,90 @@
+{ pkgs, haskellLib }:
+
+self: super:
+
+let
+  inherit (pkgs) lib;
+
+  warnAfterVersion =
+    ver: pkg:
+    lib.warnIf (lib.versionOlder ver
+      super.${pkg.pname}.version
+    ) "override for haskell.packages.ghc912.${pkg.pname} may no longer be needed" pkg;
+
+in
+
+with haskellLib;
+
+{
+  # Disable GHC core libraries
+  array = null;
+  base = null;
+  binary = null;
+  bytestring = null;
+  Cabal = null;
+  Cabal-syntax = null;
+  containers = null;
+  deepseq = null;
+  directory = null;
+  exceptions = null;
+  file-io = null;
+  filepath = null;
+  ghc-bignum = null;
+  ghc-boot = null;
+  ghc-boot-th = null;
+  ghc-compact = null;
+  ghc-experimental = null;
+  ghc-heap = null;
+  ghc-internal = null;
+  ghc-platform = null;
+  ghc-prim = null;
+  ghc-toolchain = null;
+  ghci = null;
+  haddock-api = null;
+  haddock-library = null;
+  haskeline = null;
+  hpc = null;
+  integer-gmp = null;
+  mtl = null;
+  os-string = null;
+  parsec = null;
+  pretty = null;
+  process = null;
+  rts = null;
+  semaphore-compat = null;
+  stm = null;
+  system-cxx-std-lib = null;
+  template-haskell = null;
+  template-haskell-lift = null;
+  template-haskell-quasiquoter = null;
+  # GHC only builds terminfo if it is a native compiler
+  terminfo =
+    if pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform then
+      null
+    else
+      haskellLib.doDistribute self.terminfo_0_4_1_7;
+  text = null;
+  time = null;
+  transformers = null;
+  unix = null;
+  xhtml = null;
+  Win32 = null;
+
+  #
+  # Version upgrades
+  #
+
+  #
+  # Jailbreaks
+  #
+
+  primitive = doJailbreak (dontCheck super.primitive); # base <4.22 and a lot of dependencies on packages not yet working.
+  splitmix = doJailbreak super.splitmix; # base <4.22
+
+  # https://github.com/sjakobi/newtype-generics/pull/28/files
+  newtype-generics = warnAfterVersion "0.6.2" (doJailbreak super.newtype-generics);
+
+  #
+  # Test suite issues
+  #
+}

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -134,6 +134,15 @@ in
         inherit buildTargetLlvmPackages llvmPackages;
       };
       ghc912 = compiler.ghc9122;
+      ghc9141 = callPackage ../development/compilers/ghc/9.14.1.nix {
+        bootPkgs =
+          # No suitable bindist packaged yet
+          bb.packages.ghc9103;
+        inherit (buildPackages.python3Packages) sphinx;
+        inherit (buildPackages.darwin) xattr autoSignDarwinBinariesHook;
+        inherit buildTargetLlvmPackages llvmPackages;
+      };
+      ghc914 = compiler.ghc9141;
       ghcHEAD = callPackage ../development/compilers/ghc/head.nix {
         bootPkgs = bb.packages.ghc984Binary;
         inherit (buildPackages.python3Packages) sphinx;
@@ -221,6 +230,12 @@ in
         compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-9.12.x.nix { };
       };
       ghc912 = packages.ghc9122;
+      ghc9141 = callPackage ../development/haskell-modules {
+        buildHaskellPackages = bh.packages.ghc9141;
+        ghc = bh.compiler.ghc9141;
+        compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-9.14.x.nix { };
+      };
+      ghc914 = packages.ghc9141;
       ghcHEAD = callPackage ../development/haskell-modules {
         buildHaskellPackages = bh.packages.ghcHEAD;
         ghc = bh.compiler.ghcHEAD;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This is a WIP for ghc 9.14.

Done:

- [X] Build of ghc 9.14 (currently -rc1)
- [ ] WIP: started to add some override for packages. I'm currently trying to use that at work and will progressively refine the branch with my findings.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
