### PR TITLE
dockerTools: preserve xattrs from buildImage root-layer and layeredIm…

### DIFF
--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -98,6 +98,7 @@ let
       cp /bin/test-script /test-script
       bin/setcap 'cap_net_bind_service=+ep' /test-script
     '';
+    preserveXAttrsInRootLayer = true;
   };
 
   layeredXattrsTestImage = pkgs.dockerTools.streamLayeredImage {
@@ -111,6 +112,7 @@ let
       cp bin/test-script test-script
       bin/setcap 'cap_net_bind_service=+ep' test-script
     '';
+    preserveXAttrsInRootLayer = true;
   };
 in
 {

--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -563,7 +563,7 @@ rec {
 
         echo "Packing layer..."
         mkdir -p $out
-        tarhash=$(tar -C layer --hard-dereference --sort=name --mtime="@$SOURCE_DATE_EPOCH" -cf - . |
+        tarhash=$(tar --xattrs --xattrs-include='*' -C layer --hard-dereference --sort=name --mtime="@$SOURCE_DATE_EPOCH" -cf - . |
                     tee -p $out/layer.tar |
                     ${lib.getExe tarsum})
 
@@ -1092,6 +1092,7 @@ rec {
                   source $stdenv/setup
                   eval "$fakeRootCommands"
                   tar \
+                    --xattrs --xattrs-include='"'"'*'"'"' \
                     --sort name \
                     --exclude=./dev \
                     --exclude=./proc \
@@ -1111,6 +1112,7 @@ rec {
                   cd old_out
                   eval "$fakeRootCommands"
                   tar \
+                    --xattrs --xattrs-include='"'"'*'"'"' \
                     --sort name \
                     --numeric-owner --mtime "@$SOURCE_DATE_EPOCH" \
                     --hard-dereference \


### PR DESCRIPTION
Docker build preserves xattrs from RUN-statements:
https://github.com/moby/moby/pull/47175

One usecase is adding effective file caps, e.g.: https://github.com/coredns/coredns/blob/master/Dockerfile#L9

Currently there's no way to do this with dockerTools. Afaik, you cannot add security wrappers to images.

This PR adds preservation of xattrs in the tar'ed layers from `runAsRoot` and `fakeRootCommands`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
