### PR TITLE
cssmodules-language-server: init at 1.5.2

### DIFF
--- a/pkgs/by-name/cs/cssmodules-language-server/package.nix
+++ b/pkgs/by-name/cs/cssmodules-language-server/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "cssmodules-language-server";
+  version = "1.5.2";
+
+  src = fetchFromGitHub {
+    owner = "antonk52";
+    repo = "cssmodules-language-server";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-9RZNXdmBP4OK7k/0LuuvqxYGG2fESYTCFNCkAWZQapk=";
+  };
+
+  npmDepsHash = "sha256-1CnCgut0Knf97+YHVJGUZqnRId/BwHw+jH1YPIrDPCA=";
+
+  meta = {
+    description = "Language server for autocompletion and go-to-definition functionality for css modules";
+    changelog = "https://github.com/antonk52/cssmodules-language-server/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/antonk52/cssmodules-language-server";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nicknb ];
+    mainProgram = "cssmodules-language-server";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Adds cssmodules-language-server.

https://github.com/antonk52/cssmodules-language-server

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
