### PR TITLE
nixos/etc-overlay: pad the mode when building the composefs dump

### DIFF
--- a/nixos/modules/system/etc/build-composefs-dump.py
+++ b/nixos/modules/system/etc/build-composefs-dump.py
@@ -61,7 +61,15 @@ class ComposefsPath:
         self.path = path
         self.size = size
         self.filetype = filetype
-        self.mode = mode
+
+        match len(mode):
+            case 3 | 4:
+                # We need to pad the mode, because we will later use the concatentation
+                # filetype|mode, which assumes that the mode has a length of 4.
+                self.mode = f"{mode:0>4}"
+            case _:
+                raise ValueError(f"mode should be 3 or 4 octal digits, got: {mode}")
+
         self.uid = attrs["uid"]
         self.gid = attrs["gid"]
         self.payload = payload

--- a/nixos/tests/activation/etc-overlay-immutable.nix
+++ b/nixos/tests/activation/etc-overlay-immutable.nix
@@ -11,6 +11,17 @@
       system.etc.overlay.enable = true;
       system.etc.overlay.mutable = false;
 
+      environment.etc = {
+        modetest = {
+          text = "foo";
+          mode = "300";
+        };
+        modetest2 = {
+          text = "foo";
+          mode = "0300";
+        };
+      };
+
       # Prerequisites
       systemd.sysusers.enable = true;
       users.mutableUsers = false;
@@ -48,6 +59,10 @@
 
       with subtest("/etc is mounted as an overlay"):
         machine.succeed("findmnt --kernel --type overlay /etc")
+
+      with subtest("modes work correctly"):
+        machine.succeed("stat --format '%F' /etc/modetest | tee /dev/stderr | grep -q 'regular file'")
+        machine.succeed("stat --format '%F' /etc/modetest2 | tee /dev/stderr | grep -q 'regular file'")
 
       with subtest("direct symlinks point to the target without indirection"):
         assert machine.succeed("readlink -n /etc/localtime") == "/etc/zoneinfo/Utc"

--- a/nixos/tests/activation/etc-overlay-mutable.nix
+++ b/nixos/tests/activation/etc-overlay-mutable.nix
@@ -11,6 +11,17 @@
       system.etc.overlay.enable = true;
       system.etc.overlay.mutable = true;
 
+      environment.etc = {
+        modetest = {
+          text = "foo";
+          mode = "300";
+        };
+        modetest2 = {
+          text = "foo";
+          mode = "0300";
+        };
+      };
+
       # Prerequisites
       boot.initrd.systemd.enable = true;
       boot.kernelPackages = pkgs.linuxPackages_latest;
@@ -36,6 +47,12 @@
 
       with subtest("/etc is mounted as an overlay"):
         machine.succeed("findmnt --kernel --type overlay /etc")
+
+      with subtest("modes work correctly"):
+        machine.succeed("stat --format '%F' /etc/modetest | tee /dev/stderr | grep -Eq '^regular file$'")
+        machine.succeed("stat --format '%a' /etc/modetest | tee /dev/stderr | grep -Eq '^300$'")
+        machine.succeed("stat --format '%F' /etc/modetest2 | tee /dev/stderr | grep -Eq '^regular file$'")
+        machine.succeed("stat --format '%a' /etc/modetest2 | tee /dev/stderr | grep -Eq '^300$'")
 
       with subtest("switching to the same generation"):
         machine.succeed("/run/current-system/bin/switch-to-configuration test")


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Fixes https://github.com/NixOS/nixpkgs/issues/462972

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
