### PR TITLE
various: maintenance updates for multiple packages

### DIFF
--- a/pkgs/by-name/au/autotrash/package.nix
+++ b/pkgs/by-name/au/autotrash/package.nix
@@ -41,7 +41,7 @@ python3Packages.buildPythonPackage rec {
     description = "Tool to automatically purge old trashed files";
     license = lib.licenses.gpl3Plus;
     homepage = "https://bneijt.nl/pr/autotrash";
-    changelog = "https://github.com/bneijt/autotrash/releases/tag/${src.tag}";
+    changelog = "https://github.com/bneijt/autotrash/releases/tag/${version}";
     maintainers = with lib.maintainers; [
       sigmanificient
       mithicspirit

--- a/pkgs/by-name/ba/banana-vera/package.nix
+++ b/pkgs/by-name/ba/banana-vera/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "Epitech";
     repo = "banana-vera";
     tag = "v${finalAttrs.version}";
-    sha256 = "sha256-sSN3trSySJe3KVyrb/hc5HUGRS4M3c4UX9SLlzBM43c=";
+    hash = "sha256-sSN3trSySJe3KVyrb/hc5HUGRS4M3c4UX9SLlzBM43c=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/by-name/ca/cano/package.nix
+++ b/pkgs/by-name/ca/cano/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "CobbCoding1";
     repo = "Cano";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-OaWj0AKw3+sEhcAbIjgOLfxwCKRG6O1k+zSp0GnnFn8=";
   };
 

--- a/pkgs/by-name/ci/cista/package.nix
+++ b/pkgs/by-name/ci/cista/package.nix
@@ -5,26 +5,26 @@
   cmake,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "cista";
   version = "0.16";
 
   src = fetchFromGitHub {
     owner = "felixguendling";
     repo = "cista";
-    rev = "v${version}";
-    sha256 = "sha256-Q7IDQckFa/iMZ/f3Bim/yWyKCGqsNxJJ5C9PTToFZYI=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Q7IDQckFa/iMZ/f3Bim/yWyKCGqsNxJJ5C9PTToFZYI=";
   };
 
   nativeBuildInputs = [ cmake ];
 
   cmakeFlags = [ "-DCISTA_INSTALL=ON" ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://cista.rocks";
     description = "Simple, high-performance, zero-copy C++ serialization & reflection library";
-    license = licenses.mit;
-    maintainers = [ maintainers.sigmanificient ];
-    platforms = platforms.all;
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.sigmanificient ];
+    platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/co/coost/package.nix
+++ b/pkgs/by-name/co/coost/package.nix
@@ -17,14 +17,14 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "idealvin";
     repo = "coost";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-HbMenAL/UWsqQ1o7cMeWfwXkLh4GxIKV7iuZQD3hDA8=";
   };
 
   postPatch = ''
     substituteInPlace cmake/coost.pc.in \
-      --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
-      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@ \
+      --replace-fail '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
+      --replace-fail '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@ \
   '';
 
   nativeBuildInputs = [ cmake ];
@@ -45,11 +45,11 @@ stdenv.mkDerivation (finalAttrs: {
     allowedVersions = "^[0-9]";
   };
 
-  meta = with lib; {
+  meta = {
     description = "Tiny boost library in C++11";
     homepage = "https://github.com/idealvin/coost";
-    license = licenses.mit;
-    maintainers = [ maintainers.sigmanificient ];
-    platforms = platforms.unix;
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.sigmanificient ];
+    platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/cp/cppi/package.nix
+++ b/pkgs/by-name/cp/cppi/package.nix
@@ -4,13 +4,13 @@
   stdenv,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "cppi";
   version = "1.18";
 
   src = fetchurl {
-    url = "mirror://gnu/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "1jk42cjaggk71rimjnx3qpmb6hivps0917vl3z7wbxk3i2whb98j";
+    url = "mirror://gnu/cppi/cppi-${finalAttrs.version}.tar.xz";
+    hash = "sha256-EqUFuYhj9sXPH3SfkIC+O0Kz6sWjW1ljDme+pyQTZMo=";
   };
 
   doCheck = true;
@@ -34,4 +34,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ sigmanificient ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/cr/criterion/package.nix
+++ b/pkgs/by-name/cr/criterion/package.nix
@@ -36,14 +36,14 @@ let
     hash = "sha256-+GaI5nXz4jYI0rO17xDhNtFpLlGL2WzeSVLMfB6Cl6E=";
   };
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "criterion";
   version = "2.4.2";
 
   src = fetchFromGitHub {
     owner = "Snaipe";
     repo = "Criterion";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-5GH7AYjrnBnqiSmp28BoaM1Xmy8sPs1atfqJkGy3Yf0=";
   };
@@ -98,7 +98,7 @@ stdenv.mkDerivation rec {
     testers.testVersion {
       package = criterion;
       command = "${lib.getExe tester} --version";
-      version = "v${version}";
+      version = "v${finalAttrs.version}";
     };
 
   meta = {
@@ -112,4 +112,4 @@ stdenv.mkDerivation rec {
     ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/di/diagrams-as-code/package.nix
+++ b/pkgs/by-name/di/diagrams-as-code/package.nix
@@ -37,7 +37,7 @@ python3Packages.buildPythonPackage rec {
   doCheck = false; # no tests
 
   passthru.tests = {
-    simple = runCommand "${pname}-test" { } ''
+    simple = runCommand "diagrams-as-code-test" { } ''
       # giving full path to diagrams-as-code causes
       # a bad path concatenation
       cp ${diagrams-as-code.src}/examples/all-fields.yaml .

--- a/pkgs/by-name/fi/filterpath/package.nix
+++ b/pkgs/by-name/fi/filterpath/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "Sigmanificient";
     repo = "filterpath";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-GW8f3o7D5ddHQ8WZvds6rcsKPmlTSr/w4k2mU7oR6aM=";
   };
 

--- a/pkgs/by-name/fz/fzf-make/package.nix
+++ b/pkgs/by-name/fz/fzf-make/package.nix
@@ -16,7 +16,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "kyu08";
     repo = "fzf-make";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-KL2dRyfwwa365hEMeVixAP9DFx3QObJVeesj95tOUmo=";
   };
 
@@ -39,7 +39,7 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Fuzzy finder for Makefile";
     inherit (src.meta) homepage;
-    changelog = "https://github.com/kyu08/fzf-make/releases/tag/${src.rev}";
+    changelog = "https://github.com/kyu08/fzf-make/releases/tag/v${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       sigmanificient

--- a/pkgs/by-name/gb/gbsplay/package.nix
+++ b/pkgs/by-name/gb/gbsplay/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "mmitch";
     repo = "gbsplay";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-vsfpBhx3bNs6hQDO+xAPWFsf8L8fMtfdU5XKjF/r6PA=";
   };
 

--- a/pkgs/by-name/gf/gfold/package.nix
+++ b/pkgs/by-name/gf/gfold/package.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "nickgerace";
     repo = "gfold";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-sPvhZaDGInXH2PT8fg28m7wyDZiIE4fFScNO8WIjV9s=";
   };
 

--- a/pkgs/by-name/gi/git-pr/package.nix
+++ b/pkgs/by-name/gi/git-pr/package.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "picosh";
     repo = "git-pr";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-2A2rP7yr8faVoIYAWprr+t7MwDPerhsuOjWWEl1mhXw=";
   };
 

--- a/pkgs/by-name/gi/git-standup/package.nix
+++ b/pkgs/by-name/gi/git-standup/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "kamranahmedse";
     repo = "git-standup";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-x7Z4w4UzshXYc25ag6HopRrKbP+/ELkFPdsUBaUE1vY=";
   };
 
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Recall what you did on the last working day";
     homepage = "https://github.com/kamranahmedse/git-standup";
-    changelog = "https://github.com/kamranahmedse/git-standup/releases/tag/${finalAttrs.src.rev}";
+    changelog = "https://github.com/kamranahmedse/git-standup/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ sigmanificient ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/he/hexedit/package.nix
+++ b/pkgs/by-name/he/hexedit/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "pixel";
     repo = "hexedit";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-fIgPbr7qmxyEga2YaAD0+NBM8LeDm/tVAq99ub7aiAI=";
   };
 

--- a/pkgs/by-name/hu/hueadm/package.nix
+++ b/pkgs/by-name/hu/hueadm/package.nix
@@ -11,7 +11,7 @@ buildNpmPackage rec {
   src = fetchFromGitHub {
     owner = "bahamas10";
     repo = "hueadm";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-QNjkfE8V/lUkYP8NAf11liKXILBk3wSNm3NSrgaH+nc=";
   };
 

--- a/pkgs/by-name/ks/ksh/package.nix
+++ b/pkgs/by-name/ks/ksh/package.nix
@@ -17,14 +17,14 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "att";
     repo = "ast";
-    sha256 = "0cdxz0nhpq03gb9rd76fn0x1yzs2c8q289b7vcxnzlsrz1imz65j";
+    hash = "sha256-sphfY/hZ028722clJDBiQn8fOrDOnJbTegPgCy34vTE=";
     tag = finalAttrs.version;
   };
 
   patches = [
     (fetchpatch {
       url = "https://github.com/att/ast/commit/11983a71f5e29df578b7e2184400728b4e3f451d.patch";
-      sha256 = "1n9558c4v2qpgpjb1vafs29n3qn3z0770wr1ayc0xjf5z5j4g3kv";
+      hash = "sha256-e45HZPnFyQ6YVyFzcA74w+Jhk9BO7bDkfReLTRgqJdk=";
     })
   ];
 

--- a/pkgs/by-name/li/liboqs/package.nix
+++ b/pkgs/by-name/li/liboqs/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "open-quantum-safe";
     repo = "liboqs";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-ATnI1QFFljTmMib6oOCiieDQMTwnEe+xIvcAzrz3bbI=";
   };
 
@@ -47,11 +47,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     description = "C library for prototyping and experimenting with quantum-resistant cryptography";
     homepage = "https://openquantumsafe.org";
-    license = licenses.mit;
-    platforms = platforms.all;
-    maintainers = [ maintainers.sigmanificient ];
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.sigmanificient ];
   };
 })

--- a/pkgs/by-name/li/libowlevelzs/package.nix
+++ b/pkgs/by-name/li/libowlevelzs/package.nix
@@ -5,15 +5,15 @@
   stdenv,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libowlevelzs";
   version = "0.1.1";
 
   src = fetchFromGitHub {
     owner = "fogti";
     repo = "libowlevelzs";
-    rev = "v${version}";
-    sha256 = "y/EaMMsmJEmnptfjwiat4FC2+iIKlndC2Wdpop3t7vY=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-y/EaMMsmJEmnptfjwiat4FC2+iIKlndC2Wdpop3t7vY=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -25,4 +25,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ sigmanificient ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/li/libsv/package.nix
+++ b/pkgs/by-name/li/libsv/package.nix
@@ -5,24 +5,24 @@
   cmake,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libsv";
   version = "1.2";
 
   src = fetchFromGitHub {
     owner = "uael";
     repo = "sv";
-    rev = "v${version}";
-    sha256 = "sha256-sc7WTRY8XTm5+J+zlS7tGa2f+2d7apj+XHyBafZXXeE=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-sc7WTRY8XTm5+J+zlS7tGa2f+2d7apj+XHyBafZXXeE=";
   };
 
   nativeBuildInputs = [ cmake ];
 
-  meta = with lib; {
+  meta = {
     description = "Public domain cross-platform semantic versioning in C99";
     homepage = "https://github.com/uael/sv";
-    license = licenses.unlicense;
+    license = lib.licenses.unlicense;
     maintainers = [ lib.maintainers.sigmanificient ];
-    platforms = platforms.unix;
+    platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/mi/mini-calc/package.nix
+++ b/pkgs/by-name/mi/mini-calc/package.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "vanilla-extracts";
     repo = "calc";
-    rev = version;
+    tag = version;
     hash = "sha256-601BmecY+jbiD39buN68MeJKd5wguH0hahHquHadsL4=";
   };
 

--- a/pkgs/by-name/np/nph/package.nix
+++ b/pkgs/by-name/np/nph/package.nix
@@ -22,7 +22,7 @@ buildNimPackage' (finalAttrs: {
   src = fetchFromGitHub {
     owner = "arnetheduck";
     repo = "nph";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-RIuggg09l7jZDg91FPrjwdoE+gCxgb7c8fEvCiwQk5U=";
   };
 

--- a/pkgs/by-name/ph/physac/package.nix
+++ b/pkgs/by-name/ph/physac/package.nix
@@ -28,8 +28,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     includedir=$out/include
 
     Name: physac
-    Description: ${finalAttrs.meta.description}
-    URL: ${finalAttrs.meta.homepage}
+    Description: 2D physics header-only library for raylib
+    URL: https://github.com/victorfisac/Physac
     Version: ${finalAttrs.version}
     Cflags: -I"{includedir}"
     EOF

--- a/pkgs/by-name/ps/ps_mem/package.nix
+++ b/pkgs/by-name/ps/ps_mem/package.nix
@@ -12,7 +12,7 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "pixelb";
     repo = "ps_mem";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-jCfPtPSky/QFk9Xo/tq3W7609Pie1yLC4iS4dqjCa+E=";
   };
 

--- a/pkgs/by-name/ra/ragnarwm/package.nix
+++ b/pkgs/by-name/ra/ragnarwm/package.nix
@@ -19,14 +19,14 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "cococry";
     repo = "Ragnar";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-OZhIwrKEhTfkw9K8nZIwGZzxXBObseWS92Y+85HmdNs=";
   };
 
   prePatch = ''
     substituteInPlace Makefile \
-      --replace '/usr/bin' "$out/bin" \
-      --replace '/usr/share' "$out/share"
+      --replace-fail '/usr/bin' "$out/bin" \
+      --replace-fail '/usr/share' "$out/share"
   '';
 
   postPatch =

--- a/pkgs/by-name/ra/rasm/package.nix
+++ b/pkgs/by-name/ra/rasm/package.nix
@@ -4,14 +4,14 @@
   fetchFromGitHub,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "rasm";
   version = "3.0";
 
   src = fetchFromGitHub {
     owner = "EdouardBERGE";
     repo = "rasm";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-pRDfaQVqR7OVwSKh2dMU4QjEb5SGQ2eoG8g9aUJwrXU=";
   };
 
@@ -31,4 +31,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ sigmanificient ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/ra/raygui/package.nix
+++ b/pkgs/by-name/ra/raygui/package.nix
@@ -28,8 +28,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     includedir=$out/include
 
     Name: raygui
-    Description: ${finalAttrs.meta.description}
-    URL: ${finalAttrs.meta.homepage}
+    Description: Simple and easy-to-use immediate-mode gui library
+    URL: https://github.com/raysan5/raygui
     Version: ${finalAttrs.version}
     Cflags: -I"{includedir}"
     EOF

--- a/pkgs/by-name/sx/sxcs/package.nix
+++ b/pkgs/by-name/sx/sxcs/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
     domain = "codeberg.org";
     owner = "NRK";
     repo = "sxcs";
-    rev = "refs/tags/v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-rYmbbdZjeLCvGvNocI3+KVU2KBkYvRisayTyScTRay8=";
   };
 

--- a/pkgs/by-name/to/toolong/package.nix
+++ b/pkgs/by-name/to/toolong/package.nix
@@ -38,11 +38,11 @@ python3Packages.buildPythonApplication {
     command = "${lib.getExe toolong} --version";
   };
 
-  meta = with lib; {
+  meta = {
     description = "Terminal application to view, tail, merge, and search log files (plus JSONL)";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     homepage = "https://github.com/textualize/toolong";
-    maintainers = with maintainers; [ sigmanificient ];
+    maintainers = with lib.maintainers; [ sigmanificient ];
     mainProgram = "tl";
   };
 }

--- a/pkgs/by-name/tu/tuifimanager/package.nix
+++ b/pkgs/by-name/tu/tuifimanager/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  python3,
+  python3Packages,
   fetchFromGitHub,
   kdePackages,
   gnome-themes-extra,
@@ -18,7 +18,7 @@
 lib.throwIf (enableDragAndDrop && !hasDndSupport)
   "Drag and drop support is only available for linux with xorg."
 
-  python3.pkgs.buildPythonApplication
+  python3Packages.buildPythonApplication
   rec {
     pname = "tuifimanager";
     version = "5.1.5";
@@ -32,7 +32,7 @@ lib.throwIf (enableDragAndDrop && !hasDndSupport)
       hash = "sha256-5ShrmjEFKGdmaGBFjMnIfcM6p8AZd13uIEFwDVAkU/8=";
     };
 
-    build-system = with python3.pkgs; [
+    build-system = with python3Packages; [
       setuptools
       setuptools-scm
     ];
@@ -44,15 +44,15 @@ lib.throwIf (enableDragAndDrop && !hasDndSupport)
         makeWrapper
       ]);
 
-    propagatedBuildInputs = [
-      python3.pkgs.send2trash
-      python3.pkgs.unicurses
+    dependencies = [
+      python3Packages.send2trash
+      python3Packages.unicurses
     ]
     ++ (lib.optionals enableDragAndDrop [
-      python3.pkgs.pynput
-      python3.pkgs.pyside6
-      python3.pkgs.requests
-      python3.pkgs.xlib
+      python3Packages.pynput
+      python3Packages.pyside6
+      python3Packages.requests
+      python3Packages.xlib
       kdePackages.qtbase
       kdePackages.qt6gtk2
     ]);

--- a/pkgs/by-name/un/unipicker/package.nix
+++ b/pkgs/by-name/un/unipicker/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "jeremija";
     repo = "unipicker";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Br9nCK5eWoSN1i4LM2F31B62L9vuN5KzjS9pC9lq9oM=";
   };
 

--- a/pkgs/by-name/us/ustr/package.nix
+++ b/pkgs/by-name/us/ustr/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchgit {
     url = "http://www.and.org/ustr/ustr.git";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-pQrQy+S9fVFl8Mop4QmwEAXGiBSheQE4HgAZ4srFz64=";
   };
 

--- a/pkgs/by-name/vi/viu/package.nix
+++ b/pkgs/by-name/vi/viu/package.nix
@@ -13,8 +13,8 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "atanunq";
     repo = "viu";
-    rev = "v${version}";
-    sha256 = "sha256-sx8BH01vTFsAEnMKTcVZTDMHiVi230BVVGRexoBNxeo=";
+    tag = "v${version}";
+    hash = "sha256-sx8BH01vTFsAEnMKTcVZTDMHiVi230BVVGRexoBNxeo=";
   };
 
   # tests need an interactive terminal
@@ -25,11 +25,11 @@ rustPlatform.buildRustPackage rec {
   buildFeatures = lib.optional withSixel "sixel";
   buildInputs = lib.optional withSixel libsixel;
 
-  meta = with lib; {
+  meta = {
     description = "Command-line application to view images from the terminal written in Rust";
     homepage = "https://github.com/atanunq/viu";
-    license = licenses.mit;
-    maintainers = with maintainers; [
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
       chuangzhu
       sigmanificient
     ];

--- a/pkgs/by-name/xm/xml-tooling-c/package.nix
+++ b/pkgs/by-name/xm/xml-tooling-c/package.nix
@@ -12,13 +12,13 @@
   xml-security-c,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "xml-tooling-c";
   version = "3.3.0";
 
   src = fetchgit {
     url = "https://git.shibboleth.net/git/cpp-xmltooling.git";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-czmBu7ThDwq+x7FahgZDMHqid8jeUNnTuKMI/Fj4IIw=";
   };
 
@@ -50,4 +50,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.sigmanificient ];
   };
-}
+})

--- a/pkgs/by-name/yy/yyjson/package.nix
+++ b/pkgs/by-name/yy/yyjson/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "ibireme";
     repo = "yyjson";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-1CYnEgUMUc7eqdkv6M/KyL/MdVQBMov9HgLCycF6++w=";
   };
 
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Fastest JSON library in C";
     homepage = "https://github.com/ibireme/yyjson";
-    changelog = "https://github.com/ibireme/yyjson/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/ibireme/yyjson/blob/${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ sigmanificient ];
     platforms = lib.platforms.all;


### PR DESCRIPTION
- Switch from 'rev' to 'tag' attribute in fetchFromGitHub/fetchgit calls
- Update 'sha256' to 'hash' for consistency
- Convert to finalAttrs pattern where applicable
- Replace 'with lib' with explicit lib prefixes
- Use 'replace-fail' variants for substitutions
- Update python3.pkgs to python3Packages pattern
- Switch propagatedBuildInputs to dependencies for Python packages
- Fix .pc file meta attribute interpolation

Affected packages: autotrash, banana-vera, cano, cista, coost, cppi, criterion, diagrams-as-code, filterpath, fzf-make, gbsplay, gfold, git-pr, git-standup, hexedit, hueadm, ksh, liboqs, libowlevelzs, libsv, mini-calc, nph, physac, ps_mem, ragnarwm, rasm, raygui, sxcs, toolong, tuifimanager, unipicker, ustr, viu, xml-tooling-c, yyjson


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
