### PR TITLE
python313Packages.pytest-postgresql: 6.0.0 -> 7.0.2

### DIFF
--- a/pkgs/development/python-modules/port-for/default.nix
+++ b/pkgs/development/python-modules/port-for/default.nix
@@ -8,19 +8,20 @@
 
 buildPythonPackage rec {
   pname = "port-for";
-  version = "0.7.1";
+  version = "1.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "kmike";
     repo = "port-for";
     tag = "v${version}";
-    hash = "sha256-/45TQ2crmTupRgL9hgZGw5IvFKywezSIHqHFbeAkMoo=";
+    hash = "sha256-vv2xjXyUh6g7T0zGDAlOs3K+YM18wSE8rEvgSP1ZBL4=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
 
   nativeCheckInputs = [ pytestCheckHook ];
+
   pythonImportsCheck = [ "port_for" ];
 
   meta = {

--- a/pkgs/development/python-modules/pytest-postgresql/default.nix
+++ b/pkgs/development/python-modules/pytest-postgresql/default.nix
@@ -7,6 +7,7 @@
   pytest-cov-stub,
   setuptools,
   mirakuru,
+  packaging,
   port-for,
   psycopg,
   pytest,
@@ -15,21 +16,21 @@
 
 buildPythonPackage rec {
   pname = "pytest-postgresql";
-  version = "6.0.0";
+  version = "7.0.2";
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "ClearcodeHQ";
+    owner = "dbfixtures";
     repo = "pytest-postgresql";
     tag = "v${version}";
-    hash = "sha256-6D9QNcfq518ORQDYCH5G+LLJ7tVWPFwB6ylZR3LOZ5g=";
+    hash = "sha256-/EekUveW3wb8NlcKacMJpjjU7bpFvnNMpAuZ9h0sbpw=";
   };
 
   postPatch = ''
-    substituteInPlace pyproject.toml  \
-      --replace-fail "--max-worker-restart=0" ""
     sed -i 's#/usr/lib/postgresql/.*/bin/pg_ctl#${postgresql}/bin/pg_ctl#' pytest_postgresql/plugin.py
   '';
+
+  build-system = [ setuptools ];
 
   buildInputs = [ pytest ];
 
@@ -37,7 +38,7 @@ buildPythonPackage rec {
     mirakuru
     port-for
     psycopg
-    setuptools # requires 'pkg_resources' at runtime
+    packaging
   ];
 
   nativeCheckInputs = [
@@ -50,12 +51,14 @@ buildPythonPackage rec {
   ];
   disabledTestPaths = [ "tests/docker/test_noproc_docker.py" ]; # requires Docker
   disabledTests = [
-    # permissions issue running pg as Nixbld user
-    "test_executor_init_with_password"
     # "ValueError: Pytest terminal summary report not found"
+    "test_postgres_drop_test_database"
     "test_postgres_loader_in_cli"
+    "test_postgres_loader_in_ini"
     "test_postgres_options_config_in_cli"
     "test_postgres_options_config_in_ini"
+    "test_postgres_port_search_count_in_cli_is_int"
+    "test_postgres_port_search_count_in_ini_is_int"
   ];
   pythonImportsCheck = [
     "pytest_postgresql"
@@ -69,7 +72,7 @@ buildPythonPackage rec {
   meta = {
     homepage = "https://pypi.python.org/pypi/pytest-postgresql";
     description = "Pytest plugin that enables you to test code on a temporary PostgreSQL database";
-    changelog = "https://github.com/ClearcodeHQ/pytest-postgresql/blob/v${version}/CHANGES.rst";
+    changelog = "https://github.com/dbfixtures/pytest-postgresql/blob/v${version}/CHANGES.rst";
     license = lib.licenses.lgpl3Plus;
     maintainers = with lib.maintainers; [ bcdarwin ];
   };


### PR DESCRIPTION
python313Packages.port-for: 0.7.1 -> 1.0.0

Routine update (note change of repo URL; old now redirects to new) [pytest-postgresql changelog](https://github.com/dbfixtures/pytest-postgresql/blob/main/CHANGES.rst) [port-for changelog](https://github.com/fizyk/port-for/blob/master/CHANGES.rst)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
