### PR TITLE
ci/github-script/bot: skip expired artifacts, log PR author; ci/github-script/reviewers: convert all usernames to lowercase

### DIFF
--- a/ci/github-script/bot.js
+++ b/ci/github-script/bot.js
@@ -152,6 +152,8 @@ module.exports = async ({ github, context, core, dry }) => {
       })
     ).data
 
+    log('author', pull_request.user?.login)
+
     const maintainers = await getMaintainerMap(pull_request.base.ref)
 
     const merge_bot_eligible = await handleMerge({

--- a/ci/github-script/bot.js
+++ b/ci/github-script/bot.js
@@ -46,7 +46,7 @@ module.exports = async ({ github, context, core, dry }) => {
           name: 'maintainers',
         })
       ).data.artifacts[0]
-      if (!artifact) continue
+      if (!artifact || artifact.expired) continue
 
       await artifactClient.downloadArtifact(artifact.id, {
         findBy: {

--- a/ci/github-script/reviewers.js
+++ b/ci/github-script/reviewers.js
@@ -14,7 +14,7 @@ async function handleReviewers({
   const pull_number = pull_request.number
 
   const requested_reviewers = new Set(
-    pull_request.requested_reviewers.map(({ login }) => login),
+    pull_request.requested_reviewers.map(({ login }) => login.toLowerCase()),
   )
   log(
     'reviewers - requested_reviewers',
@@ -22,7 +22,7 @@ async function handleReviewers({
   )
 
   const existing_reviewers = new Set(
-    reviews.map(({ user }) => user?.login).filter(Boolean),
+    reviews.map(({ user }) => user?.login.toLowerCase()).filter(Boolean),
   )
   log(
     'reviewers - existing_reviewers',
@@ -43,9 +43,11 @@ async function handleReviewers({
 
   const users = new Set([
     ...(await Promise.all(
-      maintainers.map(async (id) => (await getUser(id)).login),
+      maintainers.map(async (id) => (await getUser(id)).login.toLowerCase()),
     )),
-    ...owners.filter((handle) => handle && !handle.includes('/')),
+    ...owners
+      .filter((handle) => handle && !handle.includes('/'))
+      .map((handle) => handle.toLowerCase()),
   ])
   log('reviewers - users', Array.from(users).join(', '))
 
@@ -60,14 +62,14 @@ async function handleReviewers({
   const team_members = new Set(
     (await Promise.all(Array.from(teams, getTeamMembers)))
       .flat(1)
-      .map(({ login }) => login),
+      .map(({ login }) => login.toLowerCase()),
   )
   log('reviewers - team_members', Array.from(team_members).join(', '))
 
   const new_reviewers = users
     .union(team_members)
     // We can't request a review from the author.
-    .difference(new Set([pull_request.user?.login]))
+    .difference(new Set([pull_request.user?.login.toLowerCase()]))
   log('reviewers - new_reviewers', Array.from(new_reviewers).join(', '))
 
   // Filter users to repository collaborators. If they're not, they can't be requested


### PR DESCRIPTION
The bot workflow has been broken since https://github.com/NixOS/nixpkgs/actions/runs/19564993901.

- **ci/github-script/bot: skip expired artifacts**
  Should prevent "Unhandled error: HttpError: Artifact has expired", as was present in https://github.com/NixOS/nixpkgs/actions/runs/19594659032 and many others recently, or at least allow fallback to master for PRs that target other branches.
- **ci/github-script/bot: log author of pull request**
  Would help in debugging future issues like the next one.
- **ci/github-script/reviewers: convert all usernames to lowercase**
  Should fix https://github.com/nixos/nixpkgs/pull/463686#issuecomment-3563126753

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
