### PR TITLE
zaread: init at 0-unstable-2025-11-11

### DIFF
--- a/pkgs/by-name/za/zaread/package.nix
+++ b/pkgs/by-name/za/zaread/package.nix
@@ -1,0 +1,59 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  lib,
+  zathura,
+  libreoffice,
+  libreofficeSupport ? true,
+  md2pdf,
+  markdownSupport ? true,
+  calibre,
+  mobiSupport ? true,
+  typst,
+  typstSupport ? true,
+  makeWrapper,
+  bashNonInteractive,
+}:
+
+stdenv.mkDerivation {
+  pname = "zaread";
+  version = "0-unstable-2025-11-11";
+
+  src = fetchFromGitHub {
+    owner = "paoloap";
+    repo = "zaread";
+    rev = "d4935a72d19bf9c5c035c1363ef798574b6738e7";
+    hash = "sha256-4tqi9tvFqB5MZIEluqVmmMWH+hN1c2Jy10C1/iGI6e4=";
+  };
+
+  pathAdd = lib.makeBinPath (
+    [
+      zathura
+    ]
+    ++ lib.optionals libreofficeSupport [ libreoffice ]
+    ++ lib.optionals markdownSupport [ md2pdf ]
+    ++ lib.optionals mobiSupport [ calibre ]
+    ++ lib.optionals typstSupport [ typst ]
+  );
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ bashNonInteractive ];
+  dontBuild = true;
+
+  installPhase = ''
+    install -Dm 755 $src/zaread $out/bin/zaread
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/zaread --prefix PATH : $pathAdd
+  '';
+
+  meta = {
+    description = "Lightweight document reader";
+    homepage = "https://github.com/paoloap/zaread";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ nicknb ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
Adds zaread, a lightweight document reader using zathura.

https://github.com/paoloap/zaread

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

