### PR TITLE
python3Packages.langchain-core: 1.0.7 -> 1.1.0; python3Packages.langchain-tests: 1.0.1 -> 1.0.2; python3Packages.anthropic: 0.71.0 -> 0.75.0; python3Packages.langchain-anthropic: 1.0.0 -> 1.2.0

### DIFF
--- a/pkgs/development/python-modules/anthropic/default.nix
+++ b/pkgs/development/python-modules/anthropic/default.nix
@@ -34,14 +34,14 @@
 
 buildPythonPackage rec {
   pname = "anthropic";
-  version = "0.71.0";
+  version = "0.75.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "anthropics";
     repo = "anthropic-sdk-python";
     tag = "v${version}";
-    hash = "sha256-n8hu2RFuZN0ojHhhU4qPQaT2DUvqSglFhBo2ORln/mc=";
+    hash = "sha256-wwaH9/o7qr8eXKvmKpj+/ubOdDydcXId/qiA6dXpd2I=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/langchain-anthropic/default.nix
+++ b/pkgs/development/python-modules/langchain-anthropic/default.nix
@@ -12,6 +12,7 @@
   pydantic,
 
   # tests
+  blockbuster,
   langchain,
   langchain-tests,
   pytest-asyncio,
@@ -23,14 +24,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-anthropic";
-  version = "1.0.0";
+  version = "1.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-anthropic==${version}";
-    hash = "sha256-3kW5w98t5F199k14MoCY2dZGrC/HdBzKuRpM37EY3LQ=";
+    hash = "sha256-dmuDgKQW1yAz/8tjQx7LaUiuz5Sh4cAyd9nt33mCPbI=";
   };
 
   sourceRoot = "${src.name}/libs/partners/anthropic";
@@ -43,21 +44,23 @@ buildPythonPackage rec {
     pydantic
   ];
 
-  pythonRelaxDeps = [
-    # Each component release requests the exact latest core.
-    # That prevents us from updating individual components.
-    "langchain-core"
-  ];
-
   nativeCheckInputs = [
+    blockbuster
     langchain
     langchain-tests
     pytest-asyncio
     pytestCheckHook
   ];
 
-  disabledTestPaths = [
-    "tests/integration_tests"
+  enabledTestPaths = [
+    "tests/unit_tests"
+  ];
+
+  disabledTests = [
+    # TypeError from Pydantic
+    # https://github.com/langchain-ai/langchain/issues/34068
+    "test_creates_bash_tool"
+    "test_replaces_tool_with_claude_descriptor"
   ];
 
   pythonImportsCheck = [ "langchain_anthropic" ];

--- a/pkgs/development/python-modules/langchain-core/default.nix
+++ b/pkgs/development/python-modules/langchain-core/default.nix
@@ -36,14 +36,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-core";
-  version = "1.0.7";
+  version = "1.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-core==${version}";
-    hash = "sha256-esMMA9z8z9Q909buPGZP1jujEWzdXT+Mxlwvjz0XqKk=";
+    hash = "sha256-uDMex+2wvvNvdFSTHjShsrJeeMymOMKCmfS+AyMMH6c=";
   };
 
   sourceRoot = "${src.name}/libs/core";

--- a/pkgs/development/python-modules/langchain-tests/default.nix
+++ b/pkgs/development/python-modules/langchain-tests/default.nix
@@ -30,14 +30,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-tests";
-  version = "1.0.1";
+  version = "1.0.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-tests==${version}";
-    hash = "sha256-a7tqW4h34YbfUIAK2L417egaSNyKbvZJ+GEnPdC2wME=";
+    hash = "sha256-ke/nIvZRtwyeN5uQuqOjJ4KdE+cJOc9XkmDuT+nnZpQ=";
   };
 
   sourceRoot = "${src.name}/libs/standard-tests";


### PR DESCRIPTION
1. `python3Packages.langchain-core`: bump to 1.1.0 to support anthropic API 0.75.0
2. `python3Packages.langchain-tests`: bump to 1.0.2 to pick up fixed tests (n.b. requires `blockbuster`, see https://github.com/langchain-ai/langchain/issues/34110)
3. `python3Packages.anthropic`: version bump via update script.
4. `python3Packages.langchain-anthropic`: version bump, disabled broken tests & filed upstream issues, `disabledTestPaths` -> `enabledTestPaths` per convention.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
