### PR TITLE
nixos/programs/fish: use runCommandLocal consistently

### DIFF
--- a/nixos/modules/programs/fish.nix
+++ b/nixos/modules/programs/fish.nix
@@ -337,5 +337,8 @@ in
       '';
 
   };
-  meta.maintainers = with lib.maintainers; [ sigmasquadron ];
+  meta.maintainers = with lib.maintainers; [
+    llakala
+    sigmasquadron
+  ];
 }

--- a/nixos/modules/programs/fish.nix
+++ b/nixos/modules/programs/fish.nix
@@ -7,7 +7,6 @@
 
 let
   cfge = config.environment;
-
   cfg = config.programs.fish;
 
   fishAbbrs = lib.concatStringsSep "\n" (
@@ -21,9 +20,7 @@ let
   );
 
   envShellInit = pkgs.writeText "shellInit" cfge.shellInit;
-
   envLoginShellInit = pkgs.writeText "loginShellInit" cfge.loginShellInit;
-
   envInteractiveShellInit = pkgs.writeText "interactiveShellInit" cfge.interactiveShellInit;
 
   # Need to use --no-config to prevent fish_indent from trying to read from config
@@ -52,7 +49,6 @@ let
     pkgs.runCommandLocal "${name}.fish" {
       nativeBuildInputs = [ pkgs.babelfish ];
     } "babelfish < ${path} > $out;";
-
 in
 {
   options = {

--- a/nixos/modules/programs/fish.nix
+++ b/nixos/modules/programs/fish.nix
@@ -302,8 +302,7 @@ in
       # include programs that bring their own completions
       {
         pathsToLink =
-          [ ]
-          ++ lib.optional cfg.vendor.config.enable "/share/fish/vendor_conf.d"
+          lib.optional cfg.vendor.config.enable "/share/fish/vendor_conf.d"
           ++ lib.optional cfg.vendor.completions.enable "/share/fish/vendor_completions.d"
           ++ lib.optional cfg.vendor.functions.enable "/share/fish/vendor_functions.d";
       }

--- a/nixos/modules/programs/fish.nix
+++ b/nixos/modules/programs/fish.nix
@@ -30,7 +30,7 @@ let
   # See https://github.com/fish-shell/fish-shell/issues/12079
   indentFishFile =
     name: text:
-    pkgs.runCommand name {
+    pkgs.runCommandLocal name {
       nativeBuildInputs = [ cfg.package ];
       inherit text;
       passAsFile = [ "text" ];
@@ -49,8 +49,7 @@ let
 
   babelfishTranslate =
     path: name:
-    pkgs.runCommand "${name}.fish" {
-      preferLocalBuild = true;
+    pkgs.runCommandLocal "${name}.fish" {
       nativeBuildInputs = [ pkgs.babelfish ];
     } "babelfish < ${path} > $out;";
 
@@ -275,7 +274,7 @@ in
             };
             generateCompletions =
               package:
-              pkgs.runCommand
+              pkgs.runCommandLocal
                 (
                   with lib.strings;
                   let
@@ -287,7 +286,6 @@ in
                 (
                   {
                     inherit package;
-                    preferLocalBuild = true;
                   }
                   // lib.optionalAttrs (package ? meta.priority) { meta.priority = package.meta.priority; }
                 )

--- a/nixos/modules/programs/fish.nix
+++ b/nixos/modules/programs/fish.nix
@@ -272,8 +272,8 @@ in
               package:
               pkgs.runCommandLocal
                 (
-                  with lib.strings;
                   let
+                    inherit (lib.strings) stringLength substring storeDir;
                     storeLength = stringLength storeDir + 34; # Nix' StorePath::HashLen + 2 for the separating slash and dash
                     pathName = substring storeLength (stringLength package - storeLength) package;
                   in


### PR DESCRIPTION
There were several places where `preferLocalBuild` was used, but that doesn't actually affect substituters - only whether remote build machines are used (see the relevant section of [the manual](https://nix.dev/manual/nix/2.32/language/advanced-attributes.html?highlight=preferLocal#build-scheduling)). I was hitting some calls to `cache.nixos.org` when building offline that definitely were never going to hit, so I think disabling substituters here is best. It might be better to keep the substituters for generating completions, though - open to feedback on this one.

Also included some small refactors, and added myself as a maintainer of the module.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
