### PR TITLE
maintainers: drop andrewchambers

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1646,12 +1646,6 @@
     githubId = 9131943;
     name = "Andrew Bastin";
   };
-  andrewchambers = {
-    email = "ac@acha.ninja";
-    github = "andrewchambers";
-    githubId = 962885;
-    name = "Andrew Chambers";
-  };
   andrewfield = {
     email = "andrew_field@hotmail.co.uk";
     github = "andrew-field";

--- a/pkgs/by-name/bu/bupstash/package.nix
+++ b/pkgs/by-name/bu/bupstash/package.nix
@@ -40,7 +40,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://bupstash.io";
     license = licenses.mit;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ andrewchambers ];
+    maintainers = [ ];
     mainProgram = "bupstash";
   };
 }

--- a/pkgs/by-name/re/redo-apenwarr/package.nix
+++ b/pkgs/by-name/re/redo-apenwarr/package.nix
@@ -83,7 +83,6 @@ stdenv.mkDerivation rec {
     description = "Smaller, easier, more powerful, and more reliable than make. An implementation of djb's redo";
     homepage = "https://github.com/apenwarr/redo";
     maintainers = with maintainers; [
-      andrewchambers
       ck3d
     ];
     license = licenses.asl20;

--- a/pkgs/development/interpreters/janet/default.nix
+++ b/pkgs/development/interpreters/janet/default.nix
@@ -69,7 +69,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://janet-lang.org/";
     license = licenses.mit;
     maintainers = with maintainers; [
-      andrewchambers
       peterhoeg
     ];
     platforms = platforms.all;


### PR DESCRIPTION
- Hasn't commented since [January 2023](https://github.com/NixOS/nixpkgs/issues?q=commenter:andrewchambers),
- hasn't opened any tickets themselves since [December 2021](https://github.com/NixOS/nixpkgs/issues?q=author:andrewchambers)
- was requested a lot since then [with no reaction](https://github.com/NixOS/nixpkgs/issues?q=is:pr+involves:andrewchambers+-commenter:andrewchambers+-author:andrewchambers+-reviewed-by:andrewchambers),

all of which are longer than the 3 months, specified in the [maintainer README](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status), which makes them eligible for removal from Nixpkgs. Also not a member of the `nixos/nixpkgs-maintainers` team (either hasn't joined, or left at some point) and thus can't be requested for a review.

Andrew @andrewchambers, you have a week (until 19:00 UTC, Nov 29) to object and show us your intent to continue maintenance. Even if you don't make it, you're still welcome back.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
