### PR TITLE
python3Packages.symbex: revert disabled tests due to click issue

### DIFF
--- a/pkgs/development/python-modules/symbex/default.nix
+++ b/pkgs/development/python-modules/symbex/default.nix
@@ -39,6 +39,8 @@ buildPythonPackage rec {
     # Fails with `TypeError: CliRunner.__init__() got an unexpected keyword argument 'mix_std...`
     # https://github.com/simonw/symbex/issues/48
     "test_errors"
+    # Fails with AssertionError (SystemExit(1).stdout is '' not the expected message)
+    "test_output"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/symbex/default.nix
+++ b/pkgs/development/python-modules/symbex/default.nix
@@ -35,6 +35,12 @@ buildPythonPackage rec {
     writableTmpDirAsHomeHook
   ];
 
+  disabledTests = [
+    # Fails with `TypeError: CliRunner.__init__() got an unexpected keyword argument 'mix_std...`
+    # https://github.com/simonw/symbex/issues/48
+    "test_errors"
+  ];
+
   meta = {
     description = "Find the Python code for specified symbols";
     homepage = "https://github.com/simonw/symbex";

--- a/pkgs/development/python-modules/symbex/default.nix
+++ b/pkgs/development/python-modules/symbex/default.nix
@@ -35,15 +35,6 @@ buildPythonPackage rec {
     writableTmpDirAsHomeHook
   ];
 
-  disabledTests = [
-    # Broken due to click 8.2.0 update
-    # https://github.com/simonw/symbex/issues/48
-    "test_output"
-    "test_replace"
-    "test_replace_errors"
-    "test_errors"
-  ];
-
   meta = {
     description = "Find the Python code for specified symbols";
     homepage = "https://github.com/simonw/symbex";


### PR DESCRIPTION
1. Reverts the `symbex` portion of #454329 now that #459528 is merged
2. Disables `test_errors` that fails due to a removed keyword in click >= 8.2.0.
3. Disables `test_output` that fails due to `SystemExit(1).stdout` returning an empty string.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
