### PR TITLE
nixos-rebuild: add `-F` convenience flag for `--flake`

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/nixos-rebuild.8.scd
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/nixos-rebuild.8.scd
@@ -279,7 +279,7 @@ It must be one of the following:
 	attribute path from file specified by the *--file* option. If specified
 	without *--file* option, uses _default.nix_ in current directory.
 
-*--flake* _flake-uri[#name]_
+*--flake* _flake-uri[#name]_, *-F* _flake-uri[#name]_
 	Build the NixOS system from the specified flake. It defaults to the
 	directory containing the target of the symlink _/etc/nixos/flake.nix_,
 	if it exists. The flake must contain an output named

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -100,6 +100,7 @@ def get_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.ArgumentPa
     )
     main_parser.add_argument(
         "--flake",
+        "-F",
         nargs="?",
         const=True,
         help="Build the NixOS system from the specified flake",

--- a/pkgs/os-specific/linux/nixos-rebuild/_nixos-rebuild
+++ b/pkgs/os-specific/linux/nixos-rebuild/_nixos-rebuild
@@ -51,7 +51,7 @@ _nixos-rebuild() {
 
     # flakes options
     --commit-lock-file
-    --flake # flake-uri
+    --flake -F # flake-uri
     --override-input # input-name flake-uri
     --recreate-lock-file
     --update-input

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.8
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.8
@@ -21,7 +21,7 @@
 .br
 .Op Fl -file | f Ar path
 .Op Fl -attr | A Ar attrPath
-.Op Fl -flake Ar flake-uri
+.Op Fl -flake | F Ar flake-uri
 .Op Fl -no-flake
 .Op Fl -recreate-lock-file
 .Op Fl -no-update-lock-file

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -176,7 +176,7 @@ while [ "$#" -gt 0 ]; do
       --no-ssh-tty)
         noSSHTTY=1
         ;;
-      --flake)
+      --flake|-F)
         flake="$1"
         shift 1
         ;;


### PR DESCRIPTION
One of my frustrations when using nixos-rebuild is that I'm constantly having to type out the full `--flake`. Hoping I can make this better. Added to both the `-ng` version and the old bash one.

Haven't done this before - let me know if I missed anything!
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
