### PR TITLE
lanraragi: 0.9.50 -> 0.9.60

### DIFF
--- a/pkgs/by-name/la/lanraragi/lower-version-reqs.patch
+++ b/pkgs/by-name/la/lanraragi/lower-version-reqs.patch
@@ -1,0 +1,13 @@
+diff --git a/tools/cpanfile b/tools/cpanfile
+index e70c6e7..1fb5860 100644
+--- a/tools/cpanfile
++++ b/tools/cpanfile
+@@ -33,7 +33,7 @@ requires 'Test::Harness',    3.42;
+ requires 'Test::MockObject', 1.20200122;
+ requires 'Test::Trap',       0.3.4;
+ requires 'Test::Deep',       1.130;
+-requires 'Test::MockModule', 0.180;
++requires 'Test::MockModule', 0.177;
+ 
+ # Mojo stuff
+ requires 'Mojolicious',                          9.39;

--- a/pkgs/by-name/la/lanraragi/vips-lib-path.patch
+++ b/pkgs/by-name/la/lanraragi/vips-lib-path.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/LANraragi/Utils/Vips.pm b/lib/LANraragi/Utils/Vips.pm
+index fba395e..0579bdc 100644
+--- a/lib/LANraragi/Utils/Vips.pm
++++ b/lib/LANraragi/Utils/Vips.pm
+@@ -20,7 +20,7 @@ my $glib_ffi = undef;
+ my $gobject_ffi = undef;
+ 
+ if (IS_UNIX) {
+-    my @vips_libs = find_lib(lib => [ 'vips', 'vips-42' ]);
++    my @vips_libs = find_lib(lib => [ 'vips', 'vips-42' ], libpath => '@vips_lib@');
+     my $lib_path;
+ 
+     if (@vips_libs) {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -12970,10 +12970,10 @@ with self;
 
   FFIPlatypus = buildPerlPackage {
     pname = "FFI-Platypus";
-    version = "2.09";
+    version = "2.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/FFI-Platypus-2.09.tar.gz";
-      hash = "sha256-nTEjEiieeHNbRcMRt6wWqejaCT93m/aUaccK+sTdW2M=";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/FFI-Platypus-2.10.tar.gz";
+      hash = "sha256-ZxFcAjF7I9EZtu4aXm1fJvr4mFlD61PPiGLFcZ54+28=";
     };
     buildInputs = [
       AlienFFI


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
## Summary of changes
Update from the current version [0.9.50](https://github.com/Difegue/LANraragi/releases/tag/v.0.9.50) to the most recent, [0.9.60](https://github.com/Difegue/LANraragi/releases/tag/v.0.9.60)

This new version has a lot of new changes that must be addressed.
Here's the overview:
- Supports libvips instead of ImageMagick (for better performance)
- There's now integration tests [link](https://github.com/psilabs-dev/aio-lanraragi) as seen in this [PR](https://github.com/Difegue/LANraragi/pull/1344)
- Fixes a memory leak on 0.9.50

I'm wondering if it's worth it to try and support the tests via passthru or if it should be updated, just rechecking the current patches and adding the new dependency.

@TomaSajt 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
