### PR TITLE
python3Packages.timezonefinder: 8.0.0 -> 8.1.0

### DIFF
--- a/pkgs/development/python-modules/timezonefinder/default.nix
+++ b/pkgs/development/python-modules/timezonefinder/default.nix
@@ -2,15 +2,15 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  poetry-core,
+  setuptools,
   cffi,
   flatbuffers,
   h3,
-  numba,
   numpy,
-  poetry-core,
-  pytestCheckHook,
-  setuptools,
+  numba,
   pydantic,
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -62,12 +62,12 @@ buildPythonPackage rec {
     "tests/utils_test.py"
   ];
 
-  meta = with lib; {
-    description = "Module for finding the timezone of any point on earth (coordinates) offline";
+  meta = {
+    description = "Find the timezone of any point on earth (coordinates) offline";
     homepage = "https://github.com/MrMinimal64/timezonefinder";
     changelog = "https://github.com/jannikmi/timezonefinder/blob/${src.tag}/CHANGELOG.rst";
-    license = licenses.mit;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "timezonefinder";
   };
 }

--- a/pkgs/development/python-modules/timezonefinder/default.nix
+++ b/pkgs/development/python-modules/timezonefinder/default.nix
@@ -10,18 +10,19 @@
   poetry-core,
   pytestCheckHook,
   setuptools,
+  pydantic,
 }:
 
 buildPythonPackage rec {
   pname = "timezonefinder";
-  version = "8.0.0";
+  version = "8.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jannikmi";
     repo = "timezonefinder";
     tag = version;
-    hash = "sha256-AvuNsIpJBZymlJe4HLPEmHfxN1jhqPmrEgRPb3W+B3E=";
+    hash = "sha256-jIsS8RcbMNhj5Z/AYbNyVsbQOozbk75tXSLRqhez9Ug=";
   };
 
   build-system = [
@@ -40,6 +41,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     numba
+    pydantic
     pytestCheckHook
   ];
 


### PR DESCRIPTION
Fix https://hydra.nixos.org/build/313506353
Tracking: #457852

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
