### PR TITLE
{bitmap,editres,fonttosfnt,iceauth,oclock,setxkbmap}: refactor & move to pkgs/by-name from xorg namespace

### DIFF
--- a/pkgs/by-name/bi/bitmap/package.nix
+++ b/pkgs/by-name/bi/bitmap/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  pkg-config,
+  util-macros,
+  autoreconfHook,
+  wrapWithXFileSearchPathHook,
+  libx11,
+  libxaw,
+  xbitmaps,
+  libxmu,
+  xorgproto,
+  libxt,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "bitmap";
+  version = "1.1.1";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "app";
+    repo = "bitmap";
+    tag = "bitmap-${finalAttrs.version}";
+    hash = "sha256-UZxPc19jAqvJPwZSMf4seqxJNHeLOXA8bXh4y6D4gRE=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    util-macros
+    autoreconfHook
+    wrapWithXFileSearchPathHook
+  ];
+
+  buildInputs = [
+    libx11
+    libxaw
+    xbitmaps
+    libxmu
+    xorgproto
+    libxt
+  ];
+
+  installFlags = [ "appdefaultdir=$(out)/share/X11/app-defaults" ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=bitmap-(.*)" ]; };
+  meta = {
+    description = "X bitmap (XBM) editor and converter utilities";
+    homepage = "https://gitlab.freedesktop.org/xorg/app/bitmap";
+    license = lib.licenses.mitOpenGroup;
+    mainProgram = "bitmap";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/ed/editres/package.nix
+++ b/pkgs/by-name/ed/editres/package.nix
@@ -1,40 +1,70 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitLab,
   pkg-config,
-  libXt,
-  libXaw,
-  libXres,
-  utilmacros,
+  util-macros,
+  autoreconfHook,
+  wrapWithXFileSearchPathHook,
+  libx11,
+  libxaw,
+  libxkbfile,
+  libxmu,
+  libxres,
+  libxt,
+  xorgproto,
+  nix-update-script,
 }:
-
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "editres";
-  version = "1.0.8";
+  version = "1.0.9";
 
-  src = fetchurl {
-    url = "mirror://xorg/individual/app/editres-${version}.tar.gz";
-    sha256 = "sha256-LVbWB3vHZ6+n4DD+ssNy/mvok/7EApoj9FodVZ/YRq4=";
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "app";
+    repo = "editres";
+    tag = "editres-${finalAttrs.version}";
+    hash = "sha256-fdp6j8zS8mtzHpG9js9c8iIt1vsKsqGG9MdkpLh8UB0=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [
-    libXt
-    libXaw
-    libXres
-    utilmacros
-  ];
-
-  configureFlags = [ "--with-appdefaultdir=$(out)/share/X11/app-defaults/editres" ];
+  strictDeps = true;
 
   hardeningDisable = [ "format" ];
 
-  meta = with lib; {
-    homepage = "https://cgit.freedesktop.org/xorg/app/editres/";
+  nativeBuildInputs = [
+    pkg-config
+    util-macros
+    autoreconfHook
+    wrapWithXFileSearchPathHook
+  ];
+
+  buildInputs = [
+    libx11
+    libxaw
+    libxkbfile
+    libxmu
+    libxres
+    libxt
+    xorgproto
+  ];
+
+  installFlags = [ "appdefaultdir=$(out)/share/X11/app-defaults" ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=editres-(.*)" ]; };
+
+  meta = {
     description = "Dynamic resource editor for X Toolkit applications";
-    license = licenses.mit;
-    platforms = platforms.linux;
+    longDescription = ''
+      Editres is a tool that allows users and application developers to view the full widget
+      hierarchy of any Xt Toolkit application that speaks the Editres protocol. In addition, editres
+      will help the user construct resource specifications, allow the user to apply the resource
+      to the application and view the results dynamically. Once the user is happy with a resource
+      specification editres will append the resource string to the user's X Resources file.
+    '';
+    homepage = "https://gitlab.freedesktop.org/xorg/app/editres";
+    license = lib.licenses.mitOpenGroup;
     mainProgram = "editres";
+    platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/fo/fonttosfnt/package.nix
+++ b/pkgs/by-name/fo/fonttosfnt/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  pkg-config,
+  util-macros,
+  autoreconfHook,
+  libfontenc,
+  freetype,
+  xorgproto,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fonttosfnt";
+  version = "1.2.4";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "app";
+    repo = "fonttosfnt";
+    tag = "fonttosfnt-${finalAttrs.version}";
+    hash = "sha256-DPPouSLsPurJ7fscxraF9HEYENbuCvZcxZ44bBY7ytU=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    util-macros
+    autoreconfHook
+  ];
+
+  buildInputs = [
+    libfontenc
+    freetype
+    xorgproto
+  ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=fonttosfnt-(.*)" ]; };
+
+  meta = {
+    description = "Wraps a set of bdf or pcf bitmap fonts in a sfnt (TrueType or OpenType) wrapper";
+    homepage = "https://gitlab.freedesktop.org/xorg/app/fonttosfnt";
+    license = lib.licenses.mit;
+    mainProgram = "fonttosfnt";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+    # something about missing `gzgetc` `gzopen` and `gzclose`
+    # works on pkgsMusl so definitely a static problem
+    broken = stdenv.hostPlatform.isStatic;
+  };
+})

--- a/pkgs/by-name/ic/iceauth/package.nix
+++ b/pkgs/by-name/ic/iceauth/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  pkg-config,
+  util-macros,
+  autoreconfHook,
+  xorgproto,
+  libice,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "iceauth";
+  version = "1.0.10";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "app";
+    repo = "iceauth";
+    tag = "iceauth-${finalAttrs.version}";
+    hash = "sha256-XAk+hffmX02/0wJlXZVSY325I1AyiJ6AozJizsv39Mg=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    util-macros
+    autoreconfHook
+  ];
+
+  buildInputs = [
+    xorgproto
+    libice
+  ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=iceauth-(.*)" ]; };
+
+  meta = {
+    description = "libICE authority file utility";
+    longDescription = ''
+      The iceauth program is used to edit and display the authorization information used in
+      connecting with ICE (the X11 Inter-Client Exchange protocol). It operates very much like the
+      xauth program for X11 connection authentication records.
+    '';
+    homepage = "https://gitlab.freedesktop.org/xorg/app/iceauth";
+    license = lib.licenses.mitOpenGroup;
+    mainProgram = "iceauth";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/oc/oclock/package.nix
+++ b/pkgs/by-name/oc/oclock/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  pkg-config,
+  util-macros,
+  autoreconfHook,
+  libxkbfile,
+  libx11,
+  libxext,
+  libxmu,
+  libxt,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "oclock";
+  version = "1.0.6";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "app";
+    repo = "oclock";
+    tag = "oclock-${finalAttrs.version}";
+    hash = "sha256-rk+PV2iEoqRwXN8bq0kCPk0qW0VPwid1T1XrH+Y9yLw=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    util-macros
+    autoreconfHook
+  ];
+
+  buildInputs = [
+    libxkbfile
+    libx11
+    libxext
+    libxmu
+    libxt
+  ];
+
+  installFlags = [ "appdefaultdir=$(out)/share/X11/app-defaults" ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=oclock-(.*)" ]; };
+
+  meta = {
+    description = "simple analog clock using the X11 SHAPE extension to make a round window";
+    homepage = "https://gitlab.freedesktop.org/xorg/app/oclock";
+    license = with lib.licenses; [
+      mitOpenGroup
+      x11
+    ];
+    mainProgram = "oclock";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/se/setxkbmap/package.nix
+++ b/pkgs/by-name/se/setxkbmap/package.nix
@@ -1,0 +1,58 @@
+# TODO: replace build system with meson next update
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  pkg-config,
+  util-macros,
+  autoreconfHook,
+  libx11,
+  libxkbfile,
+  libxrandr,
+  xkeyboard-config,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "setxkbmap";
+  version = "1.3.4";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "app";
+    repo = "setxkbmap";
+    tag = "setxkbmap-${finalAttrs.version}";
+    hash = "sha256-eEh1rifV+XY5RuKbA3Rgn9vmQPnyWvSae/m5lZA3FGE=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    util-macros
+    autoreconfHook
+  ];
+
+  buildInputs = [
+    libx11
+    libxkbfile
+    libxrandr
+  ];
+
+  configureFlags = [ "--with-xkb-config-root=${xkeyboard-config}/etc/X11/xkb" ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=setxkbmap-(.*)" ]; };
+
+  meta = {
+    description = "Set keymaps, layouts, and options via the X Keyboard Extension (XKB)";
+    longDescription = ''
+      setxkbmap is an X11 client to change the keymaps in the X server for a specified keyboard to
+      use the layout determined by the options listed on the command line.
+    '';
+    homepage = "https://gitlab.freedesktop.org/xorg/app/setxkbmap";
+    license = lib.licenses.hpnd;
+    mainProgram = "setxkbmap";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -104,6 +104,7 @@
   oclock,
   pixman,
   sessreg,
+  setxkbmap,
   smproxy,
   tab-window-manager,
   transset,
@@ -182,6 +183,7 @@ self: with self; {
     oclock
     pixman
     sessreg
+    setxkbmap
     smproxy
     transset
     viewres
@@ -347,44 +349,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xtrap" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  setxkbmap = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      libxkbfile,
-      libXrandr,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "setxkbmap";
-      version = "1.3.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/setxkbmap-1.3.4.tar.xz";
-        sha256 = "1pps0x66512y3f7v6xgnb6gjbllsgi4q5zxmjcdiv60fsia8b3dy";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libX11
-        libxkbfile
-        libXrandr
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -4,6 +4,7 @@
   appres,
   bdftopcf,
   bitmap,
+  editres,
   font-adobe-100dpi,
   font-adobe-75dpi,
   font-adobe-utopia-100dpi,
@@ -157,6 +158,7 @@ self: with self; {
     appres
     bdftopcf
     bitmap
+    editres
     gccmakedep
     ico
     imake
@@ -303,54 +305,6 @@ self: with self; {
   xorgcffiles = xorg-cf-files;
   xorgdocs = xorg-docs;
   xorgsgmldoctools = xorg-sgml-doctools;
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  editres = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libxkbfile,
-      libX11,
-      libXaw,
-      libXmu,
-      xorgproto,
-      libXt,
-      wrapWithXFileSearchPathHook,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "editres";
-      version = "1.0.9";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/editres-1.0.9.tar.xz";
-        sha256 = "1imk7mgdc3q9lf058xisajij374x8r31ynvqmwbs9khfdxx3zz6d";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        wrapWithXFileSearchPathHook
-      ];
-      buildInputs = [
-        libxkbfile
-        libX11
-        libXaw
-        libXmu
-        xorgproto
-        libXt
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
 
   # THIS IS A GENERATED FILE.  DO NOT EDIT!
   fonttosfnt = callPackage (

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -101,6 +101,7 @@
   luit,
   makedepend,
   mkfontscale,
+  oclock,
   pixman,
   sessreg,
   smproxy,
@@ -178,6 +179,7 @@ self: with self; {
     luit
     makedepend
     mkfontscale
+    oclock
     pixman
     sessreg
     smproxy
@@ -345,52 +347,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xtrap" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  oclock = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libxkbfile,
-      libX11,
-      libXext,
-      libXmu,
-      libXt,
-      wrapWithXFileSearchPathHook,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "oclock";
-      version = "1.0.6";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/oclock-1.0.6.tar.xz";
-        sha256 = "1gi41nmf5glvzasri0glka19h6gkpbiy0bwbvdxwl7i15mg5xs1y";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        wrapWithXFileSearchPathHook
-      ];
-      buildInputs = [
-        libxkbfile
-        libX11
-        libXext
-        libXmu
-        libXt
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -44,6 +44,7 @@
   font-winitzki-cyrillic,
   font-xfree86-type1,
   gccmakedep,
+  iceauth,
   ico,
   imake,
   libapplewm,
@@ -162,6 +163,7 @@ self: with self; {
     editres
     fonttosfnt
     gccmakedep
+    iceauth
     ico
     imake
     libdmx
@@ -307,42 +309,6 @@ self: with self; {
   xorgcffiles = xorg-cf-files;
   xorgdocs = xorg-docs;
   xorgsgmldoctools = xorg-sgml-doctools;
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  iceauth = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libICE,
-      xorgproto,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "iceauth";
-      version = "1.0.10";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/iceauth-1.0.10.tar.xz";
-        sha256 = "0ad0kbr5bfdk9na3jmjpg26gd6hwv4lxja2nkdwxrybal9yzpvix";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libICE
-        xorgproto
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
 
   # THIS IS A GENERATED FILE.  DO NOT EDIT!
   libXTrap = callPackage (

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -39,6 +39,7 @@
   font-screen-cyrillic,
   font-sony-misc,
   font-sun-misc,
+  fonttosfnt,
   font-util,
   font-winitzki-cyrillic,
   font-xfree86-type1,
@@ -159,6 +160,7 @@ self: with self; {
     bdftopcf
     bitmap
     editres
+    fonttosfnt
     gccmakedep
     ico
     imake
@@ -305,44 +307,6 @@ self: with self; {
   xorgcffiles = xorg-cf-files;
   xorgdocs = xorg-docs;
   xorgsgmldoctools = xorg-sgml-doctools;
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fonttosfnt = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libfontenc,
-      freetype,
-      xorgproto,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "fonttosfnt";
-      version = "1.2.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/fonttosfnt-1.2.4.tar.xz";
-        sha256 = "0wk3fs038sh2sl1sqayzfjvygmcdp903qa1pd3aankxrgzv3b5i4";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libfontenc
-        freetype
-        xorgproto
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
 
   # THIS IS A GENERATED FILE.  DO NOT EDIT!
   iceauth = callPackage (

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -3,6 +3,7 @@
   lib,
   appres,
   bdftopcf,
+  bitmap,
   font-adobe-100dpi,
   font-adobe-75dpi,
   font-adobe-utopia-100dpi,
@@ -155,6 +156,7 @@ self: with self; {
   inherit
     appres
     bdftopcf
+    bitmap
     gccmakedep
     ico
     imake
@@ -301,54 +303,6 @@ self: with self; {
   xorgcffiles = xorg-cf-files;
   xorgdocs = xorg-docs;
   xorgsgmldoctools = xorg-sgml-doctools;
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  bitmap = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      libXaw,
-      xbitmaps,
-      libXmu,
-      xorgproto,
-      libXt,
-      wrapWithXFileSearchPathHook,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "bitmap";
-      version = "1.1.1";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/bitmap-1.1.1.tar.xz";
-        sha256 = "1ri66kxa9m6s3xw25mz85k34qhjyksa4kbs4jfrri0g47yv2xm33";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        wrapWithXFileSearchPathHook
-      ];
-      buildInputs = [
-        libX11
-        libXaw
-        xbitmaps
-        libXmu
-        xorgproto
-        libXt
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
 
   # THIS IS A GENERATED FILE.  DO NOT EDIT!
   editres = callPackage (

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -375,6 +375,7 @@ print OUT <<EOF;
   font-winitzki-cyrillic,
   font-xfree86-type1,
   gccmakedep,
+  iceauth,
   ico,
   imake,
   libapplewm,
@@ -493,6 +494,7 @@ self: with self; {
     editres
     fonttosfnt
     gccmakedep
+    iceauth
     ico
     imake
     libdmx

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -334,6 +334,7 @@ print OUT <<EOF;
   lib,
   appres,
   bdftopcf,
+  bitmap,
   font-adobe-100dpi,
   font-adobe-75dpi,
   font-adobe-utopia-100dpi,
@@ -486,6 +487,7 @@ self: with self; {
   inherit
     appres
     bdftopcf
+    bitmap
     gccmakedep
     ico
     imake

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -370,6 +370,7 @@ print OUT <<EOF;
   font-screen-cyrillic,
   font-sony-misc,
   font-sun-misc,
+  fonttosfnt,
   font-util,
   font-winitzki-cyrillic,
   font-xfree86-type1,
@@ -490,6 +491,7 @@ self: with self; {
     bdftopcf
     bitmap
     editres
+    fonttosfnt
     gccmakedep
     ico
     imake

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -435,6 +435,7 @@ print OUT <<EOF;
   oclock,
   pixman,
   sessreg,
+  setxkbmap,
   smproxy,
   tab-window-manager,
   transset,
@@ -513,6 +514,7 @@ self: with self; {
     oclock
     pixman
     sessreg
+    setxkbmap
     smproxy
     transset
     viewres

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -335,6 +335,7 @@ print OUT <<EOF;
   appres,
   bdftopcf,
   bitmap,
+  editres,
   font-adobe-100dpi,
   font-adobe-75dpi,
   font-adobe-utopia-100dpi,
@@ -488,6 +489,7 @@ self: with self; {
     appres
     bdftopcf
     bitmap
+    editres
     gccmakedep
     ico
     imake

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -432,6 +432,7 @@ print OUT <<EOF;
   luit,
   makedepend,
   mkfontscale,
+  oclock,
   pixman,
   sessreg,
   smproxy,
@@ -509,6 +510,7 @@ self: with self; {
     luit
     makedepend
     mkfontscale
+    oclock
     pixman
     sessreg
     smproxy

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -158,8 +158,6 @@ self: super:
     };
   });
 
-  oclock = addMainProgram super.oclock { };
-
   xf86inputevdev = super.xf86inputevdev.overrideAttrs (attrs: {
     outputs = [
       "out"

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -113,13 +113,6 @@ self: super:
       )
   ) { };
 
-  editres = super.editres.overrideAttrs (attrs: {
-    hardeningDisable = [ "format" ];
-    meta = attrs.meta // {
-      mainProgram = "editres";
-    };
-  });
-
   fonttosfnt = super.fonttosfnt.overrideAttrs (attrs: {
     meta = attrs.meta // {
       license = lib.licenses.mit;

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -147,17 +147,6 @@ self: super:
     };
   });
 
-  setxkbmap = super.setxkbmap.overrideAttrs (attrs: {
-    postInstall = ''
-      mkdir -p $out/share/man/man7
-      ln -sfn ${xorg.xkeyboardconfig}/etc/X11 $out/share/X11
-      ln -sfn ${xorg.xkeyboardconfig}/share/man/man7/xkeyboard-config.7.gz $out/share/man/man7
-    '';
-    meta = attrs.meta // {
-      mainProgram = "setxkbmap";
-    };
-  });
-
   xf86inputevdev = super.xf86inputevdev.overrideAttrs (attrs: {
     outputs = [
       "out"

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -113,8 +113,6 @@ self: super:
       )
   ) { };
 
-  bitmap = addMainProgram super.bitmap { };
-
   editres = super.editres.overrideAttrs (attrs: {
     hardeningDisable = [ "format" ];
     meta = attrs.meta // {

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -113,8 +113,6 @@ self: super:
       )
   ) { };
 
-  iceauth = addMainProgram super.iceauth { };
-
   mkfontdir = xorg.mkfontscale;
 
   xdpyinfo = super.xdpyinfo.overrideAttrs (attrs: {

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -113,13 +113,6 @@ self: super:
       )
   ) { };
 
-  fonttosfnt = super.fonttosfnt.overrideAttrs (attrs: {
-    meta = attrs.meta // {
-      license = lib.licenses.mit;
-      mainProgram = "fonttosfnt";
-    };
-  });
-
   iceauth = addMainProgram super.iceauth { };
 
   mkfontdir = xorg.mkfontscale;

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -1,4 +1,3 @@
-mirror://xorg/individual/app/bitmap-1.1.1.tar.xz
 mirror://xorg/individual/app/editres-1.0.9.tar.xz
 mirror://xorg/individual/app/fonttosfnt-1.2.4.tar.xz
 mirror://xorg/individual/app/iceauth-1.0.10.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -1,4 +1,3 @@
-mirror://xorg/individual/app/setxkbmap-1.3.4.tar.xz
 mirror://xorg/individual/app/xclock-1.1.1.tar.xz
 mirror://xorg/individual/app/xdm-1.1.17.tar.xz
 mirror://xorg/individual/app/xdpyinfo-1.3.4.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -1,4 +1,3 @@
-mirror://xorg/individual/app/editres-1.0.9.tar.xz
 mirror://xorg/individual/app/fonttosfnt-1.2.4.tar.xz
 mirror://xorg/individual/app/iceauth-1.0.10.tar.xz
 mirror://xorg/individual/app/oclock-1.0.6.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -1,4 +1,3 @@
-mirror://xorg/individual/app/iceauth-1.0.10.tar.xz
 mirror://xorg/individual/app/oclock-1.0.6.tar.xz
 mirror://xorg/individual/app/setxkbmap-1.3.4.tar.xz
 mirror://xorg/individual/app/xclock-1.1.1.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -1,4 +1,3 @@
-mirror://xorg/individual/app/oclock-1.0.6.tar.xz
 mirror://xorg/individual/app/setxkbmap-1.3.4.tar.xz
 mirror://xorg/individual/app/xclock-1.1.1.tar.xz
 mirror://xorg/individual/app/xdm-1.1.17.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -1,4 +1,3 @@
-mirror://xorg/individual/app/fonttosfnt-1.2.4.tar.xz
 mirror://xorg/individual/app/iceauth-1.0.10.tar.xz
 mirror://xorg/individual/app/oclock-1.0.6.tar.xz
 mirror://xorg/individual/app/setxkbmap-1.3.4.tar.xz


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
    - [x] pkgs
    - [x] pkgsStatic (except bitmap, which is broken on static)
    - [x] pkgsCross.aarch64-multiplatform
    - [x] pkgsCross.aarch64-multiplatform.pkgsStatic (except bitmap)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`. (none)
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - [x] bitmap (-version & -help output, i don't know how to use this program)
  - [x] editres
  - [x] fonttosfnt (converting one pcf font)
  - [x] iceauth (through xwayland, just the help and info output, idc enough to understand iceauthority to test this properly)
  - [x] oclock
  - [x] setxkbmap (on xwayland, keyboard switching works (`env WAYLAND_DISPLAY= alacritty` successfully types with the switched layout)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
