### PR TITLE
owncloud-client: 5.3.2 -> 6.0.2

### DIFF
--- a/pkgs/by-name/ow/owncloud-client/package.nix
+++ b/pkgs/by-name/ow/owncloud-client/package.nix
@@ -1,13 +1,14 @@
 {
   lib,
   stdenv,
+  fetchpatch,
   fetchFromGitHub,
   nix-update-script,
   qt6Packages,
   # nativeBuildInputs
   pkg-config,
   cmake,
-  extra-cmake-modules,
+  kdePackages,
   # buildInputs
   sqlite,
   libsecret,
@@ -19,19 +20,26 @@
 
 stdenv.mkDerivation rec {
   pname = "owncloud-client";
-  version = "5.3.2";
+  version = "6.0.2";
 
   src = fetchFromGitHub {
     owner = "owncloud";
     repo = "client";
     tag = "v${version}";
-    hash = "sha256-HEnjtedmdNJTpc/PmEyoEsLGUydFkVF3UAsSdzQ4L1Q=";
+    hash = "sha256-cqnDe9q7+qQ0MNrt48zTw6TcNYCEFgQmwXkmQCjR1Uc=";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/owncloud/client/commit/ef0791a727051191f0c0ff7bca78b10d5dd97e1e.patch";
+      hash = "sha256-r/TlRjmnZdPWXZ8Kn/9GgcisWiF/qOO5X8m2ReooKWo=";
+    })
+  ];
 
   nativeBuildInputs = [
     pkg-config
     cmake
-    extra-cmake-modules
+    kdePackages.extra-cmake-modules
     qt6Packages.qttools
     qt6Packages.wrapQtAppsHook
   ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bump version. However, I am seeing the same error as in https://github.com/NixOS/nixpkgs/pull/401584#pullrequestreview-2795408605. Everything works after unset the environment variable `QT_STYLE_OVERRIDE=kvantum`.
 
<img width="566" height="116" alt="image" src="https://github.com/user-attachments/assets/d744e51d-320f-4fee-9084-bfd960118086" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
