### PR TITLE
beads: init at 0.27.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13433,6 +13433,11 @@
     githubId = 37185887;
     name = "Calvin Kim";
   };
+  kedry = {
+    name = "Kevin Edry";
+    github = "kedry";
+    githubId = 12020122;
+  };
   keegancsmith = {
     email = "keegan.csmith@gmail.com";
     name = "Keegan Carruthers-Smith";

--- a/pkgs/by-name/be/beads/package.nix
+++ b/pkgs/by-name/be/beads/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  gitMinimal,
+  installShellFiles,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "beads";
+  version = "0.27.2";
+
+  src = fetchFromGitHub {
+    owner = "steveyegge";
+    repo = "beads";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-PpuyQCQocmOqt4EYDsjx1nh0dRxt2e7Vu1/KQ74B88Q=";
+  };
+
+  vendorHash = "sha256-5p4bHTBB6X30FosIn6rkMDJoap8tOvB7bLmVKsy09D8=";
+
+  subPackages = [ "cmd/bd" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  nativeCheckInputs = [
+    gitMinimal
+    writableTmpDirAsHomeHook
+  ];
+
+  # Skip security tests on Darwin - they check for /etc/passwd which isn't available in sandbox
+  checkFlags = lib.optionals stdenv.hostPlatform.isDarwin [
+    "-skip=TestCleanupMergeArtifacts_CommandInjectionPrevention"
+  ];
+
+  preCheck = ''
+    export PATH="$out/bin:$PATH"
+  '';
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd bd \
+      --bash <($out/bin/bd completion bash) \
+      --fish <($out/bin/bd completion fish) \
+      --zsh <($out/bin/bd completion zsh)
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+  versionCheckProgramArg = "version";
+  doInstallCheck = true;
+
+  meta = {
+    description = "Lightweight memory system for AI coding agents with graph-based issue tracking";
+    homepage = "https://github.com/steveyegge/beads";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kedry ];
+    mainProgram = "bd";
+  };
+})


### PR DESCRIPTION
  # beads: init at 0.24.5

  Lightweight memory system for AI coding agents with graph-based issue tracking. Enables
  agents to manage complex, multi-step tasks by tracking dependencies between issues using
  four relationship types: blocks, related, parent-child, and discovered-from connections.

  This package provides the `bd` CLI tool for managing issues with first-class dependency
  support, local SQLite storage, and Git-based synchronization.

  **Homepage**: https://github.com/steveyegge/beads

  ## Things done

  - Built on platform:
    - [ ] x86_64-linux
    - [ ] aarch64-linux
    - [x] x86_64-darwin
    - [ ] aarch64-darwin
  - Tested, as applicable:
    - [ ] [NixOS tests] in [nixos/tests].
    - [ ] [Package tests] at `passthru.tests`.
    - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - Nixpkgs Release Notes
    - [x] Package update: when the change is major or breaking.
  - NixOS Release Notes
    - [ ] Module addition: when adding a new NixOS module.
    - [ ] Module update: when the change is significant.
  - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

  **Note**: Tests are disabled (`doCheck = false`) as they require the `bd` binary to be in
  PATH during the test phase.

  [NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
  [Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
  [nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

  [CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
  [lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
  [maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
  [nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
  [pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
  [pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

  ---

  Add a :+1: [reaction] to [pull requests you find important].

  [reaction]:
  https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
  [pull requests you find important]:
  https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc