### PR TITLE
reaper, libswell: fix directory opening

### DIFF
--- a/pkgs/applications/audio/reaper/default.nix
+++ b/pkgs/applications/audio/reaper/default.nix
@@ -22,6 +22,9 @@
   jackLibrary,
   pulseaudioSupport ? config.pulseaudio or stdenv.hostPlatform.isLinux,
   libpulseaudio,
+
+  libswell,
+  openssl,
 }:
 
 let
@@ -78,6 +81,7 @@ stdenv.mkDerivation rec {
   runtimeDependencies =
     lib.optionals stdenv.hostPlatform.isLinux [
       gtk3 # libSwell needs libgdk-3.so.0
+      xdg-utils # Required for desktop integration
     ]
     ++ lib.optional jackSupport jackLibrary
     ++ lib.optional pulseaudioSupport libpulseaudio;
@@ -121,6 +125,7 @@ stdenv.mkDerivation rec {
               vlc
               xdotool
               stdenv.cc.cc
+              openssl
             ]
           }"
 
@@ -130,6 +135,8 @@ stdenv.mkDerivation rec {
         # Avoid store path in Exec, since we already link to $out/bin
         substituteInPlace $out/share/applications/cockos-reaper.desktop \
           --replace-fail "Exec=\"$out/opt/REAPER/reaper\"" "Exec=reaper"
+
+        ln -sf "${libswell}/lib/libSwell.so" "$out/opt/REAPER/libSwell.so"
 
         runHook postInstall
       '';

--- a/pkgs/by-name/li/libswell/package.nix
+++ b/pkgs/by-name/li/libswell/package.nix
@@ -1,0 +1,61 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  fetchpatch,
+  gtk3,
+  freetype,
+  pkg-config,
+}:
+
+stdenv.mkDerivation {
+  pname = "libswell";
+  version = "unstable-2025-11-23";
+
+  src = fetchFromGitHub {
+    owner = "justinfrankel";
+    repo = "WDL";
+    rev = "c2db86d782b20a6008a88906ae964e71ed2cb099";
+    hash = "sha256-Z7I194DGP2ml4loTKOIXolWzopxpN9tzVUbLgJBzaDQ=";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/justinfrankel/WDL/commit/08677fc16e8f1c165070d65033fba50fc0ac7f71.patch";
+      hash = "sha256-/tHMHi8Zs2GHTHjn75fdzUQTOb7aQ51zumsBERXTUGk=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    gtk3
+    freetype
+  ];
+
+  preBuild = ''
+    cd WDL/swell
+  '';
+
+  installPhase = ''
+    mkdir -p "$out"/lib
+    cp libSwell.${if stdenv.isDarwin then "dylib" else "so"} "$out"/lib
+  '';
+
+  meta = with lib; {
+    description = "Simple Windows Emulation Layer";
+    homepage = "https://www.cockos.com/wdl/";
+    license = licenses.unfree; # possibly? see homepage
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    maintainers = with maintainers; [
+      viraptor
+    ];
+  };
+}


### PR DESCRIPTION
## Things done

Replace bundled libSwell in reaper. The original one has a hardcoded path to xdg-open. It's not the best solution, but upstream ignored the provided patch for a long time and we can't really identify which version of libswell is bundled.

Also, to make xdg-open work we need to ensure the right version of openssl is available since it's loaded as a transitive dependency.

Fixes https://github.com/NixOS/nixpkgs/issues/341752

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
