### PR TITLE
[25.05] immich: 2.2.3 -> 2.3.1

### DIFF
--- a/nixos/modules/services/web-apps/immich.nix
+++ b/nixos/modules/services/web-apps/immich.nix
@@ -404,7 +404,7 @@ in
       wantedBy = [ "multi-user.target" ];
       inherit (cfg.machine-learning) environment;
       serviceConfig = commonServiceConfig // {
-        ExecStart = lib.getExe (cfg.package.machine-learning.override { immich = cfg.package; });
+        ExecStart = lib.getExe cfg.package.machine-learning;
         Slice = "system-immich.slice";
         CacheDirectory = "immich";
         User = cfg.user;

--- a/pkgs/by-name/ex/extism-js/package.nix
+++ b/pkgs/by-name/ex/extism-js/package.nix
@@ -1,0 +1,74 @@
+# Building this from source requires cross-compiling Rust to wasm32-wasip1.
+# An attempt to do so was made in https://github.com/NixOS/nixpkgs/pull/463349.
+# FIXME revisit once https://github.com/NixOS/nixpkgs/pull/463720 is merged
+
+{
+  autoPatchelfHook,
+  fetchurl,
+  lib,
+  libgcc,
+  stdenvNoCC,
+  versionCheckHook,
+}:
+
+let
+  version = "1.5.1";
+  tag = "v${version}";
+  system = lib.replaceStrings [ "darwin" ] [ "macos" ] stdenvNoCC.hostPlatform.system;
+  hashes = {
+    aarch64-darwin = "sha256-BHld8Dwwd6fexc05oHOIawa5PtGZAI61wQGWE8T+iMs=";
+    aarch64-linux = "sha256-KM3/y31OdLmEAcc48TSLmXei2GD6FhOHYlD7W/ErP+I=";
+    x86_64-darwin = "sha256-cE0JJK92pTJyGnHEZ7wA6+dpMvVOTMzFM2Mkwfy5kbQ=";
+    x86_64-linux = "sha256-9qSjqPFmUaUnpGQ/ldIpyFSgTWbUYozcckpYxpm5PJU=";
+  };
+in
+stdenvNoCC.mkDerivation {
+  pname = "extism-js";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/extism/js-pdk/releases/download/${tag}/extism-js-${system}-${tag}.gz";
+    hash = hashes.${stdenvNoCC.hostPlatform.system};
+  };
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    gunzip -cf "$src" > extism-js
+
+    runHook postUnpack
+  '';
+
+  nativeBuildInputs = lib.optionals stdenvNoCC.hostPlatform.isLinux [
+    autoPatchelfHook
+  ];
+
+  buildInputs = lib.optionals stdenvNoCC.hostPlatform.isLinux [
+    libgcc
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dt $out/bin extism-js
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  meta = {
+    changelog = "https://github.com/extism/js-pdk/releases/tag/${tag}";
+    description = "Write Extism plugins in JavaScript & TypeScript";
+    homepage = "https://github.com/extism/js-pdk";
+    license = lib.licenses.bsd3;
+    mainProgram = "extism-js";
+    maintainers = [ lib.maintainers.dotlambda ];
+    platforms = lib.attrNames hashes;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+}

--- a/pkgs/by-name/im/immich-cli/package.nix
+++ b/pkgs/by-name/im/immich-cli/package.nix
@@ -12,7 +12,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "immich-cli";
-  version = "2.2.101";
+  version = "2.2.103";
   inherit (immich) src pnpmDeps;
 
   postPatch = ''

--- a/pkgs/by-name/im/immich/package.nix
+++ b/pkgs/by-name/im/immich/package.nix
@@ -12,8 +12,10 @@
   # build-time deps
   pkg-config,
   makeWrapper,
+  binaryen,
   curl,
   cacert,
+  extism-js,
   unzip,
   # runtime deps
   cairo,
@@ -105,20 +107,20 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "immich";
-  version = "2.2.3";
+  version = "2.3.1";
 
   src = fetchFromGitHub {
     owner = "immich-app";
     repo = "immich";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-OoToTRDPXWOa7d1j1xvkZt+vKWBX4eHDiIsFs3bIlvw=";
+    hash = "sha256-K/E5bQraTlvNx1Cd0bKyY6ZhesafGccqVZ9Mu6Q0pZ0=";
   };
 
   pnpmDeps = pnpm.fetchDeps {
     pname = "immich";
     inherit (finalAttrs) version src;
     fetcherVersion = 2;
-    hash = "sha256-igkO0ID0/9uPtFAXL2v5bcFbCpZK2lcYEctWBKtFKdU=";
+    hash = "sha256-i0JHKjsQcdDUrDLK0hJGOvVRh/aOyvms/k+6WEPbyh8=";
   };
 
   postPatch = ''
@@ -189,6 +191,7 @@ stdenv.mkDerivation (finalAttrs: {
     \) -exec rm -r {} +
 
     mkdir -p "$packageOut/build"
+    ln -s '${finalAttrs.passthru.plugins}' "$packageOut/build/corePlugin"
     ln -s '${finalAttrs.passthru.web}' "$packageOut/build/www"
     ln -s '${geodata}' "$packageOut/build/geodata"
 
@@ -220,6 +223,37 @@ stdenv.mkDerivation (finalAttrs: {
 
     machine-learning = immich-machine-learning.override {
       immich = finalAttrs.finalPackage;
+    };
+
+    plugins = stdenv.mkDerivation {
+      pname = "immich-plugins";
+      inherit (finalAttrs) version src pnpmDeps;
+
+      nativeBuildInputs = [
+        binaryen
+        extism-js
+        nodejs
+        pnpm
+        pnpm.configHook
+      ];
+
+      buildPhase = ''
+        runHook preBuild
+
+        pnpm --filter plugins build
+
+        runHook postBuild
+      '';
+
+      installPhase = ''
+        runHook preInstall
+
+        cd plugins
+        mkdir $out
+        cp -r dist manifest.json $out
+
+        runHook postInstall
+      '';
     };
 
     web = stdenv.mkDerivation {


### PR DESCRIPTION
Backport to 25.05 of:
- https://github.com/NixOS/nixpkgs/pull/460603
- https://github.com/NixOS/nixpkgs/pull/463349 (except versionCheckHook)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
