### PR TITLE
rollo-printer: init at 1.8.4

### DIFF
--- a/pkgs/by-name/ro/rollo-printer/package.nix
+++ b/pkgs/by-name/ro/rollo-printer/package.nix
@@ -1,0 +1,36 @@
+{
+  cups,
+  fetchurl,
+  lib,
+  stdenv,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "rollo-printer";
+  version = "1.8.4";
+
+  src = fetchurl {
+    url = "https://rollo-main.b-cdn.net/driver-dl/linux/rollo-cups-driver-${finalAttrs.version}.tar.gz";
+    hash = "sha256-v61/5HY25cvhVbHF+dXOOGrDfZZzvvicJEy7MKTAG10=";
+  };
+
+  nativeBuildInputs = [ cups ];
+
+  buildInputs = [ cups ];
+
+  makeFlags = [
+    "CUPS_DATADIR=${placeholder "out"}/share/cups"
+    "CUPS_SERVERBIN=${placeholder "out"}/lib/cups"
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    description = "CUPS driver for Rollo label printers";
+    homepage = "https://www.rollo.com/driver-linux/";
+    license = with lib.licenses; gpl3Plus;
+    maintainers = with lib.maintainers; [ shymega ];
+    platforms = cups.meta.platforms;
+    broken = stdenv.hostPlatform.isDarwin;
+  };
+})

--- a/pkgs/by-name/ro/rollo-printer/package.nix
+++ b/pkgs/by-name/ro/rollo-printer/package.nix
@@ -2,6 +2,7 @@
   cups,
   fetchurl,
   lib,
+  pkg-config,
   stdenv,
 }:
 stdenv.mkDerivation (finalAttrs: {
@@ -13,10 +14,13 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-v61/5HY25cvhVbHF+dXOOGrDfZZzvvicJEy7MKTAG10=";
   };
 
-  nativeBuildInputs = [ cups ];
+  nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [ cups ];
 
+  # configure unconditionally derives CUPS_DATADIR/CUPS_SERVERBIN from
+  # pkg-config, which points into the cups store path; override at make time
+  # so the filter and PPD are installed into $out instead.
   makeFlags = [
     "CUPS_DATADIR=${placeholder "out"}/share/cups"
     "CUPS_SERVERBIN=${placeholder "out"}/lib/cups"


### PR DESCRIPTION
This PR adds the Rollo label printer CUPS driver - which is also used by some Munbyn label printers. It currently only works over USB.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
