### PR TITLE
pixinsight: 1.8.9-3-20240625 -> 1.9.3-20250402

### DIFF
--- a/pkgs/by-name/pi/pixinsight/package.nix
+++ b/pkgs/by-name/pi/pixinsight/package.nix
@@ -22,6 +22,11 @@
   libdrm,
   cups,
   avahi-compat,
+  libidn2,
+  libdeflate,
+  brotli,
+  libxkbcommon,
+  libxcb,
   xorg,
   wayland,
   libudev0-shim,
@@ -30,141 +35,10 @@
   gdk-pixbuf,
   gtk3,
   pango,
-  qt6Packages,
+  buildFHSEnv,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
-  pname = "pixinsight";
-  version = "1.8.9-3-20240625";
-
-  src = requireFile rec {
-    name = "PI-linux-x64-${finalAttrs.version}-c.tar.xz";
-    url = "https://pixinsight.com/";
-    hash = "sha256-jqp5pt+fC7QvENCwRjr7ENQiCZpwNhC5q76YdzRBJis=";
-    message = ''
-      PixInsight is available from ${url} and requires a commercial (or trial) license.
-      After a license has been obtained, PixInsight can be downloaded from the software distribution
-      (choose Linux 64bit).
-      The PixInsight tarball must be added to the nix-store, i.e. via
-        nix-prefetch-url --type sha256 file:///path/to/${name}
-    '';
-  };
-  sourceRoot = ".";
-
-  nativeBuildInputs = [
-    unixtools.script
-    fakeroot
-    qt6Packages.wrapQtAppsHook
-    autoPatchelfHook
-    mailcap
-    libudev0-shim
-    bubblewrap
-  ];
-
-  buildInputs = [
-    (lib.getLib stdenv.cc.cc)
-    stdenv.cc
-    libGL
-    libpulseaudio
-    alsa-lib
-    nss
-    gd
-    gst_all_1.gstreamer
-    gst_all_1.gst-plugins-base
-    nspr
-    expat
-    fontconfig
-    dbus
-    glib
-    zlib
-    openssl
-    libdrm
-    wayland
-    cups
-    avahi-compat
-    libjpeg8
-    gdk-pixbuf
-    gtk3
-    pango
-    # Qt stuff
-    qt6Packages.qt3d
-    qt6Packages.mlt
-    qt6Packages.qtbase
-    #qtgamepad
-    qt6Packages.qtserialport
-    qt6Packages.qtserialbus
-    qt6Packages.qtvirtualkeyboard
-    qt6Packages.qtmultimedia
-    qt6Packages.qtlocation
-    qt6Packages.qtwebengine
-    qt6Packages.qtquick3d
-    qt6Packages.qtwayland
-    qt6Packages.qtwebview
-    qt6Packages.qtscxml
-  ]
-  ++ (with xorg; [
-    libX11
-    libXdamage
-    xrandr
-    libXtst
-    libXcomposite
-    libXext
-    libXfixes
-    libXrandr
-    libxkbfile
-  ]);
-
-  postPatch = ''
-    patchelf ./installer \
-      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      --set-rpath ${lib.getLib stdenv.cc.cc}/lib
-  '';
-
-  dontConfigure = true;
-  dontBuild = true;
-
-  installPhase = ''
-    mkdir -p $out/bin $out/opt/PixInsight $out/share/{applications,mime/packages,icons/hicolor}
-
-    bwrap --bind /build /build --bind $out/opt /opt --bind /nix /nix --dev /dev fakeroot script -ec "./installer \
-      --yes \
-      --install-desktop-dir=$out/share/applications \
-      --install-mime-dir=$out/share/mime \
-      --install-icons-dir=$out/share/icons/hicolor \
-      --no-bin-launcher \
-      --no-remove"
-
-    rm -rf $out/opt/PixInsight-old-0
-    ln -s $out/opt/PixInsight/bin/PixInsight $out/bin/.
-    ln -s $out/opt/PixInsight/bin/lib $out/lib
-
-    # Remove signatures of plugins, as they are only working if actually installed
-    # under /opt. In the Nix setup, they are causing trouble.
-    find $out/opt/PixInsight/ -name "*.xsgn" -exec rm {} \;
-  '';
-
-  # Some very exotic Qt libraries are not available in nixpkgs
-  autoPatchelfIgnoreMissingDeps = true;
-
-  # This mimics what is happening in PixInsight.sh and adds on top the libudev0-shim, which
-  # without PixInsight crashes at startup.
-  qtWrapperArgs = [
-    "--prefix LD_LIBRARY_PATH : ${libudev0-shim}/lib"
-    "--set LC_ALL en_US.utf8"
-    "--set AVAHI_COMPAT_NOWARN 1"
-    "--set QT_PLUGIN_PATH $out/opt/PixInsight/bin/lib/qt-plugins"
-    "--set QT_QPA_PLATFORM_PLUGIN_PATH $out/opt/PixInsight/bin/lib/qt-plugins/platforms"
-    "--set QT_AUTO_SCREEN_SCALE_FACTOR 0"
-    "--set QT_ENABLE_HIGHDPI_SCALING 0"
-    "--set QT_SCALE_FACTOR 1"
-    "--set QT_LOGGING_RULES '*=false'"
-    "--set QTWEBENGINEPROCESS_PATH $out/opt/PixInsight/bin/libexec/QtWebEngineProcess"
-  ];
-  dontWrapQtApps = true;
-  postFixup = ''
-    wrapProgram $out/opt/PixInsight/bin/PixInsight ${toString finalAttrs.qtWrapperArgs}
-  '';
-
+let
   meta = with lib; {
     description = "Scientific image processing program for astrophotography";
     homepage = "https://pixinsight.com/";
@@ -175,4 +49,128 @@ stdenv.mkDerivation (finalAttrs: {
     hydraPlatforms = [ ];
     mainProgram = "PixInsight";
   };
-})
+
+  pname = "pixinsight";
+  version = "1.9.3-20250402";
+
+  installPkg = stdenv.mkDerivation (finalAttrs: {
+    inherit meta pname version;
+
+    src = requireFile rec {
+      name = "PI-linux-x64-${finalAttrs.version}-c.tar.xz";
+      url = "https://pixinsight.com/";
+      hash = "sha256-MOAWH64A13vVLeNiBC9nO78P0ELmXXHR5ilh5uUhWhs=";
+      message = ''
+        PixInsight is available from ${url} and requires a commercial (or trial) license.
+        After a license has been obtained, PixInsight can be downloaded from the software distribution
+        (choose Linux 64bit).
+        The PixInsight tarball must be added to the nix-store, i.e. via
+          nix-prefetch-url --type sha256 file:///path/to/${name}
+      '';
+    };
+    sourceRoot = ".";
+
+    nativeBuildInputs = [
+      unixtools.script
+      fakeroot
+      mailcap
+      libudev0-shim
+      bubblewrap
+    ];
+
+    postPatch = ''
+      patchelf ./installer \
+        --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+        --set-rpath ${lib.getLib stdenv.cc.cc}/lib
+    '';
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/bin $out/opt/PixInsight $out/share/{applications,mime/packages,icons/hicolor}
+
+      bwrap --bind /build /build --bind $out/opt /opt --bind /nix /nix --dev /dev fakeroot script -ec "./installer \
+        --yes \
+        --install-desktop-dir=$out/share/applications \
+        --install-mime-dir=$out/share/mime \
+        --install-icons-dir=$out/share/icons/hicolor \
+        --no-bin-launcher \
+        --no-remove"
+
+      rm -rf $out/opt/PixInsight-old-0
+      ln -s $out/opt/PixInsight/bin/PixInsight $out/bin/.
+      ln -s $out/opt/PixInsight/bin/lib $out/lib
+
+      runHook postInstall
+    '';
+
+  });
+
+  runPkg = buildFHSEnv {
+    inherit meta pname version;
+
+    targetPkgs =
+      pkgs:
+      with pkgs;
+      [
+        # PI itself
+        installPkg
+        # runtime deps
+        mailcap
+        libudev0-shim
+        (lib.getLib stdenv.cc.cc)
+        stdenv.cc
+        libGL
+        libpulseaudio
+        alsa-lib
+        nss
+        gd
+        gst_all_1.gstreamer
+        gst_all_1.gst-plugins-base
+        nspr
+        expat
+        fontconfig
+        dbus
+        glib
+        zlib
+        openssl
+        libdrm
+        wayland
+        cups
+        avahi-compat
+        libjpeg8
+        gdk-pixbuf
+        gtk3
+        pango
+        libidn2
+        libdeflate
+        brotli
+        libxkbcommon
+        libxcb
+      ]
+      ++ (with pkgs.xorg; [
+        libX11
+        libXdamage
+        xrandr
+        libXtst
+        libXcomposite
+        libXext
+        libXfixes
+        libXrandr
+        libxkbfile
+      ]);
+
+    profile = ''
+      export QT_QPA_PLATFORM_PLUGIN_PATH=/opt/PixInsight/bin/lib/qt-plugins/platforms
+      export QT_PLUGIN_PATH=/opt/PixInsight/bin/lib/qt-plugins
+      export LD_LIBRARY_PATH=${libudev0-shim}/lib
+    '';
+
+    runScript = "${installPkg}/bin/PixInsight";
+  };
+
+in
+runPkg


### PR DESCRIPTION
This updates the commercial PixInsight image processing program to the latest version, 1.9.3. PixInsight requires being installed in `/opt` since the 1.8 series and now also being run from `/opt`, so that plugin code signatures match. Thus, in the first step, I'm now using the installer to install PixInsight into `$out/opt` using bubblewrap, to make the installer think, it is actually installing to `/opt`. Then, in a second step, I'm constructing an fhsEnv, which ensures that also at runtime PixInsight appears to run from `/opt` and finds external libraries in the expectet `/usr/lib` locations. The former `autoPatchelf` approach doesn't work anymore with signed plugins, unfortunately.

https://pixinsight.com/forum/index.php?threads/pixinsight-1-9-3-lockhart-build-1646-released.25511/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
