### PR TITLE
budgie-media-player-applet: 1.2.0 -> 1.3.0

### DIFF
--- a/pkgs/by-name/bu/budgie-media-player-applet/package.nix
+++ b/pkgs/by-name/bu/budgie-media-player-applet/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "budgie-media-player-applet";
-  version = "1.2.0";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "zalesyc";
     repo = "budgie-media-player-applet";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-FTc/cl4qjVYx45SuZPizOGC09JERIuifCo86+Tqu5hk=";
+    hash = "sha256-Ekt6OXSjqKF4d6a9lmZyUa06pqz1uYkCHbzvLM7Z+W8=";
   };
 
   strictDeps = true;
@@ -44,17 +44,11 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   mesonFlags = [
-    # The meson option actually enables libpeas2 support
-    # https://github.com/BuddiesOfBudgie/budgie-desktop/issues/749
-    "-Dfor-wayland=true"
+    "-Dbudgie-api-v2=true"
   ];
 
   postPatch = ''
     substituteInPlace meson.build --replace-fail "/usr" "$out"
-
-    # https://github.com/zalesyc/budgie-media-player-applet/issues/25
-    substituteInPlace src/{applet,testWin,Popover,BudgieMediaPlayer}.py \
-      --replace-fail "gi.require_version('Budgie', '1.0')" "gi.require_version('Budgie', '2.0')"
   '';
 
   postFixup = ''


### PR DESCRIPTION
https://github.com/zalesyc/budgie-media-player-applet/compare/v1.2.0...v1.3.0




## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

