### PR TITLE
cronopete: init at 4.18.0

### DIFF
--- a/pkgs/by-name/cr/cronopete/fix-hardcoded-paths.patch
+++ b/pkgs/by-name/cr/cronopete/fix-hardcoded-paths.patch
@@ -1,0 +1,28 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ae90d4e..1f658fd 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -56,10 +56,6 @@ set(MODULES_TO_CHECK ${MODULES_TO_CHECK} udisks2)
+ 
+ pkg_check_modules(DEPS REQUIRED ${MODULES_TO_CHECK})
+ 
+-if ( (NOT EXISTS "/usr/bin/rsync"))
+-	message(FATAL_ERROR "Can't find any of the files /usr/bin/rsync")
+-endif()
+-
+ find_program ( WHERE_gtk_update_icon_cache gtk-update-icon-cache )
+ if ( NOT WHERE_gtk_update_icon_cache )
+ 	find_program ( WHERE_gtk_update_icon_cache gtk-update-icon-cache.3.0 )
+diff --git a/data/CMakeLists.txt b/data/CMakeLists.txt
+index a73a639..b57bcee 100644
+--- a/data/CMakeLists.txt
++++ b/data/CMakeLists.txt
+@@ -6,7 +6,7 @@ install(PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/cronopete_restore.sh DESTINATION ${
+ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/cronopete_preferences.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications/ )
+ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/cronopete_restore.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications/ )
+ if( NOT ( ${CMAKE_INSTALL_PREFIX} MATCHES "^/home/" ) )
+-	install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/cronopete.desktop DESTINATION /etc/xdg/autostart/ )
++	install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/cronopete.desktop DESTINATION ${CMAKE_INSTALL_PREFIX}/share/applications)
+ else()
+ 	MESSAGE(STATUS "[33mAutostart file data/cronopete.desktop will not be installed. You must create your own .desktop file and put it at ~/.config/autostart[39m")
+ endif()

--- a/pkgs/by-name/cr/cronopete/package.nix
+++ b/pkgs/by-name/cr/cronopete/package.nix
@@ -1,0 +1,97 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  cmake,
+  meson,
+  ninja,
+  pkg-config,
+
+  cairo,
+  gdk-pixbuf,
+  gobject-introspection,
+  gtk3,
+  libXdmcp,
+  libXtst,
+  libayatana-appindicator,
+  libdatrie,
+  libepoxy,
+  libgee,
+  libnotify,
+  libselinux,
+  libsepol,
+  libthai,
+  libxkbcommon,
+  pango,
+  pcre,
+  pcre2,
+  udisks,
+  util-linuxMinimal,
+  rsync,
+  vala,
+  wrapGAppsHook4,
+  makeWrapper,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cronopete";
+  version = "4.18.0";
+
+  src = fetchFromGitLab {
+    owner = "rastersoft";
+    repo = "cronopete";
+    tag = finalAttrs.version;
+    hash = "sha256-UCYewGxPYq7oZGJ/NZC+rTygGy2+8xNsUBPS7h6+8pE=";
+  };
+
+  patches = [
+    ./fix-hardcoded-paths.patch
+  ];
+
+  strictDeps = true;
+
+  buildInputs = [
+    cairo
+    gdk-pixbuf
+    gtk3
+    udisks
+    gobject-introspection
+    libnotify
+    pango
+    libayatana-appindicator
+    libgee
+    pcre2
+    util-linuxMinimal # provides libmount
+    libselinux
+    libsepol
+    pcre
+    libthai
+    libdatrie
+    libXdmcp
+    libxkbcommon
+    libepoxy
+    libXtst
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    meson
+    ninja
+    pkg-config
+    vala
+    makeWrapper
+    wrapGAppsHook4
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/cronopete --prefix PATH : ${lib.makeBinPath [ rsync ]}
+  '';
+
+  meta = {
+    description = "An Apple's TimeMachine clone for Linux";
+    homepage = "https://gitlab.com/rastersoft/cronopete";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ dit7ya ];
+    mainProgram = "cronopete";
+  };
+})


### PR DESCRIPTION
Cronopete is a backup utility for Linux, modeled after Apple's Time Machine. It aims to simplify the creation of periodic backups.

https://gitlab.com/rastersoft/cronopete

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
