### PR TITLE
nixos/pam: add rule for `pam_umask`

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -583,6 +583,13 @@ let
           '';
         };
 
+        enableUMask = lib.mkOption {
+          default = config.security.pam.enableUMask;
+          defaultText = lib.literalExpression "config.security.pam.enableUMask";
+          type = lib.types.bool;
+          description = "If enabled, the pam_umask module will be loaded.";
+        };
+
         failDelay = {
           enable = lib.mkOption {
             type = lib.types.bool;
@@ -1291,6 +1298,12 @@ let
                   enable = cfg.ttyAudit.enablePattern;
                   disable = cfg.ttyAudit.disablePattern;
                 };
+              }
+              {
+                name = "umask";
+                enable = cfg.enableUMask;
+                control = "optional";
+                modulePath = "${package}/lib/security/pam_umask.so";
               }
               {
                 name = "systemd_home";
@@ -2207,6 +2220,8 @@ in
         '';
       };
     };
+
+    security.pam.enableUMask = lib.mkEnableOption "umask PAM module";
 
     security.pam.enableEcryptfs = lib.mkEnableOption "eCryptfs PAM module (mounting ecryptfs home directory on login)";
     security.pam.enableFscrypt = lib.mkEnableOption ''


### PR DESCRIPTION
This PR adds the PAM module for `pam_umask.so` under `security.pam.services.<service>.rules.session.umask`.

By default, it applies the umask set in the user's GECOS field `users.users.<user>.description` or `security.loginDefs.settings.UMASK` (see the default order [here](https://man7.org/linux/man-pages/man8/pam_umask.8.html)), but it can be customized using e.g. `security.pam.services.<service>.rules.session.umask.settings.umask = "0027"`.

Until now the `loginDefs.settings.UMASK` default was `0077`, but it wasn't being applied because this PAM module wasn't included, so the effective default was `0022`. To preserve the existing behavior, the PAM module is gated behind a new `security.pam.enableUMask` option (which defaults to `false`).

Closes https://github.com/NixOS/nixpkgs/issues/302262, Closes https://github.com/NixOS/nixpkgs/issues/447021.

Related: https://github.com/NixOS/nixpkgs/issues/346922.

Pinging @Majiir, @SuperSandro2000, and @LordGrimmauld for potential reviews (based on recent commits to this file).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of the `umask` PAM module. ~~all binary files, usually in `./result/bin/`.~~
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
