### PR TITLE
anchor: 0.31.1 -> 0.32.1

### DIFF
--- a/pkgs/by-name/an/anchor/package.nix
+++ b/pkgs/by-name/an/anchor/package.nix
@@ -1,22 +1,27 @@
 {
   lib,
+  perl,
   rustPlatform,
   fetchFromGitHub,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "anchor";
-  version = "0.31.1";
+  version = "0.32.1";
 
   src = fetchFromGitHub {
     owner = "coral-xyz";
     repo = "anchor";
     tag = "v${version}";
-    hash = "sha256-pvD0v4y7DilqCrhT8iQnAj5kBxGQVqNvObJUBzFLqzA=";
+    hash = "sha256-oyCe8STDciRtdhOWgJrT+k50HhUWL2LSG8m4Ewnu2dc=";
     fetchSubmodules = true;
   };
 
-  cargoHash = "sha256-fjhLA+utQdgR75wg+/N4VwASW6+YBHglRPj14sPHmGA=";
+  nativeBuildInputs = [
+    perl
+  ];
+
+  cargoHash = "sha256-XrVvhJ1lFLBA+DwWgTV34jufrcjszpbCgXpF+TUoEvo=";
 
   checkFlags = [
     # the following test cases try to access network, skip them

--- a/pkgs/by-name/an/anchor/package.nix
+++ b/pkgs/by-name/an/anchor/package.nix
@@ -6,9 +6,17 @@
   pkg-config,
   stdenv,
   udev,
+  llvmPackages_18,
 }:
 
-rustPlatform.buildRustPackage rec {
+let
+  # Use older clang for x86_64-darwin to support macOS < 14.0
+  stdenv' =
+    if stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64
+    then llvmPackages_18.stdenv
+    else stdenv;
+in
+(rustPlatform.override { stdenv = stdenv'; }).buildRustPackage rec {
   pname = "anchor";
   version = "0.32.1";
 
@@ -25,7 +33,7 @@ rustPlatform.buildRustPackage rec {
     pkg-config
   ];
 
-  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+  buildInputs = lib.optionals stdenv'.hostPlatform.isLinux [
     udev
   ];
 

--- a/pkgs/by-name/an/anchor/package.nix
+++ b/pkgs/by-name/an/anchor/package.nix
@@ -3,6 +3,9 @@
   perl,
   rustPlatform,
   fetchFromGitHub,
+  pkg-config,
+  stdenv,
+  udev,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -19,6 +22,11 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [
     perl
+    pkg-config
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    udev
   ];
 
   cargoHash = "sha256-XrVvhJ1lFLBA+DwWgTV34jufrcjszpbCgXpF+TUoEvo=";

--- a/pkgs/by-name/an/anchor/package.nix
+++ b/pkgs/by-name/an/anchor/package.nix
@@ -6,17 +6,9 @@
   pkg-config,
   stdenv,
   udev,
-  llvmPackages_18,
 }:
 
-let
-  # Use older clang for x86_64-darwin to support macOS < 14.0
-  stdenv' =
-    if stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64
-    then llvmPackages_18.stdenv
-    else stdenv;
-in
-(rustPlatform.override { stdenv = stdenv'; }).buildRustPackage rec {
+rustPlatform.buildRustPackage rec {
   pname = "anchor";
   version = "0.32.1";
 
@@ -33,7 +25,7 @@ in
     pkg-config
   ];
 
-  buildInputs = lib.optionals stdenv'.hostPlatform.isLinux [
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     udev
   ];
 
@@ -53,5 +45,6 @@ in
     license = licenses.asl20;
     maintainers = with maintainers; [ Denommus ];
     mainProgram = "anchor";
+    broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64;
   };
 }


### PR DESCRIPTION

## Things done
https://github.com/solana-foundation/anchor/releases/tag/v0.32.0
https://github.com/solana-foundation/anchor/releases/tag/v0.32.1

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
