### PR TITLE
typstPackages: Simplify configuration

### DIFF
--- a/doc/languages-frameworks/typst.section.md
+++ b/doc/languages-frameworks/typst.section.md
@@ -22,7 +22,7 @@ Since **Typst Universe** does not provide a way to fetch a package with a specif
 ```nix
 typst.withPackages.override
   (old: {
-    typstPackages = old.typstPackages.extend (
+    typstPackages = old.typstPackages.overrideScope (
       _: previous: {
         polylux_0_4_0 = previous.polylux_0_4_0.overrideAttrs (oldPolylux: {
           src = oldPolylux.src.overrideAttrs { outputHash = YourUpToDatePolyluxHash; };

--- a/pkgs/by-name/ty/typst/build-universe-package.nix
+++ b/pkgs/by-name/ty/typst/build-universe-package.nix
@@ -2,31 +2,50 @@
   lib,
   buildTypstPackage,
   fetchzip,
-  # typstPackages from within the scope
-  packages,
-  hash,
-  description,
-  license,
-  typstDeps,
-  homepage ? null,
+  typstPackages,
 }:
-buildTypstPackage (finalAttrs: {
-  inherit pname version;
+lib.extendMkDerivation {
+  inheritFunctionArgs = false;
+  constructDrv = buildTypstPackage;
 
-  src = fetchzip {
-    inherit hash;
-    url = "https://packages.typst.org/preview/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
-    stripRoot = false;
-  };
+  excludeDrvArgNames = [
+    "description"
+    "hash"
+    "license"
+    "homepage"
+    "typstDeps"
+  ];
 
-  typstDeps = builtins.filter (x: x != null) (
-    lib.map (d: (lib.attrsets.attrByPath [ d ] null packages)) typstDeps
-  );
+  extendDrvArgs =
+    finalAttrs:
+    {
+      pname,
+      version,
+      description,
+      hash,
+      license,
+      homepage ? null,
+      typstDeps ? [ ],
+    }:
+    {
+      src = fetchzip {
+        inherit hash;
+        url = "https://packages.typst.org/preview/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
+        stripRoot = false;
+      };
 
-  meta = {
-    inherit description;
-    maintainers = with lib.maintainers; [ cherrypiejam ];
-    license = lib.map (lib.flip lib.getAttr lib.licensesSpdx) license;
-  }
-  // (if homepage != null then { inherit homepage; } else { });
-})
+      typstDeps = builtins.filter (x: x != null) (
+        lib.map (d: (lib.attrsets.attrByPath [ d ] null typstPackages)) typstDeps
+      );
+
+      meta = {
+        inherit description;
+        maintainers = with lib.maintainers; [
+          cherrypiejam
+          RossSmyth
+        ];
+        license = lib.map (lib.flip lib.getAttr lib.licensesSpdx) license;
+      }
+      // lib.optionalAttrs (homepage != null) { inherit homepage; };
+    };
+}

--- a/pkgs/by-name/ty/typst/build-universe-package.nix
+++ b/pkgs/by-name/ty/typst/build-universe-package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildTypstPackage,
+  fetchzip,
+  # typstPackages from within the scope
+  packages,
+  hash,
+  description,
+  license,
+  typstDeps,
+  homepage ? null,
+}:
+buildTypstPackage (finalAttrs: {
+  inherit pname version;
+
+  src = fetchzip {
+    inherit hash;
+    url = "https://packages.typst.org/preview/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
+    stripRoot = false;
+  };
+
+  typstDeps = builtins.filter (x: x != null) (
+    lib.map (d: (lib.attrsets.attrByPath [ d ] null packages)) typstDeps
+  );
+
+  meta = {
+    inherit description;
+    maintainers = with lib.maintainers; [ cherrypiejam ];
+    license = lib.map (lib.flip lib.getAttr lib.licensesSpdx) license;
+  }
+  // (if homepage != null then { inherit homepage; } else { });
+})

--- a/pkgs/by-name/ty/typst/typst-packages.nix
+++ b/pkgs/by-name/ty/typst/typst-packages.nix
@@ -1,13 +1,14 @@
 {
   lib,
   callPackage,
+  newScope,
 }:
 
 let
   toPackageName = name: version: "${name}_${lib.replaceStrings [ "." ] [ "_" ] version}";
 in
-lib.makeExtensible (
-  final:
+lib.makeScope newScope (
+  self:
   lib.recurseIntoAttrs (
     lib.foldlAttrs (
       packageSet: pname: versionSet:
@@ -16,7 +17,7 @@ lib.makeExtensible (
         subPackageSet: version: packageSpec:
         subPackageSet
         // {
-          ${toPackageName pname version} = callPackage (
+          ${toPackageName pname version} = self.callPackage (
             {
               lib,
               buildTypstPackage,
@@ -32,7 +33,7 @@ lib.makeExtensible (
               };
 
               typstDeps = builtins.filter (x: x != null) (
-                lib.map (d: (lib.attrsets.attrByPath [ d ] null final)) packageSpec.typstDeps
+                lib.map (d: (lib.attrsets.attrByPath [ d ] null self)) packageSpec.typstDeps
               );
 
               meta = {
@@ -46,7 +47,7 @@ lib.makeExtensible (
         }
       ) { } versionSet)
       // {
-        ${pname} = final.${toPackageName pname (lib.last (lib.attrNames versionSet))};
+        ${pname} = self.${toPackageName pname (lib.last (lib.attrNames versionSet))};
       }
     ) { } (lib.importTOML ./typst-packages-from-universe.toml)
   )

--- a/pkgs/by-name/ty/typst/typst-packages.nix
+++ b/pkgs/by-name/ty/typst/typst-packages.nix
@@ -9,46 +9,44 @@ let
 in
 lib.makeScope newScope (
   self:
-  lib.recurseIntoAttrs (
-    lib.foldlAttrs (
-      packageSet: pname: versionSet:
-      packageSet
-      // (lib.foldlAttrs (
-        subPackageSet: version: packageSpec:
-        subPackageSet
-        // {
-          ${toPackageName pname version} = self.callPackage (
-            {
-              lib,
-              buildTypstPackage,
-              fetchzip,
-            }:
-            buildTypstPackage (finalAttrs: {
-              inherit pname version;
-
-              src = fetchzip {
-                inherit (packageSpec) hash;
-                url = "https://packages.typst.org/preview/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
-                stripRoot = false;
-              };
-
-              typstDeps = builtins.filter (x: x != null) (
-                lib.map (d: (lib.attrsets.attrByPath [ d ] null self)) packageSpec.typstDeps
-              );
-
-              meta = {
-                inherit (packageSpec) description;
-                maintainers = with lib.maintainers; [ cherrypiejam ];
-                license = lib.map (lib.flip lib.getAttr lib.licensesSpdx) packageSpec.license;
-              }
-              // (if packageSpec ? "homepage" then { inherit (packageSpec) homepage; } else { });
-            })
-          ) { };
-        }
-      ) { } versionSet)
+  lib.foldlAttrs (
+    packageSet: pname: versionSet:
+    packageSet
+    // (lib.foldlAttrs (
+      subPackageSet: version: packageSpec:
+      subPackageSet
       // {
-        ${pname} = self.${toPackageName pname (lib.last (lib.attrNames versionSet))};
+        ${toPackageName pname version} = self.callPackage (
+          {
+            lib,
+            buildTypstPackage,
+            fetchzip,
+          }:
+          buildTypstPackage (finalAttrs: {
+            inherit pname version;
+
+            src = fetchzip {
+              inherit (packageSpec) hash;
+              url = "https://packages.typst.org/preview/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
+              stripRoot = false;
+            };
+
+            typstDeps = builtins.filter (x: x != null) (
+              lib.map (d: (lib.attrsets.attrByPath [ d ] null self)) packageSpec.typstDeps
+            );
+
+            meta = {
+              inherit (packageSpec) description;
+              maintainers = with lib.maintainers; [ cherrypiejam ];
+              license = lib.map (lib.flip lib.getAttr lib.licensesSpdx) packageSpec.license;
+            }
+            // (if packageSpec ? "homepage" then { inherit (packageSpec) homepage; } else { });
+          })
+        ) { };
       }
-    ) { } (lib.importTOML ./typst-packages-from-universe.toml)
-  )
+    ) { } versionSet)
+    // {
+      ${pname} = self.${toPackageName pname (lib.last (lib.attrNames versionSet))};
+    }
+  ) { } (lib.importTOML ./typst-packages-from-universe.toml)
 )

--- a/pkgs/by-name/ty/typst/typst-packages.nix
+++ b/pkgs/by-name/ty/typst/typst-packages.nix
@@ -16,33 +16,15 @@ lib.makeScope newScope (
       subPackageSet: version: packageSpec:
       subPackageSet
       // {
-        ${toPackageName pname version} = self.callPackage (
-          {
-            lib,
-            buildTypstPackage,
-            fetchzip,
-          }:
-          buildTypstPackage (finalAttrs: {
-            inherit pname version;
-
-            src = fetchzip {
-              inherit (packageSpec) hash;
-              url = "https://packages.typst.org/preview/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
-              stripRoot = false;
-            };
-
-            typstDeps = builtins.filter (x: x != null) (
-              lib.map (d: (lib.attrsets.attrByPath [ d ] null self)) packageSpec.typstDeps
-            );
-
-            meta = {
-              inherit (packageSpec) description;
-              maintainers = with lib.maintainers; [ cherrypiejam ];
-              license = lib.map (lib.flip lib.getAttr lib.licensesSpdx) packageSpec.license;
-            }
-            // (if packageSpec ? "homepage" then { inherit (packageSpec) homepage; } else { });
-          })
-        ) { };
+        ${toPackageName pname version} = self.callPackage ./build-universe-package.nix {
+          inherit (packageSpec)
+            hash
+            description
+            license
+            typstDeps
+            homepage
+            ;
+        };
       }
     ) { } versionSet)
     // {

--- a/pkgs/by-name/ty/typst/typst-packages.nix
+++ b/pkgs/by-name/ty/typst/typst-packages.nix
@@ -9,6 +9,10 @@ let
 in
 lib.makeScope newScope (
   self:
+  let
+    # Not public, so do not expose to the package set
+    buildUniversePackage = self.callPackage ./build-universe-package.nix { typstPackages = self; };
+  in
   lib.foldlAttrs (
     packageSet: pname: versionSet:
     packageSet
@@ -16,7 +20,8 @@ lib.makeScope newScope (
       subPackageSet: version: packageSpec:
       subPackageSet
       // {
-        ${toPackageName pname version} = self.callPackage ./build-universe-package.nix {
+        ${toPackageName pname version} = buildUniversePackage {
+          inherit pname version;
           inherit (packageSpec)
             hash
             description

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12413,7 +12413,7 @@ with pkgs;
 
   buildTypstPackage = callPackage ../build-support/build-typst-package.nix { };
 
-  typstPackages = typst.packages;
+  typstPackages = recurseIntoAttrs typst.packages;
 
   ueberzug = with python3Packages; toPythonApplication ueberzug;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Review by-commit

I found the previous reivision a bit hard to see what is going on, so I spent some time staring at it, then making it easier to follow

1. Use `makeScope` rather than `makeExtensible` since that is much more idiomatic for package sets
2. Move `recurseIntoAttrs` up to `all-packages.nix` as that is where it is usually placed 
3. Move the builder to its own file
   Note that all the commits before this have zero rebuilds :)
5. Have the builder use `extendMkDerivation` rather than ad-hoc extension
6. Rather than a bunch of nested `foldAttrs` with attrset merging, I use `mapAttrsToListRecursive` and `listToAttrs` to make it more clear what it happening with let binds and such

I find this much more clear to read.

Maybe should add an alias for `extend` to alias `overrideScope`. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
