### PR TITLE
prmers: init at 4.15.35-alpha

### DIFF
--- a/pkgs/by-name/pr/prmers/package.nix
+++ b/pkgs/by-name/pr/prmers/package.nix
@@ -1,0 +1,60 @@
+{
+  curl,
+  fetchFromGitHub,
+  gmp,
+  lib,
+  ocl-icd,
+  opencl-headers,
+  stdenv,
+  versionCheckHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "prmers";
+  version = "4.15.35-alpha";
+
+  src = fetchFromGitHub {
+    owner = "cherubrock-seb";
+    repo = "PrMers";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-LAbWyz1FT9Zza4gewgKeMvQt8rwkfBhHRWBGpN+DIXE=";
+  };
+
+  enableParallelBuilding = true;
+
+  buildInputs = [
+    curl
+    gmp
+    ocl-icd
+    opencl-headers
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    make install PREFIX=$out KERNEL_PATH=$out/bin/kernels
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  versionCheckProgramArg = "-v";
+
+  meta = {
+    description = "GPU-accelerated Mersenne primality testing";
+    longDescription = ''
+      PrMers is a high-performance GPU application for Lucas–Lehmer (LL), PRP, and P-1 testing of Mersenne numbers.
+         It uses OpenCL and integer NTT/IBDWT kernels and is built for long, reliable runs with checkpointing and PrimeNet submission.
+    '';
+    homepage = "https://github.com/cherubrock-seb/PrMers";
+    downloadPage = "https://github.com/cherubrock-seb/PrMers/releases/tag/v${finalAttrs.version}";
+    maintainers = with lib.maintainers; [ dstremur ];
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "prmers";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adding the PrMers package for mersenne prime searching.
https://github.com/cherubrock-seb/PrMers

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
