### PR TITLE
Revert "openvino: use system protobuf"

### DIFF
--- a/pkgs/by-name/op/openvino/package.nix
+++ b/pkgs/by-name/op/openvino/package.nix
@@ -118,7 +118,7 @@ stdenv.mkDerivation rec {
     "-DCMAKE_MODULE_PATH:PATH=${placeholder "out"}/lib/cmake"
     "-DCMAKE_PREFIX_PATH:PATH=${placeholder "out"}"
     "-DOpenCV_DIR=${lib.getLib opencv}/lib/cmake/opencv4/"
-    "-DCMAKE_PREFIX_PATH=${lib.getLib protobuf}"
+    "-DProtobuf_LIBRARIES=${protobuf}/lib/libprotobuf${stdenv.hostPlatform.extensions.sharedLibrary}"
     "-DPython_EXECUTABLE=${python.interpreter}"
 
     (cmakeBool "CMAKE_VERBOSE_MAKEFILE" true)
@@ -142,8 +142,7 @@ stdenv.mkDerivation rec {
     # system libs
     (cmakeBool "ENABLE_SYSTEM_FLATBUFFERS" true)
     (cmakeBool "ENABLE_SYSTEM_OPENCL" true)
-    (cmakeBool "ENABLE_SYSTEM_PROTOBUF" true)
-    (cmakeBool "Protobuf_USE_STATIC_LIBS" false)
+    (cmakeBool "ENABLE_SYSTEM_PROTOBUF" false)
     (cmakeBool "ENABLE_SYSTEM_PUGIXML" true)
     (cmakeBool "ENABLE_SYSTEM_SNAPPY" true)
     (cmakeBool "ENABLE_SYSTEM_TBB" true)
@@ -164,7 +163,6 @@ stdenv.mkDerivation rec {
     libxml2
     ocl-icd
     opencv
-    protobuf
     pugixml
     snappy
     onetbb


### PR DESCRIPTION
This reverts commit e1ece2c5218fa3141ee7bef86f16710640c10d4c.

This crashes the Python interpreter in the Frigate test phase, likely due to a weird mix of protobuf versions.

Ultimately this should be reverted once we have reduce the number of protobuf versions that transitively leak into frigate.

Closes: #461064

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
