### PR TITLE
vimPlugins.{avante-nvim,blink-cmp, blink-pairs, codesnap-nvim, fff-nvim}: fix darwin build

### DIFF
--- a/pkgs/applications/editors/vim/plugins/non-generated/avante-nvim/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/avante-nvim/default.nix
@@ -37,6 +37,9 @@ let
 
     buildFeatures = [ "luajit" ];
 
+    # Allow undefined symbols on Darwin - they will be provided by Neovim's LuaJIT runtime
+    env.RUSTFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-C link-arg=-undefined -C link-arg=dynamic_lookup";
+
     checkFlags = [
       # Disabled because they access the network.
       "--skip=test_hf"

--- a/pkgs/applications/editors/vim/plugins/non-generated/blink-cmp/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/blink-cmp/default.nix
@@ -26,6 +26,8 @@ let
     env = {
       # TODO: remove this if plugin stops using nightly rust
       RUSTC_BOOTSTRAP = true;
+      # Allow undefined symbols on Darwin - they will be provided by Neovim's LuaJIT runtime
+      RUSTFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-C link-arg=-undefined -C link-arg=dynamic_lookup";
     };
   };
 in

--- a/pkgs/applications/editors/vim/plugins/non-generated/blink-pairs/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/blink-pairs/default.nix
@@ -23,7 +23,12 @@ let
 
     cargoHash = "sha256-Cn9zRsQkBwaKbBD/JEpFMBOF6CBZTDx7fQa6Aoic4YU=";
 
-    env.RUSTC_BOOTSTRAP = 1;
+    env = {
+      RUSTC_BOOTSTRAP = 1;
+
+      # Allow undefined symbols on Darwin - they will be provided by Neovim's LuaJIT runtime
+      RUSTFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-C link-arg=-undefined -C link-arg=dynamic_lookup";
+    };
 
     # NOTE: Disabled upstream too
     doCheck = false;

--- a/pkgs/applications/editors/vim/plugins/non-generated/codesnap-nvim/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/codesnap-nvim/default.nix
@@ -29,6 +29,9 @@ let
       rustPlatform.bindgenHook
     ];
 
+    # Allow undefined symbols on Darwin - they will be provided by Neovim's LuaJIT runtime
+    env.RUSTFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-C link-arg=-undefined -C link-arg=dynamic_lookup";
+
     buildInputs = [
       libuv.dev
     ];

--- a/pkgs/applications/editors/vim/plugins/non-generated/fff-nvim/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/fff-nvim/default.nix
@@ -2,11 +2,12 @@
   lib,
   fetchFromGitHub,
   rustPlatform,
-  pkg-config,
-  perl,
-  openssl,
-  vimUtils,
   nix-update-script,
+  openssl,
+  perl,
+  pkg-config,
+  stdenv,
+  vimUtils,
 }:
 let
   version = "65aeacf-unstable-2025-11-03";
@@ -35,6 +36,9 @@ let
       RUSTC_BOOTSTRAP = 1; # We need rust unstable features
 
       OPENSSL_NO_VENDOR = true;
+
+      # Allow undefined symbols on Darwin - they will be provided by Neovim's LuaJIT runtime
+      RUSTFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-C link-arg=-undefined -C link-arg=dynamic_lookup";
     };
   };
 in


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Looks like these args are what blink-cmp uses upstream for their lib build. Going to use them for the other cargo packages that are failing to build. https://github.com/saghen/blink.cmp/blob/main/.cargo/config.toml#L7-L11

Fixes https://github.com/NixOS/nixpkgs/issues/464168

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
