### PR TITLE
lemmy-ui: fix asset URLs

### DIFF
--- a/nixos/modules/services/web-apps/lemmy.nix
+++ b/nixos/modules/services/web-apps/lemmy.nix
@@ -210,7 +210,7 @@ in
               root * ${cfg.ui.package}/dist
               file_server
             }
-            handle_path /static/${cfg.ui.package.passthru.commit_sha}/* {
+            handle_path /static/${cfg.ui.package.version}/* {
               root * ${cfg.ui.package}/dist
               file_server
             }

--- a/pkgs/servers/web-apps/lemmy/ui.nix
+++ b/pkgs/servers/web-apps/lemmy/ui.nix
@@ -18,15 +18,13 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "lemmy-ui";
   version = pinData.uiVersion;
 
-  src =
-    with finalAttrs;
-    fetchFromGitHub {
-      owner = "LemmyNet";
-      repo = "lemmy-ui";
-      rev = version;
-      fetchSubmodules = true;
-      hash = pinData.uiHash;
-    };
+  src = fetchFromGitHub {
+    owner = "LemmyNet";
+    repo = "lemmy-ui";
+    tag = finalAttrs.version;
+    fetchSubmodules = true;
+    hash = pinData.uiHash;
+  };
 
   nativeBuildInputs = [
     nodejs
@@ -48,20 +46,17 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   buildPhase = ''
     runHook preBuild
 
-    pnpm build:prod
+    pnpm run prebuild:prod
+    # Required to pass a custom value for COMMIT_HASH, as the normal
+    # `pnpm build:prod` tries to derive its value by running `git`.
+    # This value is only injected into the templated asset URLs for cache invalidation,
+    # so we don't really need a commit hash here, just a value that changes on every
+    # update.
+    pnpm exec webpack --env COMMIT_HASH="${finalAttrs.version}" --mode=production
 
     runHook postBuild
   '';
 
-  # installPhase = ''
-  #     runHook preInstall
-
-  #     mkdir -p $out/{bin,lib/${finalAttrs.pname}}
-  #     mv {dist,node_modules} $out/lib/${finalAttrs.pname}
-
-  #     runHook postInstall
-
-  #  '';
   preInstall = ''
     mkdir $out
     cp -R ./dist $out
@@ -81,7 +76,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   passthru = {
     updateScript = ./update.py;
     tests.lemmy-ui = nixosTests.lemmy;
-    commit_sha = finalAttrs.src.rev;
   };
 
   meta = {


### PR DESCRIPTION
As `fetchFromGitHub` does not preserve the `.git` directory, lemmy-ui fails to derive the value for its `COMMIT_HASH` variable during the build.
The package previously (and mistakenly) assumed that `src.rev` would somehow return the commit hash and not the version. Fortunately, we do not need to know the precise commit rev. This value is only used to generate the templated URLs without further processing (and is also only injected for cache invalidation).

Without this fix, `undefined` is injected into the URLs and lemmy fails to load any of the UI's static assets when using the Caddy mode of the lemmy module.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
