### PR TITLE
Qt 6.10.1

### DIFF
--- a/pkgs/development/libraries/qt-6/fetch.sh
+++ b/pkgs/development/libraries/qt-6/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.qt.io/official_releases/qt/6.10/6.10.0/submodules/ -A '*.tar.xz' )
+WGET_ARGS=( https://download.qt.io/official_releases/qt/6.10/6.10.1/submodules/ -A '*.tar.xz' )

--- a/pkgs/development/libraries/qt-6/modules/qtconnectivity.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtconnectivity.nix
@@ -20,8 +20,4 @@ qtModule {
     qtbase
     qtdeclarative
   ];
-
-  postPatch = ''
-    substituteInPlace src/nfc/configure.cmake --replace-fail "qt_configure_add_summary_entry(ARGS pcslite)" "qt_configure_add_summary_entry(ARGS pcsclite)"
-  '';
 }

--- a/pkgs/development/libraries/qt-6/modules/qtdeclarative/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtdeclarative/default.nix
@@ -1,5 +1,4 @@
 {
-  fetchpatch,
   qtModule,
   qtbase,
   qtlanguageserver,
@@ -36,18 +35,6 @@ qtModule {
     })
     # add version specific QML import path
     ./use-versioned-import-path.patch
-    # Fix common crash
-    # https://bugreports.qt.io/browse/QTBUG-140018
-    (fetchpatch {
-      url = "https://invent.kde.org/qt/qt/qtdeclarative/-/commit/2b7f93da38d41ffaeb5322a7dca40ec26fc091a1.diff";
-      hash = "sha256-AOXey18lJlswpZ8tpTTZeFb0VE9k1louXy8TPPGNiA4=";
-    })
-    # Fix another common crash
-    # https://bugreports.qt.io/browse/QTBUG-139626
-    (fetchpatch {
-      url = "https://invent.kde.org/qt/qt/qtdeclarative/-/commit/0de0b0ffdb44d73c605e20f00934dfb44bdf7ad9.diff";
-      hash = "sha256-DCoaSxH1MgywGXmmK21LLzCBi2KAmJIv5YKpFS6nw7M=";
-    })
   ];
 
   cmakeFlags = [

--- a/pkgs/development/libraries/qt-6/modules/qtmqtt.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtmqtt.nix
@@ -6,13 +6,13 @@
 
 qtModule rec {
   pname = "qtmqtt";
-  version = "6.10.0";
+  version = "6.10.1";
 
   src = fetchFromGitHub {
     owner = "qt";
     repo = "qtmqtt";
     tag = "v${version}";
-    hash = "sha256-0o0zC8SUlug5xOV5AX9PiTim1td8NA4fq6WfBR5aSXA=";
+    hash = "sha256-ve9fyhUZFI6TAr/SFRXJudA1yTmTlg8+Fgyc9OUv3ds=";
   };
 
   propagatedBuildInputs = [ qtbase ];

--- a/pkgs/development/libraries/qt-6/modules/qttranslations.nix
+++ b/pkgs/development/libraries/qt-6/modules/qttranslations.nix
@@ -6,5 +6,7 @@
 qtModule {
   pname = "qttranslations";
   nativeBuildInputs = [ qttools ];
+  separateDebugInfo = false;
   outputs = [ "out" ];
+  allowedReferences = [ "out" ];
 }

--- a/pkgs/development/libraries/qt-6/srcs.nix
+++ b/pkgs/development/libraries/qt-6/srcs.nix
@@ -4,315 +4,315 @@
 
 {
   qt3d = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qt3d-everywhere-src-6.10.0.tar.xz";
-      sha256 = "1dz9g3nlwgwfycwl5a0c7h339s7azq2xvq99kd76wjqzfkrmz25x";
-      name = "qt3d-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qt3d-everywhere-src-6.10.1.tar.xz";
+      sha256 = "16lw0gpjcaf90iqnff95hxw3hng42c8hzknxczf4h7kv9zakynb0";
+      name = "qt3d-everywhere-src-6.10.1.tar.xz";
     };
   };
   qt5compat = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qt5compat-everywhere-src-6.10.0.tar.xz";
-      sha256 = "0zibn0kq8grlpkvfasjciz71bv6x4cgz02v5l5giyplbcnfwa9fh";
-      name = "qt5compat-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qt5compat-everywhere-src-6.10.1.tar.xz";
+      sha256 = "097yvzmfz9w5xsrr3dxd2gv4q826mplwmw0wnh0ywg8m18b6sfbj";
+      name = "qt5compat-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtactiveqt = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtactiveqt-everywhere-src-6.10.0.tar.xz";
-      sha256 = "15m7g4h4aa3fk5q4an3apd0bdqkxdknnx64p72brrmah773mmlpm";
-      name = "qtactiveqt-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtactiveqt-everywhere-src-6.10.1.tar.xz";
+      sha256 = "078bnj8a1faln3dibx14wxdsic5s94m00x73zwncfzx7ywczcr05";
+      name = "qtactiveqt-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtbase = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtbase-everywhere-src-6.10.0.tar.xz";
-      sha256 = "0v84f9pw387m0ghd4n6s9ipwjvniqspabqxkqmbj58slrcxn5m7a";
-      name = "qtbase-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtbase-everywhere-src-6.10.1.tar.xz";
+      sha256 = "0p96bnkgfb9s5aw6qkfcy1y49xgkafx1w4i36bf1zd9xwbvjcqjs";
+      name = "qtbase-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtcharts = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtcharts-everywhere-src-6.10.0.tar.xz";
-      sha256 = "0svz8frryxv811xyg8cawn5icjcin6909mw4k6hlvgz7429m5zqv";
-      name = "qtcharts-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtcharts-everywhere-src-6.10.1.tar.xz";
+      sha256 = "1x1adsv3nnx44y9ldfjrz4nlhacxalsixdklxypqzyvw05w2568p";
+      name = "qtcharts-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtconnectivity = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtconnectivity-everywhere-src-6.10.0.tar.xz";
-      sha256 = "16gs86zyaq8rvzd9jribgg51hanas15gpy8zh45n58004v7xa2jn";
-      name = "qtconnectivity-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtconnectivity-everywhere-src-6.10.1.tar.xz";
+      sha256 = "1zsl46nbacpkvgma9si39p8k7qhqq3cdwnfw7pij0f67j0xgvbkv";
+      name = "qtconnectivity-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtdatavis3d = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtdatavis3d-everywhere-src-6.10.0.tar.xz";
-      sha256 = "1qinrrk1j9qknwq2x7rl9aw8ajrp1h7kpfg29wcvaklbz9jj5xpx";
-      name = "qtdatavis3d-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtdatavis3d-everywhere-src-6.10.1.tar.xz";
+      sha256 = "01xva2m5x71avdqzp48zlq57l8v7kishzg75iwjjbrbazpx7q730";
+      name = "qtdatavis3d-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtdeclarative = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtdeclarative-everywhere-src-6.10.0.tar.xz";
-      sha256 = "1c7nar7q92w8l7wkmwbl0f6j4g1c8kw8jbn1bf35sf821593bzbf";
-      name = "qtdeclarative-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtdeclarative-everywhere-src-6.10.1.tar.xz";
+      sha256 = "0gl4akd7p0g6sf0y234lwkxvr16njjbxc19maj465fg0jjwfzd2g";
+      name = "qtdeclarative-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtdoc = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtdoc-everywhere-src-6.10.0.tar.xz";
-      sha256 = "0fvx690kap3s2h9lg4d4w3nsiks6h2idggskisg1r1gpwks2brgc";
-      name = "qtdoc-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtdoc-everywhere-src-6.10.1.tar.xz";
+      sha256 = "16h90yp34yn17z56y570yldl287glfasq4ayci7sk09jpd5n39h3";
+      name = "qtdoc-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtgraphs = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtgraphs-everywhere-src-6.10.0.tar.xz";
-      sha256 = "1shllyk4f5lidw0hij9zhgapck3rf3hm6qw4m1nn79mynfrz3j3f";
-      name = "qtgraphs-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtgraphs-everywhere-src-6.10.1.tar.xz";
+      sha256 = "0vjpbv7ck5p8z38j9a70a6kgsjvfx432lvh5slmbgim33yra0ksd";
+      name = "qtgraphs-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtgrpc = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtgrpc-everywhere-src-6.10.0.tar.xz";
-      sha256 = "0id4j4xgamx9wndc3cgnf5m42ax257xyfy2khq4aw0b10s4j4wpv";
-      name = "qtgrpc-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtgrpc-everywhere-src-6.10.1.tar.xz";
+      sha256 = "0zspyhlhl4irwrr4vm4pg3mppyybyw0q76zlgvpj4j9wcfw8y4wq";
+      name = "qtgrpc-everywhere-src-6.10.1.tar.xz";
     };
   };
   qthttpserver = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qthttpserver-everywhere-src-6.10.0.tar.xz";
-      sha256 = "1i8z4l1is5xashh5lq9afj1syhvvz15zgcr5f27mwhjzvc0mfw74";
-      name = "qthttpserver-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qthttpserver-everywhere-src-6.10.1.tar.xz";
+      sha256 = "0fz98hczfkkrhjmkwxi7159zpal4wvv5sb2y8pid9d2bsfb8sv52";
+      name = "qthttpserver-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtimageformats = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtimageformats-everywhere-src-6.10.0.tar.xz";
-      sha256 = "1shcghzjn3v9mbgms0ykk5d91q7hdm8mxv8n6vjhsm3wa190lib4";
-      name = "qtimageformats-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtimageformats-everywhere-src-6.10.1.tar.xz";
+      sha256 = "0wksip3a9xszlkq6368fdkz60qszfqy3wawl13w9dnw14ggsp3j9";
+      name = "qtimageformats-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtlanguageserver = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtlanguageserver-everywhere-src-6.10.0.tar.xz";
-      sha256 = "19i151qxh2fw2h5w6082bh0myk6skz3dihhs4mahhb1rkzh077jc";
-      name = "qtlanguageserver-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtlanguageserver-everywhere-src-6.10.1.tar.xz";
+      sha256 = "0v2m18bbm82n9lhb0lxabqnsabfh2nga8a8yndrncmad9xmm4q1k";
+      name = "qtlanguageserver-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtlocation = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtlocation-everywhere-src-6.10.0.tar.xz";
-      sha256 = "007qbni20qajdq6villwp7bc7hqzjlppc30yw3ccqb2bzf3kxm6b";
-      name = "qtlocation-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtlocation-everywhere-src-6.10.1.tar.xz";
+      sha256 = "02agg502pkdqgl3156al26bn4ascgyjz6ybsd7b53p4wp7qii5ib";
+      name = "qtlocation-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtlottie = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtlottie-everywhere-src-6.10.0.tar.xz";
-      sha256 = "09bvm3jr2s0hg14dq8b7604hfgxj3cm1i93lkkbjh2n2bfpi793h";
-      name = "qtlottie-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtlottie-everywhere-src-6.10.1.tar.xz";
+      sha256 = "1hjp0hml4cih3vk9dgn3cs94klp7q2di29cdk457jva890y3d75w";
+      name = "qtlottie-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtmultimedia = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtmultimedia-everywhere-src-6.10.0.tar.xz";
-      sha256 = "09hixwp8sq771rfp4c8bvmpzl6jd906k2rsrkxwij78drwhl0hh4";
-      name = "qtmultimedia-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtmultimedia-everywhere-src-6.10.1.tar.xz";
+      sha256 = "1f371qrcf9rp384niqxqfx0wa01m7p5hv7rjyzwz1m2052ygk97p";
+      name = "qtmultimedia-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtnetworkauth = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtnetworkauth-everywhere-src-6.10.0.tar.xz";
-      sha256 = "1j5k6dn0zc5rq82k89nyz5w0ny89mg1pg5aw0h41ybg2f5fqaq04";
-      name = "qtnetworkauth-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtnetworkauth-everywhere-src-6.10.1.tar.xz";
+      sha256 = "039qrymh18as1ksch470mzrxixr3fry2jnkrs7bqin3jh5cynd8l";
+      name = "qtnetworkauth-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtpositioning = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtpositioning-everywhere-src-6.10.0.tar.xz";
-      sha256 = "1q8yd9sjbm1vzcda1i21x0qf0n4md0k6wwbmr5jrvqbbcf8brgzc";
-      name = "qtpositioning-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtpositioning-everywhere-src-6.10.1.tar.xz";
+      sha256 = "08xy8rzm86b55pr8hk1g5rym7y0kblk0wj121l4rzqyn3gpi3cxb";
+      name = "qtpositioning-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtquick3d = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtquick3d-everywhere-src-6.10.0.tar.xz";
-      sha256 = "126lxiizd4pxxp43zzwv3k4i73806bgg329qsygz5qbnm0g8q9cq";
-      name = "qtquick3d-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtquick3d-everywhere-src-6.10.1.tar.xz";
+      sha256 = "1rh3wi6pxahdpzlnxw8xrxfx5l931k7kncv03fvxmw6fprr05m0p";
+      name = "qtquick3d-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtquick3dphysics = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtquick3dphysics-everywhere-src-6.10.0.tar.xz";
-      sha256 = "0hj90pdxh6x6zm1b4iflhr89sy13qrbwc79pv9z9m7gdwyzhid62";
-      name = "qtquick3dphysics-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtquick3dphysics-everywhere-src-6.10.1.tar.xz";
+      sha256 = "1vigiln79xy6xgr00wgmbfngqqpv6wsr5pviww8yfvmyy5yq8wyr";
+      name = "qtquick3dphysics-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtquickeffectmaker = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtquickeffectmaker-everywhere-src-6.10.0.tar.xz";
-      sha256 = "0vmr5s6b4cqxpw5kl5shzydj3if89znm3izj5nrhzsgbic11vhk4";
-      name = "qtquickeffectmaker-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtquickeffectmaker-everywhere-src-6.10.1.tar.xz";
+      sha256 = "1jdc2bgkrk1kl72h2cjb6j8p9pd2p7ck0zbw9afgam2hqm69hdih";
+      name = "qtquickeffectmaker-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtquicktimeline = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtquicktimeline-everywhere-src-6.10.0.tar.xz";
-      sha256 = "182bn72mifx8s867hsmramjfl9qr8szpla9fqw7bi3ywb1fiig6z";
-      name = "qtquicktimeline-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtquicktimeline-everywhere-src-6.10.1.tar.xz";
+      sha256 = "1dsiwbvd5gqlwm87s05w4qb20731sxqmlm724kisqaf2nj4x4bl8";
+      name = "qtquicktimeline-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtremoteobjects = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtremoteobjects-everywhere-src-6.10.0.tar.xz";
-      sha256 = "1616dagpzs68rhi1wiq1dwl1kbgf2c1mmrb3c7ni204k0rcjsh5i";
-      name = "qtremoteobjects-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtremoteobjects-everywhere-src-6.10.1.tar.xz";
+      sha256 = "03cakd52p33qi8cjn9zjjmympjd74bc2fsk22cyy6064wbdmd7kw";
+      name = "qtremoteobjects-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtscxml = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtscxml-everywhere-src-6.10.0.tar.xz";
-      sha256 = "1r1ic7kr3xzrg0vyrj4smj2vzyidazwrb5jqn2l6irg1bx06r55m";
-      name = "qtscxml-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtscxml-everywhere-src-6.10.1.tar.xz";
+      sha256 = "0s8q7873bklgd19ynwil0fxi03m0b7wbx39z07iqim66skjs0rzb";
+      name = "qtscxml-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtsensors = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtsensors-everywhere-src-6.10.0.tar.xz";
-      sha256 = "0fc7cq067sddfwcn43j5v4h6xzjrvj5gvi08l9bfag43s4d5wlk7";
-      name = "qtsensors-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtsensors-everywhere-src-6.10.1.tar.xz";
+      sha256 = "15dkhkb6hfybzy4wib3w2bzjqmkymi7fzb7wdmq8jii36gh9rkj9";
+      name = "qtsensors-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtserialbus = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtserialbus-everywhere-src-6.10.0.tar.xz";
-      sha256 = "0c7cljc555vcs7jkm63mczxxpg085b161b6vpd9vnrz2zyzv49y6";
-      name = "qtserialbus-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtserialbus-everywhere-src-6.10.1.tar.xz";
+      sha256 = "1m9ymfggv3l8lj7ji6kgayr5x6cisi20r3ikasbsbpzjgbvzqf95";
+      name = "qtserialbus-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtserialport = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtserialport-everywhere-src-6.10.0.tar.xz";
-      sha256 = "01gqv6hc2ycd877jhq6ffnfgizh9pgnzc1gn6m6cfp8ximwa07jg";
-      name = "qtserialport-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtserialport-everywhere-src-6.10.1.tar.xz";
+      sha256 = "0k2c1zbx20mcrn6hkcnsxy1252g1ycjh3mszqyh8axzn6n2gdchp";
+      name = "qtserialport-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtshadertools = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtshadertools-everywhere-src-6.10.0.tar.xz";
-      sha256 = "1xpvzmpisglbk3nnczqvj0n1dv6zd79phvczqwpqc9yq7y64gfl7";
-      name = "qtshadertools-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtshadertools-everywhere-src-6.10.1.tar.xz";
+      sha256 = "1djvynddqksxnbb94m2pvf1ngkdqc8631xa61nnkvdaj6fk98y5n";
+      name = "qtshadertools-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtspeech = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtspeech-everywhere-src-6.10.0.tar.xz";
-      sha256 = "07m59akg31010khz82lvbrgjwwacavra5qsi17jqpk0chdk300qk";
-      name = "qtspeech-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtspeech-everywhere-src-6.10.1.tar.xz";
+      sha256 = "0kvzic83d98szj6scgkm6hhj1p6jgr3i17c1523dw43f1xafrjj2";
+      name = "qtspeech-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtsvg = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtsvg-everywhere-src-6.10.0.tar.xz";
-      sha256 = "0cr5vaz485n23fvw4kvh1ykqny61bpdr5vd2q9szywsy9phc1ljy";
-      name = "qtsvg-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtsvg-everywhere-src-6.10.1.tar.xz";
+      sha256 = "07xh78s2krgnhvdsysf2ji5dicmfns4g92v2990czfzkb1d3aby0";
+      name = "qtsvg-everywhere-src-6.10.1.tar.xz";
     };
   };
   qttools = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qttools-everywhere-src-6.10.0.tar.xz";
-      sha256 = "0anhvd7yqs9l3dryl43f0f7zq22rwrvz93g16ygmjgiyryc50vfq";
-      name = "qttools-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qttools-everywhere-src-6.10.1.tar.xz";
+      sha256 = "16yl0hj540bnf1c1w4h7ph6s6bk15f0mqc1638807spzh21l0j41";
+      name = "qttools-everywhere-src-6.10.1.tar.xz";
     };
   };
   qttranslations = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qttranslations-everywhere-src-6.10.0.tar.xz";
-      sha256 = "1pkc0a5kigcp0jcq3ny1ykl0rqw0vabz45w14d2mgjyhrx9q4vij";
-      name = "qttranslations-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qttranslations-everywhere-src-6.10.1.tar.xz";
+      sha256 = "0513kpwmsmmk85rwzh77nkmmgkwi58kvvrws8xm3fb51i3gs4jcf";
+      name = "qttranslations-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtvirtualkeyboard = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtvirtualkeyboard-everywhere-src-6.10.0.tar.xz";
-      sha256 = "108klc6cr2ihaka9gnqaqv9i8r4lr8m39yviic3nviibd3r6gcmb";
-      name = "qtvirtualkeyboard-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtvirtualkeyboard-everywhere-src-6.10.1.tar.xz";
+      sha256 = "1pxnp4lg6i3v57ynqvisljp3dmfcjpp6q0dr0av03g5gi0qxx72v";
+      name = "qtvirtualkeyboard-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtwayland = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtwayland-everywhere-src-6.10.0.tar.xz";
-      sha256 = "07vnfd0xmzg8vc68g9j2i88lilmic5vhv22gn47vs94v4l52ngv0";
-      name = "qtwayland-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtwayland-everywhere-src-6.10.1.tar.xz";
+      sha256 = "04yb4x7k0dv4m7j6qagvgxz2k08yvl1msk0zjwn6nyi202w6vgs9";
+      name = "qtwayland-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtwebchannel = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtwebchannel-everywhere-src-6.10.0.tar.xz";
-      sha256 = "02ahm7cz8wgvfcgyq85sc2v566x4ihymalmv5xi0wn5zz9j5h5kl";
-      name = "qtwebchannel-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtwebchannel-everywhere-src-6.10.1.tar.xz";
+      sha256 = "049iv4vhzx061ka5skz2803npjsb477c20nfxxc0zrihy8jnk8bv";
+      name = "qtwebchannel-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtwebengine = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtwebengine-everywhere-src-6.10.0.tar.xz";
-      sha256 = "0765a5kfkxxi7rq58pivi32xwb17pvg3h2ix88dx3y9h3jqpfk64";
-      name = "qtwebengine-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtwebengine-everywhere-src-6.10.1.tar.xz";
+      sha256 = "1qyix9wbb2k96ybfavl56ffh3s6kbkfswvv5irmrlhm0hrhymdbp";
+      name = "qtwebengine-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtwebsockets = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtwebsockets-everywhere-src-6.10.0.tar.xz";
-      sha256 = "0vl091wnzqjpnp0i0l2dqlbhlwcfzw2ry1p48aifxf63lmyjw2fi";
-      name = "qtwebsockets-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtwebsockets-everywhere-src-6.10.1.tar.xz";
+      sha256 = "00dxjl3zr2vgj374vd31frnp8sxxknl3pmw46cxv3qhq8klwfai7";
+      name = "qtwebsockets-everywhere-src-6.10.1.tar.xz";
     };
   };
   qtwebview = {
-    version = "6.10.0";
+    version = "6.10.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.10/6.10.0/submodules/qtwebview-everywhere-src-6.10.0.tar.xz";
-      sha256 = "03rszbcr3lnf9cnk7hz99ibxx8na4l3i98q19fahj36ilpk68dd9";
-      name = "qtwebview-everywhere-src-6.10.0.tar.xz";
+      url = "${mirror}/official_releases/qt/6.10/6.10.1/submodules/qtwebview-everywhere-src-6.10.1.tar.xz";
+      sha256 = "0vvgn95bkrisjqwml16964zk0r9s6qvc6g81anl69xbs7mc80422";
+      name = "qtwebview-everywhere-src-6.10.1.tar.xz";
     };
   };
 }


### PR DESCRIPTION
Targeting master for now to make branch-off, can retarget to staging if we decide this is too much.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
