### PR TITLE
python3Packages.{langchain,langgraph}: updates

### DIFF
--- a/pkgs/development/python-modules/anthropic/default.nix
+++ b/pkgs/development/python-modules/anthropic/default.nix
@@ -34,14 +34,14 @@
 
 buildPythonPackage rec {
   pname = "anthropic";
-  version = "0.71.0";
+  version = "0.74.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "anthropics";
     repo = "anthropic-sdk-python";
     tag = "v${version}";
-    hash = "sha256-n8hu2RFuZN0ojHhhU4qPQaT2DUvqSglFhBo2ORln/mc=";
+    hash = "sha256-GTY4af+/eDftRog3yvxf/ImQcCDoSZVu6YPTbF41/Uk=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/langchain-anthropic/default.nix
+++ b/pkgs/development/python-modules/langchain-anthropic/default.nix
@@ -23,14 +23,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-anthropic";
-  version = "1.0.0";
+  version = "1.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-anthropic==${version}";
-    hash = "sha256-3kW5w98t5F199k14MoCY2dZGrC/HdBzKuRpM37EY3LQ=";
+    hash = "sha256-Fnre5RYJg4X4FlpEaZydrcH146ooau5hse1RgNcV+qc=";
   };
 
   sourceRoot = "${src.name}/libs/partners/anthropic";
@@ -43,12 +43,6 @@ buildPythonPackage rec {
     pydantic
   ];
 
-  pythonRelaxDeps = [
-    # Each component release requests the exact latest core.
-    # That prevents us from updating individual components.
-    "langchain-core"
-  ];
-
   nativeCheckInputs = [
     langchain
     langchain-tests
@@ -56,8 +50,21 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  enabledTestPaths = [
+    "tests/unit_tests"
+  ];
+
+  disabledTests = [
+    # TypeError from Pydantic
+    # https://github.com/langchain-ai/langchain/issues/34068
+    "test_creates_bash_tool"
+    "test_replaces_tool_with_claude_descriptor"
+  ];
+
   disabledTestPaths = [
-    "tests/integration_tests"
+    # TypeError from Pydantic
+    # https://github.com/langchain-ai/langchain/issues/34069
+    "tests/unit_tests/test_standard.py::TestAnthropicStandard::test_with_structured_output[PersonB] "
   ];
 
   pythonImportsCheck = [ "langchain_anthropic" ];

--- a/pkgs/development/python-modules/langchain-core/default.nix
+++ b/pkgs/development/python-modules/langchain-core/default.nix
@@ -36,14 +36,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-core";
-  version = "1.0.7";
+  version = "1.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-core==${version}";
-    hash = "sha256-esMMA9z8z9Q909buPGZP1jujEWzdXT+Mxlwvjz0XqKk=";
+    hash = "sha256-uDMex+2wvvNvdFSTHjShsrJeeMymOMKCmfS+AyMMH6c=";
   };
 
   sourceRoot = "${src.name}/libs/core";

--- a/pkgs/development/python-modules/langchain-google-genai/default.nix
+++ b/pkgs/development/python-modules/langchain-google-genai/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
 
   # build-system
-  pdm-backend,
+  hatchling,
 
   # dependencies
   filetype,
@@ -29,19 +29,19 @@
 
 buildPythonPackage rec {
   pname = "langchain-google-genai";
-  version = "3.0.0";
+  version = "3.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain-google";
     tag = "libs/genai/v${version}";
-    hash = "sha256-9Z0iRSICApA5/iHB7NTVYGpkktaoynG74W2mvn9zeMg=";
+    hash = "sha256-xyomN6N/rhtnGbS68YeEniXTL4V8xQhVaAjZ2gMayFw=";
   };
 
   sourceRoot = "${src.name}/libs/genai";
 
-  build-system = [ pdm-backend ];
+  build-system = [ hatchling ];
 
   pythonRelaxDeps = [
     # Each component release requests the exact latest core.

--- a/pkgs/development/python-modules/langchain-tests/default.nix
+++ b/pkgs/development/python-modules/langchain-tests/default.nix
@@ -30,14 +30,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-tests";
-  version = "1.0.0";
+  version = "1.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-tests==${version}";
-    hash = "sha256-t+3o7XoemvEALVYMx+FpkGQVx2c/npRrK3cNDp3bp9A=";
+    hash = "sha256-a7tqW4h34YbfUIAK2L417egaSNyKbvZJ+GEnPdC2wME=";
   };
 
   sourceRoot = "${src.name}/libs/standard-tests";

--- a/pkgs/development/python-modules/langchain/default.nix
+++ b/pkgs/development/python-modules/langchain/default.nix
@@ -45,14 +45,14 @@
 
 buildPythonPackage rec {
   pname = "langchain";
-  version = "1.0.2";
+  version = "1.0.8";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain==${version}";
-    hash = "sha256-NQra/L7OfnVyFTbGkSDcG30r8W733eAs9abII53wy4g=";
+    hash = "sha256-fvg5L9AtGEk9lkl7ruuRXFNvB10peah11Gy5v1e0xYE=";
   };
 
   sourceRoot = "${src.name}/libs/langchain_v1";

--- a/pkgs/development/python-modules/langgraph-checkpoint-postgres/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint-postgres/default.nix
@@ -26,14 +26,14 @@
 
 buildPythonPackage rec {
   pname = "langgraph-checkpoint-postgres";
-  version = "3.0.0";
+  version = "3.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
     tag = "checkpointpostgres==${version}";
-    hash = "sha256-YjO8KfDx7lZOps+dG7CPsY7LOqhKIBdfCXexPsR2pB4=";
+    hash = "sha256-bEaBrCsYbBTguNYrY/CibVj1d3SXjFKNToF4iyTj7ZI=";
   };
 
   postgresqlTestSetupPost = ''

--- a/pkgs/development/python-modules/langgraph/default.nix
+++ b/pkgs/development/python-modules/langgraph/default.nix
@@ -40,14 +40,14 @@
 }:
 buildPythonPackage rec {
   pname = "langgraph";
-  version = "1.0.1";
+  version = "1.0.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
     tag = version;
-    hash = "sha256-YjO8KfDx7lZOps+dG7CPsY7LOqhKIBdfCXexPsR2pB4=";
+    hash = "sha256-aLcozJi02L7jLbsiu87CqeeLiHZP2oqNdD6z2danCUA=";
   };
 
   postgresqlTestSetupPost = ''

--- a/pkgs/development/python-modules/langsmith/default.nix
+++ b/pkgs/development/python-modules/langsmith/default.nix
@@ -31,14 +31,14 @@
 
 buildPythonPackage rec {
   pname = "langsmith";
-  version = "0.4.41";
+  version = "0.4.45";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langsmith-sdk";
     tag = "v${version}";
-    hash = "sha256-hZRZ4IAPKxCtvDZfk9D5irkYk0KM6pG2l+HSq742KYw=";
+    hash = "sha256-m5JzGAi+l57F0Sg/KcUSDRiLXF0kh6inqpF7EktgwrQ=";
   };
 
   sourceRoot = "${src.name}/python";
@@ -85,6 +85,10 @@ buildPythonPackage rec {
     "test_chat_sync_api"
     "test_completions_async_api"
     "test_completions_sync_api"
+    # flaky -- compares two timestamps that can differ by a small amount
+    # ex: `assert 1763763094282 == 1763763094283`
+    "test_traceable_uses_uuidv7_and_start_time_matches_run_id"
+    "test_run_tree_default_uuidv7_and_start_time_match"
   ];
 
   disabledTestPaths = [


### PR DESCRIPTION
### DRAFT -- Awaiting for prerequisites to be merged

https://github.com/NixOS/nixpkgs/pull/464062
https://github.com/NixOS/nixpkgs/pull/464412

---

[python312Packages.langchain: 1.0.2 -> 1.0.8](https://github.com/NixOS/nixpkgs/pull/464365/commits/026be8bb058c7feb1bc729a0011ea7387a7407b6)
[python312Packages.langchain-core: 1.0.7 -> 1.1.0](https://github.com/NixOS/nixpkgs/pull/464365/commits/26dc82f0ccb60ba0466c8ad98622be22c98381d0)
[python312Packages.langchain-google-genai: 3.0.0 -> 3.1.0](https://github.com/NixOS/nixpkgs/pull/464365/commits/73440d8fad7006e0504bf5476c4013a5d0b27487)
[python312Packages.langchain-tests: 1.0.0 -> 1.0.1](https://github.com/NixOS/nixpkgs/pull/464365/commits/20b4adbe8e798f7c9a3847f3a86475bc1172730c)
[python312Packages.langgraph: 1.0.1 -> 1.0.3](https://github.com/NixOS/nixpkgs/pull/464365/commits/2d7928d1b5b6943e028e43c17515292df145c9de)
[python312Packages.langsmith: 0.4.41 -> 0.4.45](https://github.com/NixOS/nixpkgs/pull/464365/commits/9612bcf4369e583800efc2c71e0ddaa3eaf95a2d)
[python312Packages.langgraph-prebuilt: 1.0.1 -> 1.0.5](https://github.com/NixOS/nixpkgs/pull/464365/commits/4969719f81d02f23b50460a387d300b3d291adc5)
[python312Packages.langgraph-checkpoint-postgres: 3.0.0 -> 3.0.1](https://github.com/NixOS/nixpkgs/pull/464365/commits/b24ed0c142a9a8b75ca99502bec4e0c5c04c0625)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
