### PR TITLE
python3Packages.pynacl: 1.6.0 -> 1.6.2; libsodium: 1.0.20 -> 1.0.20-unstable-2025-12-31

### DIFF
--- a/pkgs/by-name/li/libsodium/package.nix
+++ b/pkgs/by-name/li/libsodium/package.nix
@@ -43,7 +43,10 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Modern and easy-to-use crypto library";
     homepage = "https://doc.libsodium.org/";
     license = lib.licenses.isc;
-    maintainers = with lib.maintainers; [ raskin ];
+    maintainers = with lib.maintainers; [
+      mdaniels5757
+      raskin
+    ];
     pkgConfigModules = [ "libsodium" ];
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/li/libsodium/package.nix
+++ b/pkgs/by-name/li/libsodium/package.nix
@@ -1,18 +1,21 @@
 {
   lib,
   stdenv,
-  fetchurl,
   autoreconfHook,
+  fetchFromGitHub,
   testers,
+  unstableGitUpdater,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libsodium";
-  version = "1.0.20";
+  version = "1.0.20-unstable-2025-12-31";
 
-  src = fetchurl {
-    url = "https://download.libsodium.org/libsodium/releases/libsodium-${finalAttrs.version}.tar.gz";
-    hash = "sha256-67Ze9spDkzPCu0GgwZkFhyiNoH9sf9B8s6GMwY0wzhk=";
+  src = fetchFromGitHub {
+    owner = "jedisct1";
+    repo = "libsodium";
+    rev = "d44593f1a5b7d31b5122689605b489577356f7e8";
+    hash = "sha256-6DC9JJLUwAoZHrYdCIiqOtAlWOEczec2r2FmaBbsa/Q=";
   };
 
   outputs = [
@@ -37,7 +40,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
 
-  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    updateScript = unstableGitUpdater {
+      branch = "stable";
+      tagConverter = "cut -d - -f 1";
+    };
+  };
 
   meta = {
     description = "Modern and easy-to-use crypto library";

--- a/pkgs/development/python-modules/pynacl/default.nix
+++ b/pkgs/development/python-modules/pynacl/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "pynacl";
-  version = "1.6.0";
+  version = "1.6.2";
   outputs = [
     "out"
     "doc"
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "pyca";
     repo = "pynacl";
     tag = version;
-    hash = "sha256-7SDJB2bXn0IGJQi597yehs9epdfmS7slbQ97vFVUkEA=";
+    hash = "sha256-EzzJVRDgYQO6T8YIQjad/Eb9O+BXT4IpOpa48fpBPnc=";
   };
 
   build-system = [


### PR DESCRIPTION
pynacl changelog: https://github.com/pyca/pynacl/blob/1.6.1/CHANGELOG.rst; https://github.com/pyca/pynacl/blob/1.6.2/CHANGELOG.rst

libsodium diff: https://github.com/jedisct1/libsodium/compare/1.0.20-RELEASE...stable
libsodium changelog: https://github.com/jedisct1/libsodium/blob/d44593f1a5b7d31b5122689605b489577356f7e8/ChangeLog
libsodium CVE: CVE-2025-69277

Switched libsodium to the stable branch per https://github.com/jedisct1/libsodium/commit/98e0129d6f71724acf3774ed1461533e519c8ed7 (and the security fix). We had to switch to GitHub for this: although they have a download for the stable branch, the URL stays the same even when the content changes.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
