### PR TITLE
corrosion: 0.5.2 -> 0.6.1

### DIFF
--- a/pkgs/by-name/co/corrosion/package.nix
+++ b/pkgs/by-name/co/corrosion/package.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation rec {
   pname = "corrosion";
-  version = "0.5.2";
+  version = "0.6.1";
 
   src = fetchFromGitHub {
     owner = "corrosion-rs";
     repo = "corrosion";
     rev = "v${version}";
-    hash = "sha256-sO2U0llrDOWYYjnfoRZE+/ofg3kb+ajFmqvaweRvT7c=";
+    hash = "sha256-ppuDNObfKhneD9AlnPAvyCRHKW3BidXKglD1j/LE9CM=";
   };
 
   buildInputs = lib.optional stdenv.hostPlatform.isDarwin libiconv;
@@ -32,12 +32,22 @@ stdenv.mkDerivation rec {
   checkPhase =
     let
       excludedTests = [
-        "cbindgen_rust2cpp_build"
-        "cbindgen_rust2cpp_run_cpp-exe"
+        "cbindgen_install"
+        "cbindgen_manual_build"
+        "cbindgen_manual_run_cpp-exe"
+        "cbindgen_rust2cpp_auto_build"
+        "cbindgen_rust2cpp_auto_run_cpp-exe"
+        "config_discovery_build"
+        "config_discovery_run_cargo_clean"
+        "config_discovery_run_config_discovery"
+        "custom_target_build"
+        "custom_target_run_rust-bin"
+        "custom_target_run_test-exe"
         "hostbuild_build"
         "hostbuild_run_rust-host-program"
-        "parse_target_triple_build"
-        "rustup_proxy_build"
+        "install_lib_build"
+        "install_lib_run_main-shared"
+        "install_lib_run_main-static"
       ];
       excludedTestsRegex = lib.concatStringsSep "|" excludedTests;
     in


### PR DESCRIPTION
Diff: https://github.com/corrosion-rs/corrosion/compare/v0.5.2...v0.6.1

Changelog: https://github.com/corrosion-rs/corrosion/blob/v0.6.1/RELEASES.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
