### PR TITLE
jarl: init at 0.1.2

### DIFF
--- a/pkgs/by-name/ja/jarl/package.nix
+++ b/pkgs/by-name/ja/jarl/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "jarl";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "etiennebacher";
+    repo = "jarl";
+    tag = finalAttrs.version;
+    hash = "sha256-ioX2Vh/uQ+VT/gra+DruG0tMOiobEkbcioeucJHBLfQ=";
+  };
+
+  postPatch = ''
+    # Nix sandbox uses build/.tmp as temp dir
+    substituteInPlace crates/jarl/tests/integration/helpers/command_ext.rs \
+    --replace-fail '(?:/private)?/(?:tmp|var/folders/[^/]+/[^/]+/T)/' \
+                   '(?:/nix)?/(?:build)/(?:nix[\-0-9]+/)?'
+  '';
+
+  cargoHash = "sha256-QdOd/l3FNMaVahGo35hdOMel2GDYcf8ZctkwG00KiNM=";
+
+  # Don't run integration_tests for jarl-lsp, because it doesn't see
+  # the CARGO_BIN_EXE_jarl env var even if exported in preCheck
+  cargoTestFlags = [
+    "--lib"
+    "--bins"
+    "--test integration"
+    # "--test integration_tests"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  postInstall = ''
+    rm $out/bin/xtask_codegen
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Just another R linter";
+    homepage = "https://jarl.etiennebacher.com";
+    changelog = "https://jarl.etiennebacher.com/changelog";
+    mainProgram = "jarl";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.kupac ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
