### PR TITLE
pkgs/by-name: add version pins

### DIFF
--- a/pkgs/by-name/bl/blender/package.nix
+++ b/pkgs/by-name/bl/blender/package.nix
@@ -16,7 +16,7 @@
   embree,
   fetchzip,
   fetchFromGitHub,
-  ffmpeg_7,
+  ffmpeg,
   fftw,
   fftwFloat,
   freetype,
@@ -234,7 +234,7 @@ stdenv'.mkDerivation (finalAttrs: {
   buildInputs = [
     alembic
     boost
-    ffmpeg_7
+    ffmpeg
     fftw
     fftwFloat
     freetype

--- a/pkgs/by-name/bl/blender/pins.nix
+++ b/pkgs/by-name/bl/blender/pins.nix
@@ -1,0 +1,4 @@
+{ ffmpeg_7 }:
+{
+  ffmpeg = ffmpeg_7;
+}

--- a/pkgs/by-name/ch/chiaki/package.nix
+++ b/pkgs/by-name/ch/chiaki/package.nix
@@ -4,7 +4,7 @@
   fetchgit,
   cmake,
   pkg-config,
-  ffmpeg_7,
+  ffmpeg,
   libopus,
   SDL2,
   libevdev,
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   buildInputs = [
-    ffmpeg_7 # needs avcodec_close which was removed in ffmpeg 8
+    ffmpeg
     libopus
     libsForQt5.qtbase
     libsForQt5.qtmultimedia

--- a/pkgs/by-name/ch/chiaki/pins.nix
+++ b/pkgs/by-name/ch/chiaki/pins.nix
@@ -1,0 +1,5 @@
+{ ffmpeg_7 }:
+{
+  # needs avcodec_close which was removed in ffmpeg 8
+  ffmpeg = ffmpeg_7;
+}

--- a/pkgs/by-name/dj/djv/package.nix
+++ b/pkgs/by-name/dj/djv/package.nix
@@ -6,7 +6,7 @@
   pkg-config,
   bzip2,
   feather-tk,
-  ffmpeg_7,
+  ffmpeg,
   freetype,
   glfw,
   imath,
@@ -56,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     bzip2
     feather-tk
-    ffmpeg_7
+    ffmpeg
     freetype
     glfw
     imath

--- a/pkgs/by-name/dj/djv/pins.nix
+++ b/pkgs/by-name/dj/djv/pins.nix
@@ -1,0 +1,4 @@
+{ ffmpeg_7 }:
+{
+  ffmpeg = ffmpeg_7;
+}

--- a/pkgs/by-name/ml/mlt/package.nix
+++ b/pkgs/by-name/ml/mlt/package.nix
@@ -6,7 +6,7 @@
   cmake,
   pkg-config,
   which,
-  ffmpeg_7,
+  ffmpeg,
   fftw,
   frei0r,
   libdv,
@@ -71,8 +71,8 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    (opencv4.override { inherit ffmpeg_7; })
-    ffmpeg_7
+    (opencv4.override { ffmpeg_7 = ffmpeg; })
+    ffmpeg
     fftw
     frei0r
     libdv
@@ -137,7 +137,7 @@ stdenv.mkDerivation rec {
   '';
 
   passthru = {
-    ffmpeg = ffmpeg_7;
+    ffmpeg = ffmpeg;
   };
 
   passthru.updateScript = gitUpdater {

--- a/pkgs/by-name/ml/mlt/pins.nix
+++ b/pkgs/by-name/ml/mlt/pins.nix
@@ -1,0 +1,4 @@
+{ ffmpeg_7 }:
+{
+  ffmpeg = ffmpeg_7;
+}

--- a/pkgs/by-name/re/retroarch-bare/package.nix
+++ b/pkgs/by-name/re/retroarch-bare/package.nix
@@ -5,7 +5,7 @@
   alsa-lib,
   dbus,
   fetchFromGitHub,
-  ffmpeg_7,
+  ffmpeg,
   flac,
   freetype,
   gamemode,
@@ -75,7 +75,7 @@ stdenv.mkDerivation rec {
   ++ lib.optional (runtimeLibs != [ ]) makeBinaryWrapper;
 
   buildInputs = [
-    ffmpeg_7
+    ffmpeg
     flac
     freetype
     libGL

--- a/pkgs/by-name/re/retroarch-bare/pins.nix
+++ b/pkgs/by-name/re/retroarch-bare/pins.nix
@@ -1,0 +1,4 @@
+{ ffmpeg_7 }:
+{
+  ffmpeg = ffmpeg_7;
+}

--- a/pkgs/by-name/rp/rpcs3/package.nix
+++ b/pkgs/by-name/rp/rpcs3/package.nix
@@ -14,7 +14,7 @@
   vulkan-loader,
   libpng,
   libSM,
-  ffmpeg_7,
+  ffmpeg,
   libevdev,
   libusb1,
   zlib,
@@ -120,7 +120,7 @@ stdenv.mkDerivation (finalAttrs: {
     vulkan-headers
     vulkan-loader
     libpng
-    ffmpeg_7
+    ffmpeg
     libevdev
     zlib
     libusb1

--- a/pkgs/by-name/rp/rpcs3/pins.nix
+++ b/pkgs/by-name/rp/rpcs3/pins.nix
@@ -1,0 +1,4 @@
+{ ffmpeg_7 }:
+{
+  ffmpeg = ffmpeg_7;
+}

--- a/pkgs/by-name/ru/rustdesk-flutter/package.nix
+++ b/pkgs/by-name/ru/rustdesk-flutter/package.nix
@@ -5,7 +5,7 @@
   copyDesktopItems,
   fetchFromGitHub,
   flutter329,
-  ffmpeg_7,
+  ffmpeg,
   gst_all_1,
   fuse3,
   libXtst,
@@ -119,7 +119,7 @@ flutter329.buildFlutterApplication rec {
   ];
 
   buildInputs = [
-    ffmpeg_7
+    ffmpeg
     fuse3
     gst_all_1.gst-plugins-base
     gst_all_1.gstreamer

--- a/pkgs/by-name/ru/rustdesk-flutter/pins.nix
+++ b/pkgs/by-name/ru/rustdesk-flutter/pins.nix
@@ -1,0 +1,4 @@
+{ ffmpeg_7 }:
+{
+  ffmpeg = ffmpeg_7;
+}

--- a/pkgs/by-name/te/tenacity/package.nix
+++ b/pkgs/by-name/te/tenacity/package.nix
@@ -31,7 +31,7 @@
   expat,
   libid3tag,
   libopus,
-  ffmpeg_7,
+  ffmpeg,
   soundtouch,
   pcre,
   portaudio,
@@ -76,7 +76,7 @@ stdenv.mkDerivation (finalAttrs: {
     # looking only in a few specific directories.
     # Make sure it searches for our version of ffmpeg in the nix store.
     substituteInPlace libraries/lib-ffmpeg-support/FFmpegFunctions.cpp \
-      --replace-fail /usr/local/lib/tenacity ${lib.getLib ffmpeg_7}/lib
+      --replace-fail /usr/local/lib/tenacity ${lib.getLib ffmpeg}/lib
   '';
 
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
@@ -130,7 +130,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     expat
-    ffmpeg_7
+    ffmpeg
     file
     flac
     glib

--- a/pkgs/by-name/te/tenacity/pins.nix
+++ b/pkgs/by-name/te/tenacity/pins.nix
@@ -1,0 +1,4 @@
+{ ffmpeg_7 }:
+{
+  ffmpeg = ffmpeg_7;
+}

--- a/pkgs/by-name/tl/tlrender/package.nix
+++ b/pkgs/by-name/tl/tlrender/package.nix
@@ -7,7 +7,7 @@
 
   bzip2,
   feather-tk,
-  ffmpeg_7,
+  ffmpeg,
   freetype,
   glfw,
   imath,
@@ -112,7 +112,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals enableTiff [ libtiff ]
   ++ lib.optionals enablePng [ libpng ]
   ++ lib.optionals enableOpenexr [ openexr ]
-  ++ lib.optionals enableFfmpeg [ ffmpeg_7 ]
+  ++ lib.optionals enableFfmpeg [ ffmpeg ]
   ++ lib.optionals enableUsd [ openusd ];
 
   cmakeFlags = [

--- a/pkgs/by-name/tl/tlrender/pins.nix
+++ b/pkgs/by-name/tl/tlrender/pins.nix
@@ -1,0 +1,4 @@
+{ ffmpeg_7 }:
+{
+  ffmpeg = ffmpeg_7;
+}

--- a/pkgs/by-name/yt/ytdl-sub/package.nix
+++ b/pkgs/by-name/yt/ytdl-sub/package.nix
@@ -1,7 +1,7 @@
 {
   python3Packages,
   fetchFromGitHub,
-  ffmpeg_7,
+  ffmpeg,
   lib,
   versionCheckHook,
 }:
@@ -38,8 +38,8 @@ python3Packages.buildPythonApplication rec {
   ];
 
   makeWrapperArgs = [
-    "--set YTDL_SUB_FFMPEG_PATH ${lib.getExe' ffmpeg_7 "ffmpeg"}"
-    "--set YTDL_SUB_FFPROBE_PATH ${lib.getExe' ffmpeg_7 "ffprobe"}"
+    "--set YTDL_SUB_FFMPEG_PATH ${lib.getExe' ffmpeg "ffmpeg"}"
+    "--set YTDL_SUB_FFPROBE_PATH ${lib.getExe' ffmpeg "ffprobe"}"
   ];
 
   nativeCheckInputs = [
@@ -49,8 +49,8 @@ python3Packages.buildPythonApplication rec {
   versionCheckProgramArg = "--version";
 
   env = {
-    YTDL_SUB_FFMPEG_PATH = "${lib.getExe' ffmpeg_7 "ffmpeg"}";
-    YTDL_SUB_FFPROBE_PATH = "${lib.getExe' ffmpeg_7 "ffprobe"}";
+    YTDL_SUB_FFMPEG_PATH = "${lib.getExe' ffmpeg "ffmpeg"}";
+    YTDL_SUB_FFPROBE_PATH = "${lib.getExe' ffmpeg "ffprobe"}";
   };
 
   disabledTests = [

--- a/pkgs/by-name/yt/ytdl-sub/pins.nix
+++ b/pkgs/by-name/yt/ytdl-sub/pins.nix
@@ -1,0 +1,4 @@
+{ ffmpeg_7 }:
+{
+  ffmpeg = ffmpeg_7;
+}


### PR DESCRIPTION
Proof of concept implementation of https://github.com/NixOS/rfcs/pull/192

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
