### PR TITLE
mediathekarr: init at 1.0-beta.9, nixos/mediathekarr: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -12,6 +12,8 @@
 
 - Create the first release note entry in this section!
 
+- [MediathekArr](https://github.com/PCJones/MediathekArr/), a download client for the ARD/ZDF mediathek for Sonarr. Available as [services.mediathekarr](#opt-services.mediathekarr).
+
 ## Backward Incompatibilities {#sec-release-26.05-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -877,6 +877,7 @@
   ./services/misc/logkeys.nix
   ./services/misc/mame.nix
   ./services/misc/mbpfan.nix
+  ./services/misc/mediathekarr.nix
   ./services/misc/mediatomb.nix
   ./services/misc/memos.nix
   ./services/misc/metabase.nix

--- a/nixos/modules/services/misc/mediathekarr.nix
+++ b/nixos/modules/services/misc/mediathekarr.nix
@@ -1,0 +1,242 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.mediathekarr;
+
+  serviceEnvironment = {
+    DOWNLOAD_COMPLETE_PATH = cfg.completePath;
+    DOWNLOAD_INCOMPLETE_PATH = cfg.incompletePath;
+    CATEGORIES = lib.concatStringsSep "," cfg.categories;
+    CONFIG_PATH = cfg.configPath;
+  };
+
+  commonHardening = {
+    ProtectSystem = "strict";
+    ProtectHome = true;
+    PrivateTmp = true;
+    PrivateDevices = true;
+    ProtectHostname = true;
+    ProtectClock = true;
+    ProtectKernelTunables = true;
+    ProtectKernelModules = true;
+    ProtectKernelLogs = true;
+    ProtectControlGroups = true;
+    ProtectProc = "invisible";
+    ProcSubset = "pid";
+    DevicePolicy = "closed";
+    LockPersonality = true;
+    RestrictRealtime = true;
+    RestrictNamespaces = true;
+    SystemCallArchitectures = "native";
+    NoNewPrivileges = true;
+    RestrictSUIDSGID = true;
+    RemoveIPC = true;
+    CapabilityBoundingSet = "";
+    SystemCallFilter = [ "@system-service" ];
+
+    PrivateNetwork = false;
+    RestrictAddressFamilies = [
+      "AF_INET"
+      "AF_INET6"
+    ];
+
+    # Required for Dotnet (explicitly disabled for documentation here)
+    MemoryDenyWriteExecute = false;
+  };
+in
+{
+  options.services.mediathekarr = {
+    enable = lib.mkEnableOption "mediathekarr service";
+
+    package = lib.mkPackageOption pkgs "mediathekarr" { };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "mediathekarr";
+      description = "User account under which mediathekarr runs.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "mediathekarr";
+      description = "Group under which mediathekarr runs.";
+    };
+
+    categories = lib.mkOption {
+      type = with lib.types; listOf str;
+      default = [
+        "tv"
+        "movies"
+        "sonarr-blackhole"
+        "radarr-blackhole"
+      ];
+      description = "Download categories.";
+    };
+
+    configPath = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/lib/mediathekarr";
+      description = "Path to configuration directory.";
+    };
+
+    completePath = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/lib/mediathekarr/complete";
+      description = "Path for completed downloads.";
+    };
+
+    incompletePath = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/lib/mediathekarr/incomplete";
+      description = "Path for downloads in progress.";
+    };
+
+    downloaderListenAddress = lib.mkOption {
+      type = lib.types.str;
+      default = "http://localhost:5007";
+      description = "Downloader listen address.";
+    };
+
+    serverListenAddress = lib.mkOption {
+      type = lib.types.str;
+      default = "http://localhost:5008";
+      description = "Server listen address.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+
+    users.users = lib.mkIf (cfg.user == "mediathekarr") {
+      mediathekarr = {
+        isSystemUser = true;
+        description = "mediathekarr user";
+        home = cfg.configPath;
+        group = cfg.group;
+      };
+    };
+
+    users.groups = lib.mkIf (cfg.group == "mediathekarr") {
+      ${cfg.group} = { };
+    };
+
+    systemd.targets.mediathekarr = {
+      description = "Mediathekarr target";
+      after = [
+        "network.target"
+        "network-online.target"
+        "nss-lookup.target"
+      ];
+      wants = [
+        "network.target"
+        "network-online.target"
+        "nss-lookup.target"
+      ];
+      wantedBy = [ "multi-user.target" ];
+    };
+
+    systemd.services.mediathekarr = {
+      description = "Mediathekarr server";
+
+      environment = serviceEnvironment // {
+        ASPNETCORE_URLS = cfg.serverListenAddress;
+      };
+
+      after = [
+        "network-online.target"
+      ];
+      wants = [
+        "network-online.target"
+      ];
+
+      wantedBy = [ "mediathekarr.target" ];
+
+      confinement = {
+        enable = true;
+        mode = "full-apivfs";
+      };
+
+      serviceConfig = commonHardening // {
+        Type = "exec";
+        User = cfg.user;
+        Group = cfg.group;
+        StateDirectory = "mediathekarr";
+        ExecStart = "${lib.getExe' cfg.package "MediathekArrServer"}";
+        WorkingDirectory = "${lib.getLib cfg.package}/lib/mediathekarr-server";
+        Restart = "on-failure";
+
+        # Strictly speaking not necessary if they are the default paths, but include them anyway for simplicity.
+        BindPaths = [
+          cfg.completePath
+          cfg.incompletePath
+        ];
+
+        BindReadOnlyPaths = [
+          "${config.security.pki.caBundle}:/etc/ssl/certs/ca-certificates.crt"
+          "/etc/resolv.conf"
+        ];
+      };
+    };
+
+    systemd.services.mediathekarr-downloader = {
+      description = "Mediathekarr downloader";
+
+      environment = serviceEnvironment // {
+        ASPNETCORE_URLS = cfg.downloaderListenAddress;
+      };
+
+      # nss-lookup.target: Required because downloader process tries to resolve API hostname during startup.
+      after = [
+        "network-online.target"
+        "nss-lookup.target"
+      ];
+      wants = [
+        "network-online.target"
+        "nss-lookup.target"
+      ];
+
+      wantedBy = [ "mediathekarr.target" ];
+
+      confinement = {
+        enable = true;
+        mode = "full-apivfs";
+      };
+
+      serviceConfig = commonHardening // {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        StateDirectory = "mediathekarr";
+        ExecStart = "${lib.getExe' cfg.package "MediathekArrDownloader"}";
+        WorkingDirectory = "${lib.getLib cfg.package}/lib/mediathekarr-downloader";
+        Restart = "on-failure";
+
+        # Strictly speaking not necessary if they are the default paths, but include them anyway for simplicity.
+        BindPaths = [
+          cfg.completePath
+          cfg.incompletePath
+        ];
+
+        BindReadOnlyPaths = [
+          "${config.security.pki.caBundle}:/etc/ssl/certs/ca-certificates.crt"
+          "/etc/resolv.conf"
+        ];
+      };
+    };
+
+    systemd.tmpfiles.settings."51-mediathekarr" = {
+      "${cfg.completePath}"."d" = lib.mkIf (cfg.completePath == "/var/lib/mediathekarr/complete") {
+        inherit (cfg) user group;
+        mode = "0755";
+      };
+      "${cfg.incompletePath}"."d" = lib.mkIf (cfg.incompletePath == "/var/lib/mediathekarr/incomplete") {
+        inherit (cfg) user group;
+        mode = "0755";
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -931,6 +931,7 @@ in
   mautrix-meta-sqlite = runTest ./matrix/mautrix-meta-sqlite.nix;
   mealie = runTest ./mealie.nix;
   mediamtx = runTest ./mediamtx.nix;
+  mediathekarr = runTest ./mediathekarr.nix;
   mediatomb = runTest ./mediatomb.nix;
   mediawiki = handleTest ./mediawiki.nix { };
   meilisearch = runTest ./meilisearch.nix;

--- a/nixos/tests/mediathekarr.nix
+++ b/nixos/tests/mediathekarr.nix
@@ -1,0 +1,22 @@
+{ lib, ... }:
+
+{
+  name = "mediathekarr";
+  meta.maintainers = with lib.maintainers; [ tmarkus ];
+
+  nodes.machine =
+    { ... }:
+    {
+      services.mediathekarr.enable = true;
+    };
+
+  testScript = ''
+    machine.wait_for_unit("mediathekarr.target")
+    machine.wait_for_unit("mediathekarr.service")
+
+    machine.wait_for_open_port(5007)
+    machine.wait_for_open_port(5008)
+
+    machine.succeed("curl --fail http://localhost:5007/")
+  '';
+}

--- a/pkgs/by-name/me/mediathekarr/deps.json
+++ b/pkgs/by-name/me/mediathekarr/deps.json
@@ -1,0 +1,92 @@
+[
+  {
+    "pname": "Microsoft.AspNetCore.App.Runtime.linux-x64",
+    "version": "9.0.10",
+    "hash": "sha256-AqoG3JWR88xgdSoVpzs6DldX+b0JtVtLJerYH4yOPvo="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.OpenApi",
+    "version": "9.0.0",
+    "hash": "sha256-VnYIpM80bWOzps06r/x0dgVF9U89vzkkXeYT2hJfBPs="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration",
+    "version": "9.0.0",
+    "hash": "sha256-uBLeb4z60y8z7NelHs9uT3cLD6wODkdwyfJm6/YZLDM="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Abstractions",
+    "version": "9.0.0",
+    "hash": "sha256-xtG2USC9Qm0f2Nn6jkcklpyEDT3hcEZOxOwTc0ep7uc="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Binder",
+    "version": "9.0.0",
+    "hash": "sha256-6ajYWcNOQX2WqftgnoUmVtyvC1kkPOtTCif4AiKEffU="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection",
+    "version": "9.0.0",
+    "hash": "sha256-dAH52PPlTLn7X+1aI/7npdrDzMEFPMXRv4isV1a+14k="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "9.0.0",
+    "hash": "sha256-CncVwkKZ5CsIG2O0+OM9qXuYXh3p6UGyueTHSLDVL+c="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging",
+    "version": "9.0.0",
+    "hash": "sha256-kR16c+N8nQrWeYLajqnXPg7RiXjZMSFLnKLEs4VfjcM="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "9.0.0",
+    "hash": "sha256-iBTs9twjWXFeERt4CErkIIcoJZU1jrd1RWCI8V5j7KU="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Configuration",
+    "version": "9.0.0",
+    "hash": "sha256-ysPjBq64p6JM4EmeVndryXnhLWHYYszzlVpPxRWkUkw="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Console",
+    "version": "9.0.0",
+    "hash": "sha256-N2t9EUdlS6ippD4Z04qUUyBuQ4tKSR/8TpmKScb5zRw="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "9.0.0",
+    "hash": "sha256-DT5euAQY/ItB5LPI8WIp6Dnd0lSvBRP35vFkOXC68ck="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options.ConfigurationExtensions",
+    "version": "9.0.0",
+    "hash": "sha256-r1Z3sEVSIjeH2UKj+KMj86har68g/zybSqoSjESBcoA="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "9.0.0",
+    "hash": "sha256-ZNLusK1CRuq5BZYZMDqaz04PIKScE2Z7sS2tehU7EJs="
+  },
+  {
+    "pname": "Microsoft.NETCore.App.Runtime.linux-x64",
+    "version": "9.0.10",
+    "hash": "sha256-9e/kzJt6VtiVjvdkw1u+wR9bmV/OVQ29ZrZKoGC6lYM="
+  },
+  {
+    "pname": "Microsoft.OpenApi",
+    "version": "1.6.17",
+    "hash": "sha256-Wx9PwlEJPNMq1kp59nJJnLHQ+yNhqCTudcokmlP+tSk="
+  },
+  {
+    "pname": "Newtonsoft.Json",
+    "version": "13.0.3",
+    "hash": "sha256-hy/BieY4qxBWVVsDqqOPaLy1QobiIapkbrESm6v2PHc="
+  },
+  {
+    "pname": "Scalar.AspNetCore",
+    "version": "1.2.44",
+    "hash": "sha256-xOy4sKXBXs2D2Jsq9vFi4TBb7AYrlD2QPwYoWa5naLs="
+  }
+]

--- a/pkgs/by-name/me/mediathekarr/package.nix
+++ b/pkgs/by-name/me/mediathekarr/package.nix
@@ -1,0 +1,102 @@
+{
+  lib,
+  stdenvNoCC,
+  buildDotnetModule,
+  dotnetCorePackages,
+  fetchFromGitHub,
+  mkvtoolnix-cli,
+  which,
+  nix-update-script,
+}:
+
+let
+  rid = dotnetCorePackages.systemToDotnetRid stdenvNoCC.hostPlatform.system;
+in
+buildDotnetModule rec {
+  pname = "mediathekarr";
+  version = "1.0-beta.9";
+
+  src = fetchFromGitHub {
+    owner = "PCJones";
+    repo = "MediathekArr";
+    rev = "8868c2b4bd2cc13b694418d64f5c42480b90ec9d";
+    hash = "sha256-YsbgdP12pUep1okgvFeooj3VWhbfutp0gG4Nyf4Qjs8=";
+  };
+
+  projectFile = [
+    "MediathekArr/MediathekArrDownloader.csproj"
+    "MediathekArrServer/MediathekArrServer.csproj"
+  ];
+  nugetDeps = ./deps.json;
+
+  dotnet-sdk = dotnetCorePackages.sdk_9_0;
+  dotnet-runtime = dotnetCorePackages.aspnetcore_9_0;
+
+  makeWrapperArgs = [
+    "--suffix PATH : ${
+      lib.makeBinPath [
+        mkvtoolnix-cli
+        which
+      ]
+    }"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    dotnet publish MediathekArr/MediathekArrDownloader.csproj \
+       -p:ContinuousIntegrationBuild=true \
+       -p:Deterministic=true \
+       -p:OverwriteReadOnlyFiles=true \
+       --output "$out/lib/mediathekarr-downloader" \
+       --configuration Release \
+       --no-restore \
+       --no-build \
+       --runtime ${rid} \
+       --no-self-contained \
+       -p:PublishTrimmed=false \
+       -p:UseAppHost=true
+
+
+    dotnet publish MediathekArrServer/MediathekArrServer.csproj \
+       -p:ContinuousIntegrationBuild=true \
+       -p:Deterministic=true \
+       -p:OverwriteReadOnlyFiles=true \
+       --output "$out/lib/mediathekarr-server" \
+       --configuration Release \
+       --no-restore \
+       --no-build \
+       --runtime ${rid} \
+       --no-self-contained \
+       -p:PublishTrimmed=false \
+       -p:UseAppHost=true
+
+    runHook postInstall
+  '';
+
+  dontDotnetFixup = true;
+
+  fixupPhase = ''
+    runHook preFixup
+
+    wrapDotnetProgram "$out/lib/mediathekarr-server/MediathekArrServer" "$out/bin/MediathekArrServer"
+    wrapDotnetProgram "$out/lib/mediathekarr-downloader/MediathekArrDownloader" "$out/bin/MediathekArrDownloader"
+
+    runHook postFixup
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Integrate ARD&ZDF Mediathek in Prowlarr, Sonarr and Radarr";
+    homepage = "https://github.com/PCJones/MediathekArr";
+    changelog = "https://github.com/PCJones/MediathekArr/releases/tag/${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      tmarkus
+    ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Package and NixOS module for Mediathekarr, an indexer/download client for accessing the ARD/ZDF mediathek from Sonarr.
Homepage: https://github.com/PCJones/MediathekArr

TODO: Release notes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
