### PR TITLE
python3Packages.cec: init at 0.2.8, cecdaemon: init at 1.0.0-unstable-2025-11-12

### DIFF
--- a/pkgs/by-name/ce/cecdaemon/package.nix
+++ b/pkgs/by-name/ce/cecdaemon/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+  fetchpatch,
+}:
+
+python3.pkgs.buildPythonApplication {
+  pname = "cecdaemon";
+  version = "1.0.0-unstable-2025-11-12";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "simons-public";
+    repo = "cecdaemon";
+    rev = "ac6d1d9edeca4a79dfdfdad1edc8976f3f14c4dd";
+    hash = "sha256-WGKtOvmWWqKbulCA8hSmNoL/NwJqE6VW8JbcOiKWG04=";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "Fix confusing logging message";
+      url = "https://github.com/simons-public/cecdaemon/commit/7d6c889b33bd5f5a2b230d4634445acfa21c4969.diff";
+      hash = "sha256-BzcviuNs4FUHdkkB5h4Ll48jxo1LwsukU8oxRl8+Syo=";
+    })
+    (fetchpatch {
+      name = "Don't initialize `uinput` unless it's necessary";
+      url = "https://github.com/simons-public/cecdaemon/commit/86374a6567d6ec88d801d2edab27467bb6089f79.diff";
+      hash = "sha256-y/n8yFB/86G0HoTN5XPRWHdTsN6j2y/E+vpCczgnd80=";
+    })
+    (fetchpatch {
+      name = "Fix a few bugs with config parsing";
+      url = "https://github.com/simons-public/cecdaemon/commit/06c467827da0e50922be6de87440eee0540140ed.diff";
+      hash = "sha256-knUZ9iNvkucEkOyvB14A4q5Ggv7KZkwmNMPc1lWt1Dw=";
+    })
+  ];
+
+  build-system = [
+    python3.pkgs.setuptools
+    python3.pkgs.wheel
+  ];
+
+  dependencies = with python3.pkgs; [
+    cec
+    python-uinput
+    pyudev
+  ];
+
+  pythonImportsCheck = [
+    "cecdaemon"
+  ];
+
+  meta = {
+    description = "CEC Daemon for linux media centers";
+    homepage = "https://github.com/simons-public/cecdaemon";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ jfly ];
+    mainProgram = "cecdaemon";
+  };
+}

--- a/pkgs/development/python-modules/cec/default.nix
+++ b/pkgs/development/python-modules/cec/default.nix
@@ -1,0 +1,44 @@
+{
+  libcec,
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  wheel,
+}:
+
+let
+  version = "0.2.8";
+in
+buildPythonPackage {
+  pname = "cec";
+  inherit version;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "trainman419";
+    repo = "python-cec";
+    tag = version;
+    hash = "sha256-Y7XjSRT+mxsgTj5IXkOqLNpBMs5alUnJvGQU4yfR3Vw=";
+  };
+
+  buildInputs = [
+    libcec
+  ];
+
+  build-system = [
+    setuptools
+    wheel
+  ];
+
+  pythonImportsCheck = [
+    "cec"
+  ];
+
+  meta = {
+    description = "Control your TV, reciever and other CEC-compliant HDMI devices from a python script on a computer";
+    homepage = "https://github.com/trainman419/python-cec/";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ jfly ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2461,6 +2461,8 @@ self: super: with self; {
 
   cdxj-indexer = callPackage ../development/python-modules/cdxj-indexer { };
 
+  cec = callPackage ../development/python-modules/cec { };
+
   celery = callPackage ../development/python-modules/celery { };
 
   celery-batches = callPackage ../development/python-modules/celery-batches { };


### PR DESCRIPTION
Add [`cecdaemon`](https://simons-public.github.io/cecdaemon/), and a previously unpackaged Python dependency for it ([`cec`](https://pypi.org/project/cec/))

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
