### PR TITLE
treewide(by-name): set missing meta.homepage

### DIFF
--- a/pkgs/by-name/_9/_90secondportraits/package.nix
+++ b/pkgs/by-name/_9/_90secondportraits/package.nix
@@ -86,7 +86,7 @@ stdenv.mkDerivation rec {
       x11
       mit
     ];
-    downloadPage = "http://tangramgames.dk/games/90secondportraits";
+    homepage = "http://tangramgames.dk/games/90secondportraits";
   };
 
 }

--- a/pkgs/by-name/aa/aalib/package.nix
+++ b/pkgs/by-name/aa/aalib/package.nix
@@ -59,6 +59,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "ASCII art graphics library";
+    homepage = "https://aa-project.sourceforge.net/aalib/";
     platforms = lib.platforms.unix;
     license = lib.licenses.lgpl2;
   };

--- a/pkgs/by-name/ai/aitrack/package.nix
+++ b/pkgs/by-name/ai/aitrack/package.nix
@@ -44,6 +44,7 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "6DoF Head tracking software";
+    homepage = "https://github.com/mdk97/aitrack-linux";
     mainProgram = "aitrack";
     maintainers = with maintainers; [ ck3d ];
     platforms = platforms.linux;

--- a/pkgs/by-name/al/alkimia/package.nix
+++ b/pkgs/by-name/al/alkimia/package.nix
@@ -50,6 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Library used by KDE finance applications";
+    homepage = "https://invent.kde.org/office/alkimia";
     mainProgram = "onlinequoteseditor5";
     longDescription = ''
       Alkimia is the infrastructure for common storage and business

--- a/pkgs/by-name/al/altermime/package.nix
+++ b/pkgs/by-name/al/altermime/package.nix
@@ -33,7 +33,7 @@ gccStdenv.mkDerivation rec {
     maintainers = [ maintainers.raskin ];
     platforms = platforms.all;
     license.fullName = "alterMIME LICENSE";
-    downloadPage = "https://pldaniels.com/altermime/";
+    homepage = "https://pldaniels.com/altermime/";
     mainProgram = "altermime";
   };
 }

--- a/pkgs/by-name/ar/archivemount/package.nix
+++ b/pkgs/by-name/ar/archivemount/package.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Gateway between FUSE and libarchive: allows mounting of cpio, .tar.gz, .tar.bz2 archives";
+    homepage = "https://git.sr.ht/~nabijaczleweli/archivemount-ng";
     changelog = "https://git.sr.ht/~nabijaczleweli/archivemount-ng/refs/${finalAttrs.version}";
     mainProgram = "archivemount";
     license = [

--- a/pkgs/by-name/ar/argpp/package.nix
+++ b/pkgs/by-name/ar/argpp/package.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Argument Parser for C++";
+    homepage = "https://github.com/Grumbel/argpp";
     maintainers = [ lib.maintainers.SchweGELBin ];
     platforms = lib.platforms.linux;
     license = lib.licenses.free;

--- a/pkgs/by-name/ar/arj/package.nix
+++ b/pkgs/by-name/ar/arj/package.nix
@@ -60,6 +60,7 @@ gccStdenv.mkDerivation (finalAttrs: {
       compatibility and retain the feature set of the original ARJ archiver as
       provided by ARJ Software, Inc.
     '';
+    homepage = "https://arj.sourceforge.net/";
     license = lib.licenses.gpl2Plus;
     maintainers = [ lib.maintainers.sander ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/as/asterisk-module-sccp/package.nix
+++ b/pkgs/by-name/as/asterisk-module-sccp/package.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Replacement for the SCCP channel driver in Asterisk";
+    homepage = "https://github.com/chan-sccp/chan-sccp";
     license = lib.licenses.gpl1Only;
     maintainers = with lib.maintainers; [ das_j ];
     # https://github.com/chan-sccp/chan-sccp/issues/609

--- a/pkgs/by-name/at/atop/package.nix
+++ b/pkgs/by-name/at/atop/package.nix
@@ -105,6 +105,7 @@ stdenv.mkDerivation rec {
       memory growth, disk utilization, priority, username, state, and exit code.
     '';
     license = licenses.gpl2Plus;
+    homepage = "http://atoptool.nl";
     downloadPage = "http://atoptool.nl/downloadatop.php";
   };
 }

--- a/pkgs/by-name/ba/bacnet-stack/package.nix
+++ b/pkgs/by-name/ba/bacnet-stack/package.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "BACnet open source protocol stack for embedded systems, Linux, and Windows";
+    homepage = "https://github.com/bacnet-stack/bacnet-stack";
     platforms = platforms.linux;
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ WhittlesJr ];

--- a/pkgs/by-name/ba/badvpn/package.nix
+++ b/pkgs/by-name/ba/badvpn/package.nix
@@ -45,6 +45,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Set of network-related (mostly VPN-related) tools";
+    homepage = "https://github.com/ambrop72/badvpn";
     license = licenses.bsd3;
     maintainers = with maintainers; [ raskin ];
     platforms = platforms.linux;

--- a/pkgs/by-name/ba/ballerina/package.nix
+++ b/pkgs/by-name/ba/ballerina/package.nix
@@ -50,6 +50,7 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Open-source programming language for the cloud";
+    homepage = "https://ballerina.io";
     mainProgram = "bal";
     license = licenses.asl20;
     platforms = openjdk.meta.platforms;

--- a/pkgs/by-name/ba/bam/package.nix
+++ b/pkgs/by-name/ba/bam/package.nix
@@ -43,6 +43,6 @@ stdenv.mkDerivation rec {
     ];
     platforms = platforms.linux;
     license = licenses.zlib;
-    downloadPage = "http://matricks.github.com/bam/";
+    homepage = "http://matricks.github.com/bam/";
   };
 }

--- a/pkgs/by-name/ba/bash_unit/package.nix
+++ b/pkgs/by-name/ba/bash_unit/package.nix
@@ -46,6 +46,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Bash unit testing enterprise edition framework for professionals";
+    homepage = "https://github.com/bash-unit/bash_unit";
     maintainers = with maintainers; [ pamplemousse ];
     platforms = platforms.all;
     license = licenses.gpl3Plus;

--- a/pkgs/by-name/bg/bgs/package.nix
+++ b/pkgs/by-name/bg/bgs/package.nix
@@ -32,6 +32,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Extremely fast and small background setter for X";
+    homepage = "https://github.com/Gottox/bgs";
     license = licenses.mit;
     platforms = platforms.linux;
     maintainers = with maintainers; [ pSub ];

--- a/pkgs/by-name/bi/biosdevname/package.nix
+++ b/pkgs/by-name/bi/biosdevname/package.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Udev helper for naming devices per BIOS names";
+    homepage = "https://github.com/dell/biosdevname";
     license = licenses.gpl2Only;
     platforms = [
       "x86_64-linux"

--- a/pkgs/by-name/bl/blktrace/package.nix
+++ b/pkgs/by-name/bl/blktrace/package.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Block layer IO tracing mechanism";
+    homepage = "https://git.kernel.org/pub/scm/linux/kernel/git/axboe/blktrace.git/about/";
     maintainers = with maintainers; [ nickcao ];
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/by-name/bl/blobfuse/package.nix
+++ b/pkgs/by-name/bl/blobfuse/package.nix
@@ -36,6 +36,7 @@ buildGoModule {
 
   meta = with lib; {
     description = "Mount an Azure Blob storage as filesystem through FUSE";
+    homepage = "https://github.com/Azure/azure-storage-fuse";
     license = licenses.mit;
     maintainers = with maintainers; [ jbgi ];
     platforms = platforms.linux;

--- a/pkgs/by-name/bo/boxed-cpp/package.nix
+++ b/pkgs/by-name/bo/boxed-cpp/package.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation (final: {
 
   meta = with lib; {
     description = "Boxing primitive types in C++";
+    homepage = "https://github.com/contour-terminal/boxed-cpp";
     license = licenses.asl20;
     platforms = platforms.unix;
     maintainers = [ maintainers.moni ];

--- a/pkgs/by-name/bs/bsd-finger/package.nix
+++ b/pkgs/by-name/bs/bsd-finger/package.nix
@@ -196,6 +196,7 @@ stdenv.mkDerivation (finalAttrs: {
         "daemon" = "Remote user information server";
       }
       .${buildProduct};
+    homepage = "https://salsa.debian.org/debian/bsd-finger";
     license = lib.licenses.bsdOriginal;
     mainProgram =
       {

--- a/pkgs/by-name/ca/cantarell-fonts/package.nix
+++ b/pkgs/by-name/ca/cantarell-fonts/package.nix
@@ -51,6 +51,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Default typeface used in the user interface of GNOME since version 3.0";
+    homepage = "https://cantarell.gnome.org/";
     platforms = lib.platforms.all;
     license = lib.licenses.ofl;
     maintainers = [ ];

--- a/pkgs/by-name/ca/catdoc/package.nix
+++ b/pkgs/by-name/ca/catdoc/package.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "MS-Word/Excel/PowerPoint to text converter";
+    homepage = "https://www.wagner.pp.ru/~vitus/software/catdoc/";
     platforms = platforms.all;
     license = licenses.gpl2Only;
     maintainers = [ ];

--- a/pkgs/by-name/cg/cgui/package.nix
+++ b/pkgs/by-name/cg/cgui/package.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Multiplatform basic GUI library";
+    homepage = "https://cgui.sourceforge.net/";
     maintainers = [ maintainers.raskin ];
     platforms = platforms.linux;
     license = licenses.free;

--- a/pkgs/by-name/ci/cidrgrep/package.nix
+++ b/pkgs/by-name/ci/cidrgrep/package.nix
@@ -23,6 +23,7 @@ buildGoModule {
 
   meta = {
     description = "Like grep but for IPv4 CIDRs";
+    homepage = "https://github.com/tomdoherty/cidrgrep";
     mainProgram = "cidrgrep";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ das_j ];

--- a/pkgs/by-name/ck/ckdl/package.nix
+++ b/pkgs/by-name/ck/ckdl/package.nix
@@ -59,6 +59,7 @@ pkgs.stdenv.mkDerivation {
 
   meta = {
     description = "C library that implements reading and writing the KDL Document Language";
+    homepage = "https://github.com/tjol/ckdl";
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/cl/clearlyU/package.nix
+++ b/pkgs/by-name/cl/clearlyU/package.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Unicode font";
+    homepage = "https://web.archive.org/web/20090327112842/http://crl.nmsu.edu/~mleisher/cu.html";
     license = licenses.mit;
     maintainers = [ maintainers.raskin ];
   };

--- a/pkgs/by-name/co/cogl/package.nix
+++ b/pkgs/by-name/co/cogl/package.nix
@@ -127,6 +127,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Small open source library for using 3D graphics hardware for rendering";
+    homepage = "https://gitlab.gnome.org/Archive/cogl";
     maintainers = with maintainers; [ lovek323 ];
 
     longDescription = ''

--- a/pkgs/by-name/co/conspy/package.nix
+++ b/pkgs/by-name/co/conspy/package.nix
@@ -35,6 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Linux text console viewer";
+    homepage = "https://conspy.sourceforge.net/";
     mainProgram = "conspy";
     license = lib.licenses.epl10;
     maintainers = with lib.maintainers; [ raskin ];

--- a/pkgs/by-name/co/convchain/package.nix
+++ b/pkgs/by-name/co/convchain/package.nix
@@ -37,6 +37,7 @@ stdenv.mkDerivation {
   buildInputs = [ mono ];
   meta = {
     description = "Bitmap generation from a single example with convolutions and MCMC";
+    homepage = "https://github.com/mxgmn/ConvChain";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.raskin ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/co/convmv/package.nix
+++ b/pkgs/by-name/co/convmv/package.nix
@@ -63,6 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "Converts filenames from one encoding to another";
+    homepage = "https://www.j3e.de/linux/convmv/man/";
     downloadPage = "https://www.j3e.de/linux/convmv/";
     license = with licenses; [
       gpl2Only

--- a/pkgs/by-name/cr/crrcsim/package.nix
+++ b/pkgs/by-name/cr/crrcsim/package.nix
@@ -36,6 +36,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Model-airplane flight simulator";
+    homepage = "https://sourceforge.net/projects/crrcsim/";
     mainProgram = "crrcsim";
     maintainers = with lib.maintainers; [ raskin ];
     platforms = [

--- a/pkgs/by-name/cr/crystal2nix/package.nix
+++ b/pkgs/by-name/cr/crystal2nix/package.nix
@@ -37,6 +37,7 @@ crystal.buildCrystalPackage rec {
 
   meta = with lib; {
     description = "Utility to convert Crystal's shard.lock files to a Nix file";
+    homepage = "https://github.com/nix-community/crystal2nix";
     mainProgram = "crystal2nix";
     license = licenses.mit;
     maintainers = with maintainers; [

--- a/pkgs/by-name/ct/ctrtool/package.nix
+++ b/pkgs/by-name/ct/ctrtool/package.nix
@@ -37,6 +37,7 @@ stdenv.mkDerivation rec {
   meta = {
     license = lib.licenses.mit;
     description = "Tool to extract data from a 3ds rom";
+    homepage = "https://github.com/jackron/Project_CTR";
     platforms = with lib.platforms; linux ++ darwin;
     maintainers = with lib.maintainers; [ marius851000 ];
     mainProgram = "ctrtool";

--- a/pkgs/by-name/cu/cups-idprt-barcode/package.nix
+++ b/pkgs/by-name/cu/cups-idprt-barcode/package.nix
@@ -44,6 +44,7 @@ stdenvNoCC.mkDerivation {
 
   meta = {
     description = "CUPS drivers for iDPRT barcode printers (iD2P, iD2X, iD4P, iD4S, iE2P, iE2X, iE4P, iE4S, iT4B, iT4E, iT4P, iT4S, iT4X, iX4E, iX4L, iX4P, iX4E, iX6P)";
+    homepage = "https://www.idprt.com/";
     platforms = [
       "x86_64-linux"
       "x86-linux"

--- a/pkgs/by-name/cu/cups-idprt-mt888/package.nix
+++ b/pkgs/by-name/cu/cups-idprt-mt888/package.nix
@@ -44,6 +44,7 @@ stdenvNoCC.mkDerivation {
 
   meta = {
     description = "CUPS driver for the iDPRT MT888";
+    homepage = "https://www.idprt.com/";
     platforms = [
       "x86_64-linux"
       "x86-linux"

--- a/pkgs/by-name/cu/cups-idprt-mt890/package.nix
+++ b/pkgs/by-name/cu/cups-idprt-mt890/package.nix
@@ -45,6 +45,7 @@ stdenvNoCC.mkDerivation {
 
   meta = {
     description = "CUPS driver for the iDPRT MT890";
+    homepage = "https://www.idprt.com/";
     platforms = [
       "x86_64-linux"
       "x86-linux"

--- a/pkgs/by-name/cu/cups-idprt-sp900/package.nix
+++ b/pkgs/by-name/cu/cups-idprt-sp900/package.nix
@@ -53,6 +53,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   meta = {
     description = "CUPS driver for the iDPRT SP900";
+    homepage = "https://www.idprt.com/";
     platforms = [
       "x86_64-linux"
       "x86-linux"

--- a/pkgs/by-name/cu/cups-idprt-tspl/package.nix
+++ b/pkgs/by-name/cu/cups-idprt-tspl/package.nix
@@ -53,6 +53,7 @@ stdenvNoCC.mkDerivation {
 
   meta = {
     description = "CUPS drivers for TSPL-based iDPRT thermal label printers (SP210, SP310, SP320, SP320E, SP410, SP410BT, SP420, SP450, SP460BT)";
+    homepage = "https://www.idprt.com/";
     platforms = [
       "x86_64-linux"
       "x86-linux"

--- a/pkgs/by-name/da/daemon/package.nix
+++ b/pkgs/by-name/da/daemon/package.nix
@@ -30,6 +30,7 @@ stdenv.mkDerivation rec {
       writing daemons in languages other than C, C++ or Perl (e.g. /bin/sh,
       Java).
     '';
+    homepage = "https://libslack.org/daemon/";
     license = licenses.gpl2Plus;
     maintainers = [ maintainers.sander ];
     platforms = platforms.unix;

--- a/pkgs/by-name/de/debian-devscripts/package.nix
+++ b/pkgs/by-name/de/debian-devscripts/package.nix
@@ -145,6 +145,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Debian package maintenance scripts";
+    homepage = "https://salsa.debian.org/debian/devscripts";
     license = lib.licenses.free; # Mix of public domain, Artistic+GPL, GPL1+, GPL2+, GPL3+, and GPL2-only... TODO
     maintainers = with lib.maintainers; [ raskin ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/de/delly/package.nix
+++ b/pkgs/by-name/de/delly/package.nix
@@ -61,6 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "Structural variant caller for mapped DNA sequenced data";
+    homepage = "https://github.com/dellytools/delly";
     mainProgram = "delly";
     license = licenses.bsd3;
     maintainers = with maintainers; [ scalavision ];

--- a/pkgs/by-name/de/depotdownloader/package.nix
+++ b/pkgs/by-name/de/depotdownloader/package.nix
@@ -25,6 +25,7 @@ buildDotnetModule rec {
 
   meta = {
     description = "Steam depot downloader utilizing the SteamKit2 library";
+    homepage = "https://github.com/SteamRE/DepotDownloader";
     changelog = "https://github.com/SteamRE/DepotDownloader/releases/tag/DepotDownloader_${version}";
     license = lib.licenses.gpl2Only;
     maintainers = [ lib.maintainers.babbaj ];

--- a/pkgs/by-name/di/disnixos/package.nix
+++ b/pkgs/by-name/di/disnixos/package.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Provides complementary NixOS infrastructure deployment to Disnix";
+    homepage = "https://github.com/svanderburg/disnixos";
     license = lib.licenses.lgpl21Plus;
     maintainers = [ lib.maintainers.sander ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/dn/dnsviz/package.nix
+++ b/pkgs/by-name/dn/dnsviz/package.nix
@@ -43,6 +43,7 @@ python3Packages.buildPythonApplication rec {
 
   meta = {
     description = "Tool suite for analyzing and visualizing DNS and DNSSEC behavior";
+    homepage = "https://github.com/dnsviz/dnsviz";
     mainProgram = "dnsviz";
     longDescription = ''
       DNSViz is a tool suite for analysis and visualization of Domain Name System (DNS) behavior,

--- a/pkgs/by-name/do/domine/package.nix
+++ b/pkgs/by-name/do/domine/package.nix
@@ -16,5 +16,12 @@ buildDartApplication {
   };
 
   pubspecLock = lib.importJSON ./pubspec.lock.json;
-  meta.mainProgram = "domine";
+  meta = {
+    description = "Instantly search domains with expressions and AI";
+    homepage = "https://github.com/breitburg/domine";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.all;
+    maintainers = [ ];
+    mainProgram = "domine";
+  };
 }

--- a/pkgs/by-name/do/dosemu_fonts/package.nix
+++ b/pkgs/by-name/do/dosemu_fonts/package.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Various fonts from the DOSEmu project";
+    homepage = "https://dosemu.sourceforge.net/";
     license = lib.licenses.gpl2Only;
   };
 }

--- a/pkgs/by-name/dr/drone-cli/package.nix
+++ b/pkgs/by-name/dr/drone-cli/package.nix
@@ -28,6 +28,7 @@ buildGoModule rec {
 
   meta = with lib; {
     mainProgram = "drone";
+    homepage = "https://drone.io";
     maintainers = with maintainers; [ techknowlogick ];
     license = licenses.asl20;
     description = "Command line client for the Drone continuous integration server";

--- a/pkgs/by-name/ds/dssi/package.nix
+++ b/pkgs/by-name/ds/dssi/package.nix
@@ -52,6 +52,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Plugin SDK for virtual instruments";
+    homepage = "https://sourceforge.net/projects/dssi";
     maintainers = with maintainers; [
       raskin
     ];

--- a/pkgs/by-name/dy/dydisnix/package.nix
+++ b/pkgs/by-name/dy/dydisnix/package.nix
@@ -53,6 +53,7 @@ stdenv.mkDerivation {
     longDescription = ''
       Dynamic Disnix is a (very experimental!) prototype extension framework for Disnix supporting dynamic (re)deployment of service-oriented systems.
     '';
+    homepage = "https://github.com/svanderburg/dydisnix";
     license = lib.licenses.lgpl21Plus;
     maintainers = [ lib.maintainers.tomberek ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/fi/file-rename/package.nix
+++ b/pkgs/by-name/fi/file-rename/package.nix
@@ -30,6 +30,7 @@ perlPackages.buildPerlPackage {
 
   meta = with lib; {
     description = "Perl extension for renaming multiple files";
+    homepage = "https://metacpan.org/pod/File::Rename";
     license = licenses.artistic1;
     maintainers = with maintainers; [ peterhoeg ];
     mainProgram = "rename";

--- a/pkgs/by-name/sw/sway-assign-cgroups/package.nix
+++ b/pkgs/by-name/sw/sway-assign-cgroups/package.nix
@@ -33,6 +33,7 @@ python3Packages.buildPythonApplication rec {
   meta = with lib; {
     description = "Place GUI applications into systemd scopes for systemd-oomd compatibility";
     mainProgram = "assign-cgroups.py";
+    homepage = "https://github.com/alebastr/sway-systemd";
     longDescription = ''
       Automatically assign a dedicated systemd scope to the GUI applications
       launched in the same cgroup as the compositor. This could be helpful for

--- a/pkgs/by-name/xa/Xaw3d/package.nix
+++ b/pkgs/by-name/xa/Xaw3d/package.nix
@@ -39,6 +39,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "3D widget set based on the Athena Widget set";
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxaw3d";
     platforms = lib.platforms.unix;
     license = licenses.mit;
   };


### PR DESCRIPTION
It's frustrating, when you search for a package on https://search.nixos.org and the package has no homepage set up. This PR is supposed to bring justice to these packages. 

Welp, most of them, since not every project kept its homepage: 
- [arkpandora_ttf](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/ar/arkpandora_ttf/package.nix): the original homepage is dead, and Wayback copies only contain a short description or nothing[^1]
- [beecrypt](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/be/beecrypt/package.nix): the homepage is still [WIP](https://beecrypt.sourceforge.net/), probably has been for 12 years since the last code update
- [bfr](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/bf/bfr/package.nix): "no_homepage" in [Portage](https://packages.gentoo.org/packages/app-misc/bfr), can't be deduced from the src URL (which still works btw)
- cl-launch: the [source repo](https://gitlab.common-lisp.net/xcvb/cl-launch) has no Readme
- combinatorial_designs was discontinued: sagemath/sage#39631; cc @7c6f434c @timokau @collares

[^1]: https://web.archive.org/web/20180523112434/ostatic.com/arkpandorafonts/, https://web.archive.org/web/20180624023644/http://ostatic.com/arkpandorafonts/, https://web.archive.org/web/20220729033152/ostatic.com/arkpandorafonts/

## TODO
- group edits alphabetically

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
