### PR TITLE
dfmt: migrate to pyproject build

### DIFF
--- a/pkgs/by-name/df/dfmt/package.nix
+++ b/pkgs/by-name/df/dfmt/package.nix
@@ -1,24 +1,28 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchPypi,
 }:
 
-let
-  inherit (python3.pkgs)
-    buildPythonApplication
-    pythonOlder
-    ;
-in
-buildPythonApplication rec {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "dfmt";
   version = "1.2.0";
-  format = "setuptools";
+  pyproject = true;
+
+  build-system = [
+    python3Packages.poetry-core
+  ];
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "7af6360ca8d556f1cfe82b97f03b8d1ea5a9d6de1fa3018290c844b6566d9d6e";
+    inherit (finalAttrs) pname version;
+    hash = "sha256-evY2DKjVVvHP6CuX8DuNHqWp1t4fowGCkMhEtlZtnW4=";
   };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'poetry.masonry.api' 'poetry.core.masonry.api' \
+      --replace-fail 'poetry>=' 'poetry-core>=' \
+  '';
 
   meta = {
     description = "Format paragraphs, comments and doc strings";
@@ -27,4 +31,4 @@ buildPythonApplication rec {
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ cole-h ];
   };
-}
+})


### PR DESCRIPTION
The package now uses pyproject format instead of setuptools, with poetry-core as the build system. The build configuration has been updated to replace the deprecated poetry.masonry.api backend with poetry.core.masonry.api.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
