### PR TITLE
zrok: 1.0.4 -> 1.1.10, add Darwin support

### DIFF
--- a/pkgs/by-name/zr/zrok/package.nix
+++ b/pkgs/by-name/zr/zrok/package.nix
@@ -20,17 +20,17 @@ let
 
   hash =
     {
-      x86_64-linux = "sha256-Ewez2QUsIAmxyjxR8wvt7UJpXVHjIb8s6gGF1YNgrec=";
-      aarch64-linux = "sha256-5hZaOqnTYWeUJXGObzUZMqE62ZgNvJ9Wi8shVng10l8=";
-      armv7l-linux = "sha256-MOM0OS2/mhYaxowsBVnZH0poR+wXsbjsJKldU/nAfjU=";
-      x86_64-darwin = "sha256-DlB24u4CPK5NqrX+vlDJWqjtcz04X0UQurYY0hZtZ0Q=";
-      aarch64-darwin = "sha256-HS7xMpJUFm2PYEe4aXMJ5THGklDTAuziCtcCgf7sX9Q=";
+      x86_64-linux = "sha256-wCrMB2rUr4HGAAGxYeygnBR5cCpoxUbuVVYPR7p004I=";
+      aarch64-linux = "sha256-CUjuYspPQQw4L3SZSkgEAUoySBxB1X/AQHns9j4zfr0=";
+      armv7l-linux = "sha256-83Rul8eikB2+AcgVQK8M/vVGj5eAR4dPNqx8lHAcgBQ=";
+      x86_64-darwin = "sha256-fwfemZe1KTtRgdTPuCR+FBah5SrQnzevgsuZsoe8U0U=";
+      aarch64-darwin = "sha256-492zgY6rdipxeoXiK5BXTbXeD0x2DtrGxEt4lqr9ZLE=";
     }
     .${system} or throwSystem;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "zrok";
-  version = "1.0.4";
+  version = "1.1.10";
 
   src = fetchzip {
     url = "https://github.com/openziti/zrok/releases/download/v${finalAttrs.version}/zrok_${finalAttrs.version}_${plat}.tar.gz";

--- a/pkgs/by-name/zr/zrok/package.nix
+++ b/pkgs/by-name/zr/zrok/package.nix
@@ -13,6 +13,8 @@ let
       x86_64-linux = "linux_amd64";
       aarch64-linux = "linux_arm64";
       armv7l-linux = "linux_armv7";
+      x86_64-darwin = "darwin_amd64";
+      aarch64-darwin = "darwin_arm64";
     }
     .${system} or throwSystem;
 
@@ -21,6 +23,8 @@ let
       x86_64-linux = "sha256-Ewez2QUsIAmxyjxR8wvt7UJpXVHjIb8s6gGF1YNgrec=";
       aarch64-linux = "sha256-5hZaOqnTYWeUJXGObzUZMqE62ZgNvJ9Wi8shVng10l8=";
       armv7l-linux = "sha256-MOM0OS2/mhYaxowsBVnZH0poR+wXsbjsJKldU/nAfjU=";
+      x86_64-darwin = "sha256-DlB24u4CPK5NqrX+vlDJWqjtcz04X0UQurYY0hZtZ0Q=";
+      aarch64-darwin = "sha256-HS7xMpJUFm2PYEe4aXMJ5THGklDTAuziCtcCgf7sX9Q=";
     }
     .${system} or throwSystem;
 in
@@ -36,20 +40,18 @@ stdenv.mkDerivation (finalAttrs: {
 
   updateScript = ./update.sh;
 
-  installPhase =
-    let
-      interpreter = "$(< \"$NIX_CC/nix-support/dynamic-linker\")";
-    in
-    ''
-      runHook preInstall
+  installPhase = ''
+    runHook preInstall
 
-      mkdir -p $out/bin
-      cp zrok $out/bin/
-      chmod +x $out/bin/zrok
-      patchelf --set-interpreter "${interpreter}" "$out/bin/zrok"
+    mkdir -p $out/bin
+    cp zrok $out/bin/
+    chmod +x $out/bin/zrok
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      patchelf --set-interpreter "$(< "$NIX_CC/nix-support/dynamic-linker")" "$out/bin/zrok"
+    ''}
 
-      runHook postInstall
-    '';
+    runHook postInstall
+  '';
 
   meta = {
     description = "Geo-scale, next-generation sharing platform built on top of OpenZiti";
@@ -61,6 +63,8 @@ stdenv.mkDerivation (finalAttrs: {
       "x86_64-linux"
       "aarch64-linux"
       "armv7l-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
     ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };

--- a/pkgs/by-name/zr/zrok/update.sh
+++ b/pkgs/by-name/zr/zrok/update.sh
@@ -4,9 +4,9 @@
 set -euo pipefail
 
 ROOT="$(dirname "$(readlink -f "$0")")"
-NIX_DRV="$ROOT/default.nix"
+NIX_DRV="$ROOT/package.nix"
 if [ ! -f "$NIX_DRV" ]; then
-  echo "ERROR: cannot find default.nix in $ROOT"
+  echo "ERROR: cannot find package.nix in $ROOT"
   exit 1
 fi
 
@@ -30,9 +30,13 @@ ZROK_VER=$(curl -Ls -w "%{url_effective}" -o /dev/null https://github.com/openzi
 ZROK_LINUX_X64_SHA256=$(fetch_arch "$ZROK_VER" "linux_amd64")
 ZROK_LINUX_AARCH64_SHA256=$(fetch_arch "$ZROK_VER" "linux_arm64")
 ZROK_LINUX_ARMV7L_SHA256=$(fetch_arch "$ZROK_VER" "linux_armv7")
+ZROK_DARWIN_X64_SHA256=$(fetch_arch "$ZROK_VER" "darwin_amd64")
+ZROK_DARWIN_ARM64_SHA256=$(fetch_arch "$ZROK_VER" "darwin_arm64")
 
 sed -i "s/version = \".*\"/version = \"$ZROK_VER\"/" "$NIX_DRV"
 
 replace_sha "x86_64-linux" "$ZROK_LINUX_X64_SHA256"
 replace_sha "aarch64-linux" "$ZROK_LINUX_AARCH64_SHA256"
 replace_sha "armv7l-linux" "$ZROK_LINUX_ARMV7L_SHA256"
+replace_sha "x86_64-darwin" "$ZROK_DARWIN_X64_SHA256"
+replace_sha "aarch64-darwin" "$ZROK_DARWIN_ARM64_SHA256"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## zrok: 1.0.4 -> 1.1.10, add Darwin support

- Add `x86_64-darwin` and `aarch64-darwin` platform support
- Fix `update.sh` to reference `package.nix` instead of `default.nix`
- Update version from 1.0.4 to 1.1.10

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
