### PR TITLE
spotube: 5.0.0 -> 5.1.0

### DIFF
--- a/pkgs/by-name/sp/spotube/package.nix
+++ b/pkgs/by-name/sp/spotube/package.nix
@@ -22,7 +22,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "spotube";
-  version = "5.0.0";
+  version = "5.1.0";
 
   src = finalAttrs.passthru.sources.${stdenv.hostPlatform.system};
 
@@ -87,19 +87,19 @@ stdenv.mkDerivation (finalAttrs: {
     {
       "aarch64-linux" = fetchArtifact {
         suffix = "linux-aarch64.deb";
-        hash = "sha256-xMYqhywxJTghJlxqO05i79140R5PBOsMw66BYIWq5Vw=";
+        hash = "sha256-b+4IeZNWgU5psqDN4F1VDvF6nSf5B7i9XG1GdOTswYU=";
       };
       "x86_64-linux" = fetchArtifact {
         suffix = "linux-x86_64.deb";
-        hash = "sha256-ZsppON33jnn52eoVtCX7gyWy7lLlRRrhzvOz7reCP4Q=";
+        hash = "sha256-tCuOhThuyIcjJJyIpbpK+3eTCfrQMsIiNt3jZxYL5pU=";
       };
       "x86_64-darwin" = fetchArtifact {
         suffix = "macos-universal.dmg";
-        hash = "sha256-OMgDMWBsG/Powfti4ObeZfWFir8KzCbzi8ujV6Y967s=";
+        hash = "sha256-b+4IeZNWgU5psqDN4F1VDvF6nSf5B7i9XG1GdOTswYU=";
       };
       "aarch64-darwin" = fetchArtifact {
         suffix = "macos-universal.dmg";
-        hash = "sha256-OMgDMWBsG/Powfti4ObeZfWFir8KzCbzi8ujV6Y967s=";
+        hash = "sha256-OqFlyv9sR7yG5GqkZjfFb0xMzDeRNNzJOBap7Pa2etw=";
       };
     };
 


### PR DESCRIPTION
Update Spotube from 5.0.0 to 5.1.0.
https://github.com/KRTirtho/spotube/releases/tag/v5.1.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
