### PR TITLE
home-assistant: support prowl component

### DIFF
--- a/pkgs/development/python-modules/prowlpy/default.nix
+++ b/pkgs/development/python-modules/prowlpy/default.nix
@@ -1,0 +1,64 @@
+{
+  buildPythonPackage,
+  click,
+  fetchFromGitHub,
+  httpx,
+  lib,
+  loguru,
+  pytest-asyncio,
+  pytest-cov-stub,
+  pytestCheckHook,
+  respx,
+  setuptools,
+  xmltodict,
+}:
+
+buildPythonPackage rec {
+  pname = "prowlpy";
+  version = "1.1.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "OMEGARAZER";
+    repo = "prowlpy";
+    tag = "v${version}";
+    hash = "sha256-AotlO1CTe1jv9nu9drQWXYi445Pl5c+89/ep3i+vWwA=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    httpx
+    xmltodict
+  ]
+  ++ httpx.optional-dependencies.http2;
+
+  optional-dependencies = {
+    cli = [
+      click
+      loguru
+    ];
+  };
+
+  pythonImportsCheck = [ "prowlpy" ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytest-cov-stub
+    pytestCheckHook
+    respx
+  ]
+  ++ lib.concatLists (lib.attrValues optional-dependencies);
+
+  # tests fail without this
+  pytestFlags = [ "-v" ];
+
+  meta = {
+    changelog = "https://github.com/OMEGARAZER/prowlpy/blob/${src.tag}/CHANGELOG.md";
+    description = "Send push notifications to iPhones using the Prowl API";
+    homepage = "https://github.com/OMEGARAZER/prowlpy";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "prowlpy";
+    maintainers = [ lib.maintainers.dotlambda ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -4734,7 +4734,8 @@
       ];
     "prowl" =
       ps: with ps; [
-      ]; # missing inputs: prowlpy
+        prowlpy
+      ];
     "proximity" =
       ps: with ps; [
       ];
@@ -7715,6 +7716,7 @@
     "progettihwsw"
     "prometheus"
     "prosegur"
+    "prowl"
     "proximity"
     "prusalink"
     "ps4"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12461,6 +12461,8 @@ self: super: with self; {
 
   prov = callPackage ../development/python-modules/prov { };
 
+  prowlpy = callPackage ../development/python-modules/prowlpy { };
+
   prox-tv = callPackage ../development/python-modules/prox-tv { };
 
   proxmoxer = callPackage ../development/python-modules/proxmoxer { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
