### PR TITLE
hyneview: init at 4.6.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2910,6 +2910,12 @@
     githubId = 766221;
     name = "Ngoc Nguyen";
   };
+  BaptTF = {
+    email = "baptiste.jullien06@gmail.com";
+    github = "BaptTF";
+    githubId = 34722625;
+    name = "Baptiste Jullien";
+  };
   barab-i = {
     email = "barab_i@outlook.com";
     github = "barab-i";

--- a/pkgs/by-name/hy/hyneview/package.nix
+++ b/pkgs/by-name/hy/hyneview/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  appimageTools,
+  fetchurl,
+  makeFontsConf,
+  makeDesktopItem,
+  glib,
+  util-linux,
+  ibm-plex,
+}:
+
+let
+  pname = "hyneview";
+  version = "4.6.2";
+
+  src = fetchurl {
+    url = "https://download.diateam.net/hyneview/linux/${version}/DIATEAM_Cyber_Range_hyneview_${version}.AppImage";
+    hash = "sha256-sUHcTlquXvEu8NnQ0L7a5A7azUoO387L2J2X0KiJhFo=";
+  };
+
+  desktopItem = makeDesktopItem {
+    name = "hyneview";
+    desktopName = "Hyneview";
+    comment = "Visualization tool for DIATEAM Cyber Range";
+    exec = "hyneview";
+    categories = [ "Development" ];
+  };
+
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  profile =
+    let
+      myFontsConf = makeFontsConf {
+        fontDirectories = [ ibm-plex ];
+      };
+    in
+    ''
+      export LD_PRELOAD="${lib.makeLibraryPath [ glib ]}/libglib-2.0.so.0:${lib.makeLibraryPath [ glib ]}/libgio-2.0.so.0:${lib.makeLibraryPath [ glib ]}/libgmodule-2.0.so.0:${
+        lib.makeLibraryPath [ util-linux ]
+      }/libmount.so.1"
+      export FONTCONFIG_FILE="${myFontsConf}"
+    '';
+
+  extraPkgs = pkgs: [ ];
+
+  extraInstallCommands = ''
+    install -Dm444 -t $out/share/applications ${desktopItem}/share/applications/*
+  '';
+
+  meta = with lib; {
+    description = "Visualization tool for DIATEAM Cyber Range";
+    homepage = "https://diateam.net/";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ BaptTF ];
+    mainProgram = "hyneview";
+  };
+}


### PR DESCRIPTION
hyneview: init at 4.6.2

This PR adds `hyneview`, a network visualization tool used within the DIATEAM Cyber Range ecosystem.

### Packaging Notes

The upstream source is a proprietary AppImage (`unfree`) that presents challenges on a modern NixOS stack. It bundles ancient versions of core libraries that conflict with the environment provided by `appimageTools`.

To resolve runtime crashes and rendering issues, this derivation implements the following:

1.  **Runtime Fixes (`LD_PRELOAD`):**
    Running the AppImage natively resulted in crashes due to version mismatches (e.g., `symbol lookup error: undefined symbol: g_task_set_static_name`).
    I used `LD_PRELOAD` to force the application to load the system's `glib`, `gio`, `gmodule`, and `util-linux` (libmount) instead of the bundled outdated versions.

2.  **Font Configuration:**
    The application relies on specific fonts (IBM Plex) which are not visible inside the FHS environment by default. A custom `fonts.conf` is generated and injected via `FONTCONFIG_FILE` to fix Pango rendering warnings and invisible text.

3.  **Desktop Entry:**
    Since the AppImage contents are difficult to extract cleanly to retrieve the original resources, I used `makeDesktopItem` to generate a standards-compliant desktop entry, installed via `extraInstallCommands`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc