### PR TITLE
ocamlPackages.path_glob: 0.2 → 0.3

### DIFF
--- a/pkgs/development/ocaml-modules/path_glob/default.nix
+++ b/pkgs/development/ocaml-modules/path_glob/default.nix
@@ -4,13 +4,12 @@
   fetchurl,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "path_glob";
-  version = "0.2";
-  useDune2 = true;
+  version = "0.3";
   src = fetchurl {
-    url = "https://gasche.gitlab.io/path_glob/releases/path_glob-${version}.tbz";
-    sha256 = "01ra20bzjiihbgma74axsp70gqmid6x7jmiizg48mdkni0aa42ay";
+    url = "https://gasche.gitlab.io/path_glob/releases/path_glob-${finalAttrs.version}.tgz";
+    hash = "sha256-My2uI7cA+gUNH9bk89LiS43R2yyOpPdsVOLlSFHJ0iY=";
   };
 
   meta = {
@@ -18,4 +17,4 @@ buildDunePackage rec {
     description = "Checking glob patterns on paths";
     license = lib.licenses.lgpl2Only;
   };
-}
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
