### PR TITLE
vicinae: 0.16.8 → 0.16.10, fix build with strictDeps

### DIFF
--- a/pkgs/by-name/vi/vicinae/package.nix
+++ b/pkgs/by-name/vi/vicinae/package.nix
@@ -1,9 +1,9 @@
 {
+  abseil-cpp,
   cmake,
   cmark-gfm,
   fetchFromGitHub,
   fetchNpmDeps,
-  grpc-tools,
   kdePackages,
   lib,
   libqalculate,
@@ -49,6 +49,8 @@ stdenv.mkDerivation (finalAttrs: {
     "CMAKE_INSTALL_LIBDIR" = "lib";
   };
 
+  strictDeps = true;
+
   nativeBuildInputs = [
     cmake
     ninja
@@ -59,8 +61,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
+    abseil-cpp
     cmark-gfm
-    grpc-tools
     kdePackages.layer-shell-qt
     kdePackages.qtkeychain
     libqalculate

--- a/pkgs/by-name/vi/vicinae/package.nix
+++ b/pkgs/by-name/vi/vicinae/package.nix
@@ -20,13 +20,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "vicinae";
-  version = "0.16.8";
+  version = "0.16.10";
 
   src = fetchFromGitHub {
     owner = "vicinaehq";
     repo = "vicinae";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-TAKv3dmc8DSlVp0LXQeLgrgfLTbQ/saQelenFUp9sP0=";
+    hash = "sha256-4t0AscBe+TMhQ5SuzkBSgKrMXGs/2BvlRv8ke3pg+yo=";
   };
 
   apiDeps = fetchNpmDeps {


### PR DESCRIPTION
Release notes:
- https://github.com/vicinaehq/vicinae/releases/tag/v0.16.9
- https://github.com/vicinaehq/vicinae/releases/tag/v0.16.10

Enabling `strictDeps` showed that abseil-cpp was missing, and we also noticed that there were two unneeded dependencies. These problems are fixed here.

~~We cannot yet test on aarch64-linux, as we would rather not build qtdeclarative et al. ourselves, and they're not yet built by Hydra after the Qt 6.10.1 update was merged. We'll try that build in a bit after those are cached.~~ The Qt builds are now cached. This builds fine on aarch64-linux.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
