### PR TITLE
ocamlPackages.lwt-{canceler,dllist,exit,watcher}: small cleaning

### DIFF
--- a/pkgs/development/ocaml-modules/lwt-canceler/default.nix
+++ b/pkgs/development/ocaml-modules/lwt-canceler/default.nix
@@ -5,17 +5,16 @@
   lwt,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "lwt-canceler";
   version = "0.3";
 
   src = fetchFromGitLab {
     owner = "nomadic-labs";
     repo = "lwt-canceler";
-    rev = "v${version}";
-    sha256 = "1xbb7012hp901b755kxmfgg293rz34rkhwzg2z9i6sakwd7i0h9p";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-N0EQT+NTaRPTF+9zODMZP48k3nO1z1LOCiBdKAI4a/U=";
   };
-  useDune2 = true;
 
   propagatedBuildInputs = [
     lwt
@@ -29,4 +28,4 @@ buildDunePackage rec {
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.ulrikstrid ];
   };
-}
+})

--- a/pkgs/development/ocaml-modules/lwt-dllist/default.nix
+++ b/pkgs/development/ocaml-modules/lwt-dllist/default.nix
@@ -3,31 +3,26 @@
   buildDunePackage,
   fetchurl,
   lwt,
-  ocaml,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "lwt-dllist";
   version = "1.0.1";
 
-  useDune2 = true;
-
-  minimalOCamlVersion = "4.02";
-
   src = fetchurl {
-    url = "https://github.com/mirage/${pname}/releases/download/v${version}/${pname}-v${version}.tbz";
-    sha256 = "e86ce75e40f00d51514cf8b2e71e5184c4cb5dae96136be24613406cfc0dba6e";
+    url = "https://github.com/mirage/lwt-dllist/releases/download/v${finalAttrs.version}/lwt-dllist-v${finalAttrs.version}.tbz";
+    hash = "sha256-6GznXkDwDVFRTPiy5x5RhMTLXa6WE2viRhNAbPwNum4=";
   };
 
   checkInputs = [
     lwt
   ];
-  doCheck = lib.versionAtLeast ocaml.version "4.03";
+  doCheck = true;
 
-  meta = with lib; {
+  meta = {
     description = "Mutable doubly-linked list with Lwt iterators";
     homepage = "https://github.com/mirage/lwt-dllist";
-    license = licenses.mit;
-    maintainers = [ maintainers.sternenseemann ];
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.sternenseemann ];
   };
-}
+})

--- a/pkgs/development/ocaml-modules/lwt-exit/default.nix
+++ b/pkgs/development/ocaml-modules/lwt-exit/default.nix
@@ -6,19 +6,15 @@
   ptime,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "lwt-exit";
   version = "1.0";
   src = fetchFromGitLab {
     owner = "nomadic-labs";
-    repo = pname;
-    rev = version;
-    sha256 = "1k763bmj1asj9ijar39rh3h1d59rckmsf21h2y8966lgglsf42bd";
+    repo = "lwt-exit";
+    tag = finalAttrs.version;
+    hash = "sha256-bQniNH2PGpOQFzAIp+tkOZUW4IA5jaxkTFKrIOsa5sw=";
   };
-
-  useDune2 = true;
-
-  minimalOCamlVersion = "4.08";
 
   propagatedBuildInputs = [
     lwt
@@ -33,4 +29,4 @@ buildDunePackage rec {
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.ulrikstrid ];
   };
-}
+})

--- a/pkgs/development/ocaml-modules/lwt-watcher/default.nix
+++ b/pkgs/development/ocaml-modules/lwt-watcher/default.nix
@@ -5,17 +5,15 @@
   lwt,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "lwt-watcher";
   version = "0.2";
   src = fetchFromGitLab {
     owner = "nomadic-labs";
-    repo = pname;
-    rev = "v${version}";
+    repo = "lwt-watcher";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-35Z73bSzEEgTabNH2cD9lRdDczsyIMZR2ktyKx4aN9k=";
   };
-
-  useDune2 = true;
 
   propagatedBuildInputs = [
     lwt
@@ -28,4 +26,4 @@ buildDunePackage rec {
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.ulrikstrid ];
   };
-}
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
