### PR TITLE
cvc5: fix by using CaDiCaL 2.1.3

### DIFF
--- a/pkgs/by-name/ca/cadical/package.nix
+++ b/pkgs/by-name/ca/cadical/package.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
     hash =
       {
         "2.2.0" = "sha256-6O0lz0YJzk1eJblQ0/f9PnSYqD8WoendIZioQiGUpCg=";
+        "2.1.3" = "sha256-W3kO+6nVzkmJXyHJU+NZWP0oatK3gon4EWF1/03rgL4=";
         "2.0.0" = "sha256-qoeEM9SdpuFuBPeQlCzuhPLcJ+bMQkTUTGiT8QdU8rc=";
       }
       .${version};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13648,6 +13648,10 @@ with pkgs;
     stdenv = gccStdenv;
   };
 
+  cvc5 = callPackage ../by-name/cv/cvc5/package.nix {
+    cadical = cadical.override { version = "2.1.3"; };
+  };
+
   ekrhyper = callPackage ../applications/science/logic/ekrhyper {
     ocaml = ocaml-ng.ocamlPackages_4_14_unsafe_string.ocaml;
   };


### PR DESCRIPTION
`cvc5` has been broken by #463363 (cc @shnarazk).