### PR TITLE
fetchurl: reference most attributes from `finalAttrs` and make them overridable with `<pkg>.overrideAttrs`

### DIFF
--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -290,7 +290,7 @@ lib.extendMkDerivation {
             || hash_.outputHash == lib.fakeSha256
             || hash_.outputHash == lib.fakeSha512
             || hash_.outputHash == lib.fakeHash
-            || netrcPhase != null
+            || finalAttrs.netrcPhase != null
           )
         then
           "${cacert}/etc/ssl/certs/ca-bundle.crt"
@@ -324,6 +324,7 @@ lib.extendMkDerivation {
         downloadToTemp
         executable
         mirrorsFile
+        netrcPhase
         postFetch
         recursiveHash
         showURLs
@@ -336,11 +337,11 @@ lib.extendMkDerivation {
       inherit preferLocalBuild;
 
       postHook =
-        if netrcPhase == null then
+        if finalAttrs.netrcPhase == null then
           null
         else
           ''
-            ${netrcPhase}
+            ${finalAttrs.netrcPhase}
             curlOpts="$curlOpts --netrc-file $PWD/netrc"
           '';
 

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -297,7 +297,8 @@ lib.extendMkDerivation {
         else
           "/no-cert-file.crt";
 
-      outputHashMode = if (recursiveHash || executable) then "recursive" else "flat";
+      outputHashMode =
+        if (finalAttrs.recursiveHash || finalAttrs.executable) then "recursive" else "flat";
 
       curlOpts = lib.warnIf (lib.isList curlOpts) (
         let
@@ -324,6 +325,7 @@ lib.extendMkDerivation {
         executable
         mirrorsFile
         postFetch
+        recursiveHash
         showURLs
         ;
 

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -320,11 +320,11 @@ lib.extendMkDerivation {
       curlOptsList = lib.escapeShellArgs curlOptsList;
 
       inherit
-        showURLs
-        mirrorsFile
-        postFetch
         downloadToTemp
         executable
+        mirrorsFile
+        postFetch
+        showURLs
         ;
 
       impureEnvVars = impureEnvVars ++ netrcImpureEnvVars;

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -241,7 +241,7 @@ lib.extendMkDerivation {
       name =
         if finalAttrs.pname or null != null && finalAttrs.version or null != null then
           "${finalAttrs.pname}-${finalAttrs.version}"
-        else if showURLs then
+        else if finalAttrs.showURLs then
           "urls"
         else if name != null then
           name

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -324,13 +324,14 @@ lib.extendMkDerivation {
         downloadToTemp
         executable
         mirrorsFile
+        netrcImpureEnvVars
         netrcPhase
         postFetch
         recursiveHash
         showURLs
         ;
 
-      impureEnvVars = impureEnvVars ++ netrcImpureEnvVars;
+      impureEnvVars = impureEnvVars ++ finalAttrs.netrcImpureEnvVars;
 
       nixpkgsVersion = lib.trivial.release;
 


### PR DESCRIPTION
This PR fixes the `<pkg>.overrideAttrs` overriding of most `fetchurl` arguments, and make them available from `finalAttrs`.

The exceptions are
- Hash-related variables: handled in PR #463871
- `curlOptsList`: handled in PR #464475

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
