### PR TITLE
fetchurl, fetchgit: use `__structuredAttrs = true` and pass `curlOptsList` and `sparseCheckout` as lists

### DIFF
--- a/pkgs/build-support/fetchgit/builder.sh
+++ b/pkgs/build-support/fetchgit/builder.sh
@@ -4,6 +4,8 @@
 # - revision specified and remote without HEAD
 #
 
+source "$NIX_ATTRS_SH_FILE"
+
 echo "exporting $url (rev $rev) into $out"
 
 runHook preFetch

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -133,6 +133,8 @@ lib.makeOverridable (
 
         derivationArgs
         // {
+          __structuredAttrs = true;
+
           inherit name;
 
           builder = ./builder.sh;
@@ -225,7 +227,11 @@ lib.makeOverridable (
               "FETCHGIT_HTTP_PROXIES"
             ];
 
-          inherit preferLocalBuild meta allowedRequisites;
+          outputChecks.out = {
+            ${if allowedRequisites != null then "allowedRequisites" else null} = allowedRequisites;
+          };
+
+          inherit preferLocalBuild meta;
 
           passthru = {
             gitRepoUrl = url;

--- a/pkgs/build-support/fetchurl/builder.sh
+++ b/pkgs/build-support/fetchurl/builder.sh
@@ -1,3 +1,4 @@
+source "$NIX_ATTRS_SH_FILE"
 source $mirrorsFile
 
 curlVersion=$(curl -V | head -1 | cut -d' ' -f2)
@@ -22,10 +23,10 @@ if ! [ -f "$SSL_CERT_FILE" ]; then
     curl+=(--insecure)
 fi
 
-eval "curl+=($curlOptsList)"
+curl+=("${curlOptsList[@]}")
 
 curl+=(
-    $curlOpts
+    ${curlOpts[*]}
     $NIX_CURL_FLAGS
 )
 

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -300,11 +300,11 @@ lib.extendMkDerivation {
       curlOptsList = lib.escapeShellArgs curlOptsList;
 
       inherit
-        showURLs
-        mirrorsFile
-        postFetch
         downloadToTemp
         executable
+        mirrorsFile
+        postFetch
+        showURLs
         ;
 
       impureEnvVars = impureEnvVars ++ netrcImpureEnvVars;

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -136,6 +136,7 @@ lib.extendMkDerivation {
 
       # Passthru information, if any.
       passthru ? { },
+
       # Doing the download on a remote machine just duplicates network
       # traffic, so don't do that by default
       preferLocalBuild ? true,
@@ -238,6 +239,8 @@ lib.extendMkDerivation {
 
     derivationArgs
     // {
+      __structuredAttrs = true;
+
       name =
         if finalAttrs.pname or null != null && finalAttrs.version or null != null then
           "${finalAttrs.pname}-${finalAttrs.version}"
@@ -297,9 +300,8 @@ lib.extendMkDerivation {
         ''
       ) curlOpts;
 
-      curlOptsList = lib.escapeShellArgs curlOptsList;
-
       inherit
+        curlOptsList
         downloadToTemp
         executable
         mirrorsFile


### PR DESCRIPTION
While preserving existing interface, this PR enables `fetchurl` to take `__struncuredAttrs`. If specified as `true`, the `curlOptsList` will be passed to `stdenvNoCC.mkDerivation` as a list without stringification, facilitating its overriding with `<pkg>.overrideAttrs`.

To make `fetchurl/builder.sh` get the attributes when `__structuredAttrs` is `true`, it now sources `$NIX_ATTRS_SH_FILE` if presented.

As `fetchFromGitHub` switches between `fetchurl` and `fetchgit` with the same `postFetch`, this PR also converts the `fetchgit`-constructed FOD to use `__structuredAttrs = true` and passes `sparseCheckout` as a list. This way, out-of-tree projects that need to support multiple Nixpkgs releases can detect this series of changes based on `__structuredAttrs`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
