### PR TITLE
vtebench: init at 0.3.1

### DIFF
--- a/pkgs/by-name/vt/vtebench/package.nix
+++ b/pkgs/by-name/vt/vtebench/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  makeWrapper,
+  versionCheckHook,
+  bash,
+  gnuplot,
+  gitUpdater,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "vtebench";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "alacritty";
+    repo = "vtebench";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2uuH7JTilKC+yVY+sMG0lMzLFzRefqEyM/L5gnMDIJw=";
+  };
+  cargoHash = "sha256-3PQA5rw5eiqHfQCZPAgN7FF/mPK2YeZd3TT4SCnBp3I=";
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ bash ];
+  strictDeps = true;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  postInstall = ''
+    mkdir -p $out/share/vtebench
+    cp -r benchmarks gnuplot{,_summary}.sh -t $out/share/vtebench
+  '';
+
+  postFixup = ''
+    # The benchmarks and gnuplot helpers are all shell scripts
+    patchShebangs $out/share/vtebench
+
+    # vtebench tries to look for the benchmarks in the `benchmarks` folder
+    # in the current directory by default, but we patch it here to use
+    # the packaged benchmarks instead
+    wrapProgram $out/bin/vtebench \
+      --add-flags "--benchmarks $out/share/vtebench/benchmarks"
+
+    # Neither gnuplot wrapper script is included with vtebench itself,
+    # so we have to make them available as wrapped binaries to avoid users
+    # having to obtain them on their own
+    makeWrapper $out/share/vtebench/gnuplot.sh $out/bin/vtebench-gnuplot \
+      --suffix PATH : ${lib.makeBinPath [ gnuplot ]}
+    makeWrapper $out/share/vtebench/gnuplot_summary.sh $out/bin/vtebench-gnuplot-summary \
+      --suffix PATH : ${lib.makeBinPath [ gnuplot ]}
+  '';
+
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
+
+  meta = {
+    description = "Generate benchmarks for terminal emulators";
+    longDescription = ''
+      A tool for benchmarking terminal emulator PTY read performance.
+
+      The `vtebench` binary has been patched to use the default benchmarks
+      automatically. Run `vtebench-gnuplot` or `vtebench-gnuplot-summary`
+      to run the `gnuplot.sh` and `gnuplot_summary.sh` scripts respectively.
+    '';
+    homepage = "https://github.com/alacritty/vtebench";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    maintainers = with lib.maintainers; [
+      pluiedev
+    ];
+    mainProgram = "vtebench";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
