### PR TITLE
nixos-rebuild-ng: add `--use-prebuilt-closure` option

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -99,6 +99,14 @@ def get_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.ArgumentPa
         "specified attribute path from file specified by the --file option",
     )
     main_parser.add_argument(
+        "--use-prebuilt-closure",
+        "-C",
+        help="Skips building the referenced NixOS closure and causes the "
+        "specified closure path to be activated instead. "
+        "Useful when you've just copied a closure from a build machine "
+        "or are rolling back to a previous generation"
+    )
+    main_parser.add_argument(
         "--flake",
         nargs="?",
         const=True,

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
@@ -281,7 +281,11 @@ def build_and_activate_system(
     build_attr: BuildAttr,
     grouped_nix_args: GroupedNixArgs,
 ) -> None:
-    logger.info("building the system configuration...")
+    if args.use_prebuilt_closure:
+        logger.info(f"using prebuilt system configuration at {args.use_prebuilt_closure}...")
+    else:
+        logger.info("building the system configuration...")
+
     attr = _get_system_attr(
         action=action,
         args=args,
@@ -290,7 +294,9 @@ def build_and_activate_system(
         grouped_nix_args=grouped_nix_args,
     )
 
-    if args.rollback:
+    if args.use_prebuilt_closure:
+        path_to_config = Path(args.use_prebuilt_closure)
+    elif args.rollback:
         path_to_config = _rollback_system(
             action=action,
             args=args,


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds a new `--use-prebuilt-closure` option to `nixos-rebuild-ng`, which will avoid building the new system closure and instead use the prebuilt one specified.

I wanted this feature since I often `nix copy --from` closures from my build machine and want to use the proper `nixos-rebuild` script to switch into that closure. I could also see this being useful to activate old generations of closures.

As a quick sanity check, you can run something like the following to test this new feature:
```bash
sudo ./result/bin/nixos-rebuild-ng --use-prebuilt-closure /run/current-system/ switch
```
which of course, will just reactivate your currently running closure.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
