### PR TITLE
ssm: init at 1.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1872,6 +1872,12 @@
     githubId = 20933385;
     name = "Anton Latukha";
   };
+  antonjah = {
+    email = "privat@antonandersson.se";
+    github = "antonjah";
+    githubId = 45765333;
+    name = "Anton Andersson";
+  };
   antonmosich = {
     email = "anton@mosich.at";
     github = "antonmosich";

--- a/pkgs/by-name/ss/ssm/package.nix
+++ b/pkgs/by-name/ss/ssm/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "ssm";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "antonjah";
+    repo = "ssm";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-y6TgTsw0m4qS2P0brQfN4IQnKbfc9Kb9AoxT2K4y2IM=";
+  };
+
+  vendorHash = "sha256-Hxe6a27bTbRan8Z+jHVQ3X5sQtlC5K47fIXrRCgfG/E=";
+
+  cgoSupport = false;
+
+  ldflags = [
+    "-w"
+    "-s"
+    "-extldflags '-static'"
+  ];
+
+  tags = [
+    "netgo"
+    "osusergo"
+  ];
+
+  buildMode = "exe";
+
+  meta = {
+    description = "TUI for managing ssh connections";
+    longDescription = ''
+      SSM is a terminal-based user interface (TUI) tool designed for managing SSH connections.
+      It provides an intuitive way to add, edit, and connect to SSH hosts directly from the command line.
+      Key features include fuzzy search for quick host selection, support for SSH config files,
+      and integration with tmux for session management. Built with simplicity and efficiency in mind,
+      SSM helps streamline SSH workflows for developers and system administrators.
+    '';
+    homepage = "https://github.com/antonjah/ssm";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ antonjah ];
+    mainProgram = "ssm";
+  };
+})


### PR DESCRIPTION
ssm is a terminal user interface (TUI) for managing SSH connections. It provides an interactive way to select and connect to SSH hosts defined in your ~/.ssh/config file, with support for tmux integration.

This package builds a fully static binary with no runtime dependencies, using Go's pure implementations for networking and user operations.

Homepage: https://github.com/antonjah/ssm

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [Package tests] at `passthru.tests`. (Go unit tests included and passing)
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (Verified TUI launches and SSH config parsing works)
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.