### PR TITLE
code-cursor: auto-update vscodeVersion and save to sources.json

### DIFF
--- a/pkgs/by-name/co/code-cursor/package.nix
+++ b/pkgs/by-name/co/code-cursor/package.nix
@@ -14,37 +14,22 @@ let
   inherit (stdenv) hostPlatform;
   finalCommandLineArgs = "--update=false " + commandLineArgs;
 
-  sources = {
-    x86_64-linux = fetchurl {
-      url = "https://downloads.cursor.com/production/25412918da7e74b2686b25d62da1f01cfcd27683/linux/x64/Cursor-2.0.64-x86_64.AppImage";
-      hash = "sha256-zT9GhdwGDWZJQl+WpV2txbmp3/tJRtL6ds1UZQoKNzA=";
-    };
-    aarch64-linux = fetchurl {
-      url = "https://downloads.cursor.com/production/25412918da7e74b2686b25d62da1f01cfcd27683/linux/arm64/Cursor-2.0.64-aarch64.AppImage";
-      hash = "sha256-1pN9LfnplKyVUxlICQ2KsxcAn++dZY9hGR4XubHxLUY=";
-    };
-    x86_64-darwin = fetchurl {
-      url = "https://downloads.cursor.com/production/25412918da7e74b2686b25d62da1f01cfcd27683/darwin/x64/Cursor-darwin-x64.dmg";
-      hash = "sha256-lY5BJeauw5VtWuaAu8C9C2inmKFvv/OnCxOicE2Zs48=";
-    };
-    aarch64-darwin = fetchurl {
-      url = "https://downloads.cursor.com/production/25412918da7e74b2686b25d62da1f01cfcd27683/darwin/arm64/Cursor-darwin-arm64.dmg";
-      hash = "sha256-IIJbuRdxTG7kSspspWk8GH9KZsKPyLJahz0iqSvP1B0=";
-    };
-  };
+  sourcesJson = lib.importJSON ./sources.json;
+  sources = lib.mapAttrs (
+    _: info:
+    fetchurl {
+      inherit (info) url hash;
+    }
+  ) sourcesJson.sources;
 
   source = sources.${hostPlatform.system};
 in
 (callPackage vscode-generic rec {
   inherit useVSCodeRipgrep;
+  inherit (sourcesJson) version vscodeVersion;
   commandLineArgs = finalCommandLineArgs;
 
-  version = "2.0.64";
   pname = "cursor";
-
-  # You can find the current VSCode version in the About dialog:
-  # workbench.action.showAboutDialog (Help: About)
-  vscodeVersion = "1.99.3";
 
   executableName = "cursor";
   longName = "Cursor";

--- a/pkgs/by-name/co/code-cursor/sources.json
+++ b/pkgs/by-name/co/code-cursor/sources.json
@@ -1,0 +1,22 @@
+{
+  "version": "2.1.26",
+  "vscodeVersion": "1.105.1",
+  "sources": {
+    "aarch64-linux": {
+      "url": "https://downloads.cursor.com/production/f628a4761be40b8869ca61a6189cafd14756dff4/linux/arm64/Cursor-2.1.26-aarch64.AppImage",
+      "hash": "sha256-CJaY/qbTmOwQ1OOYq/s5AJu22UD6R/mGATOzqZyUkX0="
+    },
+    "x86_64-linux": {
+      "url": "https://downloads.cursor.com/production/f628a4761be40b8869ca61a6189cafd14756dff4/linux/x64/Cursor-2.1.26-x86_64.AppImage",
+      "hash": "sha256-lkvrgWjVfTozcADOjA/liZ0j5pPgXv9YvR5l0adGxBE="
+    },
+    "x86_64-darwin": {
+      "url": "https://downloads.cursor.com/production/f628a4761be40b8869ca61a6189cafd14756dff4/darwin/x64/Cursor-darwin-x64.dmg",
+      "hash": "sha256-XksvEh4bctf0GLFMJGiLkekBs8Qv1LE6kqismc51wCM="
+    },
+    "aarch64-darwin": {
+      "url": "https://downloads.cursor.com/production/f628a4761be40b8869ca61a6189cafd14756dff4/darwin/arm64/Cursor-darwin-arm64.dmg",
+      "hash": "sha256-oVaf7uEASdRHH0lmqDXnv/YZ2AWrHR06Jj7oGqNPriE="
+    }
+  }
+}

--- a/pkgs/by-name/co/code-cursor/update.sh
+++ b/pkgs/by-name/co/code-cursor/update.sh
@@ -1,39 +1,44 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl jq coreutils common-updater-scripts
-set -eu -o pipefail
+#!nix-shell -i bash -p curl jq coreutils nix _7zz
+# shellcheck shell=bash
+set -euo pipefail
 
-currentVersion=$(nix-instantiate --eval -E "with import ./. {}; code-cursor.version or (lib.getVersion code-cursor)" | tr -d '"')
+cd -- "$(dirname "${BASH_SOURCE[0]}")"
 
-declare -A platforms=( [x86_64-linux]='linux-x64' [aarch64-linux]='linux-arm64' [x86_64-darwin]='darwin-x64' [aarch64-darwin]='darwin-arm64' )
-declare -A updates=( )
-first_version=""
+META=$(curl -fsSL "https://api2.cursor.sh/updates/api/download/stable/linux-x64/cursor")
+VERSION=$(jq -r '.version' <<< "$META")
+CURRENT=$(jq -r '.version' sources.json)
 
-for platform in ${!platforms[@]}; do
-    api_platform=${platforms[$platform]}
-    result=$(curl -s "https://api2.cursor.sh/updates/api/download/stable/$api_platform/cursor")
-    version=$(echo $result | jq -r '.version')
-    if [[ "$version" == "$currentVersion" ]]; then
-      exit 0
-    fi
-    if [[ -z "$first_version" ]]; then
-      first_version=$version
-      first_platform=$platform
-    elif [[ "$version" != "$first_version" ]]; then
-      >&2 echo "Multiple versions found: $first_version ($first_platform) and $version ($platform)"
-      exit 1
-    fi
-    url=$(echo $result | jq -r '.downloadUrl')
-    # Exits with code 22 if not downloadable
-    curl --output /dev/null --silent --head --fail "$url"
-    updates+=( [$platform]="$result" )
+[[ "$VERSION" == "$CURRENT" ]] && { echo "Already up to date ($VERSION)"; exit 0; }
+
+SOURCES="{}"
+VSCODE=""
+
+for pair in \
+  x86_64-linux:linux-x64 \
+  aarch64-linux:linux-arm64 \
+  x86_64-darwin:darwin-x64 \
+  aarch64-darwin:darwin-arm64
+do
+  IFS=: read -r sys platform <<< "$pair"
+  meta=$(curl -fsSL "https://api2.cursor.sh/updates/api/download/stable/$platform/cursor")
+  version=$(jq -r '.version' <<< "$meta")
+
+  [[ "$version" != "$VERSION" ]] && { echo "Version mismatch: $sys has $version, expected $VERSION"; exit 1; }
+
+  url=$(jq -r '.downloadUrl' <<< "$meta")
+
+  { read -r hash; read -r path; } < <(nix-prefetch-url --print-path "$url")
+
+  sri=$(nix-hash --type sha256 --to-sri "$hash")
+
+  if [[ "$sys" == "x86_64-linux" ]]; then
+    VSCODE=$(7zz x -so "$path" "usr/share/cursor/resources/app/product.json" 2>/dev/null | jq -r '.vscodeVersion')
+  fi
+
+  SOURCES=$(jq -n --argjson src "$SOURCES" --arg sys "$sys" --arg url "$url" --arg hash "$sri" \
+    '$src + {($sys): {url: $url, hash: $hash}}')
 done
 
-# Install updates
-for platform in ${!updates[@]}; do
-  result=${updates[$platform]}
-  version=$(echo $result | jq -r '.version')
-  url=$(echo $result | jq -r '.downloadUrl')
-  source=$(nix-prefetch-url "$url" --name "cursor-$version")
-  hash=$(nix-hash --to-sri --type sha256 "$source")
-  update-source-version code-cursor $version $hash "$url" --system=$platform --ignore-same-version --source-key="sources.$platform"
-done
+jq -n --arg v "$VERSION" --arg vs "$VSCODE" --argjson s "$SOURCES" \
+  '{version: $v, vscodeVersion: $vs, sources: $s}' > sources.json


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Reduce maintenance efforts by auto-updating vscodeVersion.

Use sources.json to store update relevant information.

Updates 2.0.64 to 2.1.26.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
