### PR TITLE
[25.05] signal-desktop: 7.79.0 -> 7.80.0

### DIFF
--- a/pkgs/by-name/si/signal-desktop/package.nix
+++ b/pkgs/by-name/si/signal-desktop/package.nix
@@ -3,7 +3,7 @@
   lib,
   nodejs_22,
   pnpm_10,
-  electron_38,
+  electron_39,
   gn_2233,
   python3,
   makeWrapper,
@@ -20,7 +20,7 @@
 let
   nodejs = nodejs_22;
   pnpm = pnpm_10.override { inherit nodejs; };
-  electron = electron_38;
+  electron = electron_39;
   gn = gn_2233;
 
   libsignal-node = callPackage ./libsignal-node.nix { inherit nodejs; };
@@ -50,13 +50,13 @@ let
     '';
   });
 
-  version = "7.79.0";
+  version = "7.80.0";
 
   src = fetchFromGitHub {
     owner = "signalapp";
     repo = "Signal-Desktop";
     tag = "v${version}";
-    hash = "sha256-2eEUOOmJuS/MYC+M7tkWaxFTulnFUGuKE+eiD2gIIpw=";
+    hash = "sha256-CU304F6Ib4j/0/BqGUidV9uYUrsvIahpsCYVgr8MWFg=";
   };
 
   sticker-creator = stdenv.mkDerivation (finalAttrs: {
@@ -132,15 +132,15 @@ stdenv.mkDerivation (finalAttrs: {
     fetcherVersion = 1;
     hash =
       if withAppleEmojis then
-        "sha256-Gx7+/vVjYRM4oBWnUFpxWSLjha2t3nLmaZjjzDlKf+Y="
+        "sha256-7zw9qmnQt5NYRKI4bLCM5Hg0d/6kVKovy1k8CpZ/1R8="
       else
-        "sha256-YhxoyNTvtmpo/v0ef+T9OMMvwHqC/PGEwY3cUQ+EtPg=";
+        "sha256-Mya7v0uhjP4GVyD412SMiQ8/YHaq99fDIjGHCJOIWxY=";
   };
 
   env = {
     ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
     SIGNAL_ENV = "production";
-    SOURCE_DATE_EPOCH = 1762988949;
+    SOURCE_DATE_EPOCH = 1763594452;
   };
 
   preBuild = ''


### PR DESCRIPTION
Manual backport of #463404.

Solved a merge conflict caused by `gn_2233` which is only required in 25.05.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
