### PR TITLE
zuban: 0.1.0 -> 0.3.0 and typeshed fix

### DIFF
--- a/pkgs/by-name/zu/zuban/package.nix
+++ b/pkgs/by-name/zu/zuban/package.nix
@@ -4,22 +4,29 @@
   rustPlatform,
   versionCheckHook,
   nix-update-script,
+  python3,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "zuban";
 
-  version = "0.1.0";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "zubanls";
     repo = "zuban";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-nSQf3I9O5TP1V8kwJrcBRREqS/47UlILx3IZMmt5ljQ=";
+    hash = "sha256-LHIrIO9ew5iXgem9W7QkPGic8XH6fQymLrbvQbmkB0M=";
+    fetchSubmodules = true;
   };
+
+  postInstall = ''
+    mkdir -p $out/${python3.sitePackages}/zuban
+    cp -r third_party $out/${python3.sitePackages}/zuban/
+  '';
 
   buildAndTestSubdir = "crates/zuban";
 
-  cargoHash = "sha256-Q09ZUBVa52fXIKiL6aC9VZB+4Rt/hI045CIjb/t3Xyg=";
+  cargoHash = "sha256-y3lqa+WWY8+KG59DzGdpiBLMybeqeN1fMAUMFidHX3Q=";
 
   nativeInstallCheckInputs = [
     versionCheckHook

--- a/pkgs/by-name/zu/zuban/package.nix
+++ b/pkgs/by-name/zu/zuban/package.nix
@@ -46,6 +46,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://zubanls.com/blog/";
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [
+      bew
       mcjocobe
     ];
     platforms = lib.platforms.all;


### PR DESCRIPTION
Updating zuban from 0.1.0 to 0.3.0 and fixing typeshed error by wrapping with appropriate env variable and downloading missing submodules.

Signed-off-by: Safenein <safenein@cavernum.ovh>
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
Signed-off-by: Safenein <safenein@cavernum.ovh>