### PR TITLE
musl: fetch stdio patch to fix systemd procfs interactions

### DIFF
--- a/pkgs/by-name/mu/musl/package.nix
+++ b/pkgs/by-name/mu/musl/package.nix
@@ -94,6 +94,10 @@ stdenv.mkDerivation rec {
       url = "https://www.openwall.com/lists/musl/2025/02/13/1/2";
       hash = "sha256-BiD87k6KTlLr4ep14rUdIZfr2iQkicBYaSTq+p6WBqE=";
     })
+    # required for systemd user namespacing and oomd to work correctly on musl
+    # drop next release
+    # https://git.musl-libc.org/cgit/musl/commit/?id=fde29c04adbab9d5b081bf6717b5458188647f1c
+    ./stdio-skip-empty-iovec-when-buffering-is-disabled.patch
   ];
   CFLAGS = [
     "-fstack-protector-strong"

--- a/pkgs/by-name/mu/musl/stdio-skip-empty-iovec-when-buffering-is-disabled.patch
+++ b/pkgs/by-name/mu/musl/stdio-skip-empty-iovec-when-buffering-is-disabled.patch
@@ -1,0 +1,31 @@
+From fde29c04adbab9d5b081bf6717b5458188647f1c Mon Sep 17 00:00:00 2001
+From: Casey Connolly <kcxt@postmarketos.org>
+Date: Wed, 23 Apr 2025 15:06:48 +0200
+Subject: stdio: skip empty iovec when buffering is disabled
+
+When buffering on a FILE is disabled we still send both iovecs, even
+though the first one is always empty. Clean things up by skipping the
+empty iovec instead.
+---
+ src/stdio/__stdio_write.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/stdio/__stdio_write.c b/src/stdio/__stdio_write.c
+index d2d89475..5356553d 100644
+--- a/src/stdio/__stdio_write.c
++++ b/src/stdio/__stdio_write.c
+@@ -11,6 +11,11 @@ size_t __stdio_write(FILE *f, const unsigned char *buf, size_t len)
+ 	size_t rem = iov[0].iov_len + iov[1].iov_len;
+ 	int iovcnt = 2;
+ 	ssize_t cnt;
++
++	if (!iov->iov_len) {
++		iov++;
++		iovcnt--;
++	}
+ 	for (;;) {
+ 		cnt = syscall(SYS_writev, f->fd, iov, iovcnt);
+ 		if (cnt == rem) {
+-- 
+cgit v1.2.1
+


### PR DESCRIPTION
This fixes systemd oomd and user namespacing.
Previously musl would write an empty iovec into unbuffered procfs file streams, resulting in the kernel rejecting the file write and systemd throwing errors as a result. Alpine and Fedora already use this patch, systemd lists this patch as expplicitly required for it to work on musl following the official upstream musl support.

See also https://github.com/systemd/systemd/issues/39856 and https://github.com/systemd/systemd/pull/38825#issue-3386123778

I do already use this in my musl toy vm, and user namespacing does work there.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
