### PR TITLE
memtest86plus: 7.20 -> 8.00

### DIFF
--- a/pkgs/by-name/me/memtest86plus/package.nix
+++ b/pkgs/by-name/me/memtest86plus/package.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "memtest86+";
-  version = "7.20";
+  version = "8.00";
 
   src = fetchFromGitHub {
     owner = "memtest86plus";
     repo = "memtest86plus";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-JZ6feyk66DLKEnugc+yXN4KckQrCTMNqQL4TvCTw1EU=";
+    hash = "sha256-7oOe35TI+H8Nox2VJMrdoMGyTxzrJzebBH+DLanXtpo=";
   };
 
   # Binaries are booted directly by BIOS/UEFI or bootloader
@@ -20,14 +20,14 @@ stdenv.mkDerivation (finalAttrs: {
   dontPatchELF = true;
   dontStrip = true;
 
-  passthru.efi = "${finalAttrs.finalPackage}/memtest.efi";
+  passthru.efi = "${finalAttrs.finalPackage}/mt86plus.efi";
 
   preBuild = ''
-    cd ${if stdenv.hostPlatform.isi686 then "build32" else "build64"}
+    cd build/${if stdenv.hostPlatform.isi686 then "i586" else "x86_64"}
   '';
 
   installPhase = ''
-    install -Dm0444 -t $out/ memtest.bin memtest.efi
+    install -Dm0444 mt86plus $out/mt86plus.efi
   '';
 
   meta = {


### PR DESCRIPTION
There is now one combined binary that runs in both legacy and EFI mode.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
