### PR TITLE
nix-prefetch-pijul: fixup invalid JSON

### DIFF
--- a/pkgs/build-support/fetchpijul/nix-prefetch-pijul
+++ b/pkgs/build-support/fetchpijul/nix-prefetch-pijul
@@ -123,10 +123,10 @@ cat <<EOF
 	"channel": $(json_escape "$channel"),
 EOF
 if [ -n "$change" ]; then cat <<EOF
-	"change": "$(json_escape "$change")",
+	"change": $(json_escape "$change"),
 EOF
 elif [ -n "$state" ]; then cat <<EOF
-	"state": "$(json_escape "$state")",
+	"state": $(json_escape "$state"),
 EOF
 fi; cat <<EOF
 	"path": "$final_path",


### PR DESCRIPTION
accidentally doubly-quoted string output on change + state

Just like: https://github.com/NixOS/nixpkgs/pull/460691

Splitting just the JSON part out of <https://github.com/NixOS/nixpkgs/pull/462758> in hopes of getting a review with a smaller merge request

Note how this can now successfully pipe to `jq`:

```sh-session
$ nix-build -A nix-prefetch-pijul
/nix/store/fm6rlg3qwjdglssli3db331rb26ir0j9-nix-prefetch-pijul
$ result/bin/nix-prefetch-pijul --state DUWNJEAZCSSE6FIKUMGWKXZKDNIQABT5KUCPFQ573RRNL7453N4QC https://nest.pijul.com/toastal/test-lightweight-markup-language-rendering | jq --tab
Repository created at /tmp/pijul-clone-tmp-N19gODIC/fetchpijul
Downloading changes  [==================================================] 2/2 [00:00:01]
Applying changes     [==================================================] 2/2 [00:00:01]
Downloading changes  [                                                  ] 0/2 [00:00:00]
Downloading changes  [==================================================] 2/2 [00:00:00]                                                                   Completing changes... done!
{
	"remote": "https://nest.pijul.com/toastal/test-lightweight-markup-language-rendering",
	"channel": "main",
	"state": "DUWNJEAZCSSE6FIKUMGWKXZKDNIQABT5KUCPFQ573RRNL7453N4QC",
	"path": "/nix/store/bb4sw61908njg0p65npd8r67zb0fg5ds-fetchpijul",
	"sha256": "07zclwdkl0bz1bk91rd5nfqqyz42kkr4q60hx0zcx37p3dnn2r2v",
	"hash": "sha256-W2RhbRv3jM4+6BAYTPKcgnyPsbOl5ZDmCn8BOhun7B8="
}
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
