### PR TITLE
echidna: mark as broken

### DIFF
--- a/pkgs/by-name/ec/echidna/package.nix
+++ b/pkgs/by-name/ec/echidna/package.nix
@@ -127,4 +127,6 @@ haskellPackages.mkDerivation rec {
   ];
   platforms = lib.platforms.unix;
   mainProgram = "echidna";
+  # Fails to build since https://hydra.nixos.org/build/313316669/nixlog/2
+  broken = true;
 }


### PR DESCRIPTION
This is a top-level haskell package, so it's not marked broken automatically at the end of haskell-updates cycles. It has been failing since October now, so it's time to mark it as broken.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
