### PR TITLE
limine: allow protocolOverride

### DIFF
--- a/nixos/modules/system/boot/loader/limine/limine-install.py
+++ b/nixos/modules/system/boot/loader/limine/limine-install.py
@@ -287,7 +287,7 @@ def xen_config_entry(
 
 def config_entry(levels: int, bootspec: BootSpec, label: str, time: str) -> str:
     entry = '/' * levels + label + '\n'
-    entry += 'protocol: linux\n'
+    entry += 'protocol: ' + config('protocolOverride') + '\n'
     entry += f'comment: {bootspec.label}, built on {time}\n'
     entry += 'kernel_path: ' + get_kernel_uri(bootspec.kernel) + '\n'
     entry += 'cmdline: ' + ' '.join(['init=' + bootspec.init] + bootspec.kernelParams).strip() + '\n'

--- a/nixos/modules/system/boot/loader/limine/limine.nix
+++ b/nixos/modules/system/boot/loader/limine/limine.nix
@@ -34,6 +34,7 @@ let
       additionalFiles = cfg.additionalFiles;
       validateChecksums = cfg.validateChecksums;
       panicOnChecksumMismatch = cfg.panicOnChecksumMismatch;
+      protocolOverride = cfg.protocolOverride;
     }
   );
   defaultWallpaper = pkgs.nixos-artwork.wallpapers.simple-dark-gray-bootloader.gnomeFilePath;
@@ -108,6 +109,15 @@ in
         A set of files to be copied to {file}`/boot`. Each attribute name denotes the
         destination file name in {file}`/boot`, while the corresponding attribute value
         specifies the source file.
+      '';
+    };
+
+    protocolOverride = lib.mkOption {
+      default = "linux";
+      type = lib.types.str;
+      description = ''
+        Override the protocol for nixos entries.
+        Valid values are "linux", "limine", "multiboot", "multiboot1", "multiboot2", "efi", "bios".
       '';
     };
 


### PR DESCRIPTION
Adds the ability to manually override the boot protocol. This is useful for myself and all other framework users on the latest firmware apparently (see https://www.reddit.com/r/framework/comments/1ngxniy/linux_boot_issues_using_limine_after_most_recent/ with fix in https://www.reddit.com/r/framework/comments/1ngxniy/comment/nn6p2d9/). In any case, this may also prove useful to others
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin (N/A)
  - [ ] aarch64-darwin (N/A)
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
