### PR TITLE
workflows: run smaller jobs on ubuntu-slim

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -22,7 +22,7 @@ jobs:
   backport:
     name: Backport Pull Request
     if: vars.NIXPKGS_CI_APP_ID && github.event.pull_request.merged == true && (github.event.action != 'labeled' || startsWith(github.event.label.name, 'backport'))
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-slim
     timeout-minutes: 3
     steps:
       # Use a GitHub App to create the PR so that CI gets triggered

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -39,7 +39,7 @@ defaults:
 
 jobs:
   run:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-slim
     if: github.event_name != 'schedule' || github.repository_owner == 'NixOS'
     env:
       # TODO: Remove after 2026-03-04, when Node 24 becomes the default.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,7 +32,7 @@ jobs:
     if: inputs.baseBranch && inputs.headBranch
     permissions:
       pull-requests: write
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-slim
     timeout-minutes: 3
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -19,7 +19,7 @@ jobs:
   # a reaction to these comments.
   react:
     name: React with eyes
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-slim
     timeout-minutes: 2
     if: contains(github.event.comment.body, '@NixOS/nixpkgs-merge-bot merge')
     steps:

--- a/.github/workflows/edited.yml
+++ b/.github/workflows/edited.yml
@@ -29,7 +29,7 @@ defaults:
 jobs:
   base:
     name: Trigger jobs
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     if: github.event.changes.base.ref.from && github.event.changes.base.ref.from != github.event.pull_request.base.ref
     timeout-minutes: 2
     steps:

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -33,7 +33,7 @@ defaults:
 jobs:
   versions:
     if: inputs.testVersions
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-slim
     outputs:
       versions: ${{ steps.versions.outputs.versions }}
     steps:
@@ -257,7 +257,7 @@ jobs:
 
   # Creates a matrix of Eval performance for various versions and systems.
   report:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-slim
     needs: [versions, eval]
     steps:
       - name: Download output paths and eval stats for all versions

--- a/.github/workflows/merge-group.yml
+++ b/.github/workflows/merge-group.yml
@@ -18,7 +18,7 @@ permissions: {}
 
 jobs:
   prepare:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-slim
     outputs:
       baseBranch: ${{ steps.prepare.outputs.base }}
       mergedSha: ${{ steps.prepare.outputs.mergedSha }}
@@ -113,7 +113,7 @@ jobs:
     needs:
       - lint
       - eval
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-slim
     permissions:
       statuses: write
     steps:

--- a/.github/workflows/periodic-merge.yml
+++ b/.github/workflows/periodic-merge.yml
@@ -21,7 +21,7 @@ defaults:
 
 jobs:
   merge:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-slim
     timeout-minutes: 5
     steps:
       # Use a GitHub App to create the PR so that CI gets triggered

--- a/.github/workflows/pull-request-target.yml
+++ b/.github/workflows/pull-request-target.yml
@@ -19,7 +19,7 @@ permissions: {}
 
 jobs:
   prepare:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-slim
     permissions:
       # wrong branch review comment
       pull-requests: write
@@ -121,7 +121,7 @@ jobs:
       - lint
       - eval
       - build
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-slim
     permissions:
       statuses: write
     steps:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -17,7 +17,7 @@ defaults:
 
 jobs:
   process:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-slim
     timeout-minutes: 2
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0

--- a/.github/workflows/reviewed.yml
+++ b/.github/workflows/reviewed.yml
@@ -12,6 +12,6 @@ defaults:
 
 jobs:
   trigger:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-slim
     steps:
       - run: echo This is a no-op only used as a trigger for workflow_run.

--- a/.github/workflows/teams.yml
+++ b/.github/workflows/teams.yml
@@ -15,7 +15,7 @@ defaults:
 jobs:
   sync:
     if: github.event_name != 'schedule' || github.repository_owner == 'NixOS'
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-slim
     steps:
       # Use a GitHub App to create the PR so that CI gets triggered and to
       # request team member lists.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
   prepare:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-slim
     outputs:
       merge-group: ${{ steps.files.outputs.merge-group }}
       mergedSha: ${{ steps.prepare.outputs.mergedSha }}


### PR DESCRIPTION
This is in [public preview](https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/) now. These runners run in a docker container with only a single vCPU instead of 4 like the other jobs. For most of our jobs, this should be plenty, except for eval and linting.

We'll have to see whether some of the jobs regress in run-time, but we can always revert some of these later.

## Things done

- [x] ~~Fix our custom checkout action on these runners.~~ `git` version is just the first thing, there's more after that - no point in trying to rewrite that thing. Just backed out the changes to the two jobs which make use of that.
- [x] Update actionlint to support the new runner label: #464869
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
