### PR TITLE
peppercarrot-fonts: init at v1.0.0

### DIFF
--- a/pkgs/by-name/pe/peppercarrot-fonts/package.nix
+++ b/pkgs/by-name/pe/peppercarrot-fonts/package.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  fetchFromGitLab,
+  fontforge,
+  stdenvNoCC,
+  installFonts,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "peppercarrot-fonts";
+  version = "1.0.0";
+
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
+  src = fetchFromGitLab {
+    domain = "framagit.org";
+    owner = "peppercarrot";
+    repo = "fonts";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-tabiNRJZRwSYGV3DtXhg0C78E7TlDQYcpa/5bJrkhfs=";
+  };
+
+  # Other folders include third-party fonts for other alphabets
+  sourceRoot = "${finalAttrs.src.name}/Latin";
+
+  postPatch = ''
+    # Some fonts are duplicated with symlinks
+    find . -type l -delete
+
+    # Already in pkgs.yanone-kaffeesatz
+    rm YanoneKaffeesatz*
+  '';
+
+  nativeBuildInputs = [
+    fontforge
+    installFonts
+  ];
+
+  # Those are only built as woff2
+  buildPhase = ''
+    runHook preBuild
+    fontforge -lang=ff -c 'Open("sources/Handserah.sfd"); Generate("Handserah.otf")'
+    fontforge -lang=ff -c 'Open("sources/PepperCarrot.sfd"); Generate("PepperCarrot.otf")'
+    runHook postBuild
+  '';
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Open fonts used in the webcomic Pepper&Carrot";
+    homepage = "https://www.peppercarrot.com/en/fonts";
+    changelog = "https://framagit.org/peppercarrot/fonts/-/blob/master/CHANGELOG.md";
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.nim65s ];
+    license =
+      with lib.licenses;
+      let
+        gpl2font = {
+          deprecated = true;
+          free = true;
+          fullName = "GNU General Public License v2.0 w/Font exception";
+          redistributable = true;
+          shortName = "gpl2font";
+          spdxId = " GPL-2.0-with-font-exception";
+          url = "https://spdx.org/licenses/GPL-2.0-with-font-exception.html";
+        };
+        ofl10 = {
+          deprecated = false;
+          free = true;
+          fullName = "SIL Open Font License 1.0";
+          redistributable = true;
+          shortName = "ofl10";
+          spdxId = "OFL-1.0";
+          url = "https://spdx.org/licenses/OFL-1.0.html";
+        };
+      in
+      [
+        asl20
+        cc-by-30
+        gpl2font
+        gpl3
+        mplus
+        ofl
+        ofl10
+      ];
+  };
+})


### PR DESCRIPTION
Add fonts from https://www.peppercarrot.com/en/fonts
Here is a screenshot from libroffice with this:

<img width="795" height="1124" alt="fonts" src="https://github.com/user-attachments/assets/46513d35-f692-4421-a14d-74b790ef08e3" />



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
