### PR TITLE
noriskclient-launcher: init at 0.6.14

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10799,6 +10799,12 @@
     githubId = 2090758;
     keys = [ { fingerprint = "24F4 1925 28C4 8797 E539  F247 DB2D 93D1 BFAA A6EA"; } ];
   };
+  hythera = {
+    name = "Hythera";
+    github = "Hythera";
+    githubId = 87016780;
+    matrix = "@hythera:matrix.org";
+  };
   hyzual = {
     email = "hyzual@gmail.com";
     github = "Hyzual";

--- a/pkgs/by-name/no/noriskclient-launcher-unwrapped/disable-bundling.patch
+++ b/pkgs/by-name/no/noriskclient-launcher-unwrapped/disable-bundling.patch
@@ -1,0 +1,22 @@
+diff --git a/src-tauri/tauri.conf.json b/src-tauri/tauri.conf.json
+index bb58d13..c1046f8 100644
+--- a/src-tauri/tauri.conf.json
++++ b/src-tauri/tauri.conf.json
+@@ -100,7 +100,7 @@
+         }
+       }
+     },
+-    "active": true,
++    "active": false,
+     "targets": ["app", "dmg", "deb", "appimage", "nsis"],
+     "icon": [
+       "icons/32x32.png",
+@@ -109,7 +109,7 @@
+       "icons/icon.icns",
+       "icons/icon.ico"
+     ],
+-    "createUpdaterArtifacts": true,
++    "createUpdaterArtifacts": false,
+     "fileAssociations": [
+       {
+         "ext": ["noriskpack"],

--- a/pkgs/by-name/no/noriskclient-launcher-unwrapped/java-from-path.patch
+++ b/pkgs/by-name/no/noriskclient-launcher-unwrapped/java-from-path.patch
@@ -1,0 +1,34 @@
+diff --git a/src-tauri/src/minecraft/downloads/java_download.rs b/src-tauri/src/minecraft/downloads/java_download.rs
+index 25ab9b2..d1af896 100644
+--- a/src-tauri/src/minecraft/downloads/java_download.rs
++++ b/src-tauri/src/minecraft/downloads/java_download.rs
+@@ -9,6 +9,7 @@ use flate2::read::GzDecoder;
+ use futures::future::try_join_all;
+ use log::{debug, error, info};
+ use reqwest;
++use std::env;
+ use std::fs::File;
+ use std::io::Cursor;
+ use std::path::PathBuf;
+@@ -526,6 +527,21 @@ impl JavaDownloadService {
+             ],
+         };
+ 
++        let target = format!("openjdk-{}", version);
++        match env::var_os("PATH") {
++            Some(paths) => {
++                for path in env::split_paths(&paths) {
++                    if let Some(path_str) = path.to_str() {
++                        if path_str.contains(&target) {
++                            debug!("Found Java binary at: {:?}", path);
++                            return Ok(path)
++                        }
++                    }
++                }
++            }
++            none => debug!("PATH is not defined"),
++        }
++
+         // Try all possible paths
+         for java_binary in java_binary_paths {
+             debug!("Checking for Java binary at: {:?}", java_binary);

--- a/pkgs/by-name/no/noriskclient-launcher-unwrapped/package.nix
+++ b/pkgs/by-name/no/noriskclient-launcher-unwrapped/package.nix
@@ -1,0 +1,93 @@
+{
+  cargo-tauri,
+  desktop-file-utils,
+  fetchFromGitHub,
+  fetchYarnDeps,
+  glib,
+  gtk3,
+  libayatana-appindicator,
+  lib,
+  nix-update-script,
+  nodejs,
+  openssl,
+  pkg-config,
+  rustPlatform,
+  stdenv,
+  webkitgtk_4_1,
+  yarnConfigHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "noriskclient-launcher-unwrapped";
+  version = "0.6.14";
+
+  src = fetchFromGitHub {
+    owner = "NoRiskClient";
+    repo = "noriskclient-launcher";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-9UUNIS8r/695maQ2j2+Wj2L5qy55Wfs/MNhKJnwC6GI=";
+  };
+
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = "${finalAttrs.src}/yarn.lock";
+    hash = "sha256-IWgP4VEyEBNsxALKGMpk8WZCIc76qcEu5K+kYqsdYkQ=";
+  };
+
+  patches = [
+    # The tauri.conf.json is configured to build multiple apps. We don't want that here.
+    ./disable-bundling.patch
+
+    # Make the launcher find java from PATH, instead of downloading its own, which is not going to work on NixOS.
+    ./java-from-path.patch
+  ];
+
+  postPatch = lib.optionalString stdenv.hostPlatform.isLinux ''
+    substituteInPlace $cargoDepsCopy/libappindicator-sys-*/src/lib.rs \
+      --replace-fail "libayatana-appindicator3.so.1" "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
+  '';
+
+  cargoHash = "sha256-heSUEW7r9Lt26Fu68Jo/7BHW6Qmp8GrRSavukCS+ySk=";
+
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    desktop-file-utils
+    nodejs
+    pkg-config
+    yarnConfigHook
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    libayatana-appindicator
+    openssl
+    webkitgtk_4_1
+  ];
+
+  postInstall = ''
+    desktop-file-edit \
+    --set-name "NoRiskClient Launcher" \
+    --set-comment "Launcher for NoRiskClient" \
+    --set-key="Categories" --set-value="Game" \
+    --set-key="Keywords" --set-value="nrc;minecraft;mc;" \
+    $out/share/applications/NoRisk\ Launcher.desktop
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Minecraft Launcher for NoRisk Client";
+    homepage = "https://norisk.gg";
+    license = lib.licenses.gpl3;
+    longDescription = ''
+      An easy way to launch the NoRisk Client, create modpacks,
+      manage content for Minecraft, and much more - written in tauri.
+    '';
+    maintainers = with lib.maintainers; [ hythera ];
+    mainProgram = "noriskclient-launcher-v3";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/no/noriskclient-launcher-unwrapped/package.nix
+++ b/pkgs/by-name/no/noriskclient-launcher-unwrapped/package.nix
@@ -12,7 +12,6 @@
   openssl,
   pkg-config,
   rustPlatform,
-  stdenv,
   webkitgtk_4_1,
   yarnConfigHook,
 }:
@@ -41,7 +40,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     ./java-from-path.patch
   ];
 
-  postPatch = lib.optionalString stdenv.hostPlatform.isLinux ''
+  postPatch = ''
     substituteInPlace $cargoDepsCopy/libappindicator-sys-*/src/lib.rs \
       --replace-fail "libayatana-appindicator3.so.1" "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
   '';
@@ -81,7 +80,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Minecraft Launcher for NoRisk Client";
     homepage = "https://norisk.gg";
-    license = lib.licenses.gpl3;
+    license = lib.licenses.gpl3Only;
     longDescription = ''
       An easy way to launch the NoRisk Client, create modpacks,
       manage content for Minecraft, and much more - written in tauri.

--- a/pkgs/by-name/no/noriskclient-launcher/package.nix
+++ b/pkgs/by-name/no/noriskclient-launcher/package.nix
@@ -1,0 +1,101 @@
+{
+  addDriverRunpath,
+  alsa-lib,
+  flite,
+  glib,
+  glib-networking,
+  gsettings-desktop-schemas,
+  jdk17,
+  jdk21,
+  jdk8,
+  jdks ? [
+    jdk8
+    jdk17
+    jdk21
+  ],
+  lib,
+  libGL,
+  libjack2,
+  libpulseaudio,
+  libX11,
+  libXcursor,
+  libXext,
+  libXrandr,
+  libXxf86vm,
+  noriskclient-launcher-unwrapped,
+  pipewire,
+  stdenv,
+  symlinkJoin,
+  udev,
+  wrapGAppsHook4,
+}:
+
+symlinkJoin {
+  pname = "noriskclient-launcher";
+  inherit (noriskclient-launcher-unwrapped) version;
+
+  paths = [ noriskclient-launcher-unwrapped ];
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    glib
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    glib-networking
+    gsettings-desktop-schemas
+  ];
+
+  runtimeDependencies = lib.optionalString stdenv.hostPlatform.isLinux (
+    lib.makeLibraryPath [
+      addDriverRunpath.driverLink
+
+      # glfw
+      libGL
+      libX11
+      libXcursor
+      libXext
+      libXrandr
+      libXxf86vm
+
+      # narrator support
+      flite
+
+      # openal
+      alsa-lib
+      libjack2
+      libpulseaudio
+      pipewire
+
+      # oshi
+      udev
+    ]
+  );
+
+  postBuild = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : ${lib.makeSearchPath "bin/java" jdks}
+      ${lib.optionalString stdenv.hostPlatform.isLinux ''
+        --set LD_LIBRARY_PATH $runtimeDependencies
+      ''}
+    )
+
+    glibPostInstallHook
+    gappsWrapperArgsHook
+    wrapGAppsHook
+  '';
+
+  meta = {
+    inherit (noriskclient-launcher-unwrapped.meta)
+      description
+      homepage
+      license
+      longDescription
+      maintainers
+      mainProgram
+      platforms
+      ;
+  };
+}


### PR DESCRIPTION
## Description
I've seen quit a lot of people wanting an easy way to install the launcher on Nix(OS) (#348132, #350966). Darwin seems to be officially supported by the launcher, I can't test functionality on there though, so help with that would be appreciated.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
