### PR TITLE
cargo-auditable: Refactor & clean-up, to by-name, 0.6.5 -> 0.7.2

### DIFF
--- a/pkgs/by-name/ca/cargo-auditable/builder.nix
+++ b/pkgs/by-name/ca/cargo-auditable/builder.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  installShellFiles,
+  auditable-bootstrap,
+}:
+lib.extendMkDerivation {
+  constructDrv = rustPlatform.buildRustPackage.override { cargo-auditable = auditable-bootstrap; };
+
+  extendDrvArgs =
+    finalAttrs:
+    {
+      pname ? "cargo-auditable",
+      auditable ? true,
+      hash ? "",
+      cargoHash ? "",
+      ...
+    }:
+    {
+      inherit auditable pname;
+
+      src = fetchFromGitHub {
+        owner = "rust-secure-code";
+        repo = "cargo-auditable";
+        tag = "v${finalAttrs.version}";
+        inherit hash;
+      };
+
+      nativeBuildInputs = [
+        installShellFiles
+      ];
+
+      checkFlags = [
+        # requires wasm32-unknown-unknown target
+        "--skip=test_wasm"
+        # Seems to be a bug in tests of locked vs. semver compatible packages
+        # https://github.com/rust-secure-code/cargo-auditable/issues/235
+        "--skip=test_proc_macro"
+        "--skip=test_self_hosting"
+      ];
+
+      postInstall = ''
+        installManPage cargo-auditable/cargo-auditable.1
+      '';
+
+      passthru.bootstrap = auditable-bootstrap;
+
+      meta = {
+        description = "Tool to make production Rust binaries auditable";
+        mainProgram = "cargo-auditable";
+        homepage = "https://github.com/rust-secure-code/cargo-auditable";
+        changelog = "https://github.com/rust-secure-code/cargo-auditable/blob/v${finalAttrs.version}/cargo-auditable/CHANGELOG.md";
+        license = with lib.licenses; [
+          mit # or
+          asl20
+        ];
+        maintainers = with lib.maintainers; [ RossSmyth ];
+        broken = stdenv.hostPlatform != stdenv.buildPlatform;
+      };
+    };
+}

--- a/pkgs/by-name/ca/cargo-auditable/package.nix
+++ b/pkgs/by-name/ca/cargo-auditable/package.nix
@@ -45,8 +45,8 @@ let
         checkFlags = [
           # requires wasm32-unknown-unknown target
           "--skip=test_wasm"
-        ]
-        ++ lib.optionals (!auditable) [
+          # Seems to be a bug in tests of locked vs. semver compatible packages
+          # https://github.com/rust-secure-code/cargo-auditable/issues/235
           "--skip=test_proc_macro"
           "--skip=test_self_hosting"
         ];

--- a/pkgs/by-name/ca/cargo-auditable/package.nix
+++ b/pkgs/by-name/ca/cargo-auditable/package.nix
@@ -18,9 +18,9 @@ let
     auditable-bootstrap = bootstrap;
   };
 
-  hash = "sha256-zjv2/qZM0vRyz45DeKRtPHaamv2iLtjpSedVTEXeDr8=";
-  cargoHash = "sha256-oTPGmoGlNfPVZ6qha/oXyPJp94fT2cNlVggbIGHf2bc=";
-  version = "0.6.5";
+  version = "0.7.2";
+  hash = "sha256-hR6PjTOps8JSM7UbfGlCoZmmwtWExVqYwh4lxDiFWdc=";
+  cargoHash = "sha256-JEfnUJ9J6Xak3AOCwQCnu+v+3Wl3QbXX20qVFWB6040=";
 
   # cargo-auditable cannot be built with cargo-auditable until cargo-auditable is built
   bootstrap = auditableBuilder {

--- a/pkgs/development/compilers/rust/1_91.nix
+++ b/pkgs/development/compilers/rust/1_91.nix
@@ -8,6 +8,11 @@
 #    Check the version number in the src/llvm-project git submodule in:
 #    https://github.com/rust-lang/rust/blob/<version-tag>/.gitmodules
 
+# Note: The way this is structured is:
+# 1. Import default.nix, and apply arguments as needed for the file-defined function
+# 2. Implicitly, all arguments to this file are applied to the function that is imported.
+#    if you want to add an argument to default.nix's top-level function, but not the function
+#    it instantiates, add it to the `removeAttrs` call below.
 {
   stdenv,
   lib,
@@ -22,6 +27,7 @@
   wrapRustcWith,
   llvmPackages,
   llvm,
+  cargo-auditable,
   wrapCCWith,
   overrideCC,
   fetchpatch,
@@ -51,7 +57,7 @@ import ./default.nix
     llvmSharedForHost = llvmSharedFor pkgsBuildHost;
     llvmSharedForTarget = llvmSharedFor pkgsBuildTarget;
 
-    inherit llvmPackages;
+    inherit llvmPackages cargo-auditable;
 
     # For use at runtime
     llvmShared = llvmSharedFor pkgsHostTarget;
@@ -93,5 +99,6 @@ import ./default.nix
       "overrideCC"
       "pkgsHostTarget"
       "fetchpatch"
+      "cargo-auditable"
     ]
   )

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -11,6 +11,7 @@
   llvmSharedForHost,
   llvmSharedForTarget,
   llvmPackages, # Exposed through rustc for LTO in Firefox
+  cargo-auditable,
 }:
 {
   stdenv,
@@ -125,7 +126,7 @@ in
             }
           else
             self.callPackage ./cargo_cross.nix { };
-        cargo-auditable = self.callPackage ./cargo-auditable.nix { };
+        inherit cargo-auditable;
         cargo-auditable-cargo-wrapper = self.callPackage ./cargo-auditable-cargo-wrapper.nix { };
         clippy-unwrapped = self.callPackage ./clippy.nix { };
         clippy = if !fastCross then self.clippy-unwrapped else self.callPackage ./clippy-wrapper.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5205,7 +5205,6 @@ with pkgs;
 
   inherit (rustPackages)
     cargo
-    cargo-auditable
     cargo-auditable-cargo-wrapper
     clippy
     rustc


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
