### PR TITLE
nix-run: init at 0.1.0.0-alpha.2

### DIFF
--- a/pkgs/by-name/ni/nix-run/nix-run.nix
+++ b/pkgs/by-name/ni/nix-run/nix-run.nix
@@ -1,0 +1,40 @@
+{
+  mkDerivation,
+  attoparsec,
+  base,
+  fetchgit,
+  filepath,
+  hercules-ci-optparse-applicative,
+  hpack,
+  lib,
+  nix-derivation,
+  process,
+  relude,
+  unix,
+}:
+mkDerivation rec {
+  pname = "nix-run";
+  version = "0.1.0.0-alpha.2";
+  src = fetchgit {
+    url = "https://tangled.org/weethet.bsky.social/nix-run";
+    tag = version;
+    hash = "sha256-vnYD3N32H6eEPLis8eNlglXVY+guP5DDKCf2z7CLzwA=";
+  };
+  isLibrary = false;
+  isExecutable = true;
+  libraryToolDepends = [ hpack ];
+  executableHaskellDepends = [
+    attoparsec
+    base
+    filepath
+    hercules-ci-optparse-applicative
+    nix-derivation
+    process
+    relude
+    unix
+  ];
+  prePatch = "hpack";
+  homepage = "https://tangled.org/@weethet.bsky.social/nix-run";
+  license = lib.licenses.bsd3;
+  mainProgram = "nix-run";
+}

--- a/pkgs/by-name/ni/nix-run/package.nix
+++ b/pkgs/by-name/ni/nix-run/package.nix
@@ -1,0 +1,7 @@
+{ lib, haskellPackages }:
+(haskellPackages.callPackage ./nix-run.nix { }).overrideAttrs (old: {
+  meta = old.meta // {
+    description = "A non-experimental replacement for nix run";
+    maintainers = [ lib.maintainers.WeetHet ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Lix 2.94 has finally been released and this means that both major Nix package manager implementations now support `nix-instantiate --raw`. Thus, I'm finally adding my implementation of `nix-run` to nixpkgs. Please let me know if it needs to be renamed as to not conflict with official nix packages

```
nix-run - run a Nix application

Usage: nix-run [fileish] [-p|--package package] [--arg name value]
               [--argstr name value] [-A|--attr attrPath] [-E|--expr expr]
               [-I|--include [name=]path] [--option name value] [--repair]
               [-Q|--no-build-output] [-j|--max-jobs number] [--cores number]
               [--max-silent-time seconds] [--timeout seconds] [-k|--keep-going]
               [-K|--keep-failed] [--fallback] [--readonly-mode] [-v|--verbose]
               [--quiet] [--log-format format] [--check]
```

This aims to be as faithful to `nix-build` as possible, but was written by me alone and isn't widely used so there might be bugs (thus 0.1.0.0-unstable)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
