### PR TITLE
python3Packages.pysrdaligateway: 0.16.2 -> 0.17.0

### DIFF
--- a/pkgs/development/python-modules/pysrdaligateway/default.nix
+++ b/pkgs/development/python-modules/pysrdaligateway/default.nix
@@ -3,25 +3,21 @@
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,
-  wheel,
   cryptography,
   paho-mqtt,
   psutil,
-  pytestCheckHook,
-  pytest-asyncio,
-  pytest-cov,
 }:
 
 buildPythonPackage rec {
   pname = "pysrdaligateway";
-  version = "0.16.2";
+  version = "0.17.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "maginawin";
     repo = "PySrDaliGateway";
     tag = "v${version}";
-    hash = "sha256-V6yc2SGgF6ab9UOSwxGbUh43A/9x7SCTPQDbakoTbd0=";
+    hash = "sha256-Nh8K/Eyc4wyQt1Di1q5XpAcOEnTy7Oz+8siCebnMvkM=";
   };
 
   build-system = [ setuptools ];
@@ -34,9 +30,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "PySrDaliGateway" ];
 
-  nativeCheckInputs = [
-    pytestCheckHook
-  ];
+  # upstream "relies on manual integration testing with physical DALI hardware"
+  doCheck = false;
 
   meta = {
     changelog = "https://github.com/maginawin/PySrDaliGateway/releases/tag/${src.tag}";


### PR DESCRIPTION
Upstream removed all unit tests:
https://github.com/maginawin/PySrDaliGateway/commit/a9abbb08aba94adbf89cdf464945c5329d0efbf3

Diff: https://github.com/maginawin/PySrDaliGateway/compare/v0.16.2...v0.17.0

Changelog: https://github.com/maginawin/PySrDaliGateway/releases/tag/v0.17.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
