### PR TITLE
nixos/boot: add options to configure stage 1 and stage 2 boot greetings

### DIFF
--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -73,7 +73,7 @@ trap 'fail' 0
 
 # Print a greeting.
 info
-info "[1;32m<<< @distroName@ Stage 1 >>>[0m"
+info "[1;32m@stage1Greeting@[0m"
 info
 
 # Make several required directories.

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -323,6 +323,7 @@ let
         postMountCommands
         preFailCommands
         kernelModules
+        stage1Greeting
         ;
 
       resumeDevices = map (sd: if sd ? device then sd.device else "/dev/disk/by-label/${sd.label}") (
@@ -683,6 +684,15 @@ in
 
         - `boot.consoleLogLevel = 0;`
         - `boot.kernelParams = [ "quiet" "udev.log_level=3" ];`
+      '';
+    };
+
+    boot.initrd.stage1Greeting = mkOption {
+      type = types.str;
+      default = "<<< ${config.system.nixos.distroName} Stage 1 >>>";
+      defaultText = literalExpression ''"<<< ''${config.system.nixos.distroName} Stage 1 >>>"'';
+      description = ''
+        The greeting message displayed during NixOS stage 1 boot.
       '';
     };
 

--- a/nixos/modules/system/boot/stage-2-init.sh
+++ b/nixos/modules/system/boot/stage-2-init.sh
@@ -19,7 +19,7 @@ if [ "${IN_NIXOS_SYSTEMD_STAGE1:-}" != true ]; then
 
     # Print a greeting.
     echo
-    echo -e "\e[1;32m<<< @distroName@ Stage 2 >>>\e[0m"
+    echo -e "\e[1;32m@stage2Greeting@\e[0m"
     echo
 
 

--- a/nixos/modules/system/boot/stage-2.nix
+++ b/nixos/modules/system/boot/stage-2.nix
@@ -17,9 +17,8 @@ let
     replacements = {
       shell = "${pkgs.bash}/bin/bash";
       systemConfig = null; # replaced in ../activation/top-level.nix
-      inherit (config.boot) systemdExecutable;
+      inherit (config.boot) systemdExecutable stage2Greeting;
       nixStoreMountOpts = lib.concatStringsSep " " (map lib.escapeShellArg config.boot.nixStoreMountOpts);
-      inherit (config.system.nixos) distroName;
       inherit useHostResolvConf;
       inherit (config.system.build) earlyMountScript;
       path = lib.makeBinPath (
@@ -84,6 +83,15 @@ in
         type = types.str;
         description = ''
           The program to execute to start systemd.
+        '';
+      };
+
+      stage2Greeting = mkOption {
+        type = types.str;
+        default = "<<< ${config.system.nixos.distroName} Stage 2 >>>";
+        defaultText = literalExpression ''"<<< ''${config.system.nixos.distroName} Stage 2 >>>"'';
+        description = ''
+          The greeting message displayed during NixOS stage 2 boot.
         '';
       };
 


### PR DESCRIPTION
I thought it would be a nice feature to have. Making some of the messages shown on boot actual nixos config options.

I made these 2 options:
- `boot.initrd.stage1Greeting`: normally `<<< @distroName@ Stage 1 >>>`
- `boot.stage2Greeting`: normally `<<< NixOS Stage 2 >>>`

I tested this functionality on my machine and it worked!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
