### PR TITLE
ocamlPackages.graphics: 5.1.2 → 5.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/graphics/default.nix
+++ b/pkgs/development/ocaml-modules/graphics/default.nix
@@ -1,29 +1,32 @@
 {
   lib,
-  fetchurl,
+  fetchFromGitHub,
   buildDunePackage,
   dune-configurator,
   libX11,
+  libXft,
 }:
 
-buildDunePackage rec {
-
+buildDunePackage (finalAttrs: {
   pname = "graphics";
-  version = "5.1.2";
+  version = "5.2.0";
 
-  useDune2 = true;
-
-  src = fetchurl {
-    url = "https://github.com/ocaml/graphics/releases/download/${version}/graphics-${version}.tbz";
-    sha256 = "sha256-QA/YHSPxy0FGuWl5NCwkeXHdVPWHn/0vgOx80CEuMtQ=";
+  src = fetchFromGitHub {
+    owner = "ocaml";
+    repo = "graphics";
+    tag = finalAttrs.version;
+    hash = "sha256-0lpeZW1U//J5lH04x2ReBeug4s79KCyb5QYaiVgcBZI=";
   };
 
   buildInputs = [ dune-configurator ];
-  propagatedBuildInputs = [ libX11 ];
+  propagatedBuildInputs = [
+    libX11
+    libXft
+  ];
 
   meta = {
     homepage = "https://github.com/ocaml/graphics";
     description = "Set of portable drawing primitives";
     license = lib.licenses.lgpl2;
   };
-}
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
