### PR TITLE
localstack package improvements

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5814,6 +5814,12 @@
     githubId = 75175586;
     name = "Douglas Damiano";
   };
+  damien = {
+    email = "damien@absurd.engineering";
+    github = "damien";
+    githubId = 12211;
+    name = "Damien Wilson";
+  };
   DamienCassou = {
     email = "damien@cassou.me";
     github = "DamienCassou";

--- a/pkgs/by-name/lo/localstack/package.nix
+++ b/pkgs/by-name/lo/localstack/package.nix
@@ -70,7 +70,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     description = "Fully functional local Cloud stack";
     homepage = "https://github.com/localstack/localstack";
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ damien ];
     mainProgram = "localstack";
   };
 })

--- a/pkgs/by-name/lo/localstack/package.nix
+++ b/pkgs/by-name/lo/localstack/package.nix
@@ -1,10 +1,14 @@
 {
-  lib,
-  python3,
   fetchFromGitHub,
+  lib,
+  localstack,
+  nix-update-script,
+  python3Packages,
+  testers,
+  writableTmpDirAsHomeHook,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication rec {
   pname = "localstack";
   version = "4.12.0";
   pyproject = true;
@@ -16,12 +20,12 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     hash = "sha256-k5aIdfWm3Tvl/J0s1l0gTXJqnb4j5doJdIIaLLOJXg4=";
   };
 
-  build-system = with python3.pkgs; [
+  build-system = with python3Packages; [
     setuptools
     setuptools-scm
   ];
 
-  propagatedBuildInputs = with python3.pkgs; [
+  propagatedBuildInputs = with python3Packages; [
     apispec
     asn1crypto
     boto3
@@ -48,13 +52,16 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   pythonImportsCheck = [ "localstack" ];
 
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+  ];
+
   # Test suite requires boto, which has been removed from nixpkgs
   # Just do minimal test, buildPythonPackage maps checkPhase
   # to installCheckPhase, so we can test that entrypoint point works.
   checkPhase = ''
     runHook preCheck
 
-    export HOME=$(mktemp -d)
     $out/bin/localstack --version
 
     runHook postCheck
@@ -66,11 +73,24 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     rm $out/nix-support/propagated-build-inputs
   '';
 
-  meta = {
+  passthru = {
+    updateScript = nix-update-script { };
+
+    # Localstack uses a framework called Plux to do all kinds of dynamic code loading.
+    # We'll encounter build errors when it attempts to set up cache directories in the
+    # sandboxed build/test environment unless we set `XDG_CACHE_HOME` to a writable dir.
+    tests.version = testers.testVersion {
+      package = localstack;
+      command = "XDG_CACHE_HOME=$TMPDIR localstack --version";
+      inherit version;
+    };
+  };
+
+  meta = with lib; {
     description = "Fully functional local Cloud stack";
     homepage = "https://github.com/localstack/localstack";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ damien ];
+    maintainers = with maintainers; [ damien ];
     mainProgram = "localstack";
   };
 })


### PR DESCRIPTION
I gave the localstack package a bit of TLC:

1. Added a simple version test
2. Integrated `nix-update-script` for automatic updates
3. Bumped localstack to it's latest stable version, 4.9.2 -> 4.10.0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
