### PR TITLE
ocamlPackages.logs: 0.9.0 -> 0.10.0

### DIFF
--- a/pkgs/development/ocaml-modules/logs/default.nix
+++ b/pkgs/development/ocaml-modules/logs/default.nix
@@ -69,17 +69,15 @@ buildTopkgPackage {
     inherit (param) sha512;
   };
 
-  buildInputs = [ topkg ] ++ optional_buildInputs;
-
-  strictDeps = true;
+  buildInputs = optional_buildInputs;
 
   buildPhase = "${topkg.run} build ${lib.escapeShellArgs enable_flags}";
 
-  meta = with lib; {
+  meta = {
     description = "Logging infrastructure for OCaml";
     homepage = webpage;
     inherit (ocaml.meta) platforms;
-    maintainers = [ maintainers.sternenseemann ];
-    license = licenses.isc;
+    maintainers = with lib.maintainers; [ sternenseemann ];
+    license = lib.licenses.isc;
   };
 }

--- a/pkgs/development/ocaml-modules/logs/default.nix
+++ b/pkgs/development/ocaml-modules/logs/default.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchurl,
   ocaml,
-  version ? if lib.versionAtLeast ocaml.version "4.14" then "0.9.0" else "0.8.0",
+  version ? if lib.versionAtLeast ocaml.version "4.14" then "0.10.0" else "0.8.0",
   topkg,
   buildTopkgPackage,
   cmdlinerSupport ? true,
@@ -22,9 +22,9 @@ let
         minimalOCamlVersion = "4.03";
         sha512 = "c34c67b00d6a989a2660204ea70db8521736d6105f15d1ee0ec6287a662798fe5c4d47075c6e7c84f5d5372adb5af5c4c404f79db70d69140af5e0ebbea3b6a5";
       };
-      "0.9.0" = {
+      "0.10.0" = {
         minimalOCamlVersion = "4.14";
-        sha512 = "b75fb28e83f33461b06b5c9b60972c4a9a9a1599d637b4a0c7b1e86a87f34fe5361e817cb31f42ad7e7cbb822473b28fab9f58a02870eb189ebe88dae8e045ff";
+        sha512 = "122b7a77bd07aee1e0cb8e07e82b195a12528cf015e72fa0dd5afaae26ce04bad9b29f32a6d3bd3547fe522b8a036608785e8adb900e31580a0d555719bbb7e7";
       };
     }
     .${version};

--- a/pkgs/development/ocaml-modules/logs/default.nix
+++ b/pkgs/development/ocaml-modules/logs/default.nix
@@ -20,11 +20,11 @@ let
     {
       "0.8.0" = {
         minimalOCamlVersion = "4.03";
-        sha512 = "c34c67b00d6a989a2660204ea70db8521736d6105f15d1ee0ec6287a662798fe5c4d47075c6e7c84f5d5372adb5af5c4c404f79db70d69140af5e0ebbea3b6a5";
+        hash = "sha256-mmFRQJX6QvMBIzJiO2yNYF1Ce+qQS2oNF3+OwziCNtg=";
       };
       "0.10.0" = {
         minimalOCamlVersion = "4.14";
-        sha512 = "122b7a77bd07aee1e0cb8e07e82b195a12528cf015e72fa0dd5afaae26ce04bad9b29f32a6d3bd3547fe522b8a036608785e8adb900e31580a0d555719bbb7e7";
+        hash = "sha256-dg7CkcEo11t0gmCRM3dk+SW1ykFLAuLTNqCze/MN9Oo=";
       };
     }
     .${version};
@@ -66,7 +66,7 @@ buildTopkgPackage {
 
   src = fetchurl {
     url = "${webpage}/releases/${pname}-${version}.tbz";
-    inherit (param) sha512;
+    inherit (param) hash;
   };
 
   buildInputs = optional_buildInputs;


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
