### PR TITLE
feishin: 0.12.6 -> 0.21.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8899,6 +8899,12 @@
     githubId = 26125115;
     name = "Frédéric Christ";
   };
+  FreeCap23 = {
+    name = "Dionisie Stratulat";
+    email = "dionisiestratulat@gmail.com";
+    github = "FreeCap23";
+    githubId = 62378314;
+  };
   Freed-Wu = {
     email = "wuzhenyu@ustc.edu";
     github = "Freed-Wu";

--- a/pkgs/by-name/fe/feishin/package.nix
+++ b/pkgs/by-name/fe/feishin/package.nix
@@ -1,157 +1,105 @@
 {
   lib,
   stdenv,
-  buildNpmPackage,
-  fetchFromGitHub,
-  electron_38,
-  dart-sass,
-  pnpm_10,
-  darwin,
-  copyDesktopItems,
+  fetchurl,
+  appimageTools,
+  undmg,
   makeDesktopItem,
+  ...
 }:
 let
   pname = "feishin";
   version = "0.21.2";
 
-  src = fetchFromGitHub {
-    owner = "jeffvli";
-    repo = "feishin";
-    tag = "v${version}";
-    hash = "sha256-F5m0hsN1BLfiUcl2Go54bpFnN8ktn6Rqa/df1xxoCA4=";
+  src = fetchurl {
+    url =
+      if stdenv.hostPlatform.isDarwin then
+        "https://github.com/jeffvli/feishin/releases/download/v${version}/Feishin-${version}-mac-${if stdenv.hostPlatform.isAarch64 then "arm64" else "x64"}.dmg"
+      else
+        "https://github.com/jeffvli/feishin/releases/download/v${version}/Feishin-linux-${if stdenv.hostPlatform.isAarch64 then "arm64" else "x86_64"}.AppImage";
+    hash =
+      # macOS
+      if stdenv.hostPlatform.isDarwin then
+        if stdenv.hostPlatform.isAarch64 then
+          "sha256-F4u9sFMuRlNQz5PDuMKdEZG5IbYhZF6kRZUrPF2bzQg="
+        else
+          "sha256-YK3QMJ55ENqV6PCflWIaRJi8Xy5H4Hl3tc+/HazzZFc="
+      # Linux
+      else
+        if stdenv.hostPlatform.isAarch64 then
+          "sha256-ToaBmxy+Tvv7DNF9UgrBitTVcYetVHbMwW2W0SiodKw="
+        else
+          "sha256-CDYI9xTPpU89SrXvPZ7Qm2c0piuW11qjAgXZWxtspSY=";
   };
 
-  electron = electron_38;
-  pnpm = pnpm_10;
-in
-buildNpmPackage {
-  inherit pname version;
+  appimageContents = appimageTools.extract { inherit pname version src; };
 
-  inherit src;
-
-  npmConfigHook = pnpm.configHook;
-
-  npmDeps = null;
-  pnpmDeps = pnpm.fetchDeps {
-    inherit
-      pname
-      version
-      src
-      ;
-    fetcherVersion = 2;
-    hash = "sha256-5jEXdQMZ6a0JuhjPS1eZOIGsIGQHd6nKPI02eeR35pg=";
+  desktopItem = makeDesktopItem {
+    name = "feishin";
+    desktopName = "Feishin";
+    genericName = "Music player";
+    exec = "feishin %u";
+    icon = "feishin";
+    startupWMClass = "feishin";
+    categories = [
+      "AudioVideo"
+      "Audio"
+      "Player"
+      "Music"
+    ];
+    keywords = [
+      "Navidrome"
+      "Jellyfin"
+      "Subsonic"
+      "OpenSubsonic"
+    ];
+    comment = "A player for your self-hosted music server";
   };
-
-  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
-
-  nativeBuildInputs =
-    lib.optionals (stdenv.hostPlatform.isLinux) [ copyDesktopItems ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.autoSignDarwinBinariesHook ];
-
-  postPatch = ''
-    # release/app dependencies are installed on preConfigure
-    substituteInPlace package.json \
-      --replace-fail '"postinstall": "electron-builder install-app-deps",' ""
-
-    # Don't check for updates.
-    substituteInPlace src/main/index.ts \
-      --replace-fail "autoUpdater.checkForUpdatesAndNotify();" ""
-  ''
-  + lib.optionalString stdenv.hostPlatform.isLinux ''
-    # https://github.com/electron/electron/issues/31121
-    substituteInPlace src/main/index.ts \
-      --replace-fail "process.resourcesPath" "'$out/share/feishin/resources'"
-  '';
-
-  preBuild = ''
-    rm -r node_modules/.pnpm/sass-embedded-*
-
-    test -d node_modules/.pnpm/sass-embedded@*
-    dir="$(echo node_modules/.pnpm/sass-embedded@*)/node_modules/sass-embedded/dist/lib/src/vendor/dart-sass"
-    mkdir -p "$dir"
-    ln -s ${dart-sass}/bin/dart-sass "$dir"/sass
-  '';
-
-  postBuild =
-    lib.optionalString stdenv.hostPlatform.isDarwin ''
-      # electron-builder appears to build directly on top of Electron.app, by overwriting the files in the bundle.
-      cp -r ${electron.dist}/Electron.app ./
-      find ./Electron.app -name 'Info.plist' | xargs -d '\n' chmod +rw
-
-      # Disable code signing during build on macOS.
-      # https://github.com/electron-userland/electron-builder/blob/fa6fc16/docs/code-signing.md#how-to-disable-code-signing-during-the-build-process-on-macos
-      export CSC_IDENTITY_AUTO_DISCOVERY=false
-      sed -i "/afterSign/d" package.json
-    ''
-    + ''
-      npm exec electron-builder -- \
-        --dir \
-        -c.electronDist=${if stdenv.hostPlatform.isDarwin then "./" else electron.dist} \
-        -c.electronVersion=${electron.version} \
-        -c.npmRebuild=false
-    '';
-
-  installPhase = ''
-    runHook preInstall
-  ''
-  + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    mkdir -p $out/{Applications,bin}
-    cp -r dist/**/Feishin.app $out/Applications/
-    makeWrapper $out/Applications/Feishin.app/Contents/MacOS/Feishin $out/bin/feishin
-  ''
-  + lib.optionalString stdenv.hostPlatform.isLinux ''
-    mkdir -p $out/share/feishin
-
-    pushd dist/*-unpacked/
-    cp -r locales resources{,.pak} $out/share/feishin
-    popd
-
-    # Code relies on checking app.isPackaged, which returns false if the executable is electron.
-    # Set ELECTRON_FORCE_IS_PACKAGED=1.
-    # https://github.com/electron/electron/issues/35153#issuecomment-1202718531
-    makeWrapper ${lib.getExe electron} $out/bin/feishin \
-      --add-flags $out/share/feishin/resources/app.asar \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
-      --set ELECTRON_FORCE_IS_PACKAGED=1 \
-      --inherit-argv0
-
-    for size in 32 64 128 256 512 1024; do
-      mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
-      ln -s \
-        $out/share/feishin/resources/assets/icons/"$size"x"$size".png \
-        $out/share/icons/hicolor/"$size"x"$size"/apps/feishin.png
-    done
-  ''
-  + ''
-    runHook postInstall
-  '';
-
-  desktopItems = [
-    (makeDesktopItem {
-      name = "feishin";
-      desktopName = "Feishin";
-      comment = "Full-featured Subsonic/Jellyfin compatible desktop music player";
-      icon = "feishin";
-      exec = "feishin %u";
-      categories = [
-        "Audio"
-        "AudioVideo"
-      ];
-      mimeTypes = [ "x-scheme-handler/feishin" ];
-    })
-  ];
 
   meta = {
     description = "Full-featured Subsonic/Jellyfin compatible desktop music player";
     homepage = "https://github.com/jeffvli/feishin";
     changelog = "https://github.com/jeffvli/feishin/releases/tag/v${version}";
-    sourceProvenance = with lib.sourceTypes; [ fromSource ];
     license = lib.licenses.gpl3Plus;
-    platforms = lib.platforms.unix;
-    mainProgram = "feishin";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
     maintainers = with lib.maintainers; [
       onny
       jlbribeiro
+      FreeCap23
     ];
+    mainProgram = "feishin";
   };
-}
+in
+if stdenv.hostPlatform.isDarwin then
+  stdenv.mkDerivation {
+    inherit pname version src meta;
+
+    nativeBuildInputs = [ undmg ];
+
+    sourceRoot = ".";
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/Applications
+      cp -r Feishin.app $out/Applications/
+
+      runHook postInstall
+    '';
+  }
+else
+  appimageTools.wrapType2 {
+    inherit pname version src meta;
+
+    extraInstallCommands = ''
+      mkdir -p $out/share/applications
+      cp ${desktopItem}/share/applications/* $out/share/applications/
+      cp -r ${appimageContents}/usr/share/icons $out/share
+    '';
+  }

--- a/pkgs/by-name/fe/feishin/package.nix
+++ b/pkgs/by-name/fe/feishin/package.nix
@@ -14,9 +14,13 @@ let
   src = fetchurl {
     url =
       if stdenv.hostPlatform.isDarwin then
-        "https://github.com/jeffvli/feishin/releases/download/v${version}/Feishin-${version}-mac-${if stdenv.hostPlatform.isAarch64 then "arm64" else "x64"}.dmg"
+        "https://github.com/jeffvli/feishin/releases/download/v${version}/Feishin-${version}-mac-${
+          if stdenv.hostPlatform.isAarch64 then "arm64" else "x64"
+        }.dmg"
       else
-        "https://github.com/jeffvli/feishin/releases/download/v${version}/Feishin-linux-${if stdenv.hostPlatform.isAarch64 then "arm64" else "x86_64"}.AppImage";
+        "https://github.com/jeffvli/feishin/releases/download/v${version}/Feishin-linux-${
+          if stdenv.hostPlatform.isAarch64 then "arm64" else "x86_64"
+        }.AppImage";
     hash =
       # macOS
       if stdenv.hostPlatform.isDarwin then
@@ -25,11 +29,10 @@ let
         else
           "sha256-YK3QMJ55ENqV6PCflWIaRJi8Xy5H4Hl3tc+/HazzZFc="
       # Linux
+      else if stdenv.hostPlatform.isAarch64 then
+        "sha256-ToaBmxy+Tvv7DNF9UgrBitTVcYetVHbMwW2W0SiodKw="
       else
-        if stdenv.hostPlatform.isAarch64 then
-          "sha256-ToaBmxy+Tvv7DNF9UgrBitTVcYetVHbMwW2W0SiodKw="
-        else
-          "sha256-CDYI9xTPpU89SrXvPZ7Qm2c0piuW11qjAgXZWxtspSY=";
+        "sha256-CDYI9xTPpU89SrXvPZ7Qm2c0piuW11qjAgXZWxtspSY=";
   };
 
   appimageContents = appimageTools.extract { inherit pname version src; };
@@ -78,7 +81,12 @@ let
 in
 if stdenv.hostPlatform.isDarwin then
   stdenv.mkDerivation {
-    inherit pname version src meta;
+    inherit
+      pname
+      version
+      src
+      meta
+      ;
 
     nativeBuildInputs = [ undmg ];
 
@@ -95,7 +103,12 @@ if stdenv.hostPlatform.isDarwin then
   }
 else
   appimageTools.wrapType2 {
-    inherit pname version src meta;
+    inherit
+      pname
+      version
+      src
+      meta
+      ;
 
     extraInstallCommands = ''
       mkdir -p $out/share/applications


### PR DESCRIPTION
Updated feishin from 0.12.6 to 0.21.2

Modified the package file to simply download the binaries from GitHub instead of building them from scratch, which is unreliable as the project may (as it has with this jump in version) change build requirements, tooling or build systems.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
