### PR TITLE
cups-kyocera-ecosys-m552x-p502x: fix URL & change maintainer

### DIFF
--- a/pkgs/by-name/cu/cups-kyocera-ecosys-m552x-p502x/package.nix
+++ b/pkgs/by-name/cu/cups-kyocera-ecosys-m552x-p502x/package.nix
@@ -20,11 +20,11 @@ stdenv.mkDerivation {
     cp ${region}/English/*.PPD $out/share/cups/model/Kyocera/
   '';
 
-  meta = with lib; {
+  meta = {
     description = "PPD files for Kyocera ECOSYS M5521cdn/M5521cdw/M5526cdn/M5526cdw/P5021cdn/P5021cdw/P5026cdn/P5026cdw";
     homepage = "https://www.kyoceradocumentsolutions.com";
-    license = licenses.unfree;
-    maintainers = [ maintainers.mbrgm ];
-    platforms = platforms.linux;
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ theCapypara ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/cu/cups-kyocera-ecosys-m552x-p502x/package.nix
+++ b/pkgs/by-name/cu/cups-kyocera-ecosys-m552x-p502x/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   version = "8.1602";
 
   src = fetchzip {
-    url = "https://www.kyoceradocumentsolutions.de/content/download-center/de/drivers/all/Linux_8_1602_ECOSYS_M5521_5526_P5021_5026_zip.download.zip";
+    url = "https://www.kyoceradocumentsolutions.de/content/dam/download-center-cf/de/drivers/all/Linux_8_1602_ECOSYS_M5521_5526_P5021_5026_zip.download.zip";
     sha256 = "sha256-XDH5deZmWNghfoO7JaYYvnVq++mbQ8RwLY57L2CKYaY=";
   };
 


### PR DESCRIPTION
- Fixes #460619 by setting the URL by pointing to an updated upstream URL (same hash)
- Changes the maintainer, as @mbrgm has suggested so, since they don't use this driver anymore.

@mbrgm @basdusee

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
