### PR TITLE
coc-*: update and add updateScript

### DIFF
--- a/pkgs/by-name/co/coc-clangd/package.nix
+++ b/pkgs/by-name/co/coc-clangd/package.nix
@@ -2,21 +2,23 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
 buildNpmPackage {
   pname = "coc-clangd";
-  version = "0.31.0";
+  version = "0-unstable-2025-11-18";
 
   src = fetchFromGitHub {
     owner = "clangd";
     repo = "coc-clangd";
-    # Upstream has no tagged versions
-    rev = "3a85a36f1ac08454deab1ed8d2553e0cae00cc1c";
-    hash = "sha256-uxK0nciLq4ZKFCoMJrO4dR0tuOBHYpgdZUc/KJ+JA/I=";
+    rev = "72a4edc5ec39c6d7c4fd5a49aee7d9f3f84b8b6e";
+    hash = "sha256-uNCN3+8KovQ/Grrv7k5YZz6tTCNUX+6EN1Gkm867LMc=";
   };
 
-  npmDepsHash = "sha256-93MEug2eEL/Hum+RFmXx0JYO6jUygF8QRmL5nTTFyrs=";
+  npmDepsHash = "sha256-cLW5pY3LaumtE2qyxMMP9WirCMdWq+gsSO+dZNhCc1g=";
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
 
   meta = {
     description = "clangd extension for coc.nvim";

--- a/pkgs/by-name/co/coc-diagnostic/package.nix
+++ b/pkgs/by-name/co/coc-diagnostic/package.nix
@@ -7,17 +7,17 @@
   yarnBuildHook,
   nodejs,
   npmHooks,
+  nix-update-script,
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "coc-diagnostic";
-  version = "0.24.1";
+  version = "0-unstable-2025-01-15";
 
   src = fetchFromGitHub {
     owner = "iamcco";
     repo = "coc-diagnostic";
-    # Upstream has no tagged versions
-    rev = "f4b8774bccf1c031da51f8ee52b05bc6b2337bf9";
-    hash = "sha256-+RPNFZ3OmdI9v0mY1VNJPMHs740IXvVJy4WYMgqqQSM=";
+    rev = "1515cae0c7f8e7e4284d046b6aaad7ba665489e4";
+    hash = "sha256-t5hB9lzbyHu0s7m/mYtohF/FW0Ymat9PM9zjdXwKiIM=";
   };
 
   yarnOfflineCache = fetchYarnDeps {
@@ -36,6 +36,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   postFixup = ''
     unlink $out/lib/node_modules/coc-diagnostic/node_modules/.bin/node-which
   '';
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
 
   meta = {
     description = "Diagnostic-languageserver extension for coc.nvim";

--- a/pkgs/by-name/co/coc-docker/package.nix
+++ b/pkgs/by-name/co/coc-docker/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
 buildNpmPackage (finalAttrs: {
@@ -16,6 +17,8 @@ buildNpmPackage (finalAttrs: {
   };
 
   npmDepsHash = "sha256-ow9viEFfyBUM2yDa63+pQCg6R5cAmznanqfI131fRxc=";
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Docker language server extension using dockerfile-language-server-nodejs for coc.nvim";

--- a/pkgs/by-name/co/coc-git/package.nix
+++ b/pkgs/by-name/co/coc-git/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
 buildNpmPackage (finalAttrs: {
@@ -22,6 +23,8 @@ buildNpmPackage (finalAttrs: {
   npmDepsHash = "sha256-vkAATI0vs1oeMr0/iQ8YDt3r+aJo6ND/x4mY/TlRwpg=";
 
   npmBuildScript = "prepare";
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Git integration of coc.nvim";

--- a/pkgs/by-name/co/coc-pyright/package.nix
+++ b/pkgs/by-name/co/coc-pyright/package.nix
@@ -2,21 +2,24 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
 buildNpmPackage {
   pname = "coc-pyright";
-  version = "1.1.371";
+  version = "0-unstable-2025-11-01";
 
   src = fetchFromGitHub {
     owner = "fannheyward";
     repo = "coc-pyright";
     # No tagged releases, this commit corresponds to the latest release of the package.
-    rev = "d4cfda2f530622962a2a6e3ac1ddb2ad83ea2387";
-    hash = "sha256-oNixIW63DhPn2LYJ5t/R4xcReZR3W6nqqFBnCUmo/Wo=";
+    rev = "9ac99c71ea92810b532283b690f6771601c74ff2";
+    hash = "sha256-nADl29GiApBZMKW0yQ9QVWBiduaGNXO8Cm4XxZmNfMQ=";
   };
 
-  npmDepsHash = "sha256-cTAt02RdQbKurP6H/JWwVp+VpoIysbFt9le9R69+DL4=";
+  npmDepsHash = "sha256-+9bf/3b8vZZgkiC2DA15js9X5PFHzK9dltTA9XJt+GE=";
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
 
   meta = {
     description = "Pyright extension for coc.nvim";

--- a/pkgs/by-name/co/coc-sh/package.nix
+++ b/pkgs/by-name/co/coc-sh/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
 buildNpmPackage (finalAttrs: {
@@ -21,6 +22,8 @@ buildNpmPackage (finalAttrs: {
   ];
 
   npmDepsHash = "sha256-N8bXRtTEKu9yuUnfv4oIokM74KWnqfTLVh5EvS0b1sw=";
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "bash-language-server for coc.nvim";

--- a/pkgs/by-name/co/coc-spell-checker/package.nix
+++ b/pkgs/by-name/co/coc-spell-checker/package.nix
@@ -7,10 +7,11 @@
   yarnBuildHook,
   yarnInstallHook,
   nodejs,
+  nix-update-script,
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "coc-spell-checker";
-  version = "1.3.2-unstable-2022-12-18";
+  version = "0-unstable-2022-12-19";
 
   src = fetchFromGitHub {
     owner = "iamcco";
@@ -33,6 +34,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   ];
 
   NODE_OPTIONS = "--openssl-legacy-provider";
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
 
   meta = {
     description = "Basic spell checker that works well with camelCase code for (Neo)vim";


### PR DESCRIPTION
updates several and adds updateScripts for all that were missing them

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
