### PR TITLE
buildDotnetModule: add dontPublish flag

### DIFF
--- a/pkgs/build-support/dotnet/build-dotnet-module/default.nix
+++ b/pkgs/build-support/dotnet/build-dotnet-module/default.nix
@@ -38,6 +38,7 @@ let
       # Unfortunately, dotnet has no method for doing this automatically.
       # If unset, all executables in the projects root will get installed. This may cause bloat!
       executables ? null,
+      dontPublish ? false,
       # Packs a project as a `nupkg`, and installs it to `$out/share`. If set to `true`, the derivation can be used as a dependency for another dotnet project by adding it to `projectReferences`.
       packNupkg ? false,
       # The packages project file, which contains instructions on how to compile it. This can be an array of multiple project files as well.

--- a/pkgs/build-support/dotnet/build-dotnet-module/hook/dotnet-hook.sh
+++ b/pkgs/build-support/dotnet/build-dotnet-module/hook/dotnet-hook.sh
@@ -420,13 +420,15 @@ dotnetInstallPhase() {
     done
   }
 
-  if (( ${#projectFiles[@]} == 0 )); then
-    dotnetPublish
-  else
-    local projectFile
-    for projectFile in "${projectFiles[@]}"; do
-      dotnetPublish "$projectFile"
-    done
+  if [[ -z "${dontPublish-}" ]]; then
+    if (( ${#projectFiles[@]} == 0 )); then
+      dotnetPublish
+    else
+      local projectFile
+      for projectFile in "${projectFiles[@]}"; do
+        dotnetPublish "$projectFile"
+      done
+    fi
   fi
 
   if [[ -n ${packNupkg-} ]]; then


### PR DESCRIPTION
Fixes: #464128

Cc: @NixOS/dotnet 

We could make this default to true when `packNuget` is set, but that's more of a breaking change, and possibly unintuitive.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
