### PR TITLE
nixos/etc-overlay: fix shellcheck issues and remove outdated comment

### DIFF
--- a/nixos/modules/system/etc/etc.nix
+++ b/nixos/modules/system/etc/etc.nix
@@ -345,9 +345,6 @@ in
             fi
 
             # Unmount old metadata mounts
-            # For some reason, `findmnt /tmp --submounts` does not show the nested
-            # mounts. So we'll just find all mounts of type erofs and filter on the
-            # name of the mountpoint.
             findmnt --type erofs --list --kernel --output TARGET | while read -r mountPoint; do
               if [[ ("$mountPoint" =~ ^/run/nixos-etc-metadata\..{10}$ || "$mountPoint" =~ ^/run/nixos-etc-metadata$ ) &&
                     "$mountPoint" != "$tmpMetadataMount" ]]; then

--- a/nixos/modules/system/etc/etc.nix
+++ b/nixos/modules/system/etc/etc.nix
@@ -283,23 +283,23 @@ in
             ''}
 
             tmpMetadataMount=$(TMPDIR="/run" mktemp --directory -t nixos-etc-metadata.XXXXXXXXXX)
-            mount --type erofs --options ro,nodev,nosuid ${config.system.build.etcMetadataImage} $tmpMetadataMount
+            mount --type erofs --options ro,nodev,nosuid ${config.system.build.etcMetadataImage} "$tmpMetadataMount"
 
             # There was no previous /etc mounted. This happens when we're called
             # directly without an initrd, like with nixos-enter.
             if ! mountpoint -q /etc; then
               mount --type overlay \
-                --options nodev,nosuid,lowerdir=$tmpMetadataMount::${config.system.build.etcBasedir},${etcOverlayOptions} \
+                --options nodev,nosuid,lowerdir="$tmpMetadataMount"::${config.system.build.etcBasedir},${etcOverlayOptions} \
                 overlay /etc
             else
               # Mount the new /etc overlay to a temporary private mount.
               # This needs the indirection via a private bind mount because you
               # cannot move shared mounts.
               tmpEtcMount=$(TMPDIR="/run" mktemp --directory -t nixos-etc.XXXXXXXXXX)
-              mount --bind --make-private $tmpEtcMount $tmpEtcMount
+              mount --bind --make-private "$tmpEtcMount" "$tmpEtcMount"
               mount --type overlay \
-                --options nodev,nosuid,lowerdir=$tmpMetadataMount::${config.system.build.etcBasedir},${etcOverlayOptions} \
-                overlay $tmpEtcMount
+                --options nodev,nosuid,lowerdir="$tmpMetadataMount"::${config.system.build.etcBasedir},${etcOverlayOptions} \
+                overlay "$tmpEtcMount"
 
               # Before moving the new /etc overlay under the old /etc, we have to
               # move mounts on top of /etc to the new /etc mountpoint.
@@ -334,7 +334,7 @@ in
               # This should eventually use util-linux to perform this move beneath,
               # however, this functionality is not yet in util-linux. See this
               # tracking issue: https://github.com/util-linux/util-linux/issues/2604
-              ${pkgs.move-mount-beneath}/bin/move-mount --move --beneath $tmpEtcMount /etc
+              ${pkgs.move-mount-beneath}/bin/move-mount --move --beneath "$tmpEtcMount" /etc
 
               # Unmount the top /etc mount to atomically reveal the new mount.
               umount --lazy --recursive /etc


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
