### PR TITLE
nixos/ersatztv: fix mismatch between environment type firewall port

### DIFF
--- a/nixos/modules/services/misc/ersatztv.nix
+++ b/nixos/modules/services/misc/ersatztv.nix
@@ -20,12 +20,14 @@ let
     bool
     float
     int
+    package
     ;
   cfg = config.services.ersatztv;
   defaultEnv = {
     ETV_UI_PORT = 8409;
     ETV_BASE_URL = "/";
   };
+
 in
 {
   options = {
@@ -54,6 +56,8 @@ in
             int
             float
             bool
+            path
+            package
           ]);
         default = defaultEnv;
         example = {
@@ -108,7 +112,7 @@ in
           ETV_CONFIG_FOLDER = "/var/lib/ersatztv/config";
           ETV_TRANSCODE_FOLDER = "/var/lib/ersatztv/transcode";
         }
-        // cfg.environment;
+        // (lib.mapAttrs (_: s: if lib.isBool s then lib.boolToString s else toString s) cfg.environment);
       };
     };
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -522,7 +522,7 @@ in
   };
   ergo = runTest ./ergo.nix;
   ergochat = runTest ./ergochat.nix;
-  ersatztv = handleTest ./ersatztv.nix { };
+  ersatztv = runTest ./ersatztv.nix;
   espanso = import ./espanso.nix {
     inherit (pkgs) lib;
     inherit runTest;

--- a/nixos/tests/ersatztv.nix
+++ b/nixos/tests/ersatztv.nix
@@ -1,21 +1,19 @@
-import ./make-test-python.nix (
-  { lib, ... }:
+{ lib, ... }:
 
-  {
-    name = "ersatztv";
-    meta.maintainers = with lib.maintainers; [ allout58 ];
+{
+  name = "ersatztv";
+  meta.maintainers = with lib.maintainers; [ allout58 ];
 
-    nodes.machine =
-      { ... }:
-      {
-        services.ersatztv.enable = true;
-      };
+  nodes.machine =
+    { ... }:
+    {
+      services.ersatztv.enable = true;
+    };
 
-    # ErsatzTV doesn't really have an API to speak of currently, so just check if it responds at all
-    testScript = ''
-      machine.wait_for_unit("ersatztv.service")
-      machine.wait_for_open_port(8409)
-      machine.succeed("curl --fail http://localhost:8409/")
-    '';
-  }
-)
+  # ErsatzTV doesn't really have an API to speak of currently, so just check if it responds at all
+  testScript = ''
+    machine.wait_for_unit("ersatztv.service")
+    machine.wait_for_open_port(8409)
+    machine.succeed("curl --fail http://localhost:8409/")
+  '';
+}

--- a/nixos/tests/ersatztv.nix
+++ b/nixos/tests/ersatztv.nix
@@ -4,16 +4,38 @@
   name = "ersatztv";
   meta.maintainers = with lib.maintainers; [ allout58 ];
 
-  nodes.machine =
+  nodes.basic =
     { ... }:
     {
       services.ersatztv.enable = true;
     };
+  nodes.reconfigured =
+    { ... }:
+    {
+      services.ersatztv.enable = true;
+      services.ersatztv.environment.ETV_UI_PORT = 8123;
+      services.ersatztv.openFirewall = true;
+    };
 
   # ErsatzTV doesn't really have an API to speak of currently, so just check if it responds at all
-  testScript = ''
-    machine.wait_for_unit("ersatztv.service")
-    machine.wait_for_open_port(8409)
-    machine.succeed("curl --fail http://localhost:8409/")
-  '';
+  testScript =
+    { nodes, ... }:
+    let
+      basicIp = (lib.head nodes.basic.networking.interfaces.eth1.ipv4.addresses).address;
+      reconfiguredIp = (lib.head nodes.reconfigured.networking.interfaces.eth1.ipv4.addresses).address;
+    in
+    ''
+      start_all()
+      basic.wait_for_unit("ersatztv.service")
+      basic.wait_for_open_port(8409)
+      basic.succeed("curl --fail http://localhost:8409/api/sessions")
+
+      reconfigured.wait_for_unit("ersatztv.service")
+      reconfigured.wait_for_open_port(8123)
+      reconfigured.succeed("curl --fail http://localhost:8123/api/sessions")
+
+      # Test that the firewall is open
+      reconfigured.fail("curl --fail --connect-timeout 5 http://${basicIp}:8409/api/sessions")
+      basic.succeed("curl --fail http://${reconfiguredIp}:8123/api/sessions")
+    '';
 }


### PR DESCRIPTION

- services.ersatztv.environment must not have number types, but networking.firewall.allowedTCPPorts must be an integer
- Updates nixosTests.ersatztv to test setting new UI port

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
