### PR TITLE
[nixos/config] update default channel option

### DIFF
--- a/nixos/modules/config/nix-channel.nix
+++ b/nixos/modules/config/nix-channel.nix
@@ -23,7 +23,7 @@ let
     text = builtins.concatStringsSep "\n" config.system.defaultChannels;
   };
 
-  channelsFileBase64 = pkgs.runCommand "base64-encode-file" { buildInputs = [ pkgs.basez ]; } ''
+  channelsFileBase64 = pkgs.runCommand "base64-encode-file" { nativeBuildInputs = [ pkgs.basez ]; } ''
     base64 --input="${channelsFilePlaintext}" --output="$out"
   '';
 

--- a/nixos/modules/config/nix-channel.nix
+++ b/nixos/modules/config/nix-channel.nix
@@ -79,7 +79,7 @@ in
     system = {
       defaultChannels = mkOption {
         internal = true;
-        type = types.str;
+        type = types.listOf types.str;
         default = [
           "https://channels.nixos.org/nixos-unstable nixos"
         ];

--- a/nixos/modules/config/nix-channel.nix
+++ b/nixos/modules/config/nix-channel.nix
@@ -27,6 +27,8 @@ let
     base64 --input="${channelsFilePlaintext}" --output="$out"
   '';
 
+  channelsFileEncodedContent = ''${builtins.readFile channelsFileBase64}'';
+
 in
 {
   options = {
@@ -107,7 +109,7 @@ in
     };
 
     systemd.tmpfiles.rules = lib.mkIf cfg.channel.enable [
-      ''f~ /root/.nix-channels - - - - ${builtins.readFile channelsFileBase64}''
+      ''f~ /root/.nix-channels - - - - ${channelsFileEncodedContent}''
     ];
 
     system.activationScripts.no-nix-channel = mkIf (!cfg.channel.enable) (

--- a/nixos/modules/config/nix-channel.nix
+++ b/nixos/modules/config/nix-channel.nix
@@ -6,7 +6,7 @@
   - ./nix.nix
   - ./nix-flakes.nix
 */
-{ config, lib, ... }:
+{ config, lib, pkgs, ... }:
 let
   inherit (lib)
     mkDefault


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
1. allow multiple default channels to be specified
2. allow custom channel names

the default channels file is created using tmpfiles, which requires one line of configuration per file. so to allow multiple lines to be included, we base64 encode the channels file & use the tilde `~` tmpfiles type modifier.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
