### PR TITLE
atuin-desktop: 0.1.11 -> 0.2.3

### DIFF
--- a/pkgs/by-name/at/atuin-desktop/package.nix
+++ b/pkgs/by-name/at/atuin-desktop/package.nix
@@ -18,23 +18,22 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "atuin-desktop";
-  version = "0.1.11";
+  version = "0.2.3";
 
   src = fetchFromGitHub {
     owner = "atuinsh";
     repo = "desktop";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ySws3R4CatOrKjjGrLJQU9feXIb5MdVX1uKK0fFV21s=";
+    hash = "sha256-jBCf6Wq7xTgI2VjhQ+RZ3uN7LVh+ZlQ3TDJ0epsGj0M=";
   };
 
-  cargoRoot = "backend";
-  buildAndTestSubdir = finalAttrs.cargoRoot;
-  cargoHash = "sha256-gyDg8XBPiMovOtzmb0eHVWuXmavZTBMvPPgbcdNU6xo=";
+  cargoRoot = "./.";
+  cargoHash = "sha256-329uNcc8LSNreD8CgPCpEhGCR2PebpmFoaRwZn+oscE=";
 
   pnpmDeps = pnpm.fetchDeps {
     inherit (finalAttrs) pname version src;
     fetcherVersion = 2;
-    hash = "sha256-6YDYrFo5iCelRGBnDFoI8V3Nv/8w3XPNwuArc+nSShU=";
+    hash = "sha256-2i1mL4HwwiXrmM1qaWvHhm27U2/oElbOpnXh09ziamo=";
   };
 
   nativeBuildInputs = [
@@ -54,8 +53,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   env = {
-    # Used upstream: https://github.com/atuinsh/desktop/blob/2f9a90963c4a6299bf35d8a49b0a2ffb8a28ee32/.envrc.
-    NODE_OPTIONS = "--max-old-space-size=5120";
+    # Used upstream: https://github.com/atuinsh/desktop/blob/6ddebdf66c70042defe5587f7f6c433f889b9ef4/.envrc#L1
+    NODE_OPTIONS = "--max-old-space-size=6144";
   };
 
   # Otherwise tauri will look for a private key we don't have.
@@ -72,8 +71,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   checkFlags = [
-    # Failing for unknown reason.
-    "--skip=runtime::blocks::handlers::script_output_test::tests::test_multiple_scripts"
+    "--skip=ui::viewport::tests::test_add_line_scrolling"
+    "--skip=ui::viewport::tests::test_line_wrapping"
   ];
   doCheck = !stdenv.isDarwin;
 


### PR DESCRIPTION
Major update with a new evaluation engine for the shell blocks. [Changelog](https://github.com/atuinsh/desktop/releases/tag/v0.2.0), and [0.2.1](https://github.com/atuinsh/desktop/releases/tag/v0.2.1), [0.2.2](https://github.com/atuinsh/desktop/releases/tag/v0.2.2), and [0.2.3](https://github.com/atuinsh/desktop/releases/tag/v0.2.3).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
