### PR TITLE
ocamlPackages.{ezxmlm,mparser,ocaml-print-intf,safepass}: small cleaning

### DIFF
--- a/pkgs/development/ocaml-modules/ezxmlm/default.nix
+++ b/pkgs/development/ocaml-modules/ezxmlm/default.nix
@@ -5,20 +5,18 @@
   xmlm,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "ezxmlm";
   version = "1.1.0";
 
-  useDune2 = true;
-
   src = fetchurl {
-    url = "https://github.com/mirage/ezxmlm/releases/download/v${version}/ezxmlm-v${version}.tbz";
-    sha256 = "123dn4h993mlng9gzf4nc6mw75ja7ndcxkbkwfs48j5jk1z05j6d";
+    url = "https://github.com/mirage/ezxmlm/releases/download/v${finalAttrs.version}/ezxmlm-v${finalAttrs.version}.tbz";
+    hash = "sha256-zcgCfpiySES043PNzpo9SpbDq2GWuP/Ss7SOlCCxbYg=";
   };
 
   propagatedBuildInputs = [ xmlm ];
 
-  meta = with lib; {
+  meta = {
     description = "Combinators to use with xmlm for parsing and selection";
     longDescription = ''
       An "easy" interface on top of the xmlm library. This version provides
@@ -31,8 +29,8 @@ buildDunePackage rec {
       types in this library are more specific than Xmlm, it should interoperate
       just fine with it if you decide to switch over.
     '';
-    maintainers = [ maintainers.carlosdagos ];
+    maintainers = [ lib.maintainers.carlosdagos ];
     homepage = "https://github.com/mirage/ezxmlm/";
-    license = licenses.isc;
+    license = lib.licenses.isc;
   };
-}
+})

--- a/pkgs/development/ocaml-modules/mparser/default.nix
+++ b/pkgs/development/ocaml-modules/mparser/default.nix
@@ -4,16 +4,15 @@
   buildDunePackage,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "mparser";
   version = "1.3";
-  useDune2 = true;
 
   src = fetchFromGitHub {
     owner = "murmour";
     repo = "mparser";
-    rev = version;
-    sha256 = "16j19v16r42gcsii6a337zrs5cxnf12ig0vaysxyr7sq5lplqhkx";
+    tag = finalAttrs.version;
+    hash = "sha256-fUJMLy1Yn+y79mqDF0VwtrOi8z9jKBOjZk+QbMJOQZo=";
   };
 
   meta = {
@@ -22,4 +21,4 @@ buildDunePackage rec {
     homepage = "https://github.com/murmour/mparser";
     maintainers = [ lib.maintainers.vbgl ];
   };
-}
+})

--- a/pkgs/development/ocaml-modules/mparser/pcre.nix
+++ b/pkgs/development/ocaml-modules/mparser/pcre.nix
@@ -6,7 +6,6 @@
 
 buildDunePackage {
   pname = "mparser-pcre";
-  useDune2 = true;
 
   inherit (mparser) src version;
 

--- a/pkgs/development/ocaml-modules/ocaml-print-intf/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-print-intf/default.nix
@@ -5,20 +5,16 @@
   dune-build-info,
   bos,
 }:
-let
-  author = "avsm";
+
+buildDunePackage (finalAttrs: {
   pname = "ocaml-print-intf";
   version = "1.2.0";
-in
-buildDunePackage rec {
-  inherit pname version;
-  useDune2 = true;
 
   src = fetchFromGitHub {
-    owner = author;
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "0hw4gl7irarcywibdjqxmrga8f7yj52wgy7sc7n0wyy74jzxb8np";
+    owner = "avsm";
+    repo = "ocaml-print-intf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-16LVvyTHew7sYfr4x0WR/jikXq4dy7Yi9yyrHA99hEM=";
   };
 
   buildInputs = [
@@ -28,8 +24,8 @@ buildDunePackage rec {
 
   meta = {
     description = "Pretty print an OCaml cmi/cmt/cmti file in human-readable OCaml signature form";
-    homepage = "https://github.com/${author}/${pname}";
+    homepage = "https://github.com/avsm/ocaml-print-intf";
     license = lib.licenses.isc;
     maintainers = [ lib.maintainers.nerdypepper ];
   };
-}
+})

--- a/pkgs/development/ocaml-modules/safepass/default.nix
+++ b/pkgs/development/ocaml-modules/safepass/default.nix
@@ -4,24 +4,22 @@
   buildDunePackage,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "safepass";
   version = "3.1";
-
-  useDune2 = true;
 
   src = fetchFromGitHub {
     owner = "darioteixeira";
     repo = "ocaml-safepass";
-    rev = "v${version}";
-    sha256 = "1cwslwdb1774lfmhcclj9kymvidbcpjx1vp16jnjirqdqgl4zs5q";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-uOhP6MMN5yitNOHu0OVlq8Vd/UySMgaro+ScsBqnmrM=";
   };
 
   meta = {
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/darioteixeira/ocaml-safepass";
     description = "OCaml library offering facilities for the safe storage of user passwords";
     license = lib.licenses.lgpl21;
     maintainers = with lib.maintainers; [ vbgl ];
   };
 
-}
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
