### PR TITLE
pax-utils: 1.3.8 -> 1.3.10

### DIFF
--- a/pkgs/by-name/pa/pax-utils/package.nix
+++ b/pkgs/by-name/pa/pax-utils/package.nix
@@ -18,12 +18,12 @@
 
 stdenv.mkDerivation rec {
   pname = "pax-utils";
-  version = "1.3.8";
+  version = "1.3.10";
 
   src = fetchgit {
     url = "https://anongit.gentoo.org/git/proj/pax-utils.git";
     rev = "v${version}";
-    hash = "sha256-fOdiZcS1ZWGN8U5v65LzGIZJD6hCl5dbLMHDpSyms+8=";
+    hash = "sha256-qoFXQ/RqvdjsVhXVZZjWKnE0khak9HjOGi/UrfTLS8M=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/pa/pax-utils/package.nix
+++ b/pkgs/by-name/pa/pax-utils/package.nix
@@ -5,7 +5,9 @@
   buildPackages,
   docbook_xml_dtd_44,
   docbook_xsl,
+  withFuzzing ? stdenv.hostPlatform.isLinux,
   withLibcap ? stdenv.hostPlatform.isLinux,
+  withSeccomp ? stdenv.hostPlatform.isLinux,
   libcap,
   pkg-config,
   meson,
@@ -29,7 +31,9 @@ stdenv.mkDerivation rec {
   strictDeps = true;
 
   mesonFlags = [
+    (lib.mesonBool "use_fuzzing" withFuzzing)
     (lib.mesonEnable "use_libcap" withLibcap)
+    (lib.mesonBool "use_seccomp" withSeccomp)
   ];
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];


### PR DESCRIPTION
Changes: https://gitweb.gentoo.org/proj/pax-utils.git/log/?h=v1.3.10


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
