### PR TITLE
mapserver: fix mapscript library reference on Darwin

### DIFF
--- a/pkgs/by-name/ma/mapserver/package.nix
+++ b/pkgs/by-name/ma/mapserver/package.nix
@@ -88,6 +88,12 @@ stdenv.mkDerivation rec {
     cp -r src/mapscript/python/mapscript $out/${python3.sitePackages}
   '';
 
+  # Fix mapscript library reference on Darwin
+  postFixup = lib.optionalString (withPython && stdenv.hostPlatform.isDarwin) ''
+    install_name_tool -change "@rpath/libmapserver.2.dylib" "$out/lib/libmapserver.2.dylib" \
+      $out/${python3.sitePackages}/mapscript/_mapscript.so
+  '';
+
   pythonImportsCheck = [ "mapscript" ];
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Fix mapserver on Darwin:

See: https://hydra.nixos.org/build/314396338/nixlog/2

```
    from . import _mapscript
ImportError:
dlopen(/nix/store/av8n3hrg1rs2akhi7b3x3rhn2ksap9fd-mapserver-8.4.1/lib/python3.13/site-packages/mapscript/_mapscript.so,
0x0002): Library not loaded: @rpath/libmapserver.2.dylib
  Referenced from: <9D2B480C-B82F-3E1F-93A8-E72C4A175236>
/nix/store/av8n3hrg1rs2akhi7b3x3rhn2ksap9fd-mapserver-8.4.1/lib/python3.13/site-packages/mapscript/_mapscript.so
  Reason: no LC_RPATH's found
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
