### PR TITLE
dep-scan: 6.0.0b3 -> 6.0.0b5 

### DIFF
--- a/pkgs/by-name/de/dep-scan/package.nix
+++ b/pkgs/by-name/de/dep-scan/package.nix
@@ -3,21 +3,20 @@
   fetchFromGitHub,
   python3Packages,
   writableTmpDirAsHomeHook,
-  makeWrapper,
   cdxgen,
   nixosTests,
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "dep-scan";
-  version = "6.0.0b3";
+  version = "6.0.0b5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "owasp-dep-scan";
     repo = "dep-scan";
     tag = "v${version}";
-    hash = "sha256-GdrFsECcBZ2J47ojM33flqOtrY3avchGpsZk6pt8Aks=";
+    hash = "sha256-D+ILgWifIV27CG4aJUHeI6F7ASomS0iyAG0beIIzJNk=";
   };
 
   build-system = with python3Packages; [ setuptools ];
@@ -29,6 +28,7 @@ python3Packages.buildPythonApplication rec {
     defusedxml
     ds-analysis-lib
     ds-reporting-lib
+    ds-server-lib
     ds-xbom-lib
     jinja2
     oras
@@ -43,6 +43,7 @@ python3Packages.buildPythonApplication rec {
 
   nativeCheckInputs = with python3Packages; [
     httpretty
+    pytest-asyncio
     pytest-cov-stub
     pytestCheckHook
     writableTmpDirAsHomeHook

--- a/pkgs/development/python-modules/ds-analysis-lib/default.nix
+++ b/pkgs/development/python-modules/ds-analysis-lib/default.nix
@@ -1,13 +1,19 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  dep-scan,
+
+  # build
   setuptools,
+
+  # deps
   appthreat-vulnerability-db,
   custom-json-diff,
   cvss,
   rich,
   toml,
+
+  # test
   writableTmpDirAsHomeHook,
   pytestCheckHook,
   pytest-cov-stub,
@@ -15,17 +21,14 @@
 
 buildPythonPackage rec {
   pname = "ds-analysis-lib";
-  version = "6.0.0b3";
+  inherit (dep-scan) version src;
   pyproject = true;
 
-  # pypi because library is embedded into another project's repo
-  src = fetchPypi {
-    inherit version;
-    pname = "ds_analysis_lib";
-    hash = "sha256-XZZzAxQJk65Xoq6z2OadlHUN0REYTjKmSvwz17tvVqc=";
-  };
+  sourceRoot = "${src.name}/packages/analysis-lib";
 
-  build-system = [ setuptools ];
+  build-system = [
+    setuptools
+  ];
 
   dependencies = [
     appthreat-vulnerability-db
@@ -37,12 +40,6 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "analysis_lib" ];
 
-  # relies on data files that pypi doesn't include
-  disabledTestPaths = [
-    "tests/test_analysis.py"
-    "tests/test_csaf.py"
-  ];
-
   nativeCheckInputs = [
     writableTmpDirAsHomeHook
     pytestCheckHook
@@ -51,9 +48,11 @@ buildPythonPackage rec {
 
   meta = {
     description = "Analysis library for owasp depscan";
-    homepage = "https://pypi.org/project/ds-analysis-lib/";
-    maintainers = with lib.maintainers; [ ethancedwards8 ];
-    teams = [ lib.teams.ngi ];
-    license = with lib.licenses; [ mit ];
+    inherit (dep-scan.meta)
+      homepage
+      license
+      maintainers
+      teams
+      ;
   };
 }

--- a/pkgs/development/python-modules/ds-reporting-lib/default.nix
+++ b/pkgs/development/python-modules/ds-reporting-lib/default.nix
@@ -1,23 +1,22 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  dep-scan,
+
+  # build
   setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "ds-reporting-lib";
-  version = "6.0.0b5";
+  inherit (dep-scan) version src;
   pyproject = true;
 
-  # pypi because library is embedded into another project's repo
-  src = fetchPypi {
-    inherit version;
-    pname = "ds_reporting_lib";
-    hash = "sha256-hxjNRUOorjjbuJkFpscTN3VB5NJywLZ6Ux+dB1Q1FyU=";
-  };
+  sourceRoot = "${src.name}/packages/reporting-lib";
 
-  build-system = [ setuptools ];
+  build-system = [
+    setuptools
+  ];
 
   pythonImportsCheck = [ "reporting_lib" ];
 
@@ -26,9 +25,11 @@ buildPythonPackage rec {
 
   meta = {
     description = "Reporting library for owasp depscan";
-    homepage = "https://pypi.org/project/ds-reporting-lib/";
-    maintainers = with lib.maintainers; [ ethancedwards8 ];
-    teams = [ lib.teams.ngi ];
-    license = with lib.licenses; [ mit ];
+    inherit (dep-scan.meta)
+      homepage
+      license
+      maintainers
+      teams
+      ;
   };
 }

--- a/pkgs/development/python-modules/ds-server-lib/default.nix
+++ b/pkgs/development/python-modules/ds-server-lib/default.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  buildPythonPackage,
+  dep-scan,
+
+  # build
+  setuptools,
+
+  # deps
+  appthreat-vulnerability-db,
+  custom-json-diff,
+  ds-analysis-lib,
+  quart,
+  rich,
+
+  # test
+  pytest-asyncio,
+  pytest-cov-stub,
+  pytestCheckHook,
+  writableTmpDirAsHomeHook,
+}:
+
+buildPythonPackage rec {
+  pname = "ds-server-lib";
+  inherit (dep-scan) version src;
+  pyproject = true;
+
+  sourceRoot = "${src.name}/packages/server-lib";
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    appthreat-vulnerability-db
+    custom-json-diff
+    ds-analysis-lib
+    quart
+    rich
+  ];
+
+  pythonImportsCheck = [ "server_lib" ];
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+    pytestCheckHook
+    pytest-cov-stub
+    pytest-asyncio
+  ];
+
+  meta = {
+    description = "Server library for owasp depscan";
+    inherit (dep-scan.meta)
+      homepage
+      license
+      maintainers
+      teams
+      ;
+  };
+}

--- a/pkgs/development/python-modules/ds-xbom-lib/default.nix
+++ b/pkgs/development/python-modules/ds-xbom-lib/default.nix
@@ -1,23 +1,22 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  dep-scan,
+
+  # build
   setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "ds-xbom-lib";
-  version = "6.0.0b5";
+  inherit (dep-scan) version src;
   pyproject = true;
 
-  # pypi because library is embedded into another project's repo
-  src = fetchPypi {
-    inherit version;
-    pname = "ds_xbom_lib";
-    hash = "sha256-IAqKqwetoQu1Fwb2tr4UjA3WztIIq5so/WE++Ov0VTw=";
-  };
+  sourceRoot = "${src.name}/packages/xbom-lib";
 
-  build-system = [ setuptools ];
+  build-system = [
+    setuptools
+  ];
 
   pythonImportsCheck = [ "xbom_lib" ];
 
@@ -26,9 +25,11 @@ buildPythonPackage rec {
 
   meta = {
     description = "xBOM library for owasp depscan";
-    homepage = "https://pypi.org/project/ds-xbom-lib/";
-    maintainers = with lib.maintainers; [ ethancedwards8 ];
-    teams = [ lib.teams.ngi ];
-    license = with lib.licenses; [ mit ];
+    inherit (dep-scan.meta)
+      homepage
+      license
+      maintainers
+      teams
+      ;
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4542,6 +4542,8 @@ self: super: with self; {
 
   ds-reporting-lib = callPackage ../development/python-modules/ds-reporting-lib { };
 
+  ds-server-lib = callPackage ../development/python-modules/ds-server-lib { };
+
   ds-store = callPackage ../development/python-modules/ds-store { };
 
   ds-xbom-lib = callPackage ../development/python-modules/ds-xbom-lib { };


### PR DESCRIPTION
`dep-scan` vendors some [internal libraries](https://github.com/owasp-dep-scan/dep-scan/tree/226d39586e630746fe69d48be3d6d18369a6d4ba/packages) (analysis, reporting, server, xbom), which it needs to function. Before, these deps were fetched from PyPi, each with its separate version. This resulted in situations where they would get bumped, but `dep-scan` itself wouldn't, leading to build failures (https://github.com/NixOS/nixpkgs/pull/462044).

This PR changes that by building all of them from the same source, thus we'd only need to bump `dep-scan` and everything should be up-to-date and working.

Supersedes https://github.com/NixOS/nixpkgs/pull/462044

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
