### PR TITLE
[25.11] .github/labeler-no-sync: remove release-25.05 label for CI stuff

### DIFF
--- a/.github/labeler-no-sync.yml
+++ b/.github/labeler-no-sync.yml
@@ -22,13 +22,4 @@
               - doc/**/*
               - nixos/doc/**/*
 
-"backport release-25.05":
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              - .github/actions/*
-              - .github/workflows/*
-              - ci/**/*.*
-              - maintainers/github-teams.json
-
 # keep-sorted end


### PR DESCRIPTION
This is done via master directly now.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
