### PR TITLE
aseq2json, intel-ipsec-mb, sendgmail: fix sourceRoot

### DIFF
--- a/pkgs/by-name/as/aseq2json/package.nix
+++ b/pkgs/by-name/as/aseq2json/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "8572e6313a0d7ec95492dcab04a46c5dd30ef33a";
     hash = "sha256-LQ9LLVumi3GN6c9tuMSOd1Bs2pgrwrLLQbs5XF+NZeA=";
   };
-  sourceRoot = "source/aseq2json";
+  sourceRoot = "${finalAttrs.src.name}/aseq2json";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [

--- a/pkgs/by-name/in/intel-ipsec-mb/package.nix
+++ b/pkgs/by-name/in/intel-ipsec-mb/package.nix
@@ -5,18 +5,18 @@
   nasm,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "intel-ipsec-mb";
   version = "2.0.1";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "intel-ipsec-mb";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-k/NoPMKbiWZ25tdomsPpv2gfhQuBHxzX6KRT1UY88Ko=";
   };
 
-  sourceRoot = "source/lib";
+  sourceRoot = "${finalAttrs.src.name}/lib";
 
   nativeBuildInputs = [ nasm ];
 
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     "NOLDCONFIG=y"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Intel Multi-Buffer Crypto for IPsec Library";
     longDescription = ''
       Intel Multi-Buffer Crypto for IPsec Library provides software crypto
@@ -34,8 +34,8 @@ stdenv.mkDerivation rec {
       and MPEG DRM.
     '';
     homepage = "https://github.com/intel/intel-ipsec-mb";
-    license = licenses.bsd3;
+    license = lib.licenses.bsd3;
     platforms = [ "x86_64-linux" ];
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/by-name/se/sendgmail/package.nix
+++ b/pkgs/by-name/se/sendgmail/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   nix-update-script,
 }:
-buildGoModule {
+buildGoModule (finalAttrs: {
   pname = "sendgmail";
   version = "0-unstable-2025-03-06";
 
@@ -15,7 +15,7 @@ buildGoModule {
     hash = "sha256-bzbTU9SA4dJKtQVkqESvV5o3l3MY4Uy7HDqo7jI3dhM=";
   };
 
-  sourceRoot = "source/go/sendgmail";
+  sourceRoot = "${finalAttrs.src.name}/go/sendgmail";
 
   vendorHash = "sha256-0pjcO2Ati+mUSw614uEL3CatHSgbgDUfOBE8bWpjmcw=";
 
@@ -29,4 +29,4 @@ buildGoModule {
     platforms = lib.platforms.unix;
     mainProgram = "sendgmail";
   };
-}
+})


### PR DESCRIPTION
Just a tiny continuation of https://github.com/NixOS/nixpkgs/pull/248528 while trying to find out what was causing mass rebuilds in my setup when changing `fetchedSourceNameDefault` (this wasn't it!).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
