### PR TITLE
nix-prefetch-{darcs,pijul}: add date to JSON output; nix-prefetch-darcs: fixups

### DIFF
--- a/pkgs/build-support/fetchdarcs/nix-prefetch-darcs
+++ b/pkgs/build-support/fetchdarcs/nix-prefetch-darcs
@@ -140,7 +140,7 @@ if [ -z "$final_path" ]; then
 	# Darcs has a weak hash using the XOR of the patch hashes which is useful
 	# for other scripts
 	# https://darcs.net/Internals/Hashes
-	weak_hash="$(darcs show repo | grep '^ *Weak Hash:' | cut -d: -f2- | tr -d "[:space:]")"
+	weak_hash="$(darcs show repo | awk '/^[[:space:]]*Weak Hash:/ { sub(/^[[:space:]]*Weak Hash:[[:space:]]*/, "", $0); printf $0 }')"
 	date="$(darcs log --repodir="$tmp_clone/$name" --max-count 1 | awk '/^Date:/ { sub(/^Date:[[:space:]]*/, "", $0); printf $0 }')"
 	date="$(date -u -d "$date" "+%Y-%m-%dT%H:%M:%SZ")"
 	cd - >/dev/null

--- a/pkgs/build-support/fetchdarcs/nix-prefetch-darcs
+++ b/pkgs/build-support/fetchdarcs/nix-prefetch-darcs
@@ -141,6 +141,8 @@ if [ -z "$final_path" ]; then
 	# for other scripts
 	# https://darcs.net/Internals/Hashes
 	weak_hash="$(darcs show repo | grep '^ *Weak Hash:' | cut -d: -f2- | tr -d "[:space:]")"
+	date="$(darcs log --repodir="$tmp_clone/$name" --max-count 1 | awk '/^Date:/ { sub(/^Date:[[:space:]]*/, "", $0); printf $0 }')"
+	date="$(date -u -d "$date" "+%Y-%m-%dT%H:%M:%SZ")"
 	cd - >/dev/null
 	rm -rf "$tmp_clone/$name/_darcs"
 
@@ -176,6 +178,7 @@ fi; if [ -s "$final_context" ]; then cat <<EOF
 	"context": $(json_escape "$final_context"),
 EOF
 fi; cat <<EOF
+	"date": "$date",
 	"path": "$final_path",
 	$(json_escape "$hash_algo"): $(json_escape "$hash"),
 	"hash": "$(nix-hash --to-sri --type "$hash_algo" "$hash")"

--- a/pkgs/build-support/fetchdarcs/nix-prefetch-darcs
+++ b/pkgs/build-support/fetchdarcs/nix-prefetch-darcs
@@ -132,18 +132,16 @@ if [ -z "$final_path" ]; then
 	else
 		darcs clone $clone_args "$repository" "$name" >/dev/null
 	fi
-	cd "$tmp_clone/$name"
 	# Will put the current Darcs context into the store.
 	new_context="$tmp_clone/${name}-context.txt"
-	darcs log --context > "$new_context"
+	darcs log --repodir="$tmp_clone/$name" --context > "$new_context"
 	final_context="$(nix-store --add-fixed "$hash_algo" "$new_context")"
 	# Darcs has a weak hash using the XOR of the patch hashes which is useful
 	# for other scripts
 	# https://darcs.net/Internals/Hashes
-	weak_hash="$(darcs show repo | awk '/^[[:space:]]*Weak Hash:/ { sub(/^[[:space:]]*Weak Hash:[[:space:]]*/, "", $0); printf $0 }')"
+	weak_hash="$(darcs show repo --repodir="$tmp_clone/$name" | awk '/^[[:space:]]*Weak Hash:/ { sub(/^[[:space:]]*Weak Hash:[[:space:]]*/, "", $0); printf $0 }')"
 	date="$(darcs log --repodir="$tmp_clone/$name" --max-count 1 | awk '/^Date:/ { sub(/^Date:[[:space:]]*/, "", $0); printf $0 }')"
 	date="$(date -u -d "$date" "+%Y-%m-%dT%H:%M:%SZ")"
-	cd - >/dev/null
 	rm -rf "$tmp_clone/$name/_darcs"
 
 	hash="$(nix-hash --type "$hash_algo" "$hash_format" "$tmp_clone/$name")"

--- a/pkgs/build-support/fetchpijul/nix-prefetch-pijul
+++ b/pkgs/build-support/fetchpijul/nix-prefetch-pijul
@@ -6,6 +6,7 @@ remote=
 channel="main"
 change=
 state=
+date=
 exp_hash=
 
 usage() {
@@ -100,11 +101,15 @@ if [ -z "$final_path" ]; then
 
 	cd "$tmp_clone"
 	pijul clone $clone_args "$remote" "$name"
+	latest_log="$(pijul log --repository "$tmp_clone/$name" --limit 1)"
 	# State is a stable reference is a stable reference for the patchset that
 	# doesn't depend on patch order. As a result, it will always be included.
 	if [ -z "$state" ]; then
-		state="$(pijul log --repository "$tmp_clone/$name" --state --limit 1 | awk '/^State:/ {printf $2}')"
+		state="$(printf "%s" "$latest_log" | awk '/^State:/ {printf $2}')"
 	fi
+	date="$(printf "%s" "$latest_log" | awk '/^Date:/ { sub(/^Date:[[:space:]]*/, "", $0); printf $0 }')"
+	date="$(date -u -d "$date" "+%Y-%m-%dT%H:%M:%SZ")"
+
 	rm -rf "$tmp_clone/$name/.pijul"
 
 	hash="$(nix-hash --type "$hash_algo" "$hash_format" "$tmp_clone/$name")"
@@ -132,6 +137,7 @@ if [ -n "$change" ]; then cat <<EOF
 EOF
 fi; cat <<EOF
 	"state": $(json_escape "$state"),
+	"date": $(json_escape "$date"),
 	"path": "$final_path",
 	$(json_escape "$hash_algo"): $(json_escape "$hash"),
 	"hash": "$(nix-hash --to-sri --type "$hash_algo" "$hash")"

--- a/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
+++ b/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
@@ -68,6 +68,7 @@ rec {
   nix-prefetch-darcs = mkPrefetchScript "darcs" ../../../build-support/fetchdarcs/nix-prefetch-darcs [
     darcs
     cacert
+    gawk
     jq
   ];
   nix-prefetch-git = mkPrefetchScript "git" ../../../build-support/fetchgit/nix-prefetch-git [


### PR DESCRIPTION
While I don’t fully agree with the post’s approach, *if* someone wants to introduce a [“cooldown” to their project](https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns), adding the date will be helpful track dependencies. Using coreutil’s `date` to get an ISO8601 date for normalization + better compatibility.

Additionally, moved Darc’s weak hash query from `grep`+`cut`+`tr` to AWK since AWK is now a dependency of for the date. This will eliminate `grep` as a dependency (see: https://github.com/NixOS/nixpkgs/pull/462164).

In action (note `"date"`):

```sh-session
$ nix-build -A nix-prefetch-scripts
/nix/store/fzbig8x1va330jf6ys4dslr78z12jyqq-nix-prefetch-scripts
$ result/bin/nix-prefetch-darcs --context ./context.txt https://smeder.ee/~toastal/test-delete.darcs | jq -
-tab
{
	"repository": "https://smeder.ee/~toastal/test-delete.darcs",
	"weak-hash": "9168dfb6fd8cd980513d983b1ba0841ab67ff31a",
	"context": "/nix/store/mafyzlsdzqhxbma6b0cfnr1jwkpry9s9-fetchdarcs-context.txt",
	"date": "2025-09-03T12:38:40Z",
	"path": "/nix/store/4r5saywxlhd1x2fn03cqqvakck1x8523-fetchdarcs",
	"sha256": "0hrsa78q2nzfd2awgfn34c0qsbcfybpnwx039asa4pc51s8yb52y",
	"hash": "sha256-XpTlkQ6FXaK0SgN0bu/yji2NASPDuseVaO5bgdFROkM="
}
$ result/bin/nix-prefetch-pijul --state DUWNJEAZCSSE6FIKUMGWKXZKDNIQABT5KUCPFQ573RRNL7453N4QC https://nest.
pijul.com/toastal/test-lightweight-markup-language-rendering | jq --tab
Repository created at /tmp/pijul-clone-tmp-fI0WWclN/fetchpijul
Downloading changes  [==================================================] 2/2 [00:00:00]
Applying changes     [==================================================] 2/2 [00:00:00]                                                                   Downloading changes  [==================================================] 2/2 [00:00:00]
Completing changes... done!                                                                                                                                {
	"remote": "https://nest.pijul.com/toastal/test-lightweight-markup-language-rendering",
	"channel": "main",
	"state": "DUWNJEAZCSSE6FIKUMGWKXZKDNIQABT5KUCPFQ573RRNL7453N4QC",
	"date": "2023-07-24T03:18:35Z",
	"path": "/nix/store/bb4sw61908njg0p65npd8r67zb0fg5ds-fetchpijul",
	"sha256": "07zclwdkl0bz1bk91rd5nfqqyz42kkr4q60hx0zcx37p3dnn2r2v",
	"hash": "sha256-W2RhbRv3jM4+6BAYTPKcgnyPsbOl5ZDmCn8BOhun7B8="
}
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
