### PR TITLE
Cinnamon updates 2025-11-25

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/cinnamon.nix
+++ b/nixos/modules/services/x11/desktop-managers/cinnamon.nix
@@ -270,6 +270,7 @@ in
           gnome-calendar
           gnome-screenshot
           file-roller
+          gucharmap
         ] config.environment.cinnamon.excludePackages;
     })
   ];

--- a/pkgs/by-name/hy/hypnotix/package.nix
+++ b/pkgs/by-name/hy/hypnotix/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   replaceVars,
   xapp,
+  xapp-symbolic-icons,
   circle-flags,
   gettext,
   gobject-introspection,
@@ -15,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "hypnotix";
-  version = "5.3";
+  version = "5.4";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "hypnotix";
     tag = version;
-    hash = "sha256-KJqGdBqeNtXYO3XOQvRJs4ie8jK4Hyv+YS86PB0dnOM=";
+    hash = "sha256-aLcuRg6I1PaHBKyHMEV+TYOM82wb1hPVzMuF0SZixs8=";
   };
 
   patches = [
@@ -81,6 +82,7 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/hypnotix \
       --prefix PATH : "${lib.makeBinPath [ yt-dlp ]}" \
       --prefix PYTHONPATH : "$program_PYTHONPATH" \
+      --prefix XDG_DATA_DIRS : "${lib.makeSearchPath "share" [ xapp-symbolic-icons ]}" \
       ''${gappsWrapperArgs[@]}
   '';
 

--- a/pkgs/by-name/mi/mint-l-icons/package.nix
+++ b/pkgs/by-name/mi/mint-l-icons/package.nix
@@ -10,14 +10,14 @@
 
 stdenvNoCC.mkDerivation {
   pname = "mint-l-icons";
-  version = "1.7.8";
+  version = "1.7.9";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "mint-l-icons";
     # They don't really do tags, this is just a named commit.
-    rev = "5d96655e37a85aa5e3d20bc7b38c9675a6145d13";
-    hash = "sha256-9MdGMbxJKZTchYKEc/cV4m4M4tgraF1XlSNVT5PInVY=";
+    rev = "fa88b00e10b0978e0309acccfa95d80005422b1a";
+    hash = "sha256-XXy1eO0a/5bBnP/inaUa/c09D/6QDmnik1LH382NGIw=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/by-name/mi/mint-x-icons/package.nix
+++ b/pkgs/by-name/mi/mint-x-icons/package.nix
@@ -12,13 +12,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "mint-x-icons";
-  version = "1.7.4";
+  version = "1.7.5";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "mint-x-icons";
     rev = version;
-    hash = "sha256-Ea0NkN9vnfqqqXpE+aM6zca1m7ri4mP1DMTQhvx9guQ=";
+    hash = "sha256-UNta7sj5xzZglYJekhxa0N/2RJU4cyqjX2fCFdWqoiY=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/by-name/mi/mint-y-icons/package.nix
+++ b/pkgs/by-name/mi/mint-y-icons/package.nix
@@ -10,13 +10,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "mint-y-icons";
-  version = "1.8.8";
+  version = "1.8.9";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "mint-y-icons";
     rev = version;
-    hash = "sha256-PFq0NVUD6uQtHtObJfIsn/wPSwYMT6267UWjBnIpWAQ=";
+    hash = "sha256-eUMBn+2qnU6mgDPM6i2ebwEq3mSV3Uo6bXveVew3j9U=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/by-name/xa/xapp-symbolic-icons/package.nix
+++ b/pkgs/by-name/xa/xapp-symbolic-icons/package.nix
@@ -9,13 +9,13 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "xapp-symbolic-icons";
-  version = "1.0.2";
+  version = "1.0.4";
 
   src = fetchFromGitHub {
     owner = "xapp-project";
     repo = "xapp-symbolic-icons";
     tag = finalAttrs.version;
-    hash = "sha256-Z5edMCjw1/LO0+Ms5KCfFJ/iAANO2MihVZmLcJd5d3A=";
+    hash = "sha256-W5sgzy/2N7Nz1L0uUGCYtocbRIa3zxqMJy/aZ4JcxEs=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--

mint-y-icons: 1.8.8 -> 1.8.9
mint-l-icons: 1.7.8 -> 1.7.9
mint-x-icons: 1.7.4 -> 1.7.5
xapp-symbolic-icons: 1.0.2 -> 1.0.4
hypnotix: 5.3 -> 5.4
xed-editor: 3.8.4 -> 3.8.5
xreader: 4.4.0 -> 4.6.0
xviewer: 3.4.12 -> 3.4.13


muffin: 6.4.1 -> 6.6.0
mint-themes: 2.3.2 -> 2.3.3
mint-themes: 2.3.2 -> 2.4.0
cinnamon-translations: 6.4.2 -> 6.6.0
cinnamon-settings-daemon: 6.4.3 -> 6.6.0
cinnamon-session: 6.4.2 -> 6.6.0
cinnamon-screensaver: 6.4.1 -> 6.6.0
cinnamon-menus: 6.4.0 -> 6.6.0
cinnamon-desktop: 6.4.2 -> 6.6.0
cinnamon-control-center: 6.4.2 -> 6.6.0
cinnamon: 6.4.13 -> 6.6.0

muffin: 6.4.1 -> 6.6.1
mint-themes: 2.3.2 -> 2.3.4
mint-themes: 2.3.2 -> 2.4.1
cinnamon-translations: 6.4.2 -> 6.6.1
cinnamon-settings-daemon: 6.4.3 -> 6.6.1
cinnamon-session: 6.4.2 -> 6.6.1
cinnamon-screensaver: 6.4.1 -> 6.6.1
cinnamon-menus: 6.4.0 -> 6.6.1
cinnamon-desktop: 6.4.2 -> 6.6.1
cinnamon-control-center: 6.4.2 -> 6.6.1
cinnamon: 6.4.13 -> 6.6.1

nemo-emblems: 6.4.0 -> 6.6.0
nemo-fileroller: 6.4.0 -> 6.6.0
nemo-preview: 6.4.0 -> 6.6.0
nemo-python: 6.4.0 -> 6.6.0
nemo-seahorse: 6.4.0 -> 6.6.0
nemo: 6.4.5 -> 6.6.0


nemo-emblems: 6.4.0 -> 6.6.1
nemo-fileroller: 6.4.0 -> 6.6.1
nemo-preview: 6.4.0 -> 6.6.1
nemo-python: 6.4.0 -> 6.6.1
nemo-seahorse: 6.4.0 -> 6.6.1
nemo: 6.4.5 -> 6.6.1

-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

