### PR TITLE
tclint: init at 0.6.1

### DIFF
--- a/pkgs/by-name/tc/tclint/package.nix
+++ b/pkgs/by-name/tc/tclint/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  addBinToPathHook,
+  versionCheckHook,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "tclint";
+  version = "0.6.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "nmoroze";
+    repo = "tclint";
+    tag = "v${version}";
+    hash = "sha256-z0ytMK3xxqXZJTMuY2wiBFo8LXAUZZBb13kr/kXtyjI=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+    setuptools-scm
+  ];
+
+  pythonRelaxDeps = [
+    "importlib-metadata"
+    "pathspec"
+  ];
+  dependencies = with python3Packages; [
+    importlib-metadata
+    pathspec
+    ply
+    pygls_1
+    lsprotocol_2023
+    tomli
+    voluptuous
+  ];
+
+  pythonImportsCheck = [ "tclint" ];
+
+  nativeCheckInputs = [
+    addBinToPathHook
+    python3Packages.pytestCheckHook
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--version";
+
+  disabledTestPaths = [
+    # Fails to find lsprotocol in the sandbox, even when added to nativeCheckInputs
+    # RuntimeError: Client has been stopped.
+    # Captured stderr call: ModuleNotFoundError: No module named 'lsprotocol'
+    "tests/test_tclsp.py"
+  ];
+
+  meta = {
+    description = "Modern dev tools for Tcl. Includes a linter, formatter, and editor integration";
+    homepage = "https://github.com/nmoroze/tclint";
+    changelog = "https://github.com/nmoroze/tclint/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    mainProgram = "tclint";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add [tclint](https://github.com/nmoroze/tclint), modern dev tools for Tcl (includes a linter, formatter, and editor integration).

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
