### PR TITLE
citrix_workspace: 25.05 -> 25.08.10

### DIFF
--- a/pkgs/applications/networking/remote/citrix-workspace/default.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/default.nix
@@ -4,24 +4,10 @@
 # reference guide: https://developer-docs.citrix.com/en-us/citrix-workspace-app-for-linux/citrix-workspace-app-for-linux-oem-reference-guide
 
 let
-  inherit (callPackage ./sources.nix { }) supportedVersions unsupportedVersions;
+  supportedVersions = callPackage ./sources.nix { };
 
   toAttrName = x: "citrix_workspace_${builtins.replaceStrings [ "." ] [ "_" ] x}";
-
-  unsupported = lib.listToAttrs (
-    map (
-      x:
-      lib.nameValuePair (toAttrName x) (throw ''
-        Citrix Workspace at version ${x} is not supported anymore!
-
-        Actively supported releases are listed here:
-        https://www.citrix.com/support/product-lifecycle/workspace-app.html
-      '')
-    ) unsupportedVersions
-  );
-
-  supported = lib.mapAttrs' (
-    attr: versionInfo: lib.nameValuePair (toAttrName attr) (callPackage ./generic.nix versionInfo)
-  ) supportedVersions;
 in
-supported // unsupported
+lib.mapAttrs' (
+  attr: versionInfo: lib.nameValuePair (toAttrName attr) (callPackage ./generic.nix versionInfo)
+) supportedVersions

--- a/pkgs/applications/networking/remote/citrix-workspace/generic.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/generic.nix
@@ -299,11 +299,6 @@ stdenv.mkDerivation rec {
 
       ${mkWrappers copyCert extraCerts}
 
-      # See https://developer-docs.citrix.com/en-us/citrix-workspace-app-for-linux/citrix-workspace-app-for-linux-oem-reference-guide/reference-information/#library-files
-      # Those files are fallbacks to support older libwekit.so and libjpeg.so
-      rm $out/opt/citrix-icaclient/lib/ctxjpeg_fb_8.so || true
-      rm $out/opt/citrix-icaclient/lib/UIDialogLibWebKit.so || true
-
       # We support only Gstreamer 1.0
       rm $ICAInstDir/util/{gst_aud_{play,read},gst_*0.10,libgstflatstm0.10.so} || true
       ln -sf $ICAInstDir/util/gst_play1.0 $ICAInstDir/util/gst_play

--- a/pkgs/applications/networking/remote/citrix-workspace/generic.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/generic.nix
@@ -324,12 +324,6 @@ stdenv.mkDerivation rec {
   # Make sure that `autoPatchelfHook` is executed before
   # running `ctx_rehash`.
   dontAutoPatchelf = true;
-  preFixup = ''
-    find $out/opt/citrix-icaclient/lib -name "libopencv_imgcodecs.so.*" | while read -r fname; do
-      # lib needs libtiff.so.5, but nixpkgs provides libtiff.so.6
-      patchelf --replace-needed libtiff.so.5 libtiff.so $fname
-    done
-  '';
   postFixup = ''
     autoPatchelf -- "$out"
     $out/opt/citrix-icaclient/util/ctx_rehash

--- a/pkgs/applications/networking/remote/citrix-workspace/generic.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/generic.nix
@@ -61,7 +61,6 @@
 
   homepage,
   version,
-  prefix,
   hash,
 
   extraCerts ? [ ],
@@ -97,12 +96,12 @@ stdenv.mkDerivation rec {
   inherit version;
 
   src = requireFile rec {
-    name = "${prefix}-${version}.tar.gz";
+    name = "linuxx64-${version}.tar.gz";
     sha256 = hash;
 
     message = ''
       In order to use Citrix Workspace, you need to comply with the Citrix EULA and download
-      the ${if stdenv.hostPlatform.is64bit then "64-bit" else "32-bit"} binaries, .tar.gz from:
+      the 64-bit binaries, .tar.gz from:
 
       ${homepage}
 
@@ -247,9 +246,9 @@ stdenv.mkDerivation rec {
       export HOME=$(mktemp -d)
 
       # Run upstream installer in the store-path.
-      sed -i -e 's,^ANSWER="",ANSWER="$INSTALLER_YES",g' -e 's,/bin/true,true,g' ./${prefix}/hinst
+      sed -i -e 's,^ANSWER="",ANSWER="$INSTALLER_YES",g' -e 's,/bin/true,true,g' ./linuxx64/hinst
       source_date=$(date --utc --date=@$SOURCE_DATE_EPOCH "+%F %T")
-      faketime -f "$source_date" ${stdenv.shell} ${prefix}/hinst CDROM "$(pwd)"
+      faketime -f "$source_date" ${stdenv.shell} linuxx64/hinst CDROM "$(pwd)"
 
       if [ -f "$ICAInstDir/util/setlog" ]; then
         chmod +x "$ICAInstDir/util/setlog"
@@ -318,7 +317,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.unfree;
     description = "Citrix Workspace";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    platforms = [ "x86_64-linux" ] ++ lib.optional (lib.versionOlder version "24") "i686-linux";
+    platforms = [ "x86_64-linux" ];
     maintainers = with lib.maintainers; [ flacks ];
     inherit homepage;
   };

--- a/pkgs/applications/networking/remote/citrix-workspace/sources.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/sources.nix
@@ -65,6 +65,15 @@ let
       suffix = "44";
       homepage = "https://www.citrix.com/downloads/workspace-app/linux/workspace-app-for-linux-latest.html";
     };
+
+    "25.08.0" = {
+      major = "25";
+      minor = "08";
+      patch = "0";
+      hash = "19nx7j78c84m6wlidkaicqf5rgy05rm85vzh3admhrl8q9zr1avr";
+      suffix = "88";
+      homepage = "https://www.citrix.com/downloads/workspace-app/linux/workspace-app-for-linux-latest.html";
+    };
   };
 in
 supportedVersions

--- a/pkgs/applications/networking/remote/citrix-workspace/sources.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/sources.nix
@@ -7,58 +7,26 @@ let
       major,
       minor,
       patch,
-      x64hash,
-      x86hash,
-      x64suffix,
-      x86suffix,
+      hash,
+      suffix,
       homepage,
     }:
     {
-      inherit homepage;
-      version = "${major}.${minor}.${patch}.${
-        if stdenv.hostPlatform.is64bit then x64suffix else x86suffix
-      }";
-      prefix = "linuxx${if stdenv.hostPlatform.is64bit then "64" else "86"}";
-      hash = if stdenv.hostPlatform.is64bit then x64hash else x86hash;
+      inherit hash homepage;
+      version = "${major}.${minor}.${patch}.${suffix}";
     };
 
   # Attribute-set with all actively supported versions of the Citrix workspace app
   # for Linux.
   #
   # The latest versions can be found at https://www.citrix.com/downloads/workspace-app/linux/
-  # x86 is unsupported past 23.11, see https://docs.citrix.com/en-us/citrix-workspace-app-for-linux/deprecation
   supportedVersions = lib.mapAttrs mkVersionInfo {
-
-    "23.11.0" = {
-      major = "23";
-      minor = "11";
-      patch = "0";
-      x64hash = "d3dde64baa6db7675a025eff546d552544d3523f4f3047621884f7830a9e2822";
-      x86hash = "65b8c144e51b5bd78b98ae69e0fa76d6c020a857d74fd5254be49492527072b6";
-      x64suffix = "82";
-      x86suffix = "82";
-      homepage = "https://www.citrix.com/downloads/workspace-app/legacy-workspace-app-for-linux/workspace-app-for-linux-latest10.html";
-    };
-
-    "24.02.0" = {
-      major = "24";
-      minor = "2";
-      patch = "0";
-      x64hash = "eaeb5d3bd079d4e5c9707da67f5f7a25cb765e19c36d01861290655dbf2aaee4";
-      x86hash = "";
-      x64suffix = "65";
-      x86suffix = "";
-      homepage = "https://www.citrix.com/downloads/workspace-app/legacy-workspace-app-for-linux/workspace-app-for-linux-latest12.html";
-    };
-
     "24.05.0" = {
       major = "24";
       minor = "5";
       patch = "0";
-      x64hash = "sha256-pye2JOilSbp8PFCpVXFkrRW98E8klCqoisVSWjR38nE=";
-      x86hash = "";
-      x64suffix = "76";
-      x86suffix = "";
+      hash = "sha256-pye2JOilSbp8PFCpVXFkrRW98E8klCqoisVSWjR38nE=";
+      suffix = "76";
       homepage = "https://www.citrix.com/downloads/workspace-app/legacy-workspace-app-for-linux/workspace-app-for-linux-latest1.html";
     };
 
@@ -66,10 +34,8 @@ let
       major = "24";
       minor = "8";
       patch = "0";
-      x64hash = "1jb22n6gcv4pv8khg98sv663yfpi47dpkvqgifbhps98iw5zrkbp";
-      x86hash = "";
-      x64suffix = "98";
-      x86suffix = "";
+      hash = "1jb22n6gcv4pv8khg98sv663yfpi47dpkvqgifbhps98iw5zrkbp";
+      suffix = "98";
       homepage = "https://www.citrix.com/downloads/workspace-app/legacy-workspace-app-for-linux/workspace-app-for-linux-latest-2408.html";
     };
 
@@ -77,10 +43,8 @@ let
       major = "24";
       minor = "11";
       patch = "0";
-      x64hash = "0kylvqdzkw0635mbb6r5k1lamdjf1hr9pk5rxcff63z4f8q0g3zf";
-      x86hash = "";
-      x64suffix = "85";
-      x86suffix = "";
+      hash = "0kylvqdzkw0635mbb6r5k1lamdjf1hr9pk5rxcff63z4f8q0g3zf";
+      suffix = "85";
       homepage = "https://www.citrix.com/downloads/workspace-app/legacy-workspace-app-for-linux/workspace-app-for-linux-latest13.html";
     };
 
@@ -88,10 +52,8 @@ let
       major = "25";
       minor = "03";
       patch = "0";
-      x64hash = "052zibykhig9091xl76z2x9vn4f74w5q8i9frlpc473pvfplsczk";
-      x86hash = "";
-      x64suffix = "66";
-      x86suffix = "";
+      hash = "052zibykhig9091xl76z2x9vn4f74w5q8i9frlpc473pvfplsczk";
+      suffix = "66";
       homepage = "https://www.citrix.com/downloads/workspace-app/legacy-workspace-app-for-linux/workspace-app-for-linux-latest-2503.html";
     };
 
@@ -99,10 +61,8 @@ let
       major = "25";
       minor = "05";
       patch = "0";
-      x64hash = "0fwqsxggswms40b5k8saxpm1ghkxppl27x19w8jcslq1f0i1fwqx";
-      x86hash = "";
-      x64suffix = "44";
-      x86suffix = "";
+      hash = "0fwqsxggswms40b5k8saxpm1ghkxppl27x19w8jcslq1f0i1fwqx";
+      suffix = "44";
       homepage = "https://www.citrix.com/downloads/workspace-app/linux/workspace-app-for-linux-latest.html";
     };
   };

--- a/pkgs/applications/networking/remote/citrix-workspace/sources.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/sources.nix
@@ -106,18 +106,5 @@ let
       homepage = "https://www.citrix.com/downloads/workspace-app/linux/workspace-app-for-linux-latest.html";
     };
   };
-
-  # Retain attribute-names for abandoned versions of Citrix workspace to
-  # provide a meaningful error-message if it's attempted to use such an old one.
-  #
-  # The lifespans of Citrix products can be found here:
-  # https://www.citrix.com/support/product-lifecycle/workspace-app.html
-  unsupportedVersions = [
-    "23.02.0"
-    "23.07.0"
-    "23.09.0"
-  ];
 in
-{
-  inherit supportedVersions unsupportedVersions;
-}
+supportedVersions

--- a/pkgs/applications/networking/remote/citrix-workspace/sources.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/sources.nix
@@ -21,12 +21,12 @@ let
   #
   # The latest versions can be found at https://www.citrix.com/downloads/workspace-app/linux/
   supportedVersions = lib.mapAttrs mkVersionInfo {
-    "25.08.0" = {
+    "25.08.10" = {
       major = "25";
       minor = "08";
-      patch = "0";
-      hash = "19nx7j78c84m6wlidkaicqf5rgy05rm85vzh3admhrl8q9zr1avr";
-      suffix = "88";
+      patch = "10";
+      hash = "06hdwi5rd8z43nlpvym6yrw3snfz8jh6ic3g4pihn9ji22bw5pbd";
+      suffix = "111";
       homepage = "https://www.citrix.com/downloads/workspace-app/linux/workspace-app-for-linux-latest.html";
     };
   };

--- a/pkgs/applications/networking/remote/citrix-workspace/sources.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/sources.nix
@@ -21,51 +21,6 @@ let
   #
   # The latest versions can be found at https://www.citrix.com/downloads/workspace-app/linux/
   supportedVersions = lib.mapAttrs mkVersionInfo {
-    "24.05.0" = {
-      major = "24";
-      minor = "5";
-      patch = "0";
-      hash = "sha256-pye2JOilSbp8PFCpVXFkrRW98E8klCqoisVSWjR38nE=";
-      suffix = "76";
-      homepage = "https://www.citrix.com/downloads/workspace-app/legacy-workspace-app-for-linux/workspace-app-for-linux-latest1.html";
-    };
-
-    "24.08.0" = {
-      major = "24";
-      minor = "8";
-      patch = "0";
-      hash = "1jb22n6gcv4pv8khg98sv663yfpi47dpkvqgifbhps98iw5zrkbp";
-      suffix = "98";
-      homepage = "https://www.citrix.com/downloads/workspace-app/legacy-workspace-app-for-linux/workspace-app-for-linux-latest-2408.html";
-    };
-
-    "24.11.0" = {
-      major = "24";
-      minor = "11";
-      patch = "0";
-      hash = "0kylvqdzkw0635mbb6r5k1lamdjf1hr9pk5rxcff63z4f8q0g3zf";
-      suffix = "85";
-      homepage = "https://www.citrix.com/downloads/workspace-app/legacy-workspace-app-for-linux/workspace-app-for-linux-latest13.html";
-    };
-
-    "25.03.0" = {
-      major = "25";
-      minor = "03";
-      patch = "0";
-      hash = "052zibykhig9091xl76z2x9vn4f74w5q8i9frlpc473pvfplsczk";
-      suffix = "66";
-      homepage = "https://www.citrix.com/downloads/workspace-app/legacy-workspace-app-for-linux/workspace-app-for-linux-latest-2503.html";
-    };
-
-    "25.05.0" = {
-      major = "25";
-      minor = "05";
-      patch = "0";
-      hash = "0fwqsxggswms40b5k8saxpm1ghkxppl27x19w8jcslq1f0i1fwqx";
-      suffix = "44";
-      homepage = "https://www.citrix.com/downloads/workspace-app/linux/workspace-app-for-linux-latest.html";
-    };
-
     "25.08.0" = {
       major = "25";
       minor = "08";

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -432,6 +432,8 @@ mapAliases {
   chrome-gnome-shell = throw "'chrome-gnome-shell' has been renamed to/replaced by 'gnome-browser-connector'"; # Converted to throw 2025-10-27
   ci-edit = throw "'ci-edit' has been removed due to lack of maintenance upstream"; # Added 2025-08-26
   cinnamon-common = cinnamon; # Added 2025-08-06
+  citrix_workspace_23_11_0 = throw "'citrix_workspace_23_11_0' has been removed because it has reached EOL."; # Added 2025-11-25
+  citrix_workspace_24_02_0 = throw "'citrix_workspace_24_02_0' has been removed because it has reached EOL."; # Added 2025-11-25
   clamsmtp = throw "'clamsmtp' has been removed as it is unmaintained and broken"; # Added 2025-05-17
   clang12Stdenv = throw "clang12Stdenv has been removed, as it is unmaintained and obsolete"; # Added 2025-08-10
   clang13Stdenv = throw "clang13Stdenv has been removed, as it is unmaintained and obsolete"; # Added 2025-08-10

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -434,6 +434,11 @@ mapAliases {
   cinnamon-common = cinnamon; # Added 2025-08-06
   citrix_workspace_23_11_0 = throw "'citrix_workspace_23_11_0' has been removed because it has reached EOL."; # Added 2025-11-25
   citrix_workspace_24_02_0 = throw "'citrix_workspace_24_02_0' has been removed because it has reached EOL."; # Added 2025-11-25
+  citrix_workspace_24_05_0 = throw "'citrix_workspace_24_05_0' has been removed because it depended on the removed webkitgtk_4_0."; # Added 2025-11-25
+  citrix_workspace_24_08_0 = throw "'citrix_workspace_24_08_0' has been removed because it depended on the removed webkitgtk_4_0."; # Added 2025-11-25
+  citrix_workspace_24_11_0 = throw "'citrix_workspace_24_11_0' has been removed because it depended on the removed webkitgtk_4_0."; # Added 2025-11-25
+  citrix_workspace_25_03_0 = throw "'citrix_workspace_25_03_0' has been removed because it depended on the removed webkitgtk_4_0."; # Added 2025-11-25
+  citrix_workspace_25_05_0 = throw "'citrix_workspace_25_05_0' has been removed because it depended on the removed webkitgtk_4_0."; # Added 2025-11-25
   clamsmtp = throw "'clamsmtp' has been removed as it is unmaintained and broken"; # Added 2025-05-17
   clang12Stdenv = throw "clang12Stdenv has been removed, as it is unmaintained and obsolete"; # Added 2025-08-10
   clang13Stdenv = throw "clang13Stdenv has been removed, as it is unmaintained and obsolete"; # Added 2025-08-10

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2186,8 +2186,9 @@ with pkgs;
     citrix_workspace_24_11_0
     citrix_workspace_25_03_0
     citrix_workspace_25_05_0
+    citrix_workspace_25_08_0
     ;
-  citrix_workspace = citrix_workspace_25_05_0;
+  citrix_workspace = citrix_workspace_25_08_0;
 
   colord-gtk4 = colord-gtk.override { withGtk4 = true; };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2181,9 +2181,9 @@ with pkgs;
   circus = with python310Packages; toPythonApplication circus;
 
   inherit (callPackage ../applications/networking/remote/citrix-workspace { })
-    citrix_workspace_25_08_0
+    citrix_workspace_25_08_10
     ;
-  citrix_workspace = citrix_workspace_25_08_0;
+  citrix_workspace = citrix_workspace_25_08_10;
 
   colord-gtk4 = colord-gtk.override { withGtk4 = true; };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2181,8 +2181,6 @@ with pkgs;
   circus = with python310Packages; toPythonApplication circus;
 
   inherit (callPackage ../applications/networking/remote/citrix-workspace { })
-    citrix_workspace_23_11_0
-    citrix_workspace_24_02_0
     citrix_workspace_24_05_0
     citrix_workspace_24_08_0
     citrix_workspace_24_11_0

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2181,11 +2181,6 @@ with pkgs;
   circus = with python310Packages; toPythonApplication circus;
 
   inherit (callPackage ../applications/networking/remote/citrix-workspace { })
-    citrix_workspace_24_05_0
-    citrix_workspace_24_08_0
-    citrix_workspace_24_11_0
-    citrix_workspace_25_03_0
-    citrix_workspace_25_05_0
     citrix_workspace_25_08_0
     ;
   citrix_workspace = citrix_workspace_25_08_0;


### PR DESCRIPTION
Drops all old versions and updates to the latest version 25.08. This one has... webkitgtk 4.0 bundled, which is not great, but the only way to make this work :/. Since this still depends on libsoup 2.4, it only builds when allowing insecure packages anyway.

Closes #463214

This can be backported to 25.11 including the drops, because everything is broken there anyway.

## Things done

I was able to use it and connect - it did everything that I wanted it to do. But I'm not a heavy user at all...

- Built on platform:
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
