### PR TITLE
Cinnamon 6.6

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/cinnamon.nix
+++ b/nixos/modules/services/x11/desktop-managers/cinnamon.nix
@@ -109,6 +109,7 @@ in
 
       # Default services
       services.blueman.enable = mkDefault (notExcluded pkgs.blueman);
+      services.hardware.bolt.enable = mkDefault (notExcluded pkgs.bolt);
       hardware.bluetooth.enable = mkDefault true;
       security.polkit.enable = true;
       services.accounts-daemon.enable = true;

--- a/nixos/modules/services/x11/desktop-managers/cinnamon.nix
+++ b/nixos/modules/services/x11/desktop-managers/cinnamon.nix
@@ -174,6 +174,7 @@ in
             cinnamon-translations
 
             # utils needed by some scripts
+            inxi
             killall
 
             # session requirements

--- a/nixos/tests/cinnamon.nix
+++ b/nixos/tests/cinnamon.nix
@@ -100,7 +100,7 @@
 
       with subtest("Open virtual keyboard"):
           machine.succeed("${su "dbus-send --print-reply --dest=org.Cinnamon /org/Cinnamon org.Cinnamon.ToggleKeyboard"}")
-          machine.wait_for_text('(Ctrl|Alt)')
+          machine.wait_for_text('(Esc|123)')
           machine.sleep(2)
           machine.screenshot("cinnamon_virtual_keyboard")
 

--- a/pkgs/by-name/ci/cinnamon-control-center/package.nix
+++ b/pkgs/by-name/ci/cinnamon-control-center/package.nix
@@ -12,19 +12,15 @@
   libxml2,
   colord,
   polkit,
-  libxkbfile,
   cinnamon-menus,
-  libgnomekbd,
-  libxklavier,
   networkmanager,
   libgudev,
   libwacom,
   wrapGAppsHook3,
-  glibc,
   libnma,
+  libXi,
   modemmanager,
-  xorg,
-  gdk-pixbuf,
+  xorgproto,
   meson,
   ninja,
   cinnamon-translations,
@@ -34,13 +30,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-control-center";
-  version = "6.4.2";
+  version = "6.6.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "cinnamon-control-center";
     tag = version;
-    hash = "sha256-nw70sbiz3+dp40WP957hOVo/mQOg2MJknZNN5Kw/Q/0=";
+    hash = "sha256-TjTwtTFbiC4A4qe9TIyZJtGrSymujhEgM8SpZQ92RZA=";
   };
 
   buildInputs = [
@@ -50,19 +46,15 @@ stdenv.mkDerivation rec {
     cinnamon-desktop
     libnotify
     cinnamon-menus
-    libxml2
     polkit
-    libgnomekbd
-    libxklavier
     colord
     libgudev
     libwacom
     networkmanager
     libnma
+    libXi
     modemmanager
-    xorg.libXxf86misc
-    xorg.libxkbfile
-    gdk-pixbuf
+    xorgproto
     upower
   ];
 
@@ -76,6 +68,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [
+    libxml2 # xmllint
     pkg-config
     meson
     ninja

--- a/pkgs/by-name/ci/cinnamon-desktop/package.nix
+++ b/pkgs/by-name/ci/cinnamon-desktop/package.nix
@@ -21,13 +21,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-desktop";
-  version = "6.4.2";
+  version = "6.6.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "cinnamon-desktop";
     tag = version;
-    hash = "sha256-kNxVdPtCQtz4TSyCc6uKHmAGWm2nlWnLwC3Cm0E42Jc=";
+    hash = "sha256-9qgt+E5qbzq+x9fJKkoSBFgA96HBDLysQvg6b04WbMU=";
   };
 
   outputs = [

--- a/pkgs/by-name/ci/cinnamon-menus/package.nix
+++ b/pkgs/by-name/ci/cinnamon-menus/package.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-menus";
-  version = "6.4.0";
+  version = "6.6.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "cinnamon-menus";
     tag = version;
-    hash = "sha256-ug1RSP2TBrypi0aGhF05k39koY3rGgJi0LuWyuuICd0=";
+    hash = "sha256-vjgWPFNmRkJWynimvBuxCxLK5C7tQxqJ5Y4dkZXSDSA=";
   };
 
   buildInputs = [

--- a/pkgs/by-name/ci/cinnamon-screensaver/package.nix
+++ b/pkgs/by-name/ci/cinnamon-screensaver/package.nix
@@ -21,7 +21,6 @@
   python3,
   pam,
   cairo,
-  xapp,
   xdotool,
   xorg,
   iso-flags-png-320x240,
@@ -29,13 +28,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-screensaver";
-  version = "6.4.1";
+  version = "6.6.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "cinnamon-screensaver";
     tag = version;
-    hash = "sha256-CK4WP5IafNII81e8HxUNN3Vp36Ln78Xvv5lIMvL+nbk=";
+    hash = "sha256-Jo9GRsiPvqGZ2ITaewV5H4VMc5EotTTXIaqzXwDA+Z4=";
   };
 
   patches = [
@@ -75,7 +74,6 @@ stdenv.mkDerivation rec {
         pycairo
       ]
     ))
-    xapp
     xdotool
     pam
     cairo

--- a/pkgs/by-name/ci/cinnamon-session/package.nix
+++ b/pkgs/by-name/ci/cinnamon-session/package.nix
@@ -33,13 +33,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "cinnamon-session";
-  version = "6.4.2";
+  version = "6.6.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "cinnamon-session";
     tag = version;
-    hash = "sha256-zv1X1MLZBg+Bayd4hjsmrdXkFTRkH4kz7PJe6mFTBqc=";
+    hash = "sha256-16bBehc8NuPd9vr/J7Y5MoVsqOBQWzh63pzQZ96O0vs=";
   };
 
   buildInputs = [

--- a/pkgs/by-name/ci/cinnamon-settings-daemon/package.nix
+++ b/pkgs/by-name/ci/cinnamon-settings-daemon/package.nix
@@ -8,16 +8,13 @@
   gtk3,
   lcms2,
   libcanberra-gtk3,
-  libgnomekbd,
   libnotify,
-  libxklavier,
   wrapGAppsHook3,
   pkg-config,
   lib,
   stdenv,
   systemd,
   upower,
-  dconf,
   cups,
   polkit,
   librsvg,
@@ -33,13 +30,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-settings-daemon";
-  version = "6.4.3";
+  version = "6.6.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "cinnamon-settings-daemon";
     tag = version;
-    hash = "sha256-L7+OgymYoYBdprw66RW8tiGA7XGWjTBpDpXhli8Fjoo=";
+    hash = "sha256-Ho7L4BqLJ0Vz9+ZijZ8ZhQr1NJmGVf8JWtUpplx1JF0=";
   };
 
   patches = [
@@ -54,12 +51,9 @@ stdenv.mkDerivation rec {
     gsettings-desktop-schemas
     lcms2
     libcanberra-gtk3
-    libgnomekbd
     libnotify
-    libxklavier
     systemd
     upower
-    dconf
     cups
     polkit
     librsvg
@@ -67,7 +61,6 @@ stdenv.mkDerivation rec {
     xorg.libXext
     xorg.libX11
     xorg.libXi
-    xorg.libXfixes
     fontconfig
     nss
     libgudev

--- a/pkgs/by-name/ci/cinnamon-translations/package.nix
+++ b/pkgs/by-name/ci/cinnamon-translations/package.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-translations";
-  version = "6.4.2";
+  version = "6.6.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "cinnamon-translations";
     tag = version;
-    hash = "sha256-By09Y4iHZz3XR7tRd5MyXK5BKOr01yJzTTLQHEZ00q0=";
+    hash = "sha256-+aqMXice5INNkqLmPc4hawlrc2jRnsGimDPZf28dUSE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ci/cinnamon/libdir.patch
+++ b/pkgs/by-name/ci/cinnamon/libdir.patch
@@ -17,9 +17,9 @@ index 3c1e9a4f..a77d9b3c 100644
  schemadir = join_paths(datadir, 'glib-2.0', 'schemas')
 -pkglibdir = join_paths(libdir, meson.project_name().to_lower())
 +pkglibdir = libdir
- servicedir = join_paths(datadir, 'dbus-1', 'services')
  pkgdatadir = join_paths(datadir, meson.project_name().to_lower())
  po_dir = join_paths(meson.source_root(), 'po')
+
 -- 
 2.30.0
 

--- a/pkgs/by-name/mu/muffin/package.nix
+++ b/pkgs/by-name/mu/muffin/package.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  fetchpatch,
   replaceVars,
   cairo,
   cinnamon-desktop,
@@ -44,7 +43,7 @@
 
 stdenv.mkDerivation rec {
   pname = "muffin";
-  version = "6.4.1";
+  version = "6.6.0";
 
   outputs = [
     "out"
@@ -56,19 +55,12 @@ stdenv.mkDerivation rec {
     owner = "linuxmint";
     repo = "muffin";
     rev = version;
-    hash = "sha256-cGC1yGft3uEqefm2DvZrMaROoZKYd6LNY0IJ+58f6vs=";
+    hash = "sha256-yGbnqIKw+Ouk1onr2H+KckO/YQob1N1beLmfqQhOheU=";
   };
 
   patches = [
     (replaceVars ./fix-paths.patch {
       inherit zenity;
-    })
-
-    # Fix Qt apps crashing on wayland
-    # https://github.com/linuxmint/muffin/pull/739
-    (fetchpatch {
-      url = "https://github.com/linuxmint/muffin/commit/760e2a3046e13610c4fda1291a9a28e589d2bd93.patch";
-      hash = "sha256-D0u8UxW5USzMW9KlP3Y4XCWxrQ1ySufDv+eCbrAP71c=";
     })
   ];
 
@@ -119,7 +111,6 @@ stdenv.mkDerivation rec {
 
   mesonFlags = [
     # Based on Mint's debian/rules.
-    "-Degl_device=true"
     "-Dwayland_eglstream=true"
     "-Dxwayland_path=${lib.getExe xwayland}"
   ];

--- a/pkgs/by-name/ne/nemo-emblems/package.nix
+++ b/pkgs/by-name/ne/nemo-emblems/package.nix
@@ -7,7 +7,7 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "nemo-emblems";
-  version = "6.4.0";
+  version = "6.6.0";
   pyproject = true;
 
   # nixpkgs-update: no auto update
@@ -15,7 +15,7 @@ python3.pkgs.buildPythonApplication rec {
     owner = "linuxmint";
     repo = "nemo-extensions";
     rev = version;
-    hash = "sha256-39hWA4SNuEeaPA6D5mWMHjJDs4hYK7/ZdPkTyskvm5Y=";
+    hash = "sha256-tXeMkaCYnWzg+6ng8Tyg4Ms1aUeE3xiEkQ3tKEX6Vv8=";
   };
 
   sourceRoot = "${src.name}/nemo-emblems";

--- a/pkgs/by-name/ne/nemo-fileroller/package.nix
+++ b/pkgs/by-name/ne/nemo-fileroller/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation rec {
   pname = "nemo-fileroller";
-  version = "6.4.0";
+  version = "6.6.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "nemo-extensions";
     rev = version;
-    hash = "sha256-39hWA4SNuEeaPA6D5mWMHjJDs4hYK7/ZdPkTyskvm5Y=";
+    hash = "sha256-tXeMkaCYnWzg+6ng8Tyg4Ms1aUeE3xiEkQ3tKEX6Vv8=";
   };
 
   sourceRoot = "${src.name}/nemo-fileroller";

--- a/pkgs/by-name/ne/nemo-preview/package.nix
+++ b/pkgs/by-name/ne/nemo-preview/package.nix
@@ -21,13 +21,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nemo-preview";
-  version = "6.4.0";
+  version = "6.6.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "nemo-extensions";
     tag = finalAttrs.version;
-    hash = "sha256-39hWA4SNuEeaPA6D5mWMHjJDs4hYK7/ZdPkTyskvm5Y=";
+    hash = "sha256-tXeMkaCYnWzg+6ng8Tyg4Ms1aUeE3xiEkQ3tKEX6Vv8=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/nemo-preview";

--- a/pkgs/by-name/ne/nemo-python/package.nix
+++ b/pkgs/by-name/ne/nemo-python/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "nemo-python";
-  version = "6.4.0";
+  version = "6.6.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "nemo-extensions";
     rev = version;
-    hash = "sha256-39hWA4SNuEeaPA6D5mWMHjJDs4hYK7/ZdPkTyskvm5Y=";
+    hash = "sha256-tXeMkaCYnWzg+6ng8Tyg4Ms1aUeE3xiEkQ3tKEX6Vv8=";
   };
 
   sourceRoot = "${src.name}/nemo-python";

--- a/pkgs/by-name/ne/nemo-seahorse/package.nix
+++ b/pkgs/by-name/ne/nemo-seahorse/package.nix
@@ -18,13 +18,13 @@
 
 stdenv.mkDerivation rec {
   pname = "nemo-seahorse";
-  version = "6.4.0";
+  version = "6.6.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "nemo-extensions";
     tag = version;
-    hash = "sha256-39hWA4SNuEeaPA6D5mWMHjJDs4hYK7/ZdPkTyskvm5Y=";
+    hash = "sha256-tXeMkaCYnWzg+6ng8Tyg4Ms1aUeE3xiEkQ3tKEX6Vv8=";
   };
 
   sourceRoot = "${src.name}/nemo-seahorse";

--- a/pkgs/by-name/ne/nemo/package.nix
+++ b/pkgs/by-name/ne/nemo/package.nix
@@ -13,6 +13,7 @@
   gvfs,
   cinnamon-desktop,
   xapp,
+  xapp-symbolic-icons,
   libexif,
   json-glib,
   exempi,
@@ -35,13 +36,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "nemo";
-  version = "6.4.5";
+  version = "6.6.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "nemo";
     rev = version;
-    hash = "sha256-9JfCBC5YjfQadF7KzPgZ1yPkiSjmuEO1tfMU2BmJES8=";
+    hash = "sha256-4YbWkS4J0iDkp+wnwyJg5TD/fhHsbutyh7q+yFLV9Mk=";
   };
 
   patches = [
@@ -93,9 +94,14 @@ stdenv.mkDerivation rec {
   '';
 
   preFixup = ''
-    # Used for some non-fd.o icons (e.g. xapp-text-case-symbolic)
     gappsWrapperArgs+=(
-      --prefix XDG_DATA_DIRS : "${xapp}/share"
+       --prefix XDG_DATA_DIRS : ${
+         lib.makeSearchPath "share" [
+           # For non-fd.o icons.
+           xapp
+           xapp-symbolic-icons
+         ]
+       }
     )
   '';
 


### PR DESCRIPTION
<!--

mint-y-icons: 1.8.8 -> 1.8.9
mint-l-icons: 1.7.8 -> 1.7.9
mint-x-icons: 1.7.4 -> 1.7.5
xapp-symbolic-icons: 1.0.2 -> 1.0.4
hypnotix: 5.3 -> 5.4
xed-editor: 3.8.4 -> 3.8.5
xreader: 4.4.0 -> 4.6.0
xviewer: 3.4.12 -> 3.4.13


muffin: 6.4.1 -> 6.6.0
mint-themes: 2.3.2 -> 2.3.3
mint-themes: 2.3.2 -> 2.4.0
cinnamon-translations: 6.4.2 -> 6.6.0
cinnamon-settings-daemon: 6.4.3 -> 6.6.0
cinnamon-session: 6.4.2 -> 6.6.0
cinnamon-screensaver: 6.4.1 -> 6.6.0
cinnamon-menus: 6.4.0 -> 6.6.0
cinnamon-desktop: 6.4.2 -> 6.6.0
cinnamon-control-center: 6.4.2 -> 6.6.0
cinnamon: 6.4.13 -> 6.6.0

muffin: 6.4.1 -> 6.6.1
mint-themes: 2.3.2 -> 2.3.4
mint-themes: 2.3.2 -> 2.4.1
cinnamon-translations: 6.4.2 -> 6.6.1
cinnamon-settings-daemon: 6.4.3 -> 6.6.1
cinnamon-session: 6.4.2 -> 6.6.1
cinnamon-screensaver: 6.4.1 -> 6.6.1
cinnamon-menus: 6.4.0 -> 6.6.1
cinnamon-desktop: 6.4.2 -> 6.6.1
cinnamon-control-center: 6.4.2 -> 6.6.1
cinnamon: 6.4.13 -> 6.6.1

muffin: 6.4.1 -> 6.6.2
mint-themes: 2.3.2 -> 2.3.5
mint-themes: 2.3.2 -> 2.4.2
cinnamon-translations: 6.4.2 -> 6.6.2
cinnamon-settings-daemon: 6.4.3 -> 6.6.2
cinnamon-session: 6.4.2 -> 6.6.2
cinnamon-screensaver: 6.4.1 -> 6.6.2
cinnamon-menus: 6.4.0 -> 6.6.2
cinnamon-desktop: 6.4.2 -> 6.6.2
cinnamon-control-center: 6.4.2 -> 6.6.2
cinnamon: 6.4.13 -> 6.6.2

nemo-emblems: 6.4.0 -> 6.6.0
nemo-fileroller: 6.4.0 -> 6.6.0
nemo-preview: 6.4.0 -> 6.6.0
nemo-python: 6.4.0 -> 6.6.0
nemo-seahorse: 6.4.0 -> 6.6.0
nemo: 6.4.5 -> 6.6.0


nemo-emblems: 6.4.0 -> 6.6.1
nemo-fileroller: 6.4.0 -> 6.6.1
nemo-preview: 6.4.0 -> 6.6.1
nemo-python: 6.4.0 -> 6.6.1
nemo-seahorse: 6.4.0 -> 6.6.1
nemo: 6.4.5 -> 6.6.1

nemo-emblems: 6.4.0 -> 6.6.2
nemo-fileroller: 6.4.0 -> 6.6.2
nemo-preview: 6.4.0 -> 6.6.2
nemo-python: 6.4.0 -> 6.6.2
nemo-seahorse: 6.4.0 -> 6.6.2
nemo: 6.4.5 -> 6.6.2

-->


Closes #445996

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

