### PR TITLE
cinder: init at 0.9.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9715,6 +9715,12 @@
     githubId = 19275558;
     name = "Julien Girard-Satabin";
   };
+  GiulioCocconi = {
+    name = "Giulio Cocconi";
+    email = "coccogiulio8@gmail.com";
+    github = "GiulioCocconi";
+    githubId = 31406038;
+  };
   GKasparov = {
     email = "mizozahr@gmail.com";
     github = "GKasparov";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10472,6 +10472,12 @@
     githubId = 19275558;
     name = "Julien Girard-Satabin";
   };
+  GiulioCocconi = {
+    name = "Giulio Cocconi";
+    email = "coccogiulio8@gmail.com";
+    github = "GiulioCocconi";
+    githubId = 31406038;
+  };
   GKasparov = {
     email = "mizozahr@gmail.com";
     github = "GKasparov";

--- a/pkgs/by-name/ci/cinder/package.nix
+++ b/pkgs/by-name/ci/cinder/package.nix
@@ -1,0 +1,161 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  cmake,
+  pkg-config,
+  glib,
+  zlib,
+  curl,
+  libGLX,
+  libx11,
+  xorg,
+  fontconfig,
+  pulseaudio,
+  expat,
+  libmpg123,
+  libsndfile,
+  libsysprof-capture,
+  gst_all_1,
+  cairo,
+
+  headless ? false,
+  disableAudio ? true,
+  disableVideo ? true,
+
+  buildTests ? true,
+  buildAllSamples ? false,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  name = "cinder";
+  version = "0.9.3";
+
+  src = fetchFromGitHub {
+    owner = "cinder";
+    repo = "Cinder";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-IPF8/PQ9iWmXwwJ6MBGtkbNcpOzW8VnyMaBRxXIN6DQ=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ]
+  ++ lib.optionals buildAllSamples [ cairo ];
+
+  propagatedBuildInputs = [
+    libGLX
+    curl
+    fontconfig
+    zlib
+    libx11
+    xorg.libxcb
+    xorg.libXrandr
+    xorg.libXinerama
+    xorg.libXcursor
+    xorg.libXi
+    expat
+  ]
+  ++ lib.optionals (!disableAudio) [
+    pulseaudio
+    libmpg123
+    libsndfile
+  ]
+  ++ lib.optionals (!disableVideo) [
+    glib
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-bad
+    libsysprof-capture
+  ];
+
+  prePatch = ''
+    substituteInPlace proj/cmake/modules/FindMPG123.cmake \
+      --replace-fail "NO_DEFAULT_PATH" ""
+
+    substituteInPlace proj/cmake/modules/FindSNDFILE.cmake \
+      --replace-fail "NO_DEFAULT_PATH" ""
+  '';
+
+  patches = [
+    (fetchpatch {
+      # TODO: Remove when [https://github.com/cinder/Cinder/pull/2386] get merged
+      name = "001-fixDisableVideo";
+      url = "https://github.com/cinder/Cinder/commit/94230d6dd42305c3f404a8fafd4f0fb1934349fa.patch";
+      hash = "sha256-xEWv/Zp6wMvxAOAy0BFPadhHlDGL95DrvDh9n/KRUIs=";
+    })
+    (fetchpatch {
+      name = "002-fixTimelineSamples";
+      url = "https://github.com/cinder/Cinder/commit/c7530ef4f2161be8e9e9fb4b4cafae6521272dc4.patch";
+      hash = "sha256-m5duVHNEmefy3mWbFXo6xBtUAOMaEkpednmNmH0JR+Y=";
+    })
+  ];
+
+  postPatch = lib.optionalString buildAllSamples ''
+    # Windows-specific samples
+    rm -rf samples/D3d11*
+    rm -rf samples/_opengl/NvidiaMulticast
+
+    # They don't work cause of missing blocks for Linux
+    rm -rf samples/LocationManager
+    rm -rf samples/MotionBasic
+
+    rm -rf samples/QuickTime*
+    rm -rf samples/ios*
+
+    rm -rf samples/Renderer2dBasic
+  '';
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=ON"
+  ]
+  ++ lib.optionals headless [ "-DCINDER_HEADLESS=ON" ]
+  ++ lib.optionals disableVideo [ "-DCINDER_DISABLE_VIDEO=ON" ]
+  ++ lib.optionals disableAudio [ "-DCINDER_DISABLE_AUDIO=ON" ]
+  ++ lib.optionals buildTests [ "-DCINDER_BUILD_TESTS=ON" ]
+  ++ lib.optionals buildAllSamples [ "-DCINDER_BUILD_ALL_SAMPLES=ON" ];
+
+  doCheck = buildTests;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+
+    mkdir -p $out/include/cinder
+    mkdir -p $out/lib/cmake/Cinder
+
+    cp -r ../include/cinder/* $out/include/cinder
+
+    find .. -name "libcinder.*" -exec cp {} $out/lib/ \;
+
+    find lib -name "cinderTargets.cmake" -exec cp {} $out/lib/cmake/Cinder/ \;
+
+    ${lib.optionalString buildAllSamples ''
+      mkdir -p $out/Samples
+      mkdir -p $out/bin
+
+      cp -Lr Release/* $out/Samples
+      rm -r $out/Samples/UnitTests
+
+      for dir in $out/Samples/*/; do
+        for file in "$dir"/*; do
+            [[ -x "$file" ]] && [[ -f "$file" ]] \
+              && ln -s $file $out/bin/cinder_$(basename "$file")
+        done
+      done
+    ''}
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Peer-reviewed, free, open source C++ library for creative coding";
+    homepage = "https://libcinder.org";
+    license = lib.licenses.bsd2;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ GiulioCocconi ];
+  };
+})

--- a/pkgs/by-name/ci/cinder/package.nix
+++ b/pkgs/by-name/ci/cinder/package.nix
@@ -1,0 +1,169 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  cmake,
+  pkg-config,
+  glib,
+  zlib,
+  curl,
+  libGLX,
+  libx11,
+  libxcb,
+  libxrandr,
+  libxinerama,
+  libxcursor,
+  libxi,
+  fontconfig,
+  pulseaudio,
+  expat,
+  libmpg123,
+  libsndfile,
+  libsysprof-capture,
+  patchelf,
+  gst_all_1,
+  cairo,
+
+  headless ? false,
+  enableAudio ? false,
+  enableVideo ? false,
+
+  buildTests ? true,
+  buildAllSamples ? false,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cinder";
+  version = "0.9.3";
+
+  src = fetchFromGitHub {
+    owner = "cinder";
+    repo = "Cinder";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-IPF8/PQ9iWmXwwJ6MBGtkbNcpOzW8VnyMaBRxXIN6DQ=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ]
+  ++ lib.optionals buildAllSamples [
+    cairo
+    patchelf
+  ];
+
+  propagatedBuildInputs = [
+    libGLX
+    curl
+    fontconfig
+    zlib
+    libx11
+    libxcb
+    libxrandr
+    libxinerama
+    libxcursor
+    libxi
+    expat
+  ]
+  ++ lib.optionals enableAudio [
+    pulseaudio
+    libmpg123
+    libsndfile
+  ]
+  ++ lib.optionals enableVideo [
+    glib
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-bad
+    libsysprof-capture
+  ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  patches = [
+    (fetchpatch {
+      # Remove when updating to a release containing https://github.com/cinder/Cinder/pull/2386.
+      name = "001-fixDisableVideo";
+      url = "https://github.com/cinder/Cinder/commit/94230d6dd42305c3f404a8fafd4f0fb1934349fa.patch";
+      hash = "sha256-xEWv/Zp6wMvxAOAy0BFPadhHlDGL95DrvDh9n/KRUIs=";
+    })
+    (fetchpatch {
+      name = "002-fixTimelineSamples";
+      url = "https://github.com/cinder/Cinder/commit/c7530ef4f2161be8e9e9fb4b4cafae6521272dc4.patch";
+      hash = "sha256-m5duVHNEmefy3mWbFXo6xBtUAOMaEkpednmNmH0JR+Y=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace \
+      proj/cmake/modules/FindMPG123.cmake \
+      proj/cmake/modules/FindSNDFILE.cmake \
+      --replace-fail "NO_DEFAULT_PATH" ""
+  ''
+  + lib.optionalString buildAllSamples ''
+    # Windows-specific samples
+    rm -r samples/D3d11*
+    rm -r samples/_opengl/NvidiaMulticast
+
+    # They don't work cause of missing blocks for Linux
+    rm -r samples/LocationManager
+    rm -r samples/MotionBasic
+
+    rm -r samples/QuickTime*
+    rm -r samples/ios*
+
+    rm -r samples/Renderer2dBasic
+  '';
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=ON"
+  ]
+  ++ lib.optionals headless [ "-DCINDER_HEADLESS=ON" ]
+  ++ lib.optionals (!enableVideo) [ "-DCINDER_DISABLE_VIDEO=ON" ]
+  ++ lib.optionals (!enableAudio) [ "-DCINDER_DISABLE_AUDIO=ON" ]
+  ++ lib.optionals buildTests [ "-DCINDER_BUILD_TESTS=ON" ]
+  ++ lib.optionals buildAllSamples [ "-DCINDER_BUILD_ALL_SAMPLES=ON" ];
+
+  doCheck = buildTests;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+
+    mkdir -p $out/include/cinder
+    mkdir -p $out/lib/cmake/Cinder
+
+    cp -r ../include/cinder/* $out/include/cinder
+
+    find .. -name "libcinder.*" -exec cp {} $out/lib/ \;
+
+    find lib -name "cinderTargets.cmake" -exec cp {} $out/lib/cmake/Cinder/ \;
+
+    ${lib.optionalString buildAllSamples ''
+      mkdir -p $out/share/cinder/samples
+      mkdir -p $out/bin
+
+      cp -Lr Release/* $out/share/cinder/samples
+      rm -r $out/share/cinder/samples/UnitTests
+
+      find "$out/share/cinder/samples" -mindepth 2 -maxdepth 2 -type f -executable \
+        -exec patchelf --shrink-rpath --allowed-rpath-prefixes "$NIX_STORE" {} \;
+
+      find "$out/share/cinder/samples" -mindepth 2 -maxdepth 2 -type f -executable \
+        -exec sh -c 'ln -s "$1" "$0/bin/cinder_$(basename "$1")"' "$out" {} \;
+    ''}
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Peer-reviewed, free, open source C++ library for creative coding";
+    homepage = "https://libcinder.org";
+    license = lib.licenses.bsd2;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ GiulioCocconi ];
+  };
+})


### PR DESCRIPTION
Ported Cinder library in nixpkgs. Cinder is a creative coding library for C++. 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [Package tests] at `passthru.tests`.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
