### PR TITLE
python3Packages.panasonic-viera: 0.4.2 -> 0.4.4

### DIFF
--- a/pkgs/development/python-modules/panasonic-viera/default.nix
+++ b/pkgs/development/python-modules/panasonic-viera/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   poetry-core,
   aiohttp,
   pycryptodome,
@@ -10,18 +10,17 @@
 
 buildPythonPackage rec {
   pname = "panasonic-viera";
-  version = "0.4.2";
+  version = "0.4.4";
   pyproject = true;
 
-  src = fetchPypi {
-    pname = "panasonic_viera";
-    inherit version;
-    hash = "sha256-gcFAFwEdCqiC1yHIA2B/gzmwvRwMC9fDxkgCbzIOpjM=";
+  src = fetchFromGitHub {
+    owner = "florianholzapfel";
+    repo = "panasonic-viera";
+    tag = version;
+    hash = "sha256-f/FLM6xoJwRZwq8Q6uf9W+fJN96wE6HvJozaNVmORtg=";
   };
 
   build-system = [ poetry-core ];
-
-  pythonRelaxDeps = [ "xmltodict" ];
 
   dependencies = [
     aiohttp
@@ -35,6 +34,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "panasonic_viera" ];
 
   meta = {
+    changelog = "https://github.com/florianholzapfel/panasonic-viera/releases/tag/${src.tag}";
     description = "Library to control Panasonic Viera TVs";
     homepage = "https://github.com/florianholzapfel/panasonic-viera";
     license = lib.licenses.mit;


### PR DESCRIPTION
Diff: https://github.com/florianholzapfel/panasonic-viera/compare/0.4.2...0.4.4

Changelog: https://github.com/florianholzapfel/panasonic-viera/releases/tag/0.4.4

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
