### PR TITLE
kdePackages: Gear 25.08 -> 25.12

### DIFF
--- a/pkgs/development/libraries/kquickimageedit/default.nix
+++ b/pkgs/development/libraries/kquickimageedit/default.nix
@@ -6,18 +6,19 @@
   kdePackages,
   qtbase,
   qtdeclarative,
+  opencv,
 }:
 
 stdenv.mkDerivation rec {
   pname = "kquickimageeditor";
-  version = "0.5.1";
+  version = "0.6.0";
 
   src = fetchFromGitLab {
     domain = "invent.kde.org";
     owner = "libraries";
     repo = "kquickimageeditor";
     rev = "v${version}";
-    sha256 = "sha256-8TJBg42E9lNbLpihjtc5Z/drmmSGQmic8yO45yxSNQ4=";
+    sha256 = "sha256-NhZ9aAZuIk9vUL2X7eivNbEs0zahuQpy8kl6dSdy5Lo=";
   };
 
   nativeBuildInputs = [ extra-cmake-modules ];
@@ -25,6 +26,14 @@ stdenv.mkDerivation rec {
     kdePackages.kirigami
     qtbase
     qtdeclarative
+    (opencv.override {
+      enableCuda = false; # fails to compile, disabled in case someone sets config.cudaSupport
+      enabledModules = [
+        "core"
+        "imgproc"
+      ];
+      runAccuracyTests = false; # tests will fail because of missing plugins but that's okay
+    })
   ];
   dontWrapQtApps = true;
 

--- a/pkgs/kde/default.nix
+++ b/pkgs/kde/default.nix
@@ -37,8 +37,6 @@ let
           inherit (v) version;
         }
       ) allUrls;
-
-      debugAlias = set: lib.dontRecurseIntoAttrs (lib.filterAttrs (k: v: !v.meta.broken) set);
     in
     (
       qt6Packages
@@ -46,12 +44,13 @@ let
       // gear
       // plasma
       // {
-        inherit sources;
-
         # Aliases to simplify test-building entire package sets
-        frameworks = debugAlias frameworks;
-        gear = debugAlias gear;
-        plasma = debugAlias plasma;
+        inherit
+          sources
+          frameworks
+          gear
+          plasma
+          ;
 
         mkKdeDerivation = self.callPackage (import ./lib/mk-kde-derivation.nix self) { };
 

--- a/pkgs/kde/gear/calligra/default.nix
+++ b/pkgs/kde/gear/calligra/default.nix
@@ -1,7 +1,6 @@
 {
   mkKdeDerivation,
   lib,
-  fetchpatch,
   boost,
   eigen,
   gsl,
@@ -26,14 +25,6 @@
 
 mkKdeDerivation {
   pname = "calligra";
-
-  patches = [
-    # Fix build with Poppler 25.10
-    (fetchpatch {
-      url = "https://invent.kde.org/office/calligra/-/commit/45e8b302bce1d318f310ea13599d7ce84acc477e.patch";
-      hash = "sha256-TECB3eo24+gI8TXL8gw9BIdFWqw0JBKCWpoNVqBSan8=";
-    })
-  ];
 
   extraBuildInputs = [
     boost

--- a/pkgs/kde/gear/ffmpegthumbs/default.nix
+++ b/pkgs/kde/gear/ffmpegthumbs/default.nix
@@ -1,9 +1,11 @@
 {
   mkKdeDerivation,
+  pkg-config,
   ffmpeg,
 }:
 mkKdeDerivation {
   pname = "ffmpegthumbs";
 
+  extraNativeBuildInputs = [ pkg-config ];
   extraBuildInputs = [ ffmpeg ];
 }

--- a/pkgs/kde/gear/itinerary/default.nix
+++ b/pkgs/kde/gear/itinerary/default.nix
@@ -3,6 +3,7 @@
   pkg-config,
   qtlocation,
   qtpositioning,
+  qcoro,
   shared-mime-info,
   libical,
 }:
@@ -19,6 +20,7 @@ mkKdeDerivation {
   extraBuildInputs = [
     qtlocation
     qtpositioning
+    qcoro
     libical
   ];
   meta.mainProgram = "itinerary";

--- a/pkgs/kde/gear/kalarm/default.nix
+++ b/pkgs/kde/gear/kalarm/default.nix
@@ -1,6 +1,7 @@
 {
   mkKdeDerivation,
   pkg-config,
+  kauth,
   mpv,
 }:
 mkKdeDerivation {
@@ -11,5 +12,8 @@ mkKdeDerivation {
   ];
 
   extraNativeBuildInputs = [ pkg-config ];
-  extraBuildInputs = [ mpv ];
+  extraBuildInputs = [
+    kauth
+    mpv
+  ];
 }

--- a/pkgs/kde/gear/kamoso/default.nix
+++ b/pkgs/kde/gear/kamoso/default.nix
@@ -1,6 +1,7 @@
 {
   mkKdeDerivation,
   pkg-config,
+  kirigami-addons,
   gst_all_1,
   frei0r,
 }:
@@ -9,6 +10,7 @@ mkKdeDerivation {
 
   extraNativeBuildInputs = [ pkg-config ];
   extraBuildInputs = [
+    kirigami-addons
     gst_all_1.gst-plugins-base
     (gst_all_1.gst-plugins-good.override { qt6Support = true; })
     gst_all_1.gst-plugins-bad

--- a/pkgs/kde/gear/kclock/default.nix
+++ b/pkgs/kde/gear/kclock/default.nix
@@ -1,13 +1,19 @@
 {
   mkKdeDerivation,
+  pkg-config,
   qtsvg,
   qtmultimedia,
+  wayland-protocols,
 }:
 mkKdeDerivation {
   pname = "kclock";
 
+  extraNativeBuildInputs = [ pkg-config ];
+
   extraBuildInputs = [
     qtsvg
     qtmultimedia
+
+    wayland-protocols
   ];
 }

--- a/pkgs/kde/gear/kdeconnect-kde/default.nix
+++ b/pkgs/kde/gear/kdeconnect-kde/default.nix
@@ -10,7 +10,6 @@
   wayland,
   wayland-protocols,
   libfakekey,
-  fetchpatch,
 }:
 mkKdeDerivation {
   pname = "kdeconnect-kde";
@@ -18,12 +17,6 @@ mkKdeDerivation {
   patches = [
     (replaceVars ./hardcode-sshfs-path.patch {
       sshfs = lib.getExe sshfs;
-    })
-    # Fix CVE-2025-66270 (https://kde.org/info/security/advisory-20251128-1.txt)
-    (fetchpatch {
-      name = "CVE-2025-66270.patch";
-      url = "https://invent.kde.org/network/kdeconnect-kde/-/commit/4e53bcdd5d4c28bd9fefd114b807ce35d7b3373e.patch";
-      hash = "sha256-qtcXNJ5qL4xtZQ70R/wWVCzFGzXNltr6XTgs0fpkTi4=";
     })
   ];
 

--- a/pkgs/kde/gear/kdenetwork-filesharing/dependency-paths.patch
+++ b/pkgs/kde/gear/kdenetwork-filesharing/dependency-paths.patch
@@ -1,71 +1,57 @@
 diff --git a/samba/filepropertiesplugin/authhelper.cpp b/samba/filepropertiesplugin/authhelper.cpp
-index 6cbbd90..ae1d696 100644
+index b45b25f..b71554f 100644
 --- a/samba/filepropertiesplugin/authhelper.cpp
 +++ b/samba/filepropertiesplugin/authhelper.cpp
-@@ -49,7 +49,7 @@ ActionReply AuthHelper::isuserknown(const QVariantMap &args)
+@@ -50,7 +50,7 @@ ActionReply AuthHelper::isuserknown(const QVariantMap &args)
      }
  
      QProcess p;
 -    const auto program = QStringLiteral("pdbedit");
 +    const auto program = QStringLiteral("@samba@/bin/pdbedit");
-     const auto arguments = QStringList({QStringLiteral("--debuglevel=0"), QStringLiteral("--user"), username });
+     const auto arguments = QStringList({QStringLiteral("--debuglevel=0"), QStringLiteral("--user"), username});
      p.setProgram(program);
      p.setArguments(arguments);
-@@ -88,7 +88,7 @@ ActionReply AuthHelper::createuser(const QVariantMap &args)
+@@ -92,7 +92,7 @@ ActionReply AuthHelper::createuser(const QVariantMap &args)
      }
  
      QProcess p;
 -    p.setProgram(QStringLiteral("smbpasswd"));
 +    p.setProgram(QStringLiteral("@samba@/bin/smbpasswd"));
-     p.setArguments({
-         QStringLiteral("-L"), /* local mode */
-         QStringLiteral("-s"), /* read from stdin */
-@@ -152,7 +152,7 @@ ActionReply AuthHelper::addtogroup(const QVariantMap &args)
-         QStringLiteral("-m"),
-         QStringLiteral("{%1}").arg(user.value()) });
+     p.setArguments({QStringLiteral("-L"), /* local mode */
+                     QStringLiteral("-s"), /* read from stdin */
+                     QStringLiteral("-D"),
+@@ -155,7 +155,7 @@ ActionReply AuthHelper::addtogroup(const QVariantMap &args)
+     p.setArguments(
+         {QStringLiteral("group"), QStringLiteral("mod"), QStringLiteral("{%1}").arg(group), QStringLiteral("-m"), QStringLiteral("{%1}").arg(user.value())});
  #elif defined(Q_OS_LINUX) || defined(Q_OS_HURD)
 -    p.setProgram(QStringLiteral("/usr/sbin/usermod"));
 +    p.setProgram(QStringLiteral("@usermod@"));
-     p.setArguments({
-         QStringLiteral("--append"),
-         QStringLiteral("--groups"),
+     p.setArguments({QStringLiteral("--append"), QStringLiteral("--groups"), group, user.value()});
+ #else
+ #error "Platform lacks group management support. Please add support."
 diff --git a/samba/filepropertiesplugin/groupmanager.cpp b/samba/filepropertiesplugin/groupmanager.cpp
-index a2ba851..d54f6ce 100644
+index 948f428..f25e549 100644
 --- a/samba/filepropertiesplugin/groupmanager.cpp
 +++ b/samba/filepropertiesplugin/groupmanager.cpp
 @@ -18,7 +18,7 @@ GroupManager::GroupManager(QObject *parent)
  {
-     metaObject()->invokeMethod(this, [this] {
+     QMetaObject::invokeMethod(this, [this] {
          auto proc = new QProcess;
 -        proc->setProgram(QStringLiteral("testparm"));
 +        proc->setProgram(QStringLiteral("@samba@/bin/testparm"));
          proc->setArguments({QStringLiteral("--debuglevel=0"),
                              QStringLiteral("--suppress-prompt"),
                              QStringLiteral("--verbose"),
-diff --git a/samba/filepropertiesplugin/sambausershareplugin.cpp b/samba/filepropertiesplugin/sambausershareplugin.cpp
-index 4f6642e..86ea121 100644
---- a/samba/filepropertiesplugin/sambausershareplugin.cpp
-+++ b/samba/filepropertiesplugin/sambausershareplugin.cpp
-@@ -112,7 +112,8 @@ SambaUserSharePlugin::SambaUserSharePlugin(QObject *parent)
- bool SambaUserSharePlugin::isSambaInstalled()
- {
-     return QFile::exists(QStringLiteral("/usr/sbin/smbd"))
--        || QFile::exists(QStringLiteral("/usr/local/sbin/smbd"));
-+        || QFile::exists(QStringLiteral("/usr/local/sbin/smbd"))
-+        || QFile::exists(QStringLiteral("/run/current-system/sw/bin/smbd"));
- }
- 
- void SambaUserSharePlugin::showSambaStatus()
 diff --git a/samba/filepropertiesplugin/usermanager.cpp b/samba/filepropertiesplugin/usermanager.cpp
-index 29238ce..ff20fcb 100644
+index 3be3b8c..66fd965 100644
 --- a/samba/filepropertiesplugin/usermanager.cpp
 +++ b/samba/filepropertiesplugin/usermanager.cpp
-@@ -138,7 +138,7 @@ bool UserManager::canManageSamba() const
+@@ -134,7 +134,7 @@ bool UserManager::canManageSamba() const
  void UserManager::load()
  {
      auto proc = new QProcess(this);
 -    proc->setProgram(QStringLiteral("testparm"));
 +    proc->setProgram(QStringLiteral("@samba@/bin/testparm"));
-     proc->setArguments({
-         QStringLiteral("--debuglevel=0"),
-         QStringLiteral("--suppress-prompt"),
+     proc->setArguments({QStringLiteral("--debuglevel=0"),
+                         QStringLiteral("--suppress-prompt"),
+                         QStringLiteral("--verbose"),

--- a/pkgs/kde/gear/kdenlive/default.nix
+++ b/pkgs/kde/gear/kdenlive/default.nix
@@ -9,6 +9,7 @@
   qtsvg,
   qtmultimedia,
   qtnetworkauth,
+  kddockwidgets,
   qqc2-desktop-style,
   libv4l,
   opentimelineio,
@@ -38,6 +39,7 @@ mkKdeDerivation {
     qtmultimedia
     qtnetworkauth
 
+    kddockwidgets
     qqc2-desktop-style
 
     ffmpeg-full

--- a/pkgs/kde/gear/kpkpass/default.nix
+++ b/pkgs/kde/gear/kpkpass/default.nix
@@ -1,9 +1,11 @@
 {
   mkKdeDerivation,
   shared-mime-info,
+  qtdeclarative,
 }:
 mkKdeDerivation {
   pname = "kpkpass";
 
   extraNativeBuildInputs = [ shared-mime-info ];
+  extraBuildInputs = [ qtdeclarative ];
 }

--- a/pkgs/kde/gear/kpublictransport/default.nix
+++ b/pkgs/kde/gear/kpublictransport/default.nix
@@ -1,11 +1,15 @@
 {
   mkKdeDerivation,
   qtdeclarative,
+  qtlocation,
   pkg-config,
 }:
 mkKdeDerivation {
   pname = "kpublictransport";
 
   extraNativeBuildInputs = [ pkg-config ];
-  extraBuildInputs = [ qtdeclarative ];
+  extraBuildInputs = [
+    qtdeclarative
+    qtlocation
+  ];
 }

--- a/pkgs/kde/gear/lokalize/default.nix
+++ b/pkgs/kde/gear/lokalize/default.nix
@@ -1,11 +1,16 @@
 {
   mkKdeDerivation,
   pkg-config,
+  kddockwidgets,
   hunspell,
 }:
 mkKdeDerivation {
   pname = "lokalize";
 
   extraNativeBuildInputs = [ pkg-config ];
-  extraBuildInputs = [ hunspell ];
+  extraBuildInputs = [
+    kddockwidgets
+
+    hunspell
+  ];
 }

--- a/pkgs/kde/gear/qrca/default.nix
+++ b/pkgs/kde/gear/qrca/default.nix
@@ -2,10 +2,14 @@
   mkKdeDerivation,
   pkg-config,
   qtmultimedia,
+  kirigami-addons,
 }:
 mkKdeDerivation {
   pname = "qrca";
 
   extraNativeBuildInputs = [ pkg-config ];
-  extraBuildInputs = [ qtmultimedia ];
+  extraBuildInputs = [
+    qtmultimedia
+    kirigami-addons
+  ];
 }

--- a/pkgs/kde/gear/rocs/default.nix
+++ b/pkgs/kde/gear/rocs/default.nix
@@ -6,6 +6,4 @@ mkKdeDerivation {
   pname = "rocs";
 
   extraBuildInputs = [ boost ];
-  # FIXME(qt5)
-  meta.broken = true;
 }

--- a/pkgs/kde/gear/umbrello/default.nix
+++ b/pkgs/kde/gear/umbrello/default.nix
@@ -1,6 +1,4 @@
 { mkKdeDerivation }:
 mkKdeDerivation {
   pname = "umbrello";
-  # FIXME(qt5)
-  meta.broken = true;
 }

--- a/pkgs/kde/generated/sources/gear.json
+++ b/pkgs/kde/generated/sources/gear.json
@@ -1,1247 +1,1247 @@
 {
   "accessibility-inspector": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/accessibility-inspector-25.08.3.tar.xz",
-    "hash": "sha256-qu5u3kDAOYIAffLouVLn/mxTFOFBhFCU4ox1U3NEeQA="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/accessibility-inspector-25.12.0.tar.xz",
+    "hash": "sha256-bFlWQfUKjbYUmStf1uWrCmScIm/cabHdmQkNr2Yk/Kc="
   },
   "akonadi": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/akonadi-25.08.3.tar.xz",
-    "hash": "sha256-+Gf9HhbZ1jepLaszTcQXDyD1i+EzZzkglOxTnj7uAXo="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/akonadi-25.12.0.tar.xz",
+    "hash": "sha256-idD/yebwZYV+XW/7CF81LJmK4vMcnd+BL1aW09FmYNw="
   },
   "akonadi-calendar": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/akonadi-calendar-25.08.3.tar.xz",
-    "hash": "sha256-vuMRKJCiHyq2AFholD0lbHnFGPwbWyR/AUy4vazdQMI="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/akonadi-calendar-25.12.0.tar.xz",
+    "hash": "sha256-uPmLZTFUQuO4Zt2gLs19itxYxJdBPMh/GFzPOCqw6RI="
   },
   "akonadi-calendar-tools": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/akonadi-calendar-tools-25.08.3.tar.xz",
-    "hash": "sha256-jHkM7gF8fMMx97aQqCe9MsW0kmB5Z47CS7gA0mxPHqY="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/akonadi-calendar-tools-25.12.0.tar.xz",
+    "hash": "sha256-rHvUxuHSyBfPE+VpXyL6eCjRosK3wULe131WO2Nqh3o="
   },
   "akonadi-contacts": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/akonadi-contacts-25.08.3.tar.xz",
-    "hash": "sha256-OEAOvm4cudm/U2vNwym9ZI0r2HviMn0EtJNhxmzz0k0="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/akonadi-contacts-25.12.0.tar.xz",
+    "hash": "sha256-X1KBhu7Dim+drR2cNn9ZQbnMve531hKfHG5dbxNSVHU="
   },
   "akonadi-import-wizard": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/akonadi-import-wizard-25.08.3.tar.xz",
-    "hash": "sha256-X9O1offbeIUoyXR/70tz8KjKfHvCzw41uC3ODK/tE5k="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/akonadi-import-wizard-25.12.0.tar.xz",
+    "hash": "sha256-7lNnh/jKT4KZvnKZC5TPJLYWNOTIMY489bahKtUTYos="
   },
   "akonadi-mime": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/akonadi-mime-25.08.3.tar.xz",
-    "hash": "sha256-ciKSy8ewUeaLC3wFo3H6VarzHqi8Z/LdHOcz4O2xImY="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/akonadi-mime-25.12.0.tar.xz",
+    "hash": "sha256-jd3yQCVfSzLkaX5dqgS8LxTbeJAbUiThvimTWrME9fg="
   },
   "akonadi-search": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/akonadi-search-25.08.3.tar.xz",
-    "hash": "sha256-PI19LYADtJYBgxaA/BG6kNp5xRaYbMJscWALud5531E="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/akonadi-search-25.12.0.tar.xz",
+    "hash": "sha256-jcSc9/NAiObeuxOHMU0DO7fc3k2vrXwRe3039KVMuPY="
   },
   "akonadiconsole": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/akonadiconsole-25.08.3.tar.xz",
-    "hash": "sha256-CJAdImBZ5k6kcUXw/g6XEEqf7no9SbHWnOeVxGnvRNo="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/akonadiconsole-25.12.0.tar.xz",
+    "hash": "sha256-GINFkQ9xjxDJ3BG9i3RcGPCr8+Yr40x5eqXugeYehVU="
   },
   "akregator": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/akregator-25.08.3.tar.xz",
-    "hash": "sha256-HGe7qUnvN2xwfUOV5qo3mNFy67cwOuNHIt/m1cCbD4M="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/akregator-25.12.0.tar.xz",
+    "hash": "sha256-d1LeUp3D0FL0E4nSxup2jHEKztmnaKiKlatQJy3UUZ0="
   },
   "alligator": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/alligator-25.08.3.tar.xz",
-    "hash": "sha256-OAbXqoE/jrw061PPelDgaXObSbaR1Yt8kGOAXDTcuPo="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/alligator-25.12.0.tar.xz",
+    "hash": "sha256-5eTAFkch+ywWMYUTiWyrea/OZshSIxRYObTszMDqnRQ="
   },
   "analitza": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/analitza-25.08.3.tar.xz",
-    "hash": "sha256-Gr50HD8Ymz2MuM80tRaJD9ZM8hunXQ9VizcRlWuD5NE="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/analitza-25.12.0.tar.xz",
+    "hash": "sha256-7XXsx+hn2A+2wjtAtXzXlL47ebF9OnvdCBqGioqgHr0="
   },
   "angelfish": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/angelfish-25.08.3.tar.xz",
-    "hash": "sha256-ccSns9ZlDrW9mn0ILOA++s4LtegG2POZ561nW7BkN2w="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/angelfish-25.12.0.tar.xz",
+    "hash": "sha256-XIBKUQMtpgM3bh/wcQ+t+A1a7oFxUoeLdatRMYtSJcs="
   },
   "arianna": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/arianna-25.08.3.tar.xz",
-    "hash": "sha256-Ou6H67yjIW6oZ2A2JmMSpeekrzQGwg3soS76n4tb2rQ="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/arianna-25.12.0.tar.xz",
+    "hash": "sha256-A0Mot3MJ+lz85SVLkJs67jaHDlw3KWuQK0pfSH2+Hkg="
   },
   "ark": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/ark-25.08.3.tar.xz",
-    "hash": "sha256-yk+3KV8JAoDfAtJLZPET4QxvYYE4s4e8H9eixWHeVU8="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/ark-25.12.0.tar.xz",
+    "hash": "sha256-oRB+AQSfNFeCwgsquuMXHstuljuwL/u4FOA1ewJLtcA="
   },
   "artikulate": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/artikulate-25.08.3.tar.xz",
-    "hash": "sha256-B8BF81lWTN5ri6U4xtDCq72pKDQekypFy0CBxMFdqOU="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/artikulate-25.12.0.tar.xz",
+    "hash": "sha256-wAslVXw1WVp1rrQe6WmlUCKe/UXu3T2rceYPM3asYaY="
   },
   "audex": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/audex-25.08.3.tar.xz",
-    "hash": "sha256-eaECo9FOa12Sa+DQpmNF/VtYHDwCHlqbZSCBfugT7I4="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/audex-25.12.0.tar.xz",
+    "hash": "sha256-imIVuFoxXh1eSOfYetYapZadbCtUOokUJt5TSVm6fLg="
   },
   "audiocd-kio": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/audiocd-kio-25.08.3.tar.xz",
-    "hash": "sha256-buOBRu17YVBH2wPhQgXqkiEknm64RyS9ZgmvmC9X7qw="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/audiocd-kio-25.12.0.tar.xz",
+    "hash": "sha256-6QrXfkbPXKkfkcnq6k8hQghU0Sv5LpHxBAW0ogSVVoo="
   },
   "audiotube": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/audiotube-25.08.3.tar.xz",
-    "hash": "sha256-7g7PpDufa5qrtYPe4OIB8paScfp3ua28HauzSsFJte4="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/audiotube-25.12.0.tar.xz",
+    "hash": "sha256-LYfq20L+RS0BcSBs46HmACZ64VLHWrWH1L9glPS/G3M="
   },
   "baloo-widgets": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/baloo-widgets-25.08.3.tar.xz",
-    "hash": "sha256-/AqOxTIbP0uw4fFlzY51dwGbkNV1UXCAJjSmjfw858s="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/baloo-widgets-25.12.0.tar.xz",
+    "hash": "sha256-jt+FX7k0e+00jIviuvwB0YOAp4h6Javi5xbAoR2ab4M="
   },
   "blinken": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/blinken-25.08.3.tar.xz",
-    "hash": "sha256-dwWY8ifoy7abSw3eTjum3qEHTj4Kin8H5CQ6GL+HbW0="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/blinken-25.12.0.tar.xz",
+    "hash": "sha256-qIeNVt18MbXV1T6A4juQEAqZkVLjh9CNqtoFh7LDVts="
   },
   "bomber": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/bomber-25.08.3.tar.xz",
-    "hash": "sha256-eMHM10FRXCpUIJATB7hz/FLIb0xaHlGHBHIhX4zpzJs="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/bomber-25.12.0.tar.xz",
+    "hash": "sha256-OEz4Ai0LVBvuCFETWXdBfFogW6Knhp+YZvwFTCFNHh0="
   },
   "bovo": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/bovo-25.08.3.tar.xz",
-    "hash": "sha256-3+YkhXzh3seAlgygDr7mFe5rULouf6DBSF7NGFVxzeY="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/bovo-25.12.0.tar.xz",
+    "hash": "sha256-dtvYXrqSYpUJWVBEfSt5Ya+INfE6DDb5d8nDeOECJ5s="
   },
   "calendarsupport": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/calendarsupport-25.08.3.tar.xz",
-    "hash": "sha256-g0NzWYHoxBRm1w06SOcOHOIyipKO3QvtLa6QOaPPna0="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/calendarsupport-25.12.0.tar.xz",
+    "hash": "sha256-G2+fEWsXZ0dXYgDk5xwnlD18LlbtjT1QdF3epOBmtnE="
   },
   "calindori": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/calindori-25.08.3.tar.xz",
-    "hash": "sha256-t7ylpu88XTa6qK6cVg+/V9mlPmkl1qJIYa7MKn3mzLw="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/calindori-25.12.0.tar.xz",
+    "hash": "sha256-hgcVWX0hGhDMG+4tyjVOLm/F0jWwg3cfVX6JxFc/m7U="
   },
   "calligra": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/calligra-25.08.3.tar.xz",
-    "hash": "sha256-dPrHglPEKYU+mfrgC88rhDMtvDqPU4zPcGdCWSZrklE="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/calligra-25.12.0.tar.xz",
+    "hash": "sha256-DhWQlhExxcp2kPbWkRMSObaFQD0U80bAE428fi+Kafs="
   },
   "cantor": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/cantor-25.08.3.tar.xz",
-    "hash": "sha256-VjUAf7nFDYLojez5Jk/0D7n07mWydHTFkwsbUZ6yS3I="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/cantor-25.12.0.tar.xz",
+    "hash": "sha256-Byo7viOGVEBPF/71HE4KrbG3hi7tjrj5/tfUJiiALYk="
   },
   "colord-kde": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/colord-kde-25.08.3.tar.xz",
-    "hash": "sha256-KaawondaAKO9WxsTjHc3LlOviARYDB5BK4edSOXQrt8="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/colord-kde-25.12.0.tar.xz",
+    "hash": "sha256-c8FCQeseaI9KIxOJtywmZHqfOngfpI34wZy5Cs6izIM="
   },
   "dolphin": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/dolphin-25.08.3.tar.xz",
-    "hash": "sha256-Gr1jLr44N99WFiFvacPKn2JAFl+fhFAkIiAydeqo7gk="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/dolphin-25.12.0.tar.xz",
+    "hash": "sha256-AtZwWcE8Wkz3SEfw8cDPmm3kc0XKgPLjuluo9AhIG/8="
   },
   "dolphin-plugins": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/dolphin-plugins-25.08.3.tar.xz",
-    "hash": "sha256-KESdFeCqzndWPztvE/R7oGhUFgoHXfQjh/wD9nCousU="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/dolphin-plugins-25.12.0.tar.xz",
+    "hash": "sha256-9u42YKdGvT0JPECs0QKy4e6kUWHNBh1upNwYc8sqnGw="
   },
   "dragon": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/dragon-25.08.3.tar.xz",
-    "hash": "sha256-nh0v6TAYFmQYy/yC/C+ThNHFyZvBtQDGkHLI/iz50Dg="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/dragon-25.12.0.tar.xz",
+    "hash": "sha256-zvMmhMwZfwxWGysY3fU7s6ms8KjJziKY3IhJMe9G7pk="
   },
   "elisa": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/elisa-25.08.3.tar.xz",
-    "hash": "sha256-Y2dLvQWKUY10C9mIDWWpr2qBb8M/uQTMHwwMJIRH3RM="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/elisa-25.12.0.tar.xz",
+    "hash": "sha256-3EcGcueQztHkyqzub7QWVVUmgvNLGj6iq/4ACd0yogs="
   },
   "eventviews": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/eventviews-25.08.3.tar.xz",
-    "hash": "sha256-6hbNGZOcfU9bna+575N2PosvJsLfIsZw9qV4LdEOOD4="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/eventviews-25.12.0.tar.xz",
+    "hash": "sha256-OZlITWv03dYRnbYHrLXdfYHG3qt/j1G6nRz5Ao8Yh0A="
   },
   "falkon": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/falkon-25.08.3.tar.xz",
-    "hash": "sha256-FiUtikICi/VLiOHkpa+5WHUwneRPIDFWyZxKZDcg4Sk="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/falkon-25.12.0.tar.xz",
+    "hash": "sha256-bZtNuhveDQRXBzbte7m8EojNf7lLT/6TSpkJErm3qVk="
   },
   "ffmpegthumbs": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/ffmpegthumbs-25.08.3.tar.xz",
-    "hash": "sha256-hOzRMaUHmYFfQUUi/BJwxW4O5Fu/r5b54dLJJ43ISWI="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/ffmpegthumbs-25.12.0.tar.xz",
+    "hash": "sha256-5HhO79GvV+0GYJLOWRvOhRXP/aXZlmjX5xka8FzMa88="
   },
   "filelight": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/filelight-25.08.3.tar.xz",
-    "hash": "sha256-ijqCXFocTzZi17eG91v4+u9qyfZyPI6M0p5s8VvagIA="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/filelight-25.12.0.tar.xz",
+    "hash": "sha256-NVOGzBDoiAjuv3b7yECUvCS5DXav4oqb2kG2tJOBpas="
   },
   "francis": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/francis-25.08.3.tar.xz",
-    "hash": "sha256-o71EolKHj7XhRRZYBqG6pxt+QL6T7ZTVvYd3GHWV/jE="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/francis-25.12.0.tar.xz",
+    "hash": "sha256-jgLEvfXEoubuxM8j0gAw+a1Nrgz96frVOlInrDdu+Os="
   },
   "ghostwriter": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/ghostwriter-25.08.3.tar.xz",
-    "hash": "sha256-OZlp7wcHz0iD/OFy1qIt+vKSlKmw+tLnFq1oBFICsAY="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/ghostwriter-25.12.0.tar.xz",
+    "hash": "sha256-1enTy230FTxkM7dnLQEYpinbbL2skv4V+18j6CTBGhI="
   },
   "granatier": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/granatier-25.08.3.tar.xz",
-    "hash": "sha256-9JMa+NH6DVZaEsPsiANiSih1cWxalCsWzIgZOuEBYm8="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/granatier-25.12.0.tar.xz",
+    "hash": "sha256-p0ns1FsrV3e7F/ZxhVcsTfengwu74JJi8kzdF7Y4DkY="
   },
   "grantlee-editor": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/grantlee-editor-25.08.3.tar.xz",
-    "hash": "sha256-atnws3Sd5VfsR8SdqRR1Q5JIWmZGHA1o9R/XcYhaVbU="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/grantlee-editor-25.12.0.tar.xz",
+    "hash": "sha256-R9LNJq93FlS0gjXA45kvlugtV1mgYNRw/LyCKOeKuzw="
   },
   "grantleetheme": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/grantleetheme-25.08.3.tar.xz",
-    "hash": "sha256-ZJ3pmbthKI/JtK7T6+Ix5FIBzWz9TyR2Nqf9Jw74euA="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/grantleetheme-25.12.0.tar.xz",
+    "hash": "sha256-H+Se8Ebf93LjcARfOccLyYcxDoY/nSDZRs03y7OLXEc="
   },
   "gwenview": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/gwenview-25.08.3.tar.xz",
-    "hash": "sha256-IADELUDuPpLONV+C0v3dB9J/YT9xzy5laZz+eUp27KE="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/gwenview-25.12.0.tar.xz",
+    "hash": "sha256-zzKKVoxe84XIrQUAuIXRMEndWZSS0kefXYMeI0EL94w="
   },
   "incidenceeditor": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/incidenceeditor-25.08.3.tar.xz",
-    "hash": "sha256-0MFcN1FyOrzxAaI6axYtMp4IkknpS9/UKD1o3s8hGpg="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/incidenceeditor-25.12.0.tar.xz",
+    "hash": "sha256-baIc5GY64RuvAGh9QiXGXMqBzq6cpDaqz7aE5xca588="
   },
   "isoimagewriter": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/isoimagewriter-25.08.3.tar.xz",
-    "hash": "sha256-hhC0t4mo11DG9PKOHStfmE7/1+uCKDJeZzrU9CJRLi4="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/isoimagewriter-25.12.0.tar.xz",
+    "hash": "sha256-uqqMYZdHy/emW26D6kUJIaE3/j43QomoC3zJ2o5187k="
   },
   "itinerary": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/itinerary-25.08.3.tar.xz",
-    "hash": "sha256-KPjO9H+UnOSDJvbSiC1YwceXpuMkxR9dNRDn2yIWH4c="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/itinerary-25.12.0.tar.xz",
+    "hash": "sha256-9kxjS7UhpGBKTrKNoqmkmJqe/byBsKOdepwjiQXioLw="
   },
   "juk": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/juk-25.08.3.tar.xz",
-    "hash": "sha256-uVwfu1rgZ0U7KrUrnA6MCNW7V+4+Xtyx0fsMcC+P/ok="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/juk-25.12.0.tar.xz",
+    "hash": "sha256-qy1yAc1LD2TOjeXOXrOBrnwyOtiGckh0alPGwbteS9o="
   },
   "k3b": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/k3b-25.08.3.tar.xz",
-    "hash": "sha256-Vx4fWYGeYwv/2pbJbGMm1fEoqkVW4oK+UZ9MhAkQXSU="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/k3b-25.12.0.tar.xz",
+    "hash": "sha256-XS3LLHBysYLqAlbzuE/3gIexorBpm9+1c3ChaX7z9YM="
   },
   "kaccounts-integration": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kaccounts-integration-25.08.3.tar.xz",
-    "hash": "sha256-f6A0Pww/WTdcSBfL0psP7X5Fy7MfSVbm0/YsCr4qHIs="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kaccounts-integration-25.12.0.tar.xz",
+    "hash": "sha256-1sY+V3duOFG1WabmS/DeRl0sx1HvoH0SsMKpBB6/RxE="
   },
   "kaccounts-providers": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kaccounts-providers-25.08.3.tar.xz",
-    "hash": "sha256-EipO8htZau91+iu0HM2XxzMt/NYjSiYCrubBPFhFEG8="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kaccounts-providers-25.12.0.tar.xz",
+    "hash": "sha256-qR+2aQR8ZFYR0St3El1gvGsT9lBDvUN7vmi5A1f9sow="
   },
   "kaddressbook": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kaddressbook-25.08.3.tar.xz",
-    "hash": "sha256-hTXzTM0UKGKQcq/V4uc5xZ4p5KDGfkRPCZF8pDAXqlc="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kaddressbook-25.12.0.tar.xz",
+    "hash": "sha256-j8lxInwa4dBZrfjk0hfy0/rKymn91Jea9z8Je5QX2V4="
   },
   "kajongg": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kajongg-25.08.3.tar.xz",
-    "hash": "sha256-R9WGyP0U6ZG/snih9ahTOH681PEhgdLVyc3rQ9+udXg="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kajongg-25.12.0.tar.xz",
+    "hash": "sha256-slektzNijcAte+/NzkqXpTljpnQPO3ERuZBYC+S2mBs="
   },
   "kalarm": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kalarm-25.08.3.tar.xz",
-    "hash": "sha256-NHufVkcecLTDNe6WvHan1cFIut/RRgzQDoi9s/9sZ1k="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kalarm-25.12.0.tar.xz",
+    "hash": "sha256-gL2cxV/KkWU8F1fx9ReyeyPQxeKHlvhMg9OWEofh8d4="
   },
   "kalgebra": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kalgebra-25.08.3.tar.xz",
-    "hash": "sha256-PcUwwsjUpIuhwtcRfS3hxH4GVCVfo8jUX2xtqs+bHUE="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kalgebra-25.12.0.tar.xz",
+    "hash": "sha256-+1eV2e/gPe2Pi2sZ12cwIEkThB3ICfBvpFP2mudDfNU="
   },
   "kalk": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kalk-25.08.3.tar.xz",
-    "hash": "sha256-8hip+c2oPhJECwgyxb7V18VNgLM1vHeFpjT4eSm53NA="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kalk-25.12.0.tar.xz",
+    "hash": "sha256-bwNpkZYUatnk568gyOxBAKCQu+HOsWWEuW1P2WqjKc0="
   },
   "kalm": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kalm-25.08.3.tar.xz",
-    "hash": "sha256-z9QK5UcuKGaN295py/dxCV6eKP/oDPMHxDl1MiSnT2k="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kalm-25.12.0.tar.xz",
+    "hash": "sha256-2PUuRVtrhDkZK5SSNkE7jmH23pTZ1KHl33vFwfl0Y2M="
   },
   "kalzium": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kalzium-25.08.3.tar.xz",
-    "hash": "sha256-NubE9G4aXaqs4U67Wx9trDQprV3z1PwfCt6uw+KOQgs="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kalzium-25.12.0.tar.xz",
+    "hash": "sha256-n/U6WOZVpnQFZhhSK3oqRPpUt+H3L5G00gEEwo/oKws="
   },
   "kamera": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kamera-25.08.3.tar.xz",
-    "hash": "sha256-Tca4sPtHkoi2V3tEbEVDF14hM2THkb1lC2HsevhV7RI="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kamera-25.12.0.tar.xz",
+    "hash": "sha256-CyQC61dh+cbTNQOYoLepdhURw9+eqcUS8SA8aA/YIrY="
   },
   "kamoso": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kamoso-25.08.3.tar.xz",
-    "hash": "sha256-QhlpQxS3w15yyFAI++GFmuKLuAIHsdI/tHf5v8LzGLc="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kamoso-25.12.0.tar.xz",
+    "hash": "sha256-641Zoq7kP1mKNv+2uyc+zNAWflBR9m1wEa90yNcN5q8="
   },
   "kanagram": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kanagram-25.08.3.tar.xz",
-    "hash": "sha256-wVoqCywIzvdFUiDu3fzDCV027qFNaE/F+5/y8dCly7w="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kanagram-25.12.0.tar.xz",
+    "hash": "sha256-cXXBoQlyOXqCr7D+lW9X2WMlFX+b/VxXQ3mVxUs/udI="
   },
   "kapman": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kapman-25.08.3.tar.xz",
-    "hash": "sha256-m2RJ6npbJ9Ih50cU3aLyd2Rcz0MJFVJGhD6lv/9FKXM="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kapman-25.12.0.tar.xz",
+    "hash": "sha256-SlTWgNNDoe1H/LCYzOtQmeMLpCEbe0dLLL0Ap8XeMyY="
   },
   "kapptemplate": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kapptemplate-25.08.3.tar.xz",
-    "hash": "sha256-NQbkTNMLdIgsoQgkqsUsXOJqs5axBSqOVSQcU20MXno="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kapptemplate-25.12.0.tar.xz",
+    "hash": "sha256-cNaaScUz04cYDocHuHUeUPthW/tgUjHhk+miPZ68u34="
   },
   "kasts": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kasts-25.08.3.tar.xz",
-    "hash": "sha256-zMyOMsnPIG8t/J2zYZaGQ5w+BbnTUr6KyVHJnJrYYnM="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kasts-25.12.0.tar.xz",
+    "hash": "sha256-z/JTdCKpdSnlWjwrn1fjPgrmdXSWWD+xK0UCZklpUoI="
   },
   "kate": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kate-25.08.3.tar.xz",
-    "hash": "sha256-yS64tbgcm13JG1xG0gtPOuC3gREUd5/Y+S8VMjP8qQs="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kate-25.12.0.tar.xz",
+    "hash": "sha256-6kFCxA7rOSrtUzVIVaAOPIFsRX3+JVtAfF0wyGk3f1Y="
   },
   "katomic": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/katomic-25.08.3.tar.xz",
-    "hash": "sha256-kCG+G+/Nog0lOCy1xiDNZsu/DqOqYhsKrkCpBVOrQsw="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/katomic-25.12.0.tar.xz",
+    "hash": "sha256-M/oDzHmfc4HQ4CgXnEUVlPIi6fqkjaaWBgaD7Py8fBE="
   },
   "kbackup": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kbackup-25.08.3.tar.xz",
-    "hash": "sha256-/4keGs/pu0IApPaBZUAlWbsAzs2HkTQc1NQClpVf/CQ="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kbackup-25.12.0.tar.xz",
+    "hash": "sha256-kWYcBkqXv///TxnbHU2k6geTxoTRrJEyHFgdMAoxTNA="
   },
   "kblackbox": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kblackbox-25.08.3.tar.xz",
-    "hash": "sha256-7wCVZaokDWZI4FF7vp7Sh7wfWkpEBdbyHT7t4+2/oV8="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kblackbox-25.12.0.tar.xz",
+    "hash": "sha256-y6V3DhsCuQtPMiYjwA54lQwfzPFq+YyOC123QxZnggI="
   },
   "kblocks": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kblocks-25.08.3.tar.xz",
-    "hash": "sha256-CRr+lf/Wh/tIU1d1X3QbRKQYCZOhZpUvtbopUO7OBK0="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kblocks-25.12.0.tar.xz",
+    "hash": "sha256-nU9498kODpAz4jADTlJ9ZLu2rnBVL/QmrUByeJkeUFg="
   },
   "kbounce": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kbounce-25.08.3.tar.xz",
-    "hash": "sha256-8UGeSUSGMiO1ontayzIo61giS26vTwyUFkwEYaw9kBo="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kbounce-25.12.0.tar.xz",
+    "hash": "sha256-xWFE0Cu55SSwz7JkpQ4CNvHMJkARgcSyfywzxSDImKg="
   },
   "kbreakout": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kbreakout-25.08.3.tar.xz",
-    "hash": "sha256-BYvwHpN/rc0ykS6ARVh1ZulPfAXQrXE/TmXW01GwT0A="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kbreakout-25.12.0.tar.xz",
+    "hash": "sha256-9VDPh1Dn+BjmtbYMBOFAJO12CorOcPe5zku4XT1cbR4="
   },
   "kbruch": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kbruch-25.08.3.tar.xz",
-    "hash": "sha256-j9VTZXEbvtWe285Mg5fqPoMWyASGYnyiky095Eg7s1w="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kbruch-25.12.0.tar.xz",
+    "hash": "sha256-A0q3SYD57FiX65bbT20+SlPD1N53NglCYzDyxmcENr4="
   },
   "kcachegrind": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kcachegrind-25.08.3.tar.xz",
-    "hash": "sha256-rsg436gGtDjRmPW7ZqKpkl7NuG0J2obFk6ITAgUrC74="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kcachegrind-25.12.0.tar.xz",
+    "hash": "sha256-dmlv3t0K3WJpEZG8xR7eOc1C7jGhck3kPziky7W9/Ag="
   },
   "kcalc": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kcalc-25.08.3.tar.xz",
-    "hash": "sha256-DoQslASW5H9avR7GCB9cbPKIvh3XPttQcdhPBOyhg4o="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kcalc-25.12.0.tar.xz",
+    "hash": "sha256-QxgTaPYwMFAyFyK2NEihFUgH00AT35l+DorIsdBdPww="
   },
   "kcalutils": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kcalutils-25.08.3.tar.xz",
-    "hash": "sha256-zqA3tnpRC6TjwJE6kLor/3JAcLKSUSSN8jr1+wuxii0="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kcalutils-25.12.0.tar.xz",
+    "hash": "sha256-QwSBNOBV/6PnV/3jTr0b7eyN/28mjnPscMjO/7lDPMA="
   },
   "kcharselect": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kcharselect-25.08.3.tar.xz",
-    "hash": "sha256-r+4jbl4Dda7gOO1CkqOhiPpRJR2Sq46HLNn+cTzeOuM="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kcharselect-25.12.0.tar.xz",
+    "hash": "sha256-yudTTHgwmYtUheV+wrMxwSsN9gIhNRbAu422guNP+NM="
   },
   "kclock": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kclock-25.08.3.tar.xz",
-    "hash": "sha256-2Kz8qjb/jdQk3oKuFja63Zqi9QpsTj41eI7VzDliduI="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kclock-25.12.0.tar.xz",
+    "hash": "sha256-iUekqVEOLZ+uSSOMwmfAFcwbHJHgLNBy8C2n8CBSryM="
   },
   "kcolorchooser": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kcolorchooser-25.08.3.tar.xz",
-    "hash": "sha256-as7OA7OASmEIItBY+7vNq+w/4a2mqL/+1tNpUmkwvmc="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kcolorchooser-25.12.0.tar.xz",
+    "hash": "sha256-+emXHtoXXLQG5sCSqlS3Tgi7hPC2PJya+uoRAf83Z/Y="
   },
   "kcron": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kcron-25.08.3.tar.xz",
-    "hash": "sha256-UqVAID6bKN6+UkBefDEpzia1OvHdwXFlt7UlVcx1e2c="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kcron-25.12.0.tar.xz",
+    "hash": "sha256-7y1o2rqiNGGKpn5pB3+ZOmySAXsdR0/DPFXgMAaHGIA="
   },
   "kde-dev-scripts": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kde-dev-scripts-25.08.3.tar.xz",
-    "hash": "sha256-8J52s97VzHa5nCa8sCdVONWQJn8IySG1JAwISjy75H0="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kde-dev-scripts-25.12.0.tar.xz",
+    "hash": "sha256-cds7BjeemO+nZWHwjFzYyngKXWRGXkbVUIopny92BJw="
   },
   "kde-dev-utils": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kde-dev-utils-25.08.3.tar.xz",
-    "hash": "sha256-6BlfM4lgpNXvJHxmDkYrntQFPGB40jrtN8AptiWBKkM="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kde-dev-utils-25.12.0.tar.xz",
+    "hash": "sha256-oORc3CBpsRGJWiuPnV+yr9Q2zDi0lrw7ow0umk3vQAw="
   },
   "kde-inotify-survey": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kde-inotify-survey-25.08.3.tar.xz",
-    "hash": "sha256-s5wSm5a4CQT0p7X4KOzZiJHDK2G5SW6NYxBYnakeuVs="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kde-inotify-survey-25.12.0.tar.xz",
+    "hash": "sha256-zyTNVgmvuy88cKDBAbxBoeUKrt5LFUT5GGEZ7l1+Ua4="
   },
   "kdebugsettings": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kdebugsettings-25.08.3.tar.xz",
-    "hash": "sha256-dpkOq4FsRfEWyCMdsz8Wr5VezHM8TrfIn+g5d/MpPaA="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kdebugsettings-25.12.0.tar.xz",
+    "hash": "sha256-0ZfGsVJJNRGyMlQ9OujHTs43tb2zjdbXyjiaJwnQyck="
   },
   "kdeconnect-kde": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kdeconnect-kde-25.08.3.tar.xz",
-    "hash": "sha256-bkHx8i6F9ecKkt1so+aWg2SJbeN6/l2ut82lmfA+Xis="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kdeconnect-kde-25.12.0.tar.xz",
+    "hash": "sha256-D/8k03HM/vyFjX1uAThcTVfcQL9G1nAqNNG/ZyfMcqg="
   },
   "kdeedu-data": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kdeedu-data-25.08.3.tar.xz",
-    "hash": "sha256-cfhXK1fQ7bBzQp4vOUFFkRwINosgyqNoXPZMrbxvoqo="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kdeedu-data-25.12.0.tar.xz",
+    "hash": "sha256-FAjaXTEzFFs7AiwTQ0diCYUBHKCBXZn2yAWx/CRIrh4="
   },
   "kdegraphics-mobipocket": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kdegraphics-mobipocket-25.08.3.tar.xz",
-    "hash": "sha256-pPj/FjInDBFpUJVzJmGZXZY5+DM8jWNzBlTXh9zDtVQ="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kdegraphics-mobipocket-25.12.0.tar.xz",
+    "hash": "sha256-9RX2Qn4lP4xYuaj+ZP5uplqsnngOSxm14M4pnzKScA0="
   },
   "kdegraphics-thumbnailers": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kdegraphics-thumbnailers-25.08.3.tar.xz",
-    "hash": "sha256-FfwrsleMfFhGNTPr1tjU6j7D2er0fgT3TpMiwTXJfoQ="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kdegraphics-thumbnailers-25.12.0.tar.xz",
+    "hash": "sha256-Hn7mYg2e8Cq87tW66xJ1YK9T/n6zeMoWkrEv2knN2rU="
   },
   "kdenetwork-filesharing": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kdenetwork-filesharing-25.08.3.tar.xz",
-    "hash": "sha256-0s71ZEOEO4KlwhDsWm5MKh7RoqhtUX5Xc4VZU7qWpI8="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kdenetwork-filesharing-25.12.0.tar.xz",
+    "hash": "sha256-GvHw8VddWUc6paLKg2r83xcMHCLhXCmMXt0Ap9H9TLA="
   },
   "kdenlive": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kdenlive-25.08.3.tar.xz",
-    "hash": "sha256-gbpOkRFH1dvTO89GSy8K6fV7iCTb/H+rIfPBG7ZDN4M="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kdenlive-25.12.0.tar.xz",
+    "hash": "sha256-yv7p2Owp6Z9QdyDyjWC/wJY6hzP2eg/9amhCc7gkLKU="
   },
   "kdepim-addons": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kdepim-addons-25.08.3.tar.xz",
-    "hash": "sha256-uqhcF0fJ54ly0aVNe7ezAN2/VAc0UsM4g1a8V21HnNc="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kdepim-addons-25.12.0.tar.xz",
+    "hash": "sha256-vWdpqeyLlOLLsMsIm1EIyOkH9eL3HIx/Oq9zsQJvD8c="
   },
   "kdepim-runtime": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kdepim-runtime-25.08.3.tar.xz",
-    "hash": "sha256-mLes8HJxZY09kWmlEWdlE74GWbc/XLH7RjCutU+mX4U="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kdepim-runtime-25.12.0.tar.xz",
+    "hash": "sha256-F1noziYQWXrkR8baZPAreTsKdwK6u0Enoe1xap4OQUg="
   },
   "kdesdk-kio": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kdesdk-kio-25.08.3.tar.xz",
-    "hash": "sha256-QKNbsC0nMV0BKbgYHnpvy47k9MDMa4T4GMEPo/i31nE="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kdesdk-kio-25.12.0.tar.xz",
+    "hash": "sha256-OtvMhClEPMmcCjagsQjfC1uFI7b48eahK3Rw9LPCUfU="
   },
   "kdesdk-thumbnailers": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kdesdk-thumbnailers-25.08.3.tar.xz",
-    "hash": "sha256-QWKweV1VrfvJ98G6jpZaYYqleygFiPQ9CkrbRc4I6HQ="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kdesdk-thumbnailers-25.12.0.tar.xz",
+    "hash": "sha256-f01Ck+PmfN0D0ZcchfSPTCp4jCmV3g9ewf+76iS9ct0="
   },
   "kdev-php": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kdev-php-25.08.3.tar.xz",
-    "hash": "sha256-9S7yko0u+dyyHzGtKNuc5DCcatT0+8ap0J6gc3KG1MY="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kdev-php-25.12.0.tar.xz",
+    "hash": "sha256-f76Pa2gUY29mQPKzFDaaIlUeNP9ab7fSZuFOIPKCO80="
   },
   "kdev-python": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kdev-python-25.08.3.tar.xz",
-    "hash": "sha256-VroTp+FyGuF6AVE4ZJ7270lw6Z1/9HMi8pamnxc0+z4="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kdev-python-25.12.0.tar.xz",
+    "hash": "sha256-+zezaFVkgzZGbs3JSLNx6w2r4wsS4xMTfKL2nbYCuR0="
   },
   "kdevelop": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kdevelop-25.08.3.tar.xz",
-    "hash": "sha256-TSuSzzepozJN2RNwdcX1UgR72IpnNCCqFIT83nm6zpI="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kdevelop-25.12.0.tar.xz",
+    "hash": "sha256-7/91i9WGr12CMp0vNAq/5kZnPYn8b1dwg4rqSfc/P18="
   },
   "kdf": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kdf-25.08.3.tar.xz",
-    "hash": "sha256-fldlaE/uQm/eytp6lJoXF/maikdnsv1mnJoDZrFF+mU="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kdf-25.12.0.tar.xz",
+    "hash": "sha256-RfipRdjlkcqSry6iGioCz3kymmuBHvZ5y5X8Af+gk9Q="
   },
   "kdialog": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kdialog-25.08.3.tar.xz",
-    "hash": "sha256-0sn8M+y0ii0TVkO4PnALkhLR6A/WUZccA1v68yjfurQ="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kdialog-25.12.0.tar.xz",
+    "hash": "sha256-7wZLPnuoPhrBhhR7QwxELEchOAHm9mwNPjYXRooAdKE="
   },
   "kdiamond": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kdiamond-25.08.3.tar.xz",
-    "hash": "sha256-6iRNvZWgW+NJLqNH2wOFeAAuYCRa4EsJBt4MErgrN1U="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kdiamond-25.12.0.tar.xz",
+    "hash": "sha256-ar+Ypho/oI926Z/LsUn1++m5ZQZplDA3oPW7HCJRGes="
   },
   "keditbookmarks": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/keditbookmarks-25.08.3.tar.xz",
-    "hash": "sha256-T1ehKu1z/OzDBZoGRZMdG4NrRCZxlClHY3QhMbIdOvo="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/keditbookmarks-25.12.0.tar.xz",
+    "hash": "sha256-674VmMxtvXinLWNWb9jksISb9LXjvLS7e4tXjxewokc="
   },
   "keysmith": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/keysmith-25.08.3.tar.xz",
-    "hash": "sha256-wYi87L4GV7fNU6bcZKLyyvveFH58m9LJC1hFr9CMFSU="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/keysmith-25.12.0.tar.xz",
+    "hash": "sha256-KhIlCibBGCXiSlDOsupTj4X5pRvRci5dZVTacl9tzpA="
   },
   "kfind": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kfind-25.08.3.tar.xz",
-    "hash": "sha256-dW1PmJOSCGzSEVU9WGE9X+tBMQczuOo1xQxYaTgMlRg="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kfind-25.12.0.tar.xz",
+    "hash": "sha256-U9B9zF8ZeRWgcDpbqok41zhhlh2cWaM7yyGdulF26n4="
   },
   "kfourinline": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kfourinline-25.08.3.tar.xz",
-    "hash": "sha256-xVivDA8SiiV0wTNwsLIiWJ4tTKV4pUE6qDWmENyplxI="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kfourinline-25.12.0.tar.xz",
+    "hash": "sha256-wOaQ3mJRHkfj8jhiUgRXMo3f4XOTli6Dk8EXHAZQxaI="
   },
   "kgeography": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kgeography-25.08.3.tar.xz",
-    "hash": "sha256-jIBortFwkZanbey9t33GHyq/U5vzwrJgcCR1vy4sZ7I="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kgeography-25.12.0.tar.xz",
+    "hash": "sha256-jJQVRc3u2UfyI6DC/F4iLldIBVnlmG1yj+JjXAnC158="
   },
   "kget": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kget-25.08.3.tar.xz",
-    "hash": "sha256-veDkZTVSqOs5qNMiCs214QQsdv7XcbgWJ4lTPwOn440="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kget-25.12.0.tar.xz",
+    "hash": "sha256-vRDCZsXyK7cWt1WcG5qobNEcKF++dkitDysK6PNXmSE="
   },
   "kgoldrunner": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kgoldrunner-25.08.3.tar.xz",
-    "hash": "sha256-7l+twe+Oytb2acTGLnZ6NwrzQPDAkoL/m/V6gL+Jtcw="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kgoldrunner-25.12.0.tar.xz",
+    "hash": "sha256-7oIxDl5KXzR5RvTWMn0Lppy/iCjvXJJVM9ertQFoirU="
   },
   "kgpg": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kgpg-25.08.3.tar.xz",
-    "hash": "sha256-5B6fbhRohlNM2G8UnlgWyiz2bavHuCTw81AGkxhC+K8="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kgpg-25.12.0.tar.xz",
+    "hash": "sha256-XjIuvUlXH6OBxPG5mz70Qdf/rtw1ZOOPNV/FNqSFpeA="
   },
   "kgraphviewer": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kgraphviewer-25.08.3.tar.xz",
-    "hash": "sha256-jyT6eUpePzAig6CHv2y81QqYxAI646ol4ve0lx6oZgU="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kgraphviewer-25.12.0.tar.xz",
+    "hash": "sha256-wmqy8cY/MO+Qm/Yt0/h4gpR+JDJWtTwB3H1BQscFOPY="
   },
   "khangman": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/khangman-25.08.3.tar.xz",
-    "hash": "sha256-tF9Vxx+l4tBbyPmM/anQduONRlwyXLQ9OZQu62dBr3I="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/khangman-25.12.0.tar.xz",
+    "hash": "sha256-A0G3/p4ROqMZYClDpiyiqq/9iMiASa/xCYzSJCA0Gvw="
   },
   "khealthcertificate": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/khealthcertificate-25.08.3.tar.xz",
-    "hash": "sha256-bO0XoVXevMHhn0DO4sccX0g882bUgx3rxewyI/slbdo="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/khealthcertificate-25.12.0.tar.xz",
+    "hash": "sha256-R8VKrGOqPVIaCCazGvzDXi/PjH9yTXWUeKLYO6zDWJA="
   },
   "khelpcenter": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/khelpcenter-25.08.3.tar.xz",
-    "hash": "sha256-T7S7Qk2u8xUxtR0fr5NZTIdvMBwP0gsIzXiFwT1Jm6A="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/khelpcenter-25.12.0.tar.xz",
+    "hash": "sha256-B6UXRIfHYTsVDZiw32G05lcmxJfKOBHiwFTyVJSSfag="
   },
   "kidentitymanagement": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kidentitymanagement-25.08.3.tar.xz",
-    "hash": "sha256-+7Ie/0TQAgZuOsSmkFrZFeetNVqn00+OYwcwizhP99s="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kidentitymanagement-25.12.0.tar.xz",
+    "hash": "sha256-eY4Fm7kiGKJ+/+RArWYWIDpD4E/lUtenuNnpnu8Gtts="
   },
   "kig": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kig-25.08.3.tar.xz",
-    "hash": "sha256-ETHgBXmdAOo0/q2zlMaPj7hrvbwBuYLNKjD3BsV1ToY="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kig-25.12.0.tar.xz",
+    "hash": "sha256-0KSiBtBp3ef62PHNOD5phSTqBb1QI4pnPylCdpHQqLs="
   },
   "kigo": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kigo-25.08.3.tar.xz",
-    "hash": "sha256-BTrTCeGvGk9rQVOv7D/qqUhm+x6V08ag/FLH9jV/OTs="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kigo-25.12.0.tar.xz",
+    "hash": "sha256-Ion2IHHyRjpuupBRyHrYskV+kxaOluAxSr7tbC6E95U="
   },
   "killbots": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/killbots-25.08.3.tar.xz",
-    "hash": "sha256-yqVxIJ52AmiLaAS3o44ET9IkVhaOYdwXWFqBFWSqOqs="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/killbots-25.12.0.tar.xz",
+    "hash": "sha256-aHFbEtKMOWA8VNpyBIl6GcAvg7+HP1Ek+GZFHl4cLog="
   },
   "kimagemapeditor": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kimagemapeditor-25.08.3.tar.xz",
-    "hash": "sha256-tmqzf7iiIBTjkxCY9fRU/TDJHHcr94sV1Hqm0BlMVpI="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kimagemapeditor-25.12.0.tar.xz",
+    "hash": "sha256-4beaQRRyrHtXwHI9hqHbvCuoV0An9cFXpcgjFQ/f+dM="
   },
   "kimap": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kimap-25.08.3.tar.xz",
-    "hash": "sha256-1rgwfLK4gzqN9IW4d4PVgVGiiQW3tueQgnxSQzSJqz0="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kimap-25.12.0.tar.xz",
+    "hash": "sha256-xSD02tZMPHGQNbjw7WhCVRqFAIw2U4PLoi7GTMmXo7Q="
   },
   "kio-admin": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kio-admin-25.08.3.tar.xz",
-    "hash": "sha256-WrOsvyja0G9myC+mhqVaFKAT9cXFbsFgfKhHp/RtIU0="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kio-admin-25.12.0.tar.xz",
+    "hash": "sha256-YbsmucNd0j0YnagF7OlhdKRDI6UmIqnVxiJK1byNWxQ="
   },
   "kio-extras": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kio-extras-25.08.3.tar.xz",
-    "hash": "sha256-mflm3MZjvoyzyQZ3jIKzLaSxeL0pbYzYW54/VujpwtI="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kio-extras-25.12.0.tar.xz",
+    "hash": "sha256-RTVj/vhWPmdoDa9azhe08aWr0svfgNUOHPm9rb3o30E="
   },
   "kio-gdrive": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kio-gdrive-25.08.3.tar.xz",
-    "hash": "sha256-LA8ct2X1wA3B6f77GEnscJ4zTi9WGO3k3UqGzeLkS5M="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kio-gdrive-25.12.0.tar.xz",
+    "hash": "sha256-Z7PiJj/IxpwGGwllj9d+1QxNjWmjWNQMDm1N3qb5R34="
   },
   "kio-zeroconf": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kio-zeroconf-25.08.3.tar.xz",
-    "hash": "sha256-3nuyMp3bkMBKjBt6t+EiXico7Yu3VUAp5LS0HkS1c+A="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kio-zeroconf-25.12.0.tar.xz",
+    "hash": "sha256-InyT4BZz1+tpYG5F/J8QYLDygOh5MTxiOx8kI0U84qg="
   },
   "kirigami-gallery": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kirigami-gallery-25.08.3.tar.xz",
-    "hash": "sha256-3+flmIXsSBpn6IeivvGgkSj8OoYuALRKTJYv2HJmFoY="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kirigami-gallery-25.12.0.tar.xz",
+    "hash": "sha256-0Yc5AJ66t3paoMXKDj4wU/9UkWTGpSJmlnlbVjhzplQ="
   },
   "kiriki": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kiriki-25.08.3.tar.xz",
-    "hash": "sha256-gmEkYfdbe/aT9Vf5PbxsAncG+8Kv5mpcqSUWmWchYxU="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kiriki-25.12.0.tar.xz",
+    "hash": "sha256-Vll995EfPKpwv0UnWJqcPnslMj0orKWETcrjT2IJTn8="
   },
   "kiten": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kiten-25.08.3.tar.xz",
-    "hash": "sha256-7pUwcbfbzCkMg32KHlF3ZCELpdWJim8VcAgTF28LvFQ="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kiten-25.12.0.tar.xz",
+    "hash": "sha256-mFY7Of6uC+AzoPM7tCY3ndif8rPTcgnuvbVZSZC6mYI="
   },
   "kitinerary": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kitinerary-25.08.3.tar.xz",
-    "hash": "sha256-s3QG/balE1+8F8iMy38tCIjm1T4W9C2BlOphiRH0ciA="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kitinerary-25.12.0.tar.xz",
+    "hash": "sha256-dQlqSVJjQ15uHfrvj5+0j60hUwxIrq66kfc+DThNXww="
   },
   "kjournald": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kjournald-25.08.3.tar.xz",
-    "hash": "sha256-Ce6AgQJxJgc/jP6/v7+Jh+PQsGEsHnxSXa3Tt8w6X24="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kjournald-25.12.0.tar.xz",
+    "hash": "sha256-vohxKqHQf81lGfqc9wFByAsmybLdyzEbf4F1oJjJXgk="
   },
   "kjumpingcube": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kjumpingcube-25.08.3.tar.xz",
-    "hash": "sha256-oAWb720t3hH0WNbd9NXqnoCfcyPC9nsEG9tByJr0QOM="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kjumpingcube-25.12.0.tar.xz",
+    "hash": "sha256-l2Q7vpuaFSoCnavBY90s6P1gSNgnH0EX20NTOz2+kTQ="
   },
   "kldap": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kldap-25.08.3.tar.xz",
-    "hash": "sha256-YheAQ/cjuVme+G1EZmJ9VTeAd4LJzu/kq3lZGxr3wDI="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kldap-25.12.0.tar.xz",
+    "hash": "sha256-sSWbBK+cUD0dmXpx+MlAXCuJlvJ+6O46ZnRj7CYzSlc="
   },
   "kleopatra": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kleopatra-25.08.3.tar.xz",
-    "hash": "sha256-PC9lIH7KzW9yYx6DKpM0KmxDJg6JevzChdGAO1HMZ2Y="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kleopatra-25.12.0.tar.xz",
+    "hash": "sha256-A1yXfWLmsmNYe5aefe+jGLAXu5pgtzzYEpkHU1jSu9o="
   },
   "klettres": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/klettres-25.08.3.tar.xz",
-    "hash": "sha256-cGUurM+AAXa6P1Ep/ROoKSuXF8MISYgBtV5VOk8XmHM="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/klettres-25.12.0.tar.xz",
+    "hash": "sha256-MRjc1fvkNFgVEKRMFajV49n27+gZWB7DXnoXgiUETpc="
   },
   "klickety": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/klickety-25.08.3.tar.xz",
-    "hash": "sha256-/GWRi1rRBOVXLmG/xa+kbWi6MU0V8gjukGBEPJEv7Jg="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/klickety-25.12.0.tar.xz",
+    "hash": "sha256-+VsNmGIM8v6l008SRO+p58VzKjznmb41o+4YBJIBhNg="
   },
   "klines": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/klines-25.08.3.tar.xz",
-    "hash": "sha256-CRE1uZF2YFpBpHI3L0umm8vqLzYFMTEEmu2ecYfJmnc="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/klines-25.12.0.tar.xz",
+    "hash": "sha256-5wLwTfYRJbnJ29udwPY3xzHmN86vZ5hWJmVlSBWGxcA="
   },
   "kmag": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kmag-25.08.3.tar.xz",
-    "hash": "sha256-xDB5Dlk7g0ZXFyuUq9oP8MElv2rESUayR8c32yGqtGg="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kmag-25.12.0.tar.xz",
+    "hash": "sha256-Cnx+Pse80mOZFYctBXFlN+6nhUvtLCmXJer8+ky1dG0="
   },
   "kmahjongg": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kmahjongg-25.08.3.tar.xz",
-    "hash": "sha256-KWpQulk5yUiDSoUU8u9rr7E3auUFpc+CmO7sMRnp8SM="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kmahjongg-25.12.0.tar.xz",
+    "hash": "sha256-ivJK0EZA2jB2zBVV+hsBQ4S5Bre0EaNWZubQB/pU7ro="
   },
   "kmail": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kmail-25.08.3.tar.xz",
-    "hash": "sha256-pUTofOL63026oJnAGKGeWTu7gC4KmTAWvD6RTt1qkfQ="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kmail-25.12.0.tar.xz",
+    "hash": "sha256-YskEthSRsOmJAq7o2GxaSZ6wZw6Zr7d9xP4luv8mZl0="
   },
   "kmail-account-wizard": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kmail-account-wizard-25.08.3.tar.xz",
-    "hash": "sha256-M2XxYVMgGinDF5mxCPwI4/aUwjOuFwQmiJ+BUcSYw0Q="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kmail-account-wizard-25.12.0.tar.xz",
+    "hash": "sha256-yFExJKdfb9R7C06E0H1mzt+DtSO3yVBW1Yz4VYGnZb4="
   },
   "kmailtransport": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kmailtransport-25.08.3.tar.xz",
-    "hash": "sha256-IfuF62TtJcrtJx0plwDxBmqTQxKYZH9drDbotvMlN64="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kmailtransport-25.12.0.tar.xz",
+    "hash": "sha256-SA/92S1lfSrbv44v4Xs/cj/INcE/rD1RnuJlG/wt4b8="
   },
   "kmbox": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kmbox-25.08.3.tar.xz",
-    "hash": "sha256-MWGF+jh+OFYb3S4KC5hKP8AIMqYicdBtz+vOHcfwVYw="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kmbox-25.12.0.tar.xz",
+    "hash": "sha256-OmoQm9xKFkiRjU0zKqrCRH9ncQ2H7pobz6wWmRuOk+g="
   },
   "kmime": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kmime-25.08.3.tar.xz",
-    "hash": "sha256-H0/KO/+Zn9hNnPPYBz3308FpOthVS1YAF05KmqGDfwE="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kmime-25.12.0.tar.xz",
+    "hash": "sha256-wh8XsfymgmSHzY4izVUd7pNApSI3xZZwzIxDJlsPRjU="
   },
   "kmines": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kmines-25.08.3.tar.xz",
-    "hash": "sha256-mfDaPNivn6Y0qPfTTkM77bxL+9okiGzV4L3eSOCtSj8="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kmines-25.12.0.tar.xz",
+    "hash": "sha256-wVYaXrSW24/H1i1V9DUqYYXt3dUYUxTVfZwVx3Ndyfs="
   },
   "kmix": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kmix-25.08.3.tar.xz",
-    "hash": "sha256-+EKMFgrbaM2foA026VQ65PRPNk/VmTJ+dpSrYzEI95w="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kmix-25.12.0.tar.xz",
+    "hash": "sha256-r/bALcEd/ULFdVnMTCnZ6mwO3FwYRK52LKcxU7zWVT4="
   },
   "kmousetool": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kmousetool-25.08.3.tar.xz",
-    "hash": "sha256-edPgAyHPZPEONVe1MdELxYc11r6qI3JDv3mG43Ak4I8="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kmousetool-25.12.0.tar.xz",
+    "hash": "sha256-lt8RjeXDHSGzNvAIjMSteBD29+VsWlRrLKhsT1WZDJ0="
   },
   "kmouth": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kmouth-25.08.3.tar.xz",
-    "hash": "sha256-L+9tjvkyAqLaysO7l/AtN3kMxiFMxtlJY7G7M7Hu034="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kmouth-25.12.0.tar.xz",
+    "hash": "sha256-84zSe28eMgvDgC/QhFu0/j5tYjol+6KaPEsZ3Ohu+R8="
   },
   "kmplot": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kmplot-25.08.3.tar.xz",
-    "hash": "sha256-JCNo7aVqMy9SmVKvC2JYw67GpZuQNQzfb+/OoNpnuIM="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kmplot-25.12.0.tar.xz",
+    "hash": "sha256-ivi2IT32qdsCjhSJxKB7+w+zTyiMax6dG7bhXC68Rm4="
   },
   "knavalbattle": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/knavalbattle-25.08.3.tar.xz",
-    "hash": "sha256-DYbxF2HZhYrbqgFua+uGfibr+f9SsxLXnNIm/xi+1i8="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/knavalbattle-25.12.0.tar.xz",
+    "hash": "sha256-2+vQ0jdO0CoNRwtV1FYTTpwRiXFA/GhzNbIFl1+9Rmw="
   },
   "knetwalk": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/knetwalk-25.08.3.tar.xz",
-    "hash": "sha256-z62yo0fxZqLOPpG2InFkXj7FSQb99tgCaS2aLhSjoW8="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/knetwalk-25.12.0.tar.xz",
+    "hash": "sha256-CHJYt6EfpTxf9zd9z4nKkyJoO9WHEEKN5bUaH9U45Jk="
   },
   "knights": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/knights-25.08.3.tar.xz",
-    "hash": "sha256-ygibJTDdrR6CVpWgVwnGi6pwO5lu61hjrSabY30RKD0="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/knights-25.12.0.tar.xz",
+    "hash": "sha256-tvWcVbikCqWEjimH4fpPwlzGRyN25dgIjCt9HIgHlG8="
   },
   "koko": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/koko-25.08.3.tar.xz",
-    "hash": "sha256-zWcEO5aclGnZ6cEGfPQsLqPiLgInq+86d2INj80ll1c="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/koko-25.12.0.tar.xz",
+    "hash": "sha256-XWwAgrY/hipu/7SZYzstpP1J3W1lEOrnryEYOLS6j58="
   },
   "kolf": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kolf-25.08.3.tar.xz",
-    "hash": "sha256-PZStjMm19A8cMJj7UPm1ZPbVlwhDaqo8G6ouXpR0UJ0="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kolf-25.12.0.tar.xz",
+    "hash": "sha256-AuyOEPR5SG3CpmJnSV625LtBtZ7bv8/FcNOMVWOiZPQ="
   },
   "kollision": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kollision-25.08.3.tar.xz",
-    "hash": "sha256-nfXBZsVK6K14Y8fxV06df7C2V8HfXNzuTk/1Dtyilzo="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kollision-25.12.0.tar.xz",
+    "hash": "sha256-ms6zjg/DMPVNaoseiP6ulmK8vO+D3jVeDezu4ntHVvU="
   },
   "kolourpaint": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kolourpaint-25.08.3.tar.xz",
-    "hash": "sha256-7ffBmyNhxQ2VVknbE8/JOVIwi1mpQKCUWO2JjE6xtAw="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kolourpaint-25.12.0.tar.xz",
+    "hash": "sha256-sFlSRZJ18lgPk+EV7BUhqUnf3DrAYstDtcYi4tQg478="
   },
   "kompare": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kompare-25.08.3.tar.xz",
-    "hash": "sha256-zkMG4+6PIQ0f64h+SZgVcCt9OMT9OioKp1BJWc1BT+I="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kompare-25.12.0.tar.xz",
+    "hash": "sha256-hI9cGeXQVHgYRDI89v5bs+p+BVgy2Ef40JvxNymUH0g="
   },
   "kongress": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kongress-25.08.3.tar.xz",
-    "hash": "sha256-nX9eeJU1U6Z/GAPe57DG4xgmhtwXPHZU8j86wtxVVds="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kongress-25.12.0.tar.xz",
+    "hash": "sha256-nBQcxDwTHnXKkvM6We0fXXq6PbybheIuKIhETUcgPBM="
   },
   "konqueror": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/konqueror-25.08.3.tar.xz",
-    "hash": "sha256-PPJVeXyJh2kuq+/pS4bibpSurJB/ZZMISOB/YQRMQmQ="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/konqueror-25.12.0.tar.xz",
+    "hash": "sha256-MuX2Jwm/rHfOBB/P7+o8yVKvC6a4MrKLTG9lIAHDOKA="
   },
   "konquest": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/konquest-25.08.3.tar.xz",
-    "hash": "sha256-CpDVgw6MY22JJWByJS453CkPZ81ZC1yDv0W+RO/DXvk="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/konquest-25.12.0.tar.xz",
+    "hash": "sha256-KAcn3u9BTUE3Uy62E4u8Xo1j7OccW2N85z0/zHL83qQ="
   },
   "konsole": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/konsole-25.08.3.tar.xz",
-    "hash": "sha256-CVp/8Q3zxwd5s1b7O1mEBiu8aYu+2WYjDj28z2rzZhU="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/konsole-25.12.0.tar.xz",
+    "hash": "sha256-v+Oe0iuDDJnjdYOtDmfrKOkSxDI1s6tHiYY3RnYjSjQ="
   },
   "kontact": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kontact-25.08.3.tar.xz",
-    "hash": "sha256-qEEb6WO4KCFWcStbsgs93mo743dpg3VY5ZCm1e0Fsvo="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kontact-25.12.0.tar.xz",
+    "hash": "sha256-xGkWtpF9KWIdKZeN9T469/KxmmaPTuyRvB9tbIpP+S8="
   },
   "kontactinterface": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kontactinterface-25.08.3.tar.xz",
-    "hash": "sha256-e1nQOAevvoku0A58Im/Yft6Mp+Ond6EcIoaYs9gFl4g="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kontactinterface-25.12.0.tar.xz",
+    "hash": "sha256-sPL1yhcXhRgsU7DF97E7/WZ++9EWt2MHNTWF9hl/AmY="
   },
   "kontrast": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kontrast-25.08.3.tar.xz",
-    "hash": "sha256-UgvgiPpNWS34GYRybm5Ti3hvOx7MYoE/soArpzh1nGo="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kontrast-25.12.0.tar.xz",
+    "hash": "sha256-tz0LU7UKimYCz6Bnlj2Ey++DZ80A+lwER9N1zmH9I1g="
   },
   "konversation": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/konversation-25.08.3.tar.xz",
-    "hash": "sha256-XkW3jDLY9ydczcUNl4DFrpA0GO2MeXTV2Ylo3DaFgI0="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/konversation-25.12.0.tar.xz",
+    "hash": "sha256-vIqO9JAMB9Jf1VAEmZS1fC0/xy/zcM3plt9XUggaWGg="
   },
   "kopeninghours": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kopeninghours-25.08.3.tar.xz",
-    "hash": "sha256-DmCIXSzbiP4L9C/jnwHJ4oTddVcnxYVxSDLrqYwRy3M="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kopeninghours-25.12.0.tar.xz",
+    "hash": "sha256-pOQoDJW9fxt4eSWw4rjFvA6H5ex/NYt/18i3yt+3+kc="
   },
   "korganizer": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/korganizer-25.08.3.tar.xz",
-    "hash": "sha256-YqGg0VhbkthlL/GU/Mlrsog7zAGOy9T16u9ukPawuXU="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/korganizer-25.12.0.tar.xz",
+    "hash": "sha256-Az+F9h1eaBuqX6S2NfQ5UsxOcf7knl+H7hB2FZauUSE="
   },
   "kosmindoormap": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kosmindoormap-25.08.3.tar.xz",
-    "hash": "sha256-Giziw+UUv+Aeex/elDvwmRIcrYKoj0RL2sA7V1Cb498="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kosmindoormap-25.12.0.tar.xz",
+    "hash": "sha256-PLtCGuLkQuv/QYjx1IvLgOXq7CDpmu3hi/kZbR87TtQ="
   },
   "kpat": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kpat-25.08.3.tar.xz",
-    "hash": "sha256-ZeAz17mquql1cBLUtQurzJG1wslBdMM05wQ7Z4WDJu4="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kpat-25.12.0.tar.xz",
+    "hash": "sha256-SF+G3Z7hA+1eTxAcRWKBva9Qotv9pgKh5UEfsNb9gXA="
   },
   "kpimtextedit": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kpimtextedit-25.08.3.tar.xz",
-    "hash": "sha256-Qpv/phStKz6nQkcCwcSBL4zC5C7iEM1av3yd1//kbUY="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kpimtextedit-25.12.0.tar.xz",
+    "hash": "sha256-T69psp1pR0Zl4PYtq6MnmjJXa7/z33Z2Z/+BdLn19i4="
   },
   "kpkpass": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kpkpass-25.08.3.tar.xz",
-    "hash": "sha256-OAKm8j7dkBvpdcA7PrY+R46ThDhtiDsiiftZjt8+dYs="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kpkpass-25.12.0.tar.xz",
+    "hash": "sha256-WSz6Fuj3x6tpx0mMD6zelyxdmOnPPhmdn109qZs/U/Y="
   },
   "kpmcore": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kpmcore-25.08.3.tar.xz",
-    "hash": "sha256-QwIiSYs6DdS7YdryYfBkg4+NHoNzMGOk9je1knHtaOM="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kpmcore-25.12.0.tar.xz",
+    "hash": "sha256-9pz8LrA718PA/hxWVUM43TGbub18OgnuhjH+5yDkzsw="
   },
   "kpublictransport": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kpublictransport-25.08.3.tar.xz",
-    "hash": "sha256-7Yh98j0EoevRcbWcmd+uwm1iJU6aesT4pwhLowFYbBc="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kpublictransport-25.12.0.tar.xz",
+    "hash": "sha256-Xbu/ojE5UKDU4MuHyMkaJD3mTjeGQ46+kkBUUFfgWjU="
   },
   "kqtquickcharts": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kqtquickcharts-25.08.3.tar.xz",
-    "hash": "sha256-jympyxr341HoW7d+ZtCC0wToWdJbtVDnTWX3WfARDBE="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kqtquickcharts-25.12.0.tar.xz",
+    "hash": "sha256-touLBPK65GuMxgMeXbX5cT0OAaNwlqKtV8bbo9qMaFM="
   },
   "krdc": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/krdc-25.08.3.tar.xz",
-    "hash": "sha256-qjF7iiHANitt3WnxIsoX9ETt/uui9CK3XOUcZmlQkGo="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/krdc-25.12.0.tar.xz",
+    "hash": "sha256-kgzAwFA9FRsAxrWnjH4RDhtZjXdSiMm/0uYRGAC1lkU="
   },
   "krecorder": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/krecorder-25.08.3.tar.xz",
-    "hash": "sha256-Mnj73af7xEC2+SK2RKyNMtzGPU1EO3ecwssIMXomM2E="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/krecorder-25.12.0.tar.xz",
+    "hash": "sha256-yBTLW2R0+5tmCvtyF4S5BTdY5bxYeNa8MdJ+6a2pkrU="
   },
   "kreversi": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kreversi-25.08.3.tar.xz",
-    "hash": "sha256-gf/rj2ABjRLqKCvgKhd0Xkv2ofFsBnWulyG9+cNSlSQ="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kreversi-25.12.0.tar.xz",
+    "hash": "sha256-cKWVUCsM6IwtPw5dTbXlRpIedFpJepZRDxiWtd11gac="
   },
   "krfb": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/krfb-25.08.3.tar.xz",
-    "hash": "sha256-4S+HkIm2qdS4/HK4IB5SIj6kUGZNKLo6Qxk6Yeud/0I="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/krfb-25.12.0.tar.xz",
+    "hash": "sha256-AWoK9UtFHixrRY/4IBDh3qUcXVCL+rMCSLz78lBJLY0="
   },
   "kruler": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kruler-25.08.3.tar.xz",
-    "hash": "sha256-lrIrTlkMtnaGcfEZlOENqUL4JS+sYvq57/0VYR0seaw="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kruler-25.12.0.tar.xz",
+    "hash": "sha256-xezV9nT+fYW/RPO1O6QwkP6vyOykdbe2oZUfbQQWc9w="
   },
   "ksanecore": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/ksanecore-25.08.3.tar.xz",
-    "hash": "sha256-4VZZmUGT7mDSn64J4n0uRT/DLkSfr4gIpXysip6rqZc="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/ksanecore-25.12.0.tar.xz",
+    "hash": "sha256-YX0B2W6ni61MPWgVF+ZLFvA3+co4fCWgXs77xZ482zI="
   },
   "kshisen": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kshisen-25.08.3.tar.xz",
-    "hash": "sha256-0P9OhTLCd7Mptkd25Ye/dacIbX20RkL3cCve7GcIHqg="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kshisen-25.12.0.tar.xz",
+    "hash": "sha256-z1WXo+QDXpNP5ayF21hBELJXcpeVjRa0ktuCtcZyZag="
   },
   "ksirk": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/ksirk-25.08.3.tar.xz",
-    "hash": "sha256-mSoRZ1ldy2px3lORdTFeQ0W3mSYu6Wa3UYv3c21N58Y="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/ksirk-25.12.0.tar.xz",
+    "hash": "sha256-TxbwaAyj8gX0S1OM+jGdGHq65oNwIpRIlhEAKfebItQ="
   },
   "ksmtp": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/ksmtp-25.08.3.tar.xz",
-    "hash": "sha256-FQdBgHcj8c7ka8HoY5TXhf79ffgiUj1f5TgyouQVzOY="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/ksmtp-25.12.0.tar.xz",
+    "hash": "sha256-FdZuzdxX/jw2ABvsUsc6jGgF4E/oQ9KxM1Oj8/UGGkU="
   },
   "ksnakeduel": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/ksnakeduel-25.08.3.tar.xz",
-    "hash": "sha256-G/5kAJ9iPfUDr1cZxzquUJNO31jBl3RjGGp8/8mjxsY="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/ksnakeduel-25.12.0.tar.xz",
+    "hash": "sha256-MmIpP4MVPKOUSef67huo072B+8OUg5vEjaWObhzFvJ0="
   },
   "kspaceduel": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kspaceduel-25.08.3.tar.xz",
-    "hash": "sha256-txLcpESv/zejpFdAwDcJSHwjaj+cjb4NiaezzFPz1P4="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kspaceduel-25.12.0.tar.xz",
+    "hash": "sha256-CL3NpOYYfS7JxAPD3iwZt/m5Cni7OzeUpUGPbBEmsDM="
   },
   "ksquares": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/ksquares-25.08.3.tar.xz",
-    "hash": "sha256-Wnc8jDtRj6LMXYzfvlBe6C1sDCvSeCiTeyKXcwrdtc8="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/ksquares-25.12.0.tar.xz",
+    "hash": "sha256-YDLtgqAjPT7W0jE36Jp2Rf8HHJB3djaiJPgXx44VDQE="
   },
   "ksudoku": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/ksudoku-25.08.3.tar.xz",
-    "hash": "sha256-1XexTOqFRtyLdIC1K5PT4LV+coySYjfVxoQQ7Ll9vdQ="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/ksudoku-25.12.0.tar.xz",
+    "hash": "sha256-Y1XhFpMjKwbwwEiOkEkp+nlYL5miiLzHi/o/C6DTdsc="
   },
   "ksystemlog": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/ksystemlog-25.08.3.tar.xz",
-    "hash": "sha256-41APVe04Ju1RhPzzd6R2ISHTbTBIso9DfVLeZZKzPnE="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/ksystemlog-25.12.0.tar.xz",
+    "hash": "sha256-xnKH2bgATtR4dRgVOZjeM7ytEBXZiWvySQDh8FVX3yU="
   },
   "kteatime": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kteatime-25.08.3.tar.xz",
-    "hash": "sha256-aKghjWcg/U4zlTJwdZbX0e7l7xizFE448nZW8Ntqp80="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kteatime-25.12.0.tar.xz",
+    "hash": "sha256-6ydf5em3hz5rPsdGKEhs+BHBD3+93X4vBB7kq+QQh5I="
   },
   "ktimer": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/ktimer-25.08.3.tar.xz",
-    "hash": "sha256-pLQm1jQcE9i0yYO2JBjK2npmA8c4E1chOgPIXfmF4hg="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/ktimer-25.12.0.tar.xz",
+    "hash": "sha256-kt4eFpn6WpMEwpHfL5Tf6JMfxbueqJ1nX7RVLn+OglE="
   },
   "ktnef": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/ktnef-25.08.3.tar.xz",
-    "hash": "sha256-cBVHeVARnN252bTmuUMGsbaHb0YE9Jb+voJMpicF4hM="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/ktnef-25.12.0.tar.xz",
+    "hash": "sha256-y/f92975QpZaT9mUHc2X0hEAK0YS8NcLZz9D4DQ8sPA="
   },
   "ktorrent": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/ktorrent-25.08.3.tar.xz",
-    "hash": "sha256-YsslNCYnT3YZYCgn0d4kaf/+2kN+9dlNyqTXyi3/TT4="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/ktorrent-25.12.0.tar.xz",
+    "hash": "sha256-w9O03t4XwCwBloaBVAQzGeYksPM83O2V9s17wJt9dOM="
   },
   "ktouch": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/ktouch-25.08.3.tar.xz",
-    "hash": "sha256-RxvGm+NjhpVzekatA4FHHVLy/desOfZIaxgIChqZ+Bw="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/ktouch-25.12.0.tar.xz",
+    "hash": "sha256-wz/NiA5wtQP31aSgy2ugHDIY2bPPjAIxUFYC8nKm9K0="
   },
   "ktrip": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/ktrip-25.08.3.tar.xz",
-    "hash": "sha256-67XWgzjhKR80NFaRfB0nfelXJWRjv390MAXUUnUCIL8="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/ktrip-25.12.0.tar.xz",
+    "hash": "sha256-M7X46XhVV3tlTLfMdV4u3b9TTOApDWglguKUhpLWC30="
   },
   "ktuberling": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/ktuberling-25.08.3.tar.xz",
-    "hash": "sha256-kn2uK63lPdEODGRlKSX34qr94ELSTuc8McfguntAYU0="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/ktuberling-25.12.0.tar.xz",
+    "hash": "sha256-7pbaNLUz674MH0aU+jXBP4WSiAiXeOerSVQKtyBhN6g="
   },
   "kturtle": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kturtle-25.08.3.tar.xz",
-    "hash": "sha256-niNZcCEncHPReW2prJ7ejD2G+huipyN+NyvBGuJrDgs="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kturtle-25.12.0.tar.xz",
+    "hash": "sha256-wZYktzqGQR7r4C3haKYRPlbOniQd65XoInLpoBOurZ4="
   },
   "kubrick": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kubrick-25.08.3.tar.xz",
-    "hash": "sha256-wv90F0c7FKK17TONQ5AnsHGdM8CNnflPOa0SGfLsmRI="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kubrick-25.12.0.tar.xz",
+    "hash": "sha256-fg0UyulR2FqIFgFd3txzQeKRxxXBuhWPIx1siYhGWgs="
   },
   "kunifiedpush": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kunifiedpush-25.08.3.tar.xz",
-    "hash": "sha256-6MkkQ41TWfD6CTCrNREQEgduOg/06VnWkpWVVxODMgo="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kunifiedpush-25.12.0.tar.xz",
+    "hash": "sha256-N1kdHdEpFnjg00Rw7Pp/bPGIo3I6sNsRcELRHUO2D/4="
   },
   "kwalletmanager": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kwalletmanager-25.08.3.tar.xz",
-    "hash": "sha256-VLa2PrVf1VTTEhUxnCC7r9Lhv5SKtrT6TYS1YUttxS0="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kwalletmanager-25.12.0.tar.xz",
+    "hash": "sha256-X2Uv6WJTnYkd25zD6qh+CsnME0CNl2WG4zkc+DHEnXg="
   },
   "kwave": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kwave-25.08.3.tar.xz",
-    "hash": "sha256-SNx4aADdyclG/OxxJY8896Ot7pHBMEuF2gVtJs6MolQ="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kwave-25.12.0.tar.xz",
+    "hash": "sha256-xlu8gj+UMkntBd7Xvltit/daa89pcin3MzMt4Px8f6g="
   },
   "kweather": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kweather-25.08.3.tar.xz",
-    "hash": "sha256-KNoeLq1scm5iMiMOqo8eDluaa5C3VgMOx/kVHRkNcy0="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kweather-25.12.0.tar.xz",
+    "hash": "sha256-5jO6SCr97Yuj6wD625DrTQY0LeOLm/KxZvWnV4EfSbE="
   },
   "kweathercore": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kweathercore-25.08.3.tar.xz",
-    "hash": "sha256-aTVzoCRb9l2s6rEnrEXJrPuznmt8UW2BevVBzTElsls="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kweathercore-25.12.0.tar.xz",
+    "hash": "sha256-LDDxTJcPeVSezbeYvMGVIhxzxBkjoQRMeK1ttdLIgBI="
   },
   "kwordquiz": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/kwordquiz-25.08.3.tar.xz",
-    "hash": "sha256-FD3tCu6gIDbeeq29O2zoENAGanPcyC02excZYqgSFoQ="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/kwordquiz-25.12.0.tar.xz",
+    "hash": "sha256-UjAt4NlTXAPiWXj0YYF/1V65W0yApj+7DLIIHr5tESg="
   },
   "libgravatar": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/libgravatar-25.08.3.tar.xz",
-    "hash": "sha256-lMd3JgKzraqLTUSiJ2mdlDCXAFrr/u9WPK6tt15vI/s="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/libgravatar-25.12.0.tar.xz",
+    "hash": "sha256-5EtXOj3iXMWcx+FH6FeZOa73LEV74uPkrUwW09n0r34="
   },
   "libkcddb": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/libkcddb-25.08.3.tar.xz",
-    "hash": "sha256-HYXr8890TjVv8g/fADgyeUT+pDN4Yo2jvYuZDmXTdpc="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/libkcddb-25.12.0.tar.xz",
+    "hash": "sha256-ffJehHxE8IqwmYXMsJdfKTMux7FgSbVppy4k4ZNKEZs="
   },
   "libkcompactdisc": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/libkcompactdisc-25.08.3.tar.xz",
-    "hash": "sha256-PXqeirTcFJcIukWb7gumW+hU6ux4yX97p/j2YyrjhnA="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/libkcompactdisc-25.12.0.tar.xz",
+    "hash": "sha256-105+BD4Xy9k7tdX+Nazjb/pJbiBZPZcvrpMQp7+XdWE="
   },
   "libkdcraw": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/libkdcraw-25.08.3.tar.xz",
-    "hash": "sha256-Uvp40BPhPHLGL7TWho7xCowR2JlIptJEFWR+kXqnLN8="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/libkdcraw-25.12.0.tar.xz",
+    "hash": "sha256-UVZAGll4QxOmYO7A3FUzJ8Ie8K8Cj8MUUlkm0Sr4T9Q="
   },
   "libkdegames": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/libkdegames-25.08.3.tar.xz",
-    "hash": "sha256-RvMFZ3+zeXjGtHvRerZVO1chUaYymbt7jccY03+0SKQ="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/libkdegames-25.12.0.tar.xz",
+    "hash": "sha256-Goj5mjoHo3RcGng8MC1UYc04wdp4Le4eGjZcRbdQBvE="
   },
   "libkdepim": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/libkdepim-25.08.3.tar.xz",
-    "hash": "sha256-OspVtxvjWrNpkwXy9/x2bUvQDETrt2Mb/WQcEkzQsek="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/libkdepim-25.12.0.tar.xz",
+    "hash": "sha256-HApcy/vfS+Uzvx5S/hemNNc2aH4qlJqxH+mh+b0qjbw="
   },
   "libkeduvocdocument": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/libkeduvocdocument-25.08.3.tar.xz",
-    "hash": "sha256-tNzEPB2PcR1bmsCinXji7HcQtbzYDx7GJTTosbDr3cU="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/libkeduvocdocument-25.12.0.tar.xz",
+    "hash": "sha256-YVmOx6PKCCZT+wlyVgc4mhCJHYBO5kGJ08max9AvrnA="
   },
   "libkexiv2": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/libkexiv2-25.08.3.tar.xz",
-    "hash": "sha256-CAaJhVS2Km+DTTO7SBkj2CvekbFpK6exRv7JS5pQPQM="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/libkexiv2-25.12.0.tar.xz",
+    "hash": "sha256-HesPpvJwtYiqPd2UbEKwCpdPedL8B58RJczI/w6ZuZY="
   },
   "libkgapi": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/libkgapi-25.08.3.tar.xz",
-    "hash": "sha256-WmWQ2gTPSgw7U/Kgx9fJfN9X9jhUoKSXjAhZJDv70V4="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/libkgapi-25.12.0.tar.xz",
+    "hash": "sha256-KJ3JHa/+AusaUk1sgo/0upc8zWHRYQgF1zhtmdm0pL4="
   },
   "libkleo": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/libkleo-25.08.3.tar.xz",
-    "hash": "sha256-BVOxiilctfv/X66ZA0p4KuTQfUPSwWN+r2ejHKZQuBY="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/libkleo-25.12.0.tar.xz",
+    "hash": "sha256-/7qb1WPtI7rdxiR0dgr6JiogEGTOH1FMHyaRA/E1qtk="
   },
   "libkmahjongg": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/libkmahjongg-25.08.3.tar.xz",
-    "hash": "sha256-SC+c76Nbpi0ScbOpsvC+zPDpVOt/2ECmHeTMSxi9xlc="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/libkmahjongg-25.12.0.tar.xz",
+    "hash": "sha256-fbBVPEc5BRWrk2nEKhV/IlHD9mUj1y+WVinp9cO528c="
   },
   "libkomparediff2": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/libkomparediff2-25.08.3.tar.xz",
-    "hash": "sha256-bpNvhmHzNsuaz/eeJG4d+yhPnNVmoBxlq1oliec2yew="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/libkomparediff2-25.12.0.tar.xz",
+    "hash": "sha256-k/pswsXsX+DFpOIiL1djWxj9w1meoiI1u7EMe4zqoHk="
   },
   "libksane": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/libksane-25.08.3.tar.xz",
-    "hash": "sha256-cwv078ybgjupjGgUkuQTk3mrDD5gLh5u/ynATxdtb2g="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/libksane-25.12.0.tar.xz",
+    "hash": "sha256-tP3kxqkVFnntUuTVcu1miN1LSJqiojU02PEyz73Tq5A="
   },
   "libksieve": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/libksieve-25.08.3.tar.xz",
-    "hash": "sha256-bgZj63oMQAfFZE+rg8Q2cTO7YbeuO3J4vINpcXdf/5k="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/libksieve-25.12.0.tar.xz",
+    "hash": "sha256-vl7+L+rSoPJ6I74/R8qGwKjpC1TElt9toCYBP9grhCE="
   },
   "libktorrent": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/libktorrent-25.08.3.tar.xz",
-    "hash": "sha256-z6TZb062gnpK1mzAr3JNF3PLUW3uKYgjIEzEXgrRzWk="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/libktorrent-25.12.0.tar.xz",
+    "hash": "sha256-+1lz0jE5LCcRhlndRG+roSPJnNbHfCfettqW7w44MEw="
   },
   "lokalize": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/lokalize-25.08.3.tar.xz",
-    "hash": "sha256-B54/zaOnTvessbMGPu6xAjfnNkZr1JlTdipl0I7xFIM="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/lokalize-25.12.0.tar.xz",
+    "hash": "sha256-56XfxtrcEhfj1/kmzh5rLsNBlap7z5+vSTqoB/aw6i4="
   },
   "lskat": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/lskat-25.08.3.tar.xz",
-    "hash": "sha256-lTKIRVfvJGj4K2WmzlT9y8DfPKGS/njKy44k97coKb0="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/lskat-25.12.0.tar.xz",
+    "hash": "sha256-Mva6n3swC5c/pRqK+jxVFvSJ8ns+u/P/jbbQwbJkKAA="
   },
   "mailcommon": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/mailcommon-25.08.3.tar.xz",
-    "hash": "sha256-PEaG+HOUDgC3UlmT+s1aU+LH8tlECMb2inaqE7EXQ/o="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/mailcommon-25.12.0.tar.xz",
+    "hash": "sha256-GIMa1akrLIcFhz1Hdq1GDTs4y85gD25g/rYJO+Sx1lI="
   },
   "mailimporter": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/mailimporter-25.08.3.tar.xz",
-    "hash": "sha256-8MsBq+JLOlMydW3tUZMSgT/w43lx1r+xk3wLe8xv2qk="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/mailimporter-25.12.0.tar.xz",
+    "hash": "sha256-tmmsiTFdr8H0Lrl4pkNmxPdRYl8zuo6yqqiB+PJmShU="
   },
   "marble": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/marble-25.08.3.tar.xz",
-    "hash": "sha256-ZcA02sx6LVu/U0/KZXQonosdvyvVDk9j/00atk/wcZg="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/marble-25.12.0.tar.xz",
+    "hash": "sha256-rim9mbCe7zUHn/bFj180wb6/i3cIvLeOtnBAlQyq3Hs="
   },
   "markdownpart": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/markdownpart-25.08.3.tar.xz",
-    "hash": "sha256-WVJLI3e+0JYjSotHHzwXVFU9HT8SI53rN3ycAtVDZT0="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/markdownpart-25.12.0.tar.xz",
+    "hash": "sha256-riIRwD/muwq6Vw6QUXV9PYuxOdIRwxU/yc4R3hIEKeg="
   },
   "massif-visualizer": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/massif-visualizer-25.08.3.tar.xz",
-    "hash": "sha256-Bx3Rj+LLsJIkmDpmByXVlvCbauZwM+7ATilZQbQAZ3U="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/massif-visualizer-25.12.0.tar.xz",
+    "hash": "sha256-8GdN8bd+SwyPeMBtLux8OrfvSsRP1zPVwQFWGoFvYGg="
   },
   "mbox-importer": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/mbox-importer-25.08.3.tar.xz",
-    "hash": "sha256-vULK64dpOrPKzHxC2flA4iyHWvTU0wSyZWCT3kjZuCI="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/mbox-importer-25.12.0.tar.xz",
+    "hash": "sha256-LyBqLejhqXO4V4KTSWMGU5IzEdhp9kXhtQij1vxkdRk="
   },
   "merkuro": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/merkuro-25.08.3.tar.xz",
-    "hash": "sha256-oCHLfVogUZN1pWv/hUH8Kzvd1evkhaub0l4wayETEq0="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/merkuro-25.12.0.tar.xz",
+    "hash": "sha256-WVSX3BGr4vxQ98NJVD9YhtxxdnU4pk9JALLov2N5LAg="
   },
   "messagelib": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/messagelib-25.08.3.tar.xz",
-    "hash": "sha256-p8h4gwpdeQdSyYs9lWPHbhowtqKM7FPL1Ka2ATL1Z/g="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/messagelib-25.12.0.tar.xz",
+    "hash": "sha256-mku/7JeHAID1K6nQt89N9o4/tC8Xk1Hgr5QK1mxzz3w="
   },
   "mimetreeparser": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/mimetreeparser-25.08.3.tar.xz",
-    "hash": "sha256-6hbPP8h+HKlQpBSUvRbvoHBdAGG1W1RaiZeYQ8g1uXc="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/mimetreeparser-25.12.0.tar.xz",
+    "hash": "sha256-Y2YjZ4QuJbjhPHUj0FQoR6HP+zbHIHK/47KULszdeEE="
   },
   "minuet": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/minuet-25.08.3.tar.xz",
-    "hash": "sha256-ECs5JaDltDem8+Ezq8roZ2I4lyqdaMRmbBqnblG5ukQ="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/minuet-25.12.0.tar.xz",
+    "hash": "sha256-nywTq0fYgZOOJO8UuvxxXoISGsFkRyj5EHlj0OtXizw="
   },
   "neochat": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/neochat-25.08.3.tar.xz",
-    "hash": "sha256-X62WRyoLV3qfK9fMVe1/b0gcRIv3duPVlsoJV6/MjDU="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/neochat-25.12.0.tar.xz",
+    "hash": "sha256-pS0SAtU9obupnVa30EhjjkDoFnXPdzdZGp2k2n4n/vw="
   },
   "okular": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/okular-25.08.3.tar.xz",
-    "hash": "sha256-Ay496PxUZ5YUGFlpEYjm+ALG3kmLZczLzmCqYNhlcU8="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/okular-25.12.0.tar.xz",
+    "hash": "sha256-zwWlFbunjuXn+1qgnmesQv55bz9kWkNTxrblVeYchJA="
   },
   "palapeli": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/palapeli-25.08.3.tar.xz",
-    "hash": "sha256-j8fuZ+QiXLEvFh4ePo3evMLuH1Bo/eEM/QbuWkFgiUU="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/palapeli-25.12.0.tar.xz",
+    "hash": "sha256-SF0B5gCYqshClw/eLR8S8P+B1kYPO4rFhs2ji134VnU="
   },
   "parley": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/parley-25.08.3.tar.xz",
-    "hash": "sha256-BMtueE6ChA1sp3mvriE+baW/7k3Kgrl3Er+4/RrFBWQ="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/parley-25.12.0.tar.xz",
+    "hash": "sha256-KcW/Bq0GSmwjd3haeRhWf7kLh9ugzUJ5d9/yekcfO94="
   },
   "partitionmanager": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/partitionmanager-25.08.3.tar.xz",
-    "hash": "sha256-19HbCJIZgzqVzt0yp3hZxziuzqh6smc6ym5oCaH3sXE="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/partitionmanager-25.12.0.tar.xz",
+    "hash": "sha256-OuYDBPc4MHE0illufysAKWNb9WhlT1duE/vKAlaVovo="
   },
   "picmi": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/picmi-25.08.3.tar.xz",
-    "hash": "sha256-3VzAh7jTcPHiWpNvsKjqzupoel/UnzDQASNItedoqXA="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/picmi-25.12.0.tar.xz",
+    "hash": "sha256-6SIgMwsJyjyZt8qlZJRi4vhh5jTS4FbT5NlR3eAh1xg="
   },
   "pim-data-exporter": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/pim-data-exporter-25.08.3.tar.xz",
-    "hash": "sha256-dHbHp7hZT53QhllmCh7zBCDIDUiWFIkjDMhQVosjags="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/pim-data-exporter-25.12.0.tar.xz",
+    "hash": "sha256-So83Fpc35yrHyXim43JZhrbbGOffps1HeLoxey48bBQ="
   },
   "pim-sieve-editor": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/pim-sieve-editor-25.08.3.tar.xz",
-    "hash": "sha256-nqMohVofxgLs4gvODqLJ4zHzvkFsbmro+YUYsCkqJoQ="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/pim-sieve-editor-25.12.0.tar.xz",
+    "hash": "sha256-P+vvIebqSetFx9o4kS4RnhGxIHJsIaF5Oudl+/Cajqc="
   },
   "pimcommon": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/pimcommon-25.08.3.tar.xz",
-    "hash": "sha256-/oIGtot4tVXO7YPPLmjlNIQGxZrBW8Qzkotlv56He4g="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/pimcommon-25.12.0.tar.xz",
+    "hash": "sha256-EeD66gk6hjS7zK14jjHbvvrwKHUeXRMThO9IDN8LC7I="
   },
   "plasmatube": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/plasmatube-25.08.3.tar.xz",
-    "hash": "sha256-qJ4ZBtN7Fvp2+ACWQO69jj29hzp+tjly594Jhj6MO1g="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/plasmatube-25.12.0.tar.xz",
+    "hash": "sha256-SaFfmzhASozSSwOyIAEXopg+RPgww4U9v6jjr6QP0rI="
   },
   "poxml": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/poxml-25.08.3.tar.xz",
-    "hash": "sha256-EpZ7UxNgVADo3jzzlHgTb1tmFrK0V3TcGFu2tcuue30="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/poxml-25.12.0.tar.xz",
+    "hash": "sha256-7xSZAE4h2Fm9ZS7gn/ElemC6ZHjvq2oO2FLbtKIXyMw="
   },
   "qmlkonsole": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/qmlkonsole-25.08.3.tar.xz",
-    "hash": "sha256-SFD6lJeC2zMctKqFz2fXJ+3YBrd3Gr6C1KfVag6+/E0="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/qmlkonsole-25.12.0.tar.xz",
+    "hash": "sha256-lsFvEUsPmJUX6nP7NWpV8IO8nzMcTthzTIaoRvSlucI="
   },
   "qrca": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/qrca-25.08.3.tar.xz",
-    "hash": "sha256-6lwXkYjD2pI5o1Ayw2USltVXtT2r5RNNpMFNi+qCMtc="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/qrca-25.12.0.tar.xz",
+    "hash": "sha256-X0UjexAV9NISxs1MCza2W6GvKk7cmwk4yBdSvu14e8M="
   },
   "rocs": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/rocs-25.08.3.tar.xz",
-    "hash": "sha256-R6dDofPt1J2LZwKjXyoOBV0E4FB7/wCf/dteQmEySss="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/rocs-25.12.0.tar.xz",
+    "hash": "sha256-Ym1haoir3En9Eg0xs4kWeAp6ub1Q36DKuQrbexTMf4c="
   },
   "signon-kwallet-extension": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/signon-kwallet-extension-25.08.3.tar.xz",
-    "hash": "sha256-R+ee39uX2SQOIu2fpiTrrDzSGeSi7ncMaGm4abU7mv8="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/signon-kwallet-extension-25.12.0.tar.xz",
+    "hash": "sha256-MMGHVBeGa27jz8sgh9odafybAxbvmAVyhwy3wtF6tx4="
   },
   "skanlite": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/skanlite-25.08.3.tar.xz",
-    "hash": "sha256-ga/hMhLF7a7sSlfBChBdMdwg2jteCO9l+/P3Q8CPAnY="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/skanlite-25.12.0.tar.xz",
+    "hash": "sha256-UlKHu5A4aL51uWMLNMEa5f1s4FvhP8YW2jAxXlINRs0="
   },
   "skanpage": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/skanpage-25.08.3.tar.xz",
-    "hash": "sha256-6EMcc/YpAduT5HAM7LdieZq94Far+P2Ar4cH0SnG1Fg="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/skanpage-25.12.0.tar.xz",
+    "hash": "sha256-IwQuJ92shpEq4vCn8gCM4IdVOQz4QEsSyC1ejwJo7Ik="
   },
   "skladnik": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/skladnik-25.08.3.tar.xz",
-    "hash": "sha256-5NjDXHJpOcnaeX4c1F1W0KDQSnnasfwtp6ztZqMPzo8="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/skladnik-25.12.0.tar.xz",
+    "hash": "sha256-aujdElYk1uS6yGZrIAJ78Rh5sh+m24TEUfz9cAJbx0M="
   },
   "step": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/step-25.08.3.tar.xz",
-    "hash": "sha256-sd3OT1Kgt1GIYWwGK+T6etXT13JcIR7AEXGamtJ+hvk="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/step-25.12.0.tar.xz",
+    "hash": "sha256-yAxU2LbWHhpwtjEkHMQKymk2jQyV5AQI/DNCo5zLCyM="
   },
   "svgpart": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/svgpart-25.08.3.tar.xz",
-    "hash": "sha256-l/b9tP8xEOQdjfayXw0YT1I12InYx8FcfGu7Gi8G3hc="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/svgpart-25.12.0.tar.xz",
+    "hash": "sha256-ifp+VexoAURe0iAFL34cRkdNvSk79VRyi4mP6FTqOjg="
   },
   "sweeper": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/sweeper-25.08.3.tar.xz",
-    "hash": "sha256-brC3wxqfvh+Q5NRyVIj4KFStA4lPnp/rVvYdOdBFZZ0="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/sweeper-25.12.0.tar.xz",
+    "hash": "sha256-4HIhmnX71iK3O15nBvgqUjPrlsald2N+xupAms7ieW8="
   },
   "telly-skout": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/telly-skout-25.08.3.tar.xz",
-    "hash": "sha256-RP12+uGbvD+ApoylGFN7n3B7SIQDBWSmmGYYM7RvYXA="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/telly-skout-25.12.0.tar.xz",
+    "hash": "sha256-QYvME03/D4OENlqVPSEI4381Ssr1mN/XpS4ptP2gT04="
   },
   "tokodon": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/tokodon-25.08.3.tar.xz",
-    "hash": "sha256-MyaPh3sIWJ6QF2UwsVr6u9V6uuZodPSQc+3zcGreoiE="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/tokodon-25.12.0.tar.xz",
+    "hash": "sha256-ciPNOVfoR1Xw+3OHFRDAg0VLwElSL7rMiFDWG711XG8="
   },
   "umbrello": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/umbrello-25.08.3.tar.xz",
-    "hash": "sha256-kEimFZyEhiSKlblW7QjBlUrCFwi4moH+ajsKp6Ugeiw="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/umbrello-25.12.0.tar.xz",
+    "hash": "sha256-G2Jk3qLJKuRCDDhWfUegufDGFj6n7/Zvg1T50Zgnk/c="
   },
   "yakuake": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/yakuake-25.08.3.tar.xz",
-    "hash": "sha256-2NPw/+z9mPAMhhin3PXPhe90X3BHF9+BmPYyHYNFHuw="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/yakuake-25.12.0.tar.xz",
+    "hash": "sha256-Wj+IVOdAlLFhzR1ih0WxdUW1qcQcst/hHHROUkv7PJ4="
   },
   "zanshin": {
-    "version": "25.08.3",
-    "url": "mirror://kde/stable/release-service/25.08.3/src/zanshin-25.08.3.tar.xz",
-    "hash": "sha256-3A0QGC8qE1f+8jlbXo79rsTsTl9hZVEKNRKDjAspbYE="
+    "version": "25.12.0",
+    "url": "mirror://kde/stable/release-service/25.12.0/src/zanshin-25.12.0.tar.xz",
+    "hash": "sha256-1Hn+ZRqMs2PCopa6hdGLu31AnGjPPTiQry0p/9KlW/E="
   }
 }


### PR DESCRIPTION
Now fully Qt6.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
