### PR TITLE
tests.fetchtorrent: don't run these tests on Hydra

### DIFF
--- a/pkgs/build-support/fetchtorrent/tests.nix
+++ b/pkgs/build-support/fetchtorrent/tests.nix
@@ -29,6 +29,11 @@ let
     '';
     license = lib.licenses.cc-by-30;
     homepage = "https://durian.blender.org/";
+
+    # Reported in https://github.com/NixOS/nixpkgs/pull/458193#issuecomment-3575753211 that these
+    # tests are causing Hydra to spin for hours. They all pass locally, and we don't care too much
+    # about running them on Hydra.
+    hydraPlatforms = [ ];
   };
 
   # Via https://webtorrent.io/free-torrents


### PR DESCRIPTION
@vcunat in https://github.com/NixOS/nixpkgs/pull/458193#issuecomment-3575753211

> I'm not sure where to ask, but `tests.fetchtorrent` is now frequently starting (darwin) jobs that run for 12 hours each before timing out, which... you know, it takes up the builder slots without doing anything useful apparently. Example: https://hydra.nixos.org/build/312829800 (and many more various runs)

We can just not run these on Hydra.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
