### PR TITLE
mjpg-streamer: Fix `input_uvc.so: undefined symbol: resolutions_help`

### DIFF
--- a/pkgs/by-name/mj/mjpg-streamer/fix-undefined-symbol-error.patch
+++ b/pkgs/by-name/mj/mjpg-streamer/fix-undefined-symbol-error.patch
@@ -1,0 +1,29 @@
+From 7b24e2a593a0029c6f555c9001be87a34eceecc6 Mon Sep 17 00:00:00 2001
+From: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+Date: Tue, 6 Aug 2024 17:04:55 +0200
+Subject: [PATCH] Export all symbols of mjpg_streamer binary
+
+Fixes runtime error with stripped binary
+
+    dlopen: /usr/lib/mjpg-streamer/input_uvc.so: undefined symbol: resolutions_help
+
+Source: http://lists.busybox.net/pipermail/buildroot/2024-August/759732.html
+
+Signed-off-by: Bernd Kuhls <bernd@kuhls.net>
+---
+ mjpg-streamer-experimental/CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/mjpg-streamer-experimental/CMakeLists.txt b/mjpg-streamer-experimental/CMakeLists.txt
+index cf26620e..3ff12cdf 100644
+--- a/mjpg-streamer-experimental/CMakeLists.txt
++++ b/mjpg-streamer-experimental/CMakeLists.txt
+@@ -92,6 +92,7 @@ set (CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+ add_executable(mjpg_streamer mjpg_streamer.c
+                              utils.c)
+ 
++set_property(TARGET mjpg_streamer PROPERTY ENABLE_EXPORTS ON)
+ target_link_libraries(mjpg_streamer pthread dl)
+ install(TARGETS mjpg_streamer DESTINATION bin)
+ 
+

--- a/pkgs/by-name/mj/mjpg-streamer/package.nix
+++ b/pkgs/by-name/mj/mjpg-streamer/package.nix
@@ -17,13 +17,22 @@ stdenv.mkDerivation {
     sha256 = "1cl159svfs1zzzrd3zgn4x7qy6751bvlnxfwf5hn5fmg4iszajw7";
   };
 
+  patches = [
+    # https://patchwork.ozlabs.org/project/buildroot/patch/20240808192126.1767471-1-bernd@kuhls.net/#3373402
+    # https://github.com/jacksonliam/mjpg-streamer/pull/401
+    ./fix-undefined-symbol-error.patch
+  ];
+
   prePatch = ''
-    cd mjpg-streamer-experimental
-    substituteInPlace ./CMakeLists.txt --replace-fail "cmake_minimum_required(VERSION 2.8.3)" "cmake_minimum_required(VERSION 2.8.3...3.10)"
+    substituteInPlace ./mjpg-streamer-experimental/CMakeLists.txt --replace-fail "cmake_minimum_required(VERSION 2.8.3)" "cmake_minimum_required(VERSION 2.8.3...3.10)"
   '';
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ libjpeg ];
+
+  preConfigure = ''
+    cd mjpg-streamer-experimental
+  '';
 
   postFixup = ''
     patchelf --set-rpath "$(patchelf --print-rpath $out/bin/mjpg_streamer):$out/lib/mjpg-streamer" $out/bin/mjpg_streamer


### PR DESCRIPTION
And change the `cd mjpg-streamer-experimental` to be later so we can use patches without needing to change the paths in them.

Tested on my raspi


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
