### PR TITLE
ocamlPackages.repr: 0.7.0 → 0.8.0

### DIFF
--- a/pkgs/development/ocaml-modules/repr/default.nix
+++ b/pkgs/development/ocaml-modules/repr/default.nix
@@ -1,27 +1,33 @@
 {
   lib,
   buildDunePackage,
-  fetchFromGitHub,
+  fetchurl,
   base64,
   either,
   fmt,
   jsonm,
   uutf,
   optint,
+  # This version constraint strictly applies only to ppx_repr,
+  # but is enforced here to get a consistent package set
+  # (with repr and ppx_repr at the same version)
+  ppxlib,
+  version ? if lib.versionAtLeast ppxlib.version "0.36" then "0.8.0" else "0.7.0",
 }:
 
-buildDunePackage rec {
+buildDunePackage {
   pname = "repr";
-  version = "0.7.0";
+  inherit version;
 
-  src = fetchFromGitHub {
-    owner = "mirage";
-    repo = "repr";
-    rev = version;
-    hash = "sha256-SM55m5NIaQ2UKAtznNFSt3LN4QA7As0DyTxVeQjOTjI=";
+  src = fetchurl {
+    url = "https://github.com/mirage/repr/releases/download/${version}/repr-${version}.tbz";
+    hash =
+      {
+        "0.8.0" = "sha256-FyhCO4sCCPmwMq0+Bd2WpDuSzXZBb5FG45TwsLoTM0c=";
+        "0.7.0" = "sha256-itrJ/oW/ig4g7raBDXIW6Y4bf02b05nmG7ECSs4lAaw=";
+      }
+      ."${version}";
   };
-
-  minimalOCamlVersion = "4.08";
 
   propagatedBuildInputs = [
     base64
@@ -32,10 +38,10 @@ buildDunePackage rec {
     optint
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Dynamic type representations. Provides no stability guarantee";
     homepage = "https://github.com/mirage/repr";
-    license = licenses.isc;
-    maintainers = with maintainers; [ sternenseemann ];
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ sternenseemann ];
   };
 }

--- a/pkgs/development/ocaml-modules/repr/ppx.nix
+++ b/pkgs/development/ocaml-modules/repr/ppx.nix
@@ -1,7 +1,6 @@
 {
   lib,
   buildDunePackage,
-  fetchpatch,
   ppx_deriving,
   ppxlib,
   repr,
@@ -13,17 +12,6 @@ buildDunePackage {
   pname = "ppx_repr";
 
   inherit (repr) src version;
-
-  patches = lib.optionals (lib.versionAtLeast ppxlib.version "0.36") [
-    (fetchpatch {
-      url = "https://github.com/mirage/repr/commit/460fc85a2804e3301bfc0e79413f5df472d95374.patch";
-      hash = "sha256-8nEPyeZ1s9Q/6+BKtdMb9kVhTfCdMmRrU3xpvizVZHA=";
-    })
-    (fetchpatch {
-      url = "https://github.com/mirage/repr/commit/c939a7317e126589bd6d6bd1d9e38cff749bcdb1.patch";
-      hash = "sha256-Srf5fZoc0iiJEZiW8PnIM5VdHOGofbdkhfnjQvFcTq0=";
-    })
-  ];
 
   propagatedBuildInputs = [
     ppx_deriving


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
