### PR TITLE
uv: 0.9.9 -> 0.9.12

### DIFF
--- a/pkgs/by-name/uv/uv/package.nix
+++ b/pkgs/by-name/uv/uv/package.nix
@@ -18,16 +18,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "uv";
-  version = "0.9.9";
+  version = "0.9.10";
 
   src = fetchFromGitHub {
     owner = "astral-sh";
     repo = "uv";
     tag = finalAttrs.version;
-    hash = "sha256-i9vdpHA9EfXmw5fhK1tTZG0T2zOlDbjPCGBIizvQzZw=";
+    hash = "sha256-XpWBgFxBflyqsla0K83j/3aBgq5ccedQTa5PoaYs9f0=";
   };
 
-  cargoHash = "sha256-RZkIjHQElqrj+UAz+q6w1CYW3E5/YW9uy2E5KpKvw+w=";
+  cargoHash = "sha256-9SEUnud2gu64+trX87GhpXzTlBaB/DLrXLjoZbGL0f4=";
 
   buildInputs = [
     rust-jemalloc-sys

--- a/pkgs/by-name/uv/uv/package.nix
+++ b/pkgs/by-name/uv/uv/package.nix
@@ -18,16 +18,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "uv";
-  version = "0.9.10";
+  version = "0.9.11";
 
   src = fetchFromGitHub {
     owner = "astral-sh";
     repo = "uv";
     tag = finalAttrs.version;
-    hash = "sha256-XpWBgFxBflyqsla0K83j/3aBgq5ccedQTa5PoaYs9f0=";
+    hash = "sha256-X3jTJxT8aZ7/yuCVBhIG6UCmrB4/y2sbD3z2dGBApzg=";
   };
 
-  cargoHash = "sha256-9SEUnud2gu64+trX87GhpXzTlBaB/DLrXLjoZbGL0f4=";
+  cargoHash = "sha256-4Zp+d74Auc/rQ2yJvg7ZdQB4NGqBpMSO5NmgDwsDzf0=";
 
   buildInputs = [
     rust-jemalloc-sys

--- a/pkgs/by-name/uv/uv/package.nix
+++ b/pkgs/by-name/uv/uv/package.nix
@@ -18,16 +18,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "uv";
-  version = "0.9.11";
+  version = "0.9.12";
 
   src = fetchFromGitHub {
     owner = "astral-sh";
     repo = "uv";
     tag = finalAttrs.version;
-    hash = "sha256-X3jTJxT8aZ7/yuCVBhIG6UCmrB4/y2sbD3z2dGBApzg=";
+    hash = "sha256-Lm2LQlNcHwak0939MiXb6kOrI9qwYGnkLXbJ9ujLBdQ=";
   };
 
-  cargoHash = "sha256-4Zp+d74Auc/rQ2yJvg7ZdQB4NGqBpMSO5NmgDwsDzf0=";
+  cargoHash = "sha256-hiH3eraJoyz9GXupsYNNZoGlh3sHlhcIMWKbF+Ktc+Y=";
 
   buildInputs = [
     rust-jemalloc-sys
@@ -61,10 +61,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   passthru = {
     tests.uv-python = python3Packages.uv;
-
-    # Updating `uv` needs to be done on staging until the next staging branch-off.
-    # Disabling r-ryantm update bot:
-    # nixpkgs-update: no auto update
     updateScript = nix-update-script { };
   };
 


### PR DESCRIPTION
```console
$ nom-build -A uv -A python3Packages.uv
Finished at 21:37:04 after 2s
/nix/store/22snck61wdvr0bpbnkkd4mibpi040r44-uv-0.9.12
/nix/store/nha2hc1q77mi0jm216crdkqhqabrny1d-python3.13-uv-0.9.12
```

0.9.9 -> 0.9.11 have been cherry-picked from staging, and 0.9.11 -> 0.9.12 was generated via the update script.
Now that #457247 has reached master, we can bring these updates into master without triggering too many rebuilds.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
