### PR TITLE
mpc-qt: 24.12.1-flatpak -> 25.07

### DIFF
--- a/pkgs/by-name/mp/mpc-qt/package.nix
+++ b/pkgs/by-name/mp/mpc-qt/package.nix
@@ -2,7 +2,10 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  cmake,
+  ninja,
   pkg-config,
+  boost,
   qt6Packages,
   mpv,
   gitUpdater,
@@ -10,18 +13,20 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mpc-qt";
-  version = "24.12.1-flatpak";
+  version = "25.07";
 
   src = fetchFromGitHub {
     owner = "mpc-qt";
     repo = "mpc-qt";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-gn94kVs3Lbd+ggj4jTacHpmnVO2lH/QDhFk+hJC1N/c=";
+    hash = "sha256-apZR3PgU+Fq1whnWQHhmHPZKAZBKdrVCWaGfu+H7A4s=";
   };
 
   nativeBuildInputs = [
+    boost
+    ninja
+    cmake
     pkg-config
-    qt6Packages.qmake
     qt6Packages.qttools
     qt6Packages.wrapQtAppsHook
   ];
@@ -30,16 +35,8 @@ stdenv.mkDerivation (finalAttrs: {
     mpv
   ];
 
-  postPatch = ''
-    substituteInPlace lconvert.pri --replace "qtPrepareTool(LCONVERT, lconvert)" "qtPrepareTool(LCONVERT, lconvert, , , ${qt6Packages.qttools}/bin)"
-  '';
-
-  postConfigure = ''
-    substituteInPlace Makefile --replace ${qt6Packages.qtbase}/bin/lrelease ${qt6Packages.qttools.dev}/bin/lrelease
-  '';
-
-  qmakeFlags = [
-    "MPCQT_VERSION=${finalAttrs.version}"
+  cmakeFlags = [
+    "-DMPCQT_VERSION=${finalAttrs.version}"
   ];
 
   passthru.updateScript = gitUpdater { rev-prefix = "v"; };


### PR DESCRIPTION
Release notes: https://github.com/mpc-qt/mpc-qt/releases/tag/v25.07
Full changelog: https://github.com/mpc-qt/mpc-qt/compare/v24.12.1-flatpak...v25.07

Other changes to package:
- Update build system and dependencies from qmake to cmake, ninja and boost
- Remove qmake workarounds not needed anymore

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
