### PR TITLE
python3Packages.astroquery: 0.4.10 -> 0.4.11

### DIFF
--- a/pkgs/development/python-modules/astroquery/default.nix
+++ b/pkgs/development/python-modules/astroquery/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch2,
   astropy,
   boto3,
   requests,
@@ -15,32 +14,25 @@
   pytest-astropy,
   pytest-dependency,
   pytest-rerunfailures,
+  pytest-timeout,
   pytestCheckHook,
   pyvo,
   astropy-helpers,
   setuptools,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
   pname = "astroquery";
-  version = "0.4.10";
+  version = "0.4.11";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "astropy";
     repo = "astroquery";
     tag = "v${version}";
-    hash = "sha256-5pNKV+XNfUQca7WoWboVphXffzyVIHCmfxwr4nBMaEk=";
+    hash = "sha256-BcdRBPnJfuW17p31xUhjBmP7Lv98CnmOTCO4aU0xpMM=";
   };
-
-  patches = [
-    # https://github.com/astropy/astroquery/pull/3311
-    (fetchpatch2 {
-      name = "setuptools-package-index.patch";
-      url = "https://github.com/astropy/astroquery/commit/9d43beb4b7bea424d73fff0b602ca90026155519.patch";
-      hash = "sha256-3QdOwP1rlWeScGxHT9ZVPmffE7S1XE0cbtnQ8T4bIYw=";
-    })
-  ];
 
   build-system = [
     astropy-helpers
@@ -71,23 +63,19 @@ buildPythonPackage rec {
     pytest-astropy
     pytest-dependency
     pytest-rerunfailures
+    pytest-timeout
+    writableTmpDirAsHomeHook
   ];
 
-  pytestFlags = [
-    # DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
-    "-Wignore::DeprecationWarning"
-  ];
-
-  # Tests must be run in the build directory. The tests create files
-  # in $HOME/.astropy so we need to set HOME to $TMPDIR.
+  # Tests must be run in the build directory.
   preCheck = ''
-    export HOME=$TMPDIR
     cd build/lib
   '';
 
   pythonImportsCheck = [ "astroquery" ];
 
   meta = {
+    changelog = "https://github.com/astropy/astroquery/releases/tag/${src.tag}";
     description = "Functions and classes to access online data resources";
     homepage = "https://astroquery.readthedocs.io/";
     license = lib.licenses.bsd3;


### PR DESCRIPTION
This fixes `python313Packages.astroquery` on staging.

Diff: https://github.com/astropy/astroquery/compare/v0.4.10...v0.4.11

Changelog: https://github.com/astropy/astroquery/releases/tag/v0.4.11


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
