### PR TITLE
amoebax: init at 0.2.1

### DIFF
--- a/pkgs/by-name/am/amoebax/package.nix
+++ b/pkgs/by-name/am/amoebax/package.nix
@@ -1,0 +1,50 @@
+{
+  fetchurl,
+  lib,
+  SDL,
+  SDL_image,
+  SDL_mixer,
+  stdenv,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "amoebax";
+  version = "0.2.1";
+  src = fetchurl {
+    url = "https://www.emma-soft.com/games/amoebax/download/amoebax-${finalAttrs.version}.tar.bz2";
+    hash = "sha256-cJx+ZXsyim99MxKYxiZPFyUoSJ0oyrEHxAxIPDkjQLI=";
+  };
+
+  buildInputs = [
+    SDL
+    SDL_image
+    SDL_mixer
+  ];
+
+  configureFlags = [
+    "ac_cv_file__proc_self_maps=y"
+  ];
+
+  env.NIX_CFLAGS_COMPILE = "-fpermissive";
+  env.SDL_CONFIG = lib.getExe' (lib.getDev SDL) "sdl-config";
+
+  strictDeps = true;
+
+  meta = {
+    homepage = "https://www.emma-soft.com/games/amoebax/";
+    description = "Cross-platform free Puyo-Puyo clone";
+    longDescription = ''
+      Amoebax is a free multi-platform match-3 puzzle game where the objective
+      is to beat your opponent in a battle by filling their grid up to the top
+      with garbage.
+
+      You can play as Kim or Tom against six cute creatures controlled by the
+      amoebas or you can play up to four players in a tournament to check out
+      who is the amoebas' master.
+    '';
+    license = lib.licenses.gpl2Plus;
+    mainProgram = "amoebax";
+    maintainers = with lib.maintainers; [ colinsane ];
+    platforms = lib.platforms.all;
+    broken = stdenv.hostPlatform.isDarwin;
+  };
+})


### PR DESCRIPTION
[project homepage](https://www.emma-soft.com/games/amoebax/). `license` is found inside the actual source code (COPYING), not on the project homepage. `description` and `longDescription` were also taken from the source code (README).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
