### PR TITLE
openmeters: init at 0-unstable-2025-12-15

### DIFF
--- a/pkgs/by-name/op/openmeters/package.nix
+++ b/pkgs/by-name/op/openmeters/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  makeWrapper,
+  pkg-config,
+  pipewire,
+  wayland,
+  fontconfig,
+  freetype,
+  libglvnd,
+  libxkbcommon,
+  xorg,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "openmeters";
+  version = "0-unstable-2025-12-15";
+
+  src = fetchFromGitHub {
+    owner = "httpsworldview";
+    repo = "openmeters";
+    rev = "701b22b40796e33b118719724a54be231144a5ac";
+    hash = "sha256-svsC0lxAnkVuyk6LZPyFSjeOL8H0yY3dRA37+K1e/xY=";
+  };
+
+  cargoHash = "sha256-jm/8FdJiVVh/PAyJiLA/KK4IaXi4gUBMGIKz/FL3KZ8=";
+
+  nativeBuildInputs = [
+    makeWrapper
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    pipewire
+  ];
+
+  postFixup = ''
+    patchelf --add-rpath '${
+      lib.makeLibraryPath [
+        fontconfig
+        freetype
+        libglvnd
+        libxkbcommon
+        wayland
+        xorg.libX11
+        xorg.libXcursor
+        xorg.libXi
+        xorg.libXrandr
+      ]
+    }' $out/bin/openmeters
+  '';
+
+  meta = {
+    description = "Fast and simple audio metering/visualization program for Linux";
+    homepage = "https://github.com/httpsworldview/openmeters";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.bitbloxhub ];
+    platforms = lib.platforms.linux;
+    mainProgram = "openmeters";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add [`openmeters`](https://github.com/httpsworldview/openmeters), a fast and simple audio metering/visualization program for Linux. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
