### PR TITLE
python3Packages.bugwarrior: 1.8.0 -> 2.0.0

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -178,6 +178,8 @@
 
 - `orjail` package has been removed as it is broken by the latest firejail release and seems unmaintained.
 
+- `python3Packages.bugwarrior` has been updated to major version 2.0.0 which will likely require manual intervention. See [release notes](https://github.com/GothenburgBitFactory/bugwarrior/releases/tag/2.0.0).
+
 - `pcp` has been removed because the upstream repo was archived and it hasn't been updated since 2021.
 
 - `podofo` has been updated from `0.9.8` to `1.0.0`. These releases are by nature very incompatible due to major API changes. The legacy versions can be found under `podofo_0_10` and `podofo_0_9`.

--- a/pkgs/development/python-modules/bugwarrior/default.nix
+++ b/pkgs/development/python-modules/bugwarrior/default.nix
@@ -1,68 +1,118 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
-  pythonOlder,
+  fetchFromGitHub,
+  taskwarrior3,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
   setuptools,
-  twiggy,
-  requests,
-  offtrac,
-  python-bugzilla,
-  taskw,
+  click,
+  dogpile-cache,
+  importlib-metadata,
+  jinja2,
+  lockfile,
+  pydantic,
   python-dateutil,
   pytz,
-  keyring,
-  six,
-  jinja2,
-  pycurl,
-  dogpile-cache,
-  lockfile,
-  click,
-  pyxdg,
-  future,
+  requests,
+  taskw,
+  debianbts,
+  python-bugzilla,
+  google-api-python-client,
+  google-auth-oauthlib,
   jira,
+  keyring,
+  offtrac,
+  pytestCheckHook,
+  docutils,
+  pytest-subtests,
+  responses,
+  sphinx,
+  sphinx-click,
+  sphinx-inline-tabs,
 }:
 
 buildPythonPackage rec {
   pname = "bugwarrior";
-  version = "1.8.0";
-  format = "setuptools";
-  disabled = pythonOlder "3.6";
+  version = "2.0.0";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "f024c29d2089b826f05481cace33a62aa984f33e98d226f6e41897e6f11b3f51";
+  src = fetchFromGitHub {
+    owner = "GothenburgBitFactory";
+    repo = "bugwarrior";
+    tag = version;
+    hash = "sha256-VuHTrkxLZmQOxyig2krVU9UZDDbLY08MfB9si08lh3E=";
   };
 
-  propagatedBuildInputs = [
-    setuptools
-    twiggy
-    requests
-    offtrac
-    python-bugzilla
-    taskw
+  build-system = [ setuptools ];
+
+  dependencies = [
+    click
+    dogpile-cache
+    importlib-metadata
+    jinja2
+    lockfile
+    pydantic
     python-dateutil
     pytz
-    keyring
-    six
-    jinja2
-    pycurl
-    dogpile-cache
-    lockfile
-    click
-    pyxdg
-    future
-    jira
+    requests
+    taskw
+  ]
+  ++ pydantic.optional-dependencies.email;
+  pythonRemoveDeps = [ "tomli" ];
+
+  optional-dependencies = {
+    bts = [ debianbts ];
+    bugzilla = [ python-bugzilla ];
+    gmail = [
+      google-api-python-client
+      google-auth-oauthlib
+    ];
+    jira = [ jira ];
+    keyring = [ keyring ];
+    trac = [ offtrac ];
+  };
+
+  nativeCheckInputs = [
+    taskwarrior3
+    versionCheckHook
+    writableTmpDirAsHomeHook
+    pytestCheckHook
+    docutils
+    pytest-subtests
+    responses
+    sphinx
+    sphinx-click
+    sphinx-inline-tabs
+  ]
+  ++ lib.concatAttrValues optional-dependencies;
+  disabledTestPaths = [
+    # Optional dependencies for these services aren't packaged.
+    "tests/test_kanboard.py"
+    "tests/test_phab.py"
+    "tests/test_todoist.py"
+  ];
+  disabledTests = [
+    # Requires ini2toml dependency, which isn't packaged.
+    "TestIni2Toml"
+    # Import services for which the optional dependencies aren't packaged.
+    "TestValidation"
+    "ExampleTest"
+    "TestServices"
   ];
 
-  # for the moment oauth2client <4.0.0 and megaplan>=1.4 are missing for running the test suite.
-  doCheck = false;
+  pythonImportsCheck = [ "bugwarrior" ];
 
   meta = {
     homepage = "https://github.com/GothenburgBitFactory/bugwarrior";
     description = "Sync github, bitbucket, bugzilla, and trac issues with taskwarrior";
+    changelog = "https://github.com/GothenburgBitFactory/bugwarrior/blob/${src.tag}/CHANGELOG.rst";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ pierron ];
+    mainProgram = "bugwarrior";
+    maintainers = with lib.maintainers; [
+      pierron
+      ryneeverett
+    ];
   };
 }

--- a/pkgs/development/python-modules/taskw/default.nix
+++ b/pkgs/development/python-modules/taskw/default.nix
@@ -43,10 +43,10 @@ buildPythonPackage rec {
 
   buildInputs = [
     taskwarrior2
-    distutils
   ];
 
   dependencies = [
+    distutils
     kitchen
     python-dateutil
     pytz


### PR DESCRIPTION
Resolve #353713. Also, add me as a maintainer. Disclosure: I'm the upstream maintainer.

https://github.com/GothenburgBitFactory/bugwarrior/releases/tag/2.0.0

I added release notes since the PR template suggests it. I think this needs to be backported to 25.11 even though it's a major release since bugwarrior is otherwise broken (#353713).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
