### PR TITLE
ocamlPackages.{either,hashcons,irmin-watcher,lacaml,ladspa}: small cleaning

### DIFF
--- a/pkgs/development/ocaml-modules/either/default.nix
+++ b/pkgs/development/ocaml-modules/either/default.nix
@@ -4,21 +4,19 @@
   fetchurl,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "either";
   version = "1.0.0";
 
   src = fetchurl {
-    url = "https://github.com/mirage/either/releases/download/${version}/either-${version}.tbz";
-    sha256 = "bf674de3312dee7b7215f07df1e8a96eb3d679164b8a918cdd95b8d97e505884";
+    url = "https://github.com/mirage/either/releases/download/${finalAttrs.version}/either-${finalAttrs.version}.tbz";
+    hash = "sha256-v2dN4zEt7ntyFfB98eipbrPWeRZLipGM3ZW42X5QWIQ=";
   };
 
-  useDune2 = true;
-
-  meta = with lib; {
+  meta = {
     description = "Compatibility Either module";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     homepage = "https://github.com/mirage/either";
-    maintainers = [ maintainers.sternenseemann ];
+    maintainers = [ lib.maintainers.sternenseemann ];
   };
-}
+})

--- a/pkgs/development/ocaml-modules/hashcons/default.nix
+++ b/pkgs/development/ocaml-modules/hashcons/default.nix
@@ -4,18 +4,16 @@
   buildDunePackage,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "hashcons";
-  version = "1.4";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
     owner = "backtracking";
-    repo = "ocaml-${pname}";
+    repo = "ocaml-hashcons";
     rev = "d733325eeb55878bed285120c2c088daf78f0e2b";
-    sha256 = "0h4pvwj34pndaw3pajkhl710ywwinhc9pqimgllfmkl37wz2d8zq";
+    hash = "sha256-+KMmPj+DzuoofTXimxi0kXMPwqFwSnUHV81eMiTfl0A=";
   };
-
-  useDune2 = true;
 
   doCheck = true;
 
@@ -24,4 +22,4 @@ buildDunePackage rec {
     license = lib.licenses.lgpl21;
     maintainers = [ lib.maintainers.ulrikstrid ];
   };
-}
+})

--- a/pkgs/development/ocaml-modules/irmin-watcher/default.nix
+++ b/pkgs/development/ocaml-modules/irmin-watcher/default.nix
@@ -5,25 +5,23 @@
   astring,
   fmt,
   logs,
-  ocaml_lwt,
+  lwt,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "irmin-watcher";
   version = "0.5.0";
 
-  useDune2 = true;
-
   src = fetchurl {
-    url = "https://github.com/mirage/irmin-watcher/releases/download/${version}/irmin-watcher-${version}.tbz";
-    sha256 = "sha256-vq4kwaz4QUG9x0fGEbQMAuDGjlT3/6lm8xiXTUqJmZM=";
+    url = "https://github.com/mirage/irmin-watcher/releases/download/${finalAttrs.version}/irmin-watcher-${finalAttrs.version}.tbz";
+    hash = "sha256-vq4kwaz4QUG9x0fGEbQMAuDGjlT3/6lm8xiXTUqJmZM=";
   };
 
   propagatedBuildInputs = [
     astring
     fmt
     logs
-    ocaml_lwt
+    lwt
   ];
 
   meta = {
@@ -33,4 +31,4 @@ buildDunePackage rec {
     maintainers = [ lib.maintainers.vbgl ];
   };
 
-}
+})

--- a/pkgs/development/ocaml-modules/lacaml/default.nix
+++ b/pkgs/development/ocaml-modules/lacaml/default.nix
@@ -9,17 +9,13 @@
 
 assert (!blas.isILP64) && (!lapack.isILP64);
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "lacaml";
   version = "11.1.1";
 
-  useDune2 = true;
-
-  minimalOCamlVersion = "4.08";
-
   src = fetchurl {
-    url = "https://github.com/mmottl/lacaml/releases/download/${version}/lacaml-${version}.tbz";
-    sha256 = "sha256-NEs7A/lfA+8AE6k19EPW02e1pseDE7HobGSB/ZwLcoc=";
+    url = "https://github.com/mmottl/lacaml/releases/download/${finalAttrs.version}/lacaml-${finalAttrs.version}.tbz";
+    hash = "sha256-NEs7A/lfA+8AE6k19EPW02e1pseDE7HobGSB/ZwLcoc=";
   };
 
   buildInputs = [ dune-configurator ];
@@ -28,10 +24,10 @@ buildDunePackage rec {
     blas
   ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://mmottl.github.io/lacaml";
     description = "OCaml bindings for BLAS and LAPACK";
-    license = licenses.lgpl21Plus;
-    maintainers = [ maintainers.vbgl ];
+    license = lib.licenses.lgpl21Plus;
+    maintainers = [ lib.maintainers.vbgl ];
   };
-}
+})

--- a/pkgs/development/ocaml-modules/ladspa/default.nix
+++ b/pkgs/development/ocaml-modules/ladspa/default.nix
@@ -6,26 +6,24 @@
   ladspaH,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "ladspa";
   version = "0.2.2";
-
-  useDune2 = true;
 
   src = fetchFromGitHub {
     owner = "savonet";
     repo = "ocaml-ladspa";
-    rev = "v${version}";
-    sha256 = "1y83infjaz9apzyvaaqw331zqdysmn3bpidfab061v3bczv4jzbz";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-f31J9mdr7GDAUq7Fu4at2jf8wxgcK7X9vyp9JZ2NA/k=";
   };
 
   buildInputs = [ dune-configurator ];
   propagatedBuildInputs = [ ladspaH ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/savonet/ocaml-alsa";
     description = "Bindings for the LADSPA API which provides audio effects";
-    license = licenses.lgpl21Only;
-    maintainers = with maintainers; [ dandellion ];
+    license = lib.licenses.lgpl21Only;
+    maintainers = [ lib.maintainers.dandellion ];
   };
-}
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
