### PR TITLE
nixos/networking: allow hostName to be an FQDN

### DIFF
--- a/nixos/lib/testing/network.nix
+++ b/nixos/lib/testing/network.nix
@@ -97,8 +97,8 @@ let
             config = nodes.${m'};
             hostnames =
               optionalString (
-                config.networking.domain != null
-              ) "${config.networking.hostName}.${config.networking.domain} "
+                config.networking.fqdnOrHostName != config.networking.hostName
+              ) "${config.networking.fqdn} "
               + "${config.networking.hostName}\n";
           in
           optionalString (

--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -174,9 +174,9 @@ in
     # hostname and FQDN correctly:
     networking.hosts =
       let
-        hostnames = # Note: The FQDN (canonical hostname) has to come first:
-          lib.optional (cfg.hostName != "" && cfg.domain != null) "${cfg.hostName}.${cfg.domain}"
-          ++ lib.optional (cfg.hostName != "") cfg.hostName; # Then the hostname (without the domain)
+        hostnames = # If hostName isn't an FQDN (canonical hostname), that has to come first:
+          lib.optional (cfg.fqdnOrHostName != cfg.hostName) cfg.fqdn
+          ++ lib.optional (cfg.hostName != "") cfg.hostName;
       in
       {
         "127.0.0.2" = hostnames;

--- a/nixos/modules/security/ipa.nix
+++ b/nixos/modules/security/ipa.nix
@@ -94,12 +94,12 @@ in
         type = lib.types.str;
         example = "myworkstation.example.com";
         default =
-          if config.networking.domain != null then
+          if (builtins.tryEval config.networking.fqdn).success then
             config.networking.fqdn
           else
             "${config.networking.hostName}.${cfg.domain}";
         defaultText = lib.literalExpression ''
-          if config.networking.domain != null then config.networking.fqdn
+          if (builtins.tryEval config.networking.fqdn).success then config.networking.fqdn
           else "''${networking.hostName}.''${security.ipa.domain}"
         '';
         description = "Fully-qualified hostname used to identify this host in the IPA domain.";

--- a/nixos/modules/services/matrix/synapse.md
+++ b/nixos/modules/services/matrix/synapse.md
@@ -51,7 +51,7 @@ please refer to the
   ...
 }:
 let
-  fqdn = "${config.networking.hostName}.${config.networking.domain}";
+  fqdn = config.networking.fqdn;
   baseUrl = "https://${fqdn}";
   clientConfig."m.homeserver".base_url = baseUrl;
   serverConfig."m.server" = "${fqdn}:443";

--- a/nixos/modules/services/misc/radicle.nix
+++ b/nixos/modules/services/misc/radicle.nix
@@ -243,8 +243,8 @@ in
             lib.types.submodule (
               lib.recursiveUpdate (import ../web-servers/nginx/vhost-options.nix { inherit config lib; }) {
                 options.serverName = {
-                  default = "radicle-${config.networking.hostName}.${config.networking.domain}";
-                  defaultText = "radicle-\${config.networking.hostName}.\${config.networking.domain}";
+                  default = "radicle-${config.networking.fqdnOrHostName}";
+                  defaultText = "radicle-\${config.networking.fqdnOrHostName}";
                 };
               }
             )
@@ -263,7 +263,7 @@ in
             With this option, you can customize an nginx virtual host which already has sensible defaults for `radicle-httpd`.
             Set to `{}` if you do not need any customization to the virtual host.
             If enabled, then by default, the {option}`serverName` is
-            `radicle-''${config.networking.hostName}.''${config.networking.domain}`,
+            `radicle-''${config.networking.fqdnOrHostName}`,
             TLS is active, and certificates are acquired via ACME.
             If this is set to null (the default), no nginx virtual host will be configured.
           '';

--- a/nixos/modules/services/networking/jibri/default.nix
+++ b/nixos/modules/services/networking/jibri/default.nix
@@ -296,12 +296,7 @@ in
 
             config =
               let
-                nick = mkDefault (
-                  builtins.replaceStrings [ "." ] [ "-" ] (
-                    config.networking.hostName
-                    + optionalString (config.networking.domain != null) ".${config.networking.domain}"
-                  )
-                );
+                nick = mkDefault (builtins.replaceStrings [ "." ] [ "-" ] config.networking.fqdnOrHostName);
               in
               {
                 call.login.username = nick;

--- a/nixos/modules/services/web-apps/agorakit.nix
+++ b/nixos/modules/services/web-apps/agorakit.nix
@@ -61,9 +61,8 @@ in
 
     hostName = lib.mkOption {
       type = lib.types.str;
-      default =
-        if config.networking.domain != null then config.networking.fqdn else config.networking.hostName;
-      defaultText = lib.literalExpression "config.networking.fqdn";
+      default = config.networking.fqdnOrHostName;
+      defaultText = lib.literalExpression "config.networking.fqdnOrHostName";
       example = "agorakit.example.com";
       description = ''
         The hostname to serve agorakit on.

--- a/nixos/modules/services/web-apps/anuko-time-tracker.nix
+++ b/nixos/modules/services/web-apps/anuko-time-tracker.nix
@@ -124,9 +124,8 @@ in
 
     hostname = lib.mkOption {
       type = lib.types.str;
-      default =
-        if config.networking.domain != null then config.networking.fqdn else config.networking.hostName;
-      defaultText = lib.literalExpression "config.networking.fqdn";
+      default = config.networking.fqdnOrHostName;
+      defaultText = lib.literalExpression "config.networking.fqdnOrHostName";
       example = "anuko.example.com";
       description = ''
         The hostname to serve Anuko Time Tracker on.

--- a/nixos/modules/services/web-apps/matomo.nix
+++ b/nixos/modules/services/web-apps/matomo.nix
@@ -124,7 +124,7 @@ in
           Either this option or the webServerUser option is mandatory.
           Set this to {} to just enable the virtualHost if you don't need any customization.
           If enabled, then by default, the {option}`serverName` is
-          `''${user}.''${config.networking.hostName}.''${config.networking.domain}`,
+          `''${user}.''${config.networking.fqdnOrHostName}`,
           SSL is active, and certificates are acquired via ACME.
           If this is set to null (the default), no nginx virtualHost will be configured.
         '';

--- a/nixos/modules/services/web-apps/monica.nix
+++ b/nixos/modules/services/web-apps/monica.nix
@@ -64,9 +64,8 @@ in
 
     hostname = lib.mkOption {
       type = lib.types.str;
-      default =
-        if config.networking.domain != null then config.networking.fqdn else config.networking.hostName;
-      defaultText = lib.literalExpression "config.networking.fqdn";
+      default = config.networking.fqdnOrHostName;
+      defaultText = lib.literalExpression "config.networking.fqdnOrHostName";
       example = "monica.example.com";
       description = ''
         The hostname to serve monica on.

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -560,24 +560,27 @@ in
     networking.hostName = mkOption {
       default = config.system.nixos.distroId;
       defaultText = literalExpression "config.system.nixos.distroId";
-      # Only allow hostnames without the domain name part (i.e. no FQDNs, see
-      # e.g. "man 5 hostname") and require valid DNS labels (recommended
-      # syntax). Note: We also allow underscores for compatibility/legacy
-      # reasons (as undocumented feature):
-      type = types.strMatching "^$|^[[:alnum:]]([[:alnum:]_-]{0,61}[[:alnum:]])?$";
+      # Require a valid DNS label, or a sequence of such which forms an FQDN
+      # (see "man 1 hostnamectl"). Note: We also allow underscores for
+      # compatibility/legacy reasons (as an undocumented feature).
+      type =
+        types.strMatching "^$|^[[:alnum:]]([[:alnum:]_-]*?[[:alnum:]])?(\\.[[:alnum:]]([[:alnum:]_-]*?[[:alnum:]])?)*?$"
+        // {
+          # Nix doesn't support the (?N) syntax, so the regex is a verbose version of:
+          description = "string matching the pattern ^$|^([[:alnum:]]([[:alnum:]_-]*?[[:alnum:]])?)(\\.(?1))*?$";
+        };
       description = ''
         The name of the machine. Leave it empty if you want to obtain it from a
         DHCP server (if using DHCP). The hostname must be a valid DNS label (see
         RFC 1035 section 2.3.1: "Preferred name syntax", RFC 1123 section 2.1:
-        "Host Names and Numbers") and as such must not contain the domain part.
-        This means that the hostname must start with a letter or digit,
+        "Host Names and Numbers") or a sequence of such labels separated by single
+        dots. A multi-part hostname containing dots is only allowed if `domain`
+        isn't set, as it must form a valid FQDN (see `hostnamectl(1)`).
+
+        This means that each label in the hostname must start with a letter or digit,
         end with a letter or digit, and have as interior characters only
         letters, digits, and hyphen. The maximum length is 63 characters.
         Additionally it is recommended to only use lower-case characters.
-        If (e.g. for legacy reasons) a FQDN is required as the Linux kernel
-        network node hostname (uname --nodename) the option
-        boot.kernel.sysctl."kernel.hostname" can be used as a workaround (but
-        the 64 character limit still applies).
 
         WARNING: Do not use underscores (_) or you may run into unexpected issues.
       '';
@@ -588,7 +591,9 @@ in
     networking.fqdn = mkOption {
       type = types.str;
       default =
-        if (cfg.hostName != "" && cfg.domain != null) then
+        if lib.hasInfix "." cfg.hostName then
+          cfg.hostName
+        else if (cfg.hostName != "" && cfg.domain != null) then
           "${cfg.hostName}.${cfg.domain}"
         else
           throw ''
@@ -596,16 +601,19 @@ in
             and `networking.domain`. Please ensure these options are set properly or
             set `networking.fqdn` directly.
           '';
-      defaultText = literalExpression ''"''${networking.hostName}.''${networking.domain}"'';
+      defaultText = literalExpression ''
+        if lib.hasInfix "." networking.hostName then networking.hostName else "''${networking.hostName}.''${networking.domain}"
+      '';
       description = ''
-        The fully qualified domain name (FQDN) of this host. By default, it is
-        the result of combining `networking.hostName` and `networking.domain.`
+        The fully qualified domain name (FQDN) of this host. By default, it is set to
+        `networking.hostName` alone if the hostname is defined as an FQDN (i.e. contains dots),
+        or to the result of combining `networking.hostName` and `networking.domain` if not.
 
         Using this option will result in an evaluation error if the hostname is empty or
-        no domain is specified.
+        if no domain is specified and the hostname doesn't contain dots.
 
-        Modules that accept a mere `networking.hostName` but prefer a fully qualified
-        domain name may use `networking.fqdnOrHostName` instead.
+        Modules that accept a mere single-part `networking.hostName` but prefer a fully
+        qualified domain name should use `networking.fqdnOrHostName` instead.
       '';
     };
 
@@ -625,8 +633,9 @@ in
         it does not exist.
 
         This is a convenience option for modules to read instead of `fqdn` when
-        a mere `hostName` is also an acceptable value; this option does not
-        throw an error when `domain` or `fqdn` is unset.
+        a mere single-part `hostName` is also an acceptable value; this option does
+        not throw an error when `domain` or `fqdn` is unset and `hostName` doesn't
+        contain dots.
       '';
     };
 
@@ -729,6 +738,7 @@ in
       type = types.nullOr types.str;
       description = ''
         The system domain name. Used to populate the {option}`fqdn` value.
+        Can only be set if `hostName` isn't an FQDN (doesn't contain dots).
 
         ::: {.warning}
         The domain name is not configured for DNS resolution purposes, see {option}`search` instead.
@@ -1715,6 +1725,14 @@ in
         '';
       }))
       ++ [
+        {
+          assertion = stringLength cfg.hostName < 64;
+          message = "networking.hostName is too long, it needs to be less than 64 characters.";
+        }
+        {
+          assertion = cfg.domain == null || !(lib.hasInfix "." cfg.hostName);
+          message = "networking.hostName cannot contain dots if networking.domain is set.";
+        }
         {
           assertion = cfg.hostId == null || (stringLength cfg.hostId == 8 && isHexString cfg.hostId);
           message = "Invalid value given to the networking.hostId option.";

--- a/nixos/tests/openafs.nix
+++ b/nixos/tests/openafs.nix
@@ -11,7 +11,7 @@ in
       cellServDB = {
         ${cellName} = lib.mapAttrsToList (_: config: {
           ip = config.networking.primaryIPAddress;
-          dnsname = "${config.networking.hostName}.${config.networking.domain}";
+          dnsname = config.networking.fqdn;
         }) nodes;
       };
     in


### PR DESCRIPTION
Resolves #94011.

As per the discussion in that issue, systemd's `hostnamectl(1)` states that FQDN hostnames should be allowed:

> The static and transient hostnames must each be either a single DNS label [..], or a sequence of such labels separated by single dots that forms a valid DNS FQDN.

The documented workaround of setting the `kernel.hostname` sysctl isn't sufficient, since that only sets the transient hostname, which can get overriden at runtime through things like DHCP.

---

The systemd wording requires either a single label or a valid FQDN, so `domain` can't be set if `hostName` is multi-part, and `fqdn` is set from `hostName` directly if it contains dots. This *should* be a non-breaking change since it only adds functionality, and `nixosTests.hostname.*` all pass with just the first or first+second commits applied. I've also gone through all ocurrences of `domain != null` and `hostName}.` and updated what made sense to use `fqdn`, which is the second commit.

Still, some current usages of `hostName` might be assuming it's only a single label. I'm not sure whether it's worth it to go through all of them or let maintainers fix them one by one if issues crop up, but either way here's an exhaustive list of the (possibly) affected files:

<details>
<summary><code>git grep -rl hostName | grep -v '\\.md$' | sort</code></summary>
<br>

- [ ] [`nixos/lib/testing/network.nix`](../blob/master/nixos/lib/testing/network.nix)
- [ ] [`nixos/maintainers/scripts/incus/nix.tpl`](../blob/master/nixos/maintainers/scripts/incus/nix.tpl)
- [ ] [`nixos/modules/config/networking.nix`](../blob/master/nixos/modules/config/networking.nix)
- [ ] [`nixos/modules/config/nix-remote-build.nix`](../blob/master/nixos/modules/config/nix-remote-build.nix)
- [ ] [`nixos/modules/installer/tools/tools.nix`](../blob/master/nixos/modules/installer/tools/tools.nix)
- [ ] [`nixos/modules/programs/ssh.nix`](../blob/master/nixos/modules/programs/ssh.nix)
- [ ] [`nixos/modules/security/ipa.nix`](../blob/master/nixos/modules/security/ipa.nix)
- [ ] [`nixos/modules/services/backup/bacula.nix`](../blob/master/nixos/modules/services/backup/bacula.nix)
- [ ] [`nixos/modules/services/backup/borgbackup.nix`](../blob/master/nixos/modules/services/backup/borgbackup.nix)
- [ ] [`nixos/modules/services/cluster/hadoop/default.nix`](../blob/master/nixos/modules/services/cluster/hadoop/default.nix)
- [ ] [`nixos/modules/services/cluster/kubernetes/proxy.nix`](../blob/master/nixos/modules/services/cluster/kubernetes/proxy.nix)
- [ ] [`nixos/modules/services/cluster/rancher/default.nix`](../blob/master/nixos/modules/services/cluster/rancher/default.nix)
- [ ] [`nixos/modules/services/computing/slurm/slurm.nix`](../blob/master/nixos/modules/services/computing/slurm/slurm.nix)
- [ ] [`nixos/modules/services/continuous-integration/gitea-actions-runner.nix`](../blob/master/nixos/modules/services/continuous-integration/gitea-actions-runner.nix)
- [ ] [`nixos/modules/services/continuous-integration/gitlab-runner/runner.nix`](../blob/master/nixos/modules/services/continuous-integration/gitlab-runner/runner.nix)
- [ ] [`nixos/modules/services/databases/etcd.nix`](../blob/master/nixos/modules/services/databases/etcd.nix)
- [ ] [`nixos/modules/services/games/teeworlds.nix`](../blob/master/nixos/modules/services/games/teeworlds.nix)
- [ ] [`nixos/modules/services/home-automation/wyoming/satellite.nix`](../blob/master/nixos/modules/services/home-automation/wyoming/satellite.nix)
- [ ] [`nixos/modules/services/logging/journalwatch.nix`](../blob/master/nixos/modules/services/logging/journalwatch.nix)
- [ ] [`nixos/modules/services/mail/opendkim.nix`](../blob/master/nixos/modules/services/mail/opendkim.nix)
- [ ] [`nixos/modules/services/mail/roundcube.nix`](../blob/master/nixos/modules/services/mail/roundcube.nix)
- [ ] [`nixos/modules/services/matrix/synapse.nix`](../blob/master/nixos/modules/services/matrix/synapse.nix)
- [ ] [`nixos/modules/services/misc/dysnomia.nix`](../blob/master/nixos/modules/services/misc/dysnomia.nix)
- [ ] [`nixos/modules/services/misc/gitlab.nix`](../blob/master/nixos/modules/services/misc/gitlab.nix)
- [ ] [`nixos/modules/services/monitoring/collectd.nix`](../blob/master/nixos/modules/services/monitoring/collectd.nix)
- [ ] [`nixos/modules/services/monitoring/kapacitor.nix`](../blob/master/nixos/modules/services/monitoring/kapacitor.nix)
- [ ] [`nixos/modules/services/monitoring/munin.nix`](../blob/master/nixos/modules/services/monitoring/munin.nix)
- [ ] [`nixos/modules/services/monitoring/nagios.nix`](../blob/master/nixos/modules/services/monitoring/nagios.nix)
- [ ] [`nixos/modules/services/monitoring/prometheus/exporters/rspamd.nix`](../blob/master/nixos/modules/services/monitoring/prometheus/exporters/rspamd.nix)
- [ ] [`nixos/modules/services/network-filesystems/nfsd.nix`](../blob/master/nixos/modules/services/network-filesystems/nfsd.nix)
- [ ] [`nixos/modules/services/network-filesystems/tahoe.nix`](../blob/master/nixos/modules/services/network-filesystems/tahoe.nix)
- [ ] [`nixos/modules/services/networking/avahi-daemon.nix`](../blob/master/nixos/modules/services/networking/avahi-daemon.nix)
- [ ] [`nixos/modules/services/networking/bitlbee.nix`](../blob/master/nixos/modules/services/networking/bitlbee.nix)
- [ ] [`nixos/modules/services/networking/coturn.nix`](../blob/master/nixos/modules/services/networking/coturn.nix)
- [ ] [`nixos/modules/services/networking/dnsdist.nix`](../blob/master/nixos/modules/services/networking/dnsdist.nix)
- [ ] [`nixos/modules/services/networking/frr.nix`](../blob/master/nixos/modules/services/networking/frr.nix)
- [ ] [`nixos/modules/services/networking/jibri/default.nix`](../blob/master/nixos/modules/services/networking/jibri/default.nix)
- [ ] [`nixos/modules/services/networking/jitsi-videobridge.nix`](../blob/master/nixos/modules/services/networking/jitsi-videobridge.nix)
- [ ] [`nixos/modules/services/networking/minidlna.nix`](../blob/master/nixos/modules/services/networking/minidlna.nix)
- [ ] [`nixos/modules/services/networking/murmur.nix`](../blob/master/nixos/modules/services/networking/murmur.nix)
- [ ] [`nixos/modules/services/networking/ncdns.nix`](../blob/master/nixos/modules/services/networking/ncdns.nix)
- [ ] [`nixos/modules/services/networking/ncps.nix`](../blob/master/nixos/modules/services/networking/ncps.nix)
- [ ] [`nixos/modules/services/networking/nextcloud-spreed-signaling.nix`](../blob/master/nixos/modules/services/networking/nextcloud-spreed-signaling.nix)
- [ ] [`nixos/modules/services/networking/resilio.nix`](../blob/master/nixos/modules/services/networking/resilio.nix)
- [ ] [`nixos/modules/services/networking/smokeping.nix`](../blob/master/nixos/modules/services/networking/smokeping.nix)
- [ ] [`nixos/modules/services/networking/soju.nix`](../blob/master/nixos/modules/services/networking/soju.nix)
- [ ] [`nixos/modules/services/networking/tmate-ssh-server.nix`](../blob/master/nixos/modules/services/networking/tmate-ssh-server.nix)
- [ ] [`nixos/modules/services/networking/xandikos.nix`](../blob/master/nixos/modules/services/networking/xandikos.nix)
- [ ] [`nixos/modules/services/search/nominatim.nix`](../blob/master/nixos/modules/services/search/nominatim.nix)
- [ ] [`nixos/modules/services/security/crowdsec.nix`](../blob/master/nixos/modules/services/security/crowdsec.nix)
- [ ] [`nixos/modules/services/security/tsidp.nix`](../blob/master/nixos/modules/services/security/tsidp.nix)
- [ ] [`nixos/modules/services/system/cachix-agent/default.nix`](../blob/master/nixos/modules/services/system/cachix-agent/default.nix)
- [ ] [`nixos/modules/services/web-apps/agorakit.nix`](../blob/master/nixos/modules/services/web-apps/agorakit.nix)
- [ ] [`nixos/modules/services/web-apps/dokuwiki.nix`](../blob/master/nixos/modules/services/web-apps/dokuwiki.nix)
- [ ] [`nixos/modules/services/web-apps/drupal.nix`](../blob/master/nixos/modules/services/web-apps/drupal.nix)
- [ ] [`nixos/modules/services/web-apps/fediwall.nix`](../blob/master/nixos/modules/services/web-apps/fediwall.nix)
- [ ] [`nixos/modules/services/web-apps/fluidd.nix`](../blob/master/nixos/modules/services/web-apps/fluidd.nix)
- [ ] [`nixos/modules/services/web-apps/froide-govplan.nix`](../blob/master/nixos/modules/services/web-apps/froide-govplan.nix)
- [ ] [`nixos/modules/services/web-apps/grocy.nix`](../blob/master/nixos/modules/services/web-apps/grocy.nix)
- [ ] [`nixos/modules/services/web-apps/jirafeau.nix`](../blob/master/nixos/modules/services/web-apps/jirafeau.nix)
- [ ] [`nixos/modules/services/web-apps/jitsi-meet.nix`](../blob/master/nixos/modules/services/web-apps/jitsi-meet.nix)
- [ ] [`nixos/modules/services/web-apps/kimai.nix`](../blob/master/nixos/modules/services/web-apps/kimai.nix)
- [ ] [`nixos/modules/services/web-apps/limesurvey.nix`](../blob/master/nixos/modules/services/web-apps/limesurvey.nix)
- [ ] [`nixos/modules/services/web-apps/mainsail.nix`](../blob/master/nixos/modules/services/web-apps/mainsail.nix)
- [ ] [`nixos/modules/services/web-apps/mediawiki.nix`](../blob/master/nixos/modules/services/web-apps/mediawiki.nix)
- [ ] [`nixos/modules/services/web-apps/misskey.nix`](../blob/master/nixos/modules/services/web-apps/misskey.nix)
- [ ] [`nixos/modules/services/web-apps/moodle.nix`](../blob/master/nixos/modules/services/web-apps/moodle.nix)
- [ ] [`nixos/modules/services/web-apps/nextcloud.nix`](../blob/master/nixos/modules/services/web-apps/nextcloud.nix)
- [ ] [`nixos/modules/services/web-apps/nextcloud-notify_push.nix`](../blob/master/nixos/modules/services/web-apps/nextcloud-notify_push.nix)
- [ ] [`nixos/modules/services/web-apps/pihole-web.nix`](../blob/master/nixos/modules/services/web-apps/pihole-web.nix)
- [ ] [`nixos/modules/services/web-apps/rutorrent.nix`](../blob/master/nixos/modules/services/web-apps/rutorrent.nix)
- [ ] [`nixos/modules/services/web-apps/snipe-it.nix`](../blob/master/nixos/modules/services/web-apps/snipe-it.nix)
- [ ] [`nixos/modules/services/web-apps/sogo.nix`](../blob/master/nixos/modules/services/web-apps/sogo.nix)
- [ ] [`nixos/modules/services/web-apps/trilium.nix`](../blob/master/nixos/modules/services/web-apps/trilium.nix)
- [ ] [`nixos/modules/services/web-apps/wordpress.nix`](../blob/master/nixos/modules/services/web-apps/wordpress.nix)
- [ ] [`nixos/modules/services/web-apps/zabbix.nix`](../blob/master/nixos/modules/services/web-apps/zabbix.nix)
- [ ] [`nixos/modules/services/web-servers/apache-httpd/default.nix`](../blob/master/nixos/modules/services/web-servers/apache-httpd/default.nix)
- [ ] [`nixos/modules/services/web-servers/apache-httpd/vhost-options.nix`](../blob/master/nixos/modules/services/web-servers/apache-httpd/vhost-options.nix)
- [ ] [`nixos/modules/services/web-servers/caddy/default.nix`](../blob/master/nixos/modules/services/web-servers/caddy/default.nix)
- [ ] [`nixos/modules/services/web-servers/caddy/vhost-options.nix`](../blob/master/nixos/modules/services/web-servers/caddy/vhost-options.nix)
- [ ] [`nixos/modules/services/web-servers/molly-brown.nix`](../blob/master/nixos/modules/services/web-servers/molly-brown.nix)
- [ ] [`nixos/modules/services/web-servers/nginx/default.nix`](../blob/master/nixos/modules/services/web-servers/nginx/default.nix)
- [ ] [`nixos/modules/services/web-servers/varnish/default.nix`](../blob/master/nixos/modules/services/web-servers/varnish/default.nix)
- [ ] [`nixos/modules/system/activation/top-level.nix`](../blob/master/nixos/modules/system/activation/top-level.nix)
- [ ] [`nixos/modules/system/boot/systemd/initrd.nix`](../blob/master/nixos/modules/system/boot/systemd/initrd.nix)
- [ ] [`nixos/modules/tasks/filesystems/nfs.nix`](../blob/master/nixos/modules/tasks/filesystems/nfs.nix)
- [ ] [`nixos/modules/tasks/network-interfaces.nix`](../blob/master/nixos/modules/tasks/network-interfaces.nix)
- [ ] [`nixos/modules/virtualisation/amazon-image.nix`](../blob/master/nixos/modules/virtualisation/amazon-image.nix)
- [ ] [`nixos/modules/virtualisation/azure-common.nix`](../blob/master/nixos/modules/virtualisation/azure-common.nix)
- [ ] [`nixos/modules/virtualisation/digital-ocean-config.nix`](../blob/master/nixos/modules/virtualisation/digital-ocean-config.nix)
- [ ] [`nixos/modules/virtualisation/ec2-data.nix`](../blob/master/nixos/modules/virtualisation/ec2-data.nix)
- [ ] [`nixos/modules/virtualisation/google-compute-config.nix`](../blob/master/nixos/modules/virtualisation/google-compute-config.nix)
- [ ] [`nixos/modules/virtualisation/lxc-image-metadata.nix`](../blob/master/nixos/modules/virtualisation/lxc-image-metadata.nix)
- [ ] [`nixos/modules/virtualisation/nixos-containers.nix`](../blob/master/nixos/modules/virtualisation/nixos-containers.nix)
- [ ] [`nixos/modules/virtualisation/openstack-config.nix`](../blob/master/nixos/modules/virtualisation/openstack-config.nix)
- [ ] [`nixos/modules/virtualisation/proxmox-image.nix`](../blob/master/nixos/modules/virtualisation/proxmox-image.nix)
- [ ] [`nixos/modules/virtualisation/proxmox-lxc.nix`](../blob/master/nixos/modules/virtualisation/proxmox-lxc.nix)
- [ ] [`nixos/tests/acme/dns01.nix`](../blob/master/nixos/tests/acme/dns01.nix)
- [ ] [`nixos/tests/amazon-init-shell.nix`](../blob/master/nixos/tests/amazon-init-shell.nix)
- [ ] [`nixos/tests/cloud-init-hostname.nix`](../blob/master/nixos/tests/cloud-init-hostname.nix)
- [ ] [`nixos/tests/cloud-init.nix`](../blob/master/nixos/tests/cloud-init.nix)
- [ ] [`nixos/tests/common/acme/server/default.nix`](../blob/master/nixos/tests/common/acme/server/default.nix)
- [ ] [`nixos/tests/dokuwiki.nix`](../blob/master/nixos/tests/dokuwiki.nix)
- [ ] [`nixos/tests/ec2.nix`](../blob/master/nixos/tests/ec2.nix)
- [ ] [`nixos/tests/grocy.nix`](../blob/master/nixos/tests/grocy.nix)
- [ ] [`nixos/tests/hostname.nix`](../blob/master/nixos/tests/hostname.nix)
- [ ] [`nixos/tests/installer.nix`](../blob/master/nixos/tests/installer.nix)
- [ ] [`nixos/tests/jibri.nix`](../blob/master/nixos/tests/jibri.nix)
- [ ] [`nixos/tests/jitsi-meet.nix`](../blob/master/nixos/tests/jitsi-meet.nix)
- [ ] [`nixos/tests/limesurvey.nix`](../blob/master/nixos/tests/limesurvey.nix)
- [ ] [`nixos/tests/mediawiki.nix`](../blob/master/nixos/tests/mediawiki.nix)
- [ ] [`nixos/tests/molly-brown.nix`](../blob/master/nixos/tests/molly-brown.nix)
- [ ] [`nixos/tests/moodle.nix`](../blob/master/nixos/tests/moodle.nix)
- [ ] [`nixos/tests/munin.nix`](../blob/master/nixos/tests/munin.nix)
- [ ] [`nixos/tests/mysql/mysql-replication.nix`](../blob/master/nixos/tests/mysql/mysql-replication.nix)
- [ ] [`nixos/tests/ncps.nix`](../blob/master/nixos/tests/ncps.nix)
- [ ] [`nixos/tests/networking/networkd-and-scripted.nix`](../blob/master/nixos/tests/networking/networkd-and-scripted.nix)
- [ ] [`nixos/tests/nextcloud/default.nix`](../blob/master/nixos/tests/nextcloud/default.nix)
- [ ] [`nixos/tests/nfs/kerberos.nix`](../blob/master/nixos/tests/nfs/kerberos.nix)
- [ ] [`nixos/tests/nixos-rebuild-target-host.nix`](../blob/master/nixos/tests/nixos-rebuild-target-host.nix)
- [ ] [`nixos/tests/nominatim.nix`](../blob/master/nixos/tests/nominatim.nix)
- [ ] [`nixos/tests/pangolin.nix`](../blob/master/nixos/tests/pangolin.nix)
- [ ] [`nixos/tests/proxy.nix`](../blob/master/nixos/tests/proxy.nix)
- [ ] [`nixos/tests/radicle.nix`](../blob/master/nixos/tests/radicle.nix)
- [ ] [`nixos/tests/roundcube.nix`](../blob/master/nixos/tests/roundcube.nix)
- [ ] [`nixos/tests/soju.nix`](../blob/master/nixos/tests/soju.nix)
- [ ] [`nixos/tests/stunnel.nix`](../blob/master/nixos/tests/stunnel.nix)
- [ ] [`nixos/tests/tayga.nix`](../blob/master/nixos/tests/tayga.nix)
- [ ] [`nixos/tests/trilium-server.nix`](../blob/master/nixos/tests/trilium-server.nix)
- [ ] [`nixos/tests/varnish.nix`](../blob/master/nixos/tests/varnish.nix)
- [ ] [`nixos/tests/vm-variant.nix`](../blob/master/nixos/tests/vm-variant.nix)
- [ ] [`nixos/tests/web-apps/agorakit.nix`](../blob/master/nixos/tests/web-apps/agorakit.nix)
- [ ] [`nixos/tests/web-apps/snipe-it.nix`](../blob/master/nixos/tests/web-apps/snipe-it.nix)
- [ ] [`nixos/tests/zrepl.nix`](../blob/master/nixos/tests/zrepl.nix)
- [ ] [`pkgs/by-name/ca/calamares-nixos-extensions/src/modules/nixos/main.py`](../blob/master/pkgs/by-name/ca/calamares-nixos-extensions/src/modules/nixos/main.py)
- [ ] [`pkgs/by-name/ni/nixos-container/nixos-container.pl`](../blob/master/pkgs/by-name/ni/nixos-container/nixos-container.pl)
- [ ] [`pkgs/by-name/ni/nixos-rebuild-ng/tests/repl.nix`](../blob/master/pkgs/by-name/ni/nixos-rebuild-ng/tests/repl.nix)
- [ ] [`pkgs/servers/home-assistant/custom-components/xiaomi_home/package.nix`](../blob/master/pkgs/servers/home-assistant/custom-components/xiaomi_home/package.nix)

</details>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
