### PR TITLE
editorconfig-checker: 3.5.0 -> 3.6.0

### DIFF
--- a/pkgs/by-name/ed/editorconfig-checker/package.nix
+++ b/pkgs/by-name/ed/editorconfig-checker/package.nix
@@ -7,24 +7,25 @@
   editorconfig-checker,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "editorconfig-checker";
-  version = "3.5.0";
+  version = "3.6.0";
 
   src = fetchFromGitHub {
     owner = "editorconfig-checker";
     repo = "editorconfig-checker";
-    rev = "v${version}";
-    hash = "sha256-wU9LGkhY/MWCK5kvKxU1JvPnP2esiS/4E19n6GnWLfQ=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-HQYZXwxysGpbNDAzgAruzBtSlPxfwrLuzirkZSV2Xhs=";
   };
 
-  vendorHash = "sha256-qOIwhi2btNcqfyrg0Z2ZvmM5+FE9lMrpP7l4SRzKkXg=";
+  vendorHash = "sha256-zlARI7bKf+4bdgCha9AlDZyTRbrOHtmvHeExJWhB85I=";
 
+  # Tests run on source and don't expect vendor dir.
   doCheck = false;
 
   nativeBuildInputs = [ installShellFiles ];
 
-  ldflags = [ "-X main.version=${version}" ];
+  ldflags = [ "-X main.version=${finalAttrs.version}" ];
 
   postInstall = ''
     installManPage docs/editorconfig-checker.1
@@ -34,15 +35,15 @@ buildGoModule rec {
     package = editorconfig-checker;
   };
 
-  meta = with lib; {
-    changelog = "https://github.com/editorconfig-checker/editorconfig-checker/releases/tag/${src.rev}";
+  meta = {
+    changelog = "https://github.com/editorconfig-checker/editorconfig-checker/releases/tag/${finalAttrs.src.tag}";
     description = "Tool to verify that your files are in harmony with your .editorconfig";
     mainProgram = "editorconfig-checker";
     homepage = "https://editorconfig-checker.github.io/";
-    license = licenses.mit;
-    maintainers = with maintainers; [
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
       uri-canva
       zowoq
     ];
   };
-}
+})


### PR DESCRIPTION
https://github.com/editorconfig-checker/editorconfig-checker/releases/tag/v3.6.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
