### PR TITLE
lsp-plugins: fix build options

### DIFF
--- a/pkgs/by-name/ls/lsp-plugins/package.nix
+++ b/pkgs/by-name/ls/lsp-plugins/package.nix
@@ -81,7 +81,6 @@ stdenv.mkDerivation (finalAttrs: {
     "ETCDIR=${placeholder "out"}/etc"
     "PREFIX=${placeholder "out"}"
     "SHAREDDIR=${placeholder "out"}/share"
-    "SUB_FEATURES=${lib.concatStringsSep " " subFeatures}"
   ];
 
   env.NIX_CFLAGS_COMPILE = "-DLSP_NO_EXPERIMENTAL";
@@ -89,7 +88,7 @@ stdenv.mkDerivation (finalAttrs: {
   configurePhase = ''
     runHook preConfigure
 
-    make $makeFlags config
+    make $makeFlags config SUB_FEATURES="${lib.concatStringsSep " " subFeatures}"
 
     runHook postConfigure
   '';


### PR DESCRIPTION

Build options added in #458690 don't work actually 🌚 
I'm sorry for not testing properly, it seemed to me that it would definitely work 😃 

Right now, if anyone tries to override these options, disabling builds of some formats, they will get this error (e.g. with `ladspa`):
```console
make: *** No rule to make target 'ladspa'.  Stop.
```

First I thought that the `SUB_FEATURES` list needs to be in quotes, but this didn't resolve the issue.
I ended up on a fix that just adds `SUB_FEATURES` argument separately from the `makeFlags` list. :)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
