### PR TITLE
corosync-qdevice: init at 3.0.4

### DIFF
--- a/pkgs/by-name/co/corosync-qdevice/package.nix
+++ b/pkgs/by-name/co/corosync-qdevice/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  pkg-config,
+  corosync,
+  libqb,
+  nss,
+  nspr,
+  systemd,
+  versionCheckHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "corosync-qdevice";
+  version = "3.0.4";
+
+  src = fetchFromGitHub {
+    owner = "corosync";
+    repo = "corosync-qdevice";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JJYD1owtTtXW2yTZNhponzd6Sbj6zjfhein20m/7DQw=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    corosync
+    libqb
+    nss
+    nspr
+    systemd
+  ];
+
+  configureFlags = [
+    "--sysconfdir=/etc"
+    "--localstatedir=/var"
+    "--enable-systemd"
+  ];
+
+  installFlags = [
+    "sysconfdir=$(out)/etc"
+    "localstatedir=$(out)/var"
+    "COROSYSCONFDIR=$(out)/etc/corosync"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/corosync-qnetd";
+  versionCheckProgramArg = "-v";
+  doInstallCheck = true;
+
+  meta = with lib; {
+    description = "Corosync Cluster Engine Qdevice";
+    homepage = "https://github.com/corosync/corosync-qdevice";
+    changelog = "https://github.com/corosync/corosync-qdevice/releases/tag/v${finalAttrs.version}";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ x123 ];
+    mainProgram = "corosync-qdevice";
+    platforms = platforms.linux;
+  };
+})

--- a/pkgs/by-name/co/corosync-qdevice/package.nix
+++ b/pkgs/by-name/co/corosync-qdevice/package.nix
@@ -53,13 +53,13 @@ stdenv.mkDerivation (finalAttrs: {
   versionCheckProgramArg = "-v";
   doInstallCheck = true;
 
-  meta = with lib; {
+  meta = {
     description = "Corosync Cluster Engine Qdevice";
     homepage = "https://github.com/corosync/corosync-qdevice";
     changelog = "https://github.com/corosync/corosync-qdevice/releases/tag/v${finalAttrs.version}";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ x123 ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ x123 ];
     mainProgram = "corosync-qdevice";
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
 })


### PR DESCRIPTION
init corosync-qdevice at 3.0.4 (different than pkgs.corosync)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
