### PR TITLE
mkp224o: add optional regex support

### DIFF
--- a/pkgs/by-name/mk/mkp224o/package.nix
+++ b/pkgs/by-name/mk/mkp224o/package.nix
@@ -4,6 +4,9 @@
   fetchFromGitHub,
   autoreconfHook,
   libsodium,
+  pcre2,
+  regexSupport ? false,
+  batchSize ? 2048,
 }:
 
 stdenv.mkDerivation rec {
@@ -53,10 +56,14 @@ stdenv.mkDerivation rec {
       ''
         install -D ${
           stdenv.mkDerivation {
-            name = "mkp224o-${suffix}-${version}";
-            inherit version src configureFlags;
+            pname = "mkp224o-${suffix}";
+            inherit version src;
+            configureFlags =
+              configureFlags
+              ++ [ "--enable-batchnum=${builtins.toString batchSize}" ]
+              ++ lib.optionals regexSupport [ "--enable-regex=yes" ];
             nativeBuildInputs = [ autoreconfHook ];
-            buildInputs = [ libsodium ];
+            buildInputs = [ libsodium ] ++ lib.optionals regexSupport [ pcre2 ];
             installPhase = "install -D mkp224o $out";
           }
         } $out/bin/mkp224o-${suffix}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
I added parameters for regex support and batch size. they default to what already has been default so nothing should change out of the box, but the package can now be easily overridden to compile in regex support or change the batch size when using batch mode

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
