### PR TITLE
weblate: add missing typelib for cairo

### DIFF
--- a/nixos/modules/services/web-apps/weblate.nix
+++ b/nixos/modules/services/web-apps/weblate.nix
@@ -369,9 +369,10 @@ in
             });
           in
           ''
-            ${gunicorn}/bin/gunicorn \
+            ${lib.getExe gunicorn} \
               --name=weblate \
               --bind='unix:///run/weblate.socket' \
+              --preload \
               weblate.wsgi
           '';
         ExecReload = "${lib.getExe' pkgs.coreutils "kill"} -s HUP $MAINPID";

--- a/pkgs/by-name/we/weblate/package.nix
+++ b/pkgs/by-name/we/weblate/package.nix
@@ -8,6 +8,7 @@
   librsvg,
   gdk-pixbuf,
   glib,
+  gobject-introspection,
   borgbackup,
   writeText,
   nixosTests,
@@ -154,6 +155,7 @@ python.pkgs.buildPythonApplication rec {
     librsvg
     gdk-pixbuf
     glib
+    gobject-introspection
   ];
   makeWrapperArgs = [ "--set GI_TYPELIB_PATH \"$GI_TYPELIB_PATH\"" ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Weblate is currently completely broken and fails to boot up. This fixes the issue. The fix can be verified by executing the nixos test.

The root cause was discovered by adding `--preload` to the `gunicorn` process.

(Weblate is also currently broken on 25.11)

Hydra:
- 25.11: https://hydra.nixos.org/eval/1820441?filter=weblate&compare=1820434&full=
- Unstable: https://hydra.nixos.org/eval/1820420?filter=weblate&compare=1820385&full=


ZHF: #457852

```
Nov 26 17:51:02 svc-trans01 gunicorn[54534]: Traceback (most recent call last):
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "/nix/store/4dwhn7vch8739qncyyyv1z7i4kkynjg2-python3-3.13.9-env/lib/python3.13/site-packages/gi/importer.py", line 137, in create_module
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:     introspection_module = get_introspection_module(namespace)
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "/nix/store/4dwhn7vch8739qncyyyv1z7i4kkynjg2-python3-3.13.9-env/lib/python3.13/site-packages/gi/module.py", line 244, in get_introspection_module
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:     module = IntrospectionModule(namespace, version)
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "/nix/store/4dwhn7vch8739qncyyyv1z7i4kkynjg2-python3-3.13.9-env/lib/python3.13/site-packages/gi/module.py", line 104, in __init__
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:     repository.require(namespace, version)
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:     ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
Nov 26 17:51:02 svc-trans01 gunicorn[54534]: gi.RepositoryError: Typelib file for namespace 'cairo', version '1.0' not found
Nov 26 17:51:02 svc-trans01 gunicorn[54534]: The above exception was the direct cause of the following exception:
Nov 26 17:51:02 svc-trans01 gunicorn[54534]: Traceback (most recent call last):
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "/nix/store/1gvy00pdzpq0fgkbskn6rznvgc0hsx88-python3.13-gunicorn-23.0.0/bin/.gunicorn-wrapped", line 9, in <module>
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:     sys.exit(run())
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:              ~~~^^
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "/nix/store/1gvy00pdzpq0fgkbskn6rznvgc0hsx88-python3.13-gunicorn-23.0.0/lib/python3.13/site-packages/gunicorn/app/wsgiapp.py", line 66, in run
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:     WSGIApplication("%(prog)s [OPTIONS] [APP_MODULE]", prog=prog).run()
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "/nix/store/1gvy00pdzpq0fgkbskn6rznvgc0hsx88-python3.13-gunicorn-23.0.0/lib/python3.13/site-packages/gunicorn/app/base.py", line 235, in run
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:     super().run()
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:     ~~~~~~~~~~~^^
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "/nix/store/1gvy00pdzpq0fgkbskn6rznvgc0hsx88-python3.13-gunicorn-23.0.0/lib/python3.13/site-packages/gunicorn/app/base.py", line 71, in run
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:     Arbiter(self).run()
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:     ~~~~~~~^^^^^^
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "/nix/store/1gvy00pdzpq0fgkbskn6rznvgc0hsx88-python3.13-gunicorn-23.0.0/lib/python3.13/site-packages/gunicorn/arbiter.py", line 57, in __init__
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:     self.setup(app)
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:     ~~~~~~~~~~^^^^^
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "/nix/store/1gvy00pdzpq0fgkbskn6rznvgc0hsx88-python3.13-gunicorn-23.0.0/lib/python3.13/site-packages/gunicorn/arbiter.py", line 117, in setup
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:     self.app.wsgi()
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:     ~~~~~~~~~~~~~^^
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "/nix/store/1gvy00pdzpq0fgkbskn6rznvgc0hsx88-python3.13-gunicorn-23.0.0/lib/python3.13/site-packages/gunicorn/app/base.py", line 66, in wsgi
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:     self.callable = self.load()
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:                     ~~~~~~~~~^^
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "/nix/store/1gvy00pdzpq0fgkbskn6rznvgc0hsx88-python3.13-gunicorn-23.0.0/lib/python3.13/site-packages/gunicorn/app/wsgiapp.py", line 57, in load
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:     return self.load_wsgiapp()
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:            ~~~~~~~~~~~~~~~~~^^
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "/nix/store/1gvy00pdzpq0fgkbskn6rznvgc0hsx88-python3.13-gunicorn-23.0.0/lib/python3.13/site-packages/gunicorn/app/wsgiapp.py", line 47, in load_wsgiapp
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:     return util.import_app(self.app_uri)
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:            ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "/nix/store/1gvy00pdzpq0fgkbskn6rznvgc0hsx88-python3.13-gunicorn-23.0.0/lib/python3.13/site-packages/gunicorn/util.py", line 370, in import_app
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:     mod = importlib.import_module(module)
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "/nix/store/3lll9y925zz9393sa59h653xik66srjb-python3-3.13.9/lib/python3.13/importlib/__init__.py", line 88, in import_module
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:     return _bootstrap._gcd_import(name[level:], package, level)
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:            ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "<frozen importlib._bootstrap_external>", line 1027, in exec_module
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "/nix/store/4dwhn7vch8739qncyyyv1z7i4kkynjg2-python3-3.13.9-env/lib/python3.13/site-packages/weblate/wsgi.py", line 49, in <module>
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:     application = get_wsgi_application()
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "/nix/store/4dwhn7vch8739qncyyyv1z7i4kkynjg2-python3-3.13.9-env/lib/python3.13/site-packages/django/core/wsgi.py", line 12, in get_wsgi_application
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:     django.setup(set_prefix=False)
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:     ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "/nix/store/4dwhn7vch8739qncyyyv1z7i4kkynjg2-python3-3.13.9-env/lib/python3.13/site-packages/django/__init__.py", line 24, in setup
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:     apps.populate(settings.INSTALLED_APPS)
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:     ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "/nix/store/4dwhn7vch8739qncyyyv1z7i4kkynjg2-python3-3.13.9-env/lib/python3.13/site-packages/django/apps/registry.py", line 91, in populate
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:     app_config = AppConfig.create(entry)
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "/nix/store/4dwhn7vch8739qncyyyv1z7i4kkynjg2-python3-3.13.9-env/lib/python3.13/site-packages/django/apps/config.py", line 123, in create
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:     mod = import_module(mod_path)
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "/nix/store/3lll9y925zz9393sa59h653xik66srjb-python3-3.13.9/lib/python3.13/importlib/__init__.py", line 88, in import_module
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:     return _bootstrap._gcd_import(name[level:], package, level)
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:            ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "<frozen importlib._bootstrap_external>", line 1027, in exec_module
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "/nix/store/4dwhn7vch8739qncyyyv1z7i4kkynjg2-python3-3.13.9-env/lib/python3.13/site-packages/weblate/fonts/apps.py", line 14, in <module>
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:     from .utils import render_size
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "/nix/store/4dwhn7vch8739qncyyyv1z7i4kkynjg2-python3-3.13.9-env/lib/python3.13/site-packages/weblate/fonts/utils.py", line 25, in <module>
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:     from gi.repository import Pango, PangoCairo  # noqa: E402
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:   File "/nix/store/4dwhn7vch8739qncyyyv1z7i4kkynjg2-python3-3.13.9-env/lib/python3.13/site-packages/gi/importer.py", line 139, in create_module
Nov 26 17:51:02 svc-trans01 gunicorn[54534]:     raise ImportError(e) from e
Nov 26 17:51:02 svc-trans01 gunicorn[54534]: ImportError: Typelib file for namespace 'cairo', version '1.0' not found
```


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
