### PR TITLE
netatalk: 4.2.4 -> 4.3.2

### DIFF
--- a/pkgs/by-name/bs/bstring/package.nix
+++ b/pkgs/by-name/bs/bstring/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "bstring";
+  version = "1.0.3";
+
+  src = fetchFromGitHub {
+    owner = "msteinert";
+    repo = "bstring";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-efXMSRcPgo+WlOdbS1kY2PYQqSVwcsVSyU1JfsU8OOo=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+  ];
+
+  meta = {
+    description = "Better String Library for C";
+    homepage = "https://github.com/msteinert/bstring";
+    changelog = "https://github.com/msteinert/bstring/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ nulleric ];
+  };
+})

--- a/pkgs/by-name/ne/netatalk/package.nix
+++ b/pkgs/by-name/ne/netatalk/package.nix
@@ -5,6 +5,7 @@
   acl,
   autoreconfHook,
   avahi,
+  bstring,
   db,
   libevent,
   libgcrypt,
@@ -28,11 +29,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "netatalk";
-  version = "4.2.4";
+  version = "4.3.2";
 
   src = fetchurl {
     url = "mirror://sourceforge/netatalk/netatalk/netatalk-${finalAttrs.version}.tar.xz";
-    hash = "sha256-Twe74RipUd10DT9RqHtcr7oklr0LIucEQ49CGqZnD5k=";
+    hash = "sha256-KXe0/RExgvDMGDM3uiPVcB+yvk4N/Ox+5XW01zpzjTo=";
   };
 
   nativeBuildInputs = [
@@ -45,6 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     acl
     avahi
+    bstring
     db
     libevent
     libgcrypt
@@ -69,7 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dwith-bdb-include-path=${db.dev}/include"
     "-Dwith-install-hooks=false"
     "-Dwith-init-hooks=false"
-    "-Dwith-lockfile-path=/run/lock/"
+    "-Dwith-lockfile-path=/run/lock"
     "-Dwith-cracklib=true"
     "-Dwith-cracklib-path=${cracklib.out}"
     "-Dwith-statedir-creation=false"
@@ -82,6 +84,9 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://netatalk.io/";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ jcumming ];
+    maintainers = with lib.maintainers; [
+      jcumming
+      nulleric
+    ];
   };
 })


### PR DESCRIPTION
Version bump of `netatalk` 4.2.4 -> 4.3.2. 
Requires a maintained `bstring` so added that as well.
Removed extra `/` from run dir.

Upstream Change-log: 
https://github.com/Netatalk/netatalk/releases/tag/netatalk-4-3-2



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
