### PR TITLE
dolphin-emu-primehack: fix build on release 25.11

### DIFF
--- a/pkgs/by-name/do/dolphin-emu-primehack/package.nix
+++ b/pkgs/by-name/do/dolphin-emu-primehack/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-
+  fetchpatch2,
   # nativeBuildInputs
   pkg-config,
   cmake,
@@ -12,7 +12,7 @@
   curl,
   enet,
   ffmpeg,
-  fmt,
+  fmt_9,
   gettext,
   libGL,
   libGLU,
@@ -26,12 +26,13 @@
   libpthreadstubs,
   libpulseaudio,
   libusb1,
-  mbedtls_2,
+  mbedtls,
   miniupnpc,
   openal,
   pcre,
   portaudio,
   readline,
+  SDL2,
   sfml,
   soundtouch,
   xz,
@@ -62,6 +63,13 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-/9AabEJ2ZOvHeSGXWRuOucmjleBMRcJfhX+VDeldbgo=";
   };
 
+  patches = [
+    (fetchpatch2 {
+      url = "https://github.com/dolphin-emu/dolphin/commit/8edef722ce1aae65d5a39faf58753044de48b6e0.patch?full_index=1";
+      hash = "sha256-QEG0p+AzrExWrOxL0qRPa+60GlL0DlLyVBrbG6pGuog=";
+    })
+  ];
+
   nativeBuildInputs = [
     pkg-config
     cmake
@@ -74,7 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
     curl
     enet
     ffmpeg
-    fmt
+    fmt_9
     gettext
     libGL
     libGLU
@@ -88,7 +96,7 @@ stdenv.mkDerivation (finalAttrs: {
     libpthreadstubs
     libpulseaudio
     libusb1
-    mbedtls_2
+    mbedtls
     miniupnpc
     openal
     pcre
@@ -96,6 +104,7 @@ stdenv.mkDerivation (finalAttrs: {
     qt6.qtbase
     qt6.qtsvg
     readline
+    SDL2
     sfml
     soundtouch
     xz
@@ -115,6 +124,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "USE_SHARED_ENET" true)
     (lib.cmakeBool "ENABLE_LTO" true)
+    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     (lib.cmakeBool "OSX_USE_DEFAULT_SEARCH_PATH" true)


### PR DESCRIPTION
This PR fixes the compilation of dolphin-emu-primehack in NixOS 25.11. This is my first PR to nixpkgs, so if I've missed anything, please let me know.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
