### PR TITLE
cudaPackages.cuda_nvcc: wrap binary so NVCC can always find compiler

### DIFF
--- a/pkgs/development/cuda-modules/packages/cuda_nvcc.nix
+++ b/pkgs/development/cuda-modules/packages/cuda_nvcc.nix
@@ -8,6 +8,7 @@
   cuda_cccl,
   lib,
   libnvvm,
+  makeBinaryWrapper,
 }:
 buildRedist (finalAttrs: {
   redistName = "cuda";
@@ -21,6 +22,10 @@ buildRedist (finalAttrs: {
 
   # The nvcc and cicc binaries contain hard-coded references to /usr
   allowFHSReferences = true;
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+  ];
 
   # Entries here will be in nativeBuildInputs when cuda_nvcc is in nativeBuildInputs
   propagatedBuildInputs = [ setupCudaHook ];
@@ -144,13 +149,19 @@ buildRedist (finalAttrs: {
         EOF
       ''
       # Add the dependency on backendStdenv.cc to the nvcc.profile.
+      # NOTE: NVCC explodes in horrifying fashion if GCC is not on PATH -- it fails even before
+      # reading nvcc.profile!
       + ''
-        nixLog "adding backendStdenv.cc to nvcc.profile"
+        nixLog "setting compiler-bindir to backendStdenv.cc in nvcc.profile"
         cat << EOF >> "''${!outputBin:?}/bin/nvcc.profile"
-
         # Fix a compatible backend compiler
-        PATH += "${backendStdenv.cc}/bin":
+        compiler-bindir = ${backendStdenv.cc}/bin
         EOF
+
+        nixLog "wrapping nvcc to add backendStdenv.cc to its PATH"
+        wrapProgramBinary \
+          "''${!outputBin:?}/bin/nvcc" \
+          --prefix PATH : ${lib.makeBinPath [ backendStdenv.cc ]}
       ''
     );
 

--- a/pkgs/development/cuda-modules/packages/setupCudaHook/package.nix
+++ b/pkgs/development/cuda-modules/packages/setupCudaHook/package.nix
@@ -5,9 +5,6 @@ makeSetupHook {
 
   substitutions.setupCudaHook = placeholder "out";
 
-  # Point NVCC at a compatible compiler
-  substitutions.ccRoot = "${backendStdenv.cc}";
-
   # Required in addition to ccRoot as otherwise bin/gcc is looked up
   # when building CMakeCUDACompilerId.cu
   substitutions.ccFullPath = "${backendStdenv.cc}/bin/${backendStdenv.cc.targetPrefix}c++";

--- a/pkgs/development/cuda-modules/packages/setupCudaHook/setup-cuda-hook.sh
+++ b/pkgs/development/cuda-modules/packages/setupCudaHook/setup-cuda-hook.sh
@@ -92,8 +92,6 @@ setupCUDAToolkitCompilers() {
     export CUDAHOSTCXX="@ccFullPath@"
   fi
 
-  appendToVar NVCC_PREPEND_FLAGS "--compiler-bindir=@ccRoot@/bin"
-
   # NOTE: We set -Xfatbin=-compress-all, which reduces the size of the compiled
   #   binaries. If binaries grow over 2GB, they will fail to link. This is a problem for us, as
   #   the default set of CUDA capabilities we build can regularly cause this to occur (for


### PR DESCRIPTION
- Wrap NVCC so it can always find a compatible compiler on the path.
- Set `compiler-bindir` in `nvcc.profile` instead of in `setupCudaHook` so it is always set, even when NVCC is run in ad-hoc fashion in installed environments rather than inside `mkDerivation`.

These changes needed to be made to allow the tests for pycuda (#465047) to work.

I was able to build `python3Packages.onnxruntime` and `firefox` with:

```nix
{pkgs}: {
  allowUnfreePredicate = pkgs._cuda.lib.allowUnfreeCudaPredicate;
  cudaCapabilities = [ "8.9" ];
  cudaForwardCompat = false;
  cudaSupport = true;
}
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
