### PR TITLE
python3Packages.cfn-lint: 1.38.3 -> 1.41.0

### DIFF
--- a/pkgs/development/python-modules/cfn-lint/default.nix
+++ b/pkgs/development/python-modules/cfn-lint/default.nix
@@ -6,7 +6,6 @@
   fetchFromGitHub,
   jschema-to-python,
   jsonpatch,
-  jsonschema,
   junit-xml,
   mock,
   networkx,
@@ -18,11 +17,12 @@
   sarif-om,
   setuptools,
   sympy,
+  typing-extensions,
 }:
 
 buildPythonPackage rec {
   pname = "cfn-lint";
-  version = "1.38.3";
+  version = "1.41.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -31,23 +31,19 @@ buildPythonPackage rec {
     owner = "aws-cloudformation";
     repo = "cfn-lint";
     tag = "v${version}";
-    hash = "sha256-n3NHmbo3qRhP7oqUOokw8oGnNXo4rhRhuAgL66hvfog=";
+    hash = "sha256-AudCeFMbCQucANLLAknCKC7gzi0vvFh9c9k7ll0a1MM=";
   };
 
   build-system = [ setuptools ];
 
   dependencies = [
     aws-sam-translator
-    jschema-to-python
     jsonpatch
-    jsonschema
-    junit-xml
-    networkx
     networkx
     pyyaml
     regex
-    sarif-om
     sympy
+    typing-extensions
   ];
 
   optional-dependencies = {
@@ -57,12 +53,7 @@ buildPythonPackage rec {
       jschema-to-python
       sarif-om
     ];
-    full = [
-      jschema-to-python
-      junit-xml
-      pydot
-      sarif-om
-    ];
+    full = lib.concatLists (lib.attrValues (lib.removeAttrs optional-dependencies [ "full" ]));
   };
 
   nativeCheckInputs = [
@@ -70,18 +61,11 @@ buildPythonPackage rec {
     mock
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ optional-dependencies.full;
 
   preCheck = ''
     export PATH=$out/bin:$PATH
   '';
-
-  disabledTestPaths = [
-    # tests fail starting on 2025-10-01
-    # related: https://github.com/aws-cloudformation/cfn-lint/issues/4125
-    "test/integration/test_quickstart_templates.py"
-    "test/integration/test_quickstart_templates_non_strict.py"
-  ];
 
   disabledTests = [
     # Requires git directory


### PR DESCRIPTION
Diff: https://github.com/aws-cloudformation/cfn-lint/compare/v1.38.3...v1.41.0

Changelog: https://github.com/aws-cloudformation/cfn-lint/blob/v1.41.0/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
