### PR TITLE
treewide: remove remaining nginxQuic mentions

### DIFF
--- a/nixos/modules/services/web-servers/nginx/vhost-options.nix
+++ b/nixos/modules/services/web-servers/nginx/vhost-options.nix
@@ -243,9 +243,7 @@ with lib;
       default = true;
       description = ''
         Whether to enable the HTTP/3 protocol.
-        This requires using `pkgs.nginxQuic` package
-        which can be achieved by setting `services.nginx.package = pkgs.nginxQuic;`
-        and activate the QUIC transport protocol
+        This requires activating the QUIC transport protocol
         `services.nginx.virtualHosts.<name>.quic = true;`.
         Note that HTTP/3 support is experimental and *not* yet recommended for production.
         Read more at <https://quic.nginx.org/>
@@ -258,9 +256,7 @@ with lib;
       default = false;
       description = ''
         Whether to enable the HTTP/0.9 protocol negotiation used in QUIC interoperability tests.
-        This requires using `pkgs.nginxQuic` package
-        which can be achieved by setting `services.nginx.package = pkgs.nginxQuic;`
-        and activate the QUIC transport protocol
+        This requires activating the QUIC transport protocol
         `services.nginx.virtualHosts.<name>.quic = true;`.
         Note that special application protocol support is experimental and *not* yet recommended for production.
         Read more at <https://quic.nginx.org/>
@@ -272,8 +268,6 @@ with lib;
       default = false;
       description = ''
         Whether to enable the QUIC transport protocol.
-        This requires using `pkgs.nginxQuic` package
-        which can be achieved by setting `services.nginx.package = pkgs.nginxQuic;`.
         Note that QUIC support is experimental and
         *not* yet recommended for production.
         Read more at <https://quic.nginx.org/>

--- a/nixos/tests/sing-box.nix
+++ b/nixos/tests/sing-box.nix
@@ -139,7 +139,6 @@ in
 
         services.nginx = {
           enable = true;
-          package = pkgs.nginxQuic;
 
           virtualHosts."${target_host}" = {
             onlySSL = true;


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
