### PR TITLE
protobuf_29: fix darwin build

### DIFF
--- a/pkgs/development/libraries/protobuf/generic.nix
+++ b/pkgs/development/libraries/protobuf/generic.nix
@@ -42,14 +42,23 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail 'tmpnam(b)' '"'$TMPDIR'/foo"'
   '';
 
-  patches = lib.optionals (lib.versionOlder version "22") [
-    # fix protobuf-targets.cmake installation paths, and allow for CMAKE_INSTALL_LIBDIR to be absolute
-    # https://github.com/protocolbuffers/protobuf/pull/10090
-    (fetchpatch {
-      url = "https://github.com/protocolbuffers/protobuf/commit/a7324f88e92bc16b57f3683403b6c993bf68070b.patch";
-      hash = "sha256-SmwaUjOjjZulg/wgNmR/F5b8rhYA2wkKAjHIOxjcQdQ=";
-    })
-  ];
+  patches =
+    lib.optionals (lib.versionOlder version "22") [
+      # fix protobuf-targets.cmake installation paths, and allow for CMAKE_INSTALL_LIBDIR to be absolute
+      # https://github.com/protocolbuffers/protobuf/pull/10090
+      (fetchpatch {
+        url = "https://github.com/protocolbuffers/protobuf/commit/a7324f88e92bc16b57f3683403b6c993bf68070b.patch";
+        hash = "sha256-SmwaUjOjjZulg/wgNmR/F5b8rhYA2wkKAjHIOxjcQdQ=";
+      })
+    ]
+    ++ lib.optionals (lib.versions.major version == "29") [
+      # fix temporary directory handling to avoid test failures on darwin
+      # https://github.com/NixOS/nixpkgs/issues/464439
+      (fetchpatch {
+        url = "https://github.com/protocolbuffers/protobuf/commit/0e9d0f6e77280b7a597ebe8361156d6bb1971dca.patch";
+        hash = "sha256-rIP+Ft/SWVwh9Oy8y8GSUBgP6CtLCLvGmr6nOqmyHhY=";
+      })
+    ];
 
   # hook to provide the path to protoc executable, used at build time
   build_protobuf =
@@ -99,6 +108,10 @@ stdenv.mkDerivation (finalAttrs: {
   versionCheckProgram = [ "${placeholder "out"}/bin/protoc" ];
   versionCheckProgramArg = "--version";
   doInstallCheck = true;
+
+  env = lib.optionalAttrs (lib.versions.major version == "29") {
+    GTEST_DEATH_TEST_STYLE = "threadsafe";
+  };
 
   passthru = {
     tests = {


### PR DESCRIPTION
Tests are currently failing when building on darwin platforms (fixes #464439). 

The issue is caused by the statically initialized temporary directory deleter running in a forked process (gtest's "death tests") , the temporary directory is then deleted while tests are still running, causing write failures.

## Fixes
- Backports https://github.com/protocolbuffers/protobuf/commit/0e9d0f6e77280b7a597ebe8361156d6bb1971dca from a future protobuf version which uses a different temporary directory for each test process.
- Sets the [death test style](https://google.github.io/googletest/advanced.html#death-test-styles) to `threadsafe`, causing gtest to fork and exec instead of just forking, making it create a new temporary directory for this specific test, and preventing the cleanup of the main process' temporary directory since forks inherit statically initialized data.

## Things done
- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
