### PR TITLE
tango-database: 5.25 -> 5.28

### DIFF
--- a/pkgs/by-name/ta/tango-database/package.nix
+++ b/pkgs/by-name/ta/tango-database/package.nix
@@ -17,14 +17,14 @@
 # See $out/share/tango/db/create_db.sh
 stdenv.mkDerivation rec {
   pname = "tango-database";
-  version = "5.25";
+  version = "5.28";
 
   src = fetchFromGitLab {
     owner = "tango-controls";
     repo = "TangoDatabase";
     tag = "Database-Release-${version}";
     fetchSubmodules = true;
-    hash = "sha256-hu2TIPxXyUtLK3bHFHuBYho23TGLkmsHfxEabsjsvmE=";
+    hash = "sha256-r8jrsDR22u30l1R6mK95KsLWHhheZa4/N6n/Xv4mKPc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ta/tango-database/package.nix
+++ b/pkgs/by-name/ta/tango-database/package.nix
@@ -60,6 +60,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Tango distributed control system - database server";
     homepage = "https://gitlab.com/tango-controls/TangoDatabase";
+    changelog = "https://gitlab.com/tango-controls/TangoDatabase/-/blob/Database-Release-${version}/RELEASE_NOTES.md";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.gilice ];


### PR DESCRIPTION
https://gitlab.com/tango-controls/TangoDatabase/-/blob/Database-Release-5.28/RELEASE_NOTES.md

Closes #465110

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
