### PR TITLE
python3Packages.proton-vpn-local-agent: fix wheel build script for all architectures

### DIFF
--- a/pkgs/development/python-modules/proton-vpn-local-agent/default.nix
+++ b/pkgs/development/python-modules/proton-vpn-local-agent/default.nix
@@ -47,6 +47,14 @@ buildPythonPackage rec {
     rustPlatform.cargoCheckHook
   ];
 
+  postPatch = ''
+    substituteInPlace scripts/build_wheel.py \
+      --replace-fail 'ARCH = "x86_64"' \
+                     'ARCH = "${stdenv.hostPlatform.uname.processor}"' \
+      --replace-fail 'LIB_PATH = get_lib_path("x86_64-unknown-linux-gnu")' \
+                     'LIB_PATH = get_lib_path("${stdenv.hostPlatform.config}")'
+  '';
+
   postBuild = ''
     ${python.interpreter} scripts/build_wheel.py
     mkdir -p ./dist


### PR DESCRIPTION
The upstream builds hard-codes the wheel package build to x86-64. This commit patches that script to take into consideration the build architecture.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
