### PR TITLE
element-{web,desktop}: 1.12.3 -> 1.12.6

### DIFF
--- a/pkgs/by-name/el/element-desktop/element-desktop-pin.nix
+++ b/pkgs/by-name/el/element-desktop/element-desktop-pin.nix
@@ -1,7 +1,7 @@
 {
-  "version" = "1.12.4";
+  "version" = "1.12.6";
   "hashes" = {
-    "desktopSrcHash" = "sha256-6fgbwLccILdb1iCcLrKauBzWMjMAZQgKo09gZhJB9Gk=";
-    "desktopYarnHash" = "sha256-7eYmz298m6ceREcaAo9CSMMFC3fB/ZC1+ArPb9pqc0o=";
+    "desktopSrcHash" = "sha256-3CuEFbota6MPVLPeHkXgtb0OmDW91w08+XVnT3mDHaI=";
+    "desktopYarnHash" = "sha256-SPXbp+6zmwXD0uN4ByV6kIni+DGQT8evYMioH1NZJVU=";
   };
 }

--- a/pkgs/by-name/el/element-desktop/element-desktop-pin.nix
+++ b/pkgs/by-name/el/element-desktop/element-desktop-pin.nix
@@ -1,7 +1,7 @@
 {
-  "version" = "1.12.3";
+  "version" = "1.12.4";
   "hashes" = {
-    "desktopSrcHash" = "sha256-4pv6KxcTocguJo7DlBO+/pi+n8JbTHWukMtagaGaDy8=";
-    "desktopYarnHash" = "sha256-lQn5dAiC15O/2eaWfWJedFjBgmnglAlmAEOhz+in0DM=";
+    "desktopSrcHash" = "sha256-6fgbwLccILdb1iCcLrKauBzWMjMAZQgKo09gZhJB9Gk=";
+    "desktopYarnHash" = "sha256-7eYmz298m6ceREcaAo9CSMMFC3fB/ZC1+ArPb9pqc0o=";
   };
 }

--- a/pkgs/by-name/el/element-desktop/update.sh
+++ b/pkgs/by-name/el/element-desktop/update.sh
@@ -54,6 +54,11 @@ getHashes() {
   };
 }
 EOF
+
+  if [ "$variant" = "web" ]; then
+    local shared_components_yarn_hash="$(fixupHash "$(prefetch-yarn-deps "$src_path/packages/shared-components/yarn.lock")")"
+    sed -i "/^    \"webYarnHash/a \    \"webSharedComponentsYarnHash\" = \"$shared_components_yarn_hash\";" "$output"
+  fi
 }
 
 getHashes web ../element-web-unwrapped/element-web-pin.nix

--- a/pkgs/by-name/el/element-desktop/yarn.nix
+++ b/pkgs/by-name/el/element-desktop/yarn.nix
@@ -41,4 +41,5 @@ stdenvNoCC.mkDerivation {
 
   outputHash = hash;
   outputHashMode = "recursive";
+  outputHashAlgo = "sha256";
 }

--- a/pkgs/by-name/el/element-web-unwrapped/element-web-pin.nix
+++ b/pkgs/by-name/el/element-web-unwrapped/element-web-pin.nix
@@ -1,7 +1,7 @@
 {
-  "version" = "1.12.3";
+  "version" = "1.12.4";
   "hashes" = {
-    "webSrcHash" = "sha256-a/RrUzJU/pjyD36WmNIqjSTBn5cfUOGNSe/l6iGp/0A=";
-    "webYarnHash" = "sha256-TXOehZRw5UIhGTnpR0KzvEizSW9Qk2VTr+cG/XstB+k=";
+    "webSrcHash" = "sha256-5sRKVgKbU4hr1cubY/0PdLDClBcFGxdu9TITORL6beI=";
+    "webYarnHash" = "sha256-S+glH2HkGyINEGHWn1TMK2y45gk7WtxTe+u4luqVgsw=";
   };
 }

--- a/pkgs/by-name/el/element-web-unwrapped/element-web-pin.nix
+++ b/pkgs/by-name/el/element-web-unwrapped/element-web-pin.nix
@@ -3,5 +3,6 @@
   "hashes" = {
     "webSrcHash" = "sha256-5sRKVgKbU4hr1cubY/0PdLDClBcFGxdu9TITORL6beI=";
     "webYarnHash" = "sha256-S+glH2HkGyINEGHWn1TMK2y45gk7WtxTe+u4luqVgsw=";
+    "webSharedComponentsYarnHash" = "sha256-azvUG/Oyq38q/llJd0AtEliFCX0+TrEtzfHsd+UpaEs=";
   };
 }

--- a/pkgs/by-name/el/element-web-unwrapped/element-web-pin.nix
+++ b/pkgs/by-name/el/element-web-unwrapped/element-web-pin.nix
@@ -1,8 +1,8 @@
 {
-  "version" = "1.12.4";
+  "version" = "1.12.6";
   "hashes" = {
-    "webSrcHash" = "sha256-5sRKVgKbU4hr1cubY/0PdLDClBcFGxdu9TITORL6beI=";
-    "webYarnHash" = "sha256-S+glH2HkGyINEGHWn1TMK2y45gk7WtxTe+u4luqVgsw=";
-    "webSharedComponentsYarnHash" = "sha256-azvUG/Oyq38q/llJd0AtEliFCX0+TrEtzfHsd+UpaEs=";
+    "webSrcHash" = "sha256-MZohRkaPNoevaLmOb60OcebYJDd0sI3UaPEFMXh7y38=";
+    "webYarnHash" = "sha256-3iV2XXphubxDG+FzbNC9cHY+gjSTssv6iQK9U7BLMp0=";
+    "webSharedComponentsYarnHash" = "sha256-fwRasJ3iI+4DjqfNNpZ5CceEydJITUTeB7brhcmqOKk=";
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->


Release notes `element-web`:
- https://github.com/element-hq/element-web/releases/tag/v1.12.4
- https://github.com/element-hq/element-web/releases/tag/v1.12.5
- https://github.com/element-hq/element-web/releases/tag/v1.12.6

Changelog `element-web`:
- https://github.com/element-hq/element-web/compare/v1.12.3...v1.12.6

Release notes `element-desktop`:
- https://github.com/element-hq/element-desktop/releases/tag/v1.12.4
- https://github.com/element-hq/element-desktop/releases/tag/v1.12.5
- https://github.com/element-hq/element-desktop/releases/tag/v1.12.6

Changelog `element-desktop`:
- https://github.com/element-hq/element-desktop/compare/v1.12.3...v1.12.6

Needs a fix to add the `shared-components` dependency since https://github.com/element-hq/element-web/commit/e883b05206129857aa00ca726252e10a0eb05cf9 introduced a `link:` dependency that we need to fetch as well.
`fetchYarnDeps` in `fixup.js` only supports `file:` dependencies.
See: https://github.com/NixOS/nixpkgs/blob/7c05114ab1077b3e4309129c6bdfd416bb309890/pkgs/build-support/node/fetch-yarn-deps/fixup.js#L18

Co-authored-by: @akshaymankar

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
