### PR TITLE
cc-tool: unstable-2020-05-19 -> 0.27-unstable-2025-10-17

### DIFF
--- a/pkgs/by-name/cc/cc-tool/package.nix
+++ b/pkgs/by-name/cc/cc-tool/package.nix
@@ -6,17 +6,18 @@
   boost,
   libusb1,
   pkg-config,
+  unstableGitUpdater,
 }:
 
 stdenv.mkDerivation {
   pname = "cc-tool";
-  version = "unstable-2020-05-19";
+  version = "0.27-unstable-2025-10-17";
 
   src = fetchFromGitHub {
     owner = "dashesy";
     repo = "cc-tool";
-    rev = "19e707eafaaddee8b996ad27a9f3e1aafcb900d2";
-    hash = "sha256:1f78j498fdd36xbci57jkgh25gq14g3b6xmp76imdpar0jkpyljv";
+    rev = "0d84df329e343e2ea5a960c04a3d4478ee039aa0";
+    hash = "sha256-3zZNzH+T/Wc3rn+ZmdpQ5U0Fs6ylT/QhX1pUUD8kPoE=";
   };
 
   nativeBuildInputs = [
@@ -30,14 +31,24 @@ stdenv.mkDerivation {
 
   postPatch = ''
     substituteInPlace udev/90-cc-debugger.rules \
-      --replace 'MODE="0666"' 'MODE="0660", GROUP="plugdev", TAG+="uaccess"'
+      --replace-fail 'MODE="0666"' 'MODE="0660", GROUP="plugdev", TAG+="uaccess"'
   '';
+
+  configureFlags = [
+    "--with-boost=${lib.getDev boost}"
+  ];
+
+  enableParallelBuilding = true;
 
   doInstallCheck = true;
 
   postInstall = ''
     install -D udev/90-cc-debugger.rules $out/lib/udev/rules.d/90-cc-debugger.rules
   '';
+
+  passthru.updateScript = unstableGitUpdater {
+    tagPrefix = "v";
+  };
 
   meta = {
     description = "Command line tool for the Texas Instruments CC Debugger";


### PR DESCRIPTION
Pass `--with-boost=` to fix the build on `master`
https://hydra.nixos.org/build/314316048:

    checking for Boost headers version >= 1.39.0... no
    configure: error: cannot find Boost headers version >= 1.39.0

While at it added a trivial updater and enabled build parallelism.

ZHF: #457852


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
