### PR TITLE
lib.buildInputsClosureCond: init

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -401,7 +401,12 @@ let
         renameCrossIndexTo
         mapCrossIndex
         ;
-      inherit (self.derivations) lazyDerivation optionalDrvAttr warnOnInstantiate;
+      inherit (self.derivations)
+        buildInputsClosureCond
+        lazyDerivation
+        optionalDrvAttr
+        warnOnInstantiate
+        ;
       inherit (self.generators) mkLuaInline;
       inherit (self.meta)
         addMetaAttrs

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -31,6 +31,7 @@ let
     bitOr
     bitXor
     boolToString
+    buildInputsClosureCond
     callPackagesWith
     callPackageWith
     cartesianProduct
@@ -4367,6 +4368,68 @@ runTests {
         passthru.meta.position = "/hi:23";
       };
       expected = derivation;
+    };
+
+  testBuildInputsClosureCond =
+    let
+      # Create mock derivations with drvPath and buildInputs
+      mkDrv = name: buildInputs: propagatedBuildInputs: {
+        inherit name buildInputs propagatedBuildInputs;
+        drvPath = "/nix/store/test-${name}.drv";
+      };
+
+      # Internal packages (marked by having "internal" in name)
+      internal1 = mkDrv "internal1" [ ] [ ];
+      internal2 = mkDrv "internal2" [ internal1 ] [ ];
+      internal3 = mkDrv "internal3" [ ] [ internal1 ];
+
+      # External packages
+      external1 = mkDrv "external1" [ ] [ ];
+      external2 = mkDrv "external2" [ external1 ] [ ];
+
+      # Mixed dependencies
+      mixed = mkDrv "mixed" [ internal2 external2 ] [ internal3 ];
+
+      # Predicate to filter internal packages
+      isInternal = pkg: lib.hasInfix "internal" pkg.name;
+
+      # Compute closure of mixed package, filtering for internal dependencies only
+      result = buildInputsClosureCond isInternal [ mixed ];
+
+      # Extract names for easier comparison
+      resultNames = map (d: d.name) result;
+    in
+    {
+      expr = lib.sort builtins.lessThan resultNames;
+      # Should include: mixed (from startSet, not filtered), internal2, internal3, internal1
+      # Should NOT include: external1, external2
+      expected = [
+        "internal1"
+        "internal2"
+        "internal3"
+        "mixed"
+      ];
+    };
+
+  testBuildInputsClosureCondStartSetNotFiltered =
+    let
+      mkDrv = name: {
+        inherit name;
+        drvPath = "/nix/store/test-${name}.drv";
+        buildInputs = [ ];
+        propagatedBuildInputs = [ ];
+      };
+
+      externalPkg = mkDrv "external";
+      isInternal = pkg: lib.hasInfix "internal" pkg.name;
+
+      # Even though externalPkg doesn't match the condition,
+      # it should still be in the result because it's in startSet
+      result = buildInputsClosureCond isInternal [ externalPkg ];
+    in
+    {
+      expr = map (d: d.name) result;
+      expected = [ "external" ];
     };
 
   testTypeDescriptionInt = {


### PR DESCRIPTION
Add a function to compute filtered closures of build dependencies.

Given a predicate and a starting set of derivations, this computes the transitive closure by recursively traversing buildInputs and propagatedBuildInputs, including only dependencies that satisfy the predicate.

This is useful for dev shells that need to selectively include only internal or external dependencies while maintaining semantic coherence (runtime dependencies only).

Example:
- https://github.com/NixOS/nix/pull/14489

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
