### PR TITLE
bitwarden-desktop: 2025.10.0 -> 2025.11.2

### DIFF
--- a/pkgs/by-name/bi/bitwarden-desktop/electron-builder-package-lock.patch
+++ b/pkgs/by-name/bi/bitwarden-desktop/electron-builder-package-lock.patch
@@ -1,28 +1,12 @@
-From 0629bb5b90e54491263e371bc5594e9f97ba0af4 Mon Sep 17 00:00:00 2001
-From: Andrew Marshall <andrew@johnandrewmarshall.com>
-Date: Tue, 12 Mar 2024 11:48:15 -0400
-Subject: [PATCH] Fix using unlocked dependencies in electron-builder
-
-electron-builder will perform its "installing production dependencies"
-step using this package.json, and without the package-lock.json, NPM
-will try to fetch package metadata to install the latest, unlocked
-dependencies.
----
- apps/desktop/webpack.main.js | 1 +
- 1 file changed, 1 insertion(+)
-
-diff --git a/apps/desktop/webpack.main.js b/apps/desktop/webpack.main.js
-index 9d683457d9..0ad707956e 100644
---- a/apps/desktop/webpack.main.js
-+++ b/apps/desktop/webpack.main.js
-@@ -70,6 +70,7 @@ const main = {
-     new CopyWebpackPlugin({
-       patterns: [
-         "./src/package.json",
-+        "./src/package-lock.json",
-         { from: "./src/images", to: "images" },
-         { from: "./src/locales", to: "locales" },
-       ],
--- 
-2.43.2
-
+diff --git a/apps/desktop/webpack.base.js b/apps/desktop/webpack.base.js
+index c9da84cd2e..3738bac27e 100644
+--- a/apps/desktop/webpack.base.js
++++ b/apps/desktop/webpack.base.js
+@@ -110,6 +110,7 @@ module.exports.buildConfig = function buildConfig(params) {
+       new CopyWebpackPlugin({
+         patterns: [
+           path.resolve(__dirname, "src/package.json"),
++          path.resolve(__dirname, "src/package-lock.json"),
+           { from: path.resolve(__dirname, "src/images"), to: "images" },
+           { from: path.resolve(__dirname, "src/locales"), to: "locales" },
+         ],

--- a/pkgs/by-name/bi/bitwarden-desktop/package.nix
+++ b/pkgs/by-name/bi/bitwarden-desktop/package.nix
@@ -3,10 +3,10 @@
   buildNpmPackage,
   cargo,
   copyDesktopItems,
+  dart,
   darwin,
   electron_37,
   fetchFromGitHub,
-  fetchpatch2,
   gnome-keyring,
   jq,
   llvmPackages_18,
@@ -34,13 +34,13 @@ let
 in
 buildNpmPackage' rec {
   pname = "bitwarden-desktop";
-  version = "2025.10.0";
+  version = "2025.11.2";
 
   src = fetchFromGitHub {
     owner = "bitwarden";
     repo = "clients";
     rev = "desktop-v${version}";
-    hash = "sha256-A7bxAdFDChr7yiexV70N3tqhaUVAwJdGhhRKJyX0ra8=";
+    hash = "sha256-0djpeXHHqA8tVcQsE/yCDZVnoEuYwUpln2Hhj2chGNc=";
   };
 
   patches = [
@@ -55,11 +55,6 @@ buildNpmPackage' rec {
     ./skip-afterpack-and-aftersign.patch
     # since out arch doesn't match upstream, we'll generate and use desktop_napi.node instead of desktop_napi.${platform}-${arch}.node
     ./dont-use-platform-triple.patch
-
-    (fetchpatch2 {
-      url = "https://github.com/bitwarden/clients/commit/cd56d01894c38cf046a7e44dcacc7e0ff2aa2a37.patch?full_index=1";
-      hash = "sha256-NRZiM+Y/ifh77vS+8mldbiwv/vPDr1JUOJzSu2tFMS8=";
-    })
   ];
 
   postPatch = ''
@@ -92,7 +87,7 @@ buildNpmPackage' rec {
     "--ignore-scripts"
   ];
   npmWorkspace = "apps/desktop";
-  npmDepsHash = "sha256-Qhj8Lh25vNnJzbUm/M+mKIc6Fa5plSCiy53vjevs7Tc=";
+  npmDepsHash = "sha256-l5Lcm1ggF7qFqNuSYRoRPf1Gbt/gH3g6dYu30YTXgsI=";
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit
@@ -102,7 +97,7 @@ buildNpmPackage' rec {
       cargoRoot
       patches
       ;
-    hash = "sha256-fgnf+yT3UV8dHTE2tDHdBWTBW+LHAYI/JGgfS0J/Bgk=";
+    hash = "sha256-WhiKqN+FCR/c9BuwhQT0EoidGUkP2ueSlsnupUflVlM=";
   };
   cargoRoot = "apps/desktop/desktop_native";
 
@@ -134,6 +129,9 @@ buildNpmPackage' rec {
       echo 'ERROR: electron version mismatch'
       exit 1
     fi
+
+    substituteInPlace node_modules/sass-embedded/dist/lib/src/compiler-path.js \
+      --replace-fail "\''${compiler_module_1.compilerModule}/dart-sass/src/dart" "${lib.getExe' dart "dartaotruntime"}"
 
     pushd apps/desktop/desktop_native/napi
     npm run build


### PR DESCRIPTION
Diff: https://github.com/bitwarden/clients/compare/desktop-v2025.10.0...desktop-v2025.11.2

Changelog: https://github.com/bitwarden/clients/releases/tag/desktop-v2025.11.2

Sadly not electron update from upstream

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
