### PR TITLE
lib/tests: move throwTestFailures tests to standalone script

### DIFF
--- a/lib/tests/debug.sh
+++ b/lib/tests/debug.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+# Tests lib/debug.nix
+# Run:
+# [nixpkgs]$ lib/tests/debug.sh
+# or:
+# [nixpkgs]$ nix-build lib/tests/release.nix
+
+set -euo pipefail
+shopt -s inherit_errexit
+
+# Use
+#     || die
+die() {
+  echo >&2 "test case failed: " "$@"
+  exit 1
+}
+
+if test -n "${TEST_LIB:-}"; then
+  NIX_PATH=nixpkgs="$(dirname "$TEST_LIB")"
+else
+  NIX_PATH=nixpkgs="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.."; pwd)"
+fi
+export NIX_PATH
+
+work="$(mktemp -d)"
+clean_up() {
+  rm -rf "$work"
+}
+trap clean_up EXIT
+cd "$work"
+
+expectSuccess() {
+    local expr=$1
+    local expectedResultRegex=$2
+    if ! result=$(nix-instantiate --eval --strict --json \
+        --expr "with (import <nixpkgs/lib>).debug; $expr" 2>/dev/null); then
+        die "$expr failed to evaluate, but it was expected to succeed"
+    fi
+    if [[ ! "$result" =~ $expectedResultRegex ]]; then
+        die "$expr == $result, but $expectedResultRegex was expected"
+    fi
+}
+
+expectFailure() {
+    local expr=$1
+    local expectedErrorRegex=$2
+    if result=$(nix-instantiate --eval --strict --json 2>"$work/stderr" \
+        --expr "with (import <nixpkgs/lib>).debug; $expr"); then
+        die "$expr evaluated successfully to $result, but it was expected to fail"
+    fi
+    if [[ ! "$(<"$work/stderr")" =~ $expectedErrorRegex ]]; then
+        die "Error was $(<"$work/stderr"), but $expectedErrorRegex was expected"
+    fi
+}
+
+# Test throwTestFailures with empty failures list
+expectSuccess 'throwTestFailures { failures = [ ]; }' "null"
+
+# Test throwTestFailures with actual failures
+# This should throw with a specific error message format
+expectFailure 'throwTestFailures {
+  failures = [
+    {
+      name = "testDerivation";
+      expected = builtins.derivation {
+        name = "a";
+        builder = "bash";
+        system = "x86_64-linux";
+      };
+      result = builtins.derivation {
+        name = "b";
+        builder = "bash";
+        system = "x86_64-linux";
+      };
+    }
+  ];
+}' "1 tests failed"
+
+echo >&2 tests ok

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -6,7 +6,8 @@
   which is `throw`'s and `abort`'s, without error messages.
 
   If you need to test error messages or more complex evaluations, see
-  `lib/tests/modules.sh`, `lib/tests/sources.sh` or `lib/tests/filesystem.sh` as examples.
+  `lib/tests/modules.sh`, `lib/tests/sources.sh`, `lib/tests/filesystem.sh` or
+  `lib/tests/debug.sh` as examples.
 
   To run these tests:
 
@@ -4813,32 +4814,4 @@ runTests {
       targetTarget = "prefix-tt";
     };
   };
-
-  testThrowTestFailuresEmpty = {
-    expr = lib.debug.throwTestFailures {
-      failures = [ ];
-    };
-
-    expected = null;
-  };
-
-  testThrowTestFailures = testingThrow (
-    lib.debug.throwTestFailures {
-      failures = [
-        {
-          name = "testDerivation";
-          expected = builtins.derivation {
-            name = "a";
-            builder = "bash";
-            system = "x86_64-linux";
-          };
-          result = builtins.derivation {
-            name = "b";
-            builder = "bash";
-            system = "x86_64-linux";
-          };
-        }
-      ];
-    }
-  );
 }

--- a/lib/tests/test-with-nix.nix
+++ b/lib/tests/test-with-nix.nix
@@ -60,6 +60,9 @@ pkgs.runCommand "nixpkgs-lib-tests-nix-${nix.version}"
     echo "Running lib/tests/sources.sh"
     TEST_LIB=$PWD/lib bash lib/tests/sources.sh
 
+    echo "Running lib/tests/debug.sh"
+    TEST_LIB=$PWD/lib bash lib/tests/debug.sh
+
     echo "Running lib/tests/network.sh"
     TEST_LIB=$PWD/lib bash lib/tests/network.sh
 


### PR DESCRIPTION
Hey :wave: 

Just found some confusing output in the `misc.nix` test. I've moved it into a separate test script as suggested by the comment at the top of `misc.nix`:

https://github.com/NixOS/nixpkgs/blob/dc4cf169932b676fcd73825530e441718ddfcf0c/lib/tests/misc.nix#L1-L19


The throwTestFailures tests in misc.nix produce confusing trace output that looks like test failures even when tests pass.

This commit moves these tests to a new `lib/tests/debug.sh` script, following the pattern from modules.sh, sources.sh, and filesystem.sh.

The confusing trace output does not appear in any logs anymore.

Example of the confusing log:

```
trace: FAIL "testDerivation":
Expected:
<derivation a>

Result:
<derivation b>

evaluation warning: Using `lib.generators.toPlist` without `escape = true` is deprecated [ ]
```

I've manually tested that both individual assertions can fail.


This also adds a basic assertion about the message.
Maybe that could also be improved?

My main focus is on restoring the `misc.nix` UX.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Context

- Introduced in https://github.com/NixOS/nixpkgs/pull/416207

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
