### PR TITLE
subunit: 1.4.2 -> 1.4.5

### DIFF
--- a/pkgs/by-name/su/subunit/package.nix
+++ b/pkgs/by-name/su/subunit/package.nix
@@ -1,7 +1,9 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
+  nix-update-script,
+  autoreconfHook,
   pkg-config,
   check,
   cppunit,
@@ -13,14 +15,17 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "subunit";
-  version = "1.4.2";
+  version = "1.4.5";
 
-  src = fetchurl {
-    url = "https://launchpad.net/subunit/trunk/${finalAttrs.version}/+download/subunit-${finalAttrs.version}.tar.gz";
-    hash = "sha256-hlOOv6kIC97w7ICVsuXeWrsUbVu3tCSzEVKUHXYG2dI=";
+  src = fetchFromGitHub {
+    owner = "testing-cabal";
+    repo = "subunit";
+    tag = finalAttrs.version;
+    hash = "sha256-yM5mlYV7KyPRzPhnbDYBFLn4uiwxFFEotX2r6KcKAwA=";
   };
 
   nativeBuildInputs = [
+    autoreconfHook
     pkg-config
     perl
     python3Packages.wrapPython
@@ -38,13 +43,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  postFixup = "wrapPythonPrograms";
+  passthru.updateScript = nix-update-script;
 
   meta = {
     description = "Streaming protocol for test results";
-    mainProgram = "subunit-diff";
-    homepage = "https://launchpad.net/subunit";
-    license = lib.licenses.asl20;
+    homepage = "https://github.com/testing-cabal/subunit";
+    license = with lib.licenses; [
+      asl20
+      bsd3
+    ];
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ azey7f ];
   };

--- a/pkgs/development/python-modules/subunit/default.nix
+++ b/pkgs/development/python-modules/subunit/default.nix
@@ -8,9 +8,9 @@
   pythonOlder,
 
   # python dependencies
-  extras,
   fixtures,
   hypothesis,
+  iso8601,
   pytestCheckHook,
   setuptools,
   testscenarios,
@@ -39,7 +39,7 @@ buildPythonPackage {
   ];
 
   propagatedBuildInputs = [
-    extras
+    iso8601
     testtools
   ];
 


### PR DESCRIPTION
Upsteam development seems to have mostly moved from launchpad.net to github, so we can add nix-update-script. The `postFixup` was removed because the `subunit-diff` binary is no longer included.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
