### PR TITLE
unicode-emoji: update url path, version, and hashes

### DIFF
--- a/pkgs/by-name/un/unicode-emoji/package.nix
+++ b/pkgs/by-name/un/unicode-emoji/package.nix
@@ -6,7 +6,7 @@
 }:
 
 let
-  version = "17.0";
+  version = "17.0.0";
 
   fetchData =
     { suffix, hash }:
@@ -15,7 +15,7 @@ let
       inherit version;
 
       src = fetchurl {
-        url = "https://www.unicode.org/Public/emoji/${version}/emoji-${suffix}.txt";
+        url = "https://www.unicode.org/Public/${version}/emoji/emoji-${suffix}.txt";
         inherit hash;
       };
 
@@ -35,11 +35,11 @@ let
   srcs = {
     emoji-sequences = fetchData {
       suffix = "sequences";
-      hash = "sha256-M1txywy3BISmMxoXYzGmg+LOafAdZOtAPu5mnE1XA5g=";
+      hash = "sha256-EsyCZ9wzy9Ee0yvPb8XcKtnHp3uuG9+6L0GxubPq2N0=";
     };
     emoji-test = fetchData {
       suffix = "test";
-      hash = "sha256-EYHEVX845REBhFBFD51CV02qiA0TQ9WsYfE0h34+veU=";
+      hash = "sha256-HYqUT4jXlS9+98UWf+88Z5lbyuJFQ5SXECMbA6IBrNo=";
     };
     emoji-zwj-sequences = fetchData {
       suffix = "zwj-sequences";


### PR DESCRIPTION
https://www.unicode.org/Public/emoji/ReadMe.txt
> Starting with Unicode 17.0.0, the data files for Unicode Emoji are published in https://www.unicode.org/Public/<version\>/emoji/

The previous URL doesn't exist upstream and blocks desktop environment builds in 25.11, which was updated to 17.0

hashes for emoji-sequences.txt and emoji-test.txt have also been updated

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
