### PR TITLE
intune-portal: update to `1.2511.7-noble`

### DIFF
--- a/pkgs/by-name/in/intune-portal/package.nix
+++ b/pkgs/by-name/in/intune-portal/package.nix
@@ -17,7 +17,6 @@
   sqlite,
   zlib,
   systemd,
-  msalsdk-dbusclient,
   pam,
   p11-kit,
   dbus,
@@ -30,11 +29,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "intune-portal";
-  version = "1.2503.10-noble";
+  version = "1.2511.7-noble";
 
   src = fetchurl {
     url = "https://packages.microsoft.com/ubuntu/24.04/prod/pool/main/i/intune-portal/intune-portal_${version}_amd64.deb";
-    hash = "sha256-NlJ8m7V1yLErOntprHs3EagPtwSzYWd7NBH0jc72+i4=";
+    hash = "sha256-MHvAmkemx28ZNcVloFNxJ03YbxrgVPvB7OOMYR6Oyo8=";
   };
 
   nativeBuildInputs = [ dpkg ];
@@ -59,7 +58,6 @@ stdenv.mkDerivation rec {
           sqlite
           zlib
           systemd
-          msalsdk-dbusclient
           dbus
         ];
         pam = lib.makeLibraryPath [ pam ];

--- a/pkgs/by-name/mi/microsoft-identity-broker/package.nix
+++ b/pkgs/by-name/mi/microsoft-identity-broker/package.nix
@@ -3,96 +3,84 @@
   lib,
   fetchurl,
   dpkg,
-  openjdk11,
-  jnr-posix,
-  makeWrapper,
-  zip,
   nixosTests,
-  bash,
-  glib,
+  libuuid,
   xorg,
-  alsa-lib,
+  curlMinimal,
+  openssl_3,
+  libsecret,
+  webkitgtk_4_1,
+  libsoup_3,
+  gtk3,
+  atk,
+  pango,
+  glib,
+  gdk-pixbuf,
+  harfbuzz,
+  p11-kit,
+  cairo,
+  zlib,
+  dbus,
 }:
+let
+  curlMinimal_openssl_3 = curlMinimal.override {
+    openssl = openssl_3;
+  };
+
+  runtimeLibPath = lib.makeLibraryPath [
+    stdenv.cc.cc
+    libuuid
+    xorg.libX11
+    curlMinimal_openssl_3
+    openssl_3
+    libsecret
+    webkitgtk_4_1
+    libsoup_3
+    gtk3
+    atk
+    glib
+    pango
+    harfbuzz
+    cairo
+    p11-kit
+    gdk-pixbuf
+    zlib
+    dbus
+  ];
+in
 stdenv.mkDerivation rec {
   pname = "microsoft-identity-broker";
-  version = "2.0.1";
+  version = "2.0.3";
 
   src = fetchurl {
     url = "https://packages.microsoft.com/ubuntu/24.04/prod/pool/main/m/microsoft-identity-broker/microsoft-identity-broker_${version}_amd64.deb";
-    hash = "sha256-JheJnsu1ZxJbcpt0367FqfHVdwWWvPem2fm0i8s7MGE=";
+    hash = "sha256-vorPf5pvNLABwntiDdfDSiubg1jbHaKK/o0fFkbZ000=";
   };
 
-  nativeBuildInputs = [
-    dpkg
-    makeWrapper
-    openjdk11
-    zip
-  ];
-
-  buildInputs = [
-    glib
-    xorg.libXtst
-    alsa-lib
-  ];
-
-  buildPhase = ''
-    runHook preBuild
-    rm opt/microsoft/identity-broker/lib/jnr-posix-3.1.4.jar
-    runHook postBuild
-  '';
+  nativeBuildInputs = [ dpkg ];
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/lib/microsoft-identity-broker
-    cp -a opt/microsoft/identity-broker/lib/* $out/lib/microsoft-identity-broker
-    cp -a usr/* $out
-    for jar in $out/lib/microsoft-identity-broker/*.jar; do
-      classpath="$classpath:$jar"
-    done
-    classpath="$classpath:${jnr-posix}/share/java/jnr-posix-${jnr-posix.version}.jar"
-    mkdir -p $out/bin
-    makeWrapper ${openjdk11}/bin/java $out/bin/microsoft-identity-broker \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath buildInputs}" \
-      --add-flags "-classpath $classpath" \
-      --add-flags "-Xmx256m -Xss256k -XX:+UseParallelGC -XX:ParallelGCThreads=1" \
-      --add-flags "-verbose" \
-      --add-flags "-Djava.net.useSystemProxies=true" \
-      --add-flags "com.microsoft.identity.broker.service.IdentityBrokerService"
+    mkdir -p $out
 
-    makeWrapper ${openjdk11}/bin/java $out/bin/microsoft-identity-device-broker \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath buildInputs}" \
-      --add-flags "-classpath $classpath" \
-      --add-flags "-Xmx256m -Xss256k -XX:+UseParallelGC -XX:ParallelGCThreads=1" \
-      --add-flags "-verbose" \
-      --add-flags "-Djava.net.useSystemProxies=true" \
-      --add-flags "com.microsoft.identity.broker.service.DeviceBrokerService"
+    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) --set-rpath ${runtimeLibPath} usr/bin/microsoft-identity-broker
+    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) --set-rpath ${runtimeLibPath} usr/bin/microsoft-identity-device-broker
+
+    cp -a usr/* $out
 
     runHook postInstall
   '';
 
   postInstall = ''
-    substituteInPlace \
-      $out/lib/systemd/user/microsoft-identity-broker.service \
-      $out/lib/systemd/system/microsoft-identity-device-broker.service \
-      $out/share/dbus-1/system-services/com.microsoft.identity.devicebroker1.service \
-      $out/share/dbus-1/services/com.microsoft.identity.broker1.service \
-      --replace \
-        ExecStartPre=sh \
-        ExecStartPre=${bash}/bin/sh \
-      --replace \
-        ExecStartPre=!sh \
-        ExecStartPre=!${bash}/bin/sh \
-      --replace \
-        /opt/microsoft/identity-broker/bin/microsoft-identity-broker \
-        $out/bin/microsoft-identity-broker \
-      --replace \
-        /opt/microsoft/identity-broker/bin/microsoft-identity-device-broker \
-        $out/bin/microsoft-identity-device-broker \
-      --replace \
-        /usr/lib/jvm/java-11-openjdk-amd64 \
-        ${openjdk11}
+    substituteInPlace $out/share/dbus-1/services/com.microsoft.identity.broker1.service \
+      --replace-fail /usr/bin/microsoft-identity-broker $out/bin/microsoft-identity-broker
+
+    substituteInPlace $out/lib/systemd/system/microsoft-identity-device-broker.service \
+      --replace-fail /usr/bin/microsoft-identity-device-broker $out/bin/microsoft-identity-device-broker
   '';
+
+  dontPatchELF = true;
 
   passthru = {
     updateScript = ./update.sh;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **microsoft-identity-broker: 2.0.1 -> 2.0.3**
- **intune-portal: 1.2503.10-noble -> 1.2511.7-noble**

Updates `intune-portal` to latest version, and updates dependency `microsoft-identity-broker` to new version as well,
as the new version (2.0.2>=) of it is required by new `intune-portal`.

Noticed also that the `msalsdk-dbusclient` seems to not be required anymore.

the `microsoft-identity-broker` seemed to have undergone an entire rewrite, hence no longer depending on openjdk 11.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
