### PR TITLE
exiled-exchange-2: init at  0.12.8

### DIFF
--- a/pkgs/by-name/ex/exiled-exchange-2/package.nix
+++ b/pkgs/by-name/ex/exiled-exchange-2/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  appimageTools,
+  fetchurl,
+}:
+
+let
+  version = "0.12.8";
+  pname = "Exiled-Exchange-2";
+
+  src = fetchurl {
+    url = "https://github.com/Kvan7/Exiled-Exchange-2/releases/download/v${version}/Exiled-Exchange-2-${version}.AppImage";
+    hash = "sha256-hGUmwyhFsM+8XTrFCuaLVYAA85jwrKCftkQ/wlViRHI=";
+  };
+
+  appimageContents = appimageTools.extract { inherit pname version src; };
+in
+appimageTools.wrapType2 rec {
+  inherit pname version src;
+  extraInstallCommands = ''
+    # Copy any extracted hicolor icons from the AppImage extraction output for the desktop file
+    if [ -d "${appimageContents}/usr/share/icons/hicolor" ]; then
+      find "${appimageContents}/usr/share/icons/hicolor" -type f -name "exiled-exchange-2.png" | while read -r f; do
+        rel=$(printf '%s' "$f" | sed -e "s|^${appimageContents}/usr/share/icons/hicolor/||")
+        dir=$(dirname "$rel")
+        mkdir -p "$out/share/icons/hicolor/$dir"
+        install -m 644 "$f" "$out/share/icons/hicolor/$rel"
+      done
+    fi
+
+    mkdir -p "$out/share/applications"
+
+    printf "%s\n" \
+      "[Desktop Entry]" \
+      "Type=Application" \
+      "Name=Exiled Exchange 2" \
+      "Exec=${pname}" \
+      "Icon=exiled-exchange-2" \
+      "Categories=Game;" \
+      > "$out/share/applications/${pname}.desktop"
+  '';
+
+  meta = {
+    description = "Companion app for the game Path of Exile 2 for trade price checking";
+    homepage = "https://kvan7.github.io/Exiled-Exchange-2/quick-start";
+    downloadPage = "https://github.com/Kvan7/Exiled-Exchange-2/releases";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ chrisheib ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds [Exiled-Exchange-2](https://github.com/Kvan7/Exiled-Exchange-2), a companion app for the game Path of Exile 2 to compare trade prices for items. See also https://kvan7.github.io/Exiled-Exchange-2/quick-start

Wrapped the appimg because I have no experience creating node derivations.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
