### PR TITLE
mdatagen: init at v0.135.0

### DIFF
--- a/pkgs/tools/misc/opentelemetry-collector/mdatagen.nix
+++ b/pkgs/tools/misc/opentelemetry-collector/mdatagen.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule rec {
+  pname = "mdatagen";
+  # Also update `pkgs/tools/misc/opentelemetry-collector/releases.nix`
+  # whenever that version changes.
+  version = "0.135.0";
+
+  src = fetchFromGitHub {
+    owner = "open-telemetry";
+    repo = "opentelemetry-collector";
+    rev = "cmd/mdatagen/v${version}";
+    hash = "sha256-ntRWAYbVbtZBqewXx4+YCZspRr+wSE2iGgmH8PEfj5o=";
+  };
+
+  sourceRoot = "${src.name}/cmd/mdatagen";
+  vendorHash = "sha256-YQNvvE9p4LVarU9ybKNcxQz20+K/Fur0V+meCtd7Xu8=";
+
+  env.CGO_ENABLED = 0;
+  ldflags = [
+    "-s"
+    "-w"
+    "-X go.opentelemetry.io/collector/cmd/mdatagen/internal.version=${version}"
+  ];
+
+  # Some tests download new dependencies for a modified go.mod. Nix doesn't allow network access so skipping.
+  checkFlags = [
+    "-skip TestValidateMetricDuplicates"
+  ];
+
+  meta = {
+    description = "OpenTelemetry Collector";
+    homepage = "https://github.com/open-telemetry/opentelemetry-collector.git";
+    changelog = "https://github.com/open-telemetry/opentelemetry-collector/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ aos ];
+    mainProgram = "mdatagen";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3597,6 +3597,7 @@ with pkgs;
   opentelemetry-collector-releases =
     callPackage ../tools/misc/opentelemetry-collector/releases.nix
       { };
+  mdatagen = callPackage ../tools/misc/opentelemetry-collector/mdatagen.nix { };
 
   openvswitch-dpdk = callPackage ../by-name/op/openvswitch/package.nix { withDPDK = true; };
 


### PR DESCRIPTION
Adds [mdatagen](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/mdatagen). This is used when building custom Opentelemetry collectors to generate boilerplate metrics code for the receiver.

There's already some precedence for this from
[builder.nix](https://github.com/NixOS/nixpkgs/blob/nixos-25.05/pkgs/tools/misc/opentelemetry-collector/builder.nix) so I chose to add this package as well.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
