### PR TITLE
workset: init at 0.2.1

### DIFF
--- a/pkgs/by-name/wo/workset/package.nix
+++ b/pkgs/by-name/wo/workset/package.nix
@@ -1,0 +1,41 @@
+{
+  fetchFromGitHub,
+  rustPlatform,
+  lib,
+  versionCheckHook,
+  pkg-config,
+  nix-update-script,
+  git,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "workset";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "fossable";
+    repo = "workset";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-aLSpgxTnyloMbCAIf2Uk9w0niJcJ2XZvcIl+T8Dq40U=";
+  };
+
+  cargoHash = "sha256-5bOWtKpC4ZtU5gMvwErd7Xqy+awjp7QlnQIFQ+eHGoA=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  nativeCheckInputs = [ git ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    mainProgram = "workset";
+    description = "Manage git repos with working sets";
+    homepage = "https://github.com/fossable/workset";
+    license = lib.licenses.unlicense;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ cilki ];
+  };
+})


### PR DESCRIPTION
Add package for `workset`, yet another git workspace manager.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
