### PR TITLE
nixos/firefox-syncserver: fix local database access, add a nixos test

### DIFF
--- a/nixos/modules/services/networking/firefox-syncserver.nix
+++ b/nixos/modules/services/networking/firefox-syncserver.nix
@@ -13,7 +13,7 @@ let
   defaultUser = "firefox-syncserver";
 
   dbIsLocal = cfg.database.host == "localhost";
-  dbURL = "mysql://${cfg.database.user}@${cfg.database.host}/${cfg.database.name}";
+  dbURL = "mysql://${cfg.database.user}@${cfg.database.host}/${cfg.database.name}${lib.optionalString dbIsLocal "?socket=/run/mysqld/mysqld.sock"}";
 
   format = pkgs.formats.toml { };
   settings = {

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -569,6 +569,7 @@ in
     imports = [ ./firefox.nix ];
     _module.args.firefoxPackage = pkgs.firefox-esr-140;
   };
+  firefox-syncserver = runTest ./firefox-syncserver.nix;
   firefoxpwa = runTest ./firefoxpwa.nix;
   firejail = runTest ./firejail.nix;
   firewall = runTest {

--- a/nixos/tests/firefox-syncserver.nix
+++ b/nixos/tests/firefox-syncserver.nix
@@ -1,0 +1,32 @@
+{
+  pkgs,
+  ...
+}:
+
+{
+  name = "firefox-syncserver";
+  nodes.machine = {
+    services.mysql = {
+      enable = true;
+      package = pkgs.mariadb;
+    };
+
+    services.firefox-syncserver = {
+      enable = true;
+      secrets = pkgs.writeText "secret" "this-is-a-test";
+      singleNode = {
+        enable = true;
+        hostname = "firefox-syncserver.local";
+        capacity = 1;
+      };
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("firefox-syncserver.service")
+    machine.wait_for_open_port(5000)
+
+    machine.wait_until_succeeds("curl --fail http://127.0.0.1:5000")
+
+  '';
+}

--- a/pkgs/by-name/sy/syncstorage-rs/package.nix
+++ b/pkgs/by-name/sy/syncstorage-rs/package.nix
@@ -8,6 +8,7 @@
   makeBinaryWrapper,
   lib,
   nix-update-script,
+  nixosTests,
 }:
 
 let
@@ -53,6 +54,8 @@ rustPlatform.buildRustPackage rec {
   doCheck = false;
 
   passthru.updateScript = nix-update-script { };
+
+  passthru.tests = { inherit (nixosTests) firefox-syncserver; };
 
   meta = {
     description = "Mozilla Sync Storage built with Rust";


### PR DESCRIPTION
Local database creation always assumed UNIX socket accces. During the
25.11 release cycle this seemingly changed and we now need to be
explicit.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
