### PR TITLE
woodpecker-{agent,cli,server}: build from source

### DIFF
--- a/pkgs/development/tools/continuous-integration/woodpecker/common.nix
+++ b/pkgs/development/tools/continuous-integration/woodpecker/common.nix
@@ -1,16 +1,17 @@
-{ lib, fetchzip }:
+{ lib, fetchFromGitHub }:
 let
   version = "3.12.0";
-  srcHash = "sha256-36802UcUufQS8zhpWDfbO1wTRZElDD3HpxSwNTrXGp0=";
-  vendorHash = null; # The tarball contains vendored dependencies
+  vendorHash = "sha256-TXQ53G+YGIcURZvJtkvGU66dlQx0NxMTeRkrmReCDU8=";
+  nodeModulesHash = "sha256-34N20FvgBbJAa28u56ZrYrT16J/+8OPuIm1O7EYGVc0=";
 in
 {
-  inherit version vendorHash;
+  inherit version vendorHash nodeModulesHash;
 
-  src = fetchzip {
-    url = "https://github.com/woodpecker-ci/woodpecker/releases/download/v${version}/woodpecker-src.tar.gz";
-    hash = srcHash;
-    stripRoot = false;
+  src = fetchFromGitHub {
+    owner = "woodpecker-ci";
+    repo = "woodpecker";
+    tag = "v${version}";
+    hash = "sha256-TaFAQa8QlogqzhznKeveaCiDbpk1Bl+aPSMGxiaE2ko=";
   };
 
   postInstall = ''

--- a/pkgs/development/tools/continuous-integration/woodpecker/server.nix
+++ b/pkgs/development/tools/continuous-integration/woodpecker/server.nix
@@ -1,8 +1,11 @@
-{ buildGoModule, callPackage }:
+{
+  buildGoModule,
+  callPackage,
+}:
 let
   common = callPackage ./common.nix { };
 in
-buildGoModule {
+buildGoModule (finalAttrs: {
   pname = "woodpecker-server";
   inherit (common)
     version
@@ -16,7 +19,12 @@ buildGoModule {
 
   env.CGO_ENABLED = 1;
 
+  postPatch = ''
+    cp -r ${finalAttrs.passthru.webui} web/dist
+  '';
+
   passthru = {
+    webui = callPackage ./webui.nix { };
     updateScript = ./update.sh;
   };
 
@@ -24,4 +32,4 @@ buildGoModule {
     description = "Woodpecker Continuous Integration server";
     mainProgram = "woodpecker-server";
   };
-}
+})

--- a/pkgs/development/tools/continuous-integration/woodpecker/update.sh
+++ b/pkgs/development/tools/continuous-integration/woodpecker/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p nix wget jq nix-prefetch
+#!nix-shell -i bash -p nix wget jq nix-prefetch-github nurl
 
 # shellcheck shell=bash
 
@@ -13,10 +13,11 @@ if [[ $# -gt 1 || $1 == -* ]]; then
     exit 1
 fi
 
-cd "$(dirname "$0")"
 version="$1"
 
 set -euo pipefail
+
+NIXPKGS_ROOT="$(git rev-parse --show-toplevel)"
 
 if [ -z "$version" ]; then
     version="$(wget -q -O- "${TOKEN_ARGS[@]}" "https://api.github.com/repos/woodpecker-ci/woodpecker/releases?per_page=10" | jq -r '[.[] | select(.prerelease == false)][0].tag_name')"
@@ -24,9 +25,25 @@ fi
 
 # strip leading "v"
 version="${version#v}"
+rev="v$version"
+
+cd "$(dirname "$0")"
+
+# Woodpecker repository source hash
+src_hash=$(nix-prefetch-github woodpecker-ci woodpecker --rev "$rev" | jq -r .hash)
+sed -i -E -e "s#hash = \".*\"#hash = \"$src_hash\"#" common.nix
 sed -i -E -e "s#version = \".*\"#version = \"$version\"#" common.nix
 
-# Woodpecker repository
-src_hash=$(nix-prefetch-url --type sha256 --unpack "https://github.com/woodpecker-ci/woodpecker/releases/download/v$version/woodpecker-src.tar.gz")
-src_hash=$(nix --extra-experimental-features nix-command hash convert --to sri --hash-algo sha256 "$src_hash")
-sed -i -E -e "s#srcHash = \".*\"#srcHash = \"$src_hash\"#" common.nix
+# Go modules vendor hash
+vendor_hash=$(nurl -e "(import $NIXPKGS_ROOT/. { }).woodpecker-server.goModules")
+sed -i -E -e "s#vendorHash = \".*\"#vendorHash = \"$vendor_hash\"#" common.nix
+
+# pnpm dependencies hash for web UI
+pnpm_hash=$(nurl -e "(import $NIXPKGS_ROOT/. { }).woodpecker-server.pnpmDeps")
+sed -i -E -e "s#nodeModulesHash = \".*\"#nodeModulesHash = \"$pnpm_hash\"#" common.nix
+
+echo "Update complete!"
+echo "Version: $version"
+echo "Source hash: $src_hash"
+echo "go vendor hash: $vendor_hash"
+echo "pnpm dependencies hash: $pnpm_hash"

--- a/pkgs/development/tools/continuous-integration/woodpecker/webui.nix
+++ b/pkgs/development/tools/continuous-integration/woodpecker/webui.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  callPackage,
+  nodejs,
+  pnpm,
+}:
+let
+  common = callPackage ./common.nix { };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "woodpecker-webui";
+  inherit (common) version src;
+
+  sourceRoot = "${common.src.name}/web";
+
+  pnpmDeps = pnpm.fetchDeps {
+    inherit (finalAttrs) pname version src;
+    sourceRoot = "${common.src.name}/web";
+    fetcherVersion = 2;
+    hash = common.nodeModulesHash;
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    pnpm.configHook
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r dist $out
+
+    runHook postInstall
+  '';
+
+  meta = common.meta // {
+    description = "Woodpecker Continuous Integration server webui";
+  };
+})


### PR DESCRIPTION
Because `pnpm.fetchDeps` did not exist in the past, the upstream project provided an tarball with already build webui.

Since we now have this helper I suggest we build from source.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
