### PR TITLE
reaper-sws-extension: enable Groove data, move darwin src

### DIFF
--- a/pkgs/by-name/re/reaper-sws-extension/darwin.nix
+++ b/pkgs/by-name/re/reaper-sws-extension/darwin.nix
@@ -4,6 +4,7 @@
   pname,
   version,
   meta,
+  undmg,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -12,34 +13,25 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     version
     meta
     ;
-  srcs =
-
-    let
-      plugin = fetchurl {
-        url = "https://github.com/reaper-oss/sws/releases/download/v${finalAttrs.version}/reaper_sws-arm64.dylib";
-        hash = "sha256-jmuob0qslYhxiE2ShfTwY4RJAKBLJSUb+VBEM0sQPbo=";
-      };
-    in
-    [
-      plugin
-      (fetchurl {
-        url = "https://github.com/reaper-oss/sws/releases/download/v${finalAttrs.version}/sws_python64.py";
-        hash = "sha256-GDlvfARg1g5oTH2itEug6Auxr9iFlPDdGueInGmHqSI=";
-      })
-      (fetchurl {
-        url = "https://github.com/reaper-oss/sws/releases/download/v${finalAttrs.version}/sws_python32.py";
-        hash = "sha256-np2r568csSdIS7VZHDASroZlXhpfxXwNn0gROTinWU4=";
-      })
+  src = fetchurl {
+    urls = [
+      "https://www.sws-extension.org/download/featured/sws-${finalAttrs.version}-Darwin-arm64.dmg"
+      "https://www.sws-extension.org/download/old/sws-${finalAttrs.version}-Darwin-arm64.dmg"
     ];
+    hash = "sha256-AzOLBgh3WECqbFHMTZ4EBGNLpAleXFJT2USzh7pDkQA=";
+  };
 
-  unpackCmd = ''
-    cp $curSrc $(stripHash $curSrc)
-  '';
+  nativeBuildInputs = [ undmg ];
+  sourceRoot = ".";
 
   installPhase = ''
     runHook preInstall
-    install -D -t $out/Scripts *.py
-    install -D -t $out/UserPlugins *.dylib
+
+    mkdir -p $out/Data
+    cp -r Grooves $out/Data
+    install -D *.py -t $out/Scripts
+    install -D *.dylib -t $out/UserPlugins
+
     runHook postInstall
   '';
 })

--- a/pkgs/by-name/re/reaper-sws-extension/linux.nix
+++ b/pkgs/by-name/re/reaper-sws-extension/linux.nix
@@ -36,4 +36,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ gtk3 ];
 
+  postInstall = ''
+    # This is excluded from the standard build for some reason, but we want this
+    cmake --install . --component grooves
+  '';
 })


### PR DESCRIPTION
Fixes missing data for the SWS Groove tool . On Darwin this means moving the src to the SWS website, since the GitHub releases don't contain it directly. The website is strange and hosts the current version at one link, and archived ones from another, so we list both so old versions don't break. 

I "tested" the darwin side of things by messing with the src logic to get the hashes, and checked the outputs for the right file structure, but I don't have a machine to do real darwin testing with.

At some point I'd also like to try building reaper extensions from source again on Darwin, but again, I can't test it.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
