### PR TITLE
cmdman: init at 0.1.0

### DIFF
--- a/pkgs/by-name/cm/cmdman/default.nix
+++ b/pkgs/by-name/cm/cmdman/default.nix
@@ -1,0 +1,2 @@
+{ callPackage }:
+callPackage ./package.nix { }

--- a/pkgs/by-name/cm/cmdman/package.nix
+++ b/pkgs/by-name/cm/cmdman/package.nix
@@ -1,0 +1,27 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "cmdman";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "nusendra";
+    repo = "cmdman";
+    rev = "v0.1.0";
+    hash = "sha256-e0DY9PHm3i+96d6s9VLQemwLAXkBqQCKB+3I4Il6zyI=";
+  };
+
+  cargoHash = "sha256-vFmnllS5LcyqRSc9VsI1PbYPxwnIB1gjYx/a7nHIq6Y=";
+
+  meta = with lib; {
+    description = "A CLI tool to save, manage, and execute custom commands with named aliases";
+    homepage = "https://github.com/nusendra/cmdman";
+    changelog = "https://github.com/nusendra/cmdman/releases/tag/v0.1.0";
+    license = licenses.mit;
+    maintainers = [ ];
+    mainProgram = "cmdman";
+  };
+}


### PR DESCRIPTION
This PR adds cmdman, a CLI tool to save, manage, and execute custom commands with named aliases.

## Things done
Features:
  - Save commands with short names for quick access
  - Execute commands with confirmation
  - JSON-based storage in ~/.config/cmdman/
  - Full terminal control for interactive commands like SSH

  Homepage: https://github.com/nusendra/cmdman
