### PR TITLE
nixos: use new combined memtest86plus binary

### DIFF
--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -1014,7 +1014,7 @@ in
       ]
       ++ lib.optionals (config.boot.loader.grub.memtest86.enable && config.isoImage.makeBiosBootable) [
         {
-          source = "${pkgs.memtest86plus}/memtest.bin";
+          source = pkgs.memtest86plus.efi;
           target = "/boot/memtest.bin";
         }
       ]

--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -472,7 +472,7 @@ in
         type = types.attrsOf types.path;
         default = { };
         example = literalExpression ''
-          { "memtest.bin" = "''${pkgs.memtest86plus}/memtest.bin"; }
+          { "memtest.bin" = pkgs.memtest86plus.efi; }
         '';
         description = ''
           A set of files to be copied to {file}`/boot`.

--- a/nixos/modules/system/boot/loader/grub/memtest.nix
+++ b/nixos/modules/system/boot/loader/grub/memtest.nix
@@ -69,6 +69,6 @@ in
         linux @bootRoot@/memtest.bin ${toString cfg.params}
       }
     '';
-    boot.loader.grub.extraFiles."memtest.bin" = "${memtest86}/memtest.bin";
+    boot.loader.grub.extraFiles."memtest.bin" = memtest86.efi;
   };
 }

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -391,7 +391,7 @@ in
       type = types.attrsOf types.path;
       default = { };
       example = literalExpression ''
-        { "efi/memtest86/memtest.efi" = "''${pkgs.memtest86plus}/memtest.efi"; }
+        { "efi/memtest86/memtest.efi" = pkgs.memtest86plus.efi; }
       '';
       description = ''
         A set of files to be copied to {file}`$BOOT`.
@@ -578,7 +578,7 @@ in
 
     boot.loader.systemd-boot.extraFiles = mkMerge [
       (mkIf cfg.memtest86.enable {
-        "efi/memtest86/memtest.efi" = "${pkgs.memtest86plus.efi}";
+        "efi/memtest86/memtest.efi" = pkgs.memtest86plus.efi;
       })
       (mkIf cfg.netbootxyz.enable {
         "efi/netbootxyz/netboot.xyz.efi" = "${pkgs.netbootxyz-efi}";

--- a/pkgs/by-name/me/memtest86plus/package.nix
+++ b/pkgs/by-name/me/memtest86plus/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  nixosTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -29,6 +30,8 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     install -Dm0444 mt86plus $out/mt86plus.efi
   '';
+
+  passthru.tests.systemd-boot-memtest = nixosTests.systemd-boot.memtest86;
 
   meta = {
     homepage = "https://www.memtest.org/";


### PR DESCRIPTION
Missed this in #464539

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
