### PR TITLE
nixos/tailscale-services: init Tailscale Service configuration module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14233,6 +14233,12 @@
     githubId = 2943605;
     name = "Evgeny Kurnevsky";
   };
+  kusold = {
+    email = "git@mikekusold.com";
+    github = "kusold";
+    githubId = 509966;
+    name = "Mike Kusold";
+  };
   kuwii = {
     name = "kuwii";
     email = "kuwii.someone@gmail.com";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1381,6 +1381,7 @@
   ./services/networking/syncthing.nix
   ./services/networking/tailscale-auth.nix
   ./services/networking/tailscale-derper.nix
+  ./services/networking/tailscale-services.nix
   ./services/networking/tailscale.nix
   ./services/networking/tayga.nix
   ./services/networking/tcpcrypt.nix

--- a/nixos/modules/services/networking/tailscale-services.nix
+++ b/nixos/modules/services/networking/tailscale-services.nix
@@ -170,6 +170,10 @@ let
   enabledServices = filterAttrs (_: serviceCfg: serviceCfg.enable) cfg;
 in
 {
+  meta.maintainers = with maintainers; [
+    kusold
+  ];
+
   options = {
     services.tailscale.service = mkOption {
       type = types.attrsOf (

--- a/nixos/modules/services/networking/tailscale-services.nix
+++ b/nixos/modules/services/networking/tailscale-services.nix
@@ -1,0 +1,276 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+with lib;
+let
+  cfg = config.services.tailscale.service;
+
+  # Parse endpoint key into components
+  # Format: "protocol:port" or "protocol:port:path"
+  # Examples: "https:443", "http:80", "tcp:5432", "https:443:/api"
+  parseEndpoint =
+    endpointKey:
+    let
+      parts = splitString ":" endpointKey;
+      protocol = elemAt parts 0;
+      port = elemAt parts 1;
+      path = if length parts > 2 then concatStringsSep ":" (drop 2 parts) else null;
+    in
+    {
+      inherit protocol port path;
+    };
+
+  # Generate tailscale serve command for an endpoint
+  mkServeCommand =
+    serviceName: endpointKey: target:
+    let
+      endpoint = parseEndpoint endpointKey;
+      protocolFlag =
+        if endpoint.protocol == "https" then
+          "--https"
+        else if endpoint.protocol == "http" then
+          "--http"
+        else if endpoint.protocol == "tcp" then
+          "--tcp"
+        else if endpoint.protocol == "tls-terminated-tcp" then
+          "--tls-terminated-tcp"
+        else
+          throw "Unsupported protocol: ${endpoint.protocol}";
+      pathFlag = optionalString (endpoint.path != null) "--set-path ${endpoint.path}";
+    in
+    "${protocolFlag}=${endpoint.port} ${pathFlag} ${target}";
+
+  # Generate the configuration script for a service
+  mkServiceScript =
+    serviceName: serviceCfg:
+    let
+      tailscaleBin = "${config.services.tailscale.package}/bin/tailscale";
+
+      # Generate serve commands for each endpoint
+      serveCommands = mapAttrsToList (
+        endpointKey: target:
+        let
+          cmd = mkServeCommand serviceName endpointKey target;
+        in
+        "${tailscaleBin} serve --service=svc:${serviceName} ${cmd}"
+      ) serviceCfg.endpoints;
+
+      # Add TUN mode if enabled
+      tunCommand = optionalString serviceCfg.tun "${tailscaleBin} serve --service=svc:${serviceName} --tun";
+
+      # Advertise the service
+      advertiseCommand = "${tailscaleBin} serve advertise svc:${serviceName}";
+
+      allCommands = serveCommands ++ optional serviceCfg.tun tunCommand ++ [ advertiseCommand ];
+    in
+    pkgs.writeShellScript "tailscale-service-${serviceName}" ''
+      set -e
+
+      # Wait for tailscaled to be ready
+      echo "Waiting for tailscaled to be ready..."
+      for i in {1..30}; do
+        if ${tailscaleBin} status --json >/dev/null 2>&1; then
+          STATE=$(${tailscaleBin} status --json | ${pkgs.jq}/bin/jq -r '.BackendState')
+          if [ "$STATE" = "Running" ]; then
+            echo "Tailscaled is ready."
+            break
+          fi
+        fi
+        if [ $i -eq 30 ]; then
+          echo "Timeout waiting for tailscaled to be ready."
+          exit 1
+        fi
+        sleep 1
+      done
+
+      # Function to run a command with retry on etag conflicts
+      run_with_retry() {
+        local max_attempts=10
+        local attempt=1
+        local base_delay=1
+
+        while [ $attempt -le $max_attempts ]; do
+          if output=$(eval "$@" 2>&1); then
+            echo "$output"
+            return 0
+          else
+            # Check if it's an etag/concurrent modification error
+            if echo "$output" | grep -q -E "(etag mismatch|Another client is changing|Preconditions failed)"; then
+              if [ $attempt -eq $max_attempts ]; then
+                echo "Failed after $max_attempts attempts due to concurrent modifications" >&2
+                echo "$output" >&2
+                return 1
+              fi
+
+              # Exponential backoff with jitter
+              local delay=$((base_delay * attempt + RANDOM % 3))
+              echo "Concurrent modification detected, retrying in ''${delay}s (attempt $attempt/$max_attempts)..." >&2
+              sleep $delay
+              attempt=$((attempt + 1))
+            else
+              # Different error, don't retry
+              echo "$output" >&2
+              return 1
+            fi
+          fi
+        done
+      }
+
+      # Execute commands with retry logic
+      ${concatStringsSep "\n" (map (cmd: "run_with_retry ${cmd}") allCommands)}
+    '';
+
+  # Generate the cleanup script for stopping a service
+  mkCleanupScript =
+    serviceName: serviceCfg:
+    let
+      tailscaleBin = "${config.services.tailscale.package}/bin/tailscale";
+    in
+    pkgs.writeShellScript "tailscale-service-${serviceName}-cleanup" ''
+      set -e
+
+      # Drain the service (stops accepting new connections)
+      echo "Draining service svc:${serviceName}..."
+      ${tailscaleBin} serve drain svc:${serviceName} || true
+
+      # Wait for connections to close gracefully
+      echo "Waiting for connections to close..."
+      sleep ${toString serviceCfg.drainTimeout}
+
+      # Remove all endpoint configurations for this service
+      echo "Clearing service configuration..."
+      ${tailscaleBin} serve clear svc:${serviceName} || true
+
+      echo "Service svc:${serviceName} stopped and cleaned up."
+    '';
+
+  # Create systemd service for each enabled Tailscale Service
+  mkSystemdService =
+    serviceName: serviceCfg:
+    nameValuePair "tailscale-service-${serviceName}" {
+      description = "Tailscale Service: ${serviceName}";
+      after = [ "tailscaled.service" ];
+      requires = [ "tailscaled.service" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = mkServiceScript serviceName serviceCfg;
+        ExecStop = mkCleanupScript serviceName serviceCfg;
+        # Ensure we have time to drain connections
+        TimeoutStopSec = serviceCfg.drainTimeout + 10;
+      };
+    };
+
+  # Filter enabled services
+  enabledServices = filterAttrs (_: serviceCfg: serviceCfg.enable) cfg;
+in
+{
+  options = {
+    services.tailscale.service = mkOption {
+      type = types.attrsOf (
+        types.submodule (
+          { name, ... }:
+          {
+            options = {
+              enable = mkEnableOption "Tailscale Service ${name}";
+
+              endpoints = mkOption {
+                type = types.attrsOf types.str;
+                default = { };
+                description = ''
+                  Endpoint mappings for the Tailscale Service.
+
+                  Format: "protocol:port[:path]" = "target"
+
+                  Supported protocols:
+                  - https: Layer 7 HTTPS endpoint
+                  - http: Layer 7 HTTP endpoint
+                  - tcp: Layer 4 TCP endpoint
+                  - tls-terminated-tcp: Layer 4 TLS-terminated TCP endpoint
+
+                  Examples:
+                  - "https:443" = "http://localhost:8080"
+                  - "http:80" = "http://localhost:3000"
+                  - "tcp:5432" = "tcp://localhost:5432"
+                  - "https:443:/api" = "http://localhost:8081"
+                '';
+                example = {
+                  "https:443" = "http://localhost:8080";
+                  "http:80" = "http://localhost:8080";
+                  "tcp:5432" = "tcp://localhost:5432";
+                };
+              };
+
+              tun = mkOption {
+                type = types.bool;
+                default = false;
+                description = ''
+                  Enable Layer 3 (TUN) mode for this service.
+                  This creates a protocol-agnostic endpoint that forwards all traffic
+                  to the local device without modification.
+
+                  Only works on Linux and requires additional OS configuration.
+                '';
+              };
+
+              drainTimeout = mkOption {
+                type = types.int;
+                default = 5;
+                description = ''
+                  Time in seconds to wait after draining the service for connections
+                  to close gracefully before clearing the configuration.
+                '';
+              };
+            };
+          }
+        )
+      );
+      default = { };
+      description = ''
+        Tailscale Services configuration.
+
+        Each attribute defines a Tailscale Service that will be advertised
+        from this host. The service must already be defined in your tailnet
+        through the Tailscale admin console.
+
+        This host must use a tag-based identity to act as a service host.
+      '';
+      example = {
+        web-server = {
+          enable = true;
+          endpoints = {
+            "https:443" = "http://localhost:8080";
+            "http:80" = "http://localhost:8080";
+          };
+        };
+        database = {
+          enable = true;
+          endpoints = {
+            "tcp:5432" = "tcp://localhost:5432";
+          };
+        };
+      };
+    };
+  };
+
+  config = mkIf (enabledServices != { }) {
+    # Assert that Tailscale is enabled
+    assertions = [
+      {
+        assertion = config.services.tailscale.enable;
+        message = ''
+          Tailscale Services requires services.tailscale.enable = true.
+          Please enable the base Tailscale service before configuring Tailscale Services.
+        '';
+      }
+    ];
+
+    # Create systemd services for each enabled Tailscale Service
+    systemd.services = listToAttrs (mapAttrsToList mkSystemdService enabledServices);
+  };
+}

--- a/nixos/modules/services/networking/tailscale-services.nix
+++ b/nixos/modules/services/networking/tailscale-services.nix
@@ -182,6 +182,7 @@ let
 in
 {
   meta.maintainers = with maintainers; [
+    dan-theriault
     kusold
   ];
 


### PR DESCRIPTION
Exposes services through the tailnet.

https://tailscale.com/kb/1552/tailscale-services

##### Reviewed points

- [x] module path fits the guidelines
- [ ] module tests, if any, succeed on ARCHITECTURE
- [ ] module tests, if any, are added to package `passthru.tests`
- [x] options have appropriate types
- [x] options have default
- [x] options have example
- [x] options have descriptions
- [x] No unneeded package is added to `environment.systemPackages`
- [x] `meta.maintainers` is set
- [ ] module documentation is declared in `meta.doc`

##### Possible improvements

##### Comments

## Things done

Closes #482230

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
