### PR TITLE
ocamlPackages.{markup,opti,ptmap,ptset,vector}: small cleaning

### DIFF
--- a/pkgs/development/ocaml-modules/markup/default.nix
+++ b/pkgs/development/ocaml-modules/markup/default.nix
@@ -8,17 +8,15 @@
   ounit2,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "markup";
   version = "1.0.3";
-
-  useDune2 = true;
 
   src = fetchFromGitHub {
     owner = "aantron";
     repo = "markup.ml";
-    rev = version;
-    sha256 = "sha256-tsXz39qFSyL6vPYKG7P73zSEiraaFuOySL1n0uFij6k=";
+    tag = finalAttrs.version;
+    hash = "sha256-tsXz39qFSyL6vPYKG7P73zSEiraaFuOySL1n0uFij6k=";
   };
 
   propagatedBuildInputs = [
@@ -27,13 +25,13 @@ buildDunePackage rec {
   ];
 
   checkInputs = [ ounit2 ];
-  doCheck = lib.versionAtLeast ocaml.version "4.08";
+  doCheck = true;
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/aantron/markup.ml/";
     description = "Pair of best-effort parsers implementing the HTML5 and XML specifications";
-    license = licenses.mit;
-    maintainers = with maintainers; [ gal_bolle ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ gal_bolle ];
   };
 
-}
+})

--- a/pkgs/development/ocaml-modules/opti/default.nix
+++ b/pkgs/development/ocaml-modules/opti/default.nix
@@ -4,23 +4,19 @@
   buildDunePackage,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "opti";
   version = "1.0.3";
 
-  useDune2 = true;
-
-  minimalOCamlVersion = "4.02";
-
   src = fetchurl {
-    url = "https://github.com/magnusjonsson/opti/releases/download/${version}/opti-${version}.tbz";
-    sha256 = "ed9ba56dc06e9d2b1bf097964cc65ea37db787d4f239c13d0dd74693f5b50a1e";
+    url = "https://github.com/magnusjonsson/opti/releases/download/${finalAttrs.version}/opti-${finalAttrs.version}.tbz";
+    hash = "sha256-7ZulbcBunSsb8JeWTMZeo323h9TyOcE9DddGk/W1Ch4=";
   };
 
-  meta = with lib; {
+  meta = {
     description = "DSL to generate fast incremental C code from declarative specifications";
-    license = licenses.bsd3;
-    maintainers = [ maintainers.jmagnusj ];
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.jmagnusj ];
     homepage = "https://github.com/magnusjonsson/opti";
   };
-}
+})

--- a/pkgs/development/ocaml-modules/ptmap/default.nix
+++ b/pkgs/development/ocaml-modules/ptmap/default.nix
@@ -6,15 +6,13 @@
   stdlib-shims,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "ptmap";
   version = "2.0.5";
 
-  useDune2 = true;
-
   src = fetchurl {
-    url = "https://github.com/backtracking/ptmap/releases/download/${version}/ptmap-${version}.tbz";
-    sha256 = "1apk61fc1y1g7x3m3c91fnskvxp6i0vk5nxwvipj56k7x2pzilgb";
+    url = "https://github.com/backtracking/ptmap/releases/download/${finalAttrs.version}/ptmap-${finalAttrs.version}.tbz";
+    hash = "sha256-69H4r+hnmiJv3LzbMjeI5vY9tXUhsVFHPy/4wFww86o=";
   };
 
   buildInputs = [ stdlib-shims ];
@@ -28,4 +26,4 @@ buildDunePackage rec {
     license = lib.licenses.lgpl21;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/ocaml-modules/ptset/default.nix
+++ b/pkgs/development/ocaml-modules/ptset/default.nix
@@ -5,15 +5,13 @@
   stdlib-shims,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "ptset";
   version = "1.0.1";
 
-  useDune2 = true;
-
   src = fetchurl {
-    url = "https://github.com/backtracking/ptset/releases/download/${version}/ptset-${version}.tbz";
-    sha256 = "1pr80mgk12l93mdq1wfsv2b6ccraxs334d5h92qzjh7bw2g13424";
+    url = "https://github.com/backtracking/ptset/releases/download/${finalAttrs.version}/ptset-${finalAttrs.version}.tbz";
+    hash = "sha256-RJARnuDrQPmxSLA0MobuKjNmltja8YBbHYmKMF8FKN8=";
   };
 
   doCheck = true;
@@ -26,4 +24,4 @@ buildDunePackage rec {
     license = lib.licenses.lgpl21;
     maintainers = [ lib.maintainers.vbgl ];
   };
-}
+})

--- a/pkgs/development/ocaml-modules/vector/default.nix
+++ b/pkgs/development/ocaml-modules/vector/default.nix
@@ -4,15 +4,13 @@
   fetchurl,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "vector";
   version = "1.0.0";
 
-  useDune2 = true;
-
   src = fetchurl {
-    url = "https://github.com/backtracking/vector/releases/download/${version}/vector-${version}.tbz";
-    sha256 = "sha256:0hb6prpada4c5z07sxf5ayj5xbahsnwall15vaqdwdyfjgbd24pj";
+    url = "https://github.com/backtracking/vector/releases/download/${finalAttrs.version}/vector-${finalAttrs.version}.tbz";
+    hash = "sha256-8hLR1pPON96w2iVQqrjVUK1epFfFdX3AL4yopm6+ZkE=";
   };
 
   doCheck = true;
@@ -24,4 +22,4 @@ buildDunePackage rec {
     maintainers = [ lib.maintainers.vbgl ];
   };
 
-}
+})


### PR DESCRIPTION
Let’s erase a few more occurrences of `useDune2`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
