### PR TITLE
gwq: init at 0.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20625,6 +20625,11 @@
     githubId = 31112680;
     name = "oidro";
   };
+  ojii3 = {
+    github = "OJII3";
+    githubId = 84656786;
+    name = "OJII3";
+  };
   ojsef39 = {
     name = "Josef Hofer";
     github = "ojsef39";

--- a/pkgs/by-name/gw/gwq/package.nix
+++ b/pkgs/by-name/gw/gwq/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  gitMinimal,
+  installShellFiles,
+  makeWrapper,
+  tmux,
+  writableTmpDirAsHomeHook,
+  versionCheckHook,
+  stdenv,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "gwq";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "d-kuro";
+    repo = "gwq";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-MfCYFbODWnfPxx+6sLlcMT6tqghgILHB13+ccYqVjBA=";
+  };
+
+  vendorHash = "sha256-4K01Xf1EXl/NVX1loQ76l1bW8QglBAQdvlZSo7J4NPI=";
+
+  subPackages = [ "cmd/gwq" ];
+
+  __structuredAttrs = true;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/d-kuro/gwq/internal/cmd.version=v${finalAttrs.version}"
+  ];
+
+  nativeBuildInputs = [
+    installShellFiles
+    makeWrapper
+  ];
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+  ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/gwq \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          gitMinimal
+          tmux
+        ]
+      }
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd gwq \
+      --bash <($out/bin/gwq completion bash) \
+      --fish <($out/bin/gwq completion fish) \
+      --zsh <($out/bin/gwq completion zsh)
+  '';
+
+  doInstallCheck = true;
+
+  meta = {
+    description = "Git worktree manager with fuzzy finder interface";
+    homepage = "https://github.com/d-kuro/gwq";
+    changelog = "https://github.com/d-kuro/gwq/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    mainProgram = "gwq";
+    maintainers = with lib.maintainers; [ ojii3 ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add [gwq](https://github.com/d-kuro/gwq/releases/tag/v0.0.5)
> Git worktree manager with fuzzy finder - Work on multiple branches simultaneously, perfect for parallel AI coding workflows

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
