### PR TITLE
vscode-extensions.kilocode.kilo-code: 4.118.0 -> 4.124.0

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/kilocode.kilo-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/kilocode.kilo-code/default.nix
@@ -12,19 +12,19 @@ let
   vsix = stdenvNoCC.mkDerivation (finalAttrs: {
     name = "kilo-code-${finalAttrs.version}.vsix";
     pname = "kilo-code-vsix";
-    version = "4.118.0";
+    version = "4.124.0";
 
     src = fetchFromGitHub {
       owner = "Kilo-Org";
       repo = "kilocode";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-k5dDgNUbOd+aOzPeub7P/uWDCeWO0ffyDaGtu2M87Wg=";
+      hash = "sha256-Dy0dd07pWsSbrO6BX7GEYf7CunXD0itaeIFRv9mQJks=";
     };
 
     pnpmDeps = pnpm.fetchDeps {
       inherit (finalAttrs) pname version src;
       fetcherVersion = 2;
-      hash = "sha256-YeCrmTPOeBfsSAMMv11ipHM8AgLzcy/sOW/Jg8H5H+w=";
+      hash = "sha256-hxgzmJD+Sl7E+ape1M1/Xl8XLtAhtht3AE45zHFctsQ=";
     };
 
     nativeBuildInputs = [


### PR DESCRIPTION
Update kilo-code to 4.124.0.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
