### PR TITLE
diskonaut-ng: init at 0.13.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10386,6 +10386,12 @@
     githubId = 273582;
     name = "greg";
   };
+  gregshuflin = {
+    email = "greg@everdayimshuflin.com";
+    github = "neunenak";
+    githubId = 311545;
+    name = "Greg Shuflin";
+  };
   greizgh = {
     email = "greizgh@ephax.org";
     github = "greizgh";

--- a/pkgs/by-name/di/diskonaut-ng/package.nix
+++ b/pkgs/by-name/di/diskonaut-ng/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+
+  __structuredAttrs = true;
+
+  pname = "diskonaut-ng";
+  version = "0.13.2";
+
+  src = fetchFromGitHub {
+    owner = "neunenak";
+    repo = "diskonaut";
+    tag = finalAttrs.version;
+    hash = "sha256-4gfJnqACJP1lV62Bkuarp85Idoh/H8zQ5W085yNZR5Q=";
+  };
+
+  cargoHash = "sha256-+NwZbR3fRj8Wi95GtsUQFWOyaZ0ekC4chsoJ5rsH3Zg=";
+
+  # 1 passed; 44 failed https://hydra.nixos.org/build/148943783/nixlog/1
+  doCheck = !stdenv.hostPlatform.isDarwin;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Terminal disk space navigator";
+    homepage = "https://github.com/neunenak/diskonaut";
+    changelog = "https://github.com/neunenak/diskonaut/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      gregshuflin
+    ];
+    mainProgram = "diskonaut";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

In https://github.com/NixOS/nixpkgs/pull/376644 , the diskonaut package was removed from nixpkgs for lack of maintenance. I've recently forked the project at github.com/neunenak/diskonaut/ and am starting to maintain the fork. I'd like to get the package back into nixpkgs.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
