### PR TITLE
neo4j_4: init at 4.4.46

### DIFF
--- a/pkgs/by-name/ne/neo4j_4/package.nix
+++ b/pkgs/by-name/ne/neo4j_4/package.nix
@@ -1,0 +1,65 @@
+{
+  coreutils,
+  fetchzip,
+  findutils,
+  gawk,
+  lib,
+  makeWrapper,
+  openjdk11,
+  stdenvNoCC,
+  versionCheckHook,
+  which,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "neo4j";
+  version = "4.4.46";
+
+  src = fetchzip {
+    url = "https://neo4j.com/artifact.php?name=neo4j-community-${finalAttrs.version}-unix.tar.gz";
+    hash = "sha256-qeA6lP8gqvwtJSMdJgJ0Iy2MMrtGhhUIOa4A6traSNg=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,share/neo4j}
+    cp -R * $out/share/neo4j
+
+    for NEO4J_SCRIPT in neo4j neo4j-admin cypher-shell; do
+      f="$out/share/neo4j/bin/$NEO4J_SCRIPT"
+      patchShebangs "$f"
+      makeWrapper "$f" "$out/bin/$NEO4J_SCRIPT" \
+        --prefix PATH : ${
+          lib.makeBinPath [
+            coreutils
+            findutils
+            gawk
+            openjdk11
+            which
+          ]
+        } \
+        --set JAVA_HOME ${openjdk11}
+    done
+
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  meta = {
+    description = "Highly scalable, robust (fully ACID) native graph database";
+    homepage = "https://neo4j.com";
+    changelog = "https://neo4j.com/release-notes/database/neo4j-${finalAttrs.version}";
+    downloadPage = "https://neo4j.com/deployment-center";
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.unix;
+    maintainers = [ lib.maintainers.eleonora ];
+    mainProgram = "neo4j";
+  };
+})

--- a/pkgs/by-name/ne/neo4j_4/package.nix
+++ b/pkgs/by-name/ne/neo4j_4/package.nix
@@ -42,13 +42,21 @@ stdenvNoCC.mkDerivation (finalAttrs: {
             which
           ]
         } \
-        --set JAVA_HOME ${openjdk11}
+        --set JAVA_HOME ${openjdk11} \
+        --run '
+          if [ ! -v NEO4J_HOME ]; then
+            echo "error: NEO4J_HOME must be set!" >&2
+            exit 1
+          fi'
     done
 
     runHook postInstall
   '';
 
+  env.NEO4J_HOME = "/tmp/neo4j";
+
   nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckKeepEnvironment = [ "NEO4J_HOME" ];
   versionCheckProgramArg = "--version";
   doInstallCheck = true;
 


### PR DESCRIPTION
This PR adds Neo4j version 4.4.46, which is the latest LTS release in edition 4.
BloodHound-CE, which I added in my [previous PR](https://github.com/NixOS/nixpkgs/pull/461387), still requires this version of Neo4j since it uses a feature that was deprecated in the 5.x series (for details see [here](https://github.com/SpecterOps/BloodHound/pull/1179)).

Packaging details were largely inspired by the already existing [Neo4j 5.x package](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/ne/neo4j/package.nix).

I hope that we can get this merged even though Neo4j 4.x will be out of support at the end of November. It's the last missing piece in nixpkgs required to run BloodHound-CE without relying on external container images.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
