### PR TITLE
rusthound-ce: init at 2.4.4

### DIFF
--- a/pkgs/by-name/ru/rusthound-ce/package.nix
+++ b/pkgs/by-name/ru/rusthound-ce/package.nix
@@ -1,0 +1,44 @@
+{
+  fetchCrate,
+  lib,
+  libkrb5,
+  nix-update-script,
+  pkg-config,
+  rustPlatform,
+  versionCheckHook,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rusthound-ce";
+  version = "2.4.4";
+
+  src = fetchCrate {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-WkqelaUTg6GoCoZa/DB5o40Cpfh9iAS0qrSgVwnMrHM=";
+  };
+
+  cargoHash = "sha256-LLq9Nzx/0UgGPQSPUVFpRmEpRBZwUJIaAKdM5j+mvCI=";
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    libkrb5
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Active Directory data ingestor for BloodHound Community Edition written in Rust";
+    homepage = "https://github.com/g0h4n/RustHound-CE";
+    changelog = "https://github.com/g0h4n/RustHound-CE/blob/main/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.eleonora ];
+    mainProgram = "rusthound-ce";
+  };
+})


### PR DESCRIPTION
This PR adds [RustHound-CE](https://github.com/g0h4n/RustHound-CE), a third-party Active Directory data ingestor for BloodHound-CE written in Rust.

Upstream currently doesn't use tags; see https://github.com/g0h4n/RustHound-CE/issues/26

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
