### PR TITLE
GNOME 49.2

### DIFF
--- a/pkgs/by-name/at/at-spi2-core/package.nix
+++ b/pkgs/by-name/at/at-spi2-core/package.nix
@@ -28,7 +28,7 @@
 
 stdenv.mkDerivation rec {
   pname = "at-spi2-core";
-  version = "2.58.1";
+  version = "2.58.2";
 
   outputs = [
     "out"
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/at-spi2-core/${lib.versions.majorMinor version}/at-spi2-core-${version}.tar.xz";
-    hash = "sha256-fzdKajjNcP9LMsnToDEL+oBNlG/tTJ5pp9SfrNy5Xpw=";
+    hash = "sha256-ooI7li7RbN1csfxTZQKf0hg5TYUqzUCYsyGFS9ZpL24=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ev/evolution-data-server/package.nix
+++ b/pkgs/by-name/ev/evolution-data-server/package.nix
@@ -50,7 +50,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "evolution-data-server";
-  version = "3.58.1";
+  version = "3.58.2";
 
   outputs = [
     "out"
@@ -59,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/evolution-data-server/${lib.versions.majorMinor finalAttrs.version}/evolution-data-server-${finalAttrs.version}.tar.xz";
-    hash = "sha256-qRSSiBTviH8Jebp46o17zJj5bPB8u3CwBRmAvZDsNfA=";
+    hash = "sha256-aULs/Dnrs2sLQ2Ot/wB3HBwt+jT1ToDsksO6o/6wIPs=";
   };
 
   patches = [

--- a/pkgs/by-name/gl/glib/package.nix
+++ b/pkgs/by-name/gl/glib/package.nix
@@ -74,7 +74,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "glib";
-  version = "2.86.1";
+  version = "2.86.2";
 
   outputs = [
     "bin"
@@ -87,7 +87,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/glib/${lib.versions.majorMinor finalAttrs.version}/glib-${finalAttrs.version}.tar.xz";
-    hash = "sha256-EZ0XCMoCJVbW0pie6QrRuCvZwNFmfgZpRKbQAg4tXlc=";
+    hash = "sha256-inJOlwhVNX6oEB4ncnICOSoP/VQQqYM2rtVOxZET5hE=";
   };
 
   patches =

--- a/pkgs/by-name/gn/gnome-shell/package.nix
+++ b/pkgs/by-name/gn/gnome-shell/package.nix
@@ -73,7 +73,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-shell";
-  version = "49.1";
+  version = "49.2";
 
   outputs = [
     "out"
@@ -82,7 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-shell/${lib.versions.major finalAttrs.version}/gnome-shell-${finalAttrs.version}.tar.xz";
-    hash = "sha256-tC0HMYnkAK+U/Dna66vlo2e7D2z3hOxc6VFodZXvvOs=";
+    hash = "sha256-0TuFXY35nev37M+BC24FT9sK64fvixMZGKbkyRl6Asc=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-user-share/package.nix
+++ b/pkgs/by-name/gn/gnome-user-share/package.nix
@@ -26,11 +26,11 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-user-share";
-  version = "48.1";
+  version = "48.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-user-share/${lib.versions.major finalAttrs.version}/gnome-user-share-${finalAttrs.version}.tar.xz";
-    hash = "sha256-grz9TvPqf9eyr3+6mkW0dOF03NgowcS/5/+KLvhYunc=";
+    hash = "sha256-Ayho1Ar4UIC6Thi6XatGwOZj7H5DiUnwgsgFeV9ivwY=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {

--- a/pkgs/by-name/li/libadwaita/package.nix
+++ b/pkgs/by-name/li/libadwaita/package.nix
@@ -23,7 +23,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libadwaita";
-  version = "1.8.1";
+  version = "1.8.2";
 
   outputs = [
     "out"
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "GNOME";
     repo = "libadwaita";
     tag = finalAttrs.version;
-    hash = "sha256-9CcmzwQYZZc6dZAv6x90Od4lrRcYZIejzPgm6S1vz/U=";
+    hash = "sha256-bymC3B5mY4r7oteA6WRViWIyazt0YE6T+P+RHrYifyY=";
   };
 
   depsBuildBuild = [

--- a/pkgs/by-name/mu/mutter/package.nix
+++ b/pkgs/by-name/mu/mutter/package.nix
@@ -71,7 +71,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mutter";
-  version = "49.1.1";
+  version = "49.2";
 
   outputs = [
     "out"
@@ -82,7 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/mutter/${lib.versions.major finalAttrs.version}/mutter-${finalAttrs.version}.tar.xz";
-    hash = "sha256-EykM/0l0EA4r/XsPrlwG+X+nXSH9xA8fXn5ILzPL0Cc=";
+    hash = "sha256-J2ORoIDlCVaSQKyGECVdd4q2qIoyUPmxd0AlXxNOPAo=";
   };
 
   mesonFlags = [

--- a/pkgs/by-name/mu/mutter/package.nix
+++ b/pkgs/by-name/mu/mutter/package.nix
@@ -224,13 +224,13 @@ stdenv.mkDerivation (finalAttrs: {
     };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Window manager for GNOME";
     mainProgram = "mutter";
     homepage = "https://gitlab.gnome.org/GNOME/mutter";
     changelog = "https://gitlab.gnome.org/GNOME/mutter/-/blob/${finalAttrs.version}/NEWS?ref_type=tags";
-    license = licenses.gpl2Plus;
-    teams = [ teams.gnome ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl2Plus;
+    teams = [ lib.teams.gnome ];
+    platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/na/nautilus/package.nix
+++ b/pkgs/by-name/na/nautilus/package.nix
@@ -41,7 +41,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nautilus";
-  version = "49.1";
+  version = "49.2";
 
   outputs = [
     "out"
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/nautilus/${lib.versions.major finalAttrs.version}/nautilus-${finalAttrs.version}.tar.xz";
-    hash = "sha256-rdKg5BD9ItooUd3QxbPSLJ6djDMRFRHzNpYeO0YbU14=";
+    hash = "sha256-JXazS+0ngaifCQUeyfyuOuF+txcs175nj1kqoU5MJrE=";
   };
 
   patches = [

--- a/pkgs/by-name/pa/papers/package.nix
+++ b/pkgs/by-name/pa/papers/package.nix
@@ -41,7 +41,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "papers";
-  version = "49.1";
+  version = "49.2";
 
   outputs = [
     "out"
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/papers/${lib.versions.major finalAttrs.version}/papers-${finalAttrs.version}.tar.xz";
-    hash = "sha256-SrI6Z4l73da+LWKYIQ//YCz+wPNWiLxb/ycDYLB4TCk=";
+    hash = "sha256-SanKL2LFWY+ObKTmfIf09ZxewN5wTTspnVFkyR0fakE=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
@@ -60,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
       pname
       version
       ;
-    hash = "sha256-Pjhpo44Zau2z6aWEQEcIPy3aUYplwdF/XIkO/1Zl+kg=";
+    hash = "sha256-aOVPknBqBV7AWO9LxvWRjiL2H2UQHAcpGpKY5YeoQrc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/sh/showtime/package.nix
+++ b/pkgs/by-name/sh/showtime/package.nix
@@ -20,12 +20,12 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "showtime";
-  version = "49.0";
+  version = "49.1";
   pyproject = false;
 
   src = fetchurl {
     url = "mirror://gnome/sources/showtime/${lib.versions.major version}/showtime-${version}.tar.xz";
-    hash = "sha256-Wryvl6telTADgoKEhYjozmwmFztzA+9nVr69sLIO05g=";
+    hash = "sha256-iu+7DiAJx6HNRKuAGwbKN19+loPwKaBS64b7Qzp4U5M=";
   };
 
   patches = [

--- a/pkgs/by-name/vt/vte/package.nix
+++ b/pkgs/by-name/vt/vte/package.nix
@@ -39,7 +39,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "vte";
-  version = "0.82.1";
+  version = "0.82.2";
 
   outputs = [
     "out"
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/vte/${lib.versions.majorMinor finalAttrs.version}/vte-${finalAttrs.version}.tar.xz";
-    hash = "sha256-eTdtcEAtJx4tOEJEGOGupyNXk00nLjIeOQa3Fwanjjo=";
+    hash = "sha256-4Slar8RoKztVDxI13CZ5uqD3FXDY7VQ8ABwSg9UwvpE=";
   };
 
   patches = [


### PR DESCRIPTION
## Things done

Based upon the list of packages here:

https://download.gnome.org/teams/releng/49.2/NEWS

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc