### PR TITLE
niri-taskbar: init at 0.4.0+niri.25.11

### DIFF
--- a/pkgs/by-name/ni/niri-taskbar/package.nix
+++ b/pkgs/by-name/ni/niri-taskbar/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  pkg-config,
+  rustPlatform,
+  fetchFromGitHub,
+  pango,
+  gdk-pixbuf,
+  atk,
+  gtk3,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "niri-taskbar";
+  version = "0.4.0+niri.25.11";
+
+  src = fetchFromGitHub {
+    owner = "lawngnome";
+    repo = "niri-taskbar";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-aE5v94AA6bC0CP8pv/SPBxGKpkH+GxR/p7hTKXlvk3E=";
+  };
+
+  cargoHash = "sha256-WRc1+ZVhiIfmLHaczAPq21XudI08CgVhlIhVcf0rmSw=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    pango
+    gdk-pixbuf
+    atk
+    gtk3
+  ];
+
+  meta = {
+    description = "A taskbar for the niri compositor";
+    homepage = "https://github.com/lawngnome/niri-taskbar";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ luochen1990 ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Summary
- Add niri-taskbar package to pkgs/by-name/ni/niri-taskbar
- Version 0.3.0+niri.25.08
- A taskbar for the niri compositor

## Description
niri-taskbar is a taskbar specifically designed for the niri compositor, providing:
- Modern and customizable interface for managing running applications
- Workspace management
- Integration with the niri window manager

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc