### PR TITLE
pspy: init at 1.2.1

### DIFF
--- a/pkgs/by-name/ps/pspy/package.nix
+++ b/pkgs/by-name/ps/pspy/package.nix
@@ -2,8 +2,26 @@
   buildGoModule,
   fetchFromGitHub,
   lib,
+  upx,
   versionCheckHook,
+  stdenv,
 }:
+let
+  inherit (stdenv.hostPlatform) system;
+  arch =
+    {
+      aarch64-linux = {
+        _32 = "arm";
+        _64 = "arm64";
+      };
+
+      x86_64-linux = {
+        _32 = "386";
+        _64 = "amd64";
+      };
+    }
+    .${system} or (throw "Unsupported system ${system}!");
+in
 buildGoModule (finalAttrs: {
   pname = "pspy";
   version = "1.2.1";
@@ -32,25 +50,59 @@ buildGoModule (finalAttrs: {
     "-X main.version=${finalAttrs.version}"
   ];
 
-  preBuild = ''
+  nativeBuildInputs = [ upx ];
+
+  # we build both 32 and 64 bit binaries just like upstream does
+  # however our "small" versions are not dynamically linked, only compressed
+  # since dynamically linked binaries would refer to missing Nix store paths
+  # when they are copied onto a target system
+  buildPhase = ''
+    runHook preBuild
+
     ldflags+=" -X main.commit=$(<.git_head)"
+
+    GOARCH=${arch._32} go build -ldflags "$ldflags" -o bin/pspy32
+    GOARCH=${arch._64} go build -ldflags "$ldflags" -o bin/pspy64
+
+    upx bin/pspy32 -o bin/pspy32s
+    upx bin/pspy64 -o bin/pspy64s
+
+    runHook postBuild
   '';
 
   # the various TestStart* tests defined in $src/internal/pspy/pspy_test.go
   # can in rare cases hit a race condition
   # ("Did not get message in time" or "Wrong message")
-  checkFlags = [ "-skip=^TestStart" ];
+  checkPhase = ''
+    runHook preCheck
+
+    go test -skip='^TestStart' ./...
+
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    mv bin $out
+
+    runHook postInstall
+  '';
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = "--help";
   doInstallCheck = true;
 
-  meta = with lib; {
+  meta = {
     description = "Monitor linux processes without root permissions";
     homepage = "https://github.com/DominicBreuker/pspy";
-    license = licenses.gpl3;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ eleonora ];
-    mainProgram = "pspy";
+    license = lib.licenses.gpl3;
+    platforms = [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+    maintainers = [ lib.maintainers.eleonora ];
+    mainProgram = "pspy64";
   };
 })

--- a/pkgs/by-name/ps/pspy/package.nix
+++ b/pkgs/by-name/ps/pspy/package.nix
@@ -1,0 +1,40 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+}:
+buildGoModule (finalAttrs: {
+  pname = "pspy";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "DominicBreuker";
+    repo = "pspy";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-7R4Tp0Q7wjAuTDukiehtRZOcTABr0YTnvrod9Jdwjok=";
+  };
+
+  env.CGO_ENABLED = "0";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  # the various TestStart* tests defined in $src/internal/pspy/pspy_test.go
+  # can in rare cases hit a race condition
+  # ("Did not get message in time" or "Wrong message")
+  checkFlags = [ "-skip=^TestStart" ];
+
+  vendorHash = "sha256-mgAsy2ufMDNpeCXG/cZ10zdmzFoGfcpCzPWIABnvJWU=";
+
+  meta = with lib; {
+    description = "Monitor linux processes without root permissions";
+    homepage = "https://github.com/DominicBreuker/pspy";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ eleonora ];
+    mainProgram = "pspy";
+  };
+})


### PR DESCRIPTION
This PR adds pspy, a tool for Linux that logs newly created processes without requiring root.
Since it's supposed to be copied to any target machine, I'm building a static binary here.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
