### PR TITLE
python313Packages.colcon-cmake: init at 0.2.29

### DIFF
--- a/pkgs/development/python-modules/colcon-cmake/default.nix
+++ b/pkgs/development/python-modules/colcon-cmake/default.nix
@@ -1,0 +1,59 @@
+{
+  buildPythonPackage,
+  lib,
+  fetchFromGitHub,
+  # build-system
+  setuptools,
+  # dependencies
+  colcon,
+  colcon-library-path,
+  colcon-test-result,
+  packaging,
+  # tests
+  pytestCheckHook,
+  scspell,
+  writableTmpDirAsHomeHook,
+}:
+
+buildPythonPackage rec {
+  pname = "colcon-cmake";
+  version = "0.2.29";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "colcon";
+    repo = pname;
+    tag = version;
+    hash = "sha256-v91UREVifYnwbMcM819B5CsXl8FbAH61Ydzu0vXBPX8=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    colcon
+    colcon-library-path
+    colcon-test-result
+    packaging
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    scspell
+    writableTmpDirAsHomeHook
+  ];
+
+  disabledTestPaths = [
+    # Skip the linter tests that require additional dependencies
+    "test/test_flake8.py"
+  ];
+
+  pythonImportsCheck = [ "colcon_cmake" ];
+
+  meta = {
+    description = "An extension for colcon-core to support CMake projects.";
+    homepage = "https://colcon.readthedocs.io/en/released/";
+    downloadPage = "https://github.com/colcon/colcon-cmake";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ amronos ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2944,6 +2944,8 @@ self: super: with self; {
 
   colcon-cd = callPackage ../development/python-modules/colcon-cd { };
 
+  colcon-cmake = callPackage ../development/python-modules/colcon-cmake { };
+
   colcon-coveragepy-result = callPackage ../development/python-modules/colcon-coveragepy-result { };
 
   colcon-defaults = callPackage ../development/python-modules/colcon-defaults { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

``colcon-cmake`` is an extension for [``colcon``](https://github.com/colcon/colcon-core) to support [CMake](https://cmake.org) projects. It is included in the [``colcon-common-extensions``](https://github.com/colcon/colcon-common-extensions) package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
