### PR TITLE
pfsshell: 1.1.1 -> 1.1.1-unstable-2025-07-13

### DIFF
--- a/pkgs/by-name/pf/pfsshell/package.nix
+++ b/pkgs/by-name/pf/pfsshell/package.nix
@@ -1,30 +1,34 @@
 {
+  cmake,
   lib,
   stdenv,
   fetchFromGitHub,
+  fuse,
   meson,
   ninja,
+  pkg-config,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "1.1.1";
+  version = "1.1.1-unstable-2025-07-13";
   pname = "pfsshell";
 
   src = fetchFromGitHub {
-    owner = "uyjulian";
+    owner = "ps2homebrew";
     repo = "pfsshell";
-    rev = "v${finalAttrs.version}";
-    sha256 = "0cr91al3knsbfim75rzl7rxdsglcc144x0nizn7q4jx5cad3zbn8";
+    rev = "8192de3907a05bb1844afcb1ae490179a38d4ed6";
+    fetchSubmodules = true;
+    hash = "sha256-drQNnCIqwM+Lnix5LewkD2ov8G6Mbu60xVKQKvCFbPY=";
   };
 
   nativeBuildInputs = [
+    fuse
     meson
     ninja
+    pkg-config
   ];
 
-  # Build errors since 1.1.1 when format hardening is enabled:
-  #   cc1: error: '-Wformat-security' ignored without '-Wformat' [-Werror=format-security]
-  hardeningDisable = [ "format" ];
+  mesonFlags = [ (lib.mesonBool "enable_pfsfuse" true) ];
 
   meta = {
     inherit (finalAttrs.src.meta) homepage;


### PR DESCRIPTION
remove disabled hardening and build pfsfuse to mount ps2 pfs images as a file system

1.1.1 release is almost 5 years old but development has continued



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
