### PR TITLE
gitlab: change actionmailer arguments to fix sendmail

### DIFF
--- a/nixos/modules/services/misc/gitlab.nix
+++ b/nixos/modules/services/misc/gitlab.nix
@@ -511,7 +511,7 @@ in
             ActionMailer::Base.delivery_method = :sendmail
             ActionMailer::Base.sendmail_settings = {
               location: "/run/wrappers/bin/sendmail",
-              arguments: "-i -t"
+              arguments: ['-i', '-t']
             }
           end
         '';

--- a/pkgs/by-name/gi/gitlab/remove-hardcoded-locations.patch
+++ b/pkgs/by-name/gi/gitlab/remove-hardcoded-locations.patch
@@ -12,7 +12,7 @@ index e1a7db8d860..5823f170410 100644
 -  # # }
 +  config.action_mailer.sendmail_settings = {
 +    location: '/run/wrappers/bin/sendmail',
-+    arguments: '-i -t'
++    arguments: ['-i', '-t']
 +  }
    config.action_mailer.perform_deliveries = true
    config.action_mailer.raise_delivery_errors = true


### PR DESCRIPTION
Sending notification mails via sendmail is broken since the update to gitlab v18.6.0,

because the ruby gem update also updates rails/actionmailer from 7.1.x to 7.2.x. which now needs the options it passes to sendmail as params array, the args string method is removed [0].

Tested on a local instance. Emails get sent again.

[0]: https://github.com/rails/rails/blob/7-2-stable/actionmailer/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
