### PR TITLE
nixos/nextcloud: Fix invalid variable name in nextcloud-config.php

### DIFF
--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -264,7 +264,7 @@ let
           $decoded = json_decode(nix_read_secret($credential_name), true);
 
           if (json_last_error() !== JSON_ERROR_NONE) {
-            error_log(sprintf("Cannot decode %s, because: %s", $file, json_last_error_msg()));
+            error_log(sprintf("Cannot decode %s, because: %s", $credential_name, json_last_error_msg()));
             exit(1);
           }
 


### PR DESCRIPTION
The function `nix_read_secret_and_decode_json_file` within the generated `nextcloud-config.php` refers within its error handling to the variable `$file`. That variable doesn't exist within `nix_read_secret_and_decode_json_file` and thus when hitting an error condition, PHP reports

`PHP Warning:  Undefined variable $file in /nix/store/f066xn9944sxisfcdf1vnxmnvbjl2iwr-nextcloud-config.php on line 28`

It seems like the error handling for this function was copied over from `nix_decode_json_file`, where the function parameter is called `$file`. In `nix_read_secret_and_decode_json_file` the parameter is called `$credential_name` and thus I've updated the code accordingly.

## Things done
Nothing. I'm fairly new to Nix and NixOS (in fact I'm still in the process of getting my very first configuration to run properly), so I'm lacking a setup to test this with (and lacking knowledge in how to set one up in reasonable time as well). Please excuse my lazy approach.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
