### PR TITLE
nixos/frp: guard server-only systemd options

### DIFF
--- a/nixos/modules/services/networking/frp.nix
+++ b/nixos/modules/services/networking/frp.nix
@@ -1,8 +1,7 @@
-{
-  config,
-  lib,
-  pkgs,
-  ...
+{ config
+, lib
+, pkgs
+, ...
 }:
 let
   cfg = config.services.frp;

--- a/nixos/modules/services/networking/frp.nix
+++ b/nixos/modules/services/networking/frp.nix
@@ -59,37 +59,41 @@ in
           after = if isClient then [ "network-online.target" ] else [ "network.target" ];
           wantedBy = [ "multi-user.target" ];
           description = "A fast reverse proxy frp ${cfg.role}";
-          serviceConfig = {
-            Type = "simple";
-            Restart = "on-failure";
-            RestartSec = 15;
-            ExecStart = "${cfg.package}/bin/${executableFile} --strict_config -c ${configFile}";
-            StateDirectoryMode = lib.optionalString isServer "0700";
-            DynamicUser = true;
-            # Hardening
-            UMask = lib.optionalString isServer "0007";
-            CapabilityBoundingSet = serviceCapability;
-            AmbientCapabilities = serviceCapability;
-            PrivateDevices = true;
-            ProtectHostname = true;
-            ProtectClock = true;
-            ProtectKernelTunables = true;
-            ProtectKernelModules = true;
-            ProtectKernelLogs = true;
-            ProtectControlGroups = true;
-            RestrictAddressFamilies = [
-              "AF_INET"
-              "AF_INET6"
-            ]
-            ++ lib.optionals isClient [ "AF_UNIX" ];
-            LockPersonality = true;
-            MemoryDenyWriteExecute = true;
-            RestrictRealtime = true;
-            RestrictSUIDSGID = true;
-            PrivateMounts = true;
-            SystemCallArchitectures = "native";
-            SystemCallFilter = [ "@system-service" ];
-          };
+          serviceConfig =
+            {
+              Type = "simple";
+              Restart = "on-failure";
+              RestartSec = 15;
+              ExecStart = "${cfg.package}/bin/${executableFile} --strict_config -c ${configFile}";
+              DynamicUser = true;
+              # Hardening
+              CapabilityBoundingSet = serviceCapability;
+              AmbientCapabilities = serviceCapability;
+              PrivateDevices = true;
+              ProtectHostname = true;
+              ProtectClock = true;
+              ProtectKernelTunables = true;
+              ProtectKernelModules = true;
+              ProtectKernelLogs = true;
+              ProtectControlGroups = true;
+              RestrictAddressFamilies = [
+                "AF_INET"
+                "AF_INET6"
+              ]
+              ++ lib.optionals isClient [ "AF_UNIX" ];
+              LockPersonality = true;
+              MemoryDenyWriteExecute = true;
+              RestrictRealtime = true;
+              RestrictSUIDSGID = true;
+              PrivateMounts = true;
+              SystemCallArchitectures = "native";
+              SystemCallFilter = [ "@system-service" ];
+            }
+            // lib.optionalAttrs isServer {
+              StateDirectory = "frp";
+              StateDirectoryMode = "0700";
+              UMask = "0007";
+            };
         };
       };
     };

--- a/nixos/modules/services/networking/frp.nix
+++ b/nixos/modules/services/networking/frp.nix
@@ -1,7 +1,8 @@
-{ config
-, lib
-, pkgs
-, ...
+{
+  config,
+  lib,
+  pkgs,
+  ...
 }:
 let
   cfg = config.services.frp;
@@ -58,41 +59,40 @@ in
           after = if isClient then [ "network-online.target" ] else [ "network.target" ];
           wantedBy = [ "multi-user.target" ];
           description = "A fast reverse proxy frp ${cfg.role}";
-          serviceConfig =
-            {
-              Type = "simple";
-              Restart = "on-failure";
-              RestartSec = 15;
-              ExecStart = "${cfg.package}/bin/${executableFile} --strict_config -c ${configFile}";
-              DynamicUser = true;
-              # Hardening
-              CapabilityBoundingSet = serviceCapability;
-              AmbientCapabilities = serviceCapability;
-              PrivateDevices = true;
-              ProtectHostname = true;
-              ProtectClock = true;
-              ProtectKernelTunables = true;
-              ProtectKernelModules = true;
-              ProtectKernelLogs = true;
-              ProtectControlGroups = true;
-              RestrictAddressFamilies = [
-                "AF_INET"
-                "AF_INET6"
-              ]
-              ++ lib.optionals isClient [ "AF_UNIX" ];
-              LockPersonality = true;
-              MemoryDenyWriteExecute = true;
-              RestrictRealtime = true;
-              RestrictSUIDSGID = true;
-              PrivateMounts = true;
-              SystemCallArchitectures = "native";
-              SystemCallFilter = [ "@system-service" ];
-            }
-            // lib.optionalAttrs isServer {
-              StateDirectory = "frp";
-              StateDirectoryMode = "0700";
-              UMask = "0007";
-            };
+          serviceConfig = {
+            Type = "simple";
+            Restart = "on-failure";
+            RestartSec = 15;
+            ExecStart = "${cfg.package}/bin/${executableFile} --strict_config -c ${configFile}";
+            DynamicUser = true;
+            # Hardening
+            CapabilityBoundingSet = serviceCapability;
+            AmbientCapabilities = serviceCapability;
+            PrivateDevices = true;
+            ProtectHostname = true;
+            ProtectClock = true;
+            ProtectKernelTunables = true;
+            ProtectKernelModules = true;
+            ProtectKernelLogs = true;
+            ProtectControlGroups = true;
+            RestrictAddressFamilies = [
+              "AF_INET"
+              "AF_INET6"
+            ]
+            ++ lib.optionals isClient [ "AF_UNIX" ];
+            LockPersonality = true;
+            MemoryDenyWriteExecute = true;
+            RestrictRealtime = true;
+            RestrictSUIDSGID = true;
+            PrivateMounts = true;
+            SystemCallArchitectures = "native";
+            SystemCallFilter = [ "@system-service" ];
+          }
+          // lib.optionalAttrs isServer {
+            StateDirectory = "frp";
+            StateDirectoryMode = "0700";
+            UMask = "0007";
+          };
         };
       };
     };


### PR DESCRIPTION
###### Motivation for this change
frp client units were emitting empty StateDirectoryMode/UMask values, which systemd rejects with “Failed to parse … Invalid argument”. These options are only meaningful for the server role.

###### Things done
- Only add StateDirectory/StateDirectoryMode/UMask when role == server; also set StateDirectory="frp" explicitly.
- Built nixosTests.frp locally.

###### Testing
- nixosTests.frp
