### PR TITLE
utf8proc: allow static build

### DIFF
--- a/pkgs/by-name/ut/utf8proc/package.nix
+++ b/pkgs/by-name/ut/utf8proc/package.nix
@@ -7,6 +7,8 @@
   tmux,
   fcft,
   arrow-cpp,
+  # build config
+  enableStatic ? stdenv.hostPlatform.isStatic,
 }:
 
 stdenv.mkDerivation rec {
@@ -23,8 +25,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
 
   cmakeFlags = [
-    "-DBUILD_SHARED_LIBS=ON"
-    "-DUTF8PROC_ENABLE_TESTING=ON"
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!enableStatic))
+    (lib.cmakeBool "UTF8PROC_ENABLE_TESTING" doCheck)
   ];
 
   doCheck = true;

--- a/pkgs/by-name/ut/utf8proc/package.nix
+++ b/pkgs/by-name/ut/utf8proc/package.nix
@@ -11,14 +11,14 @@
   enableStatic ? stdenv.hostPlatform.isStatic,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "utf8proc";
   version = "2.11.2";
 
   src = fetchFromGitHub {
     owner = "JuliaStrings";
     repo = "utf8proc";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-/+/IrsLQ9ykuVOaItd2ZbX60pPlP2omvS1qJz51AnWA=";
   };
 
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" (!enableStatic))
-    (lib.cmakeBool "UTF8PROC_ENABLE_TESTING" doCheck)
+    (lib.cmakeBool "UTF8PROC_ENABLE_TESTING" finalAttrs.finalPackage.doCheck)
   ];
 
   doCheck = true;
@@ -45,4 +45,4 @@ stdenv.mkDerivation rec {
       maintainers.sternenseemann
     ];
   };
-}
+})

--- a/pkgs/by-name/ut/utf8proc/package.nix
+++ b/pkgs/by-name/ut/utf8proc/package.nix
@@ -7,7 +7,6 @@
   tmux,
   fcft,
   arrow-cpp,
-  # build config
   enableStatic ? stdenv.hostPlatform.isStatic,
 }:
 


### PR DESCRIPTION
Build continues to default to a shared lib.
Also switch to lib.cmakeBool instead of raw strings for easier handling of boolean logi

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
