### PR TITLE
node-gyp-build: migrate from nodePackages

### DIFF
--- a/pkgs/by-name/ho/homepage-dashboard/package.nix
+++ b/pkgs/by-name/ho/homepage-dashboard/package.nix
@@ -1,6 +1,6 @@
 {
   fetchFromGitHub,
-  nodePackages,
+  node-gyp-build,
   makeBinaryWrapper,
   nodejs,
   pnpm_10,
@@ -56,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ cctools ];
 
   buildInputs = [
-    nodePackages.node-gyp-build
+    node-gyp-build
   ];
 
   env.PYTHON = "${python3}/bin/python";

--- a/pkgs/by-name/ma/marktext/package.nix
+++ b/pkgs/by-name/ma/marktext/package.nix
@@ -10,7 +10,7 @@
   python3,
   xorg,
   fontconfig,
-  nodePackages,
+  node-gyp-build,
   ripgrep,
   pkg-config,
   libsecret,
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
     (python3.withPackages (ps: with ps; [ packaging ]))
     pkg-config
     nodejs
-    nodePackages.node-gyp-build
+    node-gyp-build
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     xcbuild

--- a/pkgs/by-name/ma/matrix-appservice-irc/package.nix
+++ b/pkgs/by-name/ma/matrix-appservice-irc/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   fetchYarnDeps,
   fixup-yarn-lock,
-  nodejs,
+  node-gyp-build,
   nodejs-slim,
   matrix-sdk-crypto-nodejs,
   nixosTests,
@@ -44,7 +44,7 @@ stdenv.mkDerivation {
     fixup-yarn-lock
     nodejs-slim
     yarn
-    nodejs.pkgs.node-gyp-build
+    node-gyp-build
   ];
 
   configurePhase = ''

--- a/pkgs/by-name/no/node-gyp-build/package.nix
+++ b/pkgs/by-name/no/node-gyp-build/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nodejs,
+  nix-update-script,
+
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "node-gyp-build";
+  version = "4.8.4";
+
+  src = fetchFromGitHub {
+    owner = "prebuild";
+    repo = "node-gyp-build";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-65EQGGpwL0C8AOhFyf62nVEt4e2pCS0lAv+20kt3Zdk=";
+  };
+
+  dontBuild = true;
+
+  buildInputs = [
+    nodejs
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/node_modules/node-gyp-build
+    mkdir -p $out/bin
+
+    chmod +x ./{bin,build-test,optional}.js
+    mv *.js package.json $out/lib/node_modules/node-gyp-build
+
+    ln -s $out/lib/node_modules/node-gyp-build/bin.js $out/bin/node-gyp-build
+    ln -s $out/lib/node_modules/node-gyp-build/optional.js $out/bin/node-gyp-build-optional
+    ln -s $out/lib/node_modules/node-gyp-build/build-test.js $out/bin/node-gyp-build-test
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Build tool and bindings loader for node-gyp that supports prebuilds";
+    homepage = "https://github.com/prebuild/node-gyp-build";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pyrox0 ];
+    mainProgram = "node-gyp-build";
+  };
+})

--- a/pkgs/development/node-packages/aliases.nix
+++ b/pkgs/development/node-packages/aliases.nix
@@ -252,6 +252,7 @@ mapAliases {
   near-cli = throw "'near-cli' has been removed as upstream has deprecated it and archived the source code repo"; # Added 2025-11-10
   neovim = pkgs.neovim-node-client; # added 2024-11-13
   nijs = throw "'nijs' has been removed as it was unmaintained upstream"; # Added 2025-11-14
+  inherit (pkgs) node-gyp-build; # Added 2025-11-27
   node-inspector = throw "node-inspector was removed because it was broken"; # added 2023-08-21
   inherit (pkgs) node-gyp; # added 2024-08-13
   inherit (pkgs) node-pre-gyp; # added 2024-08-05

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -21,7 +21,6 @@
 , "jsdoc"
 , "lcov-result-merger"
 , "mathjax"
-, "node-gyp-build"
 , "node2nix"
 , "postcss"
 , "prebuild-install"

--- a/pkgs/development/node-packages/node-packages.nix
+++ b/pkgs/development/node-packages/node-packages.nix
@@ -23635,24 +23635,6 @@ in
     bypassCache = true;
     reconstructLock = true;
   };
-  node-gyp-build = nodeEnv.buildNodePackage {
-    name = "node-gyp-build";
-    packageName = "node-gyp-build";
-    version = "4.8.4";
-    src = fetchurl {
-      url = "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz";
-      sha512 = "LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==";
-    };
-    buildInputs = globalBuildInputs;
-    meta = {
-      description = "Build tool and bindings loader for node-gyp that supports prebuilds";
-      homepage = "https://github.com/prebuild/node-gyp-build";
-      license = "MIT";
-    };
-    production = true;
-    bypassCache = true;
-    reconstructLock = true;
-  };
   node2nix = nodeEnv.buildNodePackage {
     name = "node2nix";
     packageName = "node2nix";


### PR DESCRIPTION
Also includes a treewide migration of dependants to the standalone package. This doesn't have any deps and was very simple to move out. Tested builds of all dependant packages and they appear to work perfectly.

Part of #229475
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
