### PR TITLE
python3Packages.htpy: init 25.12.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7135,6 +7135,12 @@
       { fingerprint = "5DD7 C6F6 0630 F08E DAE7  4711 1525 585D 1B43 C62A"; }
     ];
   };
+  dunderrrrrr = {
+    email = "emil.bjorkroth@gmail.com";
+    github = "dunderrrrrr";
+    githubId = 25280555;
+    name = "Emil Björkroth";
+  };
   dunxen = {
     email = "git@dunxen.dev";
     matrix = "@dunxen:x0f.org";

--- a/pkgs/development/python-modules/htpy/default.nix
+++ b/pkgs/development/python-modules/htpy/default.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+  setuptools,
+  setuptools-scm,
+  markupsafe,
+  pytestCheckHook,
+  django,
+  flask,
+  starlette,
+  httpx,
+  black,
+  ruff,
+  markdown,
+  typing-extensions,
+}:
+
+buildPythonPackage rec {
+  pname = "htpy";
+  version = "25.12.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "pelme";
+    repo = "htpy";
+    tag = version;
+    hash = "sha256-s26I+eMue49+pIHe3dHnxMLJ/oGvs1ERZtcCR65Z8Is=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    markupsafe
+  ]
+  ++ lib.optionals (pythonOlder "3.13") [
+    typing-extensions
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    django
+    flask
+    starlette
+    httpx
+    black
+    ruff
+    markdown
+  ];
+
+  pythonImportsCheck = [ "htpy" ];
+
+  meta = {
+    mainProgram = "html2htpy";
+    description = "Generate HTML in Python without a template language";
+    license = lib.licenses.mit;
+    homepage = "https://htpy.dev";
+    maintainers = with lib.maintainers; [ dunderrrrrr ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6921,6 +6921,8 @@ self: super: with self; {
 
   htmltools = callPackage ../development/python-modules/htmltools { };
 
+  htpy = callPackage ../development/python-modules/htpy { };
+
   htseq = callPackage ../development/python-modules/htseq { };
 
   httmock = callPackage ../development/python-modules/httmock { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Added new Python package `htpy` (v25.12.0).

`htpy` is a library to generate HTML using plain Python syntax without a template language.
Homepage: https://htpy.dev

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
