### PR TITLE
imv: apply upstream patch to fix Wayland segfault

### DIFF
--- a/pkgs/by-name/im/imv/package.nix
+++ b/pkgs/by-name/im/imv/package.nix
@@ -42,6 +42,7 @@
   libwebp,
   qoi,
   wayland-scanner,
+  fetchpatch,
 }:
 
 let
@@ -101,6 +102,14 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-sOlWSv1GqdYzooTvcJjXxJI3pwWWJnlUpbGZgUAFYm0=";
   };
+
+  patches = [
+    # Fixes Wayland SIGSEGV (https://todo.sr.ht/~exec64/imv/80); remove after next release
+    (fetchpatch {
+      url = "https://git.sr.ht/~exec64/imv/commit/2dc80ccc64b6e1a315c6c2a06c26fc0138db3a13.patch";
+      hash = "sha256-EjnKwJ9bM+VyUPGuy2YHPWleLmQ/DGHHjY/QmnfRpQ4=";
+    })
+  ];
 
   mesonFlags = [
     "-Dwindows=${withWindowSystem}"


### PR DESCRIPTION
Fixes a `SIGSEGV` crash in imv on Wayland when `XCURSOR_SIZE` is unset (for example in Plasma Wayland). This PR applies the upstream patch.

- Upstream Issue: https://todo.sr.ht/~exec64/imv/80
- Patch: https://git.sr.ht/~exec64/imv/commit/2dc80ccc64b6e1a315c6c2a06c26fc0138db3a13

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
