### PR TITLE
python313Packages.splinter: fix build with lxml 6

### DIFF
--- a/pkgs/development/python-modules/splinter/default.nix
+++ b/pkgs/development/python-modules/splinter/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   buildPythonPackage,
-  pythonOlder,
   fetchFromGitHub,
   setuptools,
   urllib3,
@@ -17,9 +16,6 @@
 buildPythonPackage rec {
   pname = "splinter";
   version = "0.21.0";
-
-  disabled = pythonOlder "3.8";
-
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -33,9 +29,9 @@ buildPythonPackage rec {
     ./lxml-6.patch
   ];
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [ urllib3 ];
+  dependencies = [ urllib3 ];
 
   optional-dependencies = {
     "zope.testbrowser" = [
@@ -88,11 +84,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "splinter" ];
 
-  meta = with lib; {
+  meta = {
     changelog = "https://splinter.readthedocs.io/en/latest/news.html";
     description = "Browser abstraction for web acceptance testing";
     homepage = "https://github.com/cobrateam/splinter";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ dotlambda ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ dotlambda ];
   };
 }

--- a/pkgs/development/python-modules/splinter/default.nix
+++ b/pkgs/development/python-modules/splinter/default.nix
@@ -29,6 +29,10 @@ buildPythonPackage rec {
     hash = "sha256-PGGql8yI1YosoUBAyDoI/8k7s4sVYnXEV7eow3GHH88=";
   };
 
+  patches = [
+    ./lxml-6.patch
+  ];
+
   nativeBuildInputs = [ setuptools ];
 
   propagatedBuildInputs = [ urllib3 ];

--- a/pkgs/development/python-modules/splinter/lxml-6.patch
+++ b/pkgs/development/python-modules/splinter/lxml-6.patch
@@ -1,0 +1,42 @@
+diff --git a/tests/fake_django/urls.py b/tests/fake_django/urls.py
+index 2ab75ff..bd736ab 100644
+--- a/tests/fake_django/urls.py
++++ b/tests/fake_django/urls.py
+@@ -52,7 +52,8 @@ def post_form(request):
+ 
+ 
+ def request_headers(request):
+-    body = "\n".join(f"{key}: {value}" for key, value in request.META.items())
++    headers = "\n".join(f"{key}: {value}" for key, value in request.META.items())
++    body = f"<html><body>{headers}</body></html>"
+     return HttpResponse(body)
+ 
+ 
+@@ -67,7 +68,7 @@ def upload_file(request):
+ 
+ 
+ def foo(request):
+-    return HttpResponse("BAR!")
++    return HttpResponse("<html><body>BAR!</body></html>")
+ 
+ 
+ def query_string(request):
+diff --git a/tests/fake_webapp.py b/tests/fake_webapp.py
+index ccd5bab..efc31c5 100644
+--- a/tests/fake_webapp.py
++++ b/tests/fake_webapp.py
+@@ -119,12 +119,12 @@ def upload_file():
+ 
+ @app.route("/headers", methods=["GET"])
+ def request_headers():
+-    return str(request.headers)
++    return f"<html><body>{request.headers}</body></html>"
+ 
+ 
+ @app.route("/foo")
+ def foo():
+-    return "BAR!"
++    return "<html><body>BAR!</body></html>"
+ 
+ 
+ @app.route("/query", methods=["GET"])


### PR DESCRIPTION
lxml 6 doesn't find a `<body>` tag via the XPath expression `//body` anymore when the parsed HTML doesn't contain any tags at all. This causes some of splinter's tests to fail when lxml 6 is used.

The lxml HTML parser generally seems to behave rather erratically when there is no `<body>` tag in the parsed HTML, so consumers probably shouldn't rely on this behavior anyway.

Upstream patch: https://github.com/cobrateam/splinter/pull/1334

Hydra: https://hydra.nixos.org/build/314264704/nixlog/1
ZHF: https://github.com/NixOS/nixpkgs/issues/457852

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
