### PR TITLE
python3Packages.orbax-checkpoint: skip all benchmark tests

### DIFF
--- a/pkgs/development/python-modules/orbax-checkpoint/default.nix
+++ b/pkgs/development/python-modules/orbax-checkpoint/default.nix
@@ -120,18 +120,8 @@ buildPythonPackage rec {
     #   /build/source/checkpoint/orbax/checkpoint/_src/metadata/sharding_test.py
     "orbax/checkpoint/_src/metadata/sharding_test.py"
 
-    # Circular dependency with clu
-    "orbax/checkpoint/_src/testing/benchmarks/array_handler_benchmark_test.py"
-    "orbax/checkpoint/_src/testing/benchmarks/checkpoint_manager_benchmark_test.py"
-    "orbax/checkpoint/_src/testing/benchmarks/checkpoint_manager_perf_benchmark_test.py"
-    "orbax/checkpoint/_src/testing/benchmarks/checkpoint_policy_benchmark_test.py"
-    "orbax/checkpoint/_src/testing/benchmarks/core/config_parsing_test.py"
-    "orbax/checkpoint/_src/testing/benchmarks/core/core_test.py"
-    "orbax/checkpoint/_src/testing/benchmarks/core/metric_test.py"
-    "orbax/checkpoint/_src/testing/benchmarks/emergency_checkpoint_manager_benchmark_test.py"
-    "orbax/checkpoint/_src/testing/benchmarks/multihost_dispatchers_benchmark_test.py"
-    "orbax/checkpoint/_src/testing/benchmarks/pytree_checkpoint_benchmark_test.py"
-    "orbax/checkpoint/_src/testing/benchmarks/single_replica_benchmark_test.py"
+    # Circular dependency with clu (and we should not run benchmarks anyway)
+    "orbax/checkpoint/_src/testing/benchmarks/"
 
     # E   absl.flags._exceptions.DuplicateFlagError: The flag 'num_processes' is defined twice.
     # First from multiprocess_test, Second from orbax.checkpoint._src.testing.multiprocess_test.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Addresses #465625

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
