### PR TITLE
sapling: use Python 3.13

### DIFF
--- a/pkgs/by-name/sa/sapling/package.nix
+++ b/pkgs/by-name/sa/sapling/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  python311Packages,
+  python3Packages,
   fetchFromGitHub,
   fetchurl,
   cargo,
@@ -33,7 +33,7 @@ let
   # compilation, which doesn't work on macOS anyway so we can just stub it
   # on macOS.
   #
-  # See https://github.com/NixOS/nixpkgs/pull/198311#issuecomment-1326894295
+  # See https://github.com/NixOS/nixpkgs/pull/1983#issuecomment-1326894295
   myCargoSetupHook = rustPlatform.cargoSetupHook.overrideAttrs (old: {
     cargoConfig = lib.optionalString (!stdenv.hostPlatform.isDarwin) old.cargoConfig;
   });
@@ -78,7 +78,7 @@ let
       substituteInPlace build-tar.py \
         --replace-fail 'run(yarn + ["--cwd", src_join(), "install", "--prefer-offline"])' 'pass'
 
-      ${python311Packages.python}/bin/python3 build-tar.py \
+      ${python3Packages.python}/bin/python3 build-tar.py \
         --output isl-dist.tar.xz \
         --yarn 'yarn --offline --frozen-lockfile --ignore-engines --ignore-scripts --no-progress'
 
@@ -96,7 +96,7 @@ let
   };
 in
 # Builds the main `sl` binary and its Python extensions
-python311Packages.buildPythonApplication {
+python3Packages.buildPythonApplication {
   format = "setuptools";
   pname = "sapling";
   inherit src version;
@@ -159,6 +159,11 @@ python311Packages.buildPythonApplication {
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     curl
     libiconv
+  ];
+
+  dependencies = with python3Packages; [
+    standard-pipes
+    standard-uu
   ];
 
   HGNAME = "sl";

--- a/pkgs/development/python-modules/standard-uu/default.nix
+++ b/pkgs/development/python-modules/standard-uu/default.nix
@@ -1,0 +1,37 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  pytestCheckHook,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "standard-uu";
+  version = "3.13.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "youknowone";
+    repo = "python-deadlib";
+    tag = "v${version}";
+    hash = "sha256-vhGFTd1yXL4Frqli5D1GwOatwByDjvcP8sxgkdu6Jqg=";
+  };
+
+  sourceRoot = "${src.name}/uu";
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "uu" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Standard library sndhdr redistribution";
+    homepage = "https://github.com/youknowone/python-deadlib/tree/main/uu";
+    license = lib.licenses.psfl;
+    maintainers = [ lib.maintainers.dotlambda ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17940,6 +17940,9 @@ self: super: with self; {
     else
       null;
 
+  standard-uu =
+    if pythonAtLeast "3.13" then callPackage ../development/python-modules/standard-uu { } else null;
+
   standardwebhooks = callPackage ../development/python-modules/standardwebhooks { };
 
   stanio = callPackage ../development/python-modules/stanio { };


### PR DESCRIPTION
Fails to build with
```
error: implicit declaration of function ‘PyObject_AsCharBuffer’
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
