### PR TITLE
python3Packages.clu: init at 0.0.12

### DIFF
--- a/pkgs/development/python-modules/clu/default.nix
+++ b/pkgs/development/python-modules/clu/default.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  absl-py,
+  etils,
+  flax,
+  jax,
+  jaxlib,
+  ml-collections,
+  numpy,
+  packaging,
+  typing-extensions,
+  wrapt,
+
+  # tests
+  keras,
+  pytestCheckHook,
+  tensorflow,
+  tensorflow-datasets,
+  torch,
+}:
+
+buildPythonPackage rec {
+  pname = "clu";
+  version = "0.0.12";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "CommonLoopUtils";
+    tag = "v${version}";
+    hash = "sha256-ntqRz3fCXMf0EDQsddT68Mdi105ECBVQpVsStzk2kvQ=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    absl-py
+    etils
+    flax
+    jax
+    jaxlib
+    ml-collections
+    numpy
+    packaging
+    typing-extensions
+    wrapt
+  ]
+  ++ etils.optional-dependencies.epath;
+
+  pythonImportsCheck = [ "clu" ];
+
+  nativeCheckInputs = [
+    keras
+    pytestCheckHook
+    tensorflow
+    tensorflow-datasets
+    torch
+  ];
+
+  disabledTests = [
+    # AssertionError: [Chex] Assertion assert_trees_all_close failed
+    "test_collection_mixed_async"
+  ];
+
+  meta = {
+    description = "Common training loops in JAX";
+    homepage = "https://github.com/google/CommonLoopUtils";
+    changelog = "https://github.com/google/CommonLoopUtils/blob/${src.tag}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2792,6 +2792,8 @@ self: super: with self; {
 
   cltk = callPackage ../development/python-modules/cltk { };
 
+  clu = callPackage ../development/python-modules/clu { };
+
   clustershell = callPackage ../development/python-modules/clustershell { };
 
   clx-sdk-xms = callPackage ../development/python-modules/clx-sdk-xms { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add [clu](https://github.com/google/CommonLoopUtils) (Common Loop Utils), common functionality for writing ML training loops.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
