### PR TITLE
vbam: fix build by downgrading to ffmpeg_7

### DIFF
--- a/pkgs/by-name/vb/vbam/package.nix
+++ b/pkgs/by-name/vb/vbam/package.nix
@@ -4,7 +4,7 @@
   cairo,
   cmake,
   fetchFromGitHub,
-  ffmpeg,
+  ffmpeg_7,
   gettext,
   wxGTK32,
   gtk3,
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     cairo
-    ffmpeg
+    ffmpeg_7
     gettext
     libGLU
     libGL
@@ -66,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
       lassulus
       netali
     ];
-    homepage = "https://vba-m.com/";
+    homepage = "https://www.visualboyadvance-m.org/";
     platforms = lib.platforms.linux;
     mainProgram = "visualboyadvance-m";
   };


### PR DESCRIPTION
Fixes recent build failures, e.g. https://hydra.nixos.org/build/314955156.

This is a fallout from https://github.com/NixOS/nixpkgs/pull/450436.

I also updated the homepage, as the previous URL nowadays seems to definitely point to another thing. The new homepage is linked at the GitHub repo: https://github.com/visualboyadvance-m/visualboyadvance-m.

ZHF: #457852
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
