### PR TITLE
spacetimedb: 1.5.0 -> 1.10.0, add nix-update-script

### DIFF
--- a/pkgs/by-name/sp/spacetimedb/package.nix
+++ b/pkgs/by-name/sp/spacetimedb/package.nix
@@ -10,6 +10,7 @@
   librusty_v8 ? callPackage ./librusty_v8.nix {
     inherit (callPackage ./fetchers.nix { }) fetchLibrustyV8;
   },
+  nix-update-script,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "spacetimedb";
@@ -63,6 +64,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   postInstall = ''
     mv $out/bin/spacetimedb-cli $out/bin/spacetime
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Full-featured relational database system that lets you run your application logic inside the database";

--- a/pkgs/by-name/sp/spacetimedb/package.nix
+++ b/pkgs/by-name/sp/spacetimedb/package.nix
@@ -5,7 +5,7 @@
   rustPlatform,
   pkg-config,
   perl,
-  git,
+  openssl,
   versionCheckHook,
   librusty_v8 ? callPackage ./librusty_v8.nix {
     inherit (callPackage ./fetchers.nix { }) fetchLibrustyV8;
@@ -13,33 +13,48 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "spacetimedb";
-  version = "1.5.0";
+  version = "1.10.0";
 
   src = fetchFromGitHub {
     owner = "clockworklabs";
     repo = "spacetimedb";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-fUs3EdyOzUogEEhSOnpFrA1LeivEa/crmlhQcf2lGUE=";
+    rev = "1d576dc75ca066879f6d9ee4d156c5bce940bd31";
+    hash = "sha256-rqR4A7JpIgdTxjIvq4KNmvU3LMLUZS1AaLSQWVk+tdw=";
   };
 
-  cargoHash = "sha256-EWLfAyYN/U2kt03lmR8mVXc+j/DbjFat+RysNUt99QI=";
+  cargoHash = "sha256-FHzFxDnpQL0XSyTAfANsK60y8aOFQMkF4KZFdaspYEI=";
 
   nativeBuildInputs = [
     pkg-config
     perl
-    git
+  ];
+
+  buildInputs = [
+    openssl
   ];
 
   cargoBuildFlags = [ "-p spacetimedb-standalone -p spacetimedb-cli" ];
 
+  preCheck = ''
+    # server tests require home dir
+    export HOME=$(mktemp -d)
+  '';
+
   checkFlags = [
-    # requires wasm32-unknown-unknown target
+    # require wasm32-unknown-unknown target
     "--skip=codegen"
+    "--skip=publish"
   ];
 
   doInstallCheck = true;
 
-  env.RUSTY_V8_ARCHIVE = librusty_v8;
+  env = {
+    RUSTY_V8_ARCHIVE = librusty_v8;
+    # used by crates/cli/build.rs to set GIT_HASH at compile time
+    SPACETIMEDB_NIX_BUILD_GIT_COMMIT = finalAttrs.src.rev;
+    # required to make jemalloc_tikv_sys build
+    CFLAGS = "-O";
+  };
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgram = "${placeholder "out"}/bin/spacetime";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updates [clockworklabs/SpacetimeDB](https://github.com/clockworklabs/SpacetimeDB) to v1.10.0 and adds nix-update-script.

Diff: https://github.com/clockworklabs/SpacetimeDB/compare/v1.5.0...v1.10.0

Changelog: [clockworklabs/SpacetimeDB@v1.10.0 (release)](https://github.com/clockworklabs/SpacetimeDB/releases/tag/v1.10.0)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
