### PR TITLE
dell-bios-fan-control: init package at 0-unstable-2022-01-19 and init module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26718,6 +26718,12 @@
     githubId = 70387628;
     name = "Basil Keeler";
   };
+  totalyenglizlitrate = {
+    name = "Narendra S";
+    email = "narendra.s1232@gmail.com";
+    github = "TotalyEnglizLitrate";
+    githubId = 117704481;
+  };
   totoroot = {
     name = "Matthias Thym";
     email = "git@thym.at";

--- a/nixos/modules/services/hardware/dell-bios-fan-control.nix
+++ b/nixos/modules/services/hardware/dell-bios-fan-control.nix
@@ -1,0 +1,45 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.dell-bios-fan-control;
+  package = cfg.package;
+in
+{
+  options.services.dell-bios-fan-control = {
+    enable = lib.mkEnableOption "Disable Dell BIOS fan control";
+    package = lib.mkPackageOption pkgs "dell-bios-fan-control" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ package ];
+
+    systemd.services.dell-bios-fan-control = {
+      description = "Disables BIOS control of fans at boot";
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "dell-bios-fan-control-resume.service" ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${package}/bin/dell-bios-fan-control 0";
+        ExecStop = "${package}/bin/dell-bios-fan-control 1";
+        RemainAfterExit = true;
+      };
+    };
+
+    systemd.services.dell-bios-fan-control-resume = {
+      description = "Restart dell-bios-fan-control on resume";
+      after = [ "suspend.target" ];
+      wantedBy = [ "suspend.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${pkgs.bash}/bin/sh -c '${pkgs.coreutils}/bin/sleep 30 && ${config.systemd.package}/bin/systemctl --no-block restart dell-bios-fan-control.service'";
+      };
+    };
+  };
+}

--- a/pkgs/by-name/de/dell-bios-fan-control/package.nix
+++ b/pkgs/by-name/de/dell-bios-fan-control/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dell-bios-fan-control";
+  version = "20220119"; # upstream does not use versioning - use date of last commit
+
+  src = fetchgit {
+    url = "https://github.com/TomFreudenberg/dell-bios-fan-control.git";
+    rev = "27006106595bccd6c309da4d1499f93d38903f9a";
+    hash = "sha256-3ihzvwL86c9VJDfGpbWpkOwZ7qU0E5U2UuOeCwPMR1s=";
+  };
+
+  buildPhase = ''make'';
+  installPhase = ''
+    mkdir -p $out/bin
+    cp dell-bios-fan-control $out/bin
+  '';
+
+  meta = {
+    description = "A user space utility to set control of fans by bios on some Dell Laptops";
+    homepage = "https://www.github.com/TomFreudenberg/dell-bios-fan-control";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ totalyenglizlitrate ];
+    mainProgram = "dell-bios-fan-control";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/de/dell-bios-fan-control/package.nix
+++ b/pkgs/by-name/de/dell-bios-fan-control/package.nix
@@ -1,20 +1,20 @@
 {
   lib,
   stdenv,
-  fetchgit,
+  fetchFromGitHub,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "dell-bios-fan-control";
-  version = "20220119"; # upstream does not use versioning - use date of last commit
+  version = "0-unstable-2022-01-19";
 
-  src = fetchgit {
-    url = "https://github.com/TomFreudenberg/dell-bios-fan-control.git";
+  src = fetchFromGitHub {
+    owner = "TomFreudenberg";
+    repo = "dell-bios-fan-control";
     rev = "27006106595bccd6c309da4d1499f93d38903f9a";
     hash = "sha256-3ihzvwL86c9VJDfGpbWpkOwZ7qU0E5U2UuOeCwPMR1s=";
   };
 
-  buildPhase = ''make'';
   installPhase = ''
     mkdir -p $out/bin
     cp dell-bios-fan-control $out/bin


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds a package for `dell-bios-fan-control`, a utility to disable BIOS control of fans on some Dell laptops, allowing userspace fan control tools like `fancontrol` to manage fan speeds.

Adds a NixOS module that enables two services created using https://aur.archlinux.org/packages/dell-bios-fan-control-git as reference:
- `dell-bios-fan-control.service`: Disables BIOS fan control at boot
- `dell-bios-fan-control-resume.service`: Re-applies the setting after system resume

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
