### PR TITLE
hovercraft: migrate to pyproject and modernize build inputs

### DIFF
--- a/pkgs/by-name/ho/hovercraft/package.nix
+++ b/pkgs/by-name/ho/hovercraft/package.nix
@@ -8,7 +8,7 @@
 python3Packages.buildPythonApplication rec {
   pname = "hovercraft";
   version = "2.7";
-  format = "setuptools";
+  pyproject = true;
   disabled = !python3Packages.isPy3k;
 
   src = fetchFromGitHub {
@@ -18,7 +18,9 @@ python3Packages.buildPythonApplication rec {
     hash = "sha256-X6EaiVahAYAaFB65oqmj695wlJFXNseqz0SQLzGVD0w=";
   };
 
-  nativeCheckInputs = with python3Packages; [ manuel ];
+  build-system = [ python3Packages.setuptools ];
+
+  nativeCheckInputs = [ python3Packages.manuel ];
 
   dependencies = with python3Packages; [
     setuptools
@@ -41,6 +43,6 @@ python3Packages.buildPythonApplication rec {
     mainProgram = "hovercraft";
     homepage = "https://github.com/regebro/hovercraft";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ makefu ];
+    maintainers = [ lib.maintainers.makefu ];
   };
 }


### PR DESCRIPTION
Switch packaging to pyproject-based build by setting `pyproject = true`. Add `build-system = [ python3Packages.setuptools ]` and move `nativeCheckInputs` to an explicit list. Normalize maintainer entry to a list and keep dependency declarations consistent.

No functional changes to version or source; this is a packaging cleanup.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
