### PR TITLE
nixos/installer: move some settings from cd-base to installation-device profile

### DIFF
--- a/nixos/modules/installer/cd-dvd/installation-cd-base.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-base.nix
@@ -46,12 +46,4 @@
       esac
     done
   '';
-
-  environment.defaultPackages = with pkgs; [
-    rsync
-  ];
-
-  programs.git.enable = lib.mkDefault true;
-
-  system.stateVersion = lib.mkDefault lib.trivial.release;
 }

--- a/nixos/modules/profiles/installation-device.nix
+++ b/nixos/modules/profiles/installation-device.nix
@@ -133,7 +133,18 @@ with lib;
     # allow nix-copy to live system
     nix.settings.trusted-users = [ "nixos" ];
 
-    # Install less voices for speechd to save some space
+    # Provide rsync by default
+    environment.defaultPackages = with pkgs; [
+      rsync
+    ];
+
+    # Provide git by default
+    programs.git.enable = lib.mkDefault true;
+
+    # Set a default stateVersion to prevent evaluation warnings
+    system.stateVersion = lib.mkDefault lib.trivial.release;
+
+    # Install fewer voices for speechd to save some space
     nixpkgs.overlays = [
       (_: prev: {
         mbrola-voices = prev.mbrola-voices.override {

--- a/nixos/modules/profiles/installation-device.nix
+++ b/nixos/modules/profiles/installation-device.nix
@@ -5,9 +5,6 @@
   lib,
   ...
 }:
-
-with lib;
-
 {
   imports = [
     # Enable devices which are usually scanned, because we don't know the
@@ -28,10 +25,10 @@ with lib;
     system.nixos.variant_id = lib.mkDefault "installer";
 
     # Enable in installer, even if the minimal profile disables it.
-    documentation.enable = mkImageMediaOverride true;
+    documentation.enable = lib.mkImageMediaOverride true;
 
     # Show the manual.
-    documentation.nixos.enable = mkImageMediaOverride true;
+    documentation.nixos.enable = lib.mkImageMediaOverride true;
 
     # Use less privileged nixos user
     users.users.nixos = {
@@ -53,8 +50,8 @@ with lib;
 
     # Allow passwordless sudo from nixos user
     security.sudo = {
-      enable = mkDefault true;
-      wheelNeedsPassword = mkImageMediaOverride false;
+      enable = lib.mkDefault true;
+      wheelNeedsPassword = lib.mkImageMediaOverride false;
     };
 
     # Automatically log in at the virtual consoles.
@@ -70,7 +67,7 @@ with lib;
 
       To set up a wireless connection, run `nmtui`.
     ''
-    + optionalString config.services.xserver.enable ''
+    + lib.optionalString config.services.xserver.enable ''
 
       Type `sudo systemctl start display-manager' to
       start the graphical user interface.
@@ -82,8 +79,8 @@ with lib;
     # installation device for head-less systems i.e. arm boards by manually
     # mounting the storage in a different system.
     services.openssh = {
-      enable = mkDefault true;
-      settings.PermitRootLogin = mkDefault "yes";
+      enable = lib.mkDefault true;
+      settings.PermitRootLogin = lib.mkDefault "yes";
     };
 
     # Provide networkmanager for easy network configuration.
@@ -120,7 +117,7 @@ with lib;
     # Show all debug messages from the kernel but don't log refused packets
     # because we have the firewall enabled. This makes installs from the
     # console less cumbersome if the machine has a public IP.
-    networking.firewall.logRefusedConnections = mkDefault false;
+    networking.firewall.logRefusedConnections = lib.mkDefault false;
 
     # Prevent installation media from evacuating persistent storage, as their
     # var directory is not persistent and it would thus result in deletion of


### PR DESCRIPTION
This seems to be a better place for the packages (cf. https://github.com/NixOS/nixpkgs/pull/426916#pullrequestreview-3036087813), and this prevents warnings about unset stateVersion for sd card installers.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
