### PR TITLE
woeusb-ng: migrate to pyproject and modernize packaging

### DIFF
--- a/pkgs/by-name/wo/woeusb-ng/package.nix
+++ b/pkgs/by-name/wo/woeusb-ng/package.nix
@@ -8,19 +8,19 @@
   grub2,
 }:
 
-with python3Packages;
-
-buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "woeusb-ng";
   version = "0.2.12";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "WoeUSB";
     repo = "WoeUSB-ng";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-2opSiXbbk0zDRt6WqMh97iAt6/KhwNDopOas+OZn6TU=";
   };
+
+  build-system = [ python3Packages.setuptools ];
 
   postPatch = ''
     substituteInPlace setup.py WoeUSB/utils.py \
@@ -35,16 +35,22 @@ buildPythonApplication rec {
   ];
   dontWrapGApps = true;
   preFixup = ''
-    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+    makeWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
+      --prefix PATH : "${
+        lib.makeBinPath [
+          p7zip
+          parted
+          grub2
+        ]
+      }"
+    )
   '';
 
-  propagatedBuildInputs = [
-    p7zip
-    parted
-    grub2
-    termcolor
-    wxpython
-    six
+  dependencies = [
+    python3Packages.termcolor
+    python3Packages.wxpython
+    python3Packages.six
   ];
 
   preConfigure = ''
@@ -59,7 +65,7 @@ buildPythonApplication rec {
     homepage = "https://github.com/WoeUSB/WoeUSB-ng";
     mainProgram = "woeusb";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ stunkymonkey ];
+    maintainers = [ lib.maintainers.stunkymonkey ];
     platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
Switch to pyproject-based build (`pyproject = true`) and use `python3Packages.buildPythonApplication` directly instead of a top-level `with python3Packages`. Add `build-system = [ python3Packages.setuptools ]` and update `rev` → `tag` for the GitHub source.

Rename `propagatedBuildInputs` → `dependencies` and qualify Python dependencies with `python3Packages.`. Normalize the `maintainers` entry to a list. These are packaging and style modernizations; no upstream version or source content changes.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
