### PR TITLE
doc/stdenv/platform-notes: update Darwin documentation for SDK changes

### DIFF
--- a/doc/stdenv/platform-notes.chapter.md
+++ b/doc/stdenv/platform-notes.chapter.md
@@ -117,10 +117,11 @@ The following is a list of Xcode versions, the SDK version in Nixpkgs, and the a
 Check your package’s documentation (platform support or installation instructions) to find which Xcode or SDK version to use.
 Generally, only the last SDK release for a major version is packaged.
 
-| Xcode version      | SDK version        | Nixpkgs attribute             |
-|--------------------|--------------------|-------------------------------|
-| 15.0–15.4          | 14.4               | `apple-sdk_14` / `apple-sdk`  |
-| 16.0               | 15.0               | `apple-sdk_15`                |
+| Xcode version | SDK version | Nixpkgs attribute            |
+|---------------|-------------|------------------------------|
+| 15.0–15.4     | 14.4        | `apple-sdk_14` / `apple-sdk` |
+| 16.0          | 15.0        | `apple-sdk_15`               |
+| 26.0+         | 26.0+       | `apple-sdk_26`, etc          |
 
 
 #### Darwin Default SDK versions {#sec-darwin-troubleshooting-darwin-defaults}

--- a/doc/stdenv/platform-notes.chapter.md
+++ b/doc/stdenv/platform-notes.chapter.md
@@ -130,7 +130,7 @@ The current default version of the SDK and deployment target (minimum supported 
 Because of the ways that minimum version and SDK can be changed that are not visible to Nix, they should be treated as lower bounds.
 If you need to parameterize over a specific version, create a function that takes the version as a parameter instead of relying on these attributes.
 
-On macOS, the `darwinMinVersion` and `darwinSdkVersion` are always the same, and are currently set to 11.3.
+On macOS, the `darwinMinVersion` is 14.0, and the `darwinSdkVersion` is 14.4.
 
 
 #### `xcrun` cannot find a binary {#sec-darwin-troubleshooting-xcrun}


### PR DESCRIPTION
The default SDK is 14.4, and the default deployment target is 14.0. Also, add Xcode 26 to the SDK version table.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
