### PR TITLE
winboat: 0.8.7 -> 0.9.0

### DIFF
--- a/pkgs/by-name/wi/winboat/guest-server.nix
+++ b/pkgs/by-name/wi/winboat/guest-server.nix
@@ -7,7 +7,7 @@ buildGoModule {
   inherit (winboat) version src;
   modRoot = "guest_server";
   pname = "winboat-guest-server";
-  vendorHash = "sha256-JglpTv1hkqxmcbD8xmG80Sukul5hzGyyANfe+GeKzQ4=";
+  vendorHash = "sha256-vpBvSaqbbJ8sHNMm299z/3Qb7FKMWbr62amtKT3acYk=";
 
   env = {
     GOOS = "windows";

--- a/pkgs/by-name/wi/winboat/package.nix
+++ b/pkgs/by-name/wi/winboat/package.nix
@@ -8,6 +8,7 @@
   usbutils,
   freerdp,
   docker-compose,
+  podman-compose,
   pkgsCross,
   buildNpmPackage,
   fetchFromGitHub,
@@ -15,15 +16,16 @@
   copyDesktopItems,
   nix-update-script,
 }:
+
 buildNpmPackage (final: {
   pname = "winboat";
-  version = "0.8.7";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "TibixDev";
     repo = "winboat";
     tag = "v${final.version}";
-    hash = "sha256-30WzvdY8Zn4CAj76bbC0bevuTeOSfDo40FPWof/39Es=";
+    hash = "sha256-DgH6CAZf+XIgBav2xd2FF2MGRgGIyOs/98vqWHA3XYw=";
   };
 
   postPatch = ''
@@ -40,7 +42,7 @@ buildNpmPackage (final: {
   buildInputs = [ udev ];
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
-  npmDepsHash = "sha256-nW+cGX4Y0Ndn1ubo4U3n8ZrjM5NkxIt4epB0AghPrNQ=";
+  npmDepsHash = "sha256-DLkI9a030uM2X1et94e4nd/HEyw5ugtK8NEAn/J8p9U=";
   nodejs = nodejs_24;
   makeCacheWritable = true;
 
@@ -60,8 +62,7 @@ buildNpmPackage (final: {
     npm exec electron-builder --linux -- \
       --dir \
       -c.electronDist=${electron.dist} \
-      -c.electronVersion=${electron.version} \
-      -c.npmRebuild=false
+      -c.electronVersion=${electron.version}
   '';
 
   installPhase = ''
@@ -72,7 +73,7 @@ buildNpmPackage (final: {
     cp -r dist/linux-unpacked/resources $out/share/winboat/resources
 
     # install winboat icon
-    install -Dm444 icons/icon.png $out/share/icons/hicolor/256x256/apps/winboat.png
+    install -Dm444 icons/winboat_logo.svg $out/share/icons/hicolor/256x256/apps/winboat.svg
 
     # copy the the winboat-guest-server executable and generate the zip
     cp ${lib.getExe final.guest-server} $out/share/winboat/resources/guest_server/winboat_guest_server.exe
@@ -89,6 +90,7 @@ buildNpmPackage (final: {
         lib.makeBinPath [
           usbutils
           docker-compose
+          podman-compose
           freerdp
         ]
       }


### PR DESCRIPTION
Diff: https://github.com/TibixDev/winboat/compare/v0.8.7...v0.9.0
Changelog: https://github.com/TibixDev/winboat/releases/tag/v0.9.0


Fixes #462513

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
