### PR TITLE
edusong: 4.0 → 4.2

### DIFF
--- a/pkgs/by-name/ed/edusong/package.nix
+++ b/pkgs/by-name/ed/edusong/package.nix
@@ -6,7 +6,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "edusong";
-  version = "4.0";
+  version = "4.2";
+  # Do not trust the version 4.0/4.00 specified in edusun.pdf on the homepage, which describes the Big5 version of the font.
+  # This Unicode version has its dedicated version in the OpenType name table.
+  # Nevertheless, there are three records in the name table (in different languages) and they are inconsistent.
+  # “Version 4.2, December, 2024” is the latest record, and is consistent with the filename.
 
   src = fetchzip {
     name = "edusong-${finalAttrs.version}";
@@ -18,11 +22,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     mkdir -p $out/share/fonts/
     mv eduSong_Unicode*.ttf $out/share/fonts/eduSong_Unicode\(2024年12月\).ttf
   '';
+  # The original filename in the zip has (2024年12月) encoded in Big5, resulting in garbage characters.
 
   meta = {
     description = "MOE Song font, a Song-style Chinese character typeface";
     longDescription = ''
-      A Song-style Chinese character typeface published by the Ministry of Education of the Republic of China (Taiwan). The Song style is also referred to as 宋體, 宋体, sòngtǐ, 明體, 明体, or míngtǐ, in Chinese; 명조체, 明朝體, or myeongjo in Korean; 明朝体, みんちょうたい, or minchōtai in Japanese.
+      A Song-style Chinese character typeface published by the Ministry of Education of the Republic of China (Taiwan). Its family name is MOESongUN (UN stands for Unicode). The Song style is also referred to as 宋體, 宋体, sòngtǐ, 明體, 明体, or míngtǐ, in Chinese; 명조체, 明朝體, or myeongjo in Korean; 明朝体, みんちょうたい, or minchōtai in Japanese.
     '';
     homepage = "https://language.moe.gov.tw/result.aspx?classify_sn=23&subclassify_sn=436&content_sn=48";
     license = lib.licenses.cc-by-nd-30;


### PR DESCRIPTION
This PR corrects the version of edusong. The explanation can be found in the `*.nix` file.

The version was previously bumped in #400759.

It looks like the `fetchzip` hash does not need to be updated, as `nix-shell -p edusong` on the unstable channel already uses version 4.2.

However, I don't know how to confirm that the current hash (`sha256-4NBnwMrYufeZbgSiD2fAhe4tuy0aAA5u9tWwjQQjEQk=`) is correct… I need some help here:

```bash
$ nix-prefetch-url --unpack https://language.moe.gov.tw/001/Upload/Files/site_content/M0001/eduSong_Unicode.zip
path is '/nix/store/6ndkwrgc6si0zwqbd36vwsgd12jwz99v-eduSong_Unicode.zip'
1mkpbf0yjdwnpkw5arq09l80xsxjc6h8pab1sw5v2ykq0a7fsi6z

$ nix hash to-base64 --type sha256 1mkpbf0yjdwnpkw5arq09l80xsxjc6h8pab1sw5v2ykq0a7fsi6z --extra-experimental-features nix-command
30TtjgJ4erEL12Gpi6BhsusOEE0AZ1X4vJY36YFbd9Y=

$ curl -LO https://language.moe.gov.tw/001/Upload/Files/site_content/M0001/eduSong_Unicode.zip
$ nix hash path eduSong_Unicode.zip --extra-experimental-features nix-command
sha256-NeOfNf9IXLPBOsDG9XCOsUeuP3FiAOtNeWec/SrvuW8=

$ nix hash to-base32 sha256-NeOfNf9IXLPBOsDG9XCOsUeuP3FiAOtNeWec/SrvuW8= --extra-experimental-features nix-command
0vxrxwmgv737g56yn032f4zswixiirqgbin07b0v6p28zwsrzqrm
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
