### PR TITLE
ocamlPackages.{mirage-bootvar-unix,mirage-device,samplerate,semaphore-compat,trie}: small cleaning

### DIFF
--- a/pkgs/development/ocaml-modules/mirage-bootvar-unix/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-bootvar-unix/default.nix
@@ -6,15 +6,13 @@
   parse-argv,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "mirage-bootvar-unix";
   version = "0.1.0";
 
-  useDune2 = true;
-
   src = fetchurl {
-    url = "https://github.com/mirage/mirage-bootvar-unix/releases/download/${version}/mirage-bootvar-unix-${version}.tbz";
-    sha256 = "0r92s6y7nxg0ci330a7p0hii4if51iq0sixn20cnm5j4a2clprbf";
+    url = "https://github.com/mirage/mirage-bootvar-unix/releases/download/${finalAttrs.version}/mirage-bootvar-unix-${finalAttrs.version}.tbz";
+    hash = "sha256-buVLmVBElmoZELZHDXAMxUUSIwT3KDBGZOB1e7zRImU=";
   };
 
   propagatedBuildInputs = [
@@ -28,4 +26,4 @@ buildDunePackage rec {
     license = lib.licenses.isc;
     maintainers = [ lib.maintainers.vbgl ];
   };
-}
+})

--- a/pkgs/development/ocaml-modules/mirage-device/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-device/default.nix
@@ -3,23 +3,21 @@
   buildDunePackage,
   fetchurl,
   fmt,
-  ocaml_lwt,
+  lwt,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "mirage-device";
   version = "2.0.0";
 
-  useDune2 = true;
-
   src = fetchurl {
-    url = "https://github.com/mirage/mirage-device/releases/download/v${version}/mirage-device-v${version}.tbz";
-    sha256 = "18alxyi6wlxqvb4lajjlbdfkgcajsmklxi9xqmpcz07j51knqa04";
+    url = "https://github.com/mirage/mirage-device/releases/download/v${finalAttrs.version}/mirage-device-v${finalAttrs.version}.tbz";
+    hash = "sha256-BChsZyjygM9uxT3FTmfVUrE3XVtUSkXJ2rhTbqLvVKE=";
   };
 
   propagatedBuildInputs = [
     fmt
-    ocaml_lwt
+    lwt
   ];
 
   meta = {
@@ -28,4 +26,4 @@ buildDunePackage rec {
     license = lib.licenses.isc;
     maintainers = [ lib.maintainers.vbgl ];
   };
-}
+})

--- a/pkgs/development/ocaml-modules/samplerate/default.nix
+++ b/pkgs/development/ocaml-modules/samplerate/default.nix
@@ -6,26 +6,24 @@
   libsamplerate,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "samplerate";
   version = "0.1.6";
-
-  useDune2 = true;
 
   src = fetchFromGitHub {
     owner = "savonet";
     repo = "ocaml-samplerate";
-    rev = "v${version}";
-    sha256 = "0h0i9v9p9n2givv3wys8qrfi1i7vp8kq7lnkf14s7d3m4r8x4wrp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-N3PSUSZ1tKNJcNPSgye6+8QQXcZIez72jk/YdNNOEUA=";
   };
 
   buildInputs = [ dune-configurator ];
   propagatedBuildInputs = [ libsamplerate ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/savonet/ocaml-samplerate";
     description = "Interface for libsamplerate";
-    license = licenses.bsd2;
-    maintainers = with maintainers; [ dandellion ];
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ dandellion ];
   };
-}
+})

--- a/pkgs/development/ocaml-modules/semaphore-compat/default.nix
+++ b/pkgs/development/ocaml-modules/semaphore-compat/default.nix
@@ -4,24 +4,22 @@
   fetchurl,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "semaphore-compat";
   version = "1.0.2";
 
   src = fetchurl {
-    url = "https://github.com/mirage/semaphore-compat/releases/download/${version}/semaphore-compat-${version}.tbz";
-    sha256 = "sha256-4CnZ2vX17IPpnlA7CNeuxZEKfA5HFoeQvwH0tCKNRnY=";
+    url = "https://github.com/mirage/semaphore-compat/releases/download/${finalAttrs.version}/semaphore-compat-${finalAttrs.version}.tbz";
+    hash = "sha256-4CnZ2vX17IPpnlA7CNeuxZEKfA5HFoeQvwH0tCKNRnY=";
   };
 
-  useDune2 = true;
-
-  meta = with lib; {
+  meta = {
     description = "Compatibility Semaphore module";
     homepage = "https://github.com/mirage/semaphore-compat";
-    license = with licenses; [
+    license = with lib.licenses; [
       lgpl21Plus
       ocamlLgplLinkingException
     ];
-    maintainers = [ maintainers.sternenseemann ];
+    maintainers = [ lib.maintainers.sternenseemann ];
   };
-}
+})

--- a/pkgs/development/ocaml-modules/trie/default.nix
+++ b/pkgs/development/ocaml-modules/trie/default.nix
@@ -4,24 +4,22 @@
   fetchFromGitHub,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "trie";
   version = "1.0.0";
 
-  useDune2 = true;
-
   src = fetchFromGitHub {
     owner = "kandu";
-    repo = pname;
-    rev = version;
-    sha256 = "0s7p9swjqjsqddylmgid6cv263ggq7pmb734z4k84yfcrgb6kg4g";
+    repo = "trie";
+    tag = finalAttrs.version;
+    hash = "sha256-j7xp1svMeYIm+WScVe/B7w0jNjMtvkp9a1hLLLlO92g=";
   };
 
   meta = {
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/kandu/trie/";
     license = lib.licenses.mit;
     description = "Strict impure trie tree";
     maintainers = [ lib.maintainers.vbgl ];
   };
 
-}
+})


### PR DESCRIPTION
Removes a few occurrences of `useDune2`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
