### PR TITLE
treewide: use lib.concatAttrValues to obtain all optional-dependencies

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -303,6 +303,7 @@ let
         elem
         elemAt
         isList
+        concatAttrValues
         ;
       inherit (self.strings)
         concatStrings

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -10,7 +10,7 @@ let
     id
     warn
     ;
-  inherit (lib.attrsets) mapAttrs attrNames;
+  inherit (lib.attrsets) mapAttrs attrNames attrValues;
   inherit (lib) max;
 in
 rec {
@@ -1997,4 +1997,26 @@ rec {
   */
   mutuallyExclusive = a: b: length a == 0 || !(any (x: elem x a) b);
 
+  /**
+    Concatenate all attributes of an attribute set.
+    This assumes that every attribute of the set is a list.
+
+    # Inputs
+
+    `set`
+
+    : Attribute set with attributes that are lists
+
+    # Examples
+    :::{.example}
+    ## `lib.concatAttrValues` usage example
+
+    ```nix
+    concatAttrValues { a = [ 1 2 ]; b = [ 3 ]; }
+    => [ 1 2 3 ]
+    ```
+
+    :::
+  */
+  concatAttrValues = set: concatLists (attrValues set);
 }

--- a/pkgs/applications/networking/instant-messengers/pantalaimon/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pantalaimon/default.nix
@@ -65,7 +65,7 @@ python3Packages.buildPythonApplication rec {
       pytest-aiohttp
       pytestCheckHook
     ]
-    ++ lib.flatten (lib.attrValues optional-dependencies);
+    ++ lib.concatAttrValues optional-dependencies;
 
   nativeBuildInputs = lib.optionals enableDbusUi [
     wrapGAppsHook3

--- a/pkgs/by-name/al/alpaca/package.nix
+++ b/pkgs/by-name/al/alpaca/package.nix
@@ -96,7 +96,7 @@ pythonPackages.buildPythonApplication rec {
       gst-python
       opencv4
     ]
-    ++ lib.flatten (builtins.attrValues optional-dependencies);
+    ++ lib.concatAttrValues optional-dependencies;
 
   optional-dependencies = with pythonPackages; {
     speech-to-text = [

--- a/pkgs/by-name/ca/calibre-web/package.nix
+++ b/pkgs/by-name/ca/calibre-web/package.nix
@@ -136,7 +136,7 @@ python3Packages.buildPythonApplication rec {
     "unidecode"
   ];
 
-  nativeCheckInputs = lib.flatten (lib.attrValues optional-dependencies);
+  nativeCheckInputs = lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "calibreweb" ];
 

--- a/pkgs/by-name/es/esptool/package.nix
+++ b/pkgs/by-name/es/esptool/package.nix
@@ -82,7 +82,7 @@ python3Packages.buildPythonApplication rec {
       requests
       softhsm
     ]
-    ++ lib.flatten (lib.attrValues optional-dependencies);
+    ++ lib.concatAttrValues optional-dependencies;
 
   preCheck = ''
     export PATH="$out/bin:$PATH"

--- a/pkgs/by-name/ma/matrix-synapse-unwrapped/package.nix
+++ b/pkgs/by-name/ma/matrix-synapse-unwrapped/package.nix
@@ -135,7 +135,7 @@ python3Packages.buildPythonApplication rec {
     mock
     parameterized
   ])
-  ++ lib.filter (pkg: !pkg.meta.broken) (lib.flatten (lib.attrValues optional-dependencies));
+  ++ lib.filter (pkg: !pkg.meta.broken) (lib.concatAttrValues optional-dependencies);
 
   doCheck = !stdenv.hostPlatform.isDarwin;
 

--- a/pkgs/by-name/me/mediagoblin/package.nix
+++ b/pkgs/by-name/me/mediagoblin/package.nix
@@ -163,7 +163,7 @@ python.pkgs.buildPythonApplication rec {
 
       poppler-utils
     ]
-    ++ lib.flatten (lib.attrValues optional-dependencies);
+    ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "mediagoblin" ];
 

--- a/pkgs/by-name/me/meerk40t/package.nix
+++ b/pkgs/by-name/me/meerk40t/package.nix
@@ -40,7 +40,7 @@ python3Packages.buildPythonApplication rec {
       setuptools
       wxpython
     ]
-    ++ lib.flatten (lib.attrValues optional-dependencies);
+    ++ lib.concatAttrValues optional-dependencies;
 
   optional-dependencies = with python3Packages; {
     cam = [

--- a/pkgs/by-name/mo/modelscan/package.nix
+++ b/pkgs/by-name/mo/modelscan/package.nix
@@ -41,7 +41,7 @@ python3.pkgs.buildPythonApplication rec {
       dill
       pytestCheckHook
     ]
-    ++ lib.flatten (builtins.attrValues optional-dependencies);
+    ++ lib.concatAttrValues optional-dependencies;
 
   # tensorflow doesn0t support Python 3.12
   doCheck = false;

--- a/pkgs/by-name/mu/music-assistant/package.nix
+++ b/pkgs/by-name/mu/music-assistant/package.nix
@@ -154,7 +154,7 @@ python.pkgs.buildPythonApplication rec {
       syrupy
       pytest-timeout
     ]
-    ++ lib.flatten (lib.attrValues optional-dependencies)
+    ++ lib.concatAttrValues optional-dependencies
     ++ (providerPackages.jellyfin python.pkgs)
     ++ (providerPackages.opensubsonic python.pkgs);
 

--- a/pkgs/by-name/nb/nbqa/package.nix
+++ b/pkgs/by-name/nb/nbqa/package.nix
@@ -70,7 +70,7 @@ let
         pytestCheckHook
         yapf
       ])
-      ++ lib.flatten (lib.attrValues optional-dependencies)
+      ++ lib.concatAttrValues optional-dependencies
       ++ [
         addBinToPathHook
         versionCheckHook

--- a/pkgs/by-name/pr/pretalx/package.nix
+++ b/pkgs/by-name/pr/pretalx/package.nix
@@ -220,7 +220,7 @@ python.pkgs.buildPythonApplication rec {
       pytestCheckHook
       responses
     ]
-    ++ lib.flatten (lib.attrValues optional-dependencies);
+    ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = [
     # tries to run npm run i18n:extract

--- a/pkgs/by-name/pr/pretix/package.nix
+++ b/pkgs/by-name/pr/pretix/package.nix
@@ -256,7 +256,7 @@ python.pkgs.buildPythonApplication rec {
       fakeredis
       responses
     ]
-    ++ lib.flatten (lib.attrValues optional-dependencies);
+    ++ lib.concatAttrValues optional-dependencies;
 
   pytestFlags = [
     "--reruns=3"

--- a/pkgs/by-name/py/pyhanko-cli/package.nix
+++ b/pkgs/by-name/py/pyhanko-cli/package.nix
@@ -38,7 +38,7 @@ python3Packages.buildPythonApplication rec {
       click
       platformdirs
     ]
-    ++ lib.flatten (lib.attrValues pyhanko.optional-dependencies);
+    ++ lib.concatAttrValues pyhanko.optional-dependencies;
 
   nativeCheckInputs = with python3Packages; [
     pytestCheckHook

--- a/pkgs/by-name/yt/yt-dlp/package.nix
+++ b/pkgs/by-name/yt/yt-dlp/package.nix
@@ -48,7 +48,7 @@ python3Packages.buildPythonApplication rec {
   ];
 
   # expose optional-dependencies, but provide all features
-  dependencies = lib.flatten (lib.attrValues optional-dependencies);
+  dependencies = lib.concatAttrValues optional-dependencies;
 
   optional-dependencies = {
     default = with python3Packages; [

--- a/pkgs/development/python-modules/adb-shell/default.nix
+++ b/pkgs/development/python-modules/adb-shell/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
     pycryptodome
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "adb_shell" ];
 

--- a/pkgs/development/python-modules/aioboto3/default.nix
+++ b/pkgs/development/python-modules/aioboto3/default.nix
@@ -56,7 +56,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ]
   ++ moto.optional-dependencies.server
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = [
     "test_patches"

--- a/pkgs/development/python-modules/aiocache/default.nix
+++ b/pkgs/development/python-modules/aiocache/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage rec {
     pytestCheckHook
     redisTestHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pytestFlags = [
     "-Wignore::DeprecationWarning"

--- a/pkgs/development/python-modules/aioftp/default.nix
+++ b/pkgs/development/python-modules/aioftp/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     pytestCheckHook
     trustme
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
     # uses 127.0.0.2, which macos doesn't like

--- a/pkgs/development/python-modules/aiogram/default.nix
+++ b/pkgs/development/python-modules/aiogram/default.nix
@@ -77,7 +77,7 @@ buildPythonPackage rec {
     pytestCheckHook
     pytz
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "aiogram" ];
 

--- a/pkgs/development/python-modules/aiohomeconnect/default.nix
+++ b/pkgs/development/python-modules/aiohomeconnect/default.nix
@@ -54,7 +54,7 @@ buildPythonPackage rec {
     pytest-httpx
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "aiohomeconnect" ];
 

--- a/pkgs/development/python-modules/aiohttp-client-cache/default.nix
+++ b/pkgs/development/python-modules/aiohttp-client-cache/default.nix
@@ -67,7 +67,7 @@ buildPythonPackage rec {
     pytest-aiohttp
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pytestFlags = [ "--asyncio-mode=auto" ];
 

--- a/pkgs/development/python-modules/aiohttp-fast-zlib/default.nix
+++ b/pkgs/development/python-modules/aiohttp-fast-zlib/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     zlib_ng = [ zlib-ng ];
   };
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ lib.flatten (lib.attrValues optional-dependencies);
+  nativeCheckInputs = [ pytestCheckHook ] ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "aiohttp_fast_zlib" ];
 

--- a/pkgs/development/python-modules/aiojobs/default.nix
+++ b/pkgs/development/python-modules/aiojobs/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     pytest-aiohttp
     pytest-cov-stub
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "aiojobs" ];
 

--- a/pkgs/development/python-modules/aiomisc/default.nix
+++ b/pkgs/development/python-modules/aiomisc/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     pytestCheckHook
     setproctitle
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   optional-dependencies = {
     aiohttp = [ aiohttp ];

--- a/pkgs/development/python-modules/aioprometheus/default.nix
+++ b/pkgs/development/python-modules/aioprometheus/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage rec {
     fastapi
     uvicorn
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "aioprometheus" ];
 

--- a/pkgs/development/python-modules/aiorpcx/default.nix
+++ b/pkgs/development/python-modules/aiorpcx/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
     pytest-asyncio_0
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = [
     # network access

--- a/pkgs/development/python-modules/aiortm/default.nix
+++ b/pkgs/development/python-modules/aiortm/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
     pytest-cov-stub
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "aiortm" ];
 

--- a/pkgs/development/python-modules/aiovlc/default.nix
+++ b/pkgs/development/python-modules/aiovlc/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     pytest-timeout
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "aiovlc" ];
 

--- a/pkgs/development/python-modules/alpha-vantage/default.nix
+++ b/pkgs/development/python-modules/alpha-vantage/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
     requests-mock
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   # Starting with 3.0.0 most tests require an API key
   doCheck = false;

--- a/pkgs/development/python-modules/apischema/default.nix
+++ b/pkgs/development/python-modules/apischema/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     pytest-asyncio
     pytest8_3CheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "apischema" ];
 

--- a/pkgs/development/python-modules/apispec/default.nix
+++ b/pkgs/development/python-modules/apispec/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
     mock
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "apispec" ];
 

--- a/pkgs/development/python-modules/apptools/default.nix
+++ b/pkgs/development/python-modules/apptools/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
     preferences = [ configobj ];
   };
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ lib.flatten (lib.attrValues optional-dependencies);
+  nativeCheckInputs = [ pytestCheckHook ] ++ lib.concatAttrValues optional-dependencies;
 
   preCheck = ''
     export HOME=$TMP

--- a/pkgs/development/python-modules/arelle/default.nix
+++ b/pkgs/development/python-modules/arelle/default.nix
@@ -143,7 +143,7 @@ buildPythonPackage rec {
     pytestCheckHook
     boto3
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTestPaths = [
     "tests/integration_tests"

--- a/pkgs/development/python-modules/argilla/default.nix
+++ b/pkgs/development/python-modules/argilla/default.nix
@@ -181,7 +181,7 @@ buildPythonPackage rec {
     pytest-asyncio
     factory-boy
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTestPaths = [ "tests/server/datasets/test_dao.py" ];
 

--- a/pkgs/development/python-modules/asn1tools/default.nix
+++ b/pkgs/development/python-modules/asn1tools/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     pytestCheckHook
     versionCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
   versionCheckProgramArg = "--version";
 
   pythonImportsCheck = [ "asn1tools" ];

--- a/pkgs/development/python-modules/asyncssh/default.nix
+++ b/pkgs/development/python-modules/asyncssh/default.nix
@@ -57,7 +57,7 @@ buildPythonPackage rec {
     openssl
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   patches = [
     # Reverts https://github.com/ronf/asyncssh/commit/4b3dec994b3aa821dba4db507030b569c3a32730

--- a/pkgs/development/python-modules/avwx-engine/default.nix
+++ b/pkgs/development/python-modules/avwx-engine/default.nix
@@ -59,7 +59,7 @@ buildPythonPackage rec {
     pytestCheckHook
     time-machine
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "avwx" ];
 

--- a/pkgs/development/python-modules/azure-core/default.nix
+++ b/pkgs/development/python-modules/azure-core/default.nix
@@ -64,7 +64,7 @@ buildPythonPackage rec {
     pytestCheckHook
     trio
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   # test server needs to be available
   preCheck = ''

--- a/pkgs/development/python-modules/azure-kusto-data/default.nix
+++ b/pkgs/development/python-modules/azure-kusto-data/default.nix
@@ -56,7 +56,7 @@ buildPythonPackage rec {
     pytest-asyncio
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "azure.kusto.data" ];
 

--- a/pkgs/development/python-modules/azure-kusto-ingest/default.nix
+++ b/pkgs/development/python-modules/azure-kusto-ingest/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage rec {
     pytestCheckHook
     responses
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "azure.kusto.ingest" ];
 

--- a/pkgs/development/python-modules/banks/default.nix
+++ b/pkgs/development/python-modules/banks/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
     pytest-asyncio
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "banks" ];
 

--- a/pkgs/development/python-modules/basedmypy/default.nix
+++ b/pkgs/development/python-modules/basedmypy/default.nix
@@ -104,7 +104,7 @@ buildPythonPackage rec {
     setuptools
     tomli
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = lib.optionals (pythonAtLeast "3.12") [
     # cannot find distutils, and distutils cannot find types

--- a/pkgs/development/python-modules/bc-detect-secrets/default.nix
+++ b/pkgs/development/python-modules/bc-detect-secrets/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
     responses
     writableTmpDirAsHomeHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = [
     # Tests are failing for various reasons (missing git repo, missing test data, etc.)

--- a/pkgs/development/python-modules/beanhub-cli/default.nix
+++ b/pkgs/development/python-modules/beanhub-cli/default.nix
@@ -72,7 +72,7 @@ buildPythonPackage rec {
     starlette-wtf
     uvicorn
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   optional-dependencies = {
     login = [
@@ -100,7 +100,7 @@ buildPythonPackage rec {
     pytest-mock
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "beanhub_cli" ];
 

--- a/pkgs/development/python-modules/beautifulsoup4/default.nix
+++ b/pkgs/development/python-modules/beautifulsoup4/default.nix
@@ -77,7 +77,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = [
     # fail with latest libxml, by not actually rejecting

--- a/pkgs/development/python-modules/betterproto/default.nix
+++ b/pkgs/development/python-modules/betterproto/default.nix
@@ -59,7 +59,7 @@ buildPythonPackage rec {
     pytestCheckHook
     tomlkit
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "betterproto" ];
 

--- a/pkgs/development/python-modules/bimmer-connected/default.nix
+++ b/pkgs/development/python-modules/bimmer-connected/default.nix
@@ -58,7 +58,7 @@ buildPythonPackage rec {
     respx
     time-machine
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = [
     # presumably regressed in pytest-asyncio 0.23.0

--- a/pkgs/development/python-modules/black/default.nix
+++ b/pkgs/development/python-modules/black/default.nix
@@ -90,7 +90,7 @@ buildPythonPackage rec {
     pytestCheckHook
     parameterized
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pytestFlags = [
     "-Wignore::DeprecationWarning"

--- a/pkgs/development/python-modules/bpython/default.nix
+++ b/pkgs/development/python-modules/bpython/default.nix
@@ -60,7 +60,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "bpython" ];
 

--- a/pkgs/development/python-modules/busylight-for-humans/default.nix
+++ b/pkgs/development/python-modules/busylight-for-humans/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage rec {
     pytest-mock
     udevCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTestPaths = [ "tests/test_pydantic_models.py" ];
 

--- a/pkgs/development/python-modules/bytewax/default.nix
+++ b/pkgs/development/python-modules/bytewax/default.nix
@@ -84,7 +84,7 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-benchmark
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pytestFlags = [
     "--benchmark-disable"

--- a/pkgs/development/python-modules/cachecontrol/default.nix
+++ b/pkgs/development/python-modules/cachecontrol/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
     cherrypy
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "cachecontrol" ];
 

--- a/pkgs/development/python-modules/canals/default.nix
+++ b/pkgs/development/python-modules/canals/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTestPaths = [
     # Test requires internet connection to mermaid.ink

--- a/pkgs/development/python-modules/canmatrix/default.nix
+++ b/pkgs/development/python-modules/canmatrix/default.nix
@@ -57,7 +57,7 @@ buildPythonPackage rec {
     pytest-timeout
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pytestFlags = [
     # long_envvar_name_imports requires stable key value pair ordering

--- a/pkgs/development/python-modules/cartopy/default.nix
+++ b/pkgs/development/python-modules/cartopy/default.nix
@@ -70,7 +70,7 @@ buildPythonPackage rec {
     pytest-mpl
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   preCheck = ''
     export FONTCONFIG_FILE=${fontconfig.out}/etc/fonts/fonts.conf

--- a/pkgs/development/python-modules/cassandra-driver/default.nix
+++ b/pkgs/development/python-modules/cassandra-driver/default.nix
@@ -66,7 +66,7 @@ buildPythonPackage rec {
     pyyaml
     sure
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   # This is used to determine the version of cython that can be used
   CASS_DRIVER_ALLOWED_CYTHON_VERSION = cython.version;

--- a/pkgs/development/python-modules/catppuccin/default.nix
+++ b/pkgs/development/python-modules/catppuccin/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
     rich = [ rich ];
   };
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ lib.flatten (lib.attrValues optional-dependencies);
+  nativeCheckInputs = [ pytestCheckHook ] ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "catppuccin" ];
 

--- a/pkgs/development/python-modules/celery/default.nix
+++ b/pkgs/development/python-modules/celery/default.nix
@@ -93,7 +93,7 @@ buildPythonPackage rec {
     pytest-xdist
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTestPaths = [
     # test_eventlet touches network

--- a/pkgs/development/python-modules/cement/default.nix
+++ b/pkgs/development/python-modules/cement/default.nix
@@ -57,7 +57,7 @@ buildPythonPackage rec {
     pytestCheckHook
     requests
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "cement" ];
 

--- a/pkgs/development/python-modules/certomancer/default.nix
+++ b/pkgs/development/python-modules/certomancer/default.nix
@@ -72,7 +72,7 @@ buildPythonPackage rec {
     pytz
     requests
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "certomancer" ];
 

--- a/pkgs/development/python-modules/cf-xarray/default.nix
+++ b/pkgs/development/python-modules/cf-xarray/default.nix
@@ -58,7 +58,7 @@ buildPythonPackage rec {
     pytestCheckHook
     scipy
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "cf_xarray" ];
 

--- a/pkgs/development/python-modules/cfn-lint/default.nix
+++ b/pkgs/development/python-modules/cfn-lint/default.nix
@@ -70,7 +70,7 @@ buildPythonPackage rec {
     mock
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   preCheck = ''
     export PATH=$out/bin:$PATH

--- a/pkgs/development/python-modules/channels/default.nix
+++ b/pkgs/development/python-modules/channels/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
     pytest-django
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   # won't run in sandbox
   disabledTestPaths = [

--- a/pkgs/development/python-modules/cli-helpers/default.nix
+++ b/pkgs/development/python-modules/cli-helpers/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     pytestCheckHook
     mock
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   meta = with lib; {
     description = "Python helpers for common CLI tasks";

--- a/pkgs/development/python-modules/coinmetrics-api-client/default.nix
+++ b/pkgs/development/python-modules/coinmetrics-api-client/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-mock
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "coinmetrics.api_client" ];
 

--- a/pkgs/development/python-modules/comicapi/default.nix
+++ b/pkgs/development/python-modules/comicapi/default.nix
@@ -64,7 +64,7 @@ buildPythonPackage rec {
     icu = lib.optional (stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isLinux) pyicu;
   };
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ lib.flatten (lib.attrValues optional-dependencies);
+  nativeCheckInputs = [ pytestCheckHook ] ++ lib.concatAttrValues optional-dependencies;
 
   pythonRelaxDeps = [ "pycountry" ];
 

--- a/pkgs/development/python-modules/configargparse/default.nix
+++ b/pkgs/development/python-modules/configargparse/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
     pytestCheckHook
     mock
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = lib.optionals (pythonAtLeast "3.13") [
     # regex mismatch

--- a/pkgs/development/python-modules/confluent-kafka/default.nix
+++ b/pkgs/development/python-modules/confluent-kafka/default.nix
@@ -94,7 +94,7 @@ buildPythonPackage rec {
     requests-mock
     respx
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "confluent_kafka" ];
 

--- a/pkgs/development/python-modules/connexion/default.nix
+++ b/pkgs/development/python-modules/connexion/default.nix
@@ -74,7 +74,7 @@ buildPythonPackage rec {
     pytestCheckHook
     testfixtures
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "connexion" ];
 

--- a/pkgs/development/python-modules/construct/default.nix
+++ b/pkgs/development/python-modules/construct/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "construct" ];
 

--- a/pkgs/development/python-modules/control/default.nix
+++ b/pkgs/development/python-modules/control/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage rec {
     pytest-timeout
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "control" ];
 

--- a/pkgs/development/python-modules/cyclonedx-python-lib/default.nix
+++ b/pkgs/development/python-modules/cyclonedx-python-lib/default.nix
@@ -67,7 +67,7 @@ buildPythonPackage rec {
     pytestCheckHook
     xmldiff
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "cyclonedx" ];
 

--- a/pkgs/development/python-modules/cyclopts/default.nix
+++ b/pkgs/development/python-modules/cyclopts/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     pytest-mock
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "cyclopts" ];
 

--- a/pkgs/development/python-modules/dask-awkward/default.nix
+++ b/pkgs/development/python-modules/dask-awkward/default.nix
@@ -60,7 +60,7 @@ buildPythonPackage rec {
     pytestCheckHook
     uproot
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "dask_awkward" ];
 

--- a/pkgs/development/python-modules/dataclass-wizard/default.nix
+++ b/pkgs/development/python-modules/dataclass-wizard/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-mock
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests =
     [ ]

--- a/pkgs/development/python-modules/datamodel-code-generator/default.nix
+++ b/pkgs/development/python-modules/datamodel-code-generator/default.nix
@@ -76,7 +76,7 @@ buildPythonPackage rec {
     pytest-mock
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "datamodel_code_generator" ];
 

--- a/pkgs/development/python-modules/dateparser/default.nix
+++ b/pkgs/development/python-modules/dateparser/default.nix
@@ -61,7 +61,7 @@ buildPythonPackage rec {
     requests
     ruamel-yaml
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   preCheck = ''
     export HOME="$TEMPDIR"

--- a/pkgs/development/python-modules/deepdiff/default.nix
+++ b/pkgs/development/python-modules/deepdiff/default.nix
@@ -68,7 +68,7 @@ buildPythonPackage rec {
     pandas
     uuid6
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = [
     # Require pytest-benchmark

--- a/pkgs/development/python-modules/dependency-injector/default.nix
+++ b/pkgs/development/python-modules/dependency-injector/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     pytestCheckHook
     scipy
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "dependency_injector" ];
 

--- a/pkgs/development/python-modules/diffusers/default.nix
+++ b/pkgs/development/python-modules/diffusers/default.nix
@@ -104,7 +104,7 @@ buildPythonPackage rec {
     torchsde
     transformers
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   preCheck =
     let

--- a/pkgs/development/python-modules/dissect-cobaltstrike/default.nix
+++ b/pkgs/development/python-modules/dissect-cobaltstrike/default.nix
@@ -69,7 +69,7 @@ buildPythonPackage rec {
     pytest-httpserver
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "dissect.cobaltstrike" ];
 

--- a/pkgs/development/python-modules/django-allauth/default.nix
+++ b/pkgs/development/python-modules/django-allauth/default.nix
@@ -102,7 +102,7 @@ buildPythonPackage rec {
     pytestCheckHook
     pyyaml
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = [
     # Tests require network access

--- a/pkgs/development/python-modules/django-bootstrap5/default.nix
+++ b/pkgs/development/python-modules/django-bootstrap5/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage rec {
     pytest-django
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   preCheck = ''
     export DJANGO_SETTINGS_MODULE=tests.app.settings

--- a/pkgs/development/python-modules/django-import-export/default.nix
+++ b/pkgs/development/python-modules/django-import-export/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     psycopg2
     pytz
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   checkPhase = ''
     runHook preCheck

--- a/pkgs/development/python-modules/django-redis/default.nix
+++ b/pkgs/development/python-modules/django-redis/default.nix
@@ -63,7 +63,7 @@ buildPythonPackage rec {
     pytestCheckHook
     redisTestHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   # https://github.com/jazzband/django-redis/issues/777
   dontUsePytestXdist = true;

--- a/pkgs/development/python-modules/django-storages/default.nix
+++ b/pkgs/development/python-modules/django-storages/default.nix
@@ -63,7 +63,7 @@ buildPythonPackage rec {
     pytestCheckHook
     rsa
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   checkInputs = [ pynacl ];
 

--- a/pkgs/development/python-modules/django-stubs/default.nix
+++ b/pkgs/development/python-modules/django-stubs/default.nix
@@ -54,7 +54,7 @@ buildPythonPackage rec {
     pytest-mypy-plugins
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = [
     # AttributeError: module 'django.contrib.auth.forms' has no attribute 'SetUnusablePasswordMixin'

--- a/pkgs/development/python-modules/django-tables2/default.nix
+++ b/pkgs/development/python-modules/django-tables2/default.nix
@@ -53,7 +53,7 @@ buildPythonPackage rec {
     pytest-django
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   meta = with lib; {
     changelog = "https://github.com/jieter/django-tables2/blob/v${version}/CHANGELOG.md";

--- a/pkgs/development/python-modules/django/4.nix
+++ b/pkgs/development/python-modules/django/4.nix
@@ -137,7 +137,7 @@ buildPythonPackage rec {
     tblib
     tzdata
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   doCheck =
     !stdenv.hostPlatform.isDarwin

--- a/pkgs/development/python-modules/django/5_1.nix
+++ b/pkgs/development/python-modules/django/5_1.nix
@@ -114,7 +114,7 @@ buildPythonPackage rec {
     tblib
     tzdata
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   preCheck = ''
     # make sure the installed library gets imported

--- a/pkgs/development/python-modules/django/5_2.nix
+++ b/pkgs/development/python-modules/django/5_2.nix
@@ -106,7 +106,7 @@ buildPythonPackage rec {
     tblib
     tzdata
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   preCheck = ''
     # make sure the installed library gets imported

--- a/pkgs/development/python-modules/djangorestframework-stubs/default.nix
+++ b/pkgs/development/python-modules/djangorestframework-stubs/default.nix
@@ -57,7 +57,7 @@ buildPythonPackage rec {
     pytest-mypy-plugins
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   # Upstream recommends mypy > 1.7 which we don't have yet, thus all tests are failing with 3.14.5 and below
   doCheck = false;

--- a/pkgs/development/python-modules/docker/default.nix
+++ b/pkgs/development/python-modules/docker/default.nix
@@ -58,7 +58,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   enabledTestPaths = [ "tests/unit" ];
 

--- a/pkgs/development/python-modules/dockerflow/default.nix
+++ b/pkgs/development/python-modules/dockerflow/default.nix
@@ -74,7 +74,7 @@ buildPythonPackage rec {
     # fastapi
     httpx
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = [
     # AssertionError: assert 'c7a05e2b-8a21-4255-a3ed-92cea1e74a62' is None

--- a/pkgs/development/python-modules/dparse/default.nix
+++ b/pkgs/development/python-modules/dparse/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "dparse" ];
 

--- a/pkgs/development/python-modules/dramatiq-abort/default.nix
+++ b/pkgs/development/python-modules/dramatiq-abort/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   ];
 
   optional-dependencies = {
-    all = lib.flatten (lib.attrValues (lib.removeAttrs optional-dependencies [ "all" ]));
+    all = lib.concatAttrValues (lib.removeAttrs optional-dependencies [ "all" ]);
     gevent = [ gevent ];
     redis = [ redis ];
   };

--- a/pkgs/development/python-modules/dsnap/default.nix
+++ b/pkgs/development/python-modules/dsnap/default.nix
@@ -56,7 +56,7 @@ buildPythonPackage rec {
     mypy-boto3-ebs
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   # https://github.com/RhinoSecurityLabs/dsnap/issues/26
   # ImportError: cannot import name 'mock_iam' from 'moto'

--- a/pkgs/development/python-modules/dulwich/default.nix
+++ b/pkgs/development/python-modules/dulwich/default.nix
@@ -79,7 +79,7 @@ buildPythonPackage rec {
     glibcLocales
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   enabledTestPaths = [ "tests" ];
 

--- a/pkgs/development/python-modules/edalize/default.nix
+++ b/pkgs/development/python-modules/edalize/default.nix
@@ -53,7 +53,7 @@ buildPythonPackage rec {
     which
     yosys
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "edalize" ];
 

--- a/pkgs/development/python-modules/energyflow/default.nix
+++ b/pkgs/development/python-modules/energyflow/default.nix
@@ -65,7 +65,7 @@ buildPythonPackage rec {
     pytestCheckHook
     tf-keras
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = [
     # Issues with array

--- a/pkgs/development/python-modules/fastavro/default.nix
+++ b/pkgs/development/python-modules/fastavro/default.nix
@@ -57,7 +57,7 @@ buildPythonPackage rec {
     python-dateutil
     zlib-ng
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   # Fails with "AttributeError: module 'fastavro._read_py' has no attribute
   # 'CYTHON_MODULE'." Doesn't appear to be serious. See https://github.com/fastavro/fastavro/issues/112#issuecomment-387638676.

--- a/pkgs/development/python-modules/fastmcp/default.nix
+++ b/pkgs/development/python-modules/fastmcp/default.nix
@@ -85,7 +85,7 @@ buildPythonPackage rec {
     pytestCheckHook
     writableTmpDirAsHomeHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies)
+  ++ lib.concatAttrValues optional-dependencies
   ++ inline-snapshot.optional-dependencies.dirty-equals;
 
   disabledTests = [

--- a/pkgs/development/python-modules/fickling/default.nix
+++ b/pkgs/development/python-modules/fickling/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
     ];
   };
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ lib.flatten (builtins.attrValues optional-dependencies);
+  nativeCheckInputs = [ pytestCheckHook ] ++ lib.concatAttrValues optional-dependencies;
 
   disabledTestPaths = [
     # https://github.com/trailofbits/fickling/issues/162

--- a/pkgs/development/python-modules/flask-dance/default.nix
+++ b/pkgs/development/python-modules/flask-dance/default.nix
@@ -81,7 +81,7 @@ buildPythonPackage rec {
     ];
   };
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ lib.flatten (lib.attrValues optional-dependencies);
+  nativeCheckInputs = [ pytestCheckHook ] ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "flask_dance" ];
 

--- a/pkgs/development/python-modules/flask-jwt-extended/default.nix
+++ b/pkgs/development/python-modules/flask-jwt-extended/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "flask_jwt_extended" ];
 

--- a/pkgs/development/python-modules/flask/default.nix
+++ b/pkgs/development/python-modules/flask/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage rec {
     dotenv = [ python-dotenv ];
   };
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ lib.flatten (lib.attrValues optional-dependencies);
+  nativeCheckInputs = [ pytestCheckHook ] ++ lib.concatAttrValues optional-dependencies;
 
   passthru.tests = {
     inherit

--- a/pkgs/development/python-modules/flow-record/default.nix
+++ b/pkgs/development/python-modules/flow-record/default.nix
@@ -58,7 +58,7 @@ buildPythonPackage rec {
     elastic-transport
     pytest7CheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "flow.record" ];
 

--- a/pkgs/development/python-modules/fnllm/default.nix
+++ b/pkgs/development/python-modules/fnllm/default.nix
@@ -62,7 +62,7 @@ buildPythonPackage rec {
     pytest-cov-stub
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "fnllm" ];
 

--- a/pkgs/development/python-modules/foolscap/default.nix
+++ b/pkgs/development/python-modules/foolscap/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
     mock
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "foolscap" ];
 

--- a/pkgs/development/python-modules/frictionless/default.nix
+++ b/pkgs/development/python-modules/frictionless/default.nix
@@ -195,7 +195,7 @@ buildPythonPackage rec {
     openpyxl
     xlrd
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTestPaths = [
     # Requires optional dependencies that have not been packaged (commented out above)

--- a/pkgs/development/python-modules/githubkit/default.nix
+++ b/pkgs/development/python-modules/githubkit/default.nix
@@ -65,7 +65,7 @@ buildPythonPackage rec {
     pytest-cov-stub
     pytest-xdist
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "githubkit" ];
 

--- a/pkgs/development/python-modules/glom/default.nix
+++ b/pkgs/development/python-modules/glom/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   preCheck = ''
     # test_cli.py checks the output of running "glom"

--- a/pkgs/development/python-modules/google-auth/default.nix
+++ b/pkgs/development/python-modules/google-auth/default.nix
@@ -77,7 +77,7 @@ buildPythonPackage rec {
     pytestCheckHook
     responses
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTestPaths = [
     "samples/"

--- a/pkgs/development/python-modules/google-cloud-spanner/default.nix
+++ b/pkgs/development/python-modules/google-cloud-spanner/default.nix
@@ -79,7 +79,7 @@ buildPythonPackage rec {
     pytest-asyncio
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   preCheck = ''
     # prevent google directory from shadowing google imports

--- a/pkgs/development/python-modules/groq/default.nix
+++ b/pkgs/development/python-modules/groq/default.nix
@@ -67,7 +67,7 @@ buildPythonPackage rec {
     pytestCheckHook
     respx
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "groq" ];
 

--- a/pkgs/development/python-modules/gruut/default.nix
+++ b/pkgs/development/python-modules/gruut/default.nix
@@ -92,7 +92,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = [
     # https://github.com/rhasspy/gruut/issues/25

--- a/pkgs/development/python-modules/gstools/default.nix
+++ b/pkgs/development/python-modules/gstools/default.nix
@@ -65,7 +65,7 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-cov-stub
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   meta = {
     description = "Geostatistical toolbox";

--- a/pkgs/development/python-modules/gunicorn/default.nix
+++ b/pkgs/development/python-modules/gunicorn/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-cov-stub
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   meta = {
     description = "WSGI HTTP Server for UNIX, fast clients and sleepy applications";

--- a/pkgs/development/python-modules/hishel/default.nix
+++ b/pkgs/development/python-modules/hishel/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
     pytestCheckHook
     trio
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "hishel" ];
 

--- a/pkgs/development/python-modules/httpcore/default.nix
+++ b/pkgs/development/python-modules/httpcore/default.nix
@@ -60,7 +60,7 @@ buildPythonPackage rec {
     pytest-trio
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "httpcore" ];
 

--- a/pkgs/development/python-modules/httpx/default.nix
+++ b/pkgs/development/python-modules/httpx/default.nix
@@ -79,7 +79,7 @@ buildPythonPackage rec {
     trustme
     uvicorn
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   # testsuite wants to find installed packages for testing entrypoint
   preCheck = ''

--- a/pkgs/development/python-modules/hypercorn/default.nix
+++ b/pkgs/development/python-modules/hypercorn/default.nix
@@ -57,7 +57,7 @@ buildPythonPackage rec {
     pytest-trio
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   __darwinAllowLocalNetworking = true;
 

--- a/pkgs/development/python-modules/igraph/default.nix
+++ b/pkgs/development/python-modules/igraph/default.nix
@@ -62,7 +62,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = [
     "testAuthorityScore"

--- a/pkgs/development/python-modules/imageio/default.nix
+++ b/pkgs/development/python-modules/imageio/default.nix
@@ -94,7 +94,7 @@ buildPythonPackage rec {
     writableTmpDirAsHomeHook
   ]
   ++ fsspec.optional-dependencies.github
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pytestFlags = [ "--test-images=file://${test_images}" ];
 

--- a/pkgs/development/python-modules/inline-snapshot/default.nix
+++ b/pkgs/development/python-modules/inline-snapshot/default.nix
@@ -58,7 +58,7 @@ buildPythonPackage rec {
     pytestCheckHook
     time-machine
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   optional-dependencies = {
     black = [ black ];

--- a/pkgs/development/python-modules/intake/default.nix
+++ b/pkgs/development/python-modules/intake/default.nix
@@ -63,7 +63,7 @@ buildPythonPackage rec {
     intake-parquet
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   optional-dependencies = {
     server = [

--- a/pkgs/development/python-modules/iplotx/default.nix
+++ b/pkgs/development/python-modules/iplotx/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage rec {
     "test_labels_and_colors"
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ lib.flatten (lib.attrValues optional-dependencies);
+  nativeCheckInputs = [ pytestCheckHook ] ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "iplotx" ];
 

--- a/pkgs/development/python-modules/joserfc/default.nix
+++ b/pkgs/development/python-modules/joserfc/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     drafts = [ pycryptodome ];
   };
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ lib.flatten (lib.attrValues optional-dependencies);
+  nativeCheckInputs = [ pytestCheckHook ] ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "joserfc" ];
 

--- a/pkgs/development/python-modules/jupyter-events/default.nix
+++ b/pkgs/development/python-modules/jupyter-events/default.nix
@@ -64,7 +64,7 @@ buildPythonPackage rec {
     pytest-console-scripts
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   preCheck = ''
     export PATH="$out/bin:$PATH"

--- a/pkgs/development/python-modules/kafka-python-ng/default.nix
+++ b/pkgs/development/python-modules/kafka-python-ng/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     pytestCheckHook
     xxhash
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   meta = {
     changelog = "https://github.com/wbarnha/kafka-python-ng/releases/tag/v${version}";

--- a/pkgs/development/python-modules/keystoneauth1/default.nix
+++ b/pkgs/development/python-modules/keystoneauth1/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
     typing-extensions
   ]
   # TODO: remove this workaround and fix breakages
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   optional-dependencies = {
     betamax = [
@@ -69,7 +69,7 @@ buildPythonPackage rec {
     testresources
     testtools
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   # test_keystoneauth_betamax_fixture is incompatible with urllib3 2.0.0
   # https://bugs.launchpad.net/keystoneauth/+bug/2020112

--- a/pkgs/development/python-modules/kombu/default.nix
+++ b/pkgs/development/python-modules/kombu/default.nix
@@ -83,7 +83,7 @@ buildPythonPackage rec {
     hypothesis
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "kombu" ];
 

--- a/pkgs/development/python-modules/kserve/default.nix
+++ b/pkgs/development/python-modules/kserve/default.nix
@@ -130,7 +130,7 @@ buildPythonPackage rec {
     pytestCheckHook
     tomlkit
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "kserve" ];
 

--- a/pkgs/development/python-modules/kubernetes/default.nix
+++ b/pkgs/development/python-modules/kubernetes/default.nix
@@ -61,7 +61,7 @@ buildPythonPackage rec {
     mock
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
     # AssertionError: <class 'urllib3.poolmanager.ProxyManager'> != <class 'urllib3.poolmanager.Poolmanager'>

--- a/pkgs/development/python-modules/lance-namespace/default.nix
+++ b/pkgs/development/python-modules/lance-namespace/default.nix
@@ -74,7 +74,7 @@ buildPythonPackage rec {
     pylance
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   # Tests require pylance, which is a circular dependency
   doCheck = false;

--- a/pkgs/development/python-modules/langgraph-cli/default.nix
+++ b/pkgs/development/python-modules/langgraph-cli/default.nix
@@ -56,7 +56,7 @@ buildPythonPackage rec {
     pytestCheckHook
     docker-compose
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   enabledTestPaths = [ "tests/unit_tests" ];
 

--- a/pkgs/development/python-modules/libpass/default.nix
+++ b/pkgs/development/python-modules/libpass/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     pytest-xdist
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "passlib" ];
 

--- a/pkgs/development/python-modules/limits/default.nix
+++ b/pkgs/development/python-modules/limits/default.nix
@@ -97,7 +97,7 @@ buildPythonPackage rec {
     pytest-lazy-fixtures
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pytestFlags = [ "--benchmark-disable" ];
 

--- a/pkgs/development/python-modules/llama-stack-client/default.nix
+++ b/pkgs/development/python-modules/llama-stack-client/default.nix
@@ -83,7 +83,7 @@ buildPythonPackage rec {
     pytestCheckHook
     respx
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "llama_stack_client" ];
 

--- a/pkgs/development/python-modules/logbook/default.nix
+++ b/pkgs/development/python-modules/logbook/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-rerunfailures
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   # Some of the tests use localhost networking.
   __darwinAllowLocalNetworking = true;

--- a/pkgs/development/python-modules/mako/default.nix
+++ b/pkgs/development/python-modules/mako/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     mock
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = lib.optionals isPyPy [
     # https://github.com/sqlalchemy/mako/issues/315

--- a/pkgs/development/python-modules/manifest-ml/default.nix
+++ b/pkgs/development/python-modules/manifest-ml/default.nix
@@ -85,7 +85,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   preCheck = ''
     export HOME=$TMPDIR

--- a/pkgs/development/python-modules/markdown2/default.nix
+++ b/pkgs/development/python-modules/markdown2/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     code_syntax_highlighting = [ pygments ];
     wavedrom = [ wavedrom ];
     latex = [ latex2mathml ];
-    all = lib.flatten (lib.attrValues (lib.removeAttrs optional-dependencies [ "all" ]));
+    all = lib.concatAttrValues (lib.removeAttrs optional-dependencies [ "all" ]);
   };
 
   meta = {

--- a/pkgs/development/python-modules/mashumaro/default.nix
+++ b/pkgs/development/python-modules/mashumaro/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     pytest-mock
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "mashumaro" ];
 

--- a/pkgs/development/python-modules/mastodon-py/default.nix
+++ b/pkgs/development/python-modules/mastodon-py/default.nix
@@ -56,7 +56,7 @@ buildPythonPackage rec {
     pytest-vcr
     requests-mock
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   # disabledTests = [
   #   "test_notifications_dismiss_pre_2_9_2"

--- a/pkgs/development/python-modules/mcp/default.nix
+++ b/pkgs/development/python-modules/mcp/default.nix
@@ -109,7 +109,7 @@ buildPythonPackage rec {
     pytestCheckHook
     requests
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = [
     # attempts to run the package manager uv

--- a/pkgs/development/python-modules/meshtastic/default.nix
+++ b/pkgs/development/python-modules/meshtastic/default.nix
@@ -91,7 +91,7 @@ buildPythonPackage rec {
     hypothesis
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   preCheck = ''
     export PATH="$PATH:$out/bin";

--- a/pkgs/development/python-modules/minari/default.nix
+++ b/pkgs/development/python-modules/minari/default.nix
@@ -80,7 +80,7 @@ buildPythonPackage rec {
     jaxlib
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = [
     # Require internet access

--- a/pkgs/development/python-modules/mir-eval/default.nix
+++ b/pkgs/development/python-modules/mir-eval/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     pytest-cov-stub
     pytest-mpl
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   preCheck = ''
     pushd tests

--- a/pkgs/development/python-modules/mne/default.nix
+++ b/pkgs/development/python-modules/mne/default.nix
@@ -78,7 +78,7 @@ buildPythonPackage rec {
     pytest-timeout
     writableTmpDirAsHomeHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   preCheck = ''
     export MNE_SKIP_TESTING_DATASET_TESTS=true

--- a/pkgs/development/python-modules/mocket/default.nix
+++ b/pkgs/development/python-modules/mocket/default.nix
@@ -73,7 +73,7 @@ buildPythonPackage rec {
     requests
     sure
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   # Skip http tests, they require network access
   env.SKIP_TRUE_HTTP = true;

--- a/pkgs/development/python-modules/modern-colorthief/default.nix
+++ b/pkgs/development/python-modules/modern-colorthief/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     ];
   };
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ lib.attrValues optional-dependencies;
+  nativeCheckInputs = [ pytestCheckHook ] ++ lib.concatAttrValues optional-dependencies;
 
   disabledTestPaths = [
     # Requires `fast_colorthief`, which isn't packaged

--- a/pkgs/development/python-modules/moviepy/default.nix
+++ b/pkgs/development/python-modules/moviepy/default.nix
@@ -70,7 +70,7 @@ buildPythonPackage rec {
     pytest-timeout
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   # See https://github.com/NixOS/nixpkgs/issues/381908 and https://github.com/NixOS/nixpkgs/issues/385450.
   pytestFlags = [ "--timeout=600" ];

--- a/pkgs/development/python-modules/mrjob/default.nix
+++ b/pkgs/development/python-modules/mrjob/default.nix
@@ -72,7 +72,7 @@ buildPythonPackage rec {
     unittestCheckHook
     warcio
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   unittestFlagsArray = [ "-v" ];
 

--- a/pkgs/development/python-modules/mypy/default.nix
+++ b/pkgs/development/python-modules/mypy/default.nix
@@ -110,7 +110,7 @@ buildPythonPackage rec {
     setuptools
     tomli
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = [
     # fails with typing-extensions>=4.10

--- a/pkgs/development/python-modules/narwhals/default.nix
+++ b/pkgs/development/python-modules/narwhals/default.nix
@@ -57,7 +57,7 @@ buildPythonPackage rec {
     pytest-env
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "narwhals" ];
 

--- a/pkgs/development/python-modules/nibe/default.nix
+++ b/pkgs/development/python-modules/nibe/default.nix
@@ -56,7 +56,7 @@ buildPythonPackage rec {
     pytest-asyncio
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "nibe" ];
 

--- a/pkgs/development/python-modules/nicegui/default.nix
+++ b/pkgs/development/python-modules/nicegui/default.nix
@@ -105,7 +105,7 @@ buildPythonPackage rec {
     webdriver-manager
     writableTmpDirAsHomeHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "nicegui" ];
 

--- a/pkgs/development/python-modules/noisereduce/default.nix
+++ b/pkgs/development/python-modules/noisereduce/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     PyTorch = [ torch ];
   };
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ lib.flatten (builtins.attrValues optional-dependencies);
+  nativeCheckInputs = [ pytestCheckHook ] ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "noisereduce" ];
 

--- a/pkgs/development/python-modules/nox/default.nix
+++ b/pkgs/development/python-modules/nox/default.nix
@@ -68,7 +68,7 @@ buildPythonPackage rec {
     pytestCheckHook
     writableTmpDirAsHomeHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "nox" ];
 

--- a/pkgs/development/python-modules/numcodecs/default.nix
+++ b/pkgs/development/python-modules/numcodecs/default.nix
@@ -62,7 +62,7 @@ buildPythonPackage rec {
     pytestCheckHook
     importlib-metadata
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   # https://github.com/NixOS/nixpkgs/issues/255262
   preCheck = "pushd $out";

--- a/pkgs/development/python-modules/nutils/default.nix
+++ b/pkgs/development/python-modules/nutils/default.nix
@@ -53,7 +53,7 @@ buildPythonPackage rec {
     pkgs.graphviz
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = [
     # Error: invalid value 'x' for farg: loading 'x' as float

--- a/pkgs/development/python-modules/oauthenticator/default.nix
+++ b/pkgs/development/python-modules/oauthenticator/default.nix
@@ -58,7 +58,7 @@ buildPythonPackage rec {
     pytestCheckHook
     requests-mock
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = [
     # Tests are outdated, https://github.com/jupyterhub/oauthenticator/issues/432

--- a/pkgs/development/python-modules/oauthlib/default.nix
+++ b/pkgs/development/python-modules/oauthlib/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
     mock
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = [
     # too narrow time comparison issues

--- a/pkgs/development/python-modules/odc-loader/default.nix
+++ b/pkgs/development/python-modules/odc-loader/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
   optional-dependencies = {
     botocore = [ botocore ];
     zarr = [ zarr ];
-    all = lib.flatten (lib.attrValues (lib.removeAttrs optional-dependencies [ "all" ]));
+    all = lib.concatAttrValues (lib.removeAttrs optional-dependencies [ "all" ]);
   };
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/okonomiyaki/default.nix
+++ b/pkgs/development/python-modules/okonomiyaki/default.nix
@@ -57,7 +57,7 @@ buildPythonPackage rec {
     pytestCheckHook
     testfixtures
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   preCheck = ''
     substituteInPlace okonomiyaki/runtimes/tests/test_runtime.py \

--- a/pkgs/development/python-modules/openapi-core/default.nix
+++ b/pkgs/development/python-modules/openapi-core/default.nix
@@ -83,7 +83,7 @@ buildPythonPackage rec {
     responses
     webob
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTestPaths = [
     # Requires secrets and additional configuration

--- a/pkgs/development/python-modules/outlines-core/default.nix
+++ b/pkgs/development/python-modules/outlines-core/default.nix
@@ -97,7 +97,7 @@ buildPythonPackage rec {
     rm -rf outlines_core
   '';
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ lib.flatten (lib.attrValues optional-dependencies);
+  nativeCheckInputs = [ pytestCheckHook ] ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = [
     # Tests that need to download from Hugging Face Hub.

--- a/pkgs/development/python-modules/pandas/default.nix
+++ b/pkgs/development/python-modules/pandas/default.nix
@@ -184,7 +184,7 @@ let
       pytest-xdist
       pytestCheckHook
     ]
-    ++ lib.flatten (lib.attrValues optional-dependencies)
+    ++ lib.concatAttrValues optional-dependencies
     ++ lib.optionals (stdenv.hostPlatform.isLinux) [
       # for locale executable
       glibc

--- a/pkgs/development/python-modules/paramiko/default.nix
+++ b/pkgs/development/python-modules/paramiko/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-relaxed
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "paramiko" ];
 

--- a/pkgs/development/python-modules/persist-queue/default.nix
+++ b/pkgs/development/python-modules/persist-queue/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
     pytest-asyncio
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "persistqueue" ];
 

--- a/pkgs/development/python-modules/pettingzoo/default.nix
+++ b/pkgs/development/python-modules/pettingzoo/default.nix
@@ -53,7 +53,7 @@ buildPythonPackage rec {
   ];
 
   optional-dependencies = {
-    all = lib.flatten (lib.attrValues (lib.removeAttrs optional-dependencies [ "all" ]));
+    all = lib.concatAttrValues (lib.removeAttrs optional-dependencies [ "all" ]);
     atari = [
       # multi-agent-ale-py
       pygame

--- a/pkgs/development/python-modules/piccolo/default.nix
+++ b/pkgs/development/python-modules/piccolo/default.nix
@@ -59,7 +59,7 @@ buildPythonPackage rec {
     pytestCheckHook
     python-dateutil
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "piccolo" ];
 

--- a/pkgs/development/python-modules/pillow/default.nix
+++ b/pkgs/development/python-modules/pillow/default.nix
@@ -109,7 +109,7 @@ buildPythonPackage rec {
     pytestCheckHook
     numpy
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = [
     # Code quality mismathch 9 vs 10

--- a/pkgs/development/python-modules/pins/default.nix
+++ b/pkgs/development/python-modules/pins/default.nix
@@ -76,7 +76,7 @@ buildPythonPackage rec {
     pytest-parallel
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "pins" ];
 

--- a/pkgs/development/python-modules/pipdeptree/default.nix
+++ b/pkgs/development/python-modules/pipdeptree/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage rec {
     pytestCheckHook
     virtualenv
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "pipdeptree" ];
 

--- a/pkgs/development/python-modules/planetary-computer/default.nix
+++ b/pkgs/development/python-modules/planetary-computer/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage rec {
   optional-dependencies = {
     adlfs = [ adlfs ];
     azure = [ azure-storage-blob ];
-    all = lib.flatten (lib.attrValues (lib.removeAttrs optional-dependencies [ "all" ]));
+    all = lib.concatAttrValues (lib.removeAttrs optional-dependencies [ "all" ]);
   };
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/plotly/default.nix
+++ b/pkgs/development/python-modules/plotly/default.nix
@@ -90,7 +90,7 @@ buildPythonPackage rec {
     which
     xarray
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = [
     # failed pinning test, sensitive to dep versions

--- a/pkgs/development/python-modules/plumbum/default.nix
+++ b/pkgs/development/python-modules/plumbum/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
     pytest-timeout
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   preCheck = ''
     export HOME=$TMP

--- a/pkgs/development/python-modules/powerapi/default.nix
+++ b/pkgs/development/python-modules/powerapi/default.nix
@@ -51,7 +51,7 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-timeout
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "powerapi" ];
 

--- a/pkgs/development/python-modules/pproxy/default.nix
+++ b/pkgs/development/python-modules/pproxy/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     daemon = [ python-daemon ];
   };
 
-  nativeCheckInputs = lib.flatten (lib.attrValues optional-dependencies);
+  nativeCheckInputs = lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "pproxy" ];
 

--- a/pkgs/development/python-modules/prance/default.nix
+++ b/pkgs/development/python-modules/prance/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage rec {
     pytest-cov-stub
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   # Disable tests that require network
   disabledTestPaths = [ "tests/test_convert.py" ];

--- a/pkgs/development/python-modules/prometheus-client/default.nix
+++ b/pkgs/development/python-modules/prometheus-client/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   __darwinAllowLocalNetworking = true;
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ lib.flatten (lib.attrValues optional-dependencies);
+  nativeCheckInputs = [ pytestCheckHook ] ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "prometheus_client" ];
 

--- a/pkgs/development/python-modules/prowlpy/default.nix
+++ b/pkgs/development/python-modules/prowlpy/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
     pytestCheckHook
     respx
   ]
-  ++ lib.concatLists (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   # tests fail without this
   pytestFlags = [ "-v" ];

--- a/pkgs/development/python-modules/pulsar-client/default.nix
+++ b/pkgs/development/python-modules/pulsar-client/default.nix
@@ -67,7 +67,7 @@ buildPythonPackage rec {
       ratelimit
     ];
     avro = [ fastavro ];
-    all = lib.flatten (lib.attrValues (lib.removeAttrs optional-dependencies [ "all" ]));
+    all = lib.concatAttrValues (lib.removeAttrs optional-dependencies [ "all" ]);
   };
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/py-sucks/default.nix
+++ b/pkgs/development/python-modules/py-sucks/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     requests-mock
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = [
     # assumes $HOME is at a specific place

--- a/pkgs/development/python-modules/pycyphal/default.nix
+++ b/pkgs/development/python-modules/pycyphal/default.nix
@@ -56,7 +56,7 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-asyncio
   ]
-  ++ builtins.foldl' (x: y: x ++ y) [ ] (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   preCheck = ''
     export HOME=$TMPDIR

--- a/pkgs/development/python-modules/pydantic/1.nix
+++ b/pkgs/development/python-modules/pydantic/1.nix
@@ -51,7 +51,7 @@ buildPythonPackage rec {
     pytest7CheckHook
     writableTmpDirAsHomeHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/python-modules/pydantic/default.nix
+++ b/pkgs/development/python-modules/pydantic/default.nix
@@ -71,7 +71,7 @@ buildPythonPackage rec {
     pytestCheckHook
     rich
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies)
+  ++ lib.concatAttrValues optional-dependencies
   ++ lib.optionals (pythonOlder "3.10") [ eval-type-backport ];
 
   preCheck = ''

--- a/pkgs/development/python-modules/pydruid/default.nix
+++ b/pkgs/development/python-modules/pydruid/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     pytestCheckHook
     pycurl
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "pydruid" ];
 

--- a/pkgs/development/python-modules/pyecharts/default.nix
+++ b/pkgs/development/python-modules/pyecharts/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
     pytestCheckHook
     requests
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "pyecharts" ];
 

--- a/pkgs/development/python-modules/pygal/default.nix
+++ b/pkgs/development/python-modules/pygal/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
     pyquery
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   preCheck = ''
     # necessary on darwin to pass the testsuite

--- a/pkgs/development/python-modules/pyhanko/default.nix
+++ b/pkgs/development/python-modules/pyhanko/default.nix
@@ -99,7 +99,7 @@ buildPythonPackage rec {
     passthru.testData
     signxml
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTestPaths = [
     # ModuleNotFoundError: No module named 'csc_dummy'

--- a/pkgs/development/python-modules/pyjwt/default.nix
+++ b/pkgs/development/python-modules/pyjwt/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
 
   optional-dependencies.crypto = [ cryptography ];
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ (lib.flatten (lib.attrValues optional-dependencies));
+  nativeCheckInputs = [ pytestCheckHook ] ++ (lib.concatAttrValues optional-dependencies);
 
   disabledTests = [
     # requires internet connection

--- a/pkgs/development/python-modules/pymatgen/default.nix
+++ b/pkgs/development/python-modules/pymatgen/default.nix
@@ -127,7 +127,7 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-xdist
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   preCheck =
     # ensure tests can find these

--- a/pkgs/development/python-modules/pymbolic/default.nix
+++ b/pkgs/development/python-modules/pymbolic/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
     numpy = [ numpy ];
   };
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ lib.flatten (builtins.attrValues optional-dependencies);
+  nativeCheckInputs = [ pytestCheckHook ] ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "pymbolic" ];
 

--- a/pkgs/development/python-modules/pymodbus/default.nix
+++ b/pkgs/development/python-modules/pymodbus/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
     sqlalchemy
     twisted
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   preCheck = ''
     pushd test

--- a/pkgs/development/python-modules/pymorphy3/default.nix
+++ b/pkgs/development/python-modules/pymorphy3/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "pymorphy3" ];
 

--- a/pkgs/development/python-modules/pynws/default.nix
+++ b/pkgs/development/python-modules/pynws/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
     pytest-cov-stub
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "pynws" ];
 

--- a/pkgs/development/python-modules/pypiserver/default.nix
+++ b/pkgs/development/python-modules/pypiserver/default.nix
@@ -57,7 +57,7 @@ buildPythonPackage rec {
     webtest
     build
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   __darwinAllowLocalNetworking = true;
 

--- a/pkgs/development/python-modules/pyproject-parser/default.nix
+++ b/pkgs/development/python-modules/pyproject-parser/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
   ];
 
   optional-dependencies = {
-    all = lib.flatten (lib.attrValues (lib.removeAttrs optional-dependencies [ "all" ]));
+    all = lib.concatAttrValues (lib.removeAttrs optional-dependencies [ "all" ]);
     cli = [
       click
       consolekit

--- a/pkgs/development/python-modules/pyrate-limiter/default.nix
+++ b/pkgs/development/python-modules/pyrate-limiter/default.nix
@@ -61,7 +61,7 @@ buildPythonPackage rec {
     pytest-xdist
     redisTestHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTestPaths = [
     # Slow: > 1.5 seconds/test run standalone on a fast machine

--- a/pkgs/development/python-modules/pytablewriter/default.nix
+++ b/pkgs/development/python-modules/pytablewriter/default.nix
@@ -85,7 +85,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "pathvalidate" ];
 

--- a/pkgs/development/python-modules/pytest-aio/default.nix
+++ b/pkgs/development/python-modules/pytest-aio/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
     pytestCheckHook
     trio-asyncio
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "pytest_aio" ];
 

--- a/pkgs/development/python-modules/pytest-benchmark/default.nix
+++ b/pkgs/development/python-modules/pytest-benchmark/default.nix
@@ -56,7 +56,7 @@ buildPythonPackage rec {
     nbmake
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   preCheck = ''
     export PATH="$out/bin:$PATH"

--- a/pkgs/development/python-modules/pytest-jupyter/default.nix
+++ b/pkgs/development/python-modules/pytest-jupyter/default.nix
@@ -60,7 +60,7 @@ let
       pytest-timeout
       pytestCheckHook
     ]
-    ++ lib.flatten (builtins.attrValues optional-dependencies);
+    ++ lib.concatAttrValues optional-dependencies;
 
     passthru.tests = {
       check = self.overridePythonAttrs (_: {

--- a/pkgs/development/python-modules/pytest-regressions/default.nix
+++ b/pkgs/development/python-modules/pytest-regressions/default.nix
@@ -58,7 +58,7 @@ buildPythonPackage rec {
     pandas
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pytestFlags = [
     "-Wignore::DeprecationWarning"

--- a/pkgs/development/python-modules/pytest-variables/default.nix
+++ b/pkgs/development/python-modules/pytest-variables/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     yaml = [ pyyaml ];
   };
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ lib.flatten (builtins.attrValues optional-dependencies);
+  nativeCheckInputs = [ pytestCheckHook ] ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "pytest_variables" ];
 

--- a/pkgs/development/python-modules/python-benedict/default.nix
+++ b/pkgs/development/python-modules/python-benedict/default.nix
@@ -93,7 +93,7 @@ buildPythonPackage rec {
     pytestCheckHook
     python-decouple
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = [
     # Tests require network access

--- a/pkgs/development/python-modules/python-dali/default.nix
+++ b/pkgs/development/python-modules/python-dali/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-asyncio
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "dali" ];
 

--- a/pkgs/development/python-modules/python-engineio/default.nix
+++ b/pkgs/development/python-modules/python-engineio/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     pytest-asyncio
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   preCheck = lib.optionalString stdenv.hostPlatform.isLinux ''
     echo "nameserver 127.0.0.1" > resolv.conf

--- a/pkgs/development/python-modules/python-jose/default.nix
+++ b/pkgs/development/python-modules/python-jose/default.nix
@@ -54,7 +54,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "jose" ];
 

--- a/pkgs/development/python-modules/python-matter-server/default.nix
+++ b/pkgs/development/python-modules/python-matter-server/default.nix
@@ -166,7 +166,7 @@ buildPythonPackage rec {
     pytest-cov-stub
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   preCheck =
     let

--- a/pkgs/development/python-modules/python-socketio/default.nix
+++ b/pkgs/development/python-modules/python-socketio/default.nix
@@ -63,7 +63,7 @@ buildPythonPackage rec {
     valkey
     pytest-asyncio
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "socketio" ];
 

--- a/pkgs/development/python-modules/pythonfinder/default.nix
+++ b/pkgs/development/python-modules/pythonfinder/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     pytest-timeout
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "pythonfinder" ];
 

--- a/pkgs/development/python-modules/pytoolconfig/default.nix
+++ b/pkgs/development/python-modules/pytoolconfig/default.nix
@@ -65,7 +65,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   meta = with lib; {
     description = "Python tool configuration";

--- a/pkgs/development/python-modules/pytorch-metric-learning/default.nix
+++ b/pkgs/development/python-modules/pytorch-metric-learning/default.nix
@@ -73,7 +73,7 @@ buildPythonPackage rec {
     torchvision
     writableTmpDirAsHomeHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = [
     # network access

--- a/pkgs/development/python-modules/pyutil/default.nix
+++ b/pkgs/development/python-modules/pyutil/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage rec {
     twisted
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "pyutil" ];
 

--- a/pkgs/development/python-modules/pywinrm/default.nix
+++ b/pkgs/development/python-modules/pywinrm/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     mock
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "winrm" ];
 

--- a/pkgs/development/python-modules/qcelemental/default.nix
+++ b/pkgs/development/python-modules/qcelemental/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage rec {
     ];
   };
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ lib.flatten (lib.attrValues optional-dependencies);
+  nativeCheckInputs = [ pytestCheckHook ] ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "qcelemental" ];
 

--- a/pkgs/development/python-modules/qcengine/default.nix
+++ b/pkgs/development/python-modules/qcengine/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
     ];
   };
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ lib.flatten (builtins.attrValues optional-dependencies);
+  nativeCheckInputs = [ pytestCheckHook ] ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "qcengine" ];
 

--- a/pkgs/development/python-modules/qrcode/default.nix
+++ b/pkgs/development/python-modules/qrcode/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     mock
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   passthru.tests = {
     version = testers.testVersion {

--- a/pkgs/development/python-modules/qutip/default.nix
+++ b/pkgs/development/python-modules/qutip/default.nix
@@ -63,7 +63,7 @@ buildPythonPackage rec {
     pytest-rerunfailures
     writableTmpDirAsHomeHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   # QuTiP tries to access the home directory to create an rc file for us.
   # We need to go to another directory to run the tests from there.

--- a/pkgs/development/python-modules/ratarmountcore/default.nix
+++ b/pkgs/development/python-modules/ratarmountcore/default.nix
@@ -59,7 +59,7 @@ buildPythonPackage rec {
     fsspec
     writableTmpDirAsHomeHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "ratarmountcore" ];
 

--- a/pkgs/development/python-modules/renault-api/default.nix
+++ b/pkgs/development/python-modules/renault-api/default.nix
@@ -53,7 +53,7 @@ buildPythonPackage rec {
     syrupy
     typeguard
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "renault_api" ];
 

--- a/pkgs/development/python-modules/reptor/default.nix
+++ b/pkgs/development/python-modules/reptor/default.nix
@@ -70,7 +70,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   preCheck = ''
     export PATH="$PATH:$out/bin";

--- a/pkgs/development/python-modules/sagemaker-core/default.nix
+++ b/pkgs/development/python-modules/sagemaker-core/default.nix
@@ -76,7 +76,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTestPaths = [
     # Tries to import deprecated `sklearn`

--- a/pkgs/development/python-modules/scholarly/default.nix
+++ b/pkgs/development/python-modules/scholarly/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage rec {
     tor = [ stem ];
   };
 
-  nativeCheckInputs = lib.flatten (lib.attrValues optional-dependencies);
+  nativeCheckInputs = lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "scholarly" ];
 

--- a/pkgs/development/python-modules/schwifty/default.nix
+++ b/pkgs/development/python-modules/schwifty/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "schwifty" ];
 

--- a/pkgs/development/python-modules/seabreeze/default.nix
+++ b/pkgs/development/python-modules/seabreeze/default.nix
@@ -80,7 +80,7 @@ buildPythonPackage rec {
     mock
     zipp
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = [ "TestHardware" ];
 

--- a/pkgs/development/python-modules/seasonal/default.nix
+++ b/pkgs/development/python-modules/seasonal/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   meta = with lib; {
     description = "Robustly estimate trend and periodicity in a timeseries";

--- a/pkgs/development/python-modules/securesystemslib/default.nix
+++ b/pkgs/development/python-modules/securesystemslib/default.nix
@@ -66,7 +66,7 @@ buildPythonPackage rec {
     ed25519
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "securesystemslib" ];
 

--- a/pkgs/development/python-modules/sentence-transformers/default.nix
+++ b/pkgs/development/python-modules/sentence-transformers/default.nix
@@ -64,7 +64,7 @@ buildPythonPackage rec {
     pytest-cov-stub
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "sentence_transformers" ];
 

--- a/pkgs/development/python-modules/sfrbox-api/default.nix
+++ b/pkgs/development/python-modules/sfrbox-api/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
     pytest-asyncio
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "sfrbox_api" ];
 

--- a/pkgs/development/python-modules/shiny/default.nix
+++ b/pkgs/development/python-modules/shiny/default.nix
@@ -110,7 +110,7 @@ buildPythonPackage rec {
     pytest-xdist
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pytestFlags = [
     # ERROR: 'fixture' is not a valid asyncio_default_fixture_loop_scope.

--- a/pkgs/development/python-modules/shinychat/default.nix
+++ b/pkgs/development/python-modules/shinychat/default.nix
@@ -78,7 +78,7 @@ buildPythonPackage rec {
     pytestCheckHook
     shiny
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = [
     # AssertionError: assert False

--- a/pkgs/development/python-modules/simpful/default.nix
+++ b/pkgs/development/python-modules/simpful/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "simpful" ];
 

--- a/pkgs/development/python-modules/slack-bolt/default.nix
+++ b/pkgs/development/python-modules/slack-bolt/default.nix
@@ -89,7 +89,7 @@ buildPythonPackage rec {
     pytestCheckHook
     writableTmpDirAsHomeHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   __darwinAllowLocalNetworking = true;
 

--- a/pkgs/development/python-modules/slixmpp/default.nix
+++ b/pkgs/development/python-modules/slixmpp/default.nix
@@ -54,7 +54,7 @@ buildPythonPackage rec {
     safer-xml-parserig = [ defusedxml ];
   };
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ lib.flatten (lib.attrValues optional-dependencies);
+  nativeCheckInputs = [ pytestCheckHook ] ++ lib.concatAttrValues optional-dependencies;
 
   preCheck = ''
     # don't test against pure python version in the source tree

--- a/pkgs/development/python-modules/smart-open/default.nix
+++ b/pkgs/development/python-modules/smart-open/default.nix
@@ -70,7 +70,7 @@ buildPythonPackage rec {
     responses
   ]
   ++ moto.optional-dependencies.server
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   enabledTestPaths = [ "tests" ];
 

--- a/pkgs/development/python-modules/smolagents/default.nix
+++ b/pkgs/development/python-modules/smolagents/default.nix
@@ -128,7 +128,7 @@ buildPythonPackage rec {
     pytestCheckHook
     wikipedia-api
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "smolagents" ];
 

--- a/pkgs/development/python-modules/social-auth-core/default.nix
+++ b/pkgs/development/python-modules/social-auth-core/default.nix
@@ -63,7 +63,7 @@ buildPythonPackage rec {
     responses
     typing-extensions
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTestPaths = [
     # missing google-auth-stubs

--- a/pkgs/development/python-modules/speechrecognition/default.nix
+++ b/pkgs/development/python-modules/speechrecognition/default.nix
@@ -78,7 +78,7 @@ buildPythonPackage rec {
     pocketsphinx
     respx
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "speech_recognition" ];
 

--- a/pkgs/development/python-modules/splinter/default.nix
+++ b/pkgs/development/python-modules/splinter/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = [
     # driver is present and fails with a different error during loading

--- a/pkgs/development/python-modules/sqlalchemy-utils/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy-utils/default.nix
@@ -75,7 +75,7 @@ buildPythonPackage rec {
     pymysql
     pyodbc
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies)
+  ++ lib.concatAttrValues optional-dependencies
   ++ lib.optionals (pythonOlder "3.12") [
     # requires distutils, which were removed in 3.12
     psycopg2cffi

--- a/pkgs/development/python-modules/sqlfmt/default.nix
+++ b/pkgs/development/python-modules/sqlfmt/default.nix
@@ -65,7 +65,7 @@ buildPythonPackage rec {
     versionCheckHook
     writableTmpDirAsHomeHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
   versionCheckProgramArg = "--version";
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/sqlframe/default.nix
+++ b/pkgs/development/python-modules/sqlframe/default.nix
@@ -83,7 +83,7 @@ buildPythonPackage rec {
     pytest-xdist
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = [
     # Requires google-cloud credentials

--- a/pkgs/development/python-modules/starlette/default.nix
+++ b/pkgs/development/python-modules/starlette/default.nix
@@ -57,7 +57,7 @@ buildPythonPackage rec {
     trio
     typing-extensions
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pytestFlags = [
     "-Wignore::DeprecationWarning"

--- a/pkgs/development/python-modules/static3/default.nix
+++ b/pkgs/development/python-modules/static3/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
     pytestCheckHook
     webtest
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   meta = with lib; {
     changelog = "https://github.com/rmohr/static3/releases/tag/v${version}";

--- a/pkgs/development/python-modules/stm32loader/default.nix
+++ b/pkgs/development/python-modules/stm32loader/default.nix
@@ -51,7 +51,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   enabledTestPaths = [ "tests/unit" ];
 

--- a/pkgs/development/python-modules/strawberry-graphql/default.nix
+++ b/pkgs/development/python-modules/strawberry-graphql/default.nix
@@ -139,7 +139,7 @@ buildPythonPackage rec {
     pytestCheckHook
     sanic-testing
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "strawberry" ];
 

--- a/pkgs/development/python-modules/tabulate/default.nix
+++ b/pkgs/development/python-modules/tabulate/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   meta = {
     description = "Pretty-print tabular data";

--- a/pkgs/development/python-modules/textual-fastdatatable/default.nix
+++ b/pkgs/development/python-modules/textual-fastdatatable/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage rec {
     pytest-textual-snapshot
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "textual_fastdatatable" ];
 

--- a/pkgs/development/python-modules/tianshou/default.nix
+++ b/pkgs/development/python-modules/tianshou/default.nix
@@ -92,7 +92,7 @@ buildPythonPackage rec {
   ];
 
   optional-dependencies = {
-    all = lib.flatten (lib.attrValues (lib.removeAttrs optional-dependencies [ "all" ]));
+    all = lib.concatAttrValues (lib.removeAttrs optional-dependencies [ "all" ]);
 
     argparse = [
       docstring-parser

--- a/pkgs/development/python-modules/timezonefinder/default.nix
+++ b/pkgs/development/python-modules/timezonefinder/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     pydantic
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "timezonefinder" ];
 

--- a/pkgs/development/python-modules/trino-python-client/default.nix
+++ b/pkgs/development/python-modules/trino-python-client/default.nix
@@ -56,7 +56,7 @@ buildPythonPackage rec {
     pytestCheckHook
     testcontainers
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "trino" ];
 

--- a/pkgs/development/python-modules/tweepy/default.nix
+++ b/pkgs/development/python-modules/tweepy/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
     pytestCheckHook
     vcrpy
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "tweepy" ];
 

--- a/pkgs/development/python-modules/typed-settings/default.nix
+++ b/pkgs/development/python-modules/typed-settings/default.nix
@@ -66,7 +66,7 @@ buildPythonPackage rec {
     sybil
   ]
   ++ (lib.optional (pythonOlder "3.11") typing-extensions)
-  ++ (lib.flatten (lib.attrValues optional-dependencies));
+  ++ (lib.concatAttrValues optional-dependencies);
 
   enabledTestPaths = [ "tests" ];
 

--- a/pkgs/development/python-modules/typepy/default.nix
+++ b/pkgs/development/python-modules/typepy/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     pytestCheckHook
     tcolorpy
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "typepy" ];
 

--- a/pkgs/development/python-modules/types-lxml/default.nix
+++ b/pkgs/development/python-modules/types-lxml/default.nix
@@ -56,7 +56,7 @@ buildPythonPackage rec {
     typeguard
     urllib3
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "lxml-stubs" ];
 

--- a/pkgs/development/python-modules/ufmt/default.nix
+++ b/pkgs/development/python-modules/ufmt/default.nix
@@ -59,7 +59,7 @@ buildPythonPackage rec {
     unittestCheckHook
     versionCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
   versionCheckProgramArg = "--version";
 
   pythonImportsCheck = [ "ufmt" ];

--- a/pkgs/development/python-modules/ufolib2/default.nix
+++ b/pkgs/development/python-modules/ufolib2/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "ufoLib2" ];
 

--- a/pkgs/development/python-modules/upcloud-api/default.nix
+++ b/pkgs/development/python-modules/upcloud-api/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     pytestCheckHook
     responses
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "upcloud_api" ];
 

--- a/pkgs/development/python-modules/uplink/default.nix
+++ b/pkgs/development/python-modules/uplink/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
     pytest-asyncio
     pytest-twisted
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "uplink" ];
 

--- a/pkgs/development/python-modules/urllib3-future/default.nix
+++ b/pkgs/development/python-modules/urllib3-future/default.nix
@@ -73,7 +73,7 @@ buildPythonPackage rec {
     tornado
     trustme
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTestPaths = [
     # test connects to the internet

--- a/pkgs/development/python-modules/urllib3/default.nix
+++ b/pkgs/development/python-modules/urllib3/default.nix
@@ -54,7 +54,7 @@ let
       tornado
       trustme
     ]
-    ++ lib.flatten (builtins.attrValues optional-dependencies);
+    ++ lib.concatAttrValues optional-dependencies;
 
     # Tests in urllib3 are mostly timeout-based instead of event-based and
     # are therefore inherently flaky. On your own machine, the tests will

--- a/pkgs/development/python-modules/urwid/default.nix
+++ b/pkgs/development/python-modules/urwid/default.nix
@@ -63,7 +63,7 @@ buildPythonPackage rec {
     glibcLocales
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   env.LC_ALL = "en_US.UTF8";
 

--- a/pkgs/development/python-modules/validators/default.nix
+++ b/pkgs/development/python-modules/validators/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
     crypto-eth-addresses = [ eth-hash ] ++ eth-hash.optional-dependencies.pycryptodome;
   };
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ lib.flatten (lib.attrValues optional-dependencies);
+  nativeCheckInputs = [ pytestCheckHook ] ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "validators" ];
 

--- a/pkgs/development/python-modules/valkey/default.nix
+++ b/pkgs/development/python-modules/valkey/default.nix
@@ -74,7 +74,7 @@ buildPythonPackage rec {
     ujson
     uvloop
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTestMarks = [
     "onlycluster"

--- a/pkgs/development/python-modules/visions/default.nix
+++ b/pkgs/development/python-modules/visions/default.nix
@@ -65,7 +65,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = [
     # TypeError: Converting `np.inexact` or `np.floating` to a dtype not allowed

--- a/pkgs/development/python-modules/w1thermsensor/default.nix
+++ b/pkgs/development/python-modules/w1thermsensor/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ]
   ++ lib.optionals (pythonOlder "3.11") [ tomli ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "w1thermsensor" ];
 

--- a/pkgs/development/python-modules/watermark/default.nix
+++ b/pkgs/development/python-modules/watermark/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "watermark" ];
 

--- a/pkgs/development/python-modules/werkzeug/default.nix
+++ b/pkgs/development/python-modules/werkzeug/default.nix
@@ -53,7 +53,7 @@ buildPythonPackage rec {
     pytest-timeout
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "werkzeug" ];
 

--- a/pkgs/development/python-modules/whey/default.nix
+++ b/pkgs/development/python-modules/whey/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "whey" ];
 
   optional-dependencies = {
-    all = lib.flatten (lib.attrValues (lib.removeAttrs optional-dependencies [ "all" ]));
+    all = lib.concatAttrValues (lib.removeAttrs optional-dependencies [ "all" ]);
     editable = [
       editables
     ];

--- a/pkgs/development/python-modules/wtforms/default.nix
+++ b/pkgs/development/python-modules/wtforms/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "wtforms" ];
 

--- a/pkgs/development/python-modules/wyoming/default.nix
+++ b/pkgs/development/python-modules/wyoming/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage rec {
     pytest-asyncio
     pytestCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   passthru.tests = {
     inherit wyoming-faster-whisper wyoming-openwakeword wyoming-piper;

--- a/pkgs/development/python-modules/xarray-einstats/default.nix
+++ b/pkgs/development/python-modules/xarray-einstats/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     numba = [ numba ];
   };
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ lib.flatten (builtins.attrValues optional-dependencies);
+  nativeCheckInputs = [ pytestCheckHook ] ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [ "xarray_einstats" ];
 

--- a/pkgs/development/python-modules/zeep/default.nix
+++ b/pkgs/development/python-modules/zeep/default.nix
@@ -76,7 +76,7 @@ buildPythonPackage rec {
     pytestCheckHook
     requests-mock
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = [
     # Failed: External connections not allowed during tests.

--- a/pkgs/development/python-modules/zope-security/default.nix
+++ b/pkgs/development/python-modules/zope-security/default.nix
@@ -59,7 +59,7 @@ buildPythonPackage rec {
     zope-exceptions
     zope-testing
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   # Import process is too complex and some tests fail
   preCheck = ''

--- a/pkgs/tools/security/cve-bin-tool/default.nix
+++ b/pkgs/tools/security/cve-bin-tool/default.nix
@@ -92,7 +92,7 @@ buildPythonApplication rec {
   nativeCheckInputs = [
     versionCheckHook
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   pythonImportsCheck = [
     "cve_bin_tool"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3465,7 +3465,7 @@ with pkgs;
     toPythonApplication (
       nvchecker.overridePythonAttrs (oldAttrs: {
         propagatedBuildInputs =
-          oldAttrs.dependencies ++ lib.flatten (builtins.attrValues oldAttrs.optional-dependencies);
+          oldAttrs.dependencies ++ lib.concatAttrValues oldAttrs.optional-dependencies;
       })
     );
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
