### PR TITLE
qutebrowser: 3.6.1 -> 3.6.2

### DIFF
--- a/pkgs/by-name/qu/qutebrowser/package.nix
+++ b/pkgs/by-name/qu/qutebrowser/package.nix
@@ -26,15 +26,15 @@ let
   isQt6 = lib.versions.major qt6Packages.qtbase.version == "6";
   pdfjs =
     let
-      version = "5.4.296";
+      version = "5.4.394";
     in
     fetchzip {
       url = "https://github.com/mozilla/pdf.js/releases/download/v${version}/pdfjs-${version}-dist.zip";
-      hash = "sha256-UQ7sYOh7s95mfzH2ZbfDyEvUZiXr7MI3u0WY8WNHWv4=";
+      hash = "sha256-KMpSwF5MmoWdNoIUd4ZOwbJZZmjkid8wUoFKw7XjQFA=";
       stripRoot = false;
     };
 
-  version = "3.6.1";
+  version = "3.6.2";
 in
 
 python3.pkgs.buildPythonApplication {
@@ -44,7 +44,7 @@ python3.pkgs.buildPythonApplication {
 
   src = fetchurl {
     url = "https://github.com/qutebrowser/qutebrowser/releases/download/v${version}/qutebrowser-${version}.tar.gz";
-    hash = "sha256-9b31UPJzmsGCXmCAIb+8XMEjKnvFIEO0MozWluHYbZA=";
+    hash = "sha256-GfSkVluSwcCAvLPlW49QLmyWblTrnW9Qgqne0Qy8JJM=";
   };
 
   # Needs tox

--- a/pkgs/by-name/qu/qutebrowser/package.nix
+++ b/pkgs/by-name/qu/qutebrowser/package.nix
@@ -15,6 +15,7 @@
   pipewireSupport ? stdenv.hostPlatform.isLinux,
   pipewire,
   qt6Packages,
+  wayland,
   enableWideVine ? false,
   widevine-cdm,
   # can cause issues on some graphics chips
@@ -104,6 +105,11 @@ python3.pkgs.buildPythonApplication {
   ''
   + lib.optionalString withPdfReader ''
     sed -i "s,/usr/share/pdf.js,${pdfjs},g" qutebrowser/browser/pdfjs.py
+  ''
+  + lib.optionalString (lib.meta.availableOn stdenv.hostPlatform wayland) ''
+    substituteInPlace qutebrowser/misc/wmname.py \
+      --replace-fail '_load_library("wayland-client")' \
+                     'ctypes.CDLL("${lib.getLib wayland}/lib/libwayland-client${stdenv.hostPlatform.extensions.sharedLibrary}")'
   '';
 
   installPhase = ''


### PR DESCRIPTION
Diff: https://github.com/qutebrowser/qutebrowser/compare/v3.6.1...v3.6.2

Changelog: https://github.com/qutebrowser/qutebrowser/blob/v3.6.2/doc/changelog.asciidoc


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
