### PR TITLE
mathjax: migrate from nodePackages

### DIFF
--- a/pkgs/by-name/ap/apostrophe/package.nix
+++ b/pkgs/by-name/ap/apostrophe/package.nix
@@ -5,7 +5,7 @@
   libspelling,
   fetchFromGitHub,
   python312Packages,
-  nodePackages,
+  mathjax,
   meson,
   ninja,
   pkg-config,
@@ -57,7 +57,7 @@ python312Packages.buildPythonApplication {
   # Use mathjax from nixpkgs to avoid loading from CDN
   + ''
     substituteInPlace apostrophe/preview_converter.py \
-      --replace-fail "--mathjax" "--mathjax=file://${nodePackages.mathjax}/lib/node_modules/mathjax/es5/tex-chtml-full.js"
+      --replace-fail "--mathjax" "--mathjax=file://${mathjax}/lib/node_modules/mathjax/tex-chtml-full.js"
   '';
 
   # Should be done in postInstall, but meson checks this eagerly before build

--- a/pkgs/by-name/ma/mathjax/package.nix
+++ b/pkgs/by-name/ma/mathjax/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mathjax";
+  version = "4.0.0";
+
+  src = fetchFromGitHub {
+    owner = "mathjax";
+    repo = "mathjax";
+    tag = finalAttrs.version;
+    hash = "sha256-36lTjx4zuFeT1+QFemiQcCZfAjyh7vFPpYeRhO2mzGI=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/node_modules/mathjax
+    mv * $out/lib/node_modules/mathjax
+    # This is a MathJax v3 compat shim, notably still needed for sagemath
+    ln -s $out/lib/node_modules/mathjax $out/lib/node_modules/mathjax/es5
+
+    runHook postInstall
+  '';
+
+  meta = {
+    changelog = "https://github.com/mathjax/MathJax/releases/tag/${finalAttrs.version}";
+    description = "Beautiful and accessible math in all browsers";
+    homepage = "https://www.mathjax.org/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ pyrox0 ];
+  };
+})

--- a/pkgs/by-name/sa/sage/package.nix
+++ b/pkgs/by-name/sa/sage/package.nix
@@ -10,7 +10,7 @@
 # is always preferred, see `sage-src.nix` for that.
 
 let
-  inherit (pkgs) symlinkJoin callPackage nodePackages;
+  inherit (pkgs) symlinkJoin callPackage mathjax;
 
   python3 = pkgs.python3 // {
     pkgs = pkgs.python3.pkgs.overrideScope (
@@ -66,7 +66,7 @@ let
     inherit singular maxima;
     inherit three;
     cysignals = python3.pkgs.cysignals;
-    mathjax = nodePackages.mathjax;
+    mathjax = mathjax;
   };
 
   # The shell file that gets sourced on every sage start. Will also source

--- a/pkgs/by-name/xr/xreader/package.nix
+++ b/pkgs/by-name/xr/xreader/package.nix
@@ -20,7 +20,7 @@
   libspectre,
   libgxps,
   webkitgtk_4_1,
-  nodePackages,
+  mathjax,
   ninja,
   djvulibre,
   backends ? [
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
   ];
 
   mesonFlags = [
-    "-Dmathjax-directory=${nodePackages.mathjax}"
+    "-Dmathjax-directory=${mathjax}"
     "-Dintrospection=true"
   ]
   ++ (map (x: "-D${x}=true") backends);
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
     libspectre
     libgxps
     webkitgtk_4_1
-    nodePackages.mathjax
+    mathjax
     djvulibre
   ];
 

--- a/pkgs/development/node-packages/aliases.nix
+++ b/pkgs/development/node-packages/aliases.nix
@@ -241,6 +241,7 @@ mapAliases {
   inherit (pkgs) markdown-link-check; # added 2024-06-28
   markdownlint-cli = pkgs.markdownlint-cli; # added 2023-07-29
   inherit (pkgs) markdownlint-cli2; # added 2023-08-22
+  inherit (pkgs) mathjax; # Added 2025-11-28
   inherit (pkgs) mathjax-node-cli; # added 2023-11-02
   mastodon-bot = throw "'mastodon-bot' has been removed because it was archived by upstream in 2021."; # Added 2025-11-07
   mdctl-cli = self."@medable/mdctl-cli"; # added 2023-08-21

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -19,7 +19,6 @@
 , "js-yaml"
 , "jsdoc"
 , "lcov-result-merger"
-, "mathjax"
 , "node2nix"
 , "postcss"
 , "prebuild-install"

--- a/pkgs/development/node-packages/node-packages.nix
+++ b/pkgs/development/node-packages/node-packages.nix
@@ -21942,24 +21942,6 @@ in
     bypassCache = true;
     reconstructLock = true;
   };
-  mathjax = nodeEnv.buildNodePackage {
-    name = "mathjax";
-    packageName = "mathjax";
-    version = "3.2.2";
-    src = fetchurl {
-      url = "https://registry.npmjs.org/mathjax/-/mathjax-3.2.2.tgz";
-      sha512 = "Bt+SSVU8eBG27zChVewOicYs7Xsdt40qm4+UpHyX7k0/O9NliPc+x77k1/FEsPsjKPZGJvtRZM1vO+geW0OhGw==";
-    };
-    buildInputs = globalBuildInputs;
-    meta = {
-      description = "Beautiful and accessible math in all browsers. MathJax is an open-source JavaScript display engine for LaTeX, MathML, and AsciiMath notation that works in all browsers. This package includes the packaged components (install mathjax-full to get the source ";
-      homepage = "https://github.com/mathjax/MathJax#readme";
-      license = "Apache-2.0";
-    };
-    production = true;
-    bypassCache = true;
-    reconstructLock = true;
-  };
   node2nix = nodeEnv.buildNodePackage {
     name = "node2nix";
     packageName = "node2nix";


### PR DESCRIPTION
xreader and apostrophe build fine, currently building sage. 

Edit: sage builds fine.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
