### PR TITLE
python313Packages.rosdistro: init at 1.0.1

### DIFF
--- a/pkgs/development/python-modules/rosdistro/default.nix
+++ b/pkgs/development/python-modules/rosdistro/default.nix
@@ -1,0 +1,55 @@
+{
+  buildPythonPackage,
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  # build-system
+  setuptools,
+  # dependencies
+  catkin-pkg,
+  pyyaml,
+  rospkg,
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "rosdistro";
+  version = "1.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ros-infrastructure";
+    repo = pname;
+    tag = version;
+    hash = "sha256-ETsQzWsoGrThxNI/L3pWEzkhmrh+jpy/KIkojPMTkLw=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    catkin-pkg
+    pyyaml
+    rospkg
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTestPaths = [
+    "test/test_manifest_providers.py" # Requires internet access
+    "test/test_index.py" # Fails on darwin
+  ];
+
+  pythonImportsCheck = [ pname ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/ros-infrastructure/${pname}/blob/${version}/CHANGELOG.rst";
+    description = "Tools to work with catkinized rosdistro files";
+    homepage = "https://github.com/ros-infrastructure/${pname}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ amronos ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16777,6 +16777,8 @@ self: super: with self; {
 
   rosbags = callPackage ../development/python-modules/rosbags { };
 
+  rosdistro = callPackage ../development/python-modules/rosdistro { };
+
   rospkg = callPackage ../development/python-modules/rospkg { };
 
   rotary-embedding-torch = callPackage ../development/python-modules/rotary-embedding-torch { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[``rosdistro``](https://github.com/ros-infrastructure/rosdistro) is a package that is part of the core ROS infrastructure. It allows tools to work with catkinized rosdistro files. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
