### PR TITLE
affinity: init at 3.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6296,6 +6296,12 @@
     githubId = 51992962;
     name = "Nikita Demin";
   };
+  demis = {
+    email = "damianoshushku@gmail.com";
+    github = "D3M1S22";
+    githubId = 48984462;
+    name = "Damiano Shushku";
+  };
   demize = {
     email = "johannes@kyriasis.com";
     github = "kyrias";

--- a/pkgs/by-name/af/affinity/package.nix
+++ b/pkgs/by-name/af/affinity/package.nix
@@ -1,26 +1,25 @@
-{ lib, stdenv, fetchurl, undmg}:
+{
+  lib,
+  stdenv,
+  fetchurl,
+  undmg,
+}:
 
 let
   # Binary DMGs for each Darwin arch
-  sources = {
-    x86_64-darwin = fetchurl {
-      url  = "https://downloads.affinity.studio/Affinity.dmg";
-      hash = "sha256-Ew3fukQWwKOrl/l7dPy6ZWj9sN592V1l+qep0zvQRIk=";
-    };
-
-    aarch64-darwin = fetchurl {
-      url  = "https://downloads.affinity.studio/Affinity.dmg";
-      hash = "sha256-Ew3fukQWwKOrl/l7dPy6ZWj9sN592V1l+qep0zvQRIk=";
-    };
+  macOSDmg = fetchurl {
+    url = "https://downloads.affinity.studio/Affinity.dmg";
+    hash = "sha256-Ew3fukQWwKOrl/l7dPy6ZWj9sN592V1l+qep0zvQRIk=";
   };
+
 in
 stdenv.mkDerivation (finalAttrs: {
-  pname   = "affinity";
+  pname = "affinity";
   version = "3.0.1";
 
   # Pick the right DMG for the current platform
   # Using this system allows a future multi-platform build if needed
-  src = sources.${stdenv.hostPlatform.system};
+  src = macOSDmg;
 
   # Needed to unpack .dmg
   nativeBuildInputs = [ undmg ];
@@ -29,7 +28,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   ## Needs to be adjusted if Affinity releases separate builds per architecture
   ## For now, linux builds are not available, so we use the same DMG for both archs
-
 
   # Let the default unpackPhase handle the DMG using undmg.
   # We only override installPhase.
@@ -54,9 +52,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "Affinity all-in-one creative app";
-    homepage    = "https://www.affinity.studio";
-    license     = licenses.unfree;
-    platforms   = platforms.darwin; # Affinity is only available for macOS at this time
+    homepage = "https://www.affinity.studio";
+    license = licenses.unfree;
+    platforms = platforms.darwin; # Affinity is only available for macOS at this time
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     maintainers = with maintainers; [ demis ];
     mainProgram = "affinity";

--- a/pkgs/by-name/af/affinity/package.nix
+++ b/pkgs/by-name/af/affinity/package.nix
@@ -1,0 +1,64 @@
+{ lib, stdenv, fetchurl, undmg}:
+
+let
+  # Binary DMGs for each Darwin arch
+  sources = {
+    x86_64-darwin = fetchurl {
+      url  = "https://downloads.affinity.studio/Affinity.dmg";
+      hash = "sha256-Ew3fukQWwKOrl/l7dPy6ZWj9sN592V1l+qep0zvQRIk=";
+    };
+
+    aarch64-darwin = fetchurl {
+      url  = "https://downloads.affinity.studio/Affinity.dmg";
+      hash = "sha256-Ew3fukQWwKOrl/l7dPy6ZWj9sN592V1l+qep0zvQRIk=";
+    };
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname   = "affinity";
+  version = "3.0.1";
+
+  # Pick the right DMG for the current platform
+  # Using this system allows a future multi-platform build if needed
+  src = sources.${stdenv.hostPlatform.system};
+
+  # Needed to unpack .dmg
+  nativeBuildInputs = [ undmg ];
+
+  sourceRoot = ".";
+
+  ## Needs to be adjusted if Affinity releases separate builds per architecture
+  ## For now, linux builds are not available, so we use the same DMG for both archs
+
+
+  # Let the default unpackPhase handle the DMG using undmg.
+  # We only override installPhase.
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Applications"
+    # Adjust this if the .app name inside the DMG is different:
+    # e.g. "Affinity 3.app" or "Affinity by Canva.app"
+    cp -R "Affinity.app" "$out/Applications/Affinity.app"
+
+    # CLI wrapper so `nix run` / `affinity` works
+    mkdir -p "$out/bin"
+    cat > "$out/bin/affinity" <<EOF
+    #!/usr/bin/env bash
+    exec /usr/bin/open "$out/Applications/Affinity.app" "\$@"
+    EOF
+    chmod +x "$out/bin/affinity"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Affinity all-in-one creative app";
+    homepage    = "https://www.affinity.studio";
+    license     = licenses.unfree;
+    platforms   = platforms.darwin; # Affinity is only available for macOS at this time
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    maintainers = with maintainers; [ demis ];
+    mainProgram = "affinity";
+  };
+})


### PR DESCRIPTION
<!--
Add `affinity`: a macOS-only, proprietary all-in-one creative app by Affinity/Canva.

This package:

- Downloads the upstream Affinity DMG for macOS (darwin x86_64 + aarch64).
- Installs `Affinity.app` under `$out/Applications`.
- Provides an `affinity` wrapper in `$out/bin` that launches the app via `open`.
- Marks the package as `unfree` with `binaryNativeCode` sourceProvenance (non-redistributable proprietary software).

Homepage: https://www.affinity.studio
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ X] x86_64-darwin
  - [ X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
