### PR TITLE
gitleaks: update source repository location & add maintainer

### DIFF
--- a/pkgs/by-name/gi/gitleaks/package.nix
+++ b/pkgs/by-name/gi/gitleaks/package.nix
@@ -55,7 +55,10 @@ buildGoModule rec {
     homepage = "https://github.com/zricethezav/gitleaks";
     changelog = "https://github.com/zricethezav/gitleaks/releases/tag/v${version}";
     license = with lib.licenses; [ mit ];
-    maintainers = with lib.maintainers; [ fab ];
+    maintainers = with lib.maintainers; [
+      fab
+      friedow
+    ];
     mainProgram = "gitleaks";
   };
 }

--- a/pkgs/by-name/gi/gitleaks/package.nix
+++ b/pkgs/by-name/gi/gitleaks/package.nix
@@ -14,7 +14,7 @@ buildGoModule rec {
   version = "8.28.0";
 
   src = fetchFromGitHub {
-    owner = "zricethezav";
+    owner = "gitleaks";
     repo = "gitleaks";
     tag = "v${version}";
     hash = "sha256-smh3Ge278lYVEcs6r1F43daexgjgddy1HKhU5E4CBYM=";
@@ -52,8 +52,8 @@ buildGoModule rec {
       Gitleaks is a SAST tool for detecting hardcoded secrets like passwords,
       API keys and tokens in git repos.
     '';
-    homepage = "https://github.com/zricethezav/gitleaks";
-    changelog = "https://github.com/zricethezav/gitleaks/releases/tag/v${version}";
+    homepage = "https://github.com/gitleaks/gitleaks";
+    changelog = "https://github.com/gitleaks/gitleaks/releases/tag/v${version}";
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [
       fab


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
`gitleaks` has moved its repository into an own `gitleaks` organization on github. This PR mirrors that and updates the source repository of the package. 

I've intentionally not updated the package to the latest published version to see whether r-ryantm will pick it up for autoupdates again after this PR is merged.

Furthermore, I've added myself as a maintainer to the package :).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
