### PR TITLE
ocamlPackages.opam-file-format: 2.1.6 → 2.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/opam-file-format/default.nix
+++ b/pkgs/development/ocaml-modules/opam-file-format/default.nix
@@ -1,27 +1,26 @@
 {
   lib,
-  fetchFromGitHub,
+  fetchurl,
   buildDunePackage,
+  menhir,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "opam-file-format";
-  version = "2.1.6";
+  version = "2.2.0";
 
-  src = fetchFromGitHub {
-    owner = "ocaml";
-    repo = pname;
-    rev = version;
-    sha256 = "sha256-Ka9pMYB99kM+5X7wf9F13gUrjouZucGevvkSY0TaXGg=";
+  src = fetchurl {
+    url = "https://github.com/ocaml/opam-file-format/releases/download/${finalAttrs.version}/opam-file-format-${finalAttrs.version}.tar.gz";
+    hash = "sha256-SrU1Cw3L1EwFmrDFnYE2jzSvdwccDmXYHGpbm/ql6Ck=";
   };
 
-  useDune2 = true;
+  nativeBuildInputs = [ menhir ];
 
-  meta = with lib; {
+  meta = {
     description = "Parser and printer for the opam file syntax";
-    license = licenses.lgpl21;
-    maintainers = with maintainers; [ vbgl ];
+    license = lib.licenses.lgpl21;
+    maintainers = with lib.maintainers; [ vbgl ];
     homepage = "https://github.com/ocaml/opam-file-format/";
-    changelog = "https://github.com/ocaml/opam-file-format/raw/${version}/CHANGES";
+    changelog = "https://github.com/ocaml/opam-file-format/raw/${finalAttrs.version}/CHANGES";
   };
-}
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
