### PR TITLE
openwith: move to by-name, use darwinArch

### DIFF
--- a/pkgs/by-name/op/openwith/package.nix
+++ b/pkgs/by-name/op/openwith/package.nix
@@ -6,7 +6,7 @@
 
 let
   inherit (swiftPackages) stdenv swift;
-  arch = if stdenv.hostPlatform.isAarch64 then "arm64" else "x86_64";
+  inherit (stdenv.hostPlatform) darwinArch;
 in
 stdenv.mkDerivation {
   pname = "openwith";
@@ -21,11 +21,11 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ swift ];
 
-  makeFlags = [ "openwith_${arch}" ];
+  makeFlags = [ "openwith_${darwinArch}" ];
 
   installPhase = ''
     runHook preInstall
-    install openwith_${arch} -D $out/bin/openwith
+    install openwith_${darwinArch} -D $out/bin/openwith
     runHook postInstall
   '';
 

--- a/pkgs/top-level/darwin-aliases.nix
+++ b/pkgs/top-level/darwin-aliases.nix
@@ -138,6 +138,7 @@ stubs
   ### O ###
 
   opencflite = pkgs.opencflite; # added 2024-05-02
+  openwith = pkgs.openwith; # added 2025-11-28
 
   ### P ###
   postLinkSignHook = throw "'darwin.postLinkSignHook' has been removed because it is obsolete"; # added 2025-02-23

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -116,8 +116,6 @@ makeScopeWithSplicing' {
 
         lsusb = callPackage ../os-specific/darwin/lsusb { };
 
-        openwith = callPackage ../os-specific/darwin/openwith { };
-
         trash = callPackage ../os-specific/darwin/trash { };
 
         inherit (self.file_cmds) xattr;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
