### PR TITLE
nixos/userborn: introduce config.services.userborn.static mode

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27541,6 +27541,13 @@
     githubId = 27813;
     name = "Vincent Breitmoser";
   };
+  valpackett = {
+    email = "val@invisiblethingslab.com";
+    github = "valpackett";
+    githubId = 208340;
+    matrix = "@valpackett:mozilla.org";
+    name = "Val Packett";
+  };
   vamega = {
     email = "github@madiathv.com";
     github = "vamega";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1647,6 +1647,7 @@ in
   userborn-immutable-users = runTest ./userborn-immutable-users.nix;
   userborn-mutable-etc = runTest ./userborn-mutable-etc.nix;
   userborn-mutable-users = runTest ./userborn-mutable-users.nix;
+  userborn-static = runTest ./userborn-static.nix;
   ustreamer = runTest ./ustreamer.nix;
   uwsgi = runTest ./uwsgi.nix;
   v2ray = runTest ./v2ray.nix;

--- a/nixos/tests/userborn-static.nix
+++ b/nixos/tests/userborn-static.nix
@@ -1,0 +1,57 @@
+{ lib, ... }:
+
+let
+  sysuserPassword = "$y$j9T$3aiOV/8CADAK22OK2QT3/0$67OKd50Z4qTaZ8c/eRWHLIM.o3ujtC1.n9ysmJfv639";
+
+  common = {
+    services.userborn = {
+      enable = true;
+      static = true;
+    };
+    boot.initrd.systemd.enable = true;
+    networking.useNetworkd = true;
+    system.etc.overlay = {
+      enable = true;
+      mutable = false;
+    };
+  };
+in
+
+{
+
+  name = "userborn-static";
+
+  meta.maintainers = with lib.maintainers; [
+    mic92
+    valpackett
+  ];
+
+  nodes.machine =
+    { ... }:
+    {
+      imports = [ common ];
+
+      users.users.sysuser = {
+        uid = 1337;
+        isSystemUser = true;
+        group = "wheel";
+        home = "/var/empty";
+        initialHashedPassword = sysuserPassword;
+      };
+    };
+
+  testScript = ''
+    with subtest("Correct mode on the password files"):
+      assert machine.succeed("stat -c '%a' /etc/passwd") == "644\n"
+      assert machine.succeed("stat -c '%a' /etc/group") == "644\n"
+      assert machine.succeed("stat -c '%a' /etc/shadow") == "0\n"
+
+    with subtest("Check files"):
+      print(machine.succeed("grpck -r"))
+      print(machine.succeed("pwck -r"))
+
+    with subtest("sysuser user is created"):
+      print(machine.succeed("getent passwd sysuser"))
+      assert "${sysuserPassword}" in machine.succeed("getent shadow sysuser"), "sysuser user password is not correct"
+  '';
+}

--- a/pkgs/by-name/us/userborn/package.nix
+++ b/pkgs/by-name/us/userborn/package.nix
@@ -37,6 +37,7 @@ rustPlatform.buildRustPackage rec {
         userborn-mutable-etc
         userborn-immutable-users
         userborn-immutable-etc
+        userborn-static
         ;
     };
   };


### PR DESCRIPTION
For embedded appliance-style applications, we would like to avoid the ~100ms boot time hit that comes from running userborn or sysusers by pre-baking the final password files directly into the system closure.

Turns out, userborn is trivial to run at build time instead of boot time, so let's introduce a new "baked" mode that directly places the files into an immutable /etc.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
