### PR TITLE
libdvdread: 6.1.3 -> 7.0.1

### DIFF
--- a/pkgs/development/libraries/libdvdread/default.nix
+++ b/pkgs/development/libraries/libdvdread/default.nix
@@ -2,21 +2,31 @@
   lib,
   stdenv,
   fetchurl,
+  meson,
+  ninja,
+  pkg-config,
   libdvdcss,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libdvdread";
-  version = "6.1.3";
+  version = "7.0.1";
 
   src = fetchurl {
-    url = "http://get.videolan.org/libdvdread/${version}/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-zjVFSZeiCMvlDpEjLw5z+xrDRxllgToTuHMKjxihU2k=";
+    url = "http://get.videolan.org/libdvdread/${finalAttrs.version}/${finalAttrs.pname}-${finalAttrs.version}.tar.xz";
+    sha256 = "sha256-Lj4EowXBXDljqgOuG5qDwdI5iAAD/PPd6YbTlDNV1Ac=";
   };
 
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
   buildInputs = [ libdvdcss ];
 
-  NIX_LDFLAGS = "-ldvdcss";
+  mesonFlags = [
+    "-Dlibdvdcss=enabled"
+  ];
 
   postInstall = ''
     ln -s dvdread $out/include/libdvdread
@@ -29,4 +39,4 @@ stdenv.mkDerivation rec {
     maintainers = [ lib.maintainers.wmertens ];
     platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
Fix : https://github.com/NixOS/nixpkgs/issues/465589
Diff : https://code.videolan.org/videolan/libdvdread/-/compare/6.1.3...7.0.1?from_project_id=76

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
