### PR TITLE
python3Packages.selectolax: 0.4.3 -> 0.4.4

### DIFF
--- a/pkgs/development/python-modules/selectolax/default.nix
+++ b/pkgs/development/python-modules/selectolax/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "selectolax";
-  version = "0.4.3";
+  version = "0.4.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "rushter";
     repo = "selectolax";
     tag = "v${version}";
-    hash = "sha256-1xoHMQzoO0NYi5gJsV++Ngvkaf/O3U14nYkJLvzzbrQ=";
+    hash = "sha256-Et4v105XW06uvzzwic2tBft8ljDurTWIiuKPjCXJbx8=";
   };
 
   patches = [
@@ -36,7 +36,16 @@ buildPythonPackage rec {
 
   buildInputs = [
     modest
-    lexbor
+    (lexbor.overrideAttrs (finalAttrs: {
+      version = "0-unstable-2025-11-24";
+      src = fetchFromGitHub {
+        owner = "lexbor";
+        repo = "lexbor";
+        rev = "7d726f1bed2f489e79751496c584304e6859ee1b";
+        hash = "sha256-vLP/YJWu1Z2kiT0sFLcMPjzMJHJe457oyPTIsxafTfc=";
+      };
+      meta.changelog = "https://github.com/lexbor/lexbor/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    }))
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
## Things done

closes #465916
This also updates lexbor to match the upstream revision of submodule. I've done it in-place, because the lexbor revision is not yet released.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
