### PR TITLE
python3Packages.wxpython: 4.2.3 -> 4.2.4

### DIFF
--- a/pkgs/development/python-modules/wxpython/4.2-ctypes.patch
+++ b/pkgs/development/python-modules/wxpython/4.2-ctypes.patch
@@ -1,8 +1,17 @@
 diff --git a/wx/lib/wxcairo/wx_pycairo.py b/wx/lib/wxcairo/wx_pycairo.py
-index 7cfe3071..24d1120f 100644
+index 19a28dd131f659cd596de280bc52f3f7fb1acb5f..dc6bea6afb36e4197fac990877b7112ade84d6f4 100644
 --- a/wx/lib/wxcairo/wx_pycairo.py
 +++ b/wx/lib/wxcairo/wx_pycairo.py
-@@ -197,7 +197,12 @@ def _findCairoLib():
+@@ -25,7 +25,7 @@ import ctypes.util
+ #----------------------------------------------------------------------------
+ 
+ # A reference to the cairo shared lib via ctypes.CDLL
+-cairoLib = None
++cairoLib = ctypes.CDLL("@libcairo@")
+ 
+ # A reference to the pycairo C API structure
+ pycairoAPI = None
+@@ -196,7 +196,11 @@ def _findCairoLib():
  
  # For other DLLs we'll just use a dictionary to track them, as there
  # probably isn't any need to use them outside of this module.
@@ -10,7 +19,6 @@ index 7cfe3071..24d1120f 100644
 +_dlls = {
 +    "gdk": ctypes.CDLL("@libgdk@"),
 +    "pangocairo": ctypes.CDLL("@libpangocairo@"),
-+    "cairoLib": ctypes.CDLL("@libcairo@"),
 +    "appsvc": ctypes.CDLL(None),
 +}
  

--- a/pkgs/development/python-modules/wxpython/4.2.nix
+++ b/pkgs/development/python-modules/wxpython/4.2.nix
@@ -53,9 +53,9 @@ buildPythonPackage rec {
 
   patches = [
     (replaceVars ./4.2-ctypes.patch {
-      libgdk = "${gtk3.out}/lib/libgdk-3.so";
-      libpangocairo = "${pango}/lib/libpangocairo-1.0.so";
-      libcairo = "${cairo}/lib/libcairo.so";
+      libgdk = "${lib.getLib gtk3}/lib/libgdk-3${stdenv.hostPlatform.extensions.sharedLibrary}";
+      libpangocairo = "${lib.getLib pango}/lib/libpangocairo-1.0${stdenv.hostPlatform.extensions.sharedLibrary}";
+      libcairo = "${lib.getLib cairo}/lib/libcairo${stdenv.hostPlatform.extensions.sharedLibrary}";
     })
     ./0001-add-missing-bool-c.patch # Add missing bool.c from old source
   ];

--- a/pkgs/development/python-modules/wxpython/4.2.nix
+++ b/pkgs/development/python-modules/wxpython/4.2.nix
@@ -4,11 +4,13 @@
   buildPythonPackage,
   setuptools,
   fetchPypi,
+  fetchpatch,
   replaceVars,
 
   # build
   autoPatchelfHook,
   attrdict,
+  cython,
   doxygen,
   pkg-config,
   python,
@@ -48,13 +50,12 @@
 
 buildPythonPackage rec {
   pname = "wxpython";
-  version = "4.2.3";
+  version = "4.2.4";
   format = "other";
 
   src = fetchPypi {
-    pname = "wxPython";
-    inherit version;
-    hash = "sha256-INbgySfifO2FZDcZvWPp9/1QHfbpqKqxSJsDmJf9fAE=";
+    inherit pname version;
+    hash = "sha256-LrEjl5yHvLMp6KJFImnWD/j59lHpvyXGdXnlPE67rjw=";
   };
 
   patches = [
@@ -64,6 +65,13 @@ buildPythonPackage rec {
       libcairo = "${lib.getLib cairo}/lib/libcairo${stdenv.hostPlatform.extensions.sharedLibrary}";
     })
     ./0001-add-missing-bool-c.patch # Add missing bool.c from old source
+    # TODO: drop when updating beyond version 4.2.4
+    # https://github.com/wxWidgets/Phoenix/pull/2822
+    (fetchpatch {
+      name = "Fix-wx.svg-to-work-with-cython-3.1-generated-code.patch";
+      url = "https://github.com/wxWidgets/Phoenix/commit/31303649ab0a0fed0789e0951a7487d172b65bfa.patch";
+      hash = "sha256-OAnAsyqHGPNEAiOxLLpdEGcd92K7TCxqEBYceuIb8so=";
+    })
   ];
 
   # https://github.com/wxWidgets/Phoenix/issues/2575
@@ -76,6 +84,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     attrdict
+    cython
     pkg-config
     requests
     setuptools


### PR DESCRIPTION
https://github.com/wxWidgets/Phoenix/blob/refs/tags/wxPython-4.2.4/CHANGES.rst
https://github.com/wxWidgets/Phoenix/compare/refs/tags/wxPython-4.2.3...refs/tags/wxPython-4.2.4

This enables tests on `x86_64-linux`.  Tests on `aarch64-linux` work locally, but are disabled as they seem to cause random failures on OfBorg.

This also corrects the following issues regarding references to libraries in `wx_pycairo.py`:
+ libpangocairo was referencing the library in an incorrect package output
+ the substitution for libcairo was not having the desired effect
+ the used library extensions were not correct on all platforms

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `48a473ee86cf6eee66cf64e69d0e72702d18986b`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 68 packages built:</summary>
  <ul>
    <li>asn1editor</li>
    <li>asn1editor.dist</li>
    <li>atopile (python313Packages.atopile)</li>
    <li>atopile.dist (python313Packages.atopile.dist)</li>
    <li>chirp</li>
    <li>chirp.dist</li>
    <li>displaycal</li>
    <li>displaycal.dist</li>
    <li>easyabc</li>
    <li>grass</li>
    <li>inkscape-extensions.inkstitch</li>
    <li>inkscape-extensions.silhouette</li>
    <li>inkscape-extensions.silhouette.dist</li>
    <li>interactive-html-bom</li>
    <li>interactive-html-bom.dist</li>
    <li>kicad</li>
    <li>kicad-small</li>
    <li>kicad-testing</li>
    <li>kicad-testing-small</li>
    <li>kicad-unstable</li>
    <li>kicad-unstable-small</li>
    <li>kicadAddons.kikit</li>
    <li>kicadAddons.kikit-library</li>
    <li>kikit</li>
    <li>kikit.dist</li>
    <li>loxodo</li>
    <li>loxodo.dist</li>
    <li>mavproxy</li>
    <li>mavproxy.dist</li>
    <li>meerk40t</li>
    <li>meerk40t.dist</li>
    <li>metamorphose2</li>
    <li>mymcplus</li>
    <li>mymcplus.dist</li>
    <li>pixelflasher</li>
    <li>playonlinux</li>
    <li>printrun</li>
    <li>printrun.dist</li>
    <li>pyfa</li>
    <li>python312Packages.fslpy</li>
    <li>python312Packages.fslpy.dist</li>
    <li>python312Packages.humblewx</li>
    <li>python312Packages.humblewx.dist</li>
    <li>python312Packages.kicad</li>
    <li>python312Packages.kicadcliwrapper</li>
    <li>python312Packages.kicadcliwrapper.dist</li>
    <li>python312Packages.pcbnewtransition</li>
    <li>python312Packages.pcbnewtransition.dist</li>
    <li>python312Packages.wxpython</li>
    <li>python313Packages.fslpy</li>
    <li>python313Packages.fslpy.dist</li>
    <li>python313Packages.humblewx</li>
    <li>python313Packages.humblewx.dist</li>
    <li>python313Packages.kicad</li>
    <li>python313Packages.kicadcliwrapper</li>
    <li>python313Packages.kicadcliwrapper.dist</li>
    <li>python313Packages.pcbnewtransition</li>
    <li>python313Packages.pcbnewtransition.dist</li>
    <li>python313Packages.wxpython</li>
    <li>quisk</li>
    <li>quisk.dist</li>
    <li>timeline</li>
    <li>trelby</li>
    <li>trelby.dist</li>
    <li>woeusb-ng</li>
    <li>woeusb-ng.dist</li>
    <li>yt-dlg</li>
    <li>yt-dlg.dist</li>
  </ul>
</details>

---
### `x86_64-darwin`
<details>
  <summary>:fast_forward: 24 packages marked as broken and skipped:</summary>
  <ul>
    <li>atopile</li>
    <li>atopile.dist</li>
    <li>kicad</li>
    <li>kicad-small</li>
    <li>kicad-testing</li>
    <li>kicad-testing-small</li>
    <li>kicad-unstable</li>
    <li>kicad-unstable-small</li>
    <li>kicadAddons.kikit</li>
    <li>kicadAddons.kikit-library</li>
    <li>kikit</li>
    <li>kikit.dist</li>
    <li>python312Packages.kicad</li>
    <li>python312Packages.kicadcliwrapper</li>
    <li>python312Packages.kicadcliwrapper.dist</li>
    <li>python312Packages.pcbnewtransition</li>
    <li>python312Packages.pcbnewtransition.dist</li>
    <li>python313Packages.atopile</li>
    <li>python313Packages.atopile.dist</li>
    <li>python313Packages.kicad</li>
    <li>python313Packages.kicadcliwrapper</li>
    <li>python313Packages.kicadcliwrapper.dist</li>
    <li>python313Packages.pcbnewtransition</li>
    <li>python313Packages.pcbnewtransition.dist</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 23 packages built:</summary>
  <ul>
    <li>asn1editor</li>
    <li>asn1editor.dist</li>
    <li>chirp</li>
    <li>chirp.dist</li>
    <li>grass</li>
    <li>inkscape-extensions.inkstitch</li>
    <li>mavproxy</li>
    <li>mavproxy.dist</li>
    <li>meerk40t</li>
    <li>meerk40t.dist</li>
    <li>mymcplus</li>
    <li>mymcplus.dist</li>
    <li>printrun</li>
    <li>printrun.dist</li>
    <li>python312Packages.humblewx</li>
    <li>python312Packages.humblewx.dist</li>
    <li>python312Packages.wxpython</li>
    <li>python313Packages.humblewx</li>
    <li>python313Packages.humblewx.dist</li>
    <li>python313Packages.wxpython</li>
    <li>timeline</li>
    <li>yt-dlg</li>
    <li>yt-dlg.dist</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc