### PR TITLE
python3Packages.graph-tool: fix build against Clang >= 21

### DIFF
--- a/pkgs/development/python-modules/graph-tool/default.nix
+++ b/pkgs/development/python-modules/graph-tool/default.nix
@@ -2,9 +2,10 @@
   buildPythonPackage,
   lib,
   fetchurl,
+  fetchpatch,
   stdenv,
 
-  boost,
+  boost189,
   cairomm,
   cgal,
   expat,
@@ -25,7 +26,17 @@
 }:
 
 let
-  boost' = boost.override {
+  boost' = boost189.override {
+    patches = [
+      # required to build against Clang >= 21 (https://github.com/boostorg/lexical_cast/pull/87)
+      # TODO: drop when upgrading to Boost >= 1.90
+      (fetchpatch {
+        name = "Reduce-dependency-on-Boost.TypeTraits-now-that-C-11-.patch";
+        url = "https://github.com/boostorg/lexical_cast/commit/8fc8a19931c8cb452400af907959fdacbbdd8ec1.patch";
+        relative = "include";
+        hash = "sha256-OO39ejR+I5ufjqinrMJ6HgjTE7Ph+XBu50PqcIKaIQo=";
+      })
+    ];
     enablePython = true;
     inherit python;
   };

--- a/pkgs/development/python-modules/graph-tool/default.nix
+++ b/pkgs/development/python-modules/graph-tool/default.nix
@@ -9,6 +9,7 @@
   cairomm,
   cgal,
   expat,
+  fontconfig,
   gobject-introspection,
   gtk3,
   llvmPackages,
@@ -99,7 +100,14 @@ buildPythonPackage rec {
 
   propagatedNativeBuildInputs = [ gobject-introspection ];
 
-  pythonImportsCheck = [ "graph_tool" ];
+  preInstallCheck =
+    # avoid warnings about Matplotlib and Fontconfig configuration issues
+    ''
+      export HOME=$(mktemp -d)
+      export FONTCONFIG_FILE=${fontconfig.out}/etc/fonts/fonts.conf
+    '';
+
+  pythonImportsCheck = [ "graph_tool.all" ];
 
   passthru.updateScript = gitUpdater {
     url = "https://git.skewed.de/count0/graph-tool";

--- a/pkgs/development/python-modules/graph-tool/default.nix
+++ b/pkgs/development/python-modules/graph-tool/default.nix
@@ -11,6 +11,7 @@
   expat,
   fontconfig,
   gobject-introspection,
+  graphviz,
   gtk3,
   llvmPackages,
   matplotlib,
@@ -58,6 +59,14 @@ buildPythonPackage rec {
       substituteInPlace configure \
         --replace-fail 'tput setaf $1' : \
         --replace-fail 'tput sgr0' :
+    ''
+    +
+    # hardcode path to graphviz library to avoid find_library, which would require setting LD_LIBRARY_PATH
+    ''
+      substituteInPlace src/graph_tool/draw/graphviz_draw.py \
+        --replace-fail \
+          'ctypes.util.find_library("gvc")' \
+          '"${lib.getLib graphviz}/lib/libgvc${stdenv.hostPlatform.extensions.sharedLibrary}"'
     '';
 
   configureFlags =

--- a/pkgs/development/python-modules/graph-tool/default.nix
+++ b/pkgs/development/python-modules/graph-tool/default.nix
@@ -44,25 +44,26 @@ in
 buildPythonPackage rec {
   pname = "graph-tool";
   version = "2.98";
-  format = "other";
+  pyproject = false;
 
   src = fetchurl {
     url = "https://downloads.skewed.de/graph-tool/graph-tool-${version}.tar.bz2";
     hash = "sha256-7vGUi5N/XwQ3Se7nX+DG1+jwNlUdlF6dVeN4cLBsxSc=";
   };
 
-  postPatch = ''
+  postPatch =
     # remove error messages about tput during build process without adding ncurses
-    substituteInPlace configure \
-      --replace-fail 'tput setaf $1' : \
-      --replace-fail 'tput sgr0' :
-  '';
+    ''
+      substituteInPlace configure \
+        --replace-fail 'tput setaf $1' : \
+        --replace-fail 'tput sgr0' :
+    '';
 
-  configureFlags = [
-    "--with-python-module-path=$(out)/${python.sitePackages}"
-    "--with-boost-libdir=${boost'}/lib"
-    "--with-cgal=${cgal}"
-  ];
+  configureFlags = lib.mapAttrsToList (lib.withFeatureAs true) {
+    boost-libdir = "${lib.getLib boost'}/lib";
+    cgal = lib.getDev cgal;
+    python-module-path = "$(out)/${python.sitePackages}";
+  };
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/python-modules/graph-tool/default.nix
+++ b/pkgs/development/python-modules/graph-tool/default.nix
@@ -59,11 +59,18 @@ buildPythonPackage rec {
         --replace-fail 'tput sgr0' :
     '';
 
-  configureFlags = lib.mapAttrsToList (lib.withFeatureAs true) {
-    boost-libdir = "${lib.getLib boost'}/lib";
-    cgal = lib.getDev cgal;
-    python-module-path = "$(out)/${python.sitePackages}";
-  };
+  configureFlags =
+    lib.mapAttrsToList (lib.withFeatureAs true) {
+      boost-libdir = "${lib.getLib boost'}/lib";
+      cgal = lib.getDev cgal;
+      python-module-path = "$(out)/${python.sitePackages}";
+    }
+    ++
+      lib.optionals stdenv.cc.isGNU
+        # enable GCC's link-time optimizer in order to reduce compilation time and memory usage during compilation
+        # https://graph-tool.skewed.de/installation.html#memory-requirements-for-compilation
+        # https://git.skewed.de/count0/graph-tool/-/issues/798#note_5626
+        [ "MOD_CXXFLAGS=-flto" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/python-modules/graph-tool/default.nix
+++ b/pkgs/development/python-modules/graph-tool/default.nix
@@ -9,7 +9,6 @@
   cairomm,
   cgal,
   expat,
-  gmp,
   gobject-introspection,
   gtk3,
   llvmPackages,
@@ -22,6 +21,7 @@
   python,
   scipy,
   sparsehash,
+  zstandard,
   gitUpdater,
 }:
 
@@ -74,26 +74,30 @@ buildPythonPackage rec {
 
   enableParallelBuilding = true;
 
-  build-system = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config ];
 
   # https://graph-tool.skewed.de/installation.html#manual-compilation
-  dependencies = [
+  buildInputs = [
     boost'
     cairomm
     cgal
     expat
-    gmp
-    gobject-introspection
+    mpfr
+    sparsehash
+  ]
+  ++ lib.optionals stdenv.cc.isClang [ llvmPackages.openmp ];
+
+  dependencies = [
     gtk3
     matplotlib
-    mpfr
     numpy
     pycairo
     pygobject3
     scipy
-    sparsehash
-  ]
-  ++ lib.optionals stdenv.cc.isClang [ llvmPackages.openmp ];
+    zstandard
+  ];
+
+  propagatedNativeBuildInputs = [ gobject-introspection ];
 
   pythonImportsCheck = [ "graph_tool" ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6422,7 +6422,7 @@ self: super: with self; {
 
   granian = callPackage ../development/python-modules/granian { };
 
-  graph-tool = callPackage ../development/python-modules/graph-tool { inherit (pkgs) cgal; };
+  graph-tool = callPackage ../development/python-modules/graph-tool { inherit (pkgs) cgal graphviz; };
 
   grapheme = callPackage ../development/python-modules/grapheme { };
 


### PR DESCRIPTION
This also contains the following improvements:
+ enables GCC's link-time optimizer in order to reduce compilation time and memory usage during compilation
+ enables graphviz support
+ performs more import checks
+ correctly categorizes dependencies

#457852

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc