### PR TITLE
hayase: init at 6.4.38

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13137,6 +13137,13 @@
     github = "JuliusFreudenberger";
     githubId = 13383409;
   };
+  juliuskreutz = {
+    name = "Julius Kreutz";
+    email = "julius@kreutz.dev";
+    github = "juliuskreutz";
+    githubId = 47820349;
+    keys = [ { fingerprint = "EBE7 5BC0 5820 6BC9 F440  895F F7D6 E464 4ACD 05A4"; } ];
+  };
   juliusrickert = {
     email = "nixpkgs@juliusrickert.de";
     github = "juliusrickert";

--- a/pkgs/by-name/ha/hayase/darwin.nix
+++ b/pkgs/by-name/ha/hayase/darwin.nix
@@ -1,0 +1,37 @@
+{
+  stdenvNoCC,
+  _7zz,
+  makeWrapper,
+
+  pname,
+  version,
+  src,
+  meta,
+  passthru,
+}:
+stdenvNoCC.mkDerivation {
+  inherit
+    pname
+    version
+    src
+    meta
+    passthru
+    ;
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [
+    _7zz
+    makeWrapper
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,Applications}
+    cp -r Hayase.app $out/Applications/
+    makeWrapper $out/Applications/Hayase.app/Contents/MacOS/Hayase $out/bin/hayase
+
+    runHook postInstall
+  '';
+}

--- a/pkgs/by-name/ha/hayase/linux.nix
+++ b/pkgs/by-name/ha/hayase/linux.nix
@@ -1,0 +1,29 @@
+{
+  appimageTools,
+
+  pname,
+  version,
+  src,
+  meta,
+  passthru,
+}:
+let
+  extracted = appimageTools.extractType2 { inherit pname version src; };
+in
+appimageTools.wrapType2 {
+  inherit
+    pname
+    version
+    src
+    meta
+    passthru
+    ;
+
+  extraInstallCommands = ''
+    mkdir -p $out/share/applications
+    cp -r ${extracted}/usr/share/icons $out/share/
+    cp ${extracted}/hayase.desktop $out/share/applications/
+    substituteInPlace $out/share/applications/hayase.desktop \
+      --replace-fail 'Exec=AppRun' 'Exec=hayase'
+  '';
+}

--- a/pkgs/by-name/ha/hayase/package.nix
+++ b/pkgs/by-name/ha/hayase/package.nix
@@ -1,0 +1,52 @@
+{
+  stdenvNoCC,
+  fetchurl,
+  lib,
+  nix-update-script,
+  callPackage,
+}:
+let
+  pname = "hayase";
+  version = "6.4.38";
+  src =
+    if stdenvNoCC.hostPlatform.isDarwin then
+      fetchurl {
+        url = "https://github.com/hayase-app/docs/releases/download/v${version}/mac-hayase-${version}-mac.dmg";
+        hash = "sha256-B2gAM2zPCBpsLCct/FND5wP7V/sbE+T171qze1teM5o=";
+      }
+    else
+      fetchurl {
+        url = "https://github.com/hayase-app/docs/releases/download/v${version}/linux-hayase-${version}-linux.AppImage";
+        hash = "sha256-Pu8Orfeiwd9QJFHgIa119WR/45cND64asz9KjU11W+k=";
+      };
+  meta = {
+    description = "Stream anime torrents instantly, real-time with no waiting for downloads to finish! 🍿";
+    homepage = "https://hayase.watch/";
+    license = lib.licenses.bsl11;
+    maintainers = [ lib.maintainers.juliuskreutz ];
+    platforms = [ "x86_64-linux" ] ++ lib.platforms.darwin;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    mainProgram = "hayase";
+  };
+  passthru.updateScript = nix-update-script { };
+in
+if stdenvNoCC.hostPlatform.isDarwin then
+  callPackage ./darwin.nix {
+    inherit
+      pname
+      version
+      src
+      meta
+      passthru
+      ;
+  }
+else
+  callPackage ./linux.nix {
+    inherit
+      pname
+      version
+      src
+      meta
+      passthru
+      ;
+  }


### PR DESCRIPTION
After the maintainer of Miru has removed himself (#416897) the miru package was also removed here https://github.com/NixOS/nixpkgs/commit/110fc438fdae42a9b3621c625a282221c6bcc463.

This package is the successor of Miru called [Hayase](https://hayase.watch).

Connected issue: #429674

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
