### PR TITLE
aitrack: 0.6.5 -> 0-unstable-2024-10-17

### DIFF
--- a/pkgs/by-name/ai/aitrack/package.nix
+++ b/pkgs/by-name/ai/aitrack/package.nix
@@ -7,21 +7,23 @@
   spdlog,
   onnxruntime,
   libsForQt5,
+  cmake,
 }:
 stdenv.mkDerivation {
   pname = "aitrack";
-  version = "0.6.5";
+  version = "0-unstable-2024-10-17";
 
   src = fetchFromGitHub {
-    owner = "mdk97";
-    repo = "aitrack-linux";
-    rev = "00bcca9b685abf3a19e4eab653198ca2b1895ae4";
-    sha256 = "sha256-pPvYVLUPYdjtJKdxqZI+JN7OZ4xw9gZ3baYTnJUSTGE=";
+    owner = "franzitrone";
+    repo = "aitrack";
+    rev = "fda5d6220046fcb74b41ff7a9e826002aae09b06";
+    sha256 = "sha256-LSVQwFX+rtnPz6kYFlrm9iphBOOGHaQsxjNSfUuFz3Q=";
   };
 
   nativeBuildInputs = [
     pkg-config
-    libsForQt5.qmake
+    cmake
+    libsForQt5.qt5.qttools
     libsForQt5.wrapQtAppsHook
   ];
 
@@ -37,9 +39,17 @@ stdenv.mkDerivation {
       --replace "/usr/share/" "$out/share/"
   '';
 
-  postInstall = ''
+  postBuild = ''
+    cp -r ../models models
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
     install -Dt $out/bin aitrack
     install -Dt $out/share/aitrack/models models/*
+
+    runHook postInstall
   '';
 
   meta = with lib; {


### PR DESCRIPTION
change source to https://github.com/franzitrone/aitrack
closes https://github.com/NixOS/nixpkgs/issues/415082

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
