### PR TITLE
python313Packages.python-openstackclient: add octaviaclient in openstack-full

### DIFF
--- a/pkgs/development/python-modules/python-octaviaclient/default.nix
+++ b/pkgs/development/python-modules/python-octaviaclient/default.nix
@@ -2,30 +2,21 @@
   lib,
   buildPythonPackage,
   cliff,
-  doc8,
-  docutils,
   fetchPypi,
-  hacking,
   keystoneauth1,
   makePythonPath,
   openstackdocstheme,
   installer,
   osc-lib,
-  oslotest,
   oslo-serialization,
   oslo-utils,
   pbr,
-  pygments,
   python-neutronclient,
-  python-openstackclient,
   requests,
-  requests-mock,
   setuptools,
   sphinx,
   sphinxcontrib-apidoc,
-  stestr,
-  subunit,
-  testscenarios,
+  callPackage,
 }:
 
 buildPythonPackage rec {
@@ -39,8 +30,8 @@ buildPythonPackage rec {
     hash = "sha256-5brfxkpJQousEcXl0YerzYDjrfl0XyWV0RXPTz146Y4=";
   };
 
-  # somehow python-neutronclient cannot be found despite it being supplied
-  pythonRemoveDeps = [ "python-neutronclient" ];
+  # NOTE(vinetos): This explicit dependency is removed to avoid infinite recursion
+  pythonRemoveDeps = [ "python-openstackclient" ];
 
   build-system = [
     setuptools
@@ -57,40 +48,18 @@ buildPythonPackage rec {
     cliff
     keystoneauth1
     python-neutronclient
-    python-openstackclient
     osc-lib
     oslo-serialization
     oslo-utils
     requests
   ];
 
-  preInstall = ''
-    # TODO: I have really no idea why installer is missing...
-    export PYTHONPATH=$PYTHONPATH:${makePythonPath [ installer ]}
-  '';
+  # Checks moved to 'passthru.tests' to workaround infinite recursion
+  doCheck = false;
 
-  nativeCheckInputs = [
-    hacking
-    requests-mock
-    doc8
-    docutils
-    pygments
-    subunit
-    oslotest
-    stestr
-    testscenarios
-  ];
-
-  checkPhase = ''
-    runHook preCheck
-
-    # TODO: no idea why PYTHONPATH is broken here
-    export PYTHONPATH=$PYTHONPATH:${makePythonPath nativeCheckInputs}
-
-    stestr run
-
-    runHook postCheck
-  '';
+  passthru.tests = {
+    tests = callPackage ./tests.nix { };
+  };
 
   pythonImportsCheck = [ "octaviaclient" ];
 

--- a/pkgs/development/python-modules/python-octaviaclient/tests.nix
+++ b/pkgs/development/python-modules/python-octaviaclient/tests.nix
@@ -1,0 +1,45 @@
+{
+  buildPythonPackage,
+  python-octaviaclient,
+  python-openstackclient,
+  hacking,
+  requests-mock,
+  doc8,
+  docutils,
+  pygments,
+  subunit,
+  oslotest,
+  stestr,
+  testscenarios,
+}:
+
+buildPythonPackage {
+  pname = "python-octaviaclient-tests";
+  inherit (python-octaviaclient) version src;
+  format = "other";
+
+  dontBuild = true;
+  dontInstall = true;
+
+  nativeCheckInputs = [
+    python-octaviaclient
+    python-openstackclient
+    hacking
+    requests-mock
+    doc8
+    docutils
+    pygments
+    subunit
+    oslotest
+    stestr
+    testscenarios
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    stestr run
+
+    runHook postCheck
+  '';
+}

--- a/pkgs/development/python-modules/python-openstackclient/default.nix
+++ b/pkgs/development/python-modules/python-openstackclient/default.nix
@@ -18,6 +18,7 @@
   python-manilaclient,
   python-mistralclient,
   python-neutronclient,
+  python-octaviaclient,
   python-openstackclient,
   python-watcherclient,
   python-zaqarclient,
@@ -89,6 +90,7 @@ buildPythonPackage rec {
       python-manilaclient
       python-mistralclient
       python-neutronclient
+      python-octaviaclient
       python-watcherclient
       python-zaqarclient
       python-zunclient


### PR DESCRIPTION
This MR resolves the infinite recursion issue caused by octaviaclient when added as an optional plugin to python-openstackclient, by relaxing its explicit dependency on python-openstackclient.

Since octaviaclient cannot function without being invocated from python-openstackclient, I think it is safe to remove this dependency from the explicit requirements : the execution context will already include it.

Additionally, I moved the tests to enable running the full test suite with python-openstackclient in the dependencies.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
