### PR TITLE
kdePackages.kdeconnect-kde: fix CVE-2025-66270

### DIFF
--- a/pkgs/kde/gear/kdeconnect-kde/default.nix
+++ b/pkgs/kde/gear/kdeconnect-kde/default.nix
@@ -10,6 +10,7 @@
   wayland,
   wayland-protocols,
   libfakekey,
+  fetchpatch,
 }:
 mkKdeDerivation {
   pname = "kdeconnect-kde";
@@ -17,6 +18,12 @@ mkKdeDerivation {
   patches = [
     (replaceVars ./hardcode-sshfs-path.patch {
       sshfs = lib.getExe sshfs;
+    })
+    # Fix CVE-2025-66270 (https://kde.org/info/security/advisory-20251128-1.txt)
+    (fetchpatch {
+      name = "CVE-2025-66270.patch";
+      url = "https://invent.kde.org/network/kdeconnect-kde/-/commit/4e53bcdd5d4c28bd9fefd114b807ce35d7b3373e.patch";
+      hash = "sha256-qtcXNJ5qL4xtZQ70R/wWVCzFGzXNltr6XTgs0fpkTi4=";
     })
   ];
 


### PR DESCRIPTION
Hi,

this applies a patch for a critical vulnerability in KDEConnect: https://kde.org/info/security/advisory-20251128-1.txt

The patch cleanly applies to both release-25.05 and release-25.11 so an automated backport for both branches would be great!

Note: The upcoming KDE Gear 25.12 release (-> https://github.com/NixOS/nixpkgs/pull/464987) includes the fix and should un-apply this PR.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable: Verified that the fix works.
- [x] Ran `nixpkgs-review` on this PR: Only impacts `kdePackages.kdeconnect-kde`
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
