### PR TITLE
simavr: add Patryk27 as maintainer

### DIFF
--- a/pkgs/development/tools/simavr/default.nix
+++ b/pkgs/development/tools/simavr/default.nix
@@ -21,6 +21,7 @@ let
       avrSuffixSalt = avrgcc.suffixSalt;
     };
   } ./setup-hook-darwin.sh;
+
 in
 stdenv.mkDerivation rec {
   pname = "simavr";
@@ -68,7 +69,10 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/buserror/simavr";
     license = licenses.gpl3;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ goodrone ];
-  };
 
+    maintainers = with maintainers; [
+      goodrone
+      patryk27
+    ];
+  };
 }


### PR DESCRIPTION
I'm the maintainer of [AVR backend in rustc](https://github.com/rust-lang/rust/blob/9050733395f7c10560d49f549e022f411fa28cea/src/doc/rustc/src/platform-support/avr-none.md), also got some projects that rely on simavr (e.g. [avr-tester](https://codeberg.org/pwy/avr-tester)), so it only makes sense I help out in nixpkgs as well 😄 