### PR TITLE
nixos/ollama: remove `acceleration` option in favor of setting `package`

### DIFF
--- a/nixos/modules/services/misc/ollama.nix
+++ b/nixos/modules/services/misc/ollama.nix
@@ -8,7 +8,7 @@ let
   inherit (lib) literalExpression types;
 
   cfg = config.services.ollama;
-  ollamaPackage = cfg.package.override { inherit (cfg) acceleration; };
+  ollama = lib.getExe cfg.package;
 
   staticUser = cfg.user != null && cfg.group != null;
 in
@@ -32,12 +32,33 @@ in
       ]
       "The `models` directory is now always writable. To make other directories writable, use `systemd.services.ollama.serviceConfig.ReadWritePaths`."
     )
+    (lib.mkRemovedOptionModule [
+      "services"
+      "ollama"
+      "acceleration"
+    ] "Set `services.ollama.package` to one of `pkgs.ollama[,-vulkan,-rocm,-cuda,-cpu]` instead.")
   ];
 
   options = {
     services.ollama = {
       enable = lib.mkEnableOption "ollama server for local large language models";
-      package = lib.mkPackageOption pkgs "ollama" { };
+      package = lib.mkPackageOption pkgs "ollama" {
+        example = "pkgs.ollama-rocm";
+        extraDescription = ''
+          Different packages use different hardware acceleration.
+
+          - `ollama`: default behavior; usually equivalent to `ollama-cpu`
+            - if `nixpkgs.config.rocmSupport` is enabled, is equivalent to `ollama-rocm`
+            - if `nixpkgs.config.cudaSupport` is enabled, is equivalent to `ollama-cuda`
+            - otherwise defaults to `false`
+          - `ollama-cpu`: disable GPU; only use CPU
+          - `ollama-rocm`: supported by most modern AMD GPUs
+            - may require overriding gpu type with `services.ollama.rocmOverrideGfx`
+              if rocm doesn't detect your AMD gpu
+          - `ollama-cuda`: supported by most modern NVIDIA GPUs
+          - `ollama-vulkan`: supported by most GPUs
+        '';
+      };
 
       user = lib.mkOption {
         type = with types; nullOr str;
@@ -97,32 +118,6 @@ in
         '';
       };
 
-      acceleration = lib.mkOption {
-        type = types.nullOr (
-          types.enum [
-            false
-            "rocm"
-            "cuda"
-            "vulkan"
-          ]
-        );
-        default = null;
-        example = "rocm";
-        description = ''
-          What interface to use for hardware acceleration.
-
-          - `null`: default behavior
-            - if `nixpkgs.config.rocmSupport` is enabled, uses `"rocm"`
-            - if `nixpkgs.config.cudaSupport` is enabled, uses `"cuda"`
-            - otherwise defaults to `false`
-          - `false`: disable GPU, only use CPU
-          - `"rocm"`: supported by most modern AMD GPUs
-            - may require overriding gpu type with `services.ollama.rocmOverrideGfx`
-              if rocm doesn't detect your AMD gpu
-          - `"cuda"`: supported by most modern NVIDIA GPUs
-          - `"vulkan"`: supported by most modern GPUs on Linux
-        '';
-      };
       rocmOverrideGfx = lib.mkOption {
         type = types.nullOr types.str;
         default = null;
@@ -152,6 +147,7 @@ in
           Since `ollama run` is mostly a shell around the ollama server, this is usually sufficient.
         '';
       };
+
       loadModels = lib.mkOption {
         type = types.listOf types.str;
         apply = builtins.filter (model: model != "");
@@ -180,6 +176,7 @@ in
           removing any models that are installed but not currently declared there.
         '';
       };
+
       openFirewall = lib.mkOption {
         type = types.bool;
         default = false;
@@ -224,7 +221,7 @@ in
         // {
           Type = "exec";
           DynamicUser = true;
-          ExecStart = "${lib.getExe ollamaPackage} serve";
+          ExecStart = "${ollama} serve";
           WorkingDirectory = cfg.home;
           StateDirectory = [ "ollama" ];
           ReadWritePaths = [
@@ -309,13 +306,11 @@ in
       script =
         let
           binaryInputs = lib.mapAttrs (_: lib.getExe) {
-            ollama = ollamaPackage;
             parallel = pkgs.parallel;
             awk = pkgs.gawk;
             sed = pkgs.gnused;
           };
           inherit (binaryInputs)
-            ollama
             parallel
             awk
             sed
@@ -355,7 +350,7 @@ in
 
     networking.firewall = lib.mkIf cfg.openFirewall { allowedTCPPorts = [ cfg.port ]; };
 
-    environment.systemPackages = [ ollamaPackage ];
+    environment.systemPackages = [ cfg.package ];
   };
 
   meta.maintainers = with lib.maintainers; [

--- a/nixos/tests/ollama-cuda.nix
+++ b/nixos/tests/ollama-cuda.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib, pkgs, ... }:
 {
   name = "ollama-cuda";
   meta.maintainers = with lib.maintainers; [ abysssol ];
@@ -7,7 +7,7 @@
     { ... }:
     {
       services.ollama.enable = true;
-      services.ollama.acceleration = "cuda";
+      services.ollama.package = pkgs.ollama-cuda;
     };
 
   testScript = ''

--- a/nixos/tests/ollama-rocm.nix
+++ b/nixos/tests/ollama-rocm.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib, pkgs, ... }:
 {
   name = "ollama-rocm";
   meta.maintainers = with lib.maintainers; [ abysssol ];
@@ -7,7 +7,7 @@
     { ... }:
     {
       services.ollama.enable = true;
-      services.ollama.acceleration = "rocm";
+      services.ollama.package = pkgs.ollama-rocm;
     };
 
   testScript = ''

--- a/nixos/tests/ollama-vulkan.nix
+++ b/nixos/tests/ollama-vulkan.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib, pkgs, ... }:
 {
   name = "ollama-vulkan";
   meta.maintainers = with lib.maintainers; [ abysssol ];
@@ -7,7 +7,7 @@
     { ... }:
     {
       services.ollama.enable = true;
-      services.ollama.acceleration = "vulkan";
+      services.ollama.package = pkgs.ollama-vulkan;
     };
 
   testScript = ''

--- a/pkgs/by-name/ol/ollama/package.nix
+++ b/pkgs/by-name/ol/ollama/package.nix
@@ -57,7 +57,7 @@ let
 
   rocmRequested = shouldEnable "rocm" config.rocmSupport;
   cudaRequested = shouldEnable "cuda" config.cudaSupport;
-  vulkanRequested = shouldEnable "vulkan" false;
+  vulkanRequested = acceleration == "vulkan";
 
   enableRocm = rocmRequested && stdenv.hostPlatform.isLinux;
   enableCuda = cudaRequested && stdenv.hostPlatform.isLinux;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -390,6 +390,7 @@ with pkgs;
 
   oletools = with python3.pkgs; toPythonApplication oletools;
 
+  ollama-cpu = callPackage ../by-name/ol/ollama/package.nix { acceleration = false; };
   ollama-rocm = callPackage ../by-name/ol/ollama/package.nix { acceleration = "rocm"; };
   ollama-cuda = callPackage ../by-name/ol/ollama/package.nix { acceleration = "cuda"; };
   ollama-vulkan = callPackage ../by-name/ol/ollama/package.nix { acceleration = "vulkan"; };


### PR DESCRIPTION
This removes the `acceleration` option. Setting `services.ollama.package` should have always been how the hardware acceleration was selected; it's more flexible, and more consistent with other modules. The `acceleration` option's implementation makes it impossible to use an unstable acceleration option in a stable `services.ollama` module; the module itself must be overridden with the unstable module, which is quite inconvenient, not user friendly, and not a widely known process.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
    - `nix build -f default.nix ollama.tests`
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
