### PR TITLE
kodiPackages.sendtokodi: add deno to the kodi `PATH`

### DIFF
--- a/pkgs/applications/video/kodi/addons/sendtokodi/default.nix
+++ b/pkgs/applications/video/kodi/addons/sendtokodi/default.nix
@@ -5,6 +5,7 @@
   kodi,
   inputstreamhelper,
   requests,
+  deno,
 }:
 
 buildKodiAddon rec {
@@ -38,6 +39,8 @@ buildKodiAddon rec {
     echo "${lib.strings.getVersion kodi.pythonPackages.yt-dlp}" >lib/yt_dlp_version
     ln -s ${kodi.pythonPackages.yt-dlp}/${kodi.pythonPackages.python.sitePackages}/yt_dlp lib/
   '';
+
+  passthru.pathPackages = [ deno ];
 
   meta = with lib; {
     homepage = "https://github.com/firsttris/plugin.video.sendtokodi";

--- a/pkgs/applications/video/kodi/wrapper.nix
+++ b/pkgs/applications/video/kodi/wrapper.nix
@@ -33,9 +33,9 @@ let
   # E.g. sendtokodi asks to add deno. See any addon that supplies `passthru.pathPackages`.
   pathPackages =
     let
-      addonsHavingPathPackages = lib.filter (addon: addon ? pathPackages) addons;
+      addonsHavingPathPackages = lib.filter (addon: addon ? passthru.pathPackages) addons;
     in
-    lib.flatten (map (addon: addon.pathPackages) addonsHavingPathPackages);
+    lib.flatten (map (addon: addon.passthru.pathPackages) addonsHavingPathPackages);
 in
 
 buildEnv {


### PR DESCRIPTION
I described the problem in https://github.com/NixOS/nixpkgs/issues/466006.

~~In my local testing, I didn't see the successful "solving JS challenge with deno" log entry, but I also didn't see any other log entries from yt-dlp.~~ Edit: with debug logging you can find the relevant line (see https://github.com/NixOS/nixpkgs/issues/466006#issuecomment-3592020101). However, this properly adds deno to the `PATH` of kodi (and kodi-standalone). With that, testing would be appreciated.

I'm also not happy with the `pathPackages` name. Please suggest a better name 🙃.

Closes https://github.com/NixOS/nixpkgs/issues/466006.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
