### PR TITLE
buildMix, mixRelease: Default to `__darwinAllowLocalNetworking = true`

### DIFF
--- a/pkgs/development/beam-modules/build-mix.nix
+++ b/pkgs/development/beam-modules/build-mix.nix
@@ -57,6 +57,8 @@ let
         MIX_DEBUG = if enableDebugInfo then 1 else 0;
         HEX_OFFLINE = 1;
 
+        __darwinAllowLocalNetworking = true;
+
         ERL_COMPILER_OPTIONS =
           let
             options = erlangCompilerOptions ++ lib.optionals erlangDeterministicBuilds [ "deterministic" ];

--- a/pkgs/development/beam-modules/mix-release.nix
+++ b/pkgs/development/beam-modules/mix-release.nix
@@ -129,6 +129,8 @@ stdenv.mkDerivation (
     MIX_DEBUG = if enableDebugInfo then 1 else 0;
     HEX_OFFLINE = 1;
 
+    __darwinAllowLocalNetworking = true;
+
     DEBUG = if enableDebugInfo then 1 else 0; # for Rebar3 compilation
     # The API with `mix local.rebar rebar path` makes a copy of the binary
     # some older dependencies still use rebar.


### PR DESCRIPTION
## Things done

Adds:

```nix
__darwinAllowLocalNetworking = true;
```

to `buildMix` and `mixRelease`, which allows darwin builds of mix packages to bind to the loopback device, a requirement that is so common for `buildMix` and `mixRelease` packages that it should be the default, seeing as a common downstream usecase for these functions is in tools like [deps_nix](https://github.com/code-supply/deps_nix). 

For context, see these [ci](https://hercules-ci.com/accounts/github/nix-community/derivations/%2Fnix%2Fstore%2Farw221m306zzazfl1cwv3psy5c3pci71-expo-1.1.1.drv/log?via-job=4a865498-d649-4973-b7ca-095041aafb44) [runs](https://hercules-ci.com/accounts/github/nix-community/derivations/%2Fnix%2Fstore%2F09d0dm8j8rzaimj3mgblc298wsb4lxrw-bun2nix_phoenix-0.1.0.drv/log?via-job=8a20a874-a398-4b90-89ca-e4b56c6a915f).


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
