### PR TITLE
libcddb: fix getsockopt type (socklen_t)

### DIFF
--- a/pkgs/by-name/li/libcddb/fix-getsockopt.patch
+++ b/pkgs/by-name/li/libcddb/fix-getsockopt.patch
@@ -1,0 +1,11 @@
+--- libcddb-original/lib/cddb_net.c     2025-11-28 17:17:41.878439664 +0000
++++ libcddb-fixed/lib/cddb_net.c        2025-11-28 17:35:16.257511694 +0000
+@@ -305,7 +305,7 @@
+             int rv;
+             fd_set wfds;
+             struct timeval tv;
+-            size_t l;
++            socklen_t l;
+ 
+             /* set up select time out */
+             tv.tv_sec = timeout;

--- a/pkgs/by-name/li/libcddb/package.nix
+++ b/pkgs/by-name/li/libcddb/package.nix
@@ -14,6 +14,10 @@ stdenv.mkDerivation rec {
     sha256 = "0fr21a7vprdyy1bq6s99m0x420c9jm5fipsd63pqv8qyfkhhxkim";
   };
 
+  patches = [
+    ./fix-getsockopt.patch
+  ];
+
   buildInputs = [ libiconv ];
 
   configureFlags = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [


### PR DESCRIPTION
###### Motivation for this change

The libcddb build was failing when building a new package that had it as a dependency due to incorrect type usage in `getsockopt()`. This patch replaces `size_t` with `socklen_t` for the length argument, which is the correct type per POSIX.

This resolves build issues on modern Linux systems.

Patch added: pkgs/by-name/li/libcddb/fix-getsockopt.patch

Changelog: libcddb: fix getsockopt type for compatibility


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

###### Things done
- [x] Added patch: `pkgs/by-name/li/libcddb/fix-getsockopt.patch`
- [x] Updated `package.nix` to apply the patch
- [x] Built and tested locally with `nix-build -A libcddb`
- [x] Verified patch applies cleanly and fixes the build

###### Meta
- [x] `meta.changelog` entry added: `libcddb: fix getsockopt type for compatibility`
- [ ] `meta.license` unchanged
- [ ] `meta.platforms` unchanged

###### Notes
This fix aligns libcddb with POSIX requirements and ensures compatibility with
glibc and modern Linux kernels.

---

**Changelog category:** Fixes  
**Changelog entry:** `libcddb: fix getsockopt type for compatibility`

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
