### PR TITLE
python3Packages.pytorch-lightning: 2.5.6 -> 2.6.0

### DIFF
--- a/pkgs/development/python-modules/gluonts/default.nix
+++ b/pkgs/development/python-modules/gluonts/default.nix
@@ -3,6 +3,9 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
+
+  # build-system
   setuptools,
 
   # dependencies
@@ -23,6 +26,7 @@
   matplotlib,
   pyarrow,
   statsmodels,
+  writableTmpDirAsHomeHook,
   which,
 }:
 
@@ -37,6 +41,16 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-h0+RYgGMz0gPchiKGIu0/NGcWBky5AWNTJKzoupn/iQ=";
   };
+
+  patches = [
+    # Fixes _pickle.UnpicklingError: Weights only load failed.
+    # https://github.com/awslabs/gluonts/pull/3269
+    (fetchpatch {
+      name = "fix-torch-load_from_checkpoint";
+      url = "https://github.com/awslabs/gluonts/pull/3269/commits/6420e75cfbeabcd94e2ff09dfed3b2eeb4881710.patch";
+      hash = "sha256-UeLjgKra+Y3uPoTBle+YCxD0a1ahu6d5anrMHn4HH2I=";
+    })
+  ];
 
   build-system = [
     setuptools
@@ -83,11 +97,10 @@ buildPythonPackage rec {
     matplotlib
     pyarrow
     statsmodels
+    writableTmpDirAsHomeHook
     which
   ]
   ++ optional-dependencies.torch;
-
-  preCheck = ''export HOME=$(mktemp -d)'';
 
   disabledTestPaths = [
     # requires `cpflows`, not in Nixpkgs

--- a/pkgs/development/python-modules/pytorch-lightning/default.nix
+++ b/pkgs/development/python-modules/pytorch-lightning/default.nix
@@ -24,14 +24,14 @@
 
 buildPythonPackage rec {
   pname = "pytorch-lightning";
-  version = "2.5.6";
+  version = "2.6.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Lightning-AI";
     repo = "pytorch-lightning";
     tag = version;
-    hash = "sha256-ojmE0d6Wy4UqQu4kBBE2qtQ4AYqplHOB7wJ7hEte664=";
+    hash = "sha256-zmFA9/tz0C06LmQ37wHeoR1kBHKdoz/D1cKWMoeWHzs=";
   };
 
   preConfigure = ''


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/Lightning-AI/pytorch-lightning/compare/2.5.6...2.6.0
Changelog: https://github.com/Lightning-AI/pytorch-lightning/releases/tag/2.6.0

cc @tbenst

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc