### PR TITLE
doc/rl-2511: alphabetize

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -34,40 +34,69 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- `nixVersions.nix_2_3` has been dropped because it was insecure and unmaintained.
+- `adminneo` has been updated to version 5.1.1. Version 5 breaks compatibility with `adminer` and changes how plugins and configuration work. See the [Upgrade Guide](https://www.adminneo.org/upgrade#v5.0.0) for details. Those changes also led to changes in the arguments of the package.
 
-- The minimum version of Nix required to evaluate Nixpkgs has been raised from 2.3 to 2.18.
+- `android-udev-rules` has been removed, as it is effectively superseded by built-in uaccess rules in systemd.
 
-- `mono4` and `mono5` have been removed. Use `mono6` or `mono` instead.
+- `ansible-later` has been removed because it was discontinued by the author.
+
+- `asciidoctor-with-extension` had its `asciidoctor-mathematical` extension removed, because it fails to build, and it is not maintained properly.
+
+- `base16-builder` node package has been removed due to lack of upstream maintenance.
+
+- `budgie-desktop` has been updated [10.9.4](https://github.com/BuddiesOfBudgie/budgie-desktop/releases/tag/v10.9.4). This changes `XDG_CURRENT_DESKTOP` from `Budgie:GNOME` to `Budgie` and contains ABI bumps for libpeas2 migration.
+
+- `buildGoModule` removes the compatibility layer of `CGO_ENABLED` not specified via `env`.
+  Specifying `CGO_ENABLED` directly now results in an error.
+
+- `buildGoModule` now warns if `<pkg>.passthru.overrideModAttrs` is lost during the overriding of its result packages.
+
+- `carla` no longer support `gtk2` override.
+
+- `conduwuit` was removed due to upstream ceasing development and deleting their repository. For existing data, a migration to `matrix-conduit`, `matrix-continuwuity` or `matrix-tuwunel` may be possible.
+
+- `conftest` since `0.60.0` has moved to use rego `v1` as default. To continue using `v0` use `--rego-version v0`. For more information about upgrading to Rego v1 syntax, see the [upstream docs](https://www.openpolicyagent.org/docs/latest/v0-upgrade/).
+
+- CUDA versions below 12.6 have been removed, as they are unmaintained upstream and depend on end‐of‐life compilers.
+
+- `cudaPackages.cudatoolkit-legacy-runfile` has been removed.
+
+- `ddccontrol` service now enables `hardware.i2c` by default, and adds `ddcci_backlight` to the kernel modules, based on [experiences reported on discourse](https://discourse.nixos.org/t/brightness-control-of-external-monitors-with-ddcci-backlight/8639/).
+
+- `deadbeef` no longer supports `gtk2`.
+
+- Derivations setting both `separateDebugInfo` and one of `allowedReferences`, `allowedRequisites`, `disallowedReferences` or `disallowedRequisites` must now set `__structuredAttrs` to `true`. The effect of reference whitelisting or blacklisting will be disabled on the `debug` output created by `separateDebugInfo`.
+
+- `emacs-macport` has been moved to a fork of Mitsuharu Yamamoto's patched source code starting with Emacs v30 as the original project seems to be currently dormant. All older versions of this package have been dropped.
+  This introduces some backwards‐incompatible changes; see the NEWS for details.
+  NEWS can be viewed from Emacs by typing `C-h n`, or by clicking `Help->Emacs News` from the menu bar.
+  It can also be browsed [online](https://git.savannah.gnu.org/cgit/emacs.git/tree/etc/NEWS?h=emacs-30).
 
 - Everything related to `bower` was removed, as it is deprecated and not used by anything in nixpkgs.
 
-- `reaction` has been updated to version 2, which includes some breaking changes.
-  For more information, [check the release article](https://blog.ppom.me/en-reaction-v2).
+- `fetchFromBitBucket` has gained a `fetchgit` backend when passing in git-related arguments similar to `fetchFromGitHub`.
 
-- `mealie` has been updated to 3.0.2: This update introduces breaking changes in some API endpoints (see the [release changelog](https://github.com/mealie-recipes/mealie/releases/tag/v3.0.0)).
+- `fetchtorrent`, when using the "rqbit" backend, erroneously started fetching files into a subdirectory in Nixpkgs 24.11.  The original behaviour &ndash; which matches the behaviour using the "transmission" backend &ndash; has now been restored.  Users reliant on the erroneous behaviour can temporarily maintain it by adding `flatten = false` to the `fetchtorrent` arguments; Nix will produce an evaluation warning for anyone using `backend = "rqbit"` without `flatten = true`.
 
-- The `offrss` package was removed due to lack of upstream maintenance since 2012. It's recommended for users to migrate to another RSS reader
+- `floorp` has been replaced with a binary build, available as `floorp-bin`. Due to major changes in the upstream project structure and build system, building Floorp from source has become unfeasible. No configuration or state migration is necessary.
 
-- `installShellFiles`: Allow installManPage to take a piped input, add the `--name` flag for renaming the file when installed. Can also append `--` to opt-out of all subsequent parsing.
+- `forgejo` main program has been renamed to `bin/forgejo` from the previous `bin/gitea`.
 
 - GCC 9, 10, 11, and 12 have been removed, as they have reached end‐of‐life upstream and are no longer supported.
 
-- LLVM 12, 13, 14, 15, 16, and 17 have been removed, as they have reached end‐of‐life upstream and are no longer supported.
-
-- The `vlock` output from kbd has been removed. Instead a new package `kbdVlock` has been introduced. Use this package now instead of the output.
+- `gentium` package now provides `Gentium-*.ttf` files, and not `GentiumPlus-*.ttf` files like before. The font identifiers `Gentium Plus*` are available in the `gentium-plus` package, and if you want to use the more recently updated package `gentium` [by SIL](https://software.sil.org/gentium/), you should update your configuration files to use the `Gentium` font identifier.
 
 - GHCJS 8.10, exposed via `haskell.compiler.ghcjs` and `haskell.compiler.ghcjs810`, has been removed. Downstream users should migrate their projects to the new JavaScript backend of GHC proper which can be used via `pkgsCross.ghcjs` from Nixpkgs. Haskell packaging code, like `haskellPackages.mkDerivation`, `ghcWithPackages` and `hoogleWithPackages`, also no longer supports GHCJS.
 
 - GHC 8.6, 8.10, 9.0, 9.2, and their package sets have been removed.
 
-- The `haskellPackages.mkDerivation` builder now converts packages' cabal files to Unix line endings before `patchPhase`. This behavior can be disabled using `dontConvertCabalFileToUnix`.
+- `gnome-keyring` no longer ships with an SSH agent anymore because it has been deprecated upstream. You should use `gcr_4` instead, which provides the same features. More information on why this was done can be found on [the relevant GCR upstream PR](https://gitlab.gnome.org/GNOME/gcr/-/merge_requests/67).
 
-- `webkitgtk_4_0` has been removed because it depends on an unmaintained version of security-critical libsoup library (`libsoup_2`) and the support will be [dropped upstream soon](https://webkitgtk.org/2025/10/07/webkitgtk-soup2-deprecation.html).
+- `go-mockery` has been updated to v3. For migration instructions see the [upstream documentation](https://vektra.github.io/mockery/latest/v3/). If v2 is still required `go-mockery_v2` has been added but will be removed on or before 2029-12-31 in-line with its [upstream support lifecycle](https://vektra.github.io/mockery/)
 
-- Support for bootstrapping native GHC compilers on 32‐bit ARM and little‐endian 64‐bit PowerPC has been dropped.
-  The latter was probably broken anyway.
-  If there is interest in restoring support for these architectures, it should be possible to cross‐compile a bootstrap GHC binary.
+- `gradience` has been removed because it was archived upstream.
+
+- Greetd and its original greeters (`tuigreet`, `gtkgreet`, `qtgreet`, `regreet`, `wlgreet`) were moved from `greetd` namespace to top level (`greetd.tuigreet` -> `tuigreet`, `greetd.greetd` -> `greetd`, etc). The original attrs are available for compatibility as passthrus of `greetd`, but will emit a warning. They will be removed in future releases.
 
 - `haskellPackages` and the package sets under `haskell.packages` no longer expose an `llvmPackages` attribute,
   though it can still be accessed via `ghc.llvmPackages` (from the same package set).
@@ -75,60 +104,147 @@
   backend even if NCG is available. In this case, it is best to use the `forceLlvmCodegenBackend` helper.
   In all other cases, like linking against `libLLVM`, Haskell packages should use the appropriate version of `llvmPackages` from `pkgs`.
 
-- `uw-ttyp0` has been updated to version 2.1. The filenames of the OTB and PSF fonts have been changed to match the upstream naming convention.
-  If you were loading a font by path, for example in the `console.font` NixOS option, remember to update the filename accordingly.
+- `hiawata` has been removed, due to lack of active development upstream, lack of maintainership downstream and upcoming security issues.
 
-- `adminneo` has been updated to version 5.1.1. Version 5 breaks compatibility with `adminer` and changes how plugins and configuration work. See the [Upgrade Guide](https://www.adminneo.org/upgrade#v5.0.0) for details. Those changes also led to changes in the arguments of the package.
+- `hsd` has been upgraded to version 8. See [their changelog](https://github.com/handshake-org/hsd/blob/v8.0.0/docs/release-notes/release-notes-8.x.md) for important instructions before upgrading.
 
-- `base16-builder` node package has been removed due to lack of upstream maintenance.
+- `inspircd` has been updated to the v4 release series. Please refer to the upstream documentation for [general information](https://docs.inspircd.org/4/overview/#v4-overview) and a list of [breaking changes](https://docs.inspircd.org/4/breaking-changes/).
 
-- The default glibc ELF ABI for the powerpc64-linux platform has been changed from ELFv2 back to ELFv1, due to the latter having less remaining issues when bootstrapping & building Nixpkgs packages on hardware.
-  If glibc ELFv2 is desired, use a fuller target triplet like `powerpc64-unknown-linux-gnuabielfv2` or the provided `ppc64-elfv2` platform example.
-
-- `python3Packages.bjoern` has been removed, as the upstream is unmaintained and it depends on a 14-year-old version of http-parser with numerous vulnerabilities.
-
-- `buildGoModule` removes the compatibility layer of `CGO_ENABLED` not specified via `env`.
-  Specifying `CGO_ENABLED` directly now results in an error.
-
-- `buildGoModule` now warns if `<pkg>.passthru.overrideModAttrs` is lost during the overriding of its result packages.
-
-- `gentium` package now provides `Gentium-*.ttf` files, and not `GentiumPlus-*.ttf` files like before. The font identifiers `Gentium Plus*` are available in the `gentium-plus` package, and if you want to use the more recently updated package `gentium` [by SIL](https://software.sil.org/gentium/), you should update your configuration files to use the `Gentium` font identifier.
-
-- `space-orbit` package has been removed due to lack of upstream maintenance. Debian upstream stopped tracking it in 2011.
-
-- Derivations setting both `separateDebugInfo` and one of `allowedReferences`, `allowedRequisites`, `disallowedReferences` or `disallowedRequisites` must now set `__structuredAttrs` to `true`. The effect of reference whitelisting or blacklisting will be disabled on the `debug` output created by `separateDebugInfo`.
-
-- `k2pdfopt` has been removed, as it's broken.
-
-- `victoriametrics` no longer contains VictoriaLogs components. These have been separated into the new package `victorialogs`.
-
-- `mx-puppet-discord` was removed from Nixpkgs along with its NixOS module as it was unmaintained and was the only user of sha1 hashes in tree.
-
-- `notary` has been removed because it was [archived upstream](https://github.com/notaryproject/.github/issues/70). Upstream recommends [`notation`](https://github.com/notaryproject/notation/) instead.
-
-- `gradience` has been removed because it was archived upstream.
+- `installShellFiles`: Allow installManPage to take a piped input, add the `--name` flag for renaming the file when installed. Can also append `--` to opt-out of all subsequent parsing.
 
 - `kbd` package's `outputs` now include a `man` and `scripts` outputs. The `unicode_start` and `unicode_stop` Bash scripts are now part of the `scripts` output, allowing most usages of the `kbd` package to not pull in `bash`.
 
+- `k2pdfopt` has been removed, as it's broken.
+
+- `k3s` airgap images passthru attributes have changed:
+  - `imagesList` was removed
+  - `airgapImages` was renamed to `airgap-images`
+  - `airgapImagesAmd64` was renamed to `airgap-images-amd64-tar-zst`
+  - `airgapImagesArm64` was renamed to `airgap-images-arm64-tar-zst`
+  - `airgapImagesArm` was renamed to `airgap-images-arm-tar-zst`
+
+- LLVM 12, 13, 14, 15, 16, and 17 have been removed, as they have reached end‐of‐life upstream and are no longer supported.
+
+- `lima` package now only includes the guest agent for the host's architecture by default. If your guest VM's architecture differs from your Lima host's, you'll need to enable the `lima-additional-guestagents` package by setting `withAdditionalGuestAgents = true` when overriding lima with this input.
+
+- `libpinyin`, which is used for Chinese character input, has migrated from the unmaintained BDB database format to the newer KyotoCabinet database format. If you want to migrate your user input statistics you can consider using [bdbtokyotodb](https://codeberg.org/raboof/bdbtokyotodb).
+
+- `linux` and all other Linux kernel packages have moved all in-tree kernel modules into a new `modules` output.
+
+- `lxde` scope has been removed, and its packages have been moved the top-level.
+
+- `mariadb` now defaults to `mariadb_114` instead of `mariadb_1011`, meaning the default version was upgraded from 10.11.x to 11.4.x. See the [upgrade notes](https://mariadb.com/kb/en/upgrading-from-mariadb-10-11-to-mariadb-11-4/) for potential issues.
+
+- `mealie` has been updated to 3.0.2: This update introduces breaking changes in some API endpoints (see the [release changelog](https://github.com/mealie-recipes/mealie/releases/tag/v3.0.0)).
+
+- `meilisearch_1_11` has been removed, as it is no longer supported.
+
+- `moar` has been updated from `1.33.0` to `2.0.0`, and renamed to `moor` following an upstream decision. See the [release notes](https://github.com/walles/moor/releases/tag/v2.0.0) for more.
+
+- `mongodb-6_0` was removed as it is end of life as of 2025-07-31.
+
+- `mono4` and `mono5` have been removed. Use `mono6` or `mono` instead.
+
+- `mx-puppet-discord` was removed from Nixpkgs along with its NixOS module as it was unmaintained and was the only user of sha1 hashes in tree.
+
+- `navidrome` 0.58.0 introduces [multi-library support](https://www.navidrome.org/docs/usage/multi-library/)
+    and backwards incompatible database migrations. Ensure backups are valid and run a Full Scan after
+    starting the new version.
+
+- NetBox was updated to `>= 4.4.0`. Have a look at the breaking changes
+  of the [4.3 release](https://github.com/netbox-community/netbox/releases/tag/v4.3.0)
+  and the [4.4 release](https://github.com/netbox-community/netbox/releases/tag/v4.4.0),
+  make the required changes to your database, if needed, then upgrade by setting `services.netbox.package = pkgs.netbox_4_4;` in your configuration.
+
+- `neovimUtils.makeNeovimConfig` now uses `customLuaRC` parameter instead of accepting `luaRcContent`. The old usage is deprecated but still works with a warning.
+
+- `nixVersions.nix_2_3` has been dropped because it was insecure and unmaintained.
+
+- `nodePackages.rimraf` has been removed, as it is a Javascript library, and packages that want to use it should depend directly on it instead.
+
+- `notary` has been removed because it was [archived upstream](https://github.com/notaryproject/.github/issues/70). Upstream recommends [`notation`](https://github.com/notaryproject/notation/) instead.
+
+- `nuget-to-nix` has been removed as it was deprecated in favor of `nuget-to-json`. Out-of-tree packages that were using `nuget-to-nix` should migrate to use `nuget-to-json` instead for generating .NET dependency lock files.
+
+- `odoo16` has been dropped due to end of support by upstream, consider upgrading supported version.
+
+- `oink` service no longer accepts `settings.apiKey` and `settings.secretApiKey` options as these have been replaced by `apiKeyFile` and `secretApiKeyFile`.
+
+- `opensoldat` binaries and user configuration directory names have been prefixed by 'open', becoming opensoldat and opensoldatserver. Configuration will be moved automatically before launch when possible.
+
+- `pcp` has been removed because the upstream repo was archived and it hasn't been updated since 2021.
+
+- `podofo` has been updated from `0.9.8` to `1.0.0`. These releases are by nature very incompatible due to major API changes. The legacy versions can be found under `podofo_0_10` and `podofo_0_9`.
+  Changelog: https://github.com/podofo/podofo/blob/1.0.0/CHANGELOG.md, API-Migration-Guide: https://github.com/podofo/podofo/blob/1.0.0/API-MIGRATION.md.
+
+- `privatebin` has been updated to `2.0.0`. This release changes configuration defaults including switching the template and removing legacy features. See the [v2.0.0 changelog entry](https://github.com/PrivateBin/PrivateBin/releases/tag/2.0.0) for details on how to upgrade.
+
+- [private-gpt](https://github.com/zylon-ai/private-gpt) service has been removed by lack of maintenance upstream.
+
+- `proton-caller` has been removed due to lack of upstream maintenance.
+
+- `prometheus-script-exporter` has been updated to use a new maintained alternative. This release updates from `1.2.0 -> 3.0.1` and largely changes configuration options formats from json to yaml, among other changes.
+
+- `pulsemeeter` has been updated to `2.0.0`. The configuration file from older versions has to be deleted. For more information and instructions see the [v2.0.0 changelog entry](https://github.com/theRealCarneiro/pulsemeeter/releases/tag/v2.0.0).
+
+- `purple-matrix` has been removed, since it has been unmaintained since April 2022 and upstream does not recommend using it anymore.
+
+- `python3Full` and its versioned attributes (python3xxFull) have been removed. Bluetooth support is now enabled in the default python3 attributes. The X11 support built the tkinter module, which is available as a dedicated attribute on the package set.
+
+- `python3Packages.bjoern` has been removed, as the upstream is unmaintained and it depends on a 14-year-old version of http-parser with numerous vulnerabilities.
+
+- `python3Packages.duckduckgo-search` has been updated to v9+ and therefore has been renamed to ddgs.
+  Use `python3Packages.ddgs` instead.
+
+- `python3Packages.heif-image-plugin` has been dropped due to lack of upstream maintenance and breakage. Use `python3Packages.pillow-heif` instead.
+
+- `python3Packages.triton` no longer takes an `enableRocm` argument and supports ROCm in all build configurations via runtime binding. In most cases no action will be needed. If triton is unable to find the HIP SDK add `rocmPackages.clr` as a build input or set the environment variable `HIP_PATH="${rocmPackages.clr}"`.
+
+- `python3Packages.pyheif` has been dropped due to lack of upstream maintenance and breakage. Use `python3Packages.pillow-heif` instead.
+
+- `python3Packages.pyocr` no longer supports `cuneiform` on Linux by default. It is still possible to enable it using `withCuneiformSupport` override.
+
+- `qt5.full` and `qt6.full` aliases have been removed. Their use has always been discouraged, and downstream projects should use `qtN.env` with the right set of packages.
+  See [release note for v9.0.0](https://github.com/deedy5/ddgs/releases/tag/v9.0.0)
+
+- `rabbitmq-server` has been updated from 4.0.9 to 4.1.4. The 4.1.0 release includes breaking changes. For more information read the [changelog of 4.1.0](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.1.0)
+
+- `reaction` has been updated to version 2, which includes some breaking changes.
+  For more information, [check the release article](https://blog.ppom.me/en-reaction-v2).
+
+- `rocmPackages.triton` has been removed in favor of `python3Packages.triton`.
+
+- `rofi` has been updated to `2.0.0`. `rofi-wayland` and `rofi-wayland-unwrapped` have been merged into `rofi` and `rofi-unwrapped` respectively. For more information and instructions see the [v2.0.0 changelog entry](https://github.com/davatorium/rofi/releases/tag/2.0.0).
+
+- `rofi-emoji-wayland` has been merged into `rofi-emoji` as `rofi` has been updated to `2.0.0` and supports both X11 & Wayland.
+
+- `sail-riscv` 0.8 follows [upstream](https://github.com/riscv/sail-riscv/blob/7cc4620eb1a57bfe04832baccdcf5727e9459bd4/doc/ChangeLog.md) and provides only a single binary, `sail_riscv_sim`.
+
+- `space-orbit` package has been removed due to lack of upstream maintenance. Debian upstream stopped tracking it in 2011.
+
 - `spidermonkey_91` has been removed, as it has been EOL since September 2022.
 
-- `ddccontrol` service now enables `hardware.i2c` by default, and adds `ddcci_backlight` to the kernel modules, based on [experiences reported on discourse](https://discourse.nixos.org/t/brightness-control-of-external-monitors-with-ddcci-backlight/8639/).
+- `stalwart-mail` since `0.13.0` "introduces a significant redesign of the MTA’s delivery and queueing subsystem". See [the upgrading announcement for the `0.13.0` release](https://github.com/stalwartlabs/stalwart/blob/89b561b5ca1c5a11f2a768b4a2cfef0f473b7a01/UPGRADING.md#upgrading-from-v012x-and-v011x-to-v013x).
 
-- The license of duckstation has changed from `gpl3Only` to `cc-by-nc-nd-40` making it unfree in newer releases. The `duckstation` package has been overhauled to support the new releases and `duckstation-bin` has been aliased to `duckstation` to support darwin binary builds.
+- `stdenv.mkDerivation` and other derivation builders that use it no longer allow the value of `env` to be anything but an attribute set, for the purpose of setting environment variables that are available to the [builder](https://nix.dev/manual/nix/latest/store/derivation/#builder) process. An environment variable called `env` can still be provided by means of `mkDerivation { env.env = ...; }`, though we recommend to use a more specific name than "env".
 
-- `hiawata` has been removed, due to lack of active development upstream, lack of maintainership downstream and upcoming security issues.
+- `steamcontroller` has been removed due to lack of upstream maintenance. Consider using `sc-controller` instead.
 
-- `forgejo` main program has been renamed to `bin/forgejo` from the previous `bin/gitea`.
+- `sublime-music` has been removed because upstream has announced it is no longer maintained. Upstream suggests using `supersonic` instead.
 
-- the "pie" hardening flag has been removed. compilers are expected to enable PIE by default, as has been common practice since 2016 outside of nixpkgs. If a package needs "pie" disabled pass `-no-pie` in `CFLAGS`. It is unlikely this will be necessary in many cases; due to the prevalance of default PIE toolchains most packages incompatible with PIE already pass no-pie.
+- Support for bootstrapping native GHC compilers on 32‐bit ARM and little‐endian 64‐bit PowerPC has been dropped.
+  The latter was probably broken anyway.
+  If there is interest in restoring support for these architectures, it should be possible to cross‐compile a bootstrap GHC binary.
 
-- `wayclip` now uses the `ext-data-control-v1` Wayland protocol instead of `wlr-data-control-unstable-v1`.
+- `telegram-desktop` packages now uses `Telegram` for its binary. The previous name was `telegram-desktop`. This is due to [an upstream decision](https://github.com/telegramdesktop/tdesktop/commit/56ff5808a3d766f892bc3c3305afb106b629ef6f) to make the name consistent with other platforms.
 
-- `cudaPackages.cudatoolkit-legacy-runfile` has been removed.
+- The `archipelago-minecraft` package was removed, as upstream no longer provides support for the Minecraft APWorld.
 
-- `conduwuit` was removed due to upstream ceasing development and deleting their repository. For existing data, a migration to `matrix-conduit`, `matrix-continuwuity` or `matrix-tuwunel` may be possible.
+- The default Android NDK version has been raised to 27, and the default SDK version to 35.
+  NDK 21–26 have been removed, as they are end‐of‐life.
 
-- `asciidoctor-with-extension` had its `asciidoctor-mathematical` extension removed, because it fails to build, and it is not maintained properly.
+- The default glibc ELF ABI for the powerpc64-linux platform has been changed from ELFv2 back to ELFv1, due to the latter having less remaining issues when bootstrapping & building Nixpkgs packages on hardware.
+  If glibc ELFv2 is desired, use a fuller target triplet like `powerpc64-unknown-linux-gnuabielfv2` or the provided `ppc64-elfv2` platform example.
 
 - The `ghcInfo` and `controlPhases` functions have been removed from `haskell.lib.compose` and `haskell.lib`. They were unused and would return incorrect results.
 
@@ -138,207 +254,83 @@
   - To find a suitable `nativeGhc`, `buildHaskellPackages` should be used. `ghcInfo` would use `ghc.bootPkgs.ghc` if cross compiling,
     and the given `ghc` otherwise. This approach is not recommended since it results in mismatched GHC versions.
 
-- `gnome-keyring` no longer ships with an SSH agent anymore because it has been deprecated upstream. You should use `gcr_4` instead, which provides the same features. More information on why this was done can be found on [the relevant GCR upstream PR](https://gitlab.gnome.org/GNOME/gcr/-/merge_requests/67).
+- The `haskellPackages.mkDerivation` builder now converts packages' cabal files to Unix line endings before `patchPhase`. This behavior can be disabled using `dontConvertCabalFileToUnix`.
 
-- `python3Full` and its versioned attributes (python3xxFull) have been removed. Bluetooth support is now enabled in the default python3 attributes. The X11 support built the tkinter module, which is available as a dedicated attribute on the package set.
+- The license of duckstation has changed from `gpl3Only` to `cc-by-nc-nd-40` making it unfree in newer releases. The `duckstation` package has been overhauled to support the new releases and `duckstation-bin` has been aliased to `duckstation` to support darwin binary builds.
 
-- `stdenv.mkDerivation` and other derivation builders that use it no longer allow the value of `env` to be anything but an attribute set, for the purpose of setting environment variables that are available to the [builder](https://nix.dev/manual/nix/latest/store/derivation/#builder) process. An environment variable called `env` can still be provided by means of `mkDerivation { env.env = ...; }`, though we recommend to use a more specific name than "env".
+- The main binary of `tomlq` has been renamed from `tomlq` to `tq`.
 
-- `purple-matrix` has been removed, since it has been unmaintained since April 2022 and upstream does not recommend using it anymore.
+- The minimum version of Nix required to evaluate Nixpkgs has been raised from 2.3 to 2.18.
 
-- `sublime-music` has been removed because upstream has announced it is no longer maintained. Upstream suggests using `supersonic` instead.
+- The `offrss` package was removed due to lack of upstream maintenance since 2012. It's recommended for users to migrate to another RSS reader
 
-- The default Android NDK version has been raised to 27, and the default SDK version to 35.
-  NDK 21–26 have been removed, as they are end‐of‐life.
+- The `pie` hardening flag has been removed. compilers are expected to enable PIE by default, as has been common practice since 2016 outside of nixpkgs. If a package needs `pie` disabled pass `-no-pie` in `CFLAGS`. It is unlikely this will be necessary in many cases; due to the prevalance of default PIE toolchains most packages incompatible with PIE already pass no-pie.
 
-- `nuget-to-nix` has been removed as it was deprecated in favor of `nuget-to-json`. Out-of-tree packages that were using `nuget-to-nix` should migrate to use `nuget-to-json` instead for generating .NET dependency lock files.
-
-- `conftest` since `0.60.0` has moved to use rego `v1` as default. To continue using `v0` use `--rego-version v0`. For more information about upgrading to Rego v1 syntax, see the [upstream docs](https://www.openpolicyagent.org/docs/latest/v0-upgrade/).
-
-- Zig 0.12 has been removed.
-
-- `ansible-later` has been removed because it was discontinued by the author.
-
-- `k3s` airgap images passthru attributes have changed:
-  - `imagesList` was removed
-  - `airgapImages` was renamed to `airgap-images`
-  - `airgapImagesAmd64` was renamed to `airgap-images-amd64-tar-zst`
-  - `airgapImagesArm64` was renamed to `airgap-images-arm64-tar-zst`
-  - `airgapImagesArm` was renamed to `airgap-images-arm-tar-zst`
-
-- `stalwart-mail` since `0.13.0` "introduces a significant redesign of the MTA’s delivery and queueing subsystem". See [the upgrading announcement for the `0.13.0` release](https://github.com/stalwartlabs/stalwart/blob/89b561b5ca1c5a11f2a768b4a2cfef0f473b7a01/UPGRADING.md#upgrading-from-v012x-and-v011x-to-v013x).
-
-- `meilisearch_1_11` has been removed, as it is no longer supported.
-
-- `budgie-desktop` has been updated [10.9.4](https://github.com/BuddiesOfBudgie/budgie-desktop/releases/tag/v10.9.4). This changes `XDG_CURRENT_DESKTOP` from `Budgie:GNOME` to `Budgie` and contains ABI bumps for libpeas2 migration.
-
-- Greetd and its original greeters (`tuigreet`, `gtkgreet`, `qtgreet`, `regreet`, `wlgreet`) were moved from `greetd` namespace to top level (`greetd.tuigreet` -> `tuigreet`, `greetd.greetd` -> `greetd`, etc). The original attrs are available for compatibility as passthrus of `greetd`, but will emit a warning. They will be removed in future releases.
-
-- `carla` no longer support `gtk2` override.
-
-- The `archipelago-minecraft` package was removed, as upstream no longer provides support for the Minecraft APWorld.
-
-- `pcp` has been removed because the upstream repo was archived and it hasn't been updated since 2021.
-
-- `navidrome` 0.58.0 introduces [multi-library support](https://www.navidrome.org/docs/usage/multi-library/)
-    and backwards incompatible database migrations. Ensure backups are valid and run a Full Scan after
-    starting the new version.
-
-- `deabbeef` no longer support `gtk2`.
+- The `vlock` output from kbd has been removed. Instead a new package `kbdVlock` has been introduced. Use this package now instead of the output.
 
 - `tooling-language-server` has been renamed to `deputy` (both the package and binary), following the rename of the upstream project.
 
-- `fetchFromBitBucket` has gained a `fetchgit` backend when passing in git-related arguments similar to `fetchFromGitHub`.
+- `victoriametrics` no longer contains VictoriaLogs components. These have been separated into the new package `victorialogs`.
 
-- `fetchtorrent`, when using the "rqbit" backend, erroneously started fetching files into a subdirectory in Nixpkgs 24.11.  The original behaviour &ndash; which matches the behaviour using the "transmission" backend &ndash; has now been restored.  Users reliant on the erroneous behaviour can temporarily maintain it by adding `flatten = false` to the `fetchtorrent` arguments; Nix will produce an evaluation warning for anyone using `backend = "rqbit"` without `flatten = true`.
+- `vmware-horizon-client` was renamed to `omnissa-horizon-client`, following [VMware's sale of their end-user business to Omnissa](https://www.omnissa.com/insights/introducing-omnissa-the-former-vmware-end-user-computing-business/). The binary has been renamed from `vmware-view` to `horizon-client`.
 
-- `steamcontroller` has been removed due to lack of upstream maintenance. Consider using `sc-controller` instead.
+- `uw-ttyp0` has been updated to version 2.1. The filenames of the OTB and PSF fonts have been changed to match the upstream naming convention.
+  If you were loading a font by path, for example in the `console.font` NixOS option, remember to update the filename accordingly.
 
-- `linux` and all other Linux kernel packages have moved all in-tree kernel modules into a new `modules` output.
+- `wayclip` now uses the `ext-data-control-v1` Wayland protocol instead of `wlr-data-control-unstable-v1`.
 
 - `webfontkitgenerator` has been renamed to `webfont-bundler`, following the rename of the upstream project.
   The binary name remains `webfontkitgenerator`.
   The `webfontkitgenerator` package is an alias to `webfont-bundler`.
 
-- `python3Packages.triton` no longer takes an `enableRocm` argument and supports ROCm in all build configurations via runtime binding. In most cases no action will be needed. If triton is unable to find the HIP SDK add `rocmPackages.clr` as a build input or set the environment variable `HIP_PATH="${rocmPackages.clr}"`.
-
-- `floorp` has been replaced with a binary build, available as `floorp-bin`. Due to major changes in the upstream project structure and build system, building Floorp from source has become unfeasible. No configuration or state migration is necessary.
-
-- `inspircd` has been updated to the v4 release series. Please refer to the upstream documentation for [general information](https://docs.inspircd.org/4/overview/#v4-overview) and a list of [breaking changes](https://docs.inspircd.org/4/breaking-changes/).
-
-- `proton-caller` has been removed due to lack of upstream maintenance.
-
-- `android-udev-rules` has been removed, as it is effectively superseded by built-in uaccess rules in systemd.
-
-- `lima` package now only includes the guest agent for the host's architecture by default. If your guest VM's architecture differs from your Lima host's, you'll need to enable the `lima-additional-guestagents` package by setting `withAdditionalGuestAgents = true` when overriding lima with this input.
-
-- `mongodb-6_0` was removed as it is end of life as of 2025-07-31.
-
-- CUDA versions below 12.6 have been removed, as they are unmaintained upstream and depend on end‐of‐life compilers.
-
-- `vmware-horizon-client` was renamed to `omnissa-horizon-client`, following [VMware's sale of their end-user business to Omnissa](https://www.omnissa.com/insights/introducing-omnissa-the-former-vmware-end-user-computing-business/). The binary has been renamed from `vmware-view` to `horizon-client`.
+- `webkitgtk_4_0` has been removed because it depends on an unmaintained version of security-critical libsoup library (`libsoup_2`) and the support will be [dropped upstream soon](https://webkitgtk.org/2025/10/07/webkitgtk-soup2-deprecation.html).
 
 - `yggdrasil-jumper` has been updated to v0.4, changing traversal protocol. See [release notes](https://github.com/one-d-wide/yggdrasil-jumper/releases/tag/v0.4.0).
 
-- `neovimUtils.makeNeovimConfig` now uses `customLuaRC` parameter instead of accepting `luaRcContent`. The old usage is deprecated but still works with a warning.
-
-- `python3Packages.pyocr` no longer supports `cuneiform` on Linux by default. It is still possible to enable it using `withCuneiformSupport` override.
-
-- `telegram-desktop` packages now uses `Telegram` for its binary. The previous name was `telegram-desktop`. This is due to [an upstream decision](https://github.com/telegramdesktop/tdesktop/commit/56ff5808a3d766f892bc3c3305afb106b629ef6f) to make the name consistent with other platforms.
-
-- `hsd` has been upgraded to version 8. See [their changelog](https://github.com/handshake-org/hsd/blob/v8.0.0/docs/release-notes/release-notes-8.x.md) for important instructions before upgrading.
-
-- `sail-riscv` 0.8 follows [upstream](https://github.com/riscv/sail-riscv/blob/7cc4620eb1a57bfe04832baccdcf5727e9459bd4/doc/ChangeLog.md) and provides only a single binary, `sail_riscv_sim`.
-
-- `moar` has been updated from `1.33.0` to `2.0.0`, and renamed to `moor` following an upstream decision. See the [release notes](https://github.com/walles/moor/releases/tag/v2.0.0) for more.
-
-- `podofo` has been updated from `0.9.8` to `1.0.0`. These releases are by nature very incompatible due to major API changes. The legacy versions can be found under `podofo_0_10` and `podofo_0_9`.
-  Changelog: https://github.com/podofo/podofo/blob/1.0.0/CHANGELOG.md, API-Migration-Guide: https://github.com/podofo/podofo/blob/1.0.0/API-MIGRATION.md.
-
-- NetBox was updated to `>= 4.4.0`. Have a look at the breaking changes
-  of the [4.3 release](https://github.com/netbox-community/netbox/releases/tag/v4.3.0)
-  and the [4.4 release](https://github.com/netbox-community/netbox/releases/tag/v4.4.0),
-  make the required changes to your database, if needed, then upgrade by setting `services.netbox.package = pkgs.netbox_4_4;` in your configuration.
-
-- `privatebin` has been updated to `2.0.0`. This release changes configuration defaults including switching the template and removing legacy features. See the [v2.0.0 changelog entry](https://github.com/PrivateBin/PrivateBin/releases/tag/2.0.0) for details on how to upgrade.
-
-- `rocmPackages.triton` has been removed in favor of `python3Packages.triton`.
-
-- `oink` service no longer accepts `settings.apiKey` and `settings.secretApiKey` options as these have been replaced by `apiKeyFile` and `secretApiKeyFile`.
-
-- `linpinyin`, which is used for Chinese character input, has migrated from the unmaintained BDB database format to the newer KyotoCabinet database format. If you want to migrate your user input statistics you can consider using [bdbtokyotodb](https://codeberg.org/raboof/bdbtokyotodb).
-
-- `go-mockery` has been updated to v3. For migration instructions see the [upstream documentation](https://vektra.github.io/mockery/latest/v3/). If v2 is still required `go-mockery_v2` has been added but will be removed on or before 2029-12-31 in-line with its [upstream support lifecycle](https://vektra.github.io/mockery/)
-
-- `prometheus-script-exporter` has been updated to use a new maintained alternative. This release updates from `1.2.0 -> 3.0.1` and largely changes configuration options formats from json to yaml, among other changes.
-
-- [private-gpt](https://github.com/zylon-ai/private-gpt) service has been removed by lack of maintenance upstream.
-
-- `rabbitmq-server` has been updated from 4.0.9 to 4.1.4. The 4.1.0 release includes breaking changes. For more information read the [changelog of 4.1.0](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.1.0)
-
-- `lxde` scope has been removed, and its packages have been moved the top-level.
-
-- `pulsemeeter` has been updated to `2.0.0`. The configuration file from older versions has to be deleted. For more information and instructions see the [v2.0.0 changelog entry](https://github.com/theRealCarneiro/pulsemeeter/releases/tag/v2.0.0).
-
-- `rofi` has been updated to `2.0.0`. `rofi-wayland` and `rofi-wayland-unwrapped` have been merged into `rofi` and `rofi-unwrapped` respectively. For more information and instructions see the [v2.0.0 changelog entry](https://github.com/davatorium/rofi/releases/tag/2.0.0).
-
-- `rofi-emoji-wayland` has been merged into `rofi-emoji` as `rofi` has been updated to `2.0.0` and supports both X11 & Wayland.
-
-- The main binary of `tomlq` has been renamed from `tomlq` to `tq`.
-
-- `odoo16` has been dropped due to end of support by upstream, consider upgrading supported version.
-
-- `opensoldat` binaries and user configuration directory names have been prefixed by 'open', becoming opensoldat and opensoldatserver. Configuration will be moved automatically before launch when possible.
-
-- `emacs-macport` has been moved to a fork of Mitsuharu Yamamoto's patched source code starting with Emacs v30 as the original project seems to be currently dormant. All older versions of this package have been dropped.
-  This introduces some backwards‐incompatible changes; see the NEWS for details.
-  NEWS can be viewed from Emacs by typing `C-h n`, or by clicking `Help->Emacs News` from the menu bar.
-  It can also be browsed [online](https://git.savannah.gnu.org/cgit/emacs.git/tree/etc/NEWS?h=emacs-30).
-
-- `python3Packages.heif-image-plugin` has been dropped due to lack of upstream maintenance and breakage. Use `python3Packages.pillow-heif` instead.
-
-- `python3Packages.pyheif` has been dropped due to lack of upstream maintenance and breakage. Use `python3Packages.pillow-heif` instead.
-
-- `nodePackages.rimraf` has been removed, as it is a Javascript library, and packages that want to use it should depend directly on it instead.
-
-- `mariadb` now defaults to `mariadb_114` instead of `mariadb_1011`, meaning the default version was upgraded from 10.11.x to 11.4.x. See the [upgrade notes](https://mariadb.com/kb/en/upgrading-from-mariadb-10-11-to-mariadb-11-4/) for potential issues.
-
-- `qt5.full` and `qt6.full` aliases have been removed. Their use has always been discouraged, and downstream projects should use `qtN.env` with the right set of packages.
-
-- `python3Packages.duckduckgo-search` has been updated to v9+ and therefore has been renamed to ddgs.
-  Use `python3Packages.ddgs` instead.
-  See [release note for v9.0.0](https://github.com/deedy5/ddgs/releases/tag/v9.0.0)
-
-- `ra-multiplex` has been renamed to/replaced by `lspmux`. Its wrapper no longer includes `rust-analyzer`.
+- Zig 0.12 has been removed.
 
 ## Other Notable Changes {#sec-nixpkgs-release-25.11-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 - Added `rewriteURL` attribute to the nixpkgs `config`, to allow for rewriting the URLs downloaded by `fetchurl`.
+
 - Added `hashedMirrors` attribute to the nixpkgs `config`, to allow for customization of the hashed mirrors used by `fetchurl`.
 
 - Added `gitConfig` and `gitConfigFile` option to the nixpkgs `config`, to allow for setting a default `gitConfigFile` for all `fetchgit` invocations.
 
 - Added `npmRegistryOverrides` and `npmRegistryOverridesString` option to the nixpkgs `config`, to allow for setting a default `npmRegistryOverridesString` for all `fetchNpmDeps` invocations.
 
-- The `dockerTools.streamLayeredImage` builder now uses a better algorithm for generating layered docker images, such that much more sharing is possible when the number of store paths exceeds the layer limit. It gives each of the largest store paths its own layer and adds dependencies to those layers when they aren't used elsewhere.
-
-- The systemd initrd will now respect `x-systemd.wants` and `x-systemd.requires` for reliably unlocking multi-disk bcachefs volumes.
-
-- `neovim`: Added support for the `vim.o.exrc` option, the `VIMINIT` environment variable, and sourcing of `sysinit.vim`.
-
-  See the neovim help page [`:help startup`](https://neovim.io/doc/user/starting.html#startup) for more information, as well as [the nixpkgs neovim wrapper documentation](#neovim-custom-configuration).
-
-- `cloudflare-ddns`: Added package cloudflare-ddns.
+- `buildPythonPackage` and `buildPythonApplication` now default to `nix-update-script` as their default `updateScript`. This should improve automated updates, since nix-update is better maintained than the in-tree update script and has more robust fetcher support.
 
 - `clickhouse`: Added `serverConfig`, `usersConfig` configuration options accepting Nix attribute sets. Also added `extraServerConfig` and `extraUsersConfig` options accepting plain text (expecting XML configuration).
 
-- [`homebox` 0.20.0](https://github.com/sysadminsmedia/homebox/releases/tag/v0.20.0) changed how assets are stored and hashed. It is recommended to back up your database before this update. In particular, `--storage-data` was replaced with `--storage-conn-string` and `--storage-prefix-path`. If your configuration set `HBOX_STORAGE_DATA` manually, you must migrate it to `HBOX_STORAGE_CONN_STRING` and `HBOX_STORAGE_PREFIX_PATH`.
+- `cloudflare-ddns`: Added package cloudflare-ddns.
+
+- `dragonflydb` has been updated from version 0.1.0 to version 1.34.2.
+
+- `emacs` now disables the GC mark trace buffer by default. This improves GC performance by 5%, but can make GC issues harder to debug. This is configurable with `withGcMarkTrace`.
+
+- `fetchgit`: Add `gitConfigFile` argument to set a git config (via `$GIT_CONFIG_GLOBAL`) for the fetcher.
+
+- `fetchgit`: Add `rootDir` argument to limit the resulting source to one subdirectory of the whole Git repository. Corresponding `--root-dir` option added to `nix-prefetch-git`.
+
+- `fetchNpmDeps`: Add `npmRegistryOverridesString` argument to pass NPM registry overrides to the fetcher.
+
+- `ffmpeg_8`, `ffmpeg_8-headless`, and `ffmpeg_8-full` have been added. The default version of FFmpeg is now `ffmpeg_8`. You can install previous versions from package attributes such as `ffmpeg_7`.
+
+- `forgejo-runner`: The upgrade to version 11 brings a license change from MIT to GPLv3-or-later.
 
 - GIMP now defaults to version 3. Use `gimp2` for the old version.
-
-- `installShellCompletion`: now supports Nushell completion files
-
-- `idris2` supports being instantiated with a package environment with `idris.withPackages (p: [ ])`
-
-- New hardening flags `strictflexarrays1`, `strictflexarrays3`, `glibcxxassertions`, `libcxxhardeningfast` and `libcxxhardeningextensive` were made available.
 
 - `gramps` has been updated to 6.0.0
   Upstream recommends [backing up your Family Trees](https://gramps-project.org/wiki/index.php/Gramps_6.0_Wiki_Manual_-_Manage_Family_Trees#Backing_up_a_Family_Tree) before upgrading.
 
-- `meta.mainProgram`: Changing this `meta` entry can lead to a package rebuild due to being used to determine the `NIX_MAIN_PROGRAM` environment variable.
+- [`homebox` 0.20.0](https://github.com/sysadminsmedia/homebox/releases/tag/v0.20.0) changed how assets are stored and hashed. It is recommended to back up your database before this update. In particular, `--storage-data` was replaced with `--storage-conn-string` and `--storage-prefix-path`. If your configuration set `HBOX_STORAGE_DATA` manually, you must migrate it to `HBOX_STORAGE_CONN_STRING` and `HBOX_STORAGE_PREFIX_PATH`.
 
-- `forgejo-runner`: The upgrade to version 11 brings a license change from MIT to GPLv3-or-later.
+- `idris2` supports being instantiated with a package environment with `idris.withPackages (p: [ ])`
 
-- `waydroid-nftables`: New variant of `waydroid` that supports nftables instead of iptables.
-
-- `lisp-modules` were brought in sync with the [June 2025 Quicklisp release](http://blog.quicklisp.org/2025/07/june-2025-quicklisp-dist-now-available.html).
-
-- `ffmpeg_8`, `ffmpeg_8-headless`, and `ffmpeg_8-full` have been added. The default version of FFmpeg is now `ffmpeg_8`. You can install previous versions from package attributes such as `ffmpeg_7`.
-
-- `searx` was updated to use `envsubst` instead of `sed` for parsing secrets from environment variables.
-  If your previous configuration included a secret reference like `server.secret_key = "@SEARX_SECRET_KEY@"`, you must migrate to the new envsubst syntax: `server.secret_key = "$SEARX_SECRET_KEY"`.
+- `installShellCompletion`: now supports Nushell completion files
 
 - `jellyfin` was updated to `10.11.x`, which includes heavy backend changes.
   Make sure to backup your data and configuration directories
@@ -347,23 +339,24 @@
   and beware that the migration may take several hours depending on your library size and state.
   The process must not be interrupted.
 
-- `versionCheckHook`: Packages that previously relied solely on `pname` to locate the program used to version check, but have a differing `meta.mainProgram` entry, might now fail.
+- `lisp-modules` were brought in sync with the [June 2025 Quicklisp release](http://blog.quicklisp.org/2025/07/june-2025-quicklisp-dist-now-available.html).
 
+- `meta.mainProgram`: Changing this `meta` entry can lead to a package rebuild due to being used to determine the `NIX_MAIN_PROGRAM` environment variable.
 
-- The debug outputs produced by `separateDebugInfo = true;` now contain symlinks mapping build-ids to the original source and ELF file.
-  Specifically, if `$out/bin/ninja` has build-id `483bd7f7229bdb06462222e1e353e4f37e15c293`, then
-  * `$debug/lib/debug/.build-id/48/3bd7f7229bdb06462222e1e353e4f37e15c293.executable` is a symlink to `$out/bin/ninja`
-  * `$debug/lib/debug/.build-id/48/3bd7f7229bdb06462222e1e353e4f37e15c293.source` is a symlink to the value of `$src` during build
-  * `$debug/lib/debug/.build-id/48/3bd7f7229bdb06462222e1e353e4f37e15c293.sourceoverlay` is a symlink to a directory with the same structure as the expanded `$sourceRoot` but containing only a copy of files which were patched during the build
-  * `$debug/lib/debug/.build-id/48/3bd7f7229bdb06462222e1e353e4f37e15c293.debug` is the file containing debug symbols (like before).
+- `neovim`: Added support for the `vim.o.exrc` option, the `VIMINIT` environment variable, and sourcing of `sysinit.vim`.
+  See the neovim help page [`:help startup`](https://neovim.io/doc/user/starting.html#startup) for more information, as well as [the nixpkgs neovim wrapper documentation](#neovim-custom-configuration).
 
-- `fetchgit`: Add `gitConfigFile` argument to set a git config (via `$GIT_CONFIG_GLOBAL`) for the fetcher.
-
-- `fetchgit`: Add `rootDir` argument to limit the resulting source to one subdirectory of the whole Git repository. Corresponding `--root-dir` option added to `nix-prefetch-git`.
+- New hardening flags `strictflexarrays1`, `strictflexarrays3`, `glibcxxassertions`, `libcxxhardeningfast` and `libcxxhardeningextensive` were made available.
 
 - `nix-prefetch-git`: Added a `--no-add-path` argument to disable adding the path to the store; this is useful when working with a [read-only store](https://nix.dev/manual/nix/2.28/command-ref/new-cli/nix3-help-stores#store-experimental-local-overlay-store-read-only).
 
-- `fetchNpmDeps`: Add `npmRegistryOverridesString` argument to pass NPM registry overrides to the fetcher.
+- Passing `stdenv` to `buildPythonPackage` or `buildPythonApplication` has been deprecated and will trigger an error in a future release.
+  Instead, you should _override_ the python build helper, e.g., `(buildPythonPackage.override { stdenv = customStdenv; })`.
+  See [](#overriding-python-build-helpers).
+
+- `plasma6`: Fixed the `ksycoca` cache not being re-built when `$XDG_CACHE_HOME` is set to something that isn't `$HOME/.cache`.
+
+- `searx` was updated to use `envsubst` instead of `sed` for parsing secrets from environment variables.
 
 - `sftpman` has been updated to version 2, a rewrite in Rust which is mostly backward compatible but does include some changes to the CLI.
   For more information, [check the project's README](https://github.com/spantaleev/sftpman-rs#is-sftpman-v2-compatible-with-sftpman-v1).
@@ -372,17 +365,21 @@
   recommendation](https://clickhouse.com/docs/faq/operations/production). Users
   can continue to use the `clickhouse-lts` package if desired.
 
-- `emacs` now disables the GC mark trace buffer by default. This improves GC performance by 5%, but can make GC issues harder to debug. This is configurable with `withGcMarkTrace`.
+- The debug outputs produced by `separateDebugInfo = true;` now contain symlinks mapping build-ids to the original source and ELF file.
+  Specifically, if `$out/bin/ninja` has build-id `483bd7f7229bdb06462222e1e353e4f37e15c293`, then
+  * `$debug/lib/debug/.build-id/48/3bd7f7229bdb06462222e1e353e4f37e15c293.executable` is a symlink to `$out/bin/ninja`
+  * `$debug/lib/debug/.build-id/48/3bd7f7229bdb06462222e1e353e4f37e15c293.source` is a symlink to the value of `$src` during build
+  * `$debug/lib/debug/.build-id/48/3bd7f7229bdb06462222e1e353e4f37e15c293.sourceoverlay` is a symlink to a directory with the same structure as the expanded `$sourceRoot` but containing only a copy of files which were patched during the build
+  * `$debug/lib/debug/.build-id/48/3bd7f7229bdb06462222e1e353e4f37e15c293.debug` is the file containing debug symbols (like before).
 
-- Passing `stdenv` to `buildPythonPackage` or `buildPythonApplication` has been deprecated and will trigger an error in a future release.
-  Instead, you should _override_ the python build helper, e.g., `(buildPythonPackage.override { stdenv = customStdenv; })`.
-  See [](#overriding-python-build-helpers).
+- The `dockerTools.streamLayeredImage` builder now uses a better algorithm for generating layered docker images, such that much more sharing is possible when the number of store paths exceeds the layer limit. It gives each of the largest store paths its own layer and adds dependencies to those layers when they aren't used elsewhere.
 
-- `buildPythonPackage` and `buildPythonApplication` now default to `nix-update-script` as their default `updateScript`. This should improve automated updates, since nix-update is better maintained than the in-tree update script and has more robust fetcher support.
+- The systemd initrd will now respect `x-systemd.wants` and `x-systemd.requires` for reliably unlocking multi-disk bcachefs volumes.
 
-- `plasma6`: Fixed the `ksycoca` cache not being re-built when `$XDG_CACHE_HOME` is set to something that isn't `$HOME/.cache`.
+- `versionCheckHook`: Packages that previously relied solely on `pname` to locate the program used to version check, but have a differing `meta.mainProgram` entry, might now fail.
 
-- `dragonflydb` has been updated from version 0.1.0 to version 1.34.2.
+- `waydroid-nftables`: New variant of `waydroid` that supports nftables instead of iptables.
+  If your previous configuration included a secret reference like `server.secret_key = "@SEARX_SECRET_KEY@"`, you must migrate to the new envsubst syntax: `server.secret_key = "$SEARX_SECRET_KEY"`.
 
 ## Nixpkgs Library {#sec-nixpkgs-release-25.11-lib}
 
@@ -390,31 +387,31 @@
 
 ### Breaking changes {#sec-nixpkgs-release-25.11-lib-breaking}
 
+- `haskell.lib.addOptparseApplicativeCompletionScripts` has been removed, use `haskellPackages.generateOptparseApplicativeCompletions` instead.
+
+- `lib.attrsets.cartesianProductOfSets` has been removed, following its deprecation in NixOS 24.11. Use `lib.attrsets.cartesianProduct` instead.
+
+- `lib.attrsets.zipWithNames` has been removed, following its deprecation in 2009. Use `lib.attrsets.zipAttrsWithNames` instead.
+
+- `lib.attrsets.zip` has been removed, following its deprecation in 2013. Use `lib.attrsets.zipAttrsWith` instead.
+
 - `lib.literalExample` has been removed, use `lib.literalExpression` instead, or use `lib.literalMD` for a non-Nix description.
 
-- `lib.replaceChars` has been removed, it was a deprecated alias of `lib.replaceStrings`.
+- `lib.mapAttrsFlatten` has been removed, following its deprecation in NixOS 24.11. Use `lib.attrsets.mapAttrsToList` instead.
+
+- `lib.modules.defaultPriority` has been removed, please use `lib.modules.defaultOverridePriority` instead.
+
+- `lib.options.mkPackageOptionMD` has been removed, following its deprecation in NixOS 24.11. Use `lib.options.mkPackageOption` instead.
 
 - `lib.readPathsFromFile` has been removed, use a list instead
 
-- `lib.mapAttrsFlatten` has been removed, following its deprecation in NixOS 24.11. Use `lib.attrsets.mapAttrsToList` instead.
+- `lib.replaceChars` has been removed, it was a deprecated alias of `lib.replaceStrings`.
+
+- `lib.sources.pathType`, `lib.sources.pathIsDirectory` and `lib.sources.pathIsRegularFile` have been replaced by `lib.filesystem.pathType`, `lib.filesystem.pathIsDirectory` and `lib.filesystem.pathIsRegularFile` respectively.
 
 - `lib.strings.isCoercibleToString` has been in favor of either `lib.strings.isStringLike` or `lib.strings.isConvertibleWithToString`. Only use the latter if it needs to return true for null, numbers, booleans, or a list of those.
 
 - `lib.types.string` has been removed. See [this pull request](https://github.com/NixOS/nixpkgs/pull/66346) for better alternative types like `lib.types.str`.
-
-- `lib.modules.defaultPriority` has been removed, please use `lib.modules.defaultOverridePriority` instead.
-
-- `lib.attrsets.cartesianProductOfSets` has been removed, following its deprecation in NixOS 24.11. Use `lib.attrsets.cartesianProduct` instead.
-
-- `lib.sources.pathType`, `lib.sources.pathIsDirectory` and `lib.sources.pathIsRegularFile` have been replaced by `lib.filesystem.pathType`, `lib.filesystem.pathIsDirectory` and `lib.filesystem.pathIsRegularFile` respectively.
-
-- `lib.attrsets.zip` has been removed, following its deprecation in 2013. Use `lib.attrsets.zipAttrsWith` instead.
-
-- `lib.attrsets.zipWithNames` has been removed, following its deprecation in 2009. Use `lib.attrsets.zipAttrsWithNames` instead.
-
-- `lib.options.mkPackageOptionMD` has been removed, following its deprecation in NixOS 24.11. Use `lib.options.mkPackageOption` instead.
-
-- `haskell.lib.addOptparseApplicativeCompletionScripts` has been removed, use `haskellPackages.generateOptparseApplicativeCompletions` instead.
 
 - The `buildPythonPackage` and `buildPythonApplication` functions now require
   an explicit `format` attribute. Previously the default format used setuptools
@@ -422,6 +419,8 @@
   The modern alternative is to configure `pyproject = true` with `build-system = [ setuptools ]`.
 
 ### Deprecations {#sec-nixpkgs-release-25.11-lib-deprecations}
+
+- `lib.cli.toGNUCommandLine` and `lib.cli.toGNUCommandLineShell` have been deprecated in favor of `lib.cli.toCommandLine`, `lib.cli.toCommandLineShell`, `lib.cli.toCommandLineGNU` and `lib.cli.toCommandLineShellGNU`.
 
 - `lib.options.mkAliasOptionModuleMD` is now obsolete; use the identical [`lib.options.mkAliasOptionModule`] instead.
 
@@ -432,8 +431,6 @@
   - `oneOf`
   - `number`
   - `numbers.*`
-
-- `lib.cli.toGNUCommandLine` and `lib.cli.toGNUCommandLineShell` have been deprecated in favor of `lib.cli.toCommandLine`, `lib.cli.toCommandLineShell`, `lib.cli.toCommandLineGNU` and `lib.cli.toCommandLineShellGNU`.
 
 ### Additions and Improvements {#sec-nixpkgs-release-25.11-lib-additions-improvements}
 

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -4,23 +4,11 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- `nixos-rebuild-ng`, a full rewrite of `nixos-rebuild` in Python, is enabled by default from this release. You can disable it by setting [](#opt-system.rebuild.enableNg) to `false` in your configuration if you need, but please report any issues. It is expected that the next major version of NixOS (26.05) will remove the {option}`system.rebuild.enableNg` option.
-
-- `rEFInd`, a graphical boot manager for UEFI systems, can now be used through [](#opt-boot.loader.refind.enable).
-
-- Secure boot support can now be enabled for the Limine bootloader through {option}`boot.loader.limine.secureBoot.enable`. Bootloader install script signs the bootloader, then kernels are hashed during system rebuild and written to a config. This allows Limine to boot only the kernels installed through NixOS system.
-
-- The default PostgreSQL version for new NixOS installations (i.e. with `system.stateVersion >= 25.11`) is v17.
-
 - Added `nixos-init`, a Rust-based bashless initialization system for systemd initrd. This allows to build NixOS systems without any interpreter. Enable via `system.nixos-init.enable = true;`.
 
-- The NetworkManager module does not ship with a default set of VPN plugins anymore. All required VPN plugins must now be explicitly configured in [`networking.networkmanager.plugins`](#opt-networking.networkmanager.plugins).
-
-- The Qt 5-based versions of KDE Gear, Plasma, Maui and Deepin have been removed. Users are advised to migrate to Plasma 6 and Gear 25.08, available under `kdePackages`.
-
-- Syncthing has been updated to version 2.0.0.
-
 - COSMIC DE has been updated to the beta version, bringing it closer to its first stable release. This includes updates to its core components, applications, and overall stability.
+
+- FirewallD support has been added. It can be configured both as a standalone service (through `services.firewalld`), and as a backend to the existing `networking.firewall` options.
 
 - GNOME has been updated to version 49.
 
@@ -32,205 +20,350 @@
 
   Refer to the [GNOME release notes](https://release.gnome.org/49/) for more details.
 
-- FirewallD support has been added. It can be configured both as a standalone service (through `services.firewalld`), and as a backend to the existing `networking.firewall` options.
-
 - `networking.firewall` now has a `backend` option for choosing which backend to use.
+
+- `nixos-rebuild-ng`, a full rewrite of `nixos-rebuild` in Python, is enabled by default from this release. You can disable it by setting [](#opt-system.rebuild.enableNg) to `false` in your configuration if you need, but please report any issues. It is expected that the next major version of NixOS (26.05) will remove the {option}`system.rebuild.enableNg` option.
+
+- `rEFInd`, a graphical boot manager for UEFI systems, can now be used through [](#opt-boot.loader.refind.enable).
+
+- Secure boot support can now be enabled for the Limine bootloader through {option}`boot.loader.limine.secureBoot.enable`. Bootloader install script signs the bootloader, then kernels are hashed during system rebuild and written to a config. This allows Limine to boot only the kernels installed through NixOS system.
+
+- Syncthing has been updated to version 2.0.0.
+
+- The default PostgreSQL version for new NixOS installations (i.e. with `system.stateVersion >= 25.11`) is v17.
+
+- The NetworkManager module does not ship with a default set of VPN plugins anymore. All required VPN plugins must now be explicitly configured in [`networking.networkmanager.plugins`](#opt-networking.networkmanager.plugins).
+
+- The Qt 5-based versions of KDE Gear, Plasma, Maui and Deepin have been removed. Users are advised to migrate to Plasma 6 and Gear 25.08, available under `kdePackages`.
 
 ## New Modules {#sec-release-25.11-new-modules}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- [byedpi](https://github.com/hufrea/byedpi), a DPI bypass service. Available as [services.byedpi](#opt-services.byedpi.enable).
+- Added `nixos-init`, a Rust-based bashless initialization system for systemd initrd. This allows to build NixOS systems without any interpreter. Enable via `system.nixos-init.enable = true;`.
 
-- [Overseerr](https://overseerr.dev), a request management and media discovery tool for the Plex ecosystem. Available as [services.overseerr](#opt-services.overseerr.enable).
-
-- [services.rsync](options.html#opt-services.rsync) has been added to simplify periodic directory syncing.
-
-- [gtklock](https://github.com/jovanlanik/gtklock), a GTK-based lockscreen for Wayland. Available as [programs.gtklock](#opt-programs.gtklock.enable).
-- [Chrysalis](https://github.com/keyboardio/Chrysalis), a graphical configurator for Kaleidoscope-powered keyboards. Available as [programs.chrysalis](#opt-programs.chrysalis.enable).
-
-- [wayvnc](https://github.com/any1/wayvnc), VNC server for wlroots based Wayland compositors. Available as [programs.wayvnc](#opt-programs.wayvnc.enable).
-
-- [Pi-hole](https://pi-hole.net/), a DNS sinkhole for advertisements based on Dnsmasq. Available as [services.pihole-ftl](#opt-services.pihole-ftl.enable), and [services.pihole-web](#opt-services.pihole-web.enable) for the web GUI and API.
-
-- [Fediwall](https://fediwall.social), a web application for live displaying toots from mastodon, inspired by mastowall. Available as [services.fediwall](#opt-services.fediwall.enable).
-
-- [umami](https://github.com/umami-software/umami), a simple, fast, privacy-focused alternative to Google Analytics. Available with [services.umami](#opt-services.umami.enable).
-
-- [FirewallD](https://firewalld.org/), a firewall daemon with D-Bus interface providing a dynamic firewall. Available as [services.firewalld](#opt-services.firewalld.enable) and a [networking.firewall.backend](#opt-networking.firewall.backend).
-
-- [FileBrowser](https://filebrowser.org/), a web application for managing and sharing files. Available as [services.filebrowser](#opt-services.filebrowser.enable).
-
-- Options under [networking.getaddrinfo](#opt-networking.getaddrinfo.enable) are now allowed to declaratively configure address selection and sorting behavior of `getaddrinfo` in dual-stack networks.
-
-- [Homebridge](https://github.com/homebridge/homebridge), a lightweight Node.js server you can run on your home network that emulates the iOS HomeKit API. Available as [services.homebridge](#opt-services.homebridge.enable).
-
-- [XPPen](https://www.xp-pen.com/), the official closed-source driver for XP Pen tablets. Available as [programs.xppen](#opt-programs.xppen.enable).
-
-- [LACT](https://github.com/ilya-zlobintsev/LACT), a GPU monitoring and configuration tool, can now be enabled through [services.lact.enable](#opt-services.lact.enable).
-  Note that for LACT to work properly on AMD GPU systems, you need to enable [hardware.amdgpu.overdrive.enable](#opt-hardware.amdgpu.overdrive.enable).
+- [angrr](https://github.com/linyinfeng/angrr), a service that automatically cleans up old auto GC roots. Available as [services.angrr](#opt-services.angrr.enable).
 
 - Auto-scrub support for Bcachefs filesystems can now be enabled through [services.bcachefs.autoScrub.enable](#opt-services.bcachefs.autoScrub.enable) to periodically check for data corruption. If there's a correct copy available, it will automatically repair corrupted blocks.
 
-- [LibreTranslate](https://libretranslate.com), a free and open source machine translation API. Available as [services.libretranslate](#opt-services.libretranslate.enable).
-
-- [Linyaps](https://linyaps.org.cn/), a cross-distribution package manager with sandboxed apps and shared runtime. Available as [services.linyaps](#opt-services.linyaps.enable).
-
-- [tlsrpt-reporter](https://github.com/sys4/tlsrpt-reporter), an application suite to generate and deliver TLSRPT reports. Available as [services.tlsrpt](#opt-services.tlsrpt.enable).
-
-- [Chhoto URL](https://github.com/SinTan1729/chhoto-url), a simple, blazingly fast, selfhosted URL shortener with no unnecessary features, written in Rust. Available as [services.chhoto-url](#opt-services.chhoto-url.enable).
-
-- [go-httpbin](https://github.com/mccutchen/go-httpbin), a reasonably complete and well-tested golang port of httpbin, with zero dependencies outside the go stdlib. Available as [services.go-httpbin](#opt-services.go-httpbin.enable).
-
-- [radicle-ci-broker](https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:zwTxygwuz5LDGBq255RA2CbNGrz8), runs CI for repositories in the local [Radicle](https://radicle.xyz/) node. Available as [services.radicle.ci.broker.enable](#opt-services.radicle.ci.broker.enable).
-
-- [radicle-native-ci](https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z3qg5TKmN83afz2fj9z3fQjU8vaYE), an adapter for the [Radicle CI broker](https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:zwTxygwuz5LDGBq255RA2CbNGrz8), for performing CI runs locally. Available as [services.radicle.ci.adapters.native](#opt-services.radicle.ci.adapters.native.instances).
-
-- [llama-swap](https://github.com/mostlygeek/llama-swap), a light weight transparent proxy server that provides automatic model swapping to llama.cpp's server (or any server with an OpenAI compatible endpoint). Available as [](#opt-services.llama-swap.enable).
-
-- [tuwunel](https://matrix-construct.github.io/tuwunel/), a federated chat server implementing the Matrix protocol, forked from Conduwuit. Available as [services.matrix-tuwunel](#opt-services.matrix-tuwunel.enable).
-
-- [Broadcast Box](https://github.com/Glimesh/broadcast-box), a WebRTC broadcast server. Available as [services.broadcast-box](options.html#opt-services.broadcast-box.enable).
+- [Beszel](https://beszel.dev), a lightweight server monitoring hub with historical data, docker stats, and alerts. Available as [`services.beszel.agent`](options.html#opt-services.beszel.agent.enable) and [`services.beszel.hub`](options.html#opt-services.beszel.hub.enable).
 
 - [boot.kernel.sysfs](options.html#opt-boot.kernel.sysfs) allows setting of sysfs attributes.
 
-- [local-content-share](https://github.com/Tanq16/local-content-share), a simple web-app for storing/sharing text snippets and files in your local network. Available as [services.local-content-share](#opt-services.local-content-share.enable).
+- [Broadcast Box](https://github.com/Glimesh/broadcast-box), a WebRTC broadcast server. Available as [services.broadcast-box](options.html#opt-services.broadcast-box.enable).
 
-- Docker now defaults to 28.x, because version 27.x stopped receiving security updates and bug fixes after [May 2, 2025](https://github.com/moby/moby/pull/49910).
+- [byedpi](https://github.com/hufrea/byedpi), a DPI bypass service. Available as [services.byedpi](#opt-services.byedpi.enable).
+
+- [Chrysalis](https://github.com/keyboardio/Chrysalis), a graphical configurator for Kaleidoscope-powered keyboards. Available as [programs.chrysalis](#opt-programs.chrysalis.enable).
+
+- [Chhoto URL](https://github.com/SinTan1729/chhoto-url), a simple, blazingly fast, selfhosted URL shortener with no unnecessary features, written in Rust. Available as [services.chhoto-url](#opt-services.chhoto-url.enable).
+
+- [conman](https://github.com/dun/conman), a serial console management program. Available as [services.conman](#opt-services.conman.enable).
 
 - [Corteza](https://cortezaproject.org/), a low-code platform. Available as [services.corteza](#opt-services.corteza.enable).
-
-- [Warpgate](https://warpgate.null.page), a SSH, HTTPS, MySQL and Postgres bastion. Available as [services.warpgate](#opt-services.warpgate.enable). Note that you need to run `warpgate recover-access` to recover builtin admin account, as the initialisation script uses a throwaway value to initialise its database.
-
-- [TuneD](https://tuned-project.org/), a system tuning service for Linux. Available as [services.tuned](#opt-services.tuned.enable).
-
-- [yubikey-manager](https://github.com/Yubico/yubikey-manager), a tool for configuring YubiKey devices. Available as [programs.yubikey-manager](#opt-programs.yubikey-manager.enable).
-
-- [Linkwarden](https://linkwarden.app/) a self-hosted collaborative bookmark manager to collect, read, annotate, and fully preserve what matters, all in one place. Available as [services.linkwarden](#opt-services.linkwarden.enable).
-
-- [Draupnir](https://github.com/the-draupnir-project/draupnir), a Matrix moderation bot. Available as [services.draupnir](#opt-services.draupnir.enable).
-
-- [Pangolin](https://github.com/fosrl/pangolin), a tunneled reverse proxy server with access control. Available as [services.pangolin](#opt-services.pangolin.enable).
-
-- [postfix-tlspol](https://github.com/Zuplu/postfix-tlspol), MTA-STS and DANE resolver and TLS policy server for Postfix. Available as [services.postfix-tlspol](#opt-services.postfix-tlspol.enable).
 
 - [crowdsec](https://www.crowdsec.net/), a free, open-source and collaborative IPS. Available as [services.crowdsec](#opt-services.crowdsec.enable).
 
 - [crowdsec-firewall-bouncer](https://www.crowdsec.net/), the CrowdSec Remediation Component for fetching new and old decisions from a CrowdSec API and adding them to a blocklist used by supported firewalls. Available as [services.crowdsec-firewall-bouncer](#opt-services.crowdsec-firewall-bouncer.enable).
 
-- [tsidp](https://github.com/tailscale/tsidp), a simple OIDC / OAuth Identity Provider (IdP) server for your tailnet. Available as [services.tsidp](#opt-services.tsidp.enable).
+- Docker now defaults to 28.x, because version 27.x stopped receiving security updates and bug fixes after [May 2, 2025](https://github.com/moby/moby/pull/49910).
 
-- [Newt](https://github.com/fosrl/newt), a fully user space WireGuard tunnel client and TCP/UDP proxy, designed to securely expose private resources controlled by Pangolin. Available as [services.newt](options.html#opt-services.newt.enable).
+- [docuseal](https://github.com/docusealco/docuseal), a DocuSign alternative. Create, fill, and sign digital documents. Available at [services.docuseal](#opt-services.docuseal.enable).
+
+- [Draupnir](https://github.com/the-draupnir-project/draupnir), a Matrix moderation bot. Available as [services.draupnir](#opt-services.draupnir.enable).
+
+- [dwl](https://codeberg.org/dwl/dwl), a compact, hackable compositor for Wayland based on wlroots. Available as [programs.dwl](#opt-programs.dwl.enable).
+
+- [ente](https://github.com/ente-io/ente), a service that provides a fully open source, end-to-end encrypted platform for photos and videos. Available as [services.ente.api](#opt-services.ente.api.enable) and  [services.ente.web](#opt-services.ente.web.enable).
+
+- [ErsatzTV](https://ersatztv.org), a personal IPTV server. Available as [services.ersatztv](#opt-services.ersatztv.enable)
+
+- [Fediwall](https://fediwall.social), a web application for live displaying toots from mastodon, inspired by mastowall. Available as [services.fediwall](#opt-services.fediwall.enable).
+
+- [FileBrowser](https://filebrowser.org/), a web application for managing and sharing files. Available as [services.filebrowser](#opt-services.filebrowser.enable).
+
+- [FirewallD](https://firewalld.org/), a firewall daemon with D-Bus interface providing a dynamic firewall. Available as [services.firewalld](#opt-services.firewalld.enable) and a [networking.firewall.backend](#opt-networking.firewall.backend).
+
+- [fw-fanctrl](https://github.com/TamtamHero/fw-fanctrl), a simple systemd service to better control Framework Laptop's fan(s). Available as [hardware.fw-fanctrl](#opt-hardware.fw-fanctrl.enable).
+
+- [go-httpbin](https://github.com/mccutchen/go-httpbin), a reasonably complete and well-tested golang port of httpbin, with zero dependencies outside the go stdlib. Available as [services.go-httpbin](#opt-services.go-httpbin.enable).
+
+- [gtklock](https://github.com/jovanlanik/gtklock), a GTK-based lockscreen for Wayland. Available as [programs.gtklock](#opt-programs.gtklock.enable).
+
+- [Homebridge](https://github.com/homebridge/homebridge), a lightweight Node.js server you can run on your home network that emulates the iOS HomeKit API. Available as [services.homebridge](#opt-services.homebridge.enable).
 
 - [IfState](https://ifstate.net), manage host interface settings in a declarative manner. Available as [networking.ifstate](options.html#opt-networking.ifstate.enable) and [boot.initrd.network.ifstate](options.html#opt-boot.initrd.network.ifstate.enable).
 
-- [qBittorrent](https://www.qbittorrent.org/), is a bittorrent client programmed in C++ / Qt that uses libtorrent by Arvid Norberg. Available as [services.qbittorrent](#opt-services.qbittorrent.enable).
+- [KMinion](https://github.com/redpanda-data/kminion), feature-rich Prometheus exporter for Apache Kafka. Available as [services.prometheus.exporters.kafka](options.html#opt-services.prometheus.exporters.kafka).
 
-- [Speedify](https://speedify.com/), a proprietary VPN which allows combining multiple internet connections (Wi-Fi, 4G, 5G, Ethernet, Starlink, Satellite, and more) to improve the stability, speed, and security of online experiences. Available as [services.speedify](#opt-services.speedify.enable).
+- [LACT](https://github.com/ilya-zlobintsev/LACT), a GPU monitoring and configuration tool, can now be enabled through [services.lact.enable](#opt-services.lact.enable).
+  Note that for LACT to work properly on AMD GPU systems, you need to enable [hardware.amdgpu.overdrive.enable](#opt-hardware.amdgpu.overdrive.enable).
 
-- [Szurubooru](https://github.com/rr-/szurubooru), an image board engine inspired by services such as Danbooru, dedicated for small and medium communities. Available as [services.szurubooru](#opt-services.szurubooru.enable).
+- [lemurs](https://github.com/coastalwhite/lemurs), a customizable TUI display/login manager. Available at [services.displayManager.lemurs](#opt-services.displayManager.lemurs.enable).
+
+- [LibreTranslate](https://libretranslate.com), a free and open source machine translation API. Available as [services.libretranslate](#opt-services.libretranslate.enable).
+
+- [Linkwarden](https://linkwarden.app/) a self-hosted collaborative bookmark manager to collect, read, annotate, and fully preserve what matters, all in one place. Available as [services.linkwarden](#opt-services.linkwarden.enable).
+
+- [Linyaps](https://linyaps.org.cn/), a cross-distribution package manager with sandboxed apps and shared runtime. Available as [services.linyaps](#opt-services.linyaps.enable).
+
+- [llama-swap](https://github.com/mostlygeek/llama-swap), a light weight transparent proxy server that provides automatic model swapping to llama.cpp's server (or any server with an OpenAI compatible endpoint). Available as [](#opt-services.llama-swap.enable).
+
+- [local-content-share](https://github.com/Tanq16/local-content-share), a simple web-app for storing/sharing text snippets and files in your local network. Available as [services.local-content-share](#opt-services.local-content-share.enable).
 
 - [LubeLogger](https://lubelogger.com/), a vehicle maintenance and fuel mileage tracker.
   Available as [services.lubelogger](#opt-services.lubelogger.enable).
 
-- The [Neat IP Address Planner](https://spritelink.github.io/NIPAP/) (NIPAP) can now be enabled through [services.nipap.enable](#opt-services.nipap.enable).
-
-- [tpm2-totp](https://github.com/tpm2-software/tpm2-totp) can now be used to show a TOTP during boot using Plymouth. Available as [boot.plymouth.tpm2-totp](#opt-boot.plymouth.tpm2-totp.enable).
-
-- [nix-store-veritysetup](https://github.com/nikstur/nix-store-veritysetup-generator), a systemd generator to unlock the Nix Store as a dm-verity protected block device. Available as [boot.initrd.nix-store-veritysetup](options.html#opt-boot.initrd.nix-store-veritysetup.enable).
-
-- [ente](https://github.com/ente-io/ente), a service that provides a fully open source, end-to-end encrypted platform for photos and videos. Available as [services.ente.api](#opt-services.ente.api.enable) and  [services.ente.web](#opt-services.ente.web.enable).
-
-- [PairDrop](https://github.com/schlagmichdoch/pairdrop), a peer-to-peer file transfer web app. Available as [services.pairdrop](#opt-services.pairdrop.enable).
-
-- [SuiteNumérique Docs](https://github.com/suitenumerique/docs), a collaborative note taking, wiki and documentation web platform and alternative to Notion or Outline. Available as [services.lasuite-docs](#opt-services.lasuite-docs.enable).
-
-- [dwl](https://codeberg.org/dwl/dwl), a compact, hackable compositor for Wayland based on wlroots. Available as [programs.dwl](#opt-programs.dwl.enable).
+- [mautrix-discord](https://github.com/mautrix/discord), a Matrix-Discord puppeting/relay bridge. Available as [services.mautrix-discord](#opt-services.mautrix-discord.enable).
 
 - [nebula-lighthouse-service](https://github.com/manuels/nebula-lighthouse-service), a public Nebula VPN lighthouse service. Available as [services.nebula-lighthouse-service](#opt-services.nebula-lighthouse-service.enable).
 
-- [angrr](https://github.com/linyinfeng/angrr), a service that automatically cleans up old auto GC roots. Available as [services.angrr](#opt-services.angrr.enable).
+- [Newt](https://github.com/fosrl/newt), a fully user space WireGuard tunnel client and TCP/UDP proxy, designed to securely expose private resources controlled by Pangolin. Available as [services.newt](options.html#opt-services.newt.enable).
 
-- [Sharkey](https://joinsharkey.org), a Sharkish microblogging platform. Available as [services.sharkey](#opt-services.sharkey.enable).
+- [nixbit](https://github.com/pbek/nixbit), a GUI application for updating your NixOS system from a Nix Flakes Git repository. Available as [programs.nixbit](#opt-programs.nixbit.enable).
 
-- [fw-fanctrl](https://github.com/TamtamHero/fw-fanctrl), a simple systemd service to better control Framework Laptop's fan(s). Available as [hardware.fw-fanctrl](#opt-hardware.fw-fanctrl.enable).
+- [nix-store-veritysetup](https://github.com/nikstur/nix-store-veritysetup-generator), a systemd generator to unlock the Nix Store as a dm-verity protected block device. Available as [boot.initrd.nix-store-veritysetup](options.html#opt-boot.initrd.nix-store-veritysetup.enable).
 
-- [SillyTavern](https://sillytavern.app/), LLM Frontend for Power Users. Available as [services.sillytavern](#opt-services.sillytavern.enable).
+- [nvme-rs](https://github.com/liberodark/nvme-rs), NVMe monitoring [services.nvme-rs](#opt-services.nvme-rs.enable).
 
-- [mautrix-discord](https://github.com/mautrix/discord), a Matrix-Discord puppeting/relay bridge. Available as [services.mautrix-discord](#opt-services.mautrix-discord.enable).
+- Options under [networking.getaddrinfo](#opt-networking.getaddrinfo.enable) are now allowed to declaratively configure address selection and sorting behavior of `getaddrinfo` in dual-stack networks.
 
-- [Timekpr-nExT](https://mjasnik.gitlab.io/timekpr-next/), a time managing application that helps optimizing time spent at computer for your subordinates, children or even for yourself. Available as [](#opt-services.timekpr.enable).
+- [Overseerr](https://overseerr.dev), a request management and media discovery tool for the Plex ecosystem. Available as [services.overseerr](#opt-services.overseerr.enable).
 
-- [SuiteNumérique Meet](https://github.com/suitenumerique/meet) is an open source alternative to Google Meet and Zoom powered by LiveKit: HD video calls, screen sharing, and chat features. Built with Django and React. Available as [services.lasuite-meet](#opt-services.lasuite-meet.enable).
-
-- [Prometheus Storagebox Exporter](https://github.com/fleaz/prometheus-storagebox-exporter), a Prometheus exporter for Hetzner storage boxes.
-
-- [pmount](https://salsa.debian.org/debian/pmount), a tool that allows normal users to mount removable devices without requiring root privileges Available at [programs.pmount](#opt-programs.pmount.enable).
-
-- [rauc](https://rauc.io/) (the Robust Auto-Update Controller), a daemon that allows reliable and secure software updates in embedded Linux systems. Available at [services.rauc](#opt-services.rauc.enable).
-
-- [lemurs](https://github.com/coastalwhite/lemurs), a customizable TUI display/login manager. Available at [services.displayManager.lemurs](#opt-services.displayManager.lemurs.enable).
-
-- [docuseal](https://github.com/docusealco/docuseal), a DocuSign alternative. Create, fill, and sign digital documents. Available at [services.docuseal](#opt-services.docuseal.enable).
+- [PairDrop](https://github.com/schlagmichdoch/pairdrop), a peer-to-peer file transfer web app. Available as [services.pairdrop](#opt-services.pairdrop.enable).
 
 - [paisa](https://github.com/ananthakumaran/paisa), a personal finance tracker and dashboard. Available as [services.paisa](#opt-services.paisa.enable).
 
-- [conman](https://github.com/dun/conman), a serial console management program. Available as [services.conman](#opt-services.conman.enable).
+- [Pangolin](https://github.com/fosrl/pangolin), a tunneled reverse proxy server with access control. Available as [services.pangolin](#opt-services.pangolin.enable).
+
+- [Pi-hole](https://pi-hole.net/), a DNS sinkhole for advertisements based on Dnsmasq. Available as [services.pihole-ftl](#opt-services.pihole-ftl.enable), and [services.pihole-web](#opt-services.pihole-web.enable) for the web GUI and API.
+
+- [pmount](https://salsa.debian.org/debian/pmount), a tool that allows normal users to mount removable devices without requiring root privileges Available at [programs.pmount](#opt-programs.pmount.enable).
+
+- [postfix-tlspol](https://github.com/Zuplu/postfix-tlspol), MTA-STS and DANE resolver and TLS policy server for Postfix. Available as [services.postfix-tlspol](#opt-services.postfix-tlspol.enable).
 
 - [Prometheus Tailscale Exporter](https://github.com/adinhodovic/tailscale-exporter), a Prometheus exporter for Tailscale Tailnet metrics.
 
-- [KMinion](https://github.com/redpanda-data/kminion), feature-rich Prometheus exporter for Apache Kafka. Available as [services.prometheus.exporters.kafka](options.html#opt-services.prometheus.exporters.kafka).
+- [Prometheus Storagebox Exporter](https://github.com/fleaz/prometheus-storagebox-exporter), a Prometheus exporter for Hetzner storage boxes.
 
-- [Beszel](https://beszel.dev), a lightweight server monitoring hub with historical data, docker stats, and alerts. Available as [`services.beszel.agent`](options.html#opt-services.beszel.agent.enable) and [`services.beszel.hub`](options.html#opt-services.beszel.hub.enable).
+- [qBittorrent](https://www.qbittorrent.org/), is a bittorrent client programmed in C++ / Qt that uses libtorrent by Arvid Norberg. Available as [services.qbittorrent](#opt-services.qbittorrent.enable).
+
+- [radicle-ci-broker](https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:zwTxygwuz5LDGBq255RA2CbNGrz8), runs CI for repositories in the local [Radicle](https://radicle.xyz/) node. Available as [services.radicle.ci.broker.enable](#opt-services.radicle.ci.broker.enable).
+
+- [radicle-native-ci](https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z3qg5TKmN83afz2fj9z3fQjU8vaYE), an adapter for the [Radicle CI broker](https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:zwTxygwuz5LDGBq255RA2CbNGrz8), for performing CI runs locally. Available as [services.radicle.ci.adapters.native](#opt-services.radicle.ci.adapters.native.instances).
+
+- [rauc](https://rauc.io/) (the Robust Auto-Update Controller), a daemon that allows reliable and secure software updates in embedded Linux systems. Available at [services.rauc](#opt-services.rauc.enable).
+
+- [ringboard](https://github.com/SUPERCILEX/clipboard-history), a fast, efficient, and composable clipboard manager for Linux. Available for x11 as [services.ringboard](#opt-services.ringboard.x11.enable) and for wayland as [services.ringboard](#opt-services.ringboard.wayland.enable).
+
+- [services.rsync](options.html#opt-services.rsync) has been added to simplify periodic directory syncing.
+
+- [services.libvirtd.autoSnapshot](options.html#opt-services.libvirtd.autoSnapshot.enable), a backup service for libvirt managed vms.
+
+- [Sharkey](https://joinsharkey.org), a Sharkish microblogging platform. Available as [services.sharkey](#opt-services.sharkey.enable).
+
+- [SillyTavern](https://sillytavern.app/), LLM Frontend for Power Users. Available as [services.sillytavern](#opt-services.sillytavern.enable).
+
+- [SuiteNumérique Docs](https://github.com/suitenumerique/docs), a collaborative note taking, wiki and documentation web platform and alternative to Notion or Outline. Available as [services.lasuite-docs](#opt-services.lasuite-docs.enable).
+
+- [SuiteNumérique Meet](https://github.com/suitenumerique/meet) is an open source alternative to Google Meet and Zoom powered by LiveKit: HD video calls, screen sharing, and chat features. Built with Django and React. Available as [services.lasuite-meet](#opt-services.lasuite-meet.enable).
+
+- [Speedify](https://speedify.com/), a proprietary VPN which allows combining multiple internet connections (Wi-Fi, 4G, 5G, Ethernet, Starlink, Satellite, and more) to improve the stability, speed, and security of online experiences. Available as [services.speedify](#opt-services.speedify.enable).
 
 - [Spoolman](https://github.com/Donkie/Spoolman), a inventory management system for Filament spools. Available as [services.spoolman](#opt-services.spoolman.enable).
+
+- [Sshwifty](https://github.com/nirui/sshwifty), a Telnet and SSH client for your browser. Available as [services.sshwifty](#opt-services.sshwifty.enable).
+
+- [Szurubooru](https://github.com/rr-/szurubooru), an image board engine inspired by services such as Danbooru, dedicated for small and medium communities. Available as [services.szurubooru](#opt-services.szurubooru.enable).
 
 - [Temporal](https://temporal.io/), a durable execution platform that enables
   developers to build scalable applications without sacrificing productivity or
   reliability. Available as [services.temporal](#opt-services.temporal.enable).
 
-- `services.libvirtd.autoSnapshot`, a backup service for libvirt managed vms.
-
-- [Sshwifty](https://github.com/nirui/sshwifty), a Telnet and SSH client for your browser. Available as [services.sshwifty](#opt-services.sshwifty.enable).
-
-- Added `nixos-init`, a Rust-based bashless initialization system for systemd initrd. This allows to build NixOS systems without any interpreter. Enable via `system.nixos-init.enable = true;`.
-
-- [nvme-rs](https://github.com/liberodark/nvme-rs), NVMe monitoring [services.nvme-rs](#opt-services.nvme-rs.enable).
-
-- [ringboard](https://github.com/SUPERCILEX/clipboard-history), a fast, efficient, and composable clipboard manager for Linux. Available for x11 as [services.ringboard](#opt-services.ringboard.x11.enable) and for wayland as [services.ringboard](#opt-services.ringboard.wayland.enable).
-
 - [Tenstorrent](https://tenstorrent.com) hardware module has been added.
 
-- [nixbit](https://github.com/pbek/nixbit), a GUI application for updating your NixOS system from a Nix Flakes Git repository. Available as [programs.nixbit](#opt-programs.nixbit.enable).
+- The [Neat IP Address Planner](https://spritelink.github.io/NIPAP/) (NIPAP) can now be enabled through [services.nipap.enable](#opt-services.nipap.enable).
 
-- [ErsatzTV](https://ersatztv.org), a personal IPTV server. Available as [services.ersatztv](#opt-services.ersatztv.enable)
+- [Timekpr-nExT](https://mjasnik.gitlab.io/timekpr-next/), a time managing application that helps optimizing time spent at computer for your subordinates, children or even for yourself. Available as [](#opt-services.timekpr.enable).
+
+- [tlsrpt-reporter](https://github.com/sys4/tlsrpt-reporter), an application suite to generate and deliver TLSRPT reports. Available as [services.tlsrpt](#opt-services.tlsrpt.enable).
+
+- [tpm2-totp](https://github.com/tpm2-software/tpm2-totp) can now be used to show a TOTP during boot using Plymouth. Available as [boot.plymouth.tpm2-totp](#opt-boot.plymouth.tpm2-totp.enable).
+
+- [tsidp](https://github.com/tailscale/tsidp), a simple OIDC / OAuth Identity Provider (IdP) server for your tailnet. Available as [services.tsidp](#opt-services.tsidp.enable).
+
+- [TuneD](https://tuned-project.org/), a system tuning service for Linux. Available as [services.tuned](#opt-services.tuned.enable).
+
+- [tuwunel](https://matrix-construct.github.io/tuwunel/), a federated chat server implementing the Matrix protocol, forked from Conduwuit. Available as [services.matrix-tuwunel](#opt-services.matrix-tuwunel.enable).
+
+- [umami](https://github.com/umami-software/umami), a simple, fast, privacy-focused alternative to Google Analytics. Available with [services.umami](#opt-services.umami.enable).
+
+- [wayvnc](https://github.com/any1/wayvnc), VNC server for wlroots based Wayland compositors. Available as [programs.wayvnc](#opt-programs.wayvnc.enable).
+
+- [XPPen](https://www.xp-pen.com/), the official closed-source driver for XP Pen tablets. Available as [programs.xppen](#opt-programs.xppen.enable).
+
+- [Warpgate](https://warpgate.null.page), a SSH, HTTPS, MySQL and Postgres bastion. Available as [services.warpgate](#opt-services.warpgate.enable). Note that you need to run `warpgate recover-access` to recover builtin admin account, as the initialisation script uses a throwaway value to initialise its database.
+
+- [yubikey-manager](https://github.com/Yubico/yubikey-manager), a tool for configuring YubiKey devices. Available as [programs.yubikey-manager](#opt-programs.yubikey-manager.enable).
 
 ## Backward Incompatibilities {#sec-release-25.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- The Perl implementation of the `switch-to-configuration` program is removed. All switchable systems now use the Rust rewrite. Any prior usage of `system.switch.enableNg` must now be removed. If you have any outstanding issues with the new implementation, please open an issue on GitHub.
+- `boot.enableContainers` is only turned on when a declarative NixOS container is defined in `containers`.
+  If you use the `nixos-container` tool for imperative container management, set `boot.enableContainers = true;` explicitly.
 
-- The `no-broken-symlink` build hook now also fails builds whose output derivation contains links to $TMPDIR (typically /build, which contains the build directory).
+- Configurations with `boot.initrd.systemd.enable && !boot.initrd.enable` will have their `init` script at `$toplevel/init` instead of `$toplevel/prepare-root`. This is because it does not make sense for systemd stage 1 to affect the `init` script when stage 1 is entirely disabled (e.g. containers).
+
+- `command-not-found` package is now disabled by default; it works only for nix-channels based systems, and requires setup for it to work.
+
+- Direct use of `pkgs.formats.systemd` has been deprecated, and should now be instantiated with `pkgs.formats.systemd { }` similarly to other items in `pkgs.formats`.
 
 - `hardware.amdgpu.amdvlk` and the `amdvlk` package have been removed, as they have been deprecated by AMD. These have been replaced with the RADV driver from Mesa, which is enabled by default.
 
+- HTTP3 support has been enabled in in `nginx`, `openresty`, `angie` and `tengine`. The `nginxQuic` and `angieQuic` package flavors have been removed.
+
+- `etcd` package was upgraded to 3.6, see [migration notes](https://etcd.io/docs/v3.6/upgrades/upgrade_3_6/) for incompatibilities and upgrade procedure.
+
+- `firezone` has changed how the `Everyone` group behaves. Service Accounts are no longer considered part of `Everyone`.
+
+- `gitversion` was updated to 6.3.0, which includes a number of breaking changes, old configurations may need updating or they will cause the tool to fail to run.
+  See the [6.0.0 release notes for GitVersion](https://github.com/GitTools/GitVersion/releases/tag/6.0.0) for details on the breaking changes, [the documentation on the configuration format](https://gitversion.net/docs/reference/configuration) for the new configuration specification, and [the documentation on version variables](https://gitversion.net/docs/reference/variables) for what is now supported.
+
+- `i18n.inputMethod.fcitx5.plasma6Support` has been removed because qt6 is the only one used for fcitx5-configtool now.
+
 - Linux 5.4 and all its variants have been removed since mainline will reach its end of life within the support-span of 25.11.
+
+- `miniflux` no longer uses the hstore PostgreSQL extension. Having the extension would prevent Miniflux from starting. In case you are managing your `miniflux` PostgreSQL database externally, disable the extension with `DROP EXTENSION IF EXISTS hstore;`.
+
+- `netbox-manage` script created by the `netbox` module no longer uses `sudo -u netbox` internally. It can be run as root and will change it's user to `netbox` using `runuser`
+
+- NixOS display manager modules now strictly use tty1, where many of them previously used tty7. Options to configure display managers' VT have been dropped. A configuration with a display manager enabled will not start `getty@tty1.service`, even if the system is forced to boot into `multi-user.target` instead of `graphical.target`.
+
+- `orjail` package has been removed as it is broken by the latest firejail release and seems unmaintained.
+
+- [private-gpt](https://github.com/zylon-ai/private-gpt) service has been removed by lack of maintenance upstream.
+
+- `programs.goldwarden` has been removed, due to the software not working with newer versions of the Bitwarden and Vaultwarden servers, as well as it being abandoned upstream.
+
+- `programs.skim.fuzzyCompletions` has been removed in favor of adding the completions to the package itself.
+
+- `Prosody` has been updated to major release 13 which removed some obsoleted modules and brought a couple of major and breaking changes:
+  - The `http_files` module is now disabled by default because it now requires `http_files_dir` to be configured.
+  - The `vcard_muc` module has been removed and got replaced by the inbuilt `muc_vcard` module.
+  - The `http_upload` module has been removed and you must migrate to the `http_file_share` module to stay XEP-0423 compliant. The `httpFileShare` options got expanded to better facility that.
+  - The `admin_shell` module is now always being loaded to make `prosodyctl` functional.
+  - The `mime_types_file` setting is now set to `"${pkgs.mailcap}/etc/mime.types"` to prevent errors.
+  For a complete list of changes, please see [their announcement](https://blog.prosody.im/prosody-13.0.0-released/).
+
+- `renovate` was updated to v41. See the upstream release notes for [v40](https://github.com/renovatebot/renovate/releases/tag/40.0.0) and [v41](https://github.com/renovatebot/renovate/releases/tag/41.0.0) for breaking changes.
+
+- `river` 0.3.x has been renamed to `river-classic` upstream, and the package renamed accordingly. `programs.river` has been renamed to `programs.river-classic`.
+
+- `services.dwm-status.extraConfig` was replaced by [RFC0042](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md)-compliant [](#opt-services.dwm-status.settings), which is used to generate the config file. `services.dwm-status.order` is now moved to [](#opt-services.dwm-status.settings.order), as it's a part of the config file.
+
+- `services.forgejo.dump.age` now defaults to `4w`, which deletes dumps older than 4 weeks. This new behaviour could result in older backups being deleted.
+
+- `services.gateone` has been removed as the package was removed such that it does not work.
+
+- `services.journald.gateway.user` and `services.journald.gateway.system` now defaults to `false`. This new behaviour matches the default behaviour of the [`systemd-journal-gatewayd`](https://www.freedesktop.org/software/systemd/man/latest/systemd-journal-gatewayd.service.html) service itself.
+
+- `services.nextcloud.notify_push.enable` now installs the notify_push app. Therefore the appstore is now disabled when using `notify_push`. See `services.nextcloud.appstoreEnable`.
+
+- `services.nixseparatedebuginfod.enable = true;` has been replaced by `services.nixseparatedebuginfod2.enable = true`. If you only use the official binary cache `https://cache.nixos.org` then no further configuration should be needed. If you have other https substituters, you can add them to `services.nixseparatedebuginfod2.subsituters`. SSH substituters are not supported by nixseparatedebuginfod2. Consider running nixseparatedebuginfod2 on the substituter instead, and pointing to it with the new option `environment.debuginfodServers`.
+
+- `services.parsoid` and the `nodePackages.parsoid` package have been removed, as the JavaScript-based version this module uses is not compatible with modern MediaWiki versions.
+
+- `services.quorum` has been removed as the `quorum` package was broken and abandoned upstream.
+
+- `services.seafile` has been removed, as it is unmaintained and outdated.
+  See [the manual](https://manual.seafile.com/13.0/upgrade/upgrade_notes_for_13.0.x/#important-release-changes)
+  for details and next steps.
+
+- `services.tor.torsocks.enable` no longer defaults to true if Tor and Tor client functionality is enabled.
+
+- `sing-box` has been updated to 1.12.3, which includes a number of breaking changes, old configurations may need updating or they will cause the tool to fail to run.
+  See the [change log](https://sing-box.sagernet.org/changelog/#1123) for details and [migration](https://sing-box.sagernet.org/migration/#1120) for how to update old configurations.
+
+- `teleport` has been upgraded from major version 17 to major version 18.
+Refer to [upstream upgrade instructions](https://goteleport.com/docs/upgrading/overview/)
+and [release notes for v18](https://goteleport.com/docs/changelog/#1800-070325).
+
+- The `asterisk-lts` package was changed to v22 from v18. The default `asterisk` package was changed to v22 from v20. Asterisk version 18 has been dropped due to being EOL. The `asterisk-stable` (v20) package was unchanged. You may need to update /var/lib/asterisk to match the template files in `${asterisk-...}/var/lib/asterisk`.
+
+- The `boot.readOnlyNixStore` has been removed. Control over bind mount options on `/nix/store` is now offered by the `boot.nixStoreMountOpts` option.
+
+- The `cardboard` package and `programs.cardboard` module were removed due to the package having been broken since at least November 2024.
+
+- The `chatgpt-retrieval-plugin` package and `services.chatgpt-retrieval-plugin` module were removed due to the package having been broken since at least November 2024.
+
+- The default `kops` version is now 1.33.0 and versions 1.30 and older have been dropped. See [Upgrading Kubernetes](https://kops.sigs.k8s.io/tutorial/upgrading-kubernetes/) for instructions on how to update kOps.
+
+- The `dovecot` systemd service was renamed from `dovecot2` to `dovecot`. The former is now just an alias. Update any overrides on the systemd unit to the new name.
+
+- The `NIXOS_EXTRA_MODULE_PATH` variable from configuration evaluation has been deprecated.
+  We recommend a workflow where you update the expression files instead, but if you wish to continue
+  to use this variable, you may do so with a module like:
+
+  ```nix
+  {
+    imports = [
+      (builtins.getEnv "NIXOS_EXTRA_MODULE_PATH")
+    ];
+  }
+  ```
+
+  This has the benefit that your configuration hints at the non-standard workflow.
+
+- The `file-roller` module has been removed due to not being required for function, file roller itself has also been removed from the `services.desktopManager.gnome` module as it's not part of GNOME core applications.
+
+- The `no-broken-symlink` build hook now also fails builds whose output derivation contains links to $TMPDIR (typically /build, which contains the build directory).
+
+- The non-LTS Forgejo package (`forgejo`) has been updated to 12.0.0. This release contains breaking changes, see the [release blog post](https://forgejo.org/2025-07-release-v12-0/)
+  for all the details and how to ensure smooth upgrades.
+
+- The Perl implementation of the `switch-to-configuration` program is removed. All switchable systems now use the Rust rewrite. Any prior usage of `system.switch.enableNg` must now be removed. If you have any outstanding issues with the new implementation, please open an issue on GitHub.
+
+- The Pocket ID module ([`services.pocket-id`][#opt-services.pocket-id.enable]) and package (`pocket-id`) has been updated to 1.0.0. Some environment variables have been changed or removed, see the [migration guide](https://pocket-id.org/docs/setup/migrate-to-v1/).
+
+- The Postfix module has been updated and likely requires configuration changes:
+  - The `services.postfix.sslCert` and `sslKey` options were removed and you now need to configure
+    - [services.postfix.settings.main.smtpd_tls_chain_files](#opt-services.postfix.settings.main.smtpd_tls_chain_files) for server certificates,
+    - [services.postfix.settings.main.smtp_tls_chain_files](#opt-services.postfix.settings.main) for client certificates.
+
+- The `services.meilisearch` module now always defaults to the latest version of meilisearch, as the previous `meilisearch_1_11` package was removed. This is only an issue if you were using the old version.
+
+- The `services.mysql` module now restarts the database `on-abnormal`, which means that it now will be restarted in certain situations, it wasn't before. For example an OOM-kill.
 
 - The `services.nginx.sso` module has switched to generating its configuration
   file in `/run`. You should manually delete `/var/lib/nginx-sso/config.yaml` to
   avoid storing secret values to disk.
 
+- The `services.postgresql` module now sets up a systemd unit `postgresql.target`. Depending on `postgresql.target` guarantees that postgres is in read-write mode and initial/ensure scripts were executed. Depending on `postgresql.service` only guarantees a read-only connection.
+
 - The `services.polipo` module has been removed as `polipo` is unmaintained and archived upstream.
 
-- `services.nextcloud.notify_push.enable` now installs the notify_push app. Therefore the appstore is now disabled when using `notify_push`. See `services.nextcloud.appstoreEnable`.
+- The `services.postfixadmin` module has been removed due to a lack of active maintainers.
 
-- `boot.enableContainers` is only turned on when a declarative NixOS container is defined in `containers`.
-  If you use the `nixos-container` tool for imperative container management, set `boot.enableContainers = true;` explicitly.
+- The `services.siproxd` module has been removed as `siproxd` is unmaintained and broken with libosip 5.x.
 
-- `etcd` package was upgraded to 3.6, see [migration notes](https://etcd.io/docs/v3.6/upgrades/upgrade_3_6/) for incompatibilities and upgrade procedure.
+- The `services.snapserver` module has been migrated to use the settings option and render a configuration file instead of passing every option over the command line.
 
-- `services.parsoid` and the `nodePackages.parsoid` package have been removed, as the JavaScript-based version this module uses is not compatible with modern MediaWiki versions.
+- []{#sec-release-25.11-incompatibilities-sourcehut-removed} The `services.sourcehut` module and corresponding `sourcehut` packages were removed due to being broken and unmaintained.
+
+- The `services.traccar.settings` attribute has been reworked. Instead of the previous flat attribute set the new implementation uses nested attribute sets. You need to update you configuration manually. For instance, `services.traccar.settings.loggerConsole` becomes `services.traccar.settings.logger.console`.
+
+- The `services.tt-rss` module and package have been removed as upstream development ceased on 2025-11-01, and the source is no longer available officially.
+
+- The systemd target `kbrequest.target` is now unset by default, instead of being forcibly symlinked to `rescue.target`. In case you were relying on this behavior (Alt + ArrowUp on the tty causing the current target to be changed to `rescue.target`), you can restore it by setting `systemd.targets.rescue.aliases = [ "kbrequest.target" ];` in your configuration.
+
+- The `wstunnel` module was converted to RFC42-style settings, you will need to update your NixOS config if you make use of this module.
+
+- The `yeahwm` package and `services.xserver.windowManager.yeahwm` module were removed due to the package being broken and unmaintained upstream.
+
+- The `zigbee2mqtt` package was updated to version 2.x, which contains breaking changes. See the [discussion](https://github.com/Koenkk/zigbee2mqtt/discussions/24198) for further information.
+
+- The zookeeper project changed their logging tool to logback, therefore `services.zookeeper.logging` option has been updated to expect a logback compatible string.
 
 - `virtualisation.lxd` has been removed due to lack of Nixpkgs maintenance. Users can migrate to `virtualisation.incus`, a fork of LXD, as a replacement. See [Incus migration documentation](https://linuxcontainers.org/incus/docs/main/howto/server_migrate_lxd/) for migration information.
 
@@ -250,173 +383,16 @@
     | /run/libvirt/nix-ovmf/AAVMF_CODE.ms.fd | /run/libvirt/nix-ovmf/edk2-aarch64-code.fd       |
     | /run/libvirt/nix-ovmf/AAVMF_VARS.ms.fd | /run/libvirt/nix-ovmf/edk2-arm-vars.fd           |
 
-- The non-LTS Forgejo package (`forgejo`) has been updated to 12.0.0. This release contains breaking changes, see the [release blog post](https://forgejo.org/2025-07-release-v12-0/)
-  for all the details and how to ensure smooth upgrades.
-
-- `services.forgejo.dump.age` now defaults to `4w`, which deletes dumps older than 4 weeks. This new behaviour could result in older backups being deleted.
-
-- `sing-box` has been updated to 1.12.3, which includes a number of breaking changes, old configurations may need updating or they will cause the tool to fail to run.
-  See the [change log](https://sing-box.sagernet.org/changelog/#1123) for details and [migration](https://sing-box.sagernet.org/migration/#1120) for how to update old configurations.
-
-- The Pocket ID module ([`services.pocket-id`][#opt-services.pocket-id.enable]) and package (`pocket-id`) has been updated to 1.0.0. Some environment variables have been changed or removed, see the [migration guide](https://pocket-id.org/docs/setup/migrate-to-v1/).
-
-- `services.seafile` has been removed, as it is unmaintained and outdated.
-  See [the manual](https://manual.seafile.com/13.0/upgrade/upgrade_notes_for_13.0.x/#important-release-changes)
-  for details and next steps.
-
-- The `zigbee2mqtt` package was updated to version 2.x, which contains breaking changes. See the [discussion](https://github.com/Koenkk/zigbee2mqtt/discussions/24198) for further information.
-
-- []{#sec-release-25.11-incompatibilities-sourcehut-removed} The `services.sourcehut` module and corresponding `sourcehut` packages were removed due to being broken and unmaintained.
-- The zookeeper project changed their logging tool to logback, therefore `services.zookeeper.logging` option has been updated to expect a logback compatible string.
-- The `dovecot` systemd service was renamed from `dovecot2` to `dovecot`. The former is now just an alias. Update any overrides on the systemd unit to the new name.
-
-- Configurations with `boot.initrd.systemd.enable && !boot.initrd.enable` will have their `init` script at `$toplevel/init` instead of `$toplevel/prepare-root`. This is because it does not make sense for systemd stage 1 to affect the `init` script when stage 1 is entirely disabled (e.g. containers).
-
-- `programs.goldwarden` has been removed, due to the software not working with newer versions of the Bitwarden and Vaultwarden servers, as well as it being abandoned upstream.
-
-- The `chatgpt-retrieval-plugin` package and `services.chatgpt-retrieval-plugin` module were removed due to the package having been broken since at least November 2024.
-
-- The `cardboard` package and `programs.cardboard` module were removed due to the package having been broken since at least November 2024.
-
-- The default `kops` version is now 1.33.0 and versions 1.30 and older have been dropped. See [Upgrading Kubernetes](https://kops.sigs.k8s.io/tutorial/upgrading-kubernetes/) for instructions on how to update kOps.
-
-- `programs.skim.fuzzyCompletions` has been removed in favor of adding the completions to the package itself.
-
-- `Prosody` has been updated to major release 13 which removed some obsoleted modules and brought a couple of major and breaking changes:
-  - The `http_files` module is now disabled by default because it now requires `http_files_dir` to be configured.
-  - The `vcard_muc` module has been removed and got replaced by the inbuilt `muc_vcard` module.
-  - The `http_upload` module has been removed and you must migrate to the `http_file_share` module to stay XEP-0423 compliant. The `httpFileShare` options got expanded to better facility that.
-  - The `admin_shell` module is now always being loaded to make `prosodyctl` functional.
-  - The `mime_types_file` setting is now set to `"${pkgs.mailcap}/etc/mime.types"` to prevent errors.
-  For a complete list of changes, please see [their announcement](https://blog.prosody.im/prosody-13.0.0-released/).
-
-- HTTP3 support has been enabled in in `nginx`, `openresty`, `angie` and `tengine`. The `nginxQuic` and `angieQuic` package flavors have been removed.
-
-- The `yeahwm` package and `services.xserver.windowManager.yeahwm` module were removed due to the package being broken and unmaintained upstream.
-
-- `services.nixseparatedebuginfod.enable = true;` has been replaced by `services.nixseparatedebuginfod2.enable = true`. If you only use the official binary cache `https://cache.nixos.org` then no further configuration should be needed. If you have other https substituters, you can add them to `services.nixseparatedebuginfod2.subsituters`. SSH substituters are not supported by nixseparatedebuginfod2. Consider running nixseparatedebuginfod2 on the substituter instead, and pointing to it with the new option `environment.debuginfodServers`.
-
-- The `services.snapserver` module has been migrated to use the settings option and render a configuration file instead of passing every option over the command line.
-
-- The `services.meilisearch` module now always defaults to the latest version of meilisearch, as the previous `meilisearch_1_11` package was removed. This is only an issue if you were using the old version.
-
-- `services.journald.gateway.user` and `services.journald.gateway.system` now defaults to `false`. This new behaviour matches the default behaviour of the [`systemd-journal-gatewayd`](https://www.freedesktop.org/software/systemd/man/latest/systemd-journal-gatewayd.service.html) service itself.
-
-- The `services.postgresql` module now sets up a systemd unit `postgresql.target`. Depending on `postgresql.target` guarantees that postgres is in read-write mode and initial/ensure scripts were executed. Depending on `postgresql.service` only guarantees a read-only connection.
-
-- The `services.mysql` module now restarts the database `on-abnormal`, which means that it now will be restarted in certain situations, it wasn't before. For example an OOM-kill.
-
-- The `services.tt-rss` module and package have been removed as upstream development ceased on 2025-11-01, and the source is no longer available officially.
-
-- The `services.siproxd` module has been removed as `siproxd` is unmaintained and broken with libosip 5.x.
-
-- The `services.postfixadmin` module has been removed due to a lack of active maintainers.
-
-- `services.tor.torsocks.enable` no longer defaults to true if Tor and Tor client functionality is enabled.
-
-- `netbox-manage` script created by the `netbox` module no longer uses `sudo -u netbox` internally. It can be run as root and will change it's user to `netbox` using `runuser`
-
-- `services.gateone` has been removed as the package was removed such that it does not work.
-
-- `services.quorum` has been removed as the `quorum` package was broken and abandoned upstream.
-
-- `orjail` package has been removed as it is broken by the latest firejail release and seems unmaintained.
-
-- `teleport` has been upgraded from major version 17 to major version 18.
-Refer to [upstream upgrade instructions](https://goteleport.com/docs/upgrading/overview/)
-and [release notes for v18](https://goteleport.com/docs/changelog/#1800-070325).
-
-- `services.dwm-status.extraConfig` was replaced by [RFC0042](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md)-compliant [](#opt-services.dwm-status.settings), which is used to generate the config file. `services.dwm-status.order` is now moved to [](#opt-services.dwm-status.settings.order), as it's a part of the config file.
-
-- `gitversion` was updated to 6.3.0, which includes a number of breaking changes, old configurations may need updating or they will cause the tool to fail to run.
-  See the [6.0.0 release notes for GitVersion](https://github.com/GitTools/GitVersion/releases/tag/6.0.0) for details on the breaking changes, [the documentation on the configuration format](https://gitversion.net/docs/reference/configuration) for the new configuration specification, and [the documentation on version variables](https://gitversion.net/docs/reference/variables) for what is now supported.
-
-- `renovate` was updated to v41. See the upstream release notes for [v40](https://github.com/renovatebot/renovate/releases/tag/40.0.0) and [v41](https://github.com/renovatebot/renovate/releases/tag/41.0.0) for breaking changes.
-
-- The "NIXOS_EXTRA_MODULE_PATH" variable from configuration evaluation has been deprecated.
-  We recommend a workflow where you update the expression files instead, but if you wish to continue
-  to use this variable, you may do so with a module like:
-
-  ```nix
-  {
-    imports = [
-      (builtins.getEnv "NIXOS_EXTRA_MODULE_PATH")
-    ];
-  }
-  ```
-
-  This has the benefit that your configuration hints at the non-standard workflow.
-
-- `i18n.inputMethod.fcitx5.plasma6Support` has been removed because qt6 is the only one used for fcitx5-configtool now.
-
-- `firezone` has changed how the `Everyone` group behaves. Service Accounts are no longer considered part of `Everyone`.
-
-- The `file-roller` module has been removed due to not being required for function, file roller itself has also been removed from the `services.desktopManager.gnome` module as it's not part of GNOME core applications.
-
-- The `boot.readOnlyNixStore` has been removed. Control over bind mount options on `/nix/store` is now offered by the `boot.nixStoreMountOpts` option.
-
-- Direct use of `pkgs.formats.systemd` has been deprecated, and should now be instantiated with `pkgs.formats.systemd { }` similarly to other items in `pkgs.formats`.
-
-- The Postfix module has been updated and likely requires configuration changes:
-  - The `services.postfix.sslCert` and `sslKey` options were removed and you now need to configure
-    - [services.postfix.settings.main.smtpd_tls_chain_files](#opt-services.postfix.settings.main.smtpd_tls_chain_files) for server certificates,
-    - [services.postfix.settings.main.smtp_tls_chain_files](#opt-services.postfix.settings.main) for client certificates.
-
 - `vmalert` now supports multiple instances with the option `services.vmalert.instances."".enable`
 
 - [`virtualisation.waydroid.package`](#opt-virtualisation.waydroid.package) now defaults to `waydroid-nftables` on systems with nftables enabled.
 
 - [`services.victorialogs.package`](#opt-services.victorialogs.package) now defaults to `victorialogs`, as `victoriametrics` no longer contains the VictoriaLogs binaries.
 
-- The `services.traccar.settings` attribute has been reworked. Instead of the previous flat attribute set the new implementation uses nested attribute sets. You need to update you configuration manually. For instance, `services.traccar.settings.loggerConsole` becomes `services.traccar.settings.logger.console`.
-
-- The `wstunnel` module was converted to RFC42-style settings, you will need to update your NixOS config if you make use of this module.
-
-- [private-gpt](https://github.com/zylon-ai/private-gpt) service has been removed by lack of maintenance upstream.
-
-- The `asterisk-lts` package was changed to v22 from v18. The default `asterisk` package was changed to v22 from v20. Asterisk version 18 has been dropped due to being EOL. The `asterisk-stable` (v20) package was unchanged. You may need to update /var/lib/asterisk to match the template files in `${asterisk-...}/var/lib/asterisk`.
-
-- NixOS display manager modules now strictly use tty1, where many of them previously used tty7. Options to configure display managers' VT have been dropped. A configuration with a display manager enabled will not start `getty@tty1.service`, even if the system is forced to boot into `multi-user.target` instead of `graphical.target`.
-
-- `river` 0.3.x has been renamed to `river-classic` upstream, and the package renamed accordingly. `programs.river` has been renamed to `programs.river-classic`.
-
-- `command-not-found` package is now disabled by default; it works only for nix-channels based systems, and requires setup for it to work.
-
-- The systemd target `kbrequest.target` is now unset by default, instead of being forcibly symlinked to `rescue.target`. In case you were relying on this behavior (Alt + ArrowUp on the tty causing the current target to be changed to `rescue.target`), you can restore it by setting `systemd.targets.rescue.aliases = [ "kbrequest.target" ];` in your configuration.
-
-- `miniflux` no longer uses the hstore PostgreSQL extension. Having the extension would prevent Miniflux from starting. In case you are managing your `miniflux` PostgreSQL database externally, disable the extension with `DROP EXTENSION IF EXISTS hstore;`.
-
 ## Other Notable Changes {#sec-release-25.11-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- `services.clamsmtp` is unmaintained and was removed from Nixpkgs.
-
-- The latest available version of Nextcloud is v32 (available as `pkgs.nextcloud32`). The installation logic is as follows:
-  - If [`services.nextcloud.package`](#opt-services.nextcloud.package) is specified explicitly, this package will be installed (**recommended**)
-  - If [`system.stateVersion`](#opt-system.stateVersion) is >=25.05, `pkgs.nextcloud32` will be installed by default.
-  - If [`system.stateVersion`](#opt-system.stateVersion) is >=24.11, `pkgs.nextcloud31` will be installed by default.
-  - `nextcloud30` is EOL and was thus removed.
-  - Please note that an upgrade from v30 (or older) to v32 directly is not possible. Please upgrade to `nextcloud31` (or earlier) first. Nextcloud prohibits skipping major versions while upgrading. You can upgrade by declaring [`services.nextcloud.package = pkgs.nextcloud30;`](#opt-services.nextcloud.package).
-
-- `services.eris-server` was removed from Nixpkgs due to a hostile upstream.
-
-- `prosody` gained a config check option named `services.prosody.checkConfig` which runs `prosodyctl check config` and is turned on by default.
-
-- `services.dependency-track` removed its configuration of the JVM heap size. This lets the JVM choose its maximum heap size automatically, which should work much better in practice for most users. For deployments on systems with little RAM, it may now be necessary to manually configure a maximum heap size using  {option}`services.dependency-track.javaArgs`.
-
-- `services.dnscrypt-proxy2` was renamed to `services.dnscrypt-proxy` to match the package name. The systemd service is now also `dnscrypt-proxy`, but the old name is still provided as an alias for backwards compatibility.
-
-- `services.dnscrypt-proxy` gains a `package` option to specify dnscrypt-proxy package to use.
-
-- `boot.plymouth` now has a [`package`](#opt-boot.plymouth.package) option to specify the package used in the module.
-
-- `services.limesurvey` now supports nginx as reverse-proxy. Available through [services.limesurvey.webserver](#opt-services.limesurvey.webserver).
-
-- `services.nextcloud.configureRedis` now defaults to `true` in accordance with upstream recommendations to have caching for file locking. See the [upstream doc](https://docs.nextcloud.com/server/31/admin_manual/configuration_files/files_locking_transactional.html) for further details.
-
-- mate-wayland-session 1.28.4 is now using the default wayfire decorator instead of firedecor, thus `services.xserver.desktopManager.mate.enableWaylandSession` is no longer shipping firedecor. If you are experiencing broken window decorations after upgrade, backup and remove `~/.config/mate/wayfire.ini` and re-login.
--
 - A new option [](#opt-boot.isNspawnContainer) has been added. This option will be used to guard nspawn-specific configuration in NixOS since [](#opt-boot.isContainer) is also used for different container-runtimes such as LXC.
   - The new option is automatically set to `true` by the declarative container module and `nixos-container` when not using flakes.
     - Existing setups can be migrated by running either
@@ -426,21 +402,37 @@ and [release notes for v18](https://goteleport.com/docs/changelog/#1800-070325).
   - In all other cases, you'll need to set this option to `true` yourself.
   - `boot.isNspawnContainer` being `true` implies [](#opt-boot.isContainer) being `true`.
 
-- `users.users.*.linger` now defaults to `null` rather than `false`, meaning NixOS will not attempt to enable or disable lingering for that user account, instead allowing for imperative control over lingering using the `loginctl` commands. In practice, this is unlikely to make a difference for most people, as new users are created without lingering configured. There is a new, related option, `users.manageLingering`, which can be used to prevent NixOS attempting to manage lingering entirely.
-
-- Due to [deprecation of gnome-session X11 support](https://blogs.gnome.org/alatiera/2025/06/08/the-x11-session-removal/), `services.desktopManager.pantheon` now defaults to pantheon-wayland session. The X11 session has been removed, see [this issue](https://github.com/elementary/session-settings/issues/91) for details.
+- `amdgpu` kernel driver overdrive mode can now be enabled by setting [hardware.amdgpu.overdrive.enable](#opt-hardware.amdgpu.overdrive.enable) and customized through [hardware.amdgpu.overdrive.ppfeaturemask](#opt-hardware.amdgpu.overdrive.ppfeaturemask).
+  This allows for fine-grained control over the GPU's performance and maybe required by overclocking softwares like Corectrl and Lact. These new options replace old options such as {option}`programs.corectrl.gpuOverclock.enable` and {option}`programs.tuxclocker.enableAMD`.
 
 - `bcachefs` file systems will now use the out-of-tree module for supported kernels. The in-tree module has been removed, and users will need to switch to kernels that support the out-of-tree module.
 
-- `services.filesender` and the package `filesender` have been removed because they depend on `simplesamlphp`.
+- `boot.plymouth` now has a [`package`](#opt-boot.plymouth.package) option to specify the package used in the module.
 
-- `services.gitea` supports sending notifications with sendmail again. To do this, activate the parameter `services.gitea.mailerUseSendmail` and configure SMTP server.
+- Due to [deprecation of gnome-session X11 support](https://blogs.gnome.org/alatiera/2025/06/08/the-x11-session-removal/), `services.desktopManager.pantheon` now defaults to pantheon-wayland session. The X11 session has been removed, see [this issue](https://github.com/elementary/session-settings/issues/91) for details.
 
-- `services.mattermost` has been updated to use the 10.11 ESR instead of 10.5. While this shouldn't break anyone, we also now package Mattermost 11 as mattermostLatest. Note that Mattermost 11 drops support for MySQL. The Mattermost module will assertion fail if you try to use MySQL with Mattermost 11; support for using MySQL with Mattermost will fully be removed in NixOS 26.
+- `libvirt` now supports using `nftables` backend.
+  - The `virtualisation.libvirtd.firewallBackend` option can be used to configure the firewall backend used by libvirtd.
 
-- `simplesamlphp` has been removed since the package was severely outdated, unmaintained in nixpkgs and having known vulnerabilities.
+- `linux_libre` & `linux_latest_libre` have been removed due to a lack of maintenance.
+
+- Immich now has support for [VectorChord](https://github.com/tensorchord/VectorChord) when using the PostgreSQL configuration provided by `services.immich.database.enable`, which replaces `pgvecto-rs`. VectorChord support can be toggled with the option `services.immich.database.enableVectorChord`. Additionally, `pgvecto-rs` support is now disabled from NixOS 25.11 onwards using the option `services.immich.database.enableVectors`. This option will be removed fully in the future once Immich drops support for `pgvecto-rs` fully. See [Immich migration instructions](#module-services-immich-vectorchord-migration)
+
+- It is now possible to configure the default source address using the new options [networking.defaultGateway.source](#opt-networking.defaultGateway.source),
+  [networking.defaultGateway6.source](#opt-networking.defaultGateway6.source).
+
+- mate-wayland-session 1.28.4 is now using the default wayfire decorator instead of firedecor, thus `services.xserver.desktopManager.mate.enableWaylandSession` is no longer shipping firedecor. If you are experiencing broken window decorations after upgrade, backup and remove `~/.config/mate/wayfire.ini` and re-login.
 
 - `networking.wireless.networks.<name>` now has an option to specify SSID, hence allowing duplicated SSID setup. The BSSID option is added along side with this.
+
+- `php81` was removed.
+
+- Potential race conditions in the network setup when using `networking.interfaces` have been fixed by disabling duplicate address detection (DAD)
+  for statically configured IPv6 addresses.
+
+- `prl-tools` has been moved out of `linuxPackages` because Parallels Guest Tools become driverless since 26.1.0.
+
+- `prosody` gained a config check option named `services.prosody.checkConfig` which runs `prosodyctl check config` and is turned on by default.
 
 - Revamp of the ACME certificate acquisication and renewal process to help scale systems with lots (100+) of certificates.
 
@@ -457,12 +449,69 @@ and [release notes for v18](https://goteleport.com/docs/changelog/#1800-070325).
 
   Note that system activation will complete before all certificates may have been renewed or acquired.
 
-- `php81` was removed.
+- `services.clamsmtp` is unmaintained and was removed from Nixpkgs.
 
-- `libvirt` now supports using `nftables` backend.
-  - The `virtualisation.libvirtd.firewallBackend` option can be used to configure the firewall backend used by libvirtd.
+- `services.dependency-track` removed its configuration of the JVM heap size. This lets the JVM choose its maximum heap size automatically, which should work much better in practice for most users. For deployments on systems with little RAM, it may now be necessary to manually configure a maximum heap size using  {option}`services.dependency-track.javaArgs`.
 
-- The third-party `ant-contrib` is no longer included in the `ant` package.
+- `services.dnscrypt-proxy2` was renamed to `services.dnscrypt-proxy` to match the package name. The systemd service is now also `dnscrypt-proxy`, but the old name is still provided as an alias for backwards compatibility.
+
+- `services.dnscrypt-proxy` gains a `package` option to specify dnscrypt-proxy package to use.
+
+- `services.eris-server` was removed from Nixpkgs due to a hostile upstream.
+
+- `services.filesender` and the package `filesender` have been removed because they depend on `simplesamlphp`.
+
+- `services.gitea` supports sending notifications with sendmail again. To do this, activate the parameter `services.gitea.mailerUseSendmail` and configure SMTP server.
+
+- [](#opt-services.gnome.gnome-keyring.enable) does not ship with an SSH agent anymore, as this is now handled by the `gcr_4` package instead of `gnome-keyring`. A new module has been added to support this, under [](#opt-services.gnome.gcr-ssh-agent.enable) (its default value has been set to [](#opt-services.gnome.gnome-keyring.enable) to ensure a smooth transition). See the [relevant upstream PR](https://gitlab.gnome.org/GNOME/gcr/-/merge_requests/67) for more details.
+
+- `services.grafana` does no longer send usage statistics by default.
+
+- `services.k3s` now shares most of its code with `services.rke2`. The merge resulted in both modules providing more options, with `services.rke2` receiving the most improvements.
+  Existing configurations for either module should not be affected.
+
+- `services.limesurvey` now supports nginx as reverse-proxy. Available through [services.limesurvey.webserver](#opt-services.limesurvey.webserver).
+
+- `services.mattermost` has been updated to use the 10.11 ESR instead of 10.5. While this shouldn't break anyone, we also now package Mattermost 11 as mattermostLatest. Note that Mattermost 11 drops support for MySQL. The Mattermost module will assertion fail if you try to use MySQL with Mattermost 11; support for using MySQL with Mattermost will fully be removed in NixOS 26.
+
+- `services.matter-server` now hosts a debug dashboard on the configured port. Open the port on the firewall with `services.matter-server.openFirewall`.
+
+- `services.monero` now includes the `environmentFile` option for adding secrets to the Monero daemon config.
+
+- `services.nebula.networks.<name>` will now store configuration files in `/etc/nebula/<name>.yml` and supports config reloading.
+
+- `services.logind.extraConfig` was converted to RFC42-style `services.logind.settings.Login`.
+
+- `services.nginx.recommendedProxySettings` now sets `X-Forwarded-Server` to the hostname of nginx instead of the original host.
+
+- `services.netbird.server` now uses dedicated packages split out due to relicensing of server components to AGPLv3 with version `0.53.0`,
+
+- `services.nextcloud.configureRedis` now defaults to `true` in accordance with upstream recommendations to have caching for file locking. See the [upstream doc](https://docs.nextcloud.com/server/31/admin_manual/configuration_files/files_locking_transactional.html) for further details.
+
+- `services.ntpd-rs` now performs configuration validation.
+
+- `services.opentelemetry-collector` has a new option `validateConfigFile` option that checks the configuration file during build. It is enabled by default if the configuration file is in the Nix store.
+
+- `services.restic.backups` now includes a `command` option for passing a command to the [--stdin-from-command](https://github.com/restic/restic/pull/4410) flag.
+
+- `services.pds` has been renamed to `services.bluesky-pds`.
+
+- `services.pfix-srsd` now automatically integrates with the local Postfix instance, when enabled. This behavior can disabled using the [services.pfix-srsd.configurePostfix](#opt-services.pfix-srsd.configurePostfix) option.
+
+- `services.postsrsd` now automatically integrates with the local Postfix instance, when enabled. This behavior can disabled using the [services.postsrsd.configurePostfix](#opt-services.postsrsd.configurePostfix) option.
+
+- `services.varnish.http_address` has been superseeded by `services.varnish.listen` which is now
+  structured config for all of varnish's `-a` variations.
+
+- `services.xserver.desktopManager.deepin` and associated packages have been removed due to being unmaintained. See issue [#422090](https://github.com/NixOS/nixpkgs/issues/422090) for more details.
+
+- `simplesamlphp` has been removed since the package was severely outdated, unmaintained in nixpkgs and having known vulnerabilities.
+
+- `slurm` no longer supports gtk2.
+
+- `sparkleshare` has been removed as it no longer builds and has been abandoned upstream.
+
+- `strongSwan` has been updated to 6.0. See [strongSwan 6.0.0 release notes](https://github.com/strongswan/strongswan/releases/tag/6.0.0) for a complete list of changes.
 
 - `systemd.extraConfig` and `boot.initrd.systemd.extraConfig` was converted to RFC42-style `systemd.settings.Manager` and `boot.initrd.systemd.settings.Manager` respectively.
   - `systemd.watchdog.runtimeTime` was renamed to `systemd.settings.Manager.RuntimeWatchdogSec`
@@ -471,66 +520,20 @@ and [release notes for v18](https://goteleport.com/docs/changelog/#1800-070325).
   - `systemd.watchdog.kexecTime` was renamed to `systemd.settings.Manager.KExecWatchdogSec`
   - `systemd.enableCgroupAccounting` was removed. Cgroup accounting now needs to be disabled directly using `systemd.settings.Manager.*Accounting`.
 
-- `services.logind.extraConfig` was converted to RFC42-style `services.logind.settings.Login`.
+- The latest available version of Nextcloud is v32 (available as `pkgs.nextcloud32`). The installation logic is as follows:
+  - If [`services.nextcloud.package`](#opt-services.nextcloud.package) is specified explicitly, this package will be installed (**recommended**)
+  - If [`system.stateVersion`](#opt-system.stateVersion) is >=25.05, `pkgs.nextcloud32` will be installed by default.
+  - If [`system.stateVersion`](#opt-system.stateVersion) is >=24.11, `pkgs.nextcloud31` will be installed by default.
+  - `nextcloud30` is EOL and was thus removed.
+  - Please note that an upgrade from v30 (or older) to v32 directly is not possible. Please upgrade to `nextcloud31` (or earlier) first. Nextcloud prohibits skipping major versions while upgrading. You can upgrade by declaring [`services.nextcloud.package = pkgs.nextcloud30;`](#opt-services.nextcloud.package).
 
-- `services.ntpd-rs` now performs configuration validation.
-
-- Immich now has support for [VectorChord](https://github.com/tensorchord/VectorChord) when using the PostgreSQL configuration provided by `services.immich.database.enable`, which replaces `pgvecto-rs`. VectorChord support can be toggled with the option `services.immich.database.enableVectorChord`. Additionally, `pgvecto-rs` support is now disabled from NixOS 25.11 onwards using the option `services.immich.database.enableVectors`. This option will be removed fully in the future once Immich drops support for `pgvecto-rs` fully. See [Immich migration instructions](#module-services-immich-vectorchord-migration)
-
-- `services.restic.backups` now includes a `command` option for passing a command to the [--stdin-from-command](https://github.com/restic/restic/pull/4410) flag.
-
-- `services.grafana` does no longer send usage statistics by default.
-
-- `services.postsrsd` now automatically integrates with the local Postfix instance, when enabled. This behavior can disabled using the [services.postsrsd.configurePostfix](#opt-services.postsrsd.configurePostfix) option.
-
-- `services.pfix-srsd` now automatically integrates with the local Postfix instance, when enabled. This behavior can disabled using the [services.pfix-srsd.configurePostfix](#opt-services.pfix-srsd.configurePostfix) option.
-
-- `services.monero` now includes the `environmentFile` option for adding secrets to the Monero daemon config.
-
-- `services.netbird.server` now uses dedicated packages split out due to relicensing of server components to AGPLv3 with version `0.53.0`,
-
-- `linux_libre` & `linux_latest_libre` have been removed due to a lack of maintenance.
-
-- `services.nebula.networks.<name>` will now store configuration files in `/etc/nebula/<name>.yml` and supports config reloading.
-
-- `services.pds` has been renamed to `services.bluesky-pds`.
-
-- `services.xserver.desktopManager.deepin` and associated packages have been removed due to being unmaintained. See issue [#422090](https://github.com/NixOS/nixpkgs/issues/422090) for more details.
-
-- `services.matter-server` now hosts a debug dashboard on the configured port. Open the port on the firewall with `services.matter-server.openFirewall`.
-
-- `services.k3s` now shares most of its code with `services.rke2`. The merge resulted in both modules providing more options, with `services.rke2` receiving the most improvements.
-  Existing configurations for either module should not be affected.
+- The `nettools` package (ifconfig, arp, mii-tool, netstat, route) is not installed by default anymore. The suite is unmaintained and users should migrate to `iproute2` and `ethtool` instead.
 
 - The new option [networking.ipips](#opt-networking.ipips) has been added to create IP within IP kind of tunnels (including 4in6, ip6ip6 and ipip).
   With the existing [networking.sits](#opt-networking.sits) option (6in4), it is now possible to create all combinations of IPv4 and IPv6 encapsulation.
 
-- It is now possible to configure the default source address using the new options [networking.defaultGateway.source](#opt-networking.defaultGateway.source),
-  [networking.defaultGateway6.source](#opt-networking.defaultGateway6.source).
-
-- Potential race conditions in the network setup when using `networking.interfaces` have been fixed by disabling duplicate address detection (DAD)
-  for statically configured IPv6 addresses.
-
-- `strongSwan` has been updated to 6.0. See [strongSwan 6.0.0 release notes](https://github.com/strongswan/strongswan/releases/tag/6.0.0) for a complete list of changes.
-
-- `slurm` no longer supports gtk2.
-
-- `amdgpu` kernel driver overdrive mode can now be enabled by setting [hardware.amdgpu.overdrive.enable](#opt-hardware.amdgpu.overdrive.enable) and customized through [hardware.amdgpu.overdrive.ppfeaturemask](#opt-hardware.amdgpu.overdrive.ppfeaturemask).
-  This allows for fine-grained control over the GPU's performance and maybe required by overclocking softwares like Corectrl and Lact. These new options replace old options such as {option}`programs.corectrl.gpuOverclock.enable` and {option}`programs.tuxclocker.enableAMD`.
-
-- `services.varnish.http_address` has been superseeded by `services.varnish.listen` which is now
-  structured config for all of varnish's `-a` variations.
-
-- `services.nginx.recommendedProxySettings` now sets `X-Forwarded-Server` to the hostname of nginx instead of the original host.
-
-- [](#opt-services.gnome.gnome-keyring.enable) does not ship with an SSH agent anymore, as this is now handled by the `gcr_4` package instead of `gnome-keyring`. A new module has been added to support this, under [](#opt-services.gnome.gcr-ssh-agent.enable) (its default value has been set to [](#opt-services.gnome.gnome-keyring.enable) to ensure a smooth transition). See the [relevant upstream PR](https://gitlab.gnome.org/GNOME/gcr/-/merge_requests/67) for more details.
-
-- The `nettools` package (ifconfig, arp, mii-tool, netstat, route) is not installed by default anymore. The suite is unmaintained and users should migrate to `iproute2` and `ethtool` instead.
-
-- `sparkleshare` has been removed as it no longer builds and has been abandoned upstream.
-
 - The `open-webui` package's postgres support have been moved to optional dependencies to comply with upstream changes in 0.6.26.
 
-- `prl-tools` has been moved out of `linuxPackages` because Parallels Guest Tools become driverless since 26.1.0.
+- The third-party `ant-contrib` is no longer included in the `ant` package.
 
-- `services.opentelemetry-collector` has a new option `validateConfigFile` option that checks the configuration file during build. It is enabled by default if the configuration file is in the Nix store.
+- `users.users.*.linger` now defaults to `null` rather than `false`, meaning NixOS will not attempt to enable or disable lingering for that user account, instead allowing for imperative control over lingering using the `loginctl` commands. In practice, this is unlikely to make a difference for most people, as new users are created without lingering configured. There is a new, related option, `users.manageLingering`, which can be used to prevent NixOS attempting to manage lingering entirely.


### PR DESCRIPTION
Alphabetizes the release notes for both nixpkgs and NixOS. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
