### PR TITLE
pyspread: fix, adopt, modernize

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17325,6 +17325,11 @@
     github = "Mephistophiles";
     githubId = 4850908;
   };
+  Merikei = {
+    name = "Merikei";
+    github = "Merikei";
+    githubId = 73759842;
+  };
   merrkry = {
     email = "merrkry@tsubasa.moe";
     name = "merrkry";

--- a/pkgs/by-name/py/pyspread/package.nix
+++ b/pkgs/by-name/py/pyspread/package.nix
@@ -2,17 +2,11 @@
   lib,
   python3Packages,
   fetchPypi,
+  qt6,
+  R,
   copyDesktopItems,
-  libsForQt5,
   makeDesktopItem,
 }:
-
-let
-  inherit (libsForQt5)
-    qtsvg
-    wrapQtAppsHook
-    ;
-in
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "pyspread";
   version = "2.4";
@@ -26,21 +20,30 @@ python3Packages.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   nativeBuildInputs = [
+    R
     copyDesktopItems
-    wrapQtAppsHook
+    qt6.wrapQtAppsHook
   ];
 
-  buildInputs = [
-    qtsvg
-  ];
+  buildInputs = [ qt6.qtsvg ];
 
   dependencies = with python3Packages; [
-    python-dateutil
-    markdown2
-    matplotlib
+    pyqt6
     numpy
-    pyenchant
-    pyqt5
+    markdown2
+
+    # Optional
+    matplotlib # data visualization
+    pyenchant # spellchecker bindings
+    pip # python package installer
+    python-dateutil # extensions to standard datetime module
+    rpy2 # interface to R
+    plotnine # data visualization
+    openpyxl # r/w Excel 2010 xlsx/xlsm files
+
+    # Optional & not in nixpkgs
+    #py-moneyed # currency & money classes
+    #pycel # compile Excel spreadsheets to Python code
   ];
 
   strictDeps = true;
@@ -63,6 +66,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
       ];
     })
   ];
+
+  makeWrapperArgs = [ "--set R_HOME ${lib.getLib R}/lib/R" ];
 
   preFixup = ''
     makeWrapperArgs+=("''${qtWrapperArgs[@]}")

--- a/pkgs/by-name/py/pyspread/package.nix
+++ b/pkgs/by-name/py/pyspread/package.nix
@@ -83,6 +83,6 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     '';
     license = with lib.licenses; [ gpl3Plus ];
     mainProgram = "pyspread";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ Merikei ];
   };
 })

--- a/pkgs/by-name/py/pyspread/package.nix
+++ b/pkgs/by-name/py/pyspread/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchPypi,
   copyDesktopItems,
   libsForQt5,
@@ -13,15 +13,17 @@ let
     wrapQtAppsHook
     ;
 in
-python3.pkgs.buildPythonApplication (finalAttrs: {
-  format = "setuptools";
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "pyspread";
   version = "2.4";
+
   src = fetchPypi {
     pname = "pyspread";
     inherit (finalAttrs) version;
     hash = "sha256-MZlR2Rap5oMRfCmswg9W//FYFkSEki7eyMNhLoGZgJM=";
   };
+
+  pyproject = true;
 
   nativeBuildInputs = [
     copyDesktopItems
@@ -32,20 +34,18 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     qtsvg
   ];
 
-  propagatedBuildInputs = with python3.pkgs; [
+  dependencies = with python3Packages; [
     python-dateutil
     markdown2
     matplotlib
     numpy
     pyenchant
     pyqt5
-    setuptools
   ];
 
   strictDeps = true;
 
-  doCheck = false; # it fails miserably with a core dump
-
+  doCheck = true;
   pythonImportsCheck = [ "pyspread" ];
 
   desktopItems = [
@@ -55,7 +55,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
       icon = "pyspread";
       desktopName = "Pyspread";
       genericName = "Spreadsheet";
-      comment = "A Python-oriented spreadsheet application";
+      comment = "Python-oriented spreadsheet application";
       categories = [
         "Office"
         "Development"
@@ -84,5 +84,6 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     license = with lib.licenses; [ gpl3Plus ];
     mainProgram = "pyspread";
     maintainers = with lib.maintainers; [ Merikei ];
+    platforms = lib.platforms.linux;
   };
 })


### PR DESCRIPTION
Pyspread would not start because it's built with Qt5 but requires Qt6.

Also (as stated in the title):
- Added all optional python dependencies listed in [requirements.txt](https://gitlab.com/pyspread/pyspread/-/blob/v2.4/pyspread/requirements.txt?ref_type=tags) that are in nixpkgs & commented their purpose
- Set `doCheck` to `true` without issue
- Added self as maintainer
- Add `meta.platforms = lib.platforms.linux;`. Others work according to [pyspread.gitlab.io/install](https://pyspread.gitlab.io/install) but I'm not able to test them
- Made desktopItems.comment match meta.description

N00b. Hopefully everything including the title/commit messages are the right level of detail :)

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
