### PR TITLE
apidog: init at 2.7.51

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6890,6 +6890,12 @@
     githubId = 13937320;
     name = "Dalton Caron";
   };
+  DomagojAlaber = {
+    email = "a.domagoj@hotmail.com";
+    github = "DomagojAlaber";
+    githubId = 86619082;
+    name = "Domagoj Alaber";
+  };
   domenkozar = {
     email = "domen@dev.si";
     github = "domenkozar";

--- a/pkgs/by-name/ap/apidog/package.nix
+++ b/pkgs/by-name/ap/apidog/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  appimageTools,
+  fetchurl,
+  makeDesktopItem,
+}:
+
+let
+  pname = "apidog";
+  version = "2.7.51";
+
+  src = fetchurl {
+    url = "https://file-assets.apidog.com/download/${version}/Apidog-${version}.AppImage";
+    hash = "sha256-MEVnpzVRj0Mi+ZX9CVi5dyDlV3rxuSC5tYM03bqdw0Q=";
+  };
+
+  appimageContents = appimageTools.extract {
+    inherit pname version src;
+  };
+
+  desktopItem = makeDesktopItem {
+    name = "apidog";
+    exec = "apidog %U";
+    icon = "apidog";
+    desktopName = "Apidog";
+    comment = "All-in-One API Platform: Design, Debug, Mock, Test, and Document.";
+    categories = [
+      "Development"
+      "Utility"
+    ];
+    mimeTypes = [ "x-scheme-handler/apidog" ];
+  };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraPkgs = pkgs: [
+    pkgs.nss
+    pkgs.gtk3
+    pkgs.libx11
+    pkgs.libxcb
+    pkgs.libxrandr
+    pkgs.libxcomposite
+    pkgs.libxdamage
+    pkgs.libxfixes
+    pkgs.libxext
+    pkgs.libdbusmenu
+    pkgs.alsa-lib
+    pkgs.nodejs
+  ];
+
+  extraInstallCommands = ''
+    install -Dm444 ${appimageContents}/apidog.png \
+      $out/share/icons/hicolor/512x512/apps/apidog.png
+  '';
+
+  desktopItems = [ desktopItem ];
+
+  meta = with lib; {
+    description = "All-in-one API design, test, mock and documentation platform";
+    homepage = "https://apidog.com";
+    license = licenses.unfree;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "apidog";
+    maintainers = with maintainers; [ DomagojAlaber ];
+  };
+}


### PR DESCRIPTION
<!--
Add apidog: an AppImage-based package for the Apidog API client.

This adds a new package `apidog` which wraps the upstream proprietary AppImage
using `appimageTools.wrapType2`. It installs a desktop file and icon so the app
shows up in desktop launchers. I also added myself to `maintainer-list.nix` as
the package maintainer.

Apidog is an all-in-one API platform for designing, testing, mocking and
documenting APIs. Upstream homepage: https://apidog.com/
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests] (not applicable).
  - [ ] [Package tests] at `passthru.tests` (not applicable).
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality (not applicable).
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
