### PR TITLE
furtherance: 1.8.3 -> 25.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15071,6 +15071,12 @@
     name = "Jan Schmitt";
     keys = [ { fingerprint = "1763 9903 2D7C 5B82 5D5A  0EAD A2BC 3C6F 1435 1991"; } ];
   };
+  locnide = {
+    email = "locnide@alpaga.dev";
+    github = "locnide";
+    githubId = 49921473;
+    name = "locnide";
+  };
   locochoco = {
     email = "contact@locochoco.dev";
     github = "loco-choco";

--- a/pkgs/by-name/fu/furtherance/package.nix
+++ b/pkgs/by-name/fu/furtherance/package.nix
@@ -3,63 +3,68 @@
   stdenv,
   fetchFromGitHub,
   rustPlatform,
-  appstream-glib,
-  cargo,
-  desktop-file-utils,
-  glib,
-  libadwaita,
-  meson,
-  ninja,
+  fontconfig,
+  libxkbcommon,
+  openssl,
   pkg-config,
-  rustc,
-  wrapGAppsHook4,
-  dbus,
-  gtk4,
-  sqlite,
+  xorg,
+  vulkan-loader,
+  wayland,
 }:
-
-stdenv.mkDerivation (finalAttrs: {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "furtherance";
-  version = "1.8.3";
+  version = "25.3.0";
 
   src = fetchFromGitHub {
-    owner = "lakoliu";
+    owner = "unobserved-io";
     repo = "Furtherance";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-TxYARpCqqjjwinoRU2Wjihp+FYIvcI0YCGlOuumX6To=";
+    rev = finalAttrs.version;
+    hash = "sha256-LyGO+fbsu16Us0+sK0T6HlGq7EwZWSetd+gCIKKEbkk=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) pname version src;
-    hash = "sha256-SFp9YCmneOll2pItWmg2b2jrpRqPnvV9vwz4mjjvwM4=";
-  };
+  cargoHash = "sha256-j/5O40k12rl/gmRc1obo9ImdkZ0Mdrke2PCf6tFCWIo=";
 
   nativeBuildInputs = [
-    appstream-glib
-    desktop-file-utils
-    meson
-    ninja
     pkg-config
-    rustPlatform.cargoSetupHook
-    cargo
-    rustc
-    wrapGAppsHook4
   ];
 
   buildInputs = [
-    dbus
-    glib
-    gtk4
-    libadwaita
-    sqlite
+    fontconfig
+    openssl
+    libxkbcommon
+    xorg.libX11
+    xorg.libXScrnSaver
+    xorg.libXcursor
+    xorg.libXi
+    vulkan-loader
+    wayland
   ];
+
+  checkFlags = [
+    # panicked at src/tests/timer_tests.rs:30:9
+    "--skip=tests::timer_tests::timer_tests::test_split_task_input_basic"
+  ];
+
+  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    patchelf $out/bin/${finalAttrs.pname} \
+      --add-rpath ${
+        lib.makeLibraryPath [
+          vulkan-loader
+          libxkbcommon
+          wayland
+        ]
+      }
+  '';
 
   meta = {
     description = "Track your time without being tracked";
     mainProgram = "furtherance";
-    homepage = "https://github.com/lakoliu/Furtherance";
+    homepage = "https://github.com/unobserved-io/Furtherance";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ CaptainJawZ ];
+    maintainers = with lib.maintainers; [
+      CaptainJawZ
+      locnide
+    ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Since 1.8.3, furtherance switched from gtk to iced, thus removing gtk requirements. And its namespace has been moved to the ` unobserved-io`.

~~I did not test it on wayland.~~ (edit: it is now tested)

A previous attempt was made for this update #401288, I do not know why it was abandoned 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
