### PR TITLE
doc/rl-2511: fix missed line

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -195,6 +195,7 @@
 
 - `python3Packages.duckduckgo-search` has been updated to v9+ and therefore has been renamed to ddgs.
   Use `python3Packages.ddgs` instead.
+  See [release note for v9.0.0](https://github.com/deedy5/ddgs/releases/tag/v9.0.0)
 
 - `python3Packages.heif-image-plugin` has been dropped due to lack of upstream maintenance and breakage. Use `python3Packages.pillow-heif` instead.
 
@@ -205,7 +206,6 @@
 - `python3Packages.pyocr` no longer supports `cuneiform` on Linux by default. It is still possible to enable it using `withCuneiformSupport` override.
 
 - `qt5.full` and `qt6.full` aliases have been removed. Their use has always been discouraged, and downstream projects should use `qtN.env` with the right set of packages.
-  See [release note for v9.0.0](https://github.com/deedy5/ddgs/releases/tag/v9.0.0)
 
 - `rabbitmq-server` has been updated from 4.0.9 to 4.1.4. The 4.1.0 release includes breaking changes. For more information read the [changelog of 4.1.0](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.1.0)
 


### PR DESCRIPTION
Accidentially mis-ordered this line in the alphabetization.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
