### PR TITLE
bumper: init at 0.2.2

### DIFF
--- a/nixos/modules/services/home-automation/bumper.nix
+++ b/nixos/modules/services/home-automation/bumper.nix
@@ -1,0 +1,151 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    maintainers
+    mkEnableOption
+    mkIf
+    mkOption
+    types
+    ;
+
+  cfg = config.services.bumper;
+
+  stateDir = "/var/lib/bumper";
+in
+{
+  meta.maintainers = with maintainers; [ ananthb ];
+
+  options.services.bumper = {
+    enable = mkEnableOption "bumper, a server for Ecovacs vacuum robots";
+
+    package = lib.mkPackageOption pkgs "bumper" { };
+
+    logLevel = mkOption {
+      type = types.enum [ "DEBUG" "INFO" "WARNING" "ERROR" "CRITICAL" ];
+      default = "INFO";
+      description = "Set logging level for bumper.";
+    };
+
+    verboseLogging = mkOption {
+      type = types.nullOr (types.ints.between 1 2);
+      default = null;
+      description = "Enable verbose logging for bumper application. Value indicates verbosity level.";
+    };
+
+    address = mkOption {
+      type = types.str;
+      default = "[::]";
+      description = "Bumper listens on this address. It listens on all interfaces by default.";
+    };
+
+    announceIP = mkOption {
+      type = types.str;
+      default = "auto";
+      description = "IP address to announce to robots (default: auto-detect)";
+    };
+
+    mqttTLSPort = mkOption {
+      type = types.port;
+      default = 6052;
+      description = "MQTT TLS server port";
+    };
+
+    mqttport = mkOption {
+      type = types.port;
+      default = 6052;
+      description = "MQTT plaintext server port";
+    };
+
+    httpTLSPort = mkOption {
+      type = types.port;
+      default = 6053;
+      description = "HTTP TLS server port";
+    };
+
+    httpPort = mkOption {
+      type = types.port;
+      default = 6053;
+      description = "HTTP plaintext server port";
+    };
+
+    xmppTLSPort = mkOption {
+      type = types.port;
+      default = 6054;
+      description = "XMPP TLS server port";
+    };
+
+    openFirewall = mkOption {
+      default = false;
+      type = types.bool;
+      description = "Whether to open the firewall for bumper application ports.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [
+      cfg.mqttport
+      cfg.mqttTLSPort
+      cfg.httpPort
+      cfg.httpTLSPort
+      cfg.xmppTLSPort
+    ];
+
+    systemd.services.bumper = {
+      description = "Bumper Robot Server";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      path = [ cfg.package ];
+
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/bumper";
+        DynamicUser = true;
+        User = "bumper";
+        Group = "bumper";
+        WorkingDirectory = stateDir;
+        StateDirectory = "bumper";
+        StateDirectoryMode = "0750";
+        Restart = "on-failure";
+
+        # Hardening
+        CapabilityBoundingSet = "";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        DevicePolicy = "closed";
+        #NoNewPrivileges = true; # Implied by DynamicUser
+        PrivateUsers = true;
+        #PrivateTmp = true; # Implied by DynamicUser
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProcSubset = "pid cgroup net";
+        ProtectSystem = "strict";
+        #RemoveIPC = true; # Implied by DynamicUser
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_NETLINK"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        #RestrictSUIDSGID = true; # Implied by DynamicUser
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+        ];
+        UMask = "0077";
+      };
+    };
+  };
+}

--- a/pkgs/by-name/bu/bumper/package.nix
+++ b/pkgs/by-name/bu/bumper/package.nix
@@ -1,0 +1,47 @@
+{
+  fetchFromGitHub,
+  lib,
+  python3,
+  python3Packages,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "bumper";
+  version = "0.2.2";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "mvladislav";
+    repo = pname;
+    tag = "v${version}";
+    hash = "sha256-gLTK1ZYMSZsq7iSCo1cz/bfKI8s6qcW+4JjwANomNxI=";
+  };
+
+  build-systemd = with python3Packages; [ uv-build ];
+
+  dependencies = with python3Packages; [
+    aiodns
+    aiofiles
+    aiohttp-jinja2
+    aiohttp
+    aiomqtt
+    amqtt
+    cachetools
+    coloredlogs
+    cryptography
+    defusedxml
+    jinja2
+    passlib
+    pyjwt
+    tinydb
+    validators
+    websockets
+  ];
+
+  meta = {
+    description = "A standalone and self-hosted implementation of the central server used by Ecovacs vacuum robots.";
+    homepage = "https://mvladislav.github.io/bumper";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ ananthb ];
+    mainProgram = "bumper";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Bumper is a self-hosted ecovacs server for local Ecovacs Vacuum Cleaner
control.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
