### PR TITLE
autocorrect: 2.14.1 -> 2.16.2

### DIFF
--- a/pkgs/by-name/au/autocorrect/package.nix
+++ b/pkgs/by-name/au/autocorrect/package.nix
@@ -2,20 +2,21 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "autocorrect";
-  version = "2.14.1";
+  version = "2.16.2";
 
   src = fetchFromGitHub {
     owner = "huacnlee";
     repo = "autocorrect";
-    rev = "5af1bc295d48b0fd04f7dbc35ea99d479f682e78";
-    hash = "sha256-tbN+48a8NnwirJqUci0LgxsvJI0KzuG/aDvV/Yr8Xu8=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-IpBEmgZ40CFHMISP4tRzt2c2bE2Di9tn8e+/YJPg9RA=";
   };
 
-  cargoHash = "sha256-cEiIs7wvfjP5/tkRtYb2XEZfssw09zkbOrqZsOX9ajQ=";
+  cargoHash = "sha256-sn+72+Qq7qppaiiiMS46RXVhFcm27lCPgXmAIYORKU8=";
 
   cargoBuildFlags = [
     "-p"
@@ -25,6 +26,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "-p"
     "autocorrect-cli"
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Linter and formatter for help you improve copywriting, to correct spaces, punctuations between CJK (Chinese, Japanese, Korean)";


### PR DESCRIPTION
Diff: https://github.com/huacnlee/autocorrect/compare/v2.14.1...v2.16.2

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
