### PR TITLE
treewide: fix wrong github releases/tag page url

### DIFF
--- a/pkgs/by-name/ec/ec2-instance-selector/package.nix
+++ b/pkgs/by-name/ec/ec2-instance-selector/package.nix
@@ -41,7 +41,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Recommends instance types based on resource criteria like vcpus and memory";
     homepage = "https://github.com/aws/amazon-ec2-instance-selector";
-    changelog = "https://github.com/aws/amazon-ec2-instance-selector/tags/v${finalAttrs.version}";
+    changelog = "https://github.com/aws/amazon-ec2-instance-selector/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ wcarlsen ];
     mainProgram = "ec2-instance-selector";

--- a/pkgs/by-name/et/etterna/package.nix
+++ b/pkgs/by-name/et/etterna/package.nix
@@ -106,7 +106,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Advanced cross-platform rhythm game focused on keyboard play";
     homepage = "https://etternaonline.com";
-    changelog = "https://github.com/etternagame/etterna/release/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/etternagame/etterna/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ alikindsys ];
     mainProgram = "etterna";

--- a/pkgs/by-name/gl/glas/package.nix
+++ b/pkgs/by-name/gl/glas/package.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Language server for the Gleam programming language";
     homepage = "https://github.com/maurobalbi/glas";
-    changelog = "https://github.com/maurobalbi/glas/tag/v${version}";
+    changelog = "https://github.com/maurobalbi/glas/releases/tag/v${version}";
     license = with lib.licenses; [
       asl20
       mit

--- a/pkgs/by-name/gr/grafanactl/package.nix
+++ b/pkgs/by-name/gr/grafanactl/package.nix
@@ -44,7 +44,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Tool designed to simplify interaction with Grafana instances";
     homepage = "https://github.com/grafana/grafanactl";
-    changelog = "https://github.com/grafana/grafanactl/tags/v${finalAttrs.version}";
+    changelog = "https://github.com/grafana/grafanactl/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ wcarlsen ];
     mainProgram = "grafanactl";

--- a/pkgs/by-name/ni/nix-your-shell/package.nix
+++ b/pkgs/by-name/ni/nix-your-shell/package.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "nix-your-shell";
     description = "`nix` and `nix-shell` wrapper for shells other than `bash`";
     homepage = "https://github.com/MercuryTechnologies/nix-your-shell";
-    changelog = "https://github.com/MercuryTechnologies/nix-your-shell/releases/tags/v${version}";
+    changelog = "https://github.com/MercuryTechnologies/nix-your-shell/releases/tag/v${version}";
     license = [ lib.licenses.mit ];
     maintainers = with lib.maintainers; [ _9999years ];
   };

--- a/pkgs/by-name/po/portal/package.nix
+++ b/pkgs/by-name/po/portal/package.nix
@@ -23,7 +23,7 @@ buildGoModule rec {
   meta = {
     description = "Quick and easy command-line file transfer utility from any computer to another";
     homepage = "https://github.com/SpatiumPortae/portal";
-    changelog = "https://github.com/SpatiumPortae/portal/tag/v${version}";
+    changelog = "https://github.com/SpatiumPortae/portal/releases/tag/v${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ tennox ];
     mainProgram = "portal";

--- a/pkgs/by-name/si/siglo/package.nix
+++ b/pkgs/by-name/si/siglo/package.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
     description = "GTK app to sync InfiniTime watch with PinePhone";
     mainProgram = "siglo";
     homepage = "https://github.com/theironrobin/siglo";
-    changelog = "https://github.com/theironrobin/siglo/tags/v${version}";
+    changelog = "https://github.com/theironrobin/siglo/releases/tag/v${version}";
     license = lib.licenses.mpl20;
     maintainers = [ ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/xo/xonsh/xontribs/xontrib-jedi/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xontrib-jedi/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
   meta = {
     description = "Xonsh Python mode completions using jedi";
     homepage = "https://github.com/xonsh/xontrib-jedi";
-    changelog = "https://github.com/xonsh/xontrib-jedi.releases/tag/${version}";
+    changelog = "https://github.com/xonsh/xontrib-jedi/releases/tag/${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ greg ];
   };

--- a/pkgs/by-name/yt/ytmdesktop/package.nix
+++ b/pkgs/by-name/yt/ytmdesktop/package.nix
@@ -142,7 +142,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    changelog = "https://github.com/ytmdesktop/ytmdesktop/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/ytmdesktop/ytmdesktop/releases/tag/v${finalAttrs.version}";
     description = "Desktop App for YouTube Music";
     downloadPage = "https://github.com/ytmdesktop/ytmdesktop/releases";
     homepage = "https://ytmdesktop.app/";

--- a/pkgs/by-name/zc/zcfan/package.nix
+++ b/pkgs/by-name/zc/zcfan/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Zero-configuration fan daemon for ThinkPads";
     mainProgram = "zcfan";
     homepage = "https://github.com/cdown/zcfan";
-    changelog = "https://github.com/cdown/zcfan/tags/${finalAttrs.version}";
+    changelog = "https://github.com/cdown/zcfan/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       luftmensch-luftmensch

--- a/pkgs/development/python-modules/odc-geo/default.nix
+++ b/pkgs/development/python-modules/odc-geo/default.nix
@@ -111,7 +111,7 @@ buildPythonPackage rec {
       with geospatial metadata and geo-registered `xarray` rasters.
     '';
     homepage = "https://github.com/opendatacube/odc-geo/";
-    changelog = "https://github.com/opendatacube/odc-geo/tag/${src.tag}";
+    changelog = "https://github.com/opendatacube/odc-geo/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ daspk04 ];
   };

--- a/pkgs/development/python-modules/odc-loader/default.nix
+++ b/pkgs/development/python-modules/odc-loader/default.nix
@@ -72,7 +72,7 @@ buildPythonPackage rec {
   meta = {
     description = "Tools for constructing xarray objects from parsed metadata";
     homepage = "https://github.com/opendatacube/odc-loader/";
-    changelog = "https://github.com/opendatacube/odc-loader/tag/${version}";
+    changelog = "https://github.com/opendatacube/odc-loader/releases/tag/${version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ daspk04 ];
   };

--- a/pkgs/development/python-modules/odc-stac/default.nix
+++ b/pkgs/development/python-modules/odc-stac/default.nix
@@ -86,7 +86,7 @@ buildPythonPackage rec {
   meta = {
     description = "Load STAC items into xarray Datasets";
     homepage = "https://github.com/opendatacube/odc-stac/";
-    changelog = "https://github.com/opendatacube/odc-stac/tag/${src.tag}";
+    changelog = "https://github.com/opendatacube/odc-stac/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ daspk04 ];
   };

--- a/pkgs/development/python-modules/pylibrespot-java/default.nix
+++ b/pkgs/development/python-modules/pylibrespot-java/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   meta = {
     description = "Simple library to interface with a librespot-java server";
     homepage = "https://github.com/uvjustin/pylibrespot-java";
-    changelog = "https://github.com/uvjustin/pylibrespot-java/tag/v${version}";
+    changelog = "https://github.com/uvjustin/pylibrespot-java/releases/tag/v${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       hensoko

--- a/pkgs/development/python-modules/pyotb/default.nix
+++ b/pkgs/development/python-modules/pyotb/default.nix
@@ -93,7 +93,7 @@ buildPythonPackage rec {
   meta = {
     description = "Python extension of Orfeo Toolbox";
     homepage = "https://github.com/orfeotoolbox/pyotb";
-    changelog = "https://github.com/orfeotoolbox/pyotb/tag/${version}";
+    changelog = "https://github.com/orfeotoolbox/pyotb/releases/tag/${version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ daspk04 ];
   };

--- a/pkgs/servers/home-assistant/custom-components/daikin_onecta/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/daikin_onecta/package.nix
@@ -17,7 +17,7 @@ buildHomeAssistantComponent rec {
   };
 
   meta = {
-    changelog = "https://github.com/jwillemsen/daikin_onecta/tag/v${version}";
+    changelog = "https://github.com/jwillemsen/daikin_onecta/releases/tag/v${version}";
     description = "Home Assistant Integration for devices supported by the Daikin Onecta App";
     homepage = "https://github.com/jwillemsen/daikin_onecta";
     maintainers = with lib.maintainers; [ dandellion ];


### PR DESCRIPTION
WTF

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
