### PR TITLE
ranger: spring cleaning

### DIFF
--- a/pkgs/by-name/ra/ranger/package.nix
+++ b/pkgs/by-name/ra/ranger/package.nix
@@ -3,6 +3,8 @@
   fetchFromGitHub,
   python3Packages,
   file,
+  coreutils,
+  bashNonInteractive,
   less,
   highlight,
   w3m,
@@ -32,15 +34,26 @@ python3Packages.buildPythonApplication {
     astroid
     pylint
   ];
-  propagatedBuildInputs = [
-    less
-    file
-  ]
-  ++ lib.optionals imagePreviewSupport [ python3Packages.pillow ]
-  ++ lib.optionals sixelPreviewSupport [ imagemagick ]
-  ++ lib.optionals neoVimSupport [ python3Packages.pynvim ]
-  ++ lib.optionals improvedEncodingDetection [ python3Packages.chardet ]
-  ++ lib.optionals rightToLeftTextSupport [ python3Packages.python-bidi ];
+  propagatedBuildInputs =
+    [ ]
+    ++ lib.optionals imagePreviewSupport [ python3Packages.pillow ]
+    ++ lib.optionals neoVimSupport [ python3Packages.pynvim ]
+    ++ lib.optionals improvedEncodingDetection [ python3Packages.chardet ]
+    ++ lib.optionals rightToLeftTextSupport [ python3Packages.python-bidi ];
+
+  makeWrapperArgs = [
+    "--prefix"
+    "PATH"
+    ":"
+    (lib.makeBinPath (
+      [
+        file
+        coreutils
+        bashNonInteractive
+      ]
+      ++ lib.optionals sixelPreviewSupport [ imagemagick ]
+    ))
+  ];
 
   preConfigure = ''
     ${lib.optionalString (highlight != null) ''

--- a/pkgs/by-name/ra/ranger/package.nix
+++ b/pkgs/by-name/ra/ranger/package.nix
@@ -71,7 +71,7 @@ python3Packages.buildPythonApplication {
 
   meta = {
     description = "File manager with minimalistic curses interface";
-    homepage = "https://ranger.github.io/";
+    homepage = "https://ranger.fm/";
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/ra/ranger/package.nix
+++ b/pkgs/by-name/ra/ranger/package.nix
@@ -27,8 +27,6 @@ python3Packages.buildPythonApplication {
     hash = "sha256-vn1rAOFB2vq04Y/WAE44iH/b/zamAmvq8putUKwNqR8=";
   };
 
-  LC_ALL = "en_US.UTF-8";
-
   nativeCheckInputs = with python3Packages; [
     pytestCheckHook
     astroid

--- a/pkgs/by-name/ra/ranger/package.nix
+++ b/pkgs/by-name/ra/ranger/package.nix
@@ -20,7 +20,7 @@
 python3Packages.buildPythonApplication {
   pname = "ranger";
   version = "1.9.3-unstable-2025-11-14";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ranger";
@@ -29,17 +29,22 @@ python3Packages.buildPythonApplication {
     hash = "sha256-vn1rAOFB2vq04Y/WAE44iH/b/zamAmvq8putUKwNqR8=";
   };
 
-  nativeCheckInputs = with python3Packages; [
-    pytestCheckHook
-    astroid
-    pylint
+  build-system = with python3Packages; [
+    setuptools
   ];
-  propagatedBuildInputs =
+
+  dependencies =
     [ ]
     ++ lib.optionals imagePreviewSupport [ python3Packages.pillow ]
     ++ lib.optionals neoVimSupport [ python3Packages.pynvim ]
     ++ lib.optionals improvedEncodingDetection [ python3Packages.chardet ]
     ++ lib.optionals rightToLeftTextSupport [ python3Packages.python-bidi ];
+
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+    astroid
+    pylint
+  ];
 
   makeWrapperArgs = [
     "--prefix"

--- a/pkgs/by-name/ra/ranger/package.nix
+++ b/pkgs/by-name/ra/ranger/package.nix
@@ -14,12 +14,12 @@
   neoVimSupport ? true,
   improvedEncodingDetection ? true,
   rightToLeftTextSupport ? false,
-  unstableGitUpdater,
+  nix-update-script,
 }:
 
 python3Packages.buildPythonApplication {
   pname = "ranger";
-  version = "1.9.3-unstable-2025-11-14";
+  version = "1.9.4-unstable-2025-11-14";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -82,7 +82,9 @@ python3Packages.buildPythonApplication {
       --replace "set preview_images false" "set preview_images true"
   '';
 
-  passthru.updateScript = unstableGitUpdater { tagPrefix = "v"; };
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
 
   meta = {
     description = "File manager with minimalistic curses interface";

--- a/pkgs/by-name/ra/ranger/package.nix
+++ b/pkgs/by-name/ra/ranger/package.nix
@@ -60,12 +60,7 @@ python3Packages.buildPythonApplication {
     ))
   ];
 
-  preConfigure = ''
-    ${lib.optionalString (highlight != null) ''
-      sed -i -e 's|^\s*highlight\b|${highlight}/bin/highlight|' \
-        ranger/data/scope.sh
-    ''}
-
+  postPatch = ''
     substituteInPlace ranger/__init__.py \
       --replace "DEFAULT_PAGER = 'less'" "DEFAULT_PAGER = '${lib.getBin less}/bin/less'"
 
@@ -73,6 +68,10 @@ python3Packages.buildPythonApplication {
     substituteInPlace ranger/config/rc.conf \
       --replace /usr/share $out/share \
       --replace "#set preview_script ~/.config/ranger/scope.sh" "set preview_script $out/share/doc/ranger/config/scope.sh"
+  ''
+  + lib.optionalString (highlight != null) ''
+    sed -i -e 's|^\s*highlight\b|${highlight}/bin/highlight|' \
+      ranger/data/scope.sh
   ''
   + lib.optionalString imagePreviewSupport ''
     substituteInPlace ranger/ext/img_display.py \


### PR DESCRIPTION
- updated homepage: they changed hosting
- C.utf8 is no longer necessary for Darwin builds: https://github.com/acid-bong/nixpkgs-review-gha/actions/runs/19771893335
- moved runtime executables to `makeWrapperArgs`
- `pyproject`ized the recipe
- moved patching from preConfigure to postPatch
- fixed versioning

~~One thing i'm thinking about: what if I add `extraPackages` for [extra executables](https://github.com/ranger/ranger#optional-dependencies) one would like to wrap Ranger with?~~ will probably add separately

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
