### PR TITLE
nixos/ifstate: fix initrd tests

### DIFF
--- a/nixos/modules/services/networking/ifstate.nix
+++ b/nixos/modules/services/networking/ifstate.nix
@@ -144,6 +144,14 @@ in
   };
 
   config = lib.mkMerge [
+    (lib.mkIf (cfg.enable || initrdCfg.enable) {
+      # sane defaults to not let IfState work against the kernel
+      boot.extraModprobeConfig = ''
+        options bonding max_bonds=0
+        options dummy numdummies=0
+        options ifb numifbs=0
+      '';
+    })
     (lib.mkIf cfg.enable {
       assertions = [
         {
@@ -157,13 +165,6 @@ in
       ];
 
       networking.useDHCP = lib.mkDefault false;
-
-      # sane defaults to not let IfState work against the kernel
-      boot.extraModprobeConfig = ''
-        options bonding max_bonds=0
-        options dummy numdummies=0
-        options ifb numifbs=0
-      '';
 
       environment = {
         # ifstatecli command should be available to use user, there are other useful subcommands like check or show

--- a/nixos/modules/services/networking/ifstate.nix
+++ b/nixos/modules/services/networking/ifstate.nix
@@ -106,7 +106,7 @@ in
       settings = lib.mkOption {
         inherit (settingsFormat) type;
         default = { };
-        description = "Content of IfState's configuration file. See <https://ifstate.net/2.0/schema/> for details.";
+        description = "Content of IfState's configuration file. See <https://ifstate.net/2.2/schema/> for details.";
       };
     };
 
@@ -131,14 +131,14 @@ in
       settings = lib.mkOption {
         inherit (settingsFormat) type;
         default = { };
-        description = "Content of IfState's initrd configuration file. See <https://ifstate.net/2.0/schema/> for details.";
+        description = "Content of IfState's initrd configuration file. See <https://ifstate.net/2.2/schema/> for details.";
       };
 
       cleanupSettings = lib.mkOption {
         inherit (settingsFormat) type;
         # required by json schema
         default.interfaces = { };
-        description = "Content of IfState's initrd cleanup configuration file. See <https://ifstate.net/2.0/schema/> for details. This configuration gets applied before systemd switches to stage two. The goas is to deconfigurate the whole network in order to prevent access to services, before the firewall is configured. The stage two IfState configuration will start after the firewall is configured.";
+        description = "Content of IfState's initrd cleanup configuration file. See <https://ifstate.net/2.0/schema/> for details. This configuration gets applied before systemd switches to stage two. The goal is to deconfigurate the whole network in order to prevent access to services, before the firewall is configured. The stage two IfState configuration will start after the firewall is configured.";
       };
     };
   };

--- a/nixos/tests/ifstate/initrd-partial-broken-config.nix
+++ b/nixos/tests/ifstate/initrd-partial-broken-config.nix
@@ -28,6 +28,9 @@ in
         };
 
         boot.initrd = {
+          # otherwise the interfaces do not get created
+          kernelModules = [ "virtio_net" ];
+
           network = {
             enable = true;
             ifstate = lib.mkMerge [
@@ -46,6 +49,7 @@ in
               }
             ];
           };
+
           systemd = {
             enable = true;
             network.enable = false;

--- a/nixos/tests/ifstate/initrd-wireguard.nix
+++ b/nixos/tests/ifstate/initrd-wireguard.nix
@@ -62,6 +62,9 @@ in
         };
 
         boot.initrd = {
+          # otherwise the interfaces do not get created
+          kernelModules = [ "virtio_net" ];
+
           network = {
             enable = true;
             ifstate =
@@ -76,6 +79,7 @@ in
                 allowIfstateToDrasticlyIncreaseInitrdSize = true;
               };
           };
+
           systemd = {
             enable = true;
             network.enable = false;

--- a/nixos/tests/ifstate/initrd-wireguard.nix
+++ b/nixos/tests/ifstate/initrd-wireguard.nix
@@ -10,19 +10,20 @@ let
     {
       enable = true;
       settings = {
-        interfaces = {
-          eth1 = {
-            addresses = [ "2001:0db8:a::${builtins.toString id}/64" ];
-            link = {
-              state = "up";
-              kind = "physical";
-            };
+        namespaces.outside.interfaces.eth1 = {
+          addresses = [ "2001:0db8:a::${builtins.toString id}/64" ];
+          link = {
+            state = "up";
+            kind = "physical";
           };
+        };
+        interfaces = {
           wg0 = {
             addresses = [ "2001:0db8:b::${builtins.toString id}/64" ];
             link = {
               state = "up";
               kind = "wireguard";
+              bind_netns = "outside";
             };
             wireguard = {
               private_key = "!include ${pkgs.writeText "wg_priv.key" wgPriv}";

--- a/nixos/tests/ifstate/initrd-wireguard.nix
+++ b/nixos/tests/ifstate/initrd-wireguard.nix
@@ -73,9 +73,6 @@ in
                 wgPeerId = 2;
               }
               // {
-                package = pkgs.ifstate.override {
-                  withConfigValidation = false;
-                };
                 allowIfstateToDrasticlyIncreaseInitrdSize = true;
               };
           };

--- a/nixos/tests/ifstate/initrd.nix
+++ b/nixos/tests/ifstate/initrd.nix
@@ -26,12 +26,16 @@ in
       };
 
       boot.initrd = {
+        # otherwise the interfaces do not get created
+        kernelModules = [ "virtio_net" ];
+
         network = {
           enable = true;
           ifstate = mkIfStateConfig 1 // {
             allowIfstateToDrasticlyIncreaseInitrdSize = true;
           };
         };
+
         systemd = {
           enable = true;
           network.enable = false;


### PR DESCRIPTION
- Force loading of kernel module `virtio_net` to ensure network interfaces are present in initrd. This was not required before. But I could not identify the change that broke this. Maybe someone is willing to do a bisect.
- fix links to json schema (use correct version in url)
- configure kernel params also if ifstate is only used in initrd
- remove manual package for the initrd-wireguard test - wireguard was disabled by default in the past, but because wgnlpy is not a dependency anymore, disabling wireguard does not result in any disk space gains anymore.

## Things done


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
