### PR TITLE
upterm: 0.15.3 -> 0.20.0

### DIFF
--- a/nixos/tests/uptermd.nix
+++ b/nixos/tests/uptermd.nix
@@ -51,15 +51,14 @@ in
     client1.wait_until_succeeds("pgrep -u root bash")
 
     client1.execute("ssh-keygen -t ed25519 -N \"\" -f /root/.ssh/id_ed25519")
-    client1.send_chars("TERM=xterm upterm host --server ssh://server:1337 --force-command hostname -- bash > /tmp/session-details\n")
+    client1.send_chars("TERM=xterm upterm host --server ssh://server:1337 --accept --force-command hostname -- bash > /tmp/session-details\n")
     client1.wait_for_file("/tmp/session-details")
-    client1.send_key("q")
 
     # uptermd can't connect if we don't have a keypair
     client2.execute("ssh-keygen -t ed25519 -N \"\" -f /root/.ssh/id_ed25519")
 
     # Grep the ssh connect command from the output of 'upterm host'
-    ssh_command = client1.succeed("grep 'SSH Session' /tmp/session-details | cut -d':' -f2-").strip()
+    ssh_command = client1.succeed("grep 'SSH Command' /tmp/session-details | awk -F'│' '{print $3}'").strip()
 
     # Connect with client2. Because we used '--force-command hostname' we should get "client1" as the output
     output = client2.succeed(ssh_command)

--- a/pkgs/by-name/up/upterm/package.nix
+++ b/pkgs/by-name/up/upterm/package.nix
@@ -1,37 +1,48 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
+  writableTmpDirAsHomeHook,
   installShellFiles,
   nixosTests,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "upterm";
-  version = "0.15.3";
+  version = "0.20.0";
 
   src = fetchFromGitHub {
     owner = "owenthereal";
     repo = "upterm";
-    rev = "v${version}";
-    hash = "sha256-9h4Poz0hUg5/7CrF0ZzT4KrVaFlhvcorIgZbleMpV6w=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-4UxPeWiNxvKi/Nw0kZU6paI3QChqNRY8bLOdZKhPgr0=";
   };
 
-  vendorHash = "sha256-i92RshW5dsRE88X8bXyrj13va66cc0Yu/btpR0pvoSM=";
+  vendorHash = "sha256-mqwuCadUjKrQZA7DI5Bm3GBrnnvHxFqwl2FsgY2ZhgQ=";
 
   subPackages = [
     "cmd/upterm"
     "cmd/uptermd"
   ];
 
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs = [
+    writableTmpDirAsHomeHook
+    installShellFiles
+  ];
 
   postInstall = ''
     # force go to build for build arch rather than host arch during cross-compiling
     CGO_ENABLED=0 GOOS= GOARCH= go run cmd/gendoc/main.go
     installManPage etc/man/man*/*
-    installShellCompletion --bash --name upterm.bash etc/completion/upterm.bash_completion.sh
-    installShellCompletion --zsh --name _upterm etc/completion/upterm.zsh_completion
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    for cmd in upterm uptermd; do
+      installShellCompletion --cmd $cmd \
+        --bash <($out/bin/$cmd completion bash) \
+        --fish <($out/bin/$cmd completion fish) \
+        --zsh <($out/bin/$cmd completion zsh)
+    done
   '';
 
   doCheck = true;
@@ -46,4 +57,4 @@ buildGoModule rec {
     license = licenses.asl20;
     maintainers = with maintainers; [ hax404 ];
   };
-}
+})


### PR DESCRIPTION
Update upterm, uptermd from 0.15.3 -> 0.19.0. Update the tests to make them pass again. Enhance the shell completions (does installShellCompletion support powershell?). Obsoletes https://github.com/NixOS/nixpkgs/pull/464603
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. (I had to update the tests.)
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
