### PR TITLE
battery-toolkit: init at 1.8

### DIFF
--- a/pkgs/by-name/ba/battery-toolkit/package.nix
+++ b/pkgs/by-name/ba/battery-toolkit/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "battery-toolkit";
+  version = "1.8";
+
+  src = fetchzip {
+    url = "https://github.com/mhaeuser/Battery-Toolkit/releases/download/${finalAttrs.version}/Battery-Toolkit-${finalAttrs.version}.zip";
+    hash = "sha256-gsEXTE+pM+rsBhTeup7cWcUljY8u0T+ETON7JeA6g1A=";
+    stripRoot = false;
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Applications"
+    cp -R "Battery Toolkit.app" "$out/Applications/"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Control the platform power state of your Apple Silicon Mac";
+    longDescription = ''
+      Battery Toolkit allows you to control battery charging behavior on Apple Silicon Macs.
+      Features include setting upper and lower charge limits, disabling the power adapter,
+      and manual control over charging state.
+    '';
+    homepage = "https://github.com/mhaeuser/Battery-Toolkit";
+    changelog = "https://github.com/mhaeuser/Battery-Toolkit/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ shgew ];
+    platforms = [ "aarch64-darwin" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
Battery Toolkit is a macOS application that allows control of battery charging behavior on Apple Silicon Macs. Features include setting upper and lower charge limits, disabling the power adapter, and manual control over charging state.

Homepage: https://github.com/mhaeuser/Battery-Toolkit

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test