### PR TITLE
tgeraser: init at 1.4.2

### DIFF
--- a/pkgs/by-name/tg/tgeraser/package.nix
+++ b/pkgs/by-name/tg/tgeraser/package.nix
@@ -1,0 +1,48 @@
+{
+  fetchFromGitHub,
+  lib,
+  python3Packages,
+  versionCheckHook,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "tgeraser";
+  version = "1.4.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "en9inerd";
+    repo = "tgeraser";
+    tag = "v${version}";
+    hash = "sha256-xB6bdB6ndyS3EOb3D2h9mRbelUXSQXkBkDvzCm7m5TY=";
+  };
+
+  build-system = [ python3Packages.setuptools ];
+
+  dependencies = with python3Packages; [
+    docopt
+    pyaes
+    pyasn1
+    rsa
+    telethon
+  ];
+
+  pythonImportsCheck = [ "tgeraser" ];
+
+  nativeCheckInputs = [ versionCheckHook ];
+
+  versionCheckProgramArg = "--version";
+
+  meta = {
+    description = "Tool to delete all your messages from Telegram";
+    longDescription = ''
+      TgEraser is a Python tool that allows you to delete all your messages from
+      a chat, channel, or conversation on Telegram without requiring admin
+      privileges.
+    '';
+    homepage = "https://github.com/en9inerd/tgeraser";
+    changelog = "https://github.com/en9inerd/tgeraser/blob/${src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.azahi ];
+    mainProgram = "tgeraser";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
TgEraser is a Python tool that allows you to delete all your messages from a chat, channel, or conversation on Telegram without requiring admin privileges. Official Telegram clients do not provide a one-click solution to delete all your messages; instead, you have to manually select and delete messages, with a limit of 100 messages per batch. TgEraser solves this problem and offers a convenient way to mass-delete your messages on Telegram.
https://github.com/en9inerd/tgeraser
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
