### PR TITLE
numr: init at 0.1.7

### DIFF
--- a/pkgs/by-name/nu/numr/package.nix
+++ b/pkgs/by-name/nu/numr/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "numr";
+  version = "0.1.7";
+
+  src = fetchFromGitHub {
+    owner = "nasedkinpv";
+    repo = "numr";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-tDQxDU/CrzZvXjsVSkUtDHX53WddFt6G8RBrHd8mXyg=";
+  };
+
+  cargoHash = "sha256-4Ig35ev3L2Sr8m4JsQVv/3lSLDc9RxSFMYeI+N+Wg7A=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ];
+
+  env.OPENSSL_NO_VENDOR = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Text calculator for natural language expressions with a vim-style TUI";
+    longDescription = ''
+      Text calculator inspired by Numi - natural language expressions, variables, unit conversions.
+    '';
+    homepage = "https://github.com/nasedkinpv/numr";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ chillcicada ];
+    mainProgram = "numr";
+  };
+})


### PR DESCRIPTION
init [numr](https://github.com/nasedkinpv/numr) at 0.1.7, numr is a text calculator for natural language expressions with a vim-style TUI.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
