### PR TITLE
mac-mouse-fix: init at 3.0.8

### DIFF
--- a/pkgs/by-name/ma/mac-mouse-fix/package.nix
+++ b/pkgs/by-name/ma/mac-mouse-fix/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "mac-mouse-fix";
+  version = "3.0.8";
+
+  src = fetchzip {
+    url = "https://github.com/noah-nuebling/mac-mouse-fix/releases/download/${finalAttrs.version}/MacMouseFixApp.zip";
+    hash = "sha256-yqOxnhrceYoT46KGpk+nzFTgwOCtL9hGpu/ifUO0E6A=";
+    stripRoot = false;
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    cp -R "Mac Mouse Fix.app" "$out/Applications/"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Make your mouse better on macOS with smooth scrolling, gestures, and customizable buttons";
+    homepage = "https://noah-nuebling.github.io/mac-mouse-fix-website";
+    changelog = "https://github.com/noah-nuebling/mac-mouse-fix/releases/tag/${finalAttrs.version}";
+    # Custom license based on MIT/DBAD. Restricts commercial redistribution of
+    # compiled binaries and requires keeping monetization systems intact.
+    # Not OSI/FSF "free" due to commercial redistribution restrictions.
+    license = {
+      fullName = "MMF License";
+      url = "https://github.com/noah-nuebling/mac-mouse-fix/blob/${finalAttrs.version}/License";
+      free = false;
+    };
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ shgew ];
+    platforms = lib.platforms.darwin;
+    mainProgram = "Mac Mouse Fix";
+  };
+})


### PR DESCRIPTION
Added https://github.com/noah-nuebling/mac-mouse-fix package.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
