### PR TITLE
zeekscript: set updateScript to use VERSION file, 1.3.2-unstable-2025-11-10 -> 1.3.2-61

### DIFF
--- a/pkgs/by-name/ze/zeekscript/package.nix
+++ b/pkgs/by-name/ze/zeekscript/package.nix
@@ -7,7 +7,7 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "zeekscript";
-  version = "1.3.2-unstable-2025-11-10";
+  version = "1.3.2-61";
   pyproject = true;
 
   src = fetchFromGitHub {

--- a/pkgs/by-name/ze/zeekscript/package.nix
+++ b/pkgs/by-name/ze/zeekscript/package.nix
@@ -2,7 +2,7 @@
   lib,
   python3,
   fetchFromGitHub,
-  unstableGitUpdater,
+  writeScript,
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -36,7 +36,18 @@ python3.pkgs.buildPythonApplication rec {
     "zeekscript"
   ];
 
-  passthru.updateScript = unstableGitUpdater { tagPrefix = "v"; };
+  passthru.updateScript = writeScript "update-${pname}" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p git common-updater-scripts
+    tmpdir="$(mktemp -d)"
+    git clone "${src.gitRepoUrl}" "$tmpdir"
+    pushd "$tmpdir"
+    newVersion=$(cat VERSION)
+    newRevision=$(git log -s -n 1 --pretty='format:%H' VERSION)
+    popd
+    rm -rf "$tmpdir"
+    update-source-version "${pname}" "$newVersion" --rev="$newRevision"
+  '';
 
   meta = {
     description = "Zeek script formatter and analyzer";


### PR DESCRIPTION
- **zeekscript: set updateScript to use VERSION file**
  Per https://github.com/NixOS/nixpkgs/pull/466179#issuecomment-3591366570
- **zeekscript: 1.3.2-unstable-2025-11-10 -> 1.3.2-61**
  No actual changes, only the version number.

Closes: #466179
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
