### PR TITLE
nixos/autobrr: use AUTOBRR__SESSION_SECRET_FILE

### DIFF
--- a/nixos/modules/services/misc/autobrr.nix
+++ b/nixos/modules/services/misc/autobrr.nix
@@ -83,4 +83,6 @@ in
 
     networking.firewall = lib.mkIf cfg.openFirewall { allowedTCPPorts = [ cfg.settings.port ]; };
   };
+
+  meta.maintainers = with lib.maintainers; [ av-gal ];
 }

--- a/nixos/modules/services/misc/autobrr.nix
+++ b/nixos/modules/services/misc/autobrr.nix
@@ -8,8 +8,7 @@
 let
   cfg = config.services.autobrr;
   configFormat = pkgs.formats.toml { };
-  configTemplate = configFormat.generate "autobrr.toml" cfg.settings;
-  templaterCmd = ''${lib.getExe pkgs.dasel} put -f '${configTemplate}' -v "$(${config.systemd.package}/bin/systemd-creds cat sessionSecret)" -o %S/autobrr/config.toml "sessionSecret"'';
+  configFile = configFormat.generate "autobrr.toml" cfg.settings;
 in
 {
   options = {
@@ -79,23 +78,35 @@ in
       }
     ];
 
-    systemd.services.autobrr = {
-      description = "Autobrr";
-      after = [
-        "syslog.target"
-        "network-online.target"
-      ];
-      wants = [ "network-online.target" ];
-      wantedBy = [ "multi-user.target" ];
+    systemd = {
+      tmpfiles.settings = {
+        "10-autobrr" = {
+          # DynamicUser uses /var/lib/private/
+          "/var/lib/private/autobrr/config.toml"."L+" = {
+            argument = "${configFile}";
+          };
+        };
+      };
 
-      serviceConfig = {
-        Type = "simple";
-        DynamicUser = true;
-        LoadCredential = "sessionSecret:${cfg.secretFile}";
-        StateDirectory = "autobrr";
-        ExecStartPre = "${lib.getExe pkgs.bash} -c '${templaterCmd}'";
-        ExecStart = "${lib.getExe cfg.package} --config %S/autobrr";
-        Restart = "on-failure";
+      services.autobrr = {
+        description = "Autobrr";
+        after = [
+          "syslog.target"
+          "network-online.target"
+        ];
+        wants = [ "network-online.target" ];
+        wantedBy = [ "multi-user.target" ];
+        restartTriggers = [ configFile ];
+
+        serviceConfig = {
+          Type = "simple";
+          DynamicUser = true;
+          LoadCredential = "sessionSecret:${cfg.secretFile}";
+          Environment = [ "AUTOBRR__SESSION_SECRET_FILE=%d/sessionSecret" ];
+          StateDirectory = "autobrr";
+          ExecStart = "${lib.getExe cfg.package} --config %S/autobrr";
+          Restart = "on-failure";
+        };
       };
     };
 

--- a/nixos/modules/services/misc/autobrr.nix
+++ b/nixos/modules/services/misc/autobrr.nix
@@ -28,13 +28,31 @@ in
       };
 
       settings = lib.mkOption {
-        type = lib.types.submodule { freeformType = configFormat.type; };
-        default = {
-          host = "127.0.0.1";
-          port = 7474;
-          checkForUpdates = true;
+        type = lib.types.submodule {
+          freeformType = configFormat.type;
+          options = {
+            host = lib.mkOption {
+              type = lib.types.str;
+              default = "127.0.0.1";
+              description = "The host address autobrr listens on.";
+            };
+
+            port = lib.mkOption {
+              type = lib.types.port;
+              default = 7474;
+              description = "The port autobrr listens on.";
+            };
+
+            checkForUpdates = lib.mkOption {
+              type = lib.types.bool;
+              default = true;
+              description = "Whether autobrr needs to check for updates.";
+            };
+          };
         };
+        default = { };
         example = {
+          port = 7654;
           logLevel = "DEBUG";
         };
         description = ''

--- a/nixos/tests/autobrr.nix
+++ b/nixos/tests/autobrr.nix
@@ -6,18 +6,42 @@
 
   nodes.machine =
     { pkgs, ... }:
+    let
+      # We create this secret in the Nix store (making it readable by everyone).
+      # DO NOT DO THIS OUTSIDE OF TESTS!!
+      testSecretFile = pkgs.writeText "session_secret" "not-secret";
+    in
     {
       services.autobrr = {
         enable = true;
-        # We create this secret in the Nix store (making it readable by everyone).
-        # DO NOT DO THIS OUTSIDE OF TESTS!!
-        secretFile = pkgs.writeText "session_secret" "not-secret";
+        secretFile = testSecretFile;
+      };
+
+      # Use port other than default to test if settings options work.
+      specialisation.settingsPort.configuration = {
+        services.autobrr = {
+          enable = true;
+          secretFile = testSecretFile;
+          settings.port = 7777;
+        };
       };
     };
 
-  testScript = ''
-    machine.wait_for_unit("autobrr.service")
-    machine.wait_for_open_port(7474)
-    machine.succeed("curl --fail http://localhost:7474/")
-  '';
+  testScript =
+    { nodes, ... }:
+    let
+      settingsPort = "${nodes.machine.system.build.toplevel}/specialisation/settingsPort";
+    in
+    # python
+    ''
+      def test_webui(port):
+        machine.wait_for_unit("autobrr.service")
+        machine.wait_for_open_port(port)
+        machine.wait_until_succeeds(f"curl --fail http://localhost:{port}")
+
+      test_webui(7474)
+
+      machine.succeed("${settingsPort}/bin/switch-to-configuration test")
+      test_webui(7777)
+    '';
 }

--- a/pkgs/by-name/au/autobrr/package.nix
+++ b/pkgs/by-name/au/autobrr/package.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
   stdenvNoCC,
   nix-update-script,
+  nixosTests,
   nodejs,
   pnpm_10,
   fetchPnpmDeps,
@@ -86,11 +87,14 @@ buildGoModule (finalAttrs: {
   versionCheckProgram = "${placeholder "out"}/bin/autobrrctl";
   versionCheckProgramArg = "version";
 
-  passthru.updateScript = nix-update-script {
-    extraArgs = [
-      "--subpackage"
-      "autobrr-web"
-    ];
+  passthru = {
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--subpackage"
+        "autobrr-web"
+      ];
+    };
+    tests.testService = nixosTests.autobrr;
   };
 
   meta = {


### PR DESCRIPTION
autobrr can be configured using environment variables. The environment variables [override](https://autobrr.com/installation/docker#environment-variables) values set in the config:  With a `_FILE` suffix environment variables can also be [filled with content from a file](https://github.com/autobrr/autobrr?tab=readme-ov-file#docker-secrets). This functionality was introduced in may this year: https://github.com/autobrr/autobrr/pull/2061/

Using this functionality for the session secret, we can remove the dasel dependency and reduce the complexity a bit.

To move the config file into the statedirectory I used `install` in combination with `preStart`. If there is a nicer way to do so please let me know.

The service doesn't have a maintainer, but the test does. Are you the maintainer of the service: @av-gal? If yes, I'd appreciate your input :).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
