### PR TITLE
nixos/anki-sync-server: fix NixOS test

### DIFF
--- a/nixos/tests/anki-sync-server.nix
+++ b/nixos/tests/anki-sync-server.nix
@@ -4,11 +4,21 @@ let
     #!${pkgs.python3}/bin/python
 
     import sys
+    import os
 
-    # get site paths from anki itself
-    from runpy import run_path
-    run_path("${pkgs.anki}/bin/.anki-wrapped")
-    import anki
+    # anki is built with buildPythonApplication.
+    # anki.lib is not a 'proper' python library, meaning it
+    # is not recognized in 'withPackages' (due to hasPythonModule in
+    # https://github.com/NixOS/nixpkgs/blob/7ef35a9f3abb638647d68b10cccae549094b8054/pkgs/development/interpreters/python/python-packages-base.nix#L89
+    # and contains the collection of all python libraries used
+    # by anki rather than just the anki itself.
+    anki_libs = "${pkgs.anki.lib}/${pkgs.python3.sitePackages}"
+    if not os.path.isdir(anki_libs):
+      print(f"'{anki_libs}' not found, possible python version mismatch")
+      exit(1)
+    sys.path.append(anki_libs)
+
+    import anki.collection
 
     col = anki.collection.Collection('test_collection')
     endpoint = 'http://localhost:27701'


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
