### PR TITLE
git-gtr: init at 2.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15339,6 +15339,12 @@
     githubId = 1104419;
     name = "Lucas Hoffmann";
   };
+  luchiniatwork = {
+    email = "tiago@luchini.nyc";
+    github = "luchiniatwork";
+    githubId = 5520042;
+    name = "Tiago Luchini";
+  };
   lucperkins = {
     email = "lucperkins@gmail.com";
     github = "lucperkins";

--- a/pkgs/by-name/gi/git-gtr/package.nix
+++ b/pkgs/by-name/gi/git-gtr/package.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  git,
+  makeWrapper,
+  installShellFiles,
+  testers,
+  git-gtr,
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "git-gtr";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "coderabbitai";
+    repo = "git-worktree-runner";
+    rev = "v${version}";
+    hash = "sha256-TPd+5WtEZsR6x4/OPVkrIpW7SSDJpbZbvjYR8rzdZAs=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    installShellFiles
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    # Install library and adapter files preserving directory structure
+    # GTR_DIR expects lib/ and adapters/ subdirectories
+    mkdir -p $out/lib/git-gtr
+    cp -r lib $out/lib/git-gtr/
+    cp -r adapters $out/lib/git-gtr/
+
+    # Install gtr script with patched GTR_DIR
+    mkdir -p $out/bin
+    substitute bin/gtr $out/bin/gtr \
+      --replace-fail ': "''${GTR_DIR:=$(resolve_script_dir)}"' ": \"\''${GTR_DIR:=$out/lib/git-gtr}\""
+    chmod +x $out/bin/gtr
+
+    # Install git-gtr wrapper with patched path
+    substitute bin/git-gtr $out/bin/git-gtr \
+      --replace-fail 'exec "$SCRIPT_DIR/gtr"' "exec $out/bin/gtr"
+    chmod +x $out/bin/git-gtr
+
+    # Patch shebangs
+    patchShebangs $out/bin
+    patchShebangs $out/lib/git-gtr
+
+    # Wrap scripts to ensure git is in PATH
+    wrapProgram $out/bin/gtr \
+      --prefix PATH : ${lib.makeBinPath [ git ]}
+    wrapProgram $out/bin/git-gtr \
+      --prefix PATH : ${lib.makeBinPath [ git ]}
+
+    # Install shell completions
+    installShellCompletion --bash completions/gtr.bash
+    installShellCompletion --zsh completions/_git-gtr
+    installShellCompletion --fish completions/gtr.fish
+
+    runHook postInstall
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = git-gtr;
+    command = "git-gtr --version";
+    version = "git gtr version ${version}";
+  };
+
+  meta = {
+    description = "Git worktree manager with editor and AI tool integration";
+    longDescription = ''
+      A portable, cross-platform CLI for managing git worktrees with ease.
+      Automates per-branch worktree creation, configuration copying,
+      dependency installation, and workspace setup for efficient parallel
+      development with AI tools like Claude, Aider, and Codex.
+    '';
+    homepage = "https://github.com/coderabbitai/git-worktree-runner";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ luchiniatwork ];
+    platforms = lib.platforms.unix;
+    mainProgram = "git-gtr";
+  };
+}


### PR DESCRIPTION
## Summary

Add `git-gtr` (git-worktree-runner) version 2.0.0, a portable, cross-platform CLI for managing git worktrees with ease.

**Homepage:** https://github.com/coderabbitai/git-worktree-runner

This tool automates per-branch worktree creation, configuration copying, dependency installation, and workspace setup for efficient parallel development with AI tools like Claude, Aider, and Codex.

### Features
- Create and manage git worktrees with simple commands
- Integration with editors (VSCode, Cursor, Zed, Vim, Emacs, etc.)
- Integration with AI coding tools (Claude, Aider, Codex, etc.)
- Shell completions for bash, zsh, and fish

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux (pure bash script, should work - no local builder available)
  - [ ] x86_64-darwin (pure bash script, should work - no local builder available)
  - [ ] aarch64-darwin (pure bash script, should work - no local builder available)
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

### Testing performed
```console
$ nix-build -A git-gtr
/nix/store/...-git-gtr-2.0.0
$ ./result/bin/git-gtr --version
git gtr version 2.0.0
$ ./result/bin/git-gtr doctor
Running git gtr health check...
[OK] Git: git version 2.51.2
[OK] Repository: ...
[OK] Platform: linux
Everything looks good!
$ nix-build -A git-gtr.tests.version
/nix/store/...-git-gtr-2.0.0-test-version
```
### nixpkgs-review output
```
--------- Report for 'x86_64-linux' ---------
1 package built:
git-gtr
```
### Note on cross-platform support
This is a pure bash script package with no compiled binaries. It uses `lib.platforms.unix` which includes all Unix-like platforms. The only runtime dependency is `git`, which is available on all supported platforms. I don't have local builders for other architectures, but ofborg CI should verify builds on other platforms.
[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
```
