### PR TITLE
python3Packages.gguf: modernize, adopt, disable optional `sentencepiece` on Darwin

### DIFF
--- a/pkgs/development/python-modules/gguf/default.nix
+++ b/pkgs/development/python-modules/gguf/default.nix
@@ -49,6 +49,9 @@ buildPythonPackage rec {
     description = "Module for writing binary files in the GGUF format";
     homepage = "https://ggml.ai/";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ mitchmindtree ];
+    maintainers = with lib.maintainers; [
+      mitchmindtree
+      sarahec
+    ];
   };
 }

--- a/pkgs/development/python-modules/gguf/default.nix
+++ b/pkgs/development/python-modules/gguf/default.nix
@@ -1,40 +1,54 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
-  pythonOlder,
-  numpy,
+  fetchFromGitHub,
+
+  # build-system
   poetry-core,
+
+  # dependencies
+  numpy,
+  pyside6,
   pyyaml,
   sentencepiece,
   tqdm,
+
+  # check inputs
+  pytestCheckHook,
 }:
+
 buildPythonPackage rec {
   pname = "gguf";
   version = "0.17.1";
-  format = "pyproject";
+  pyproject = true;
 
-  disabled = pythonOlder "3.7";
-
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-Nq1xqtkAo+dfyU6+lupgKfA6TkS+difvetPQPox7y1M=";
+  src = fetchFromGitHub {
+    owner = "ggml-org";
+    repo = "llama.cpp";
+    tag = "gguf-v${version}";
+    hash = "sha256-XjDMDca4pyc72WQee4h3R6Iq9M0LzO+6ukV6CBWQO1M=";
   };
+
+  sourceRoot = "${src.name}/gguf-py";
+
+  build-system = [ poetry-core ];
 
   dependencies = [
     numpy
-    poetry-core
+    pyside6
     pyyaml
     sentencepiece
     tqdm
   ];
 
+  nativeCheckInputs = [ pytestCheckHook ];
+
   pythonImportsCheck = [ "gguf" ];
 
-  meta = with lib; {
+  meta = {
     description = "Module for writing binary files in the GGUF format";
     homepage = "https://ggml.ai/";
-    license = licenses.mit;
-    maintainers = with maintainers; [ mitchmindtree ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ mitchmindtree ];
   };
 }

--- a/pkgs/development/python-modules/gguf/default.nix
+++ b/pkgs/development/python-modules/gguf/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -37,8 +38,12 @@ buildPythonPackage rec {
     numpy
     pyside6
     pyyaml
-    sentencepiece
     tqdm
+  ]
+  # Sentencepiece is optional and its inclusion crashes darwin
+  # See https://github.com/NixOS/nixpkgs/issues/466092
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    sentencepiece
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/314455461

Code that imports `sentencepiece` on Darwin crashes (illegal instruction or exit code 139). This breaks both `pythonImportsCheck` and the unit tests.

Fortunately, `sentencepiece` is optional, so only include it on Linux until the upstream bug is fixed.

ZHF: #457852
Tracking: #466092

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
