### PR TITLE
python3Packages.mistral-common: exclude optional sentencepiece dependency on Darwin

### DIFF
--- a/pkgs/development/python-modules/mistral-common/default.nix
+++ b/pkgs/development/python-modules/mistral-common/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -61,7 +62,8 @@ buildPythonPackage rec {
     opencv = [
       opencv-python-headless
     ];
-    sentencepiece = [
+    # Broken on Darwin. See https://github.com/NixOS/nixpkgs/issues/466092
+    sentencepiece = lib.optionals (!stdenv.hostPlatform.isDarwin) [
       sentencepiece
     ];
     soundfile = [
@@ -97,7 +99,7 @@ buildPythonPackage rec {
     soxr
     uvicorn
   ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = [
     # Require internet
@@ -110,6 +112,20 @@ buildPythonPackage rec {
 
     # AssertionError, Extra items in the right set
     "test_openai_chat_fields"
+  ];
+
+  # Requires sentencepiece which segfaults when initialized on Darwin
+  # See https://github.com/NixOS/nixpkgs/issues/466092
+  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
+    "tests/experimental/test_app.py"
+    "tests/experimental/test_tools.py"
+    "tests/test_fim_tokenizer.py"
+    "tests/test_integration_samples.py"
+    "tests/test_mistral_tokenizer.py"
+    "tests/test_tokenize_v1.py"
+    "tests/test_tokenize_v2.py"
+    "tests/test_tokenize_v3.py"
+    "tests/test_tokenizer_v7.py"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/mistral-common/default.nix
+++ b/pkgs/development/python-modules/mistral-common/default.nix
@@ -14,7 +14,6 @@
   pydantic,
   pydantic-extra-types,
   requests,
-  sentencepiece,
   tiktoken,
   typing-extensions,
 
@@ -26,6 +25,7 @@
   pycountry,
   pydantic-settings,
   pytestCheckHook,
+  sentencepiece,
   soundfile,
   soxr,
   uvicorn,
@@ -53,7 +53,6 @@ buildPythonPackage rec {
     pydantic
     pydantic-extra-types
     requests
-    sentencepiece
     tiktoken
     typing-extensions
   ];
@@ -97,7 +96,8 @@ buildPythonPackage rec {
     soundfile
     soxr
     uvicorn
-  ];
+  ]
+  ++ lib.flatten (lib.attrValues optional-dependencies);
 
   disabledTests = [
     # Require internet


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/315133631 (segfault importing sentencepiece)

Code that imports sentencepiece on Darwin crashes (segfault or exit code 139). This breaks both `pythonImportsCheck` and the unit tests.

Fortunately, sentencepiece [is only an optional dependency](https://github.com/mistralai/mistral-common/blob/ea5f75b6144bbbc220048a62845d1a90f8d59998/pyproject.toml#L15-L28) so:
1. Drop it from `dependencies`
2. Fix `nativeCheckInputs` by including `optional-dependencies`
3. Make the optional dependency conditional on not being on Darwin

ZHF: #457852
Tracking: #466092

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
