### PR TITLE
yt-dlp: make deno available to python dependents

### DIFF
--- a/pkgs/by-name/yt/yt-dlp/package.nix
+++ b/pkgs/by-name/yt/yt-dlp/package.nix
@@ -38,6 +38,13 @@ python3Packages.buildPythonApplication rec {
     substituteInPlace yt_dlp/networking/_curlcffi.py \
       --replace-fail "if curl_cffi_version != (0, 5, 10) and not (0, 10) <= curl_cffi_version < (0, 14)" \
       "if curl_cffi_version != (0, 5, 10) and not (0, 10) <= curl_cffi_version"
+    ${lib.optionalString javascriptSupport ''
+      # deno is required for full YouTube support (since 2025.11.12).
+      # This makes yt-dlp find deno even if it is used as a python dependency, i.e. in kodiPackages.sendtokodi.
+      # Crafted so people can replace deno with one of the other JS runtimes.
+      substituteInPlace yt_dlp/utils/_jsruntime.py \
+        --replace-fail "path = _determine_runtime_path(self._path, '${deno.meta.mainProgram}')" "path = '${lib.getExe deno}'"
+    ''}
   '';
 
   build-system = with python3Packages; [ hatchling ];
@@ -87,7 +94,6 @@ python3Packages.buildPythonApplication rec {
 
   # Ensure these utilities are available in $PATH:
   # - ffmpeg: post-processing & transcoding support
-  # - deno: required for full YouTube support (since 2025.11.12)
   # - rtmpdump: download files over RTMP
   # - atomicparsley: embedding thumbnails
   makeWrapperArgs =
@@ -95,7 +101,6 @@ python3Packages.buildPythonApplication rec {
       packagesToBinPath =
         lib.optional atomicparsleySupport atomicparsley
         ++ lib.optional ffmpegSupport ffmpeg-headless
-        ++ lib.optional javascriptSupport deno
         ++ lib.optional rtmpSupport rtmpdump;
     in
     lib.optionals (packagesToBinPath != [ ]) [


### PR DESCRIPTION
The original problem is described in https://github.com/NixOS/nixpkgs/issues/466006, the initial attempt in https://github.com/NixOS/nixpkgs/pull/466014. This attempt fixes deno availability for all yt-dlp dependents.
As before, if `javasriptSupport` is disabled, deno is not a dependency of yt-dlp.

I tried to allow people overriding deno with another javascript runtime by using `deno.meta.mainProgram` (which returns the correct string for deno, nodejs, bun, quickjs and quickjs-ng). However, this didn't work in my local testing, probably due to a nix caching thing I assume. (tested expression: `nix build --expr 'let pkgs = import ./default.nix {}; in pkgs.yt-dlp.overrideAttrs { javascriptRuntime = pkgs.bun; }' --impure`)

I also tested kodiPackages.sendtokodi with this, ~~but as before, in the local testing I somehow don't have the correct log level. I just don't see in the logs if it works.~~ and I can confirm deno is correctly used.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
