### PR TITLE
sandbox-runtime: init at unstable-2026-01-11

### DIFF
--- a/pkgs/by-name/sa/sandbox-runtime/package.nix
+++ b/pkgs/by-name/sa/sandbox-runtime/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  buildNpmPackage,
+  ripgrep,
+  bubblewrap,
+  socat,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "sandbox-runtime";
+  version = "unstable-2025-11-29";
+
+  src = fetchFromGitHub {
+    owner = "anthropic-experimental";
+    repo = "sandbox-runtime";
+    rev = "f5902cd08e6eb396d148b7cb69cef8d3c7fe7ba7";
+    hash = "sha256-Aab/MtXtAShkH4toQfD2w1tc9kdqXcGjM0/N6HI27TI=";
+  };
+  npmDepsHash = "sha256-bKR7jDF/FYnKvsD77oseqHq/UHg5nRHiPoTxbUOkwNk=";
+
+  buildInputs = [
+    ripgrep
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    bubblewrap
+    socat
+  ];
+
+  meta = {
+    description = ''
+      A lightweight sandboxing tool for enforcing filesystem and network restrictions on arbitrary processes at the OS level, without requiring a container.
+
+      srt uses native OS sandboxing primitives (sandbox-exec on macOS, bubblewrap on Linux) and proxy-based network filtering. It can be used to sandbox the behaviour of agents, local MCP servers, bash commands and arbitrary processes.'';
+    homepage = "https://github.com/anthropic-experimental/sandbox-runtime";
+    license = lib.licenses.asl20;
+    maintainers = [ ];
+    mainProgram = "srt";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
## Things done

This library is interesting to me, because it gives a common syntax to build sandboxes on linux and darwin. Linux is not hard, but darwin sandboxes can be surprisingly tricky, especially from he command line.

This library is already used in production in claude-code, but does not have official release yet. [I did ask for that](https://github.com/anthropic-experimental/sandbox-runtime/issues/56), but no answer yet.

I would like feedback on the test-suite. I was not able to execute the unit- and integration-tests as part of the build. On darwin, because sandbox-exe is not part of the sandbox, but even if I manually configure that, still lots of tests break, for reasons I don't get. On linux, similar picture, but I think mostly because the sandbox prevents requests to example.com. 

This patch enables tests:
```diff
diff --git a/pkgs/by-name/sa/sandbox-runtime/package.nix b/pkgs/by-name/sa/sandbox-runtime/package.nix
index 0ee13744afd1..d3a4bed6b01c 100644
--- a/pkgs/by-name/sa/sandbox-runtime/package.nix
+++ b/pkgs/by-name/sa/sandbox-runtime/package.nix
@@ -4,8 +4,11 @@
   fetchFromGitHub,
   buildNpmPackage,
   ripgrep,
+  bun,
   bubblewrap,
   socat,
+  which,
+  curl,
 }:
 
 buildNpmPackage (finalAttrs: {
@@ -28,6 +31,25 @@ buildNpmPackage (finalAttrs: {
     socat
   ];
 
+  doCheck = true;
+  # Tests create a local servers to check blocking of network access
+  __darwinAllowLocalNetworking = true;
+  __impureHostDeps = lib.optionals stdenv.hostPlatform.isDarwin [
+    "/usr/bin/sandbox-exec"
+  ];
+  nativeCheckInputs = [
+    which
+    bun
+    curl
+  ]
+  ++ finalAttrs.buildInputs;
+  checkPhase = ''
+    # contains sandbox-exec
+    export PATH=$PATH:/usr/bin/
+    npm test
+    npm run test:integration
+  '';
+
   meta = {
     description = ''
       A lightweight sandboxing tool for enforcing filesystem and network restrictions on arbitrary processes at the OS level, without requiring a container.
```
On Darwin, executing the tests requires  `nix-build --attr sandbox-runtime --option extra-allowed-impure-host-deps "/usr/bin/"`

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
