### PR TITLE
emacs: bump elisp packages

### DIFF
--- a/pkgs/applications/editors/emacs/build-support/melpa.nix
+++ b/pkgs/applications/editors/emacs/build-support/melpa.nix
@@ -110,7 +110,7 @@ lib.extendMkDerivation {
         args.melpaVersion or (
           let
             parsed =
-              lib.flip builtins.match version
+              lib.flip builtins.match finalAttrs.version
                 # match <version>-unstable-YYYY-MM-DD format
                 "^.*-unstable-([[:digit:]]{4})-([[:digit:]]{2})-([[:digit:]]{2})$";
             unstableVersionInNixFormat = parsed != null; # heuristics

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-generated.nix
@@ -9,10 +9,10 @@
     elpaBuild {
       pname = "a68-mode";
       ename = "a68-mode";
-      version = "1.2.0.20250524.125533";
+      version = "1.2.0.20251029.224619";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/a68-mode-1.2.0.20250524.125533.tar";
-        sha256 = "0z8cmasvzbziwgi52p8bn4xdcz5izkhj12laf1gzwwzik1lmh5kj";
+        url = "https://elpa.gnu.org/devel/a68-mode-1.2.0.20251029.224619.tar";
+        sha256 = "11ncmphflg94r4g3qk2l9383aq26n0fd6izm1wrcdmqw0gj7n5rx";
       };
       packageRequires = [ ];
       meta = {
@@ -74,10 +74,10 @@
     elpaBuild {
       pname = "activities";
       ename = "activities";
-      version = "0.8pre0.20250223.175841";
+      version = "0.8pre0.20251118.222434";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/activities-0.8pre0.20250223.175841.tar";
-        sha256 = "0hmv2wvbs006lwc7r9bz9pf7i40dbklqllkrwdigbxbi2cn8xya8";
+        url = "https://elpa.gnu.org/devel/activities-0.8pre0.20251118.222434.tar";
+        sha256 = "0062llgn5ljf18d8fcdp4mkmn6dr67gkh8d56s8gy6rdiw354k8p";
       };
       packageRequires = [ persist ];
       meta = {
@@ -461,10 +461,10 @@
     elpaBuild {
       pname = "auctex";
       ename = "auctex";
-      version = "14.1.0.0.20251007.83053";
+      version = "14.1.0.0.20251126.231538";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/auctex-14.1.0.0.20251007.83053.tar";
-        sha256 = "18v9vfscvkzsj106rr8wp690v71x9lfh952wvar4cvb1jw6715zy";
+        url = "https://elpa.gnu.org/devel/auctex-14.1.0.0.20251126.231538.tar";
+        sha256 = "1i8c4prc3pnfrj9dkm39j2f2jj0r27aa1ywq7mns4fhz2km7jgw3";
       };
       packageRequires = [ ];
       meta = {
@@ -548,10 +548,10 @@
     elpaBuild {
       pname = "auth-source-xoauth2-plugin";
       ename = "auth-source-xoauth2-plugin";
-      version = "0.3.1.0.20250905.185219";
+      version = "0.3.2.0.20251113.213445";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/auth-source-xoauth2-plugin-0.3.1.0.20250905.185219.tar";
-        sha256 = "0jplpq1mrcqp924j12bc9kf949ndb64pzmrc4l1njn2wliykapq8";
+        url = "https://elpa.gnu.org/devel/auth-source-xoauth2-plugin-0.3.2.0.20251113.213445.tar";
+        sha256 = "02g7qy4aj85jqzzsqka9ki712hbz58ygwvr8f56ncyy1xapcjpsz";
       };
       packageRequires = [ oauth2 ];
       meta = {
@@ -719,10 +719,10 @@
     elpaBuild {
       pname = "beframe";
       ename = "beframe";
-      version = "1.4.0.0.20250808.63627";
+      version = "1.4.0.0.20251127.171120";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/beframe-1.4.0.0.20250808.63627.tar";
-        sha256 = "1pk37b1n7ng58ymajcq29ass1wgrpg0q48vrr22l7lwrpl6jcfx8";
+        url = "https://elpa.gnu.org/devel/beframe-1.4.0.0.20251127.171120.tar";
+        sha256 = "13nr21ai2pdh1bkfnka1b6zhaxn32apxn56fgbzvkzkzg4in8qrk";
       };
       packageRequires = [ ];
       meta = {
@@ -740,10 +740,10 @@
     elpaBuild {
       pname = "bicep-ts-mode";
       ename = "bicep-ts-mode";
-      version = "0.1.4.0.20251006.205101";
+      version = "0.1.4.0.20251121.60244";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/bicep-ts-mode-0.1.4.0.20251006.205101.tar";
-        sha256 = "1ciq4v2h29ic3amh6qdl27miz23c71533rhks1i5w4xp6wxvs4iz";
+        url = "https://elpa.gnu.org/devel/bicep-ts-mode-0.1.4.0.20251121.60244.tar";
+        sha256 = "0423n65lcxd56xc4q1mihwb07y81y12wh2qiwgwc1n1b7wilbpkg";
       };
       packageRequires = [ ];
       meta = {
@@ -993,10 +993,10 @@
     elpaBuild {
       pname = "bufferlo";
       ename = "bufferlo";
-      version = "1.2.0.20250914.184401";
+      version = "1.2.0.20251126.101032";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/bufferlo-1.2.0.20250914.184401.tar";
-        sha256 = "1xfgizjfwclgvy7sbjqfsrgp59xk8n7cixgkiwsnviysyyxh1rwv";
+        url = "https://elpa.gnu.org/devel/bufferlo-1.2.0.20251126.101032.tar";
+        sha256 = "178qq7rvwn3601xw1f0vpgq6k0fjq854r907rncbx866s1427kai";
       };
       packageRequires = [ ];
       meta = {
@@ -1015,10 +1015,10 @@
     elpaBuild {
       pname = "buframe";
       ename = "buframe";
-      version = "0.2.0.20250917.90933";
+      version = "0.2.0.20251126.123915";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/buframe-0.2.0.20250917.90933.tar";
-        sha256 = "1wlivzwzfmq3j8b1zgaw4bzln3c27d1xr9fvqq2p31cjh5ra36nl";
+        url = "https://elpa.gnu.org/devel/buframe-0.2.0.20251126.123915.tar";
+        sha256 = "0m0m5fllpl12d4d4nkq0g34h78qzlvjh0acjvch0zygxvisdi91g";
       };
       packageRequires = [ timeout ];
       meta = {
@@ -1084,10 +1084,10 @@
     elpaBuild {
       pname = "calibre";
       ename = "calibre";
-      version = "1.4.1.0.20240208.85735";
+      version = "1.5.0.0.20251020.212619";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/calibre-1.4.1.0.20240208.85735.tar";
-        sha256 = "1rbmck8bc28c2rf321606w748nqc5klly6yrm3r8zyviggwd1v2c";
+        url = "https://elpa.gnu.org/devel/calibre-1.5.0.0.20251020.212619.tar";
+        sha256 = "0s2r9qa1mb4rppsb9h5wwwmzny6rpkcsjcl969fi8i2kqdsygjzh";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1106,10 +1106,10 @@
     elpaBuild {
       pname = "cape";
       ename = "cape";
-      version = "2.1.0.20250920.155804";
+      version = "2.3.0.20251116.194014";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/cape-2.1.0.20250920.155804.tar";
-        sha256 = "1hh5adcv1d7p29bbd49351rn2kx57kld4g4qlp1ifzn02w1gfdpz";
+        url = "https://elpa.gnu.org/devel/cape-2.3.0.20251116.194014.tar";
+        sha256 = "0zy76c6m7xhfxy843hhbq1bmcrs17ndzcwhb382wp6pqd87by21n";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1319,10 +1319,10 @@
     elpaBuild {
       pname = "colorful-mode";
       ename = "colorful-mode";
-      version = "1.2.4.0.20251006.212555";
+      version = "1.2.5.0.20251121.52839";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/colorful-mode-1.2.4.0.20251006.212555.tar";
-        sha256 = "170v711l6qapsypzg7i56kkmwvnzc0h625wbb5hgv205zkcqvrzw";
+        url = "https://elpa.gnu.org/devel/colorful-mode-1.2.5.0.20251121.52839.tar";
+        sha256 = "0rph93j55d3b3kl2yhwfazf4aqs7grzr0q5shk13skp8s1gpg3cc";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1387,10 +1387,10 @@
     elpaBuild {
       pname = "company";
       ename = "company";
-      version = "1.0.2.0.20250911.12909";
+      version = "1.0.2.0.20251021.221153";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/company-1.0.2.0.20250911.12909.tar";
-        sha256 = "1186p5rzaxiz9hc4s254b9q7c9vpqcdv788h87mnmniabv18yf26";
+        url = "https://elpa.gnu.org/devel/company-1.0.2.0.20251021.221153.tar";
+        sha256 = "1p31ws9qx4qmwh0yqc6am454ywnls34nkqicfc3mkq6q54r7ffmn";
       };
       packageRequires = [ ];
       meta = {
@@ -1483,10 +1483,10 @@
     elpaBuild {
       pname = "compat";
       ename = "compat";
-      version = "30.1.0.1.0.20250619.142858";
+      version = "30.1.0.1.0.20251104.142701";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/compat-30.1.0.1.0.20250619.142858.tar";
-        sha256 = "0lxpm1kbshrq6f2j9ihdd5xd6lwabmypfmlk9fp2ibzv32wwajv7";
+        url = "https://elpa.gnu.org/devel/compat-30.1.0.1.0.20251104.142701.tar";
+        sha256 = "1xkgp3rf8rzqf4jnvj2mklvvimq6cb99ivahc1rwrm9vm1y2gn8z";
       };
       packageRequires = [ seq ];
       meta = {
@@ -1504,10 +1504,10 @@
     elpaBuild {
       pname = "cond-star";
       ename = "cond-star";
-      version = "1.0.0.20250310.74521";
+      version = "1.0.0.20251125.203021";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/cond-star-1.0.0.20250310.74521.tar";
-        sha256 = "1j7s227aih10np8j74b880lgk8v3g35dgpph23bzkqzrybl3w0z6";
+        url = "https://elpa.gnu.org/devel/cond-star-1.0.0.20251125.203021.tar";
+        sha256 = "1xc2w4z8bqnf1byk8vxlyji0awjfy8hr030mnnla9v4q8a15pxkl";
       };
       packageRequires = [ ];
       meta = {
@@ -1547,10 +1547,10 @@
     elpaBuild {
       pname = "consult";
       ename = "consult";
-      version = "2.8.0.20251008.43406";
+      version = "3.0.0.20251123.113714";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/consult-2.8.0.20251008.43406.tar";
-        sha256 = "05673j1jjr8il31g854ijgy73haplvcjsk0v41bri1iv9cyfiqaf";
+        url = "https://elpa.gnu.org/devel/consult-3.0.0.20251123.113714.tar";
+        sha256 = "1wsfq7l2hs2vjv15wvvmzl5bih46hjbc4fjnn1cjrc83855mi748";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1570,10 +1570,10 @@
     elpaBuild {
       pname = "consult-denote";
       ename = "consult-denote";
-      version = "0.3.1.0.20250805.41616";
+      version = "0.4.1.0.20251118.174206";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/consult-denote-0.3.1.0.20250805.41616.tar";
-        sha256 = "1ryyjcxlqbkqiivbiazkj7pxqac9sn3kyczz103z9pmvf3g3wc1r";
+        url = "https://elpa.gnu.org/devel/consult-denote-0.4.1.0.20251118.174206.tar";
+        sha256 = "1hf7hqwfssya7dg5n3bmmgxp6fbmg5wmh6g40vr06xbflz0235wd";
       };
       packageRequires = [
         consult
@@ -1660,10 +1660,10 @@
     elpaBuild {
       pname = "corfu";
       ename = "corfu";
-      version = "2.3.0.20250923.125035";
+      version = "2.5.0.20251116.194049";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/corfu-2.3.0.20250923.125035.tar";
-        sha256 = "0sc7q6l53d4vpyvnsnqhawl0bcl5p61nbna9v6xfrn1lw86xdcqi";
+        url = "https://elpa.gnu.org/devel/corfu-2.5.0.20251116.194049.tar";
+        sha256 = "07pihjminnblqwschgrpn0k9rjy68bqlycddy9v5mpl0v5c4ksi7";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1941,10 +1941,10 @@
     elpaBuild {
       pname = "dape";
       ename = "dape";
-      version = "0.24.1.0.20251006.200603";
+      version = "0.25.0.0.20251125.164207";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/dape-0.24.1.0.20251006.200603.tar";
-        sha256 = "1c1rkhzc2b8r8dnmh670gs9v9k5bh1kafkz2inli7f221hkmvq16";
+        url = "https://elpa.gnu.org/devel/dape-0.25.0.0.20251125.164207.tar";
+        sha256 = "01r4l7mjcls9x76s8mnxl2hjmj8wa75z3lsrssn4gza8pc22gx6m";
       };
       packageRequires = [ jsonrpc ];
       meta = {
@@ -1984,10 +1984,10 @@
     elpaBuild {
       pname = "dash";
       ename = "dash";
-      version = "2.20.0.0.20250814.95131";
+      version = "2.20.0.0.20251016.104741";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/dash-2.20.0.0.20250814.95131.tar";
-        sha256 = "06xrjbqbsr5ywd7pqi2gn2w9aavg3yr0vf0i8h40s5nhls683r41";
+        url = "https://elpa.gnu.org/devel/dash-2.20.0.0.20251016.104741.tar";
+        sha256 = "1d7lqzk7qwrkmxmydkk5a9mbi42zngn00ll42avhamsinld959g6";
       };
       packageRequires = [ ];
       meta = {
@@ -2028,10 +2028,10 @@
     elpaBuild {
       pname = "debbugs";
       ename = "debbugs";
-      version = "0.45.0.20250929.72502";
+      version = "0.46.0.20251109.133812";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/debbugs-0.45.0.20250929.72502.tar";
-        sha256 = "1mfvlfsjx10ndns6rfl2sap2vfb8d602ng4sn0iw0la9ywsaw6pg";
+        url = "https://elpa.gnu.org/devel/debbugs-0.46.0.20251109.133812.tar";
+        sha256 = "0c12aikl1yxclrmfb0gkrvic9ldmsj9j14v4905sc78ng4h4v695";
       };
       packageRequires = [ soap-client ];
       meta = {
@@ -2075,10 +2075,10 @@
     elpaBuild {
       pname = "denote";
       ename = "denote";
-      version = "4.0.0.0.20251007.45843";
+      version = "4.1.2.0.20251124.102356";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-4.0.0.0.20251007.45843.tar";
-        sha256 = "0b6fzi9mhkqy0wky7rz9nnq6x8wigagc5ry918qm9zb30f5pg1xg";
+        url = "https://elpa.gnu.org/devel/denote-4.1.2.0.20251124.102356.tar";
+        sha256 = "0chz1kc28dnv3a53lk6fryw83lfmq4pfwqjm0q75ahm584a9vd83";
       };
       packageRequires = [ ];
       meta = {
@@ -2097,10 +2097,10 @@
     elpaBuild {
       pname = "denote-journal";
       ename = "denote-journal";
-      version = "0.1.1.0.20250908.94202";
+      version = "0.2.1.0.20251102.81910";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-journal-0.1.1.0.20250908.94202.tar";
-        sha256 = "1gpyxh9bb1pk9frg676zazk8jdmy466r23110c3m59hx35rqmdy3";
+        url = "https://elpa.gnu.org/devel/denote-journal-0.2.1.0.20251102.81910.tar";
+        sha256 = "0j6aass4dl4320qnnz0bjshhqqkxiwl3g0p5h7rzwms172fnpmly";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2119,10 +2119,10 @@
     elpaBuild {
       pname = "denote-markdown";
       ename = "denote-markdown";
-      version = "0.1.1.0.20250719.40600";
+      version = "0.2.0.0.20251017.64227";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-markdown-0.1.1.0.20250719.40600.tar";
-        sha256 = "1ck90jkhl7bm018hgpyl1g8f33jyaj5dk12b7khjx6a949ypx4nk";
+        url = "https://elpa.gnu.org/devel/denote-markdown-0.2.0.0.20251017.64227.tar";
+        sha256 = "1qcwnisiyw3zrqsj1igwn3zrc95mvdbk36hymc05fma84nmsyb9m";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2163,10 +2163,10 @@
     elpaBuild {
       pname = "denote-org";
       ename = "denote-org";
-      version = "0.1.1.0.20250829.181530";
+      version = "0.2.0.0.20251017.63939";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-org-0.1.1.0.20250829.181530.tar";
-        sha256 = "1y6fadg2wv5lizn7p53j2hziz8mq7r5m0pxvm253b9j8r6390r8k";
+        url = "https://elpa.gnu.org/devel/denote-org-0.2.0.0.20251017.63939.tar";
+        sha256 = "0bww1m5njj09pghanmwxb7f2dd9z990lnk20r1xykznapdzvq03z";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2207,10 +2207,10 @@
     elpaBuild {
       pname = "denote-sequence";
       ename = "denote-sequence";
-      version = "0.1.1.0.20250905.174858";
+      version = "0.2.0.0.20251128.54048";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-sequence-0.1.1.0.20250905.174858.tar";
-        sha256 = "126rhzjfbp1f94s8ivqis6vd2pi85zrn5ass5k8a6sd9sh4ahnja";
+        url = "https://elpa.gnu.org/devel/denote-sequence-0.2.0.0.20251128.54048.tar";
+        sha256 = "0vqnhjlhbdfainyfv7jxf0afl32cwlnjwjvz41ya8dci42w12inl";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2229,10 +2229,10 @@
     elpaBuild {
       pname = "denote-silo";
       ename = "denote-silo";
-      version = "0.1.2.0.20250605.84406";
+      version = "0.2.0.0.20251017.64320";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-silo-0.1.2.0.20250605.84406.tar";
-        sha256 = "12wj4ydi5gzavgxv3g170p7d8wi9ydqb2apnjvzq27gnf0n2kjzi";
+        url = "https://elpa.gnu.org/devel/denote-silo-0.2.0.0.20251017.64320.tar";
+        sha256 = "1gzazd9hfn8fxg7fpnf9ljsprng6i4hmxpdfnnv0pwmnig29dcgf";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2268,20 +2268,16 @@
       elpaBuild,
       fetchurl,
       lib,
-      mathjax,
     }:
     elpaBuild {
       pname = "devdocs";
       ename = "devdocs";
-      version = "0.6.1.0.20250608.141406";
+      version = "0.7.0.20251022.125547";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/devdocs-0.6.1.0.20250608.141406.tar";
-        sha256 = "155j0c3ldrp16399fv1mqppkky0zzjy1d4bls83j8w3xl2r8ai4v";
+        url = "https://elpa.gnu.org/devel/devdocs-0.7.0.20251022.125547.tar";
+        sha256 = "1sl9y7s5r8x8sq7yrgjp7w9p0cwhpm5ii7h941zc63qsgrifz0zy";
       };
-      packageRequires = [
-        compat
-        mathjax
-      ];
+      packageRequires = [ compat ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/devdocs.html";
         license = lib.licenses.free;
@@ -2319,10 +2315,10 @@
     elpaBuild {
       pname = "dicom";
       ename = "dicom";
-      version = "1.0.0.20251008.104111";
+      version = "1.2.0.20251123.150607";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/dicom-1.0.0.20251008.104111.tar";
-        sha256 = "0fmrnw2phx45xfshi9hwjldk8hbcywdnf9dv0q2cs7yw3l60f02n";
+        url = "https://elpa.gnu.org/devel/dicom-1.2.0.20251123.150607.tar";
+        sha256 = "1g6a78m4jwq5k43si0kysxbf3aji69mwfpdbcx2ma7j8kpi1fgll";
       };
       packageRequires = [ compat ];
       meta = {
@@ -2369,10 +2365,10 @@
     elpaBuild {
       pname = "diff-hl";
       ename = "diff-hl";
-      version = "1.10.0.0.20251008.224129";
+      version = "1.10.0.0.20251126.11212";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/diff-hl-1.10.0.0.20251008.224129.tar";
-        sha256 = "1161jxws89flszfy9x7wrz1jzzlg3c9xbpcnik9x3x5wamhr7bh9";
+        url = "https://elpa.gnu.org/devel/diff-hl-1.10.0.0.20251126.11212.tar";
+        sha256 = "0nygvfizpcisb5z491yv6742vj3dyn7zj2wncm8z8nx799wj8952";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -2665,10 +2661,10 @@
     elpaBuild {
       pname = "doric-themes";
       ename = "doric-themes";
-      version = "0.4.0.0.20251004.101735";
+      version = "0.5.0.0.20251123.85033";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/doric-themes-0.4.0.0.20251004.101735.tar";
-        sha256 = "1dlsfy3faww658v03886gc44mf696pjr33igp2cfzw9ya1xsszaf";
+        url = "https://elpa.gnu.org/devel/doric-themes-0.5.0.0.20251123.85033.tar";
+        sha256 = "0jp09gz8q3zk3p5skw9ika0804vb2bw64p0kcnya3yqg6gn698fq";
       };
       packageRequires = [ ];
       meta = {
@@ -2687,10 +2683,10 @@
     elpaBuild {
       pname = "drepl";
       ename = "drepl";
-      version = "0.3.0.20240929.81709";
+      version = "0.4.0.20251012.81518";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/drepl-0.3.0.20240929.81709.tar";
-        sha256 = "14b8argsv9i1aqzvkkx11810g9rf93kn6kz2qcd552pxllcpyf1l";
+        url = "https://elpa.gnu.org/devel/drepl-0.4.0.20251012.81518.tar";
+        sha256 = "0xq39hhxx8fpkxqkxnihgn0dw3gxxyzaglpw4cpbn5f6zx2x26yy";
       };
       packageRequires = [ comint-mime ];
       meta = {
@@ -2867,10 +2863,10 @@
     elpaBuild {
       pname = "eev";
       ename = "eev";
-      version = "20250914.0.20250914.191243";
+      version = "20251123.0.20251123.201108";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/eev-20250914.0.20250914.191243.tar";
-        sha256 = "1ns804y302xdnvf2vczk4banvcysgw5dv54yv3ffjsjchgn2z5qs";
+        url = "https://elpa.gnu.org/devel/eev-20251123.0.20251123.201108.tar";
+        sha256 = "1wks48xpzp1qwbzqgmvd1wjjrwyyx055fzp51r57i8r77ngwb37k";
       };
       packageRequires = [ ];
       meta = {
@@ -2889,10 +2885,10 @@
     elpaBuild {
       pname = "ef-themes";
       ename = "ef-themes";
-      version = "1.11.0.0.20251007.75143";
+      version = "2.0.1.0.20251126.165108";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ef-themes-1.11.0.0.20251007.75143.tar";
-        sha256 = "1sg7dhgxrgs7c2sy4128rv1iikj9ymigiwz3kx0a1smwn6vrmh71";
+        url = "https://elpa.gnu.org/devel/ef-themes-2.0.1.0.20251126.165108.tar";
+        sha256 = "0indsg2qydwq3rfq227aw9qp8pb1s9n2z8c98bf0qds27slfs93n";
       };
       packageRequires = [ modus-themes ];
       meta = {
@@ -2917,10 +2913,10 @@
     elpaBuild {
       pname = "eglot";
       ename = "eglot";
-      version = "1.18.0.20251003.84456";
+      version = "1.19.0.20251118.205355";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/eglot-1.18.0.20251003.84456.tar";
-        sha256 = "0avj1q1m7qmdivvz3nqysbq9lxnzpy6cfw599wl44ij5xdfnpwrx";
+        url = "https://elpa.gnu.org/devel/eglot-1.19.0.20251118.205355.tar";
+        sha256 = "03hq3nyr2s3s57q3r3p1sfc6nlk8bbfl57xg2ar82ivx79jjmfqa";
       };
       packageRequires = [
         eldoc
@@ -2993,10 +2989,10 @@
     elpaBuild {
       pname = "eldoc";
       ename = "eldoc";
-      version = "1.16.0.0.20250709.192845";
+      version = "1.16.0.0.20251022.171210";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/eldoc-1.16.0.0.20250709.192845.tar";
-        sha256 = "1n35mlpl1r2kxvp6z0ah3zykgjlam9pq2mxbap0iamhmvrp27537";
+        url = "https://elpa.gnu.org/devel/eldoc-1.16.0.0.20251022.171210.tar";
+        sha256 = "12c7wwlawf5xwc6rg7qij7y92yf53vcwv78spmp4jprzx4h7aj06";
       };
       packageRequires = [ ];
       meta = {
@@ -3138,10 +3134,10 @@
     elpaBuild {
       pname = "embark";
       ename = "embark";
-      version = "1.1.0.20250825.75213";
+      version = "1.1.0.20251117.191148";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/embark-1.1.0.20250825.75213.tar";
-        sha256 = "0x5zg5rlhx4vlhijsjb1mjxmbc3g6mk4qf5s98ma71wprvfx3c8y";
+        url = "https://elpa.gnu.org/devel/embark-1.1.0.20251117.191148.tar";
+        sha256 = "0km0f7pk6frarfsdh4lz47vpq5d2ryfsxmb8lnksrhw5g7s3zhkw";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3162,10 +3158,10 @@
     elpaBuild {
       pname = "embark-consult";
       ename = "embark-consult";
-      version = "1.1.0.20250825.75213";
+      version = "1.1.0.20251117.191148";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/embark-consult-1.1.0.20250825.75213.tar";
-        sha256 = "0ypm3z99kd8kiszih55ysh7jhcf711s7qqyg3m8byli6wff4h40x";
+        url = "https://elpa.gnu.org/devel/embark-consult-1.1.0.20251117.191148.tar";
+        sha256 = "09710k4d5g7rp179mll9a056x9af9ckpsdjl8kcil0rfb7pc5s4r";
       };
       packageRequires = [
         compat
@@ -3194,10 +3190,10 @@
     elpaBuild {
       pname = "ement";
       ename = "ement";
-      version = "0.17pre0.20250511.153249";
+      version = "0.18pre0.20251117.191748";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ement-0.17pre0.20250511.153249.tar";
-        sha256 = "0vkkk79z2q73niffjkjbywiqr3ykdvb9ssq3095kxjnrc7k6vzvz";
+        url = "https://elpa.gnu.org/devel/ement-0.18pre0.20251117.191748.tar";
+        sha256 = "04qlw00maswc152fchhpf1028426qsg37ky1ap4lsbkpay3cfhqp";
       };
       packageRequires = [
         map
@@ -3226,10 +3222,10 @@
     elpaBuild {
       pname = "emms";
       ename = "emms";
-      version = "23.0.20251002.104209";
+      version = "24.0.20251125.62111";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/emms-23.0.20251002.104209.tar";
-        sha256 = "072l1pkqwpkk00px2251jvl4x0769kjlldd6l4a5d1cdi0kam074";
+        url = "https://elpa.gnu.org/devel/emms-24.0.20251125.62111.tar";
+        sha256 = "0gsr3kdqaj8c5cqxsi1d8wzn9q149f27k61zgllf51vl5s9jg6ir";
       };
       packageRequires = [
         cl-lib
@@ -3315,10 +3311,10 @@
     elpaBuild {
       pname = "erc";
       ename = "erc";
-      version = "5.6.1snapshot0.20250904.171225";
+      version = "5.6.2snapshot0.20251027.192944";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/erc-5.6.1snapshot0.20250904.171225.tar";
-        sha256 = "07mm33az8c055p2i22ihp4vrs460wvk75fdcy960b45qlsd19kwp";
+        url = "https://elpa.gnu.org/devel/erc-5.6.2snapshot0.20251027.192944.tar";
+        sha256 = "0hhdh7lqfv22774l0b2pgac1k75k00hf8wwi5v5w51qz5sn4v24w";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3362,10 +3358,10 @@
     elpaBuild {
       pname = "ess";
       ename = "ess";
-      version = "25.1.0.0.20251003.204431";
+      version = "25.1.0.0.20251105.165436";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ess-25.1.0.0.20251003.204431.tar";
-        sha256 = "1njv0vdxi7v9wn00mn0k3qxhxliz80hh74jx9nzm4j2n003lf8y9";
+        url = "https://elpa.gnu.org/devel/ess-25.1.0.0.20251105.165436.tar";
+        sha256 = "095jn3v8kwaa5mwc3x2lg0f9h0jjcpa4xdfq49nfqhilxspwji1r";
       };
       packageRequires = [ ];
       meta = {
@@ -3478,10 +3474,10 @@
     elpaBuild {
       pname = "exwm";
       ename = "exwm";
-      version = "0.34.0.20250919.75516";
+      version = "0.34.0.20251127.125904";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/exwm-0.34.0.20250919.75516.tar";
-        sha256 = "1fm2mmni78xif4lva5rwsrv40ywbz8m0cc1gl3krqsilb3a150y8";
+        url = "https://elpa.gnu.org/devel/exwm-0.34.0.20251127.125904.tar";
+        sha256 = "06qr87dyjca9k459byjiy4jkfx5vskr7snk85wl5ffs1bip6f01c";
       };
       packageRequires = [
         compat
@@ -3612,10 +3608,10 @@
     elpaBuild {
       pname = "flymake";
       ename = "flymake";
-      version = "1.4.1.0.20250906.55308";
+      version = "1.4.3.0.20251122.110118";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/flymake-1.4.1.0.20250906.55308.tar";
-        sha256 = "1wy77d63mlcax9sksf3js0acqmx33hkn03iz37aqlyikjy51vbs9";
+        url = "https://elpa.gnu.org/devel/flymake-1.4.3.0.20251122.110118.tar";
+        sha256 = "1mjhgpv3kjzlqlzx84c0r36mcwjn99pkzg3nvdrid4fb6c9c7d1f";
       };
       packageRequires = [
         eldoc
@@ -4170,10 +4166,10 @@
     elpaBuild {
       pname = "greader";
       ename = "greader";
-      version = "0.12.7.0.20250722.52020";
+      version = "0.13.1.0.20251125.85919";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/greader-0.12.7.0.20250722.52020.tar";
-        sha256 = "0zgwih2mz53igjqw4ifk7qa82dbvxiz5hfyydz4nlh6x18ysg825";
+        url = "https://elpa.gnu.org/devel/greader-0.13.1.0.20251125.85919.tar";
+        sha256 = "1k9r0k74wajvmgdsg9dih53h8kp1rd82jyqvivibkrfh5mm0c17l";
       };
       packageRequires = [
         compat
@@ -4215,10 +4211,10 @@
     elpaBuild {
       pname = "gtags-mode";
       ename = "gtags-mode";
-      version = "1.9.3.0.20250618.235351";
+      version = "1.9.4.0.20251110.175010";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/gtags-mode-1.9.3.0.20250618.235351.tar";
-        sha256 = "0009dg34n71lgf28dsqaghzyykfvid9la5mz6aw1d3130x6hd46j";
+        url = "https://elpa.gnu.org/devel/gtags-mode-1.9.4.0.20251110.175010.tar";
+        sha256 = "19c6ccg812lqz28pfx9jjfkms1zvfv8qs6693fd69rggsh55bp43";
       };
       packageRequires = [ ];
       meta = {
@@ -4432,10 +4428,10 @@
     elpaBuild {
       pname = "hyperbole";
       ename = "hyperbole";
-      version = "9.0.2pre0.20250914.231303";
+      version = "9.0.2pre0.20251125.212734";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/hyperbole-9.0.2pre0.20250914.231303.tar";
-        sha256 = "07nk16nkvl9myr7mxhrql5wpxsr1qa2nj4r76x4fh6lvsh9nfnim";
+        url = "https://elpa.gnu.org/devel/hyperbole-9.0.2pre0.20251125.212734.tar";
+        sha256 = "1pjhq16m6pmynn56d86xiycmjfa0z5q6n13zf0ci17v52g0c4v9w";
       };
       packageRequires = [ ];
       meta = {
@@ -4496,10 +4492,10 @@
     elpaBuild {
       pname = "indent-bars";
       ename = "indent-bars";
-      version = "0.9.2.0.20250719.204514";
+      version = "0.9.2.0.20251122.125219";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/indent-bars-0.9.2.0.20250719.204514.tar";
-        sha256 = "0dvbgzkqdnbk65gsk1mh7cn06w6n5qmdpm4mmswkx57g479j68ni";
+        url = "https://elpa.gnu.org/devel/indent-bars-0.9.2.0.20251122.125219.tar";
+        sha256 = "0vqg3hhdbzkjqp06wxnzzp49aha14ryn4q8n3qhwpdjwawl4inll";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4623,10 +4619,10 @@
     elpaBuild {
       pname = "ivy";
       ename = "ivy";
-      version = "0.15.1.0.20250519.175035";
+      version = "0.15.1.0.20251123.103239";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ivy-0.15.1.0.20250519.175035.tar";
-        sha256 = "094xx1zpxs1qf799s3cv2ymr5q7bgs87yr8haf6wqwf44rxdwycw";
+        url = "https://elpa.gnu.org/devel/ivy-0.15.1.0.20251123.103239.tar";
+        sha256 = "1cymqwcgql6mra622rmpp62yq81mwfmfvh1fgqvn7sryqndz5hnl";
       };
       packageRequires = [ ];
       meta = {
@@ -4830,10 +4826,10 @@
     elpaBuild {
       pname = "jinx";
       ename = "jinx";
-      version = "2.3.0.20251007.170933";
+      version = "2.4.0.20251126.172039";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/jinx-2.3.0.20251007.170933.tar";
-        sha256 = "0ihjqsvckn08fq9z1c8yy8ic1lfjzid2835s8xa2sq07qk7389fi";
+        url = "https://elpa.gnu.org/devel/jinx-2.4.0.20251126.172039.tar";
+        sha256 = "0w2bar28368v4ymjxqmhnlai0i5cwn6f44llvrhjghxrfdfk3lid";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4852,10 +4848,10 @@
     elpaBuild {
       pname = "jit-spell";
       ename = "jit-spell";
-      version = "0.4.0.20240810.110215";
+      version = "0.5.0.20251012.84654";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/jit-spell-0.4.0.20240810.110215.tar";
-        sha256 = "0k4icsk8wdshdza9mgdlfyg5ybnhkzdwjjkjq4s2g6d5h0ai1xzl";
+        url = "https://elpa.gnu.org/devel/jit-spell-0.5.0.20251012.84654.tar";
+        sha256 = "01df1pp16mbq793zcdgsfvk0smsnadcwwflmrazm1pv7jmk7qa9f";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4895,10 +4891,10 @@
     elpaBuild {
       pname = "json-mode";
       ename = "json-mode";
-      version = "0.2.0.20250307.75711";
+      version = "0.2.0.20251114.104352";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/json-mode-0.2.0.20250307.75711.tar";
-        sha256 = "06554pl40d8cgnabcxvixsdn904z28zsl579w6y64cqjf3da4qx3";
+        url = "https://elpa.gnu.org/devel/json-mode-0.2.0.20251114.104352.tar";
+        sha256 = "0ijpc642fz29smgwv8hyfy727f3civah63whwr904axfhp58srb8";
       };
       packageRequires = [ ];
       meta = {
@@ -4916,10 +4912,10 @@
     elpaBuild {
       pname = "jsonrpc";
       ename = "jsonrpc";
-      version = "1.0.25.0.20250907.123924";
+      version = "1.0.26.0.20251023.204446";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/jsonrpc-1.0.25.0.20250907.123924.tar";
-        sha256 = "115x2m52fga5mxj9dbvc2vk380m5qx130zczaisgc2r23qw8gwjb";
+        url = "https://elpa.gnu.org/devel/jsonrpc-1.0.26.0.20251023.204446.tar";
+        sha256 = "0a8lk6yza0a4dq7zngf3k0xblzzqsrhrjpp2nq2r8n5kaxa3p1s4";
       };
       packageRequires = [ ];
       meta = {
@@ -5231,10 +5227,10 @@
     elpaBuild {
       pname = "listen";
       ename = "listen";
-      version = "0.10pre0.20240923.201649";
+      version = "0.10pre0.20251123.212313";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/listen-0.10pre0.20240923.201649.tar";
-        sha256 = "0klkjl8g7r6i0cx5yp1f2z6vafxpx0llbsk024bp6jjx9l6n7vp9";
+        url = "https://elpa.gnu.org/devel/listen-0.10pre0.20251123.212313.tar";
+        sha256 = "038prqyiv3yvmzxjqxl7dq8nhxndzi3bg251va98a7fawaz06i2y";
       };
       packageRequires = [
         persist
@@ -5282,10 +5278,10 @@
     elpaBuild {
       pname = "llm";
       ename = "llm";
-      version = "0.27.2.0.20251004.1607";
+      version = "0.27.3.0.20251125.234031";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/llm-0.27.2.0.20251004.1607.tar";
-        sha256 = "00vf791pjf4sxja3wp9nl7s514gk3c3rcdmdw37nfcvw8vx3qa9h";
+        url = "https://elpa.gnu.org/devel/llm-0.27.3.0.20251125.234031.tar";
+        sha256 = "1s39lrbxmqdkc2jggpbqaxnhwvh0287p99zc2sjz533ybjhcd96z";
       };
       packageRequires = [
         compat
@@ -5415,10 +5411,10 @@
     elpaBuild {
       pname = "logos";
       ename = "logos";
-      version = "1.2.0.0.20250601.73518";
+      version = "1.2.0.0.20251126.175507";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/logos-1.2.0.0.20250601.73518.tar";
-        sha256 = "0c67ky0zvi26q7hzzhpj2gb9xlw1y7zzg3m94frc8glaibaj5cpl";
+        url = "https://elpa.gnu.org/devel/logos-1.2.0.0.20251126.175507.tar";
+        sha256 = "0wns1k4f7hcqy147r6siv37i2al9dfwdlk8la48x27jr89v6s68y";
       };
       packageRequires = [ ];
       meta = {
@@ -5500,10 +5496,10 @@
     elpaBuild {
       pname = "map";
       ename = "map";
-      version = "3.3.1.0.20250819.91151";
+      version = "3.3.1.0.20251101.195205";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/map-3.3.1.0.20250819.91151.tar";
-        sha256 = "0axrs58ji1q74q2b9yfq5kb8sjhz9lbjqgmqb9cv78hy28pjvq7y";
+        url = "https://elpa.gnu.org/devel/map-3.3.1.0.20251101.195205.tar";
+        sha256 = "0iaxap5cck1nrsnh3n96g3d5i6d613mdggshdhjapfr2v85xwg9w";
       };
       packageRequires = [ ];
       meta = {
@@ -5522,10 +5518,10 @@
     elpaBuild {
       pname = "marginalia";
       ename = "marginalia";
-      version = "2.3.0.20251006.112635";
+      version = "2.5.0.20251123.113311";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/marginalia-2.3.0.20251006.112635.tar";
-        sha256 = "1kca6q6c0bncal0bim1hzldkjbgm4ia0l5v40h5zl9ybakzqlvp3";
+        url = "https://elpa.gnu.org/devel/marginalia-2.5.0.20251123.113311.tar";
+        sha256 = "069s415gpy99fv0kmzg470iilqjpq5x0jq2hj5lihyglwv6pxzsv";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5585,10 +5581,10 @@
     elpaBuild {
       pname = "mathjax";
       ename = "mathjax";
-      version = "0.1.0.20241113.83941";
+      version = "0.1.0.20251012.85017";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/mathjax-0.1.0.20241113.83941.tar";
-        sha256 = "1n49nj70bpxpm72caffx0lmcnlfqdljy8sn8mzwhfiingrif2spb";
+        url = "https://elpa.gnu.org/devel/mathjax-0.1.0.20251012.85017.tar";
+        sha256 = "1yd547wvnp2f8pd6n9n52xk4h117301rix9x8lpxpabfhw0fxq2d";
       };
       packageRequires = [ ];
       meta = {
@@ -5628,10 +5624,10 @@
     elpaBuild {
       pname = "matlab-mode";
       ename = "matlab-mode";
-      version = "7.1.1.0.20251001.101359";
+      version = "7.4.1.0.20251126.215443";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/matlab-mode-7.1.1.0.20251001.101359.tar";
-        sha256 = "1s4kvfan9xlv2m1l92y59ib7lfzycnidkh456pq2pva74if810a5";
+        url = "https://elpa.gnu.org/devel/matlab-mode-7.4.1.0.20251126.215443.tar";
+        sha256 = "11xpz32z6mb182g0463hwpf5zndk29x6d39d6krca4apqblfmj87";
       };
       packageRequires = [ ];
       meta = {
@@ -5789,6 +5785,27 @@
       };
     }
   ) { };
+  minimail = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "minimail";
+      ename = "minimail";
+      version = "0.3.0.20251125.163059";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/minimail-0.3.0.20251125.163059.tar";
+        sha256 = "1x60y69j8pvrfqq589vqns52k7vxxvhjf630nl0a739a1wca9789";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/minimail.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   minimap = callPackage (
     {
       elpaBuild,
@@ -5821,10 +5838,10 @@
     elpaBuild {
       pname = "minuet";
       ename = "minuet";
-      version = "0.6.0.0.20250915.11734";
+      version = "0.6.0.0.20251121.220353";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/minuet-0.6.0.0.20250915.11734.tar";
-        sha256 = "1ghnibrqwvmq6dw3rn3z1knh50x5294jvskv4grawzirs7ki252p";
+        url = "https://elpa.gnu.org/devel/minuet-0.6.0.0.20251121.220353.tar";
+        sha256 = "10lfhvi1qkmnfq5addh3zqxvkv1qabzb0l9ckq5v8d0rxdyhpgac";
       };
       packageRequires = [
         dash
@@ -5888,10 +5905,10 @@
     elpaBuild {
       pname = "modus-themes";
       ename = "modus-themes";
-      version = "4.8.1.0.20251007.41506";
+      version = "5.1.0.0.20251128.54148";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/modus-themes-4.8.1.0.20251007.41506.tar";
-        sha256 = "0xidd1aw3byzvbz79nw1mjk9f9qnnqfgw6v4aycqbw0zlz2s8wvv";
+        url = "https://elpa.gnu.org/devel/modus-themes-5.1.0.0.20251128.54148.tar";
+        sha256 = "0z2087mbkykgqbk70qbvy9i0581gcfxws1fjivdbwg82gyqpxnz4";
       };
       packageRequires = [ ];
       meta = {
@@ -6251,10 +6268,10 @@
     elpaBuild {
       pname = "ntlm";
       ename = "ntlm";
-      version = "2.1.0.0.20250101.73917";
+      version = "2.1.0.0.20251116.182803";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ntlm-2.1.0.0.20250101.73917.tar";
-        sha256 = "0ld0xc1a237yah9ng723kd3ywmy4d5jly8rs2hjzc9f3bjd2sl6q";
+        url = "https://elpa.gnu.org/devel/ntlm-2.1.0.0.20251116.182803.tar";
+        sha256 = "0qvzs9m9n6bdm4hmw24pl5f991fy3113h4rw1201knyw67g8a4k4";
       };
       packageRequires = [ ];
       meta = {
@@ -6293,10 +6310,10 @@
     elpaBuild {
       pname = "oauth2";
       ename = "oauth2";
-      version = "0.18.3.0.20250909.170257";
+      version = "0.18.4.0.20251120.214128";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/oauth2-0.18.3.0.20250909.170257.tar";
-        sha256 = "08bgi2ql4ifqkisxrjhxqyjd6zfnx2na7sgkvd9z70mq1wxs5wfp";
+        url = "https://elpa.gnu.org/devel/oauth2-0.18.4.0.20251120.214128.tar";
+        sha256 = "1x9v0s652al0ms37hafmqwla6wl97wpgvxh7w2ixpyrwrj206c93";
       };
       packageRequires = [ ];
       meta = {
@@ -6422,10 +6439,10 @@
     elpaBuild {
       pname = "orderless";
       ename = "orderless";
-      version = "1.5.0.20250922.134410";
+      version = "1.5.0.20251128.202853";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/orderless-1.5.0.20250922.134410.tar";
-        sha256 = "10i2hyyj5ki8cga21rdprjq5qnbqlhqxw1kn92d0zm1f2w1h9ykg";
+        url = "https://elpa.gnu.org/devel/orderless-1.5.0.20251128.202853.tar";
+        sha256 = "0lpz5vzb1ldlxkln9jqhvz0kx3s09q36gdy99r3m10jwfknhq9ka";
       };
       packageRequires = [ compat ];
       meta = {
@@ -6443,10 +6460,10 @@
     elpaBuild {
       pname = "org";
       ename = "org";
-      version = "9.8pre0.20251006.171414";
+      version = "9.8pre0.20251125.190321";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-9.8pre0.20251006.171414.tar";
-        sha256 = "1sfjf93fgmlmjm3ys86npcp7djmzgdl2w8y50mjzd8bc4zgf73ab";
+        url = "https://elpa.gnu.org/devel/org-9.8pre0.20251125.190321.tar";
+        sha256 = "0shbmwq3llavq399awxfqw1gfjf8gznjgdy2d5an0c0by89miyan";
       };
       packageRequires = [ ];
       meta = {
@@ -6514,10 +6531,10 @@
     elpaBuild {
       pname = "org-gnosis";
       ename = "org-gnosis";
-      version = "0.1.1.0.20250804.81757";
+      version = "0.1.1.0.20251005.85757";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-gnosis-0.1.1.0.20250804.81757.tar";
-        sha256 = "16lw8pv8n9aamn5f8q2gk8ljzpcgwzlhsgiclw45bn98cy0cqb1d";
+        url = "https://elpa.gnu.org/devel/org-gnosis-0.1.1.0.20251005.85757.tar";
+        sha256 = "1gwdkrs6r8cxab45xx5f47j4mhsm35iz2kzr7pl21i0nqcr9g2h4";
       };
       packageRequires = [
         compat
@@ -6562,10 +6579,10 @@
     elpaBuild {
       pname = "org-modern";
       ename = "org-modern";
-      version = "1.9.0.20250924.170536";
+      version = "1.10.0.20251013.93402";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-modern-1.9.0.20250924.170536.tar";
-        sha256 = "05x6c3hq0xwml82047lmxvgck83pmxcmq4aff3vy57m6b2dd9p7w";
+        url = "https://elpa.gnu.org/devel/org-modern-1.10.0.20251013.93402.tar";
+        sha256 = "1h7p9qa60xzdlz6g17j6xwa2khhn4qx3lbccwqq7w4kpfjn0y80d";
       };
       packageRequires = [
         compat
@@ -6656,10 +6673,10 @@
     elpaBuild {
       pname = "org-transclusion";
       ename = "org-transclusion";
-      version = "1.4.0.0.20250119.195656";
+      version = "1.4.0.0.20251119.5711";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-transclusion-1.4.0.0.20250119.195656.tar";
-        sha256 = "0zyqkxl1kpy1y2wxvc84lxhdz55w8qc6jinvkjmj4vjyfdlcz35a";
+        url = "https://elpa.gnu.org/devel/org-transclusion-1.4.0.0.20251119.5711.tar";
+        sha256 = "1wfwfbxiyd1syjass4pcackym8baff8n99bzrlwqg2n1a43mmpba";
       };
       packageRequires = [ org ];
       meta = {
@@ -6742,10 +6759,10 @@
     elpaBuild {
       pname = "osm";
       ename = "osm";
-      version = "1.7.0.20251008.104137";
+      version = "1.9.0.20251116.152344";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/osm-1.7.0.20251008.104137.tar";
-        sha256 = "15c74hby5j5dzki8m4avlsf3jrnz5qz1p8cyi2khyzlaf7jihpy7";
+        url = "https://elpa.gnu.org/devel/osm-1.9.0.20251116.152344.tar";
+        sha256 = "0l8jarmgmp29xm67v9d460cd6ah3m56l3qcjd0q9dnf82ylpawbv";
       };
       packageRequires = [ compat ];
       meta = {
@@ -6955,10 +6972,10 @@
     elpaBuild {
       pname = "persist";
       ename = "persist";
-      version = "0.7.0.20250930.85116";
+      version = "0.8.0.20251011.193839";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/persist-0.7.0.20250930.85116.tar";
-        sha256 = "0iapa9d0njc1qyqjbkl71fwws7hfz5303i17b69d6xdaynb7dajr";
+        url = "https://elpa.gnu.org/devel/persist-0.8.0.20251011.193839.tar";
+        sha256 = "0pdvxdlwrk900hfwa1ik3wylb6h0fbr8f8jg38q6n0y93kndswxc";
       };
       packageRequires = [ compat ];
       meta = {
@@ -7232,10 +7249,10 @@
     elpaBuild {
       pname = "posframe";
       ename = "posframe";
-      version = "1.4.4.0.20250211.11057";
+      version = "1.5.0.0.20251125.84642";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/posframe-1.4.4.0.20250211.11057.tar";
-        sha256 = "18vmjb0qx39danlvq0r4k2crqvb8xkfrpfj5xk7yxwj7al92q390";
+        url = "https://elpa.gnu.org/devel/posframe-1.5.0.0.20251125.84642.tar";
+        sha256 = "1cydrjx1i7l2aqv96gi7qdaa0d7cnv9b71xn0c9hdmigkdj7wdxh";
       };
       packageRequires = [ ];
       meta = {
@@ -7296,10 +7313,10 @@
     elpaBuild {
       pname = "preview-auto";
       ename = "preview-auto";
-      version = "0.4.1.0.20250829.60323";
+      version = "0.4.1.0.20250831.100412";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/preview-auto-0.4.1.0.20250829.60323.tar";
-        sha256 = "0qbpzbwfg1d3jh7nh7xvxhy4pdmxd75yzl652vcyb7cy8h4kc6ac";
+        url = "https://elpa.gnu.org/devel/preview-auto-0.4.1.0.20250831.100412.tar";
+        sha256 = "0lr67fldqw76r7p8q7lbsw156k50k2adrp90m5n7w7gdsydqycdp";
       };
       packageRequires = [ auctex ];
       meta = {
@@ -7340,10 +7357,10 @@
     elpaBuild {
       pname = "project";
       ename = "project";
-      version = "0.11.1.0.20251001.102725";
+      version = "0.11.1.0.20251127.102722";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/project-0.11.1.0.20251001.102725.tar";
-        sha256 = "0cyqqz8q0qis1lvgpdkwkzddj8zgraj9vn20xlc2bq52mmdql3a2";
+        url = "https://elpa.gnu.org/devel/project-0.11.1.0.20251127.102722.tar";
+        sha256 = "1dwql5v0v12q3lxs0vgqzk8s3wdv51m24d02hyz2dysl3yncmc9p";
       };
       packageRequires = [ xref ];
       meta = {
@@ -7403,10 +7420,10 @@
     elpaBuild {
       pname = "pulsar";
       ename = "pulsar";
-      version = "1.2.0.0.20250729.33601";
+      version = "1.2.0.0.20251121.110549";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/pulsar-1.2.0.0.20250729.33601.tar";
-        sha256 = "12k9nijvsfr29c6mhw026a13z2q3gs2idaymivlkywakipzrsdzz";
+        url = "https://elpa.gnu.org/devel/pulsar-1.2.0.0.20251121.110549.tar";
+        sha256 = "0vy8n3dp4ck51nnk2blmd239wm6iqyw4zkvivz5fzyc8kqnvn3rd";
       };
       packageRequires = [ ];
       meta = {
@@ -7426,10 +7443,10 @@
     elpaBuild {
       pname = "pyim";
       ename = "pyim";
-      version = "5.3.4.0.20250225.70943";
+      version = "5.3.5.0.20251125.83959";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/pyim-5.3.4.0.20250225.70943.tar";
-        sha256 = "07549ppwkx8xr71a4xdkxwhg9ilmnmxmqac83klcpzscm9gasyh3";
+        url = "https://elpa.gnu.org/devel/pyim-5.3.5.0.20251125.83959.tar";
+        sha256 = "0l3kdkjl3p5mz8cnjf3j4cm35yri5z5lqcg2mchp1ig3i9v16jhz";
       };
       packageRequires = [
         async
@@ -7476,10 +7493,10 @@
     elpaBuild {
       pname = "python";
       ename = "python";
-      version = "0.30.0.20250925.170612";
+      version = "0.30.0.20251109.72005";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/python-0.30.0.20250925.170612.tar";
-        sha256 = "1pkanqqv9c5046nzl1b83bh2cs1wchqh28y6vzwxn23l0yn7b23i";
+        url = "https://elpa.gnu.org/devel/python-0.30.0.20251109.72005.tar";
+        sha256 = "1xrhr5qpxv6nxvi1xrrp3ynq71iviaphs5rnnry0k56x1f66d08l";
       };
       packageRequires = [
         compat
@@ -7674,10 +7691,10 @@
     elpaBuild {
       pname = "realgud";
       ename = "realgud";
-      version = "1.5.1.0.20250605.74308";
+      version = "1.5.1.0.20251024.174500";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/realgud-1.5.1.0.20250605.74308.tar";
-        sha256 = "187r7zflc4f51jwbms8864j5vwp524g61rqzggjylcrc0zypgbry";
+        url = "https://elpa.gnu.org/devel/realgud-1.5.1.0.20251024.174500.tar";
+        sha256 = "027v496szcwn1ldhvjs6sd0hfnsc2jlbbg71v775ijym4w97wz1k";
       };
       packageRequires = [
         load-relative
@@ -7820,6 +7837,32 @@
       ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/realgud-node-inspect.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  realgud-pdbpp = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+      load-relative,
+      realgud,
+    }:
+    elpaBuild {
+      pname = "realgud-pdbpp";
+      ename = "realgud-pdbpp";
+      version = "1.0.0.0.20230322.184929";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/realgud-pdbpp-1.0.0.0.20230322.184929.tar";
+        sha256 = "0sfijb7zdasglizjmk16999p75hwcclc8nik8l0h07608w2zwdal";
+      };
+      packageRequires = [
+        load-relative
+        realgud
+      ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/realgud-pdbpp.html";
         license = lib.licenses.free;
       };
     }
@@ -8190,10 +8233,10 @@
     elpaBuild {
       pname = "setup";
       ename = "setup";
-      version = "1.5.0.0.20250829.105526";
+      version = "1.5.0.0.20251027.195908";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/setup-1.5.0.0.20250829.105526.tar";
-        sha256 = "167qy96rkvz1i1np6vjh7h0f3zm32pihyr4rcpwpxamkggb8x6vj";
+        url = "https://elpa.gnu.org/devel/setup-1.5.0.0.20251027.195908.tar";
+        sha256 = "1jpilrwlpprzsf9jmpqwac1zwkspja7qxa93aj2j0v8vzcj42fr6";
       };
       packageRequires = [ ];
       meta = {
@@ -8572,10 +8615,10 @@
     elpaBuild {
       pname = "spacious-padding";
       ename = "spacious-padding";
-      version = "0.7.0.0.20250719.40007";
+      version = "0.7.0.0.20251128.50614";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/spacious-padding-0.7.0.0.20250719.40007.tar";
-        sha256 = "0zdfzk1v3niq2rxm0v52086jyijjj0vvcr7071r8780a41jr3yqm";
+        url = "https://elpa.gnu.org/devel/spacious-padding-0.7.0.0.20251128.50614.tar";
+        sha256 = "0zl3fa23sd4zjcypv7q8sxzkacbfv5ycfywm5ah4k3kjb8x1h79q";
       };
       packageRequires = [ ];
       meta = {
@@ -8769,10 +8812,10 @@
     elpaBuild {
       pname = "standard-themes";
       ename = "standard-themes";
-      version = "2.2.0.0.20251008.94216";
+      version = "3.0.2.0.20251128.61615";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/standard-themes-2.2.0.0.20251008.94216.tar";
-        sha256 = "0f5fb0d5wzzz1amqf4a6gsliwzff9d7f0q6zdgl6hjdjdcmk9dij";
+        url = "https://elpa.gnu.org/devel/standard-themes-3.0.2.0.20251128.61615.tar";
+        sha256 = "0md6j9kx21nwb645ra04yb5dxmjmd2cdwa3y3fx3d9ylx2lf48v8";
       };
       packageRequires = [ modus-themes ];
       meta = {
@@ -9142,10 +9185,10 @@
     elpaBuild {
       pname = "tempel";
       ename = "tempel";
-      version = "1.6.0.20250920.84834";
+      version = "1.8.0.20251126.143752";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tempel-1.6.0.20250920.84834.tar";
-        sha256 = "0l9b21ijpi6wx5z1da2xg95qnh1g168lhmsqkx2dqljlsrjmg5cv";
+        url = "https://elpa.gnu.org/devel/tempel-1.8.0.20251126.143752.tar";
+        sha256 = "0bhqfvalyb9zw91bc240ybfn2rxi1bzsfiwsv603sapki5pg8zqs";
       };
       packageRequires = [ compat ];
       meta = {
@@ -9163,10 +9206,10 @@
     elpaBuild {
       pname = "termint";
       ename = "termint";
-      version = "0.1.1.0.20251004.2413";
+      version = "0.1.1.0.20251102.11134";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/termint-0.1.1.0.20251004.2413.tar";
-        sha256 = "0dvfm0kbhbv84l1hjc0gwafp8vphq466mjq4x7p4awdab594x114";
+        url = "https://elpa.gnu.org/devel/termint-0.1.1.0.20251102.11134.tar";
+        sha256 = "0mdbrgpnwil9fwd9vg9bgr0jv03nz87vsb138yw5r778qa2q6hf4";
       };
       packageRequires = [ ];
       meta = {
@@ -9185,10 +9228,10 @@
     elpaBuild {
       pname = "test-simple";
       ename = "test-simple";
-      version = "1.3.0.0.20230916.123447";
+      version = "1.3.1.0.20251124.94637";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/test-simple-1.3.0.0.20230916.123447.tar";
-        sha256 = "1xbf63qg17va0qwq2mkg12jg1fk6wwrs43jjzxxccx28h6d205il";
+        url = "https://elpa.gnu.org/devel/test-simple-1.3.1.0.20251124.94637.tar";
+        sha256 = "119lz1ddsqn6hzidx4s85p42c2a62xm55c8p6xjkr0c7radyxww3";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -9333,10 +9376,10 @@
     elpaBuild {
       pname = "tmr";
       ename = "tmr";
-      version = "1.2.0.0.20251006.73242";
+      version = "1.2.1.0.20251019.73644";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tmr-1.2.0.0.20251006.73242.tar";
-        sha256 = "1ll3776pbkjvxiqy2d0n11armxakckacjfmjwz6cpm19iz3h0gx4";
+        url = "https://elpa.gnu.org/devel/tmr-1.2.1.0.20251019.73644.tar";
+        sha256 = "0q67k82yqdvvgglhmdlmkmvf1dy1pwqyfhj3b1d9nmm603j1yql4";
       };
       packageRequires = [ ];
       meta = {
@@ -9422,10 +9465,10 @@
     elpaBuild {
       pname = "tramp";
       ename = "tramp";
-      version = "2.8.0.3.0.20250929.70756";
+      version = "2.8.0.4.0.20251030.75518";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tramp-2.8.0.3.0.20250929.70756.tar";
-        sha256 = "18zlii5z5qpp18ab6cylndvbcp0586b4g6xjih536g27awqki4i9";
+        url = "https://elpa.gnu.org/devel/tramp-2.8.0.4.0.20251030.75518.tar";
+        sha256 = "1jax9c6xg8vphgms3iwxhr2dacqylss1q7q9zxmnq554zd5mklhz";
       };
       packageRequires = [ ];
       meta = {
@@ -9500,6 +9543,7 @@
   transient = callPackage (
     {
       compat,
+      cond-let,
       elpaBuild,
       fetchurl,
       lib,
@@ -9508,13 +9552,14 @@
     elpaBuild {
       pname = "transient";
       ename = "transient";
-      version = "0.10.1.0.20251006.181532";
+      version = "0.11.0.0.20251118.161122";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/transient-0.10.1.0.20251006.181532.tar";
-        sha256 = "04jzkvi4sd5mm73n86gcq3cfmqpl833864sy4q8rzqwshak211k7";
+        url = "https://elpa.gnu.org/devel/transient-0.11.0.0.20251118.161122.tar";
+        sha256 = "0krlzn9rn703wqy46fwbfsb5p121ray74hsv7n4vnm7zs20dd6bi";
       };
       packageRequires = [
         compat
+        cond-let
         seq
       ];
       meta = {
@@ -9799,10 +9844,10 @@
     elpaBuild {
       pname = "use-package";
       ename = "use-package";
-      version = "2.4.6.0.20250524.65524";
+      version = "2.4.6.0.20251107.152139";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/use-package-2.4.6.0.20250524.65524.tar";
-        sha256 = "0zayaizp0d4sk1v4mrc4kfjgzlbxzsa2jrrdadis5al6x077jabx";
+        url = "https://elpa.gnu.org/devel/use-package-2.4.6.0.20251107.152139.tar";
+        sha256 = "142j3wk0v1m67lix2bxpjl4c26qqabqz6bwyh5wcgcn8vdwmdpnk";
       };
       packageRequires = [ bind-key ];
       meta = {
@@ -9868,10 +9913,10 @@
     elpaBuild {
       pname = "vc-backup";
       ename = "vc-backup";
-      version = "1.1.1.0.20250918.224711";
+      version = "1.1.1.0.20251018.163124";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vc-backup-1.1.1.0.20250918.224711.tar";
-        sha256 = "10a6a12xqsxvhpq88wwc1ylv5zy3x347d9l2bv2wpfrq7n7nrpr7";
+        url = "https://elpa.gnu.org/devel/vc-backup-1.1.1.0.20251018.163124.tar";
+        sha256 = "0nhlnhrkgg7bvqg80zp9m3pamdns5kyavf3hngygydd8qg2kgybw";
       };
       packageRequires = [ compat ];
       meta = {
@@ -9932,10 +9977,10 @@
     elpaBuild {
       pname = "vc-jj";
       ename = "vc-jj";
-      version = "0.4.0.20251007.180307";
+      version = "0.4.0.20251128.161600";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vc-jj-0.4.0.20251007.180307.tar";
-        sha256 = "0n1kqx2wlr94qb6zsd3mgikf6imb0gn0bg1hajpqv794xv58mlh8";
+        url = "https://elpa.gnu.org/devel/vc-jj-0.4.0.20251128.161600.tar";
+        sha256 = "0hvci96gs69p6kiywnry8pza2p0lrwhxmqaq6i26fncx1bbsphrb";
       };
       packageRequires = [ compat ];
       meta = {
@@ -10019,10 +10064,10 @@
     elpaBuild {
       pname = "vecdb";
       ename = "vecdb";
-      version = "0.2.0.20250724.14151";
+      version = "0.2.2.0.20251011.220856";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vecdb-0.2.0.20250724.14151.tar";
-        sha256 = "09l02c9vldx4bk6cn69rnfg9kafxfif7nmsv538jhhxzf5q31z43";
+        url = "https://elpa.gnu.org/devel/vecdb-0.2.2.0.20251011.220856.tar";
+        sha256 = "1ybscf8cc5ybamiyp3a8xk1xcvwq0jyj6pwkjzj7skid01kx50yc";
       };
       packageRequires = [
         pg
@@ -10043,10 +10088,10 @@
     elpaBuild {
       pname = "verilog-mode";
       ename = "verilog-mode";
-      version = "2025.1.1.100165202.0.20250121.85659";
+      version = "2025.11.8.248496848.0.20251108.183358";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/verilog-mode-2025.1.1.100165202.0.20250121.85659.tar";
-        sha256 = "1m40qcgnas9sisxpg9822c59ay4pgmnvmgjl3pfi99h9wl9s87ns";
+        url = "https://elpa.gnu.org/devel/verilog-mode-2025.11.8.248496848.0.20251108.183358.tar";
+        sha256 = "1hi0lh5zkkskac9vjxhjir503jam8vrl5ziimx9h96xvgcvzkl88";
       };
       packageRequires = [ ];
       meta = {
@@ -10065,10 +10110,10 @@
     elpaBuild {
       pname = "vertico";
       ename = "vertico";
-      version = "2.5.0.20250909.214050";
+      version = "2.6.0.20251120.114024";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vertico-2.5.0.20250909.214050.tar";
-        sha256 = "0iikcz47zmdzij62q35q2f4pr6a729nk6i5hqg7bzy3fwjhryy2v";
+        url = "https://elpa.gnu.org/devel/vertico-2.6.0.20251120.114024.tar";
+        sha256 = "18zn72wm5fs4azpb2wznjf849di9ykpagx1r0ic8ck2pgmiq1crg";
       };
       packageRequires = [ compat ];
       meta = {
@@ -10196,10 +10241,10 @@
     elpaBuild {
       pname = "vundo";
       ename = "vundo";
-      version = "2.4.0.0.20250927.224241";
+      version = "2.4.0.0.20251101.131141";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vundo-2.4.0.0.20250927.224241.tar";
-        sha256 = "0y6zx6mld7dy2cqlcr81zm4g0vdm7ib92c9d1zca2b8i5pg5qfrp";
+        url = "https://elpa.gnu.org/devel/vundo-2.4.0.0.20251101.131141.tar";
+        sha256 = "0c7sva1ff3nnhk8pijj2zqkirds15chgxs0gwp8bpxsnvrh258r0";
       };
       packageRequires = [ ];
       meta = {
@@ -10563,10 +10608,10 @@
     elpaBuild {
       pname = "xelb";
       ename = "xelb";
-      version = "0.21.0.20250724.152124";
+      version = "0.22.0.20251115.95724";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/xelb-0.21.0.20250724.152124.tar";
-        sha256 = "1j9s7kqngz1vy9v7j4bbj7mbqi4ljwqz12gkix56ql92yxycw941";
+        url = "https://elpa.gnu.org/devel/xelb-0.22.0.20251115.95724.tar";
+        sha256 = "09kmrd3n5c67b05mrx0xz25zbhisy8r1f4xnh8sq4lz8hy244g81";
       };
       packageRequires = [ compat ];
       meta = {
@@ -10631,10 +10676,10 @@
     elpaBuild {
       pname = "xref";
       ename = "xref";
-      version = "1.7.0.0.20250515.124004";
+      version = "1.7.0.0.20251018.61546";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/xref-1.7.0.0.20250515.124004.tar";
-        sha256 = "1h93z4dlk7vd2wif93zsypr55mdfnd2yyy6n69wz3d410jf51jf7";
+        url = "https://elpa.gnu.org/devel/xref-1.7.0.0.20251018.61546.tar";
+        sha256 = "1rjs45x2fsdyrccj6fsil30c01qpf5mp5wkxk2n1zxas7b4wk0yz";
       };
       packageRequires = [ ];
       meta = {
@@ -10673,10 +10718,10 @@
     elpaBuild {
       pname = "yaml";
       ename = "yaml";
-      version = "1.2.0.0.20250316.172129";
+      version = "1.2.1.0.20251029.205644";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/yaml-1.2.0.0.20250316.172129.tar";
-        sha256 = "0alwrb50napf86jimcnbjbkpd3nizvizskxa8rpglqn5yllj5qlw";
+        url = "https://elpa.gnu.org/devel/yaml-1.2.1.0.20251029.205644.tar";
+        sha256 = "06cgcl18jff3dqi8qva0qxr8332blzdps0wrkc7ql8hk5a7iwds1";
       };
       packageRequires = [ ];
       meta = {
@@ -10782,10 +10827,10 @@
     elpaBuild {
       pname = "zuul";
       ename = "zuul";
-      version = "0.4.0.0.20230524.131806";
+      version = "0.4.0.0.20251119.102002";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/zuul-0.4.0.0.20230524.131806.tar";
-        sha256 = "1pvfi8dp5i6h7z35h91408pz8bsval35sd7dk02v0hr6znln0pvb";
+        url = "https://elpa.gnu.org/devel/zuul-0.4.0.0.20251119.102002.tar";
+        sha256 = "00nnsm6m2xrhixjrhfj6z923pw12p1ip8galphni1k5pjx8vdcz5";
       };
       packageRequires = [ project ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
@@ -527,10 +527,10 @@
     elpaBuild {
       pname = "auth-source-xoauth2-plugin";
       ename = "auth-source-xoauth2-plugin";
-      version = "0.3.1";
+      version = "0.3.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/auth-source-xoauth2-plugin-0.3.1.tar";
-        sha256 = "1qqyl5qz3ldp28qm1vwbq4q7csb4wy6b3w3z72fhasvkcpb266iw";
+        url = "https://elpa.gnu.org/packages/auth-source-xoauth2-plugin-0.3.2.tar";
+        sha256 = "1k48kg6n72vzxaiqidg4m0w69c2s6ynvgcr08p4i8x2fsgaigcp2";
       };
       packageRequires = [ oauth2 ];
       meta = {
@@ -1063,10 +1063,10 @@
     elpaBuild {
       pname = "calibre";
       ename = "calibre";
-      version = "1.4.1";
+      version = "1.5.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/calibre-1.4.1.tar";
-        sha256 = "1ak05y3cmmwpg8bijkwl97kvfxhxh9xxc74askyafc50n0jvaq87";
+        url = "https://elpa.gnu.org/packages/calibre-1.5.0.tar";
+        sha256 = "08rcwrydrlc995sdxn5ssm5f6ighxi5yr6i7bx9a1nf7n91mgbgh";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1085,10 +1085,10 @@
     elpaBuild {
       pname = "cape";
       ename = "cape";
-      version = "2.1";
+      version = "2.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/cape-2.1.tar";
-        sha256 = "10g0nxdg6cb2v08qip8dskh1zkdqv23vy8x2f0lyscbmwi72zkrd";
+        url = "https://elpa.gnu.org/packages/cape-2.3.tar";
+        sha256 = "11lq5hkfgr77hnyn6dwyvxw8yb8ixdfk0619pvrm0v1f0qcwmczd";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1299,10 +1299,10 @@
     elpaBuild {
       pname = "colorful-mode";
       ename = "colorful-mode";
-      version = "1.2.4";
+      version = "1.2.5";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/colorful-mode-1.2.4.tar";
-        sha256 = "18gymjgsa5hxzy502b7mi99d8sypnn07i9934k4bj1py1xwl8q2b";
+        url = "https://elpa.gnu.org/packages/colorful-mode-1.2.5.tar";
+        sha256 = "1vz4mr76y9j5z8zg4nkm8ll38ka46yfhvv7c5r9v70gvnr1glg2g";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1527,10 +1527,10 @@
     elpaBuild {
       pname = "consult";
       ename = "consult";
-      version = "2.8";
+      version = "3.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/consult-2.8.tar";
-        sha256 = "01vvv5q1rlbi7db0hya8dilr6ywq0skf43mc49jka3c3gj3a924v";
+        url = "https://elpa.gnu.org/packages/consult-3.0.tar";
+        sha256 = "1yi0hawkpyl5y2x8z87vdpbxhida17r2yz27lfjzx8qdj8v1snss";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1550,10 +1550,10 @@
     elpaBuild {
       pname = "consult-denote";
       ename = "consult-denote";
-      version = "0.3.1";
+      version = "0.4.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/consult-denote-0.3.1.tar";
-        sha256 = "1rvn90wv6r48129w4s8wcc2gp9wa92zxwc0a4yc70xc5xxm85xi4";
+        url = "https://elpa.gnu.org/packages/consult-denote-0.4.1.tar";
+        sha256 = "1cv5rhpbmvarpf062pq777i38xsymiabs9vszvn5ll73jbph4pii";
       };
       packageRequires = [
         consult
@@ -1640,10 +1640,10 @@
     elpaBuild {
       pname = "corfu";
       ename = "corfu";
-      version = "2.3";
+      version = "2.5";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/corfu-2.3.tar";
-        sha256 = "1q86z90hbizvihnvpfn81vv2cd67jlwhp4w0cz1mr4fl1bnqq5g4";
+        url = "https://elpa.gnu.org/packages/corfu-2.5.tar";
+        sha256 = "1g6fn32rrvsfhlaxmr184z34mkggrjy9z71yabmmhw7njgvhyhr6";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1900,10 +1900,10 @@
     elpaBuild {
       pname = "dape";
       ename = "dape";
-      version = "0.24.1";
+      version = "0.25.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/dape-0.24.1.tar";
-        sha256 = "01w2sr9cbs1d9zh15gajyac7xcqbz40f5xfwv0c7jmsqkn7rv7aq";
+        url = "https://elpa.gnu.org/packages/dape-0.25.0.tar";
+        sha256 = "1ffmmaqadgrc0h51zk1j8c5whrzi7c63l069jl74xmczvphh7zl4";
       };
       packageRequires = [ jsonrpc ];
       meta = {
@@ -1987,10 +1987,10 @@
     elpaBuild {
       pname = "debbugs";
       ename = "debbugs";
-      version = "0.45";
+      version = "0.46";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/debbugs-0.45.tar";
-        sha256 = "1rbj3ms2hkg0ra30y0bwzmdlcq58p15vzhin28a1rw2rmbwx5irc";
+        url = "https://elpa.gnu.org/packages/debbugs-0.46.tar";
+        sha256 = "100yshwnbk70yxah1hy0cqhva8qqh5i2pbqxi5a5j6cja2awdi38";
       };
       packageRequires = [ soap-client ];
       meta = {
@@ -2034,10 +2034,10 @@
     elpaBuild {
       pname = "denote";
       ename = "denote";
-      version = "4.0.0";
+      version = "4.1.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/denote-4.0.0.tar";
-        sha256 = "13a1aynmrj1vzq9xljs2h96pywqhr7iblyag51asxjynkzj2z27g";
+        url = "https://elpa.gnu.org/packages/denote-4.1.2.tar";
+        sha256 = "0i582mxy6nc3fjvqnk6mws530l630ayfg2ca5hj79cfr627pqvp8";
       };
       packageRequires = [ ];
       meta = {
@@ -2056,10 +2056,10 @@
     elpaBuild {
       pname = "denote-journal";
       ename = "denote-journal";
-      version = "0.1.1";
+      version = "0.2.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/denote-journal-0.1.1.tar";
-        sha256 = "0922hjzah7nz49z3q3qyq06n77yqxd7mxiw7fmawavjh920dv3fq";
+        url = "https://elpa.gnu.org/packages/denote-journal-0.2.1.tar";
+        sha256 = "1dyfh5ngz11hk2pg6g8gy38c1afg7y4780aw80fqbld8l6kwss83";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2078,10 +2078,10 @@
     elpaBuild {
       pname = "denote-markdown";
       ename = "denote-markdown";
-      version = "0.1.1";
+      version = "0.2.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/denote-markdown-0.1.1.tar";
-        sha256 = "0ic8kqfw56xsm9s0rlq7cgnh0dzjsbbcx7kdk55dggpvxv67jj62";
+        url = "https://elpa.gnu.org/packages/denote-markdown-0.2.0.tar";
+        sha256 = "0y1lnzv2x6wnw06gx9jb38wwpd4cyn1f8r430wg26zc6grb4fmsz";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2122,10 +2122,10 @@
     elpaBuild {
       pname = "denote-org";
       ename = "denote-org";
-      version = "0.1.1";
+      version = "0.2.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/denote-org-0.1.1.tar";
-        sha256 = "0nwyyzx96d5k6dw4jb8bvni9fjr1plip57mdsyabrha19p6n282d";
+        url = "https://elpa.gnu.org/packages/denote-org-0.2.0.tar";
+        sha256 = "05jyy4gmd4nhgbh0cfjnjspwjzdkrljgl12wygqlai4d4hpv54mr";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2166,10 +2166,10 @@
     elpaBuild {
       pname = "denote-sequence";
       ename = "denote-sequence";
-      version = "0.1.1";
+      version = "0.2.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/denote-sequence-0.1.1.tar";
-        sha256 = "06s2k555in897rpr2iabzv29dr79lm6fkpjp3yssidr9irxymf0h";
+        url = "https://elpa.gnu.org/packages/denote-sequence-0.2.0.tar";
+        sha256 = "0i0vm1n48aw7j4y6laa8fvs0av5smimdky980qgp69pha6hcvph5";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2188,10 +2188,10 @@
     elpaBuild {
       pname = "denote-silo";
       ename = "denote-silo";
-      version = "0.1.2";
+      version = "0.2.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/denote-silo-0.1.2.tar";
-        sha256 = "1z5afwd9gwn9fy132s87smffi5lgdk8f8c941y9ak6q7fbbpkya7";
+        url = "https://elpa.gnu.org/packages/denote-silo-0.2.0.tar";
+        sha256 = "10n4xv179dl6zz1k28lcbrgyqx8k3hfh3isd7q3qg1vcahlw04vl";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2223,6 +2223,7 @@
   ) { };
   devdocs = callPackage (
     {
+      compat,
       elpaBuild,
       fetchurl,
       lib,
@@ -2230,12 +2231,12 @@
     elpaBuild {
       pname = "devdocs";
       ename = "devdocs";
-      version = "0.6.1";
+      version = "0.7";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/devdocs-0.6.1.tar";
-        sha256 = "04m3jd3wymrsdlb1i7z6dz9pf1q8q38ihkbn3jisdca6xkk9jd6p";
+        url = "https://elpa.gnu.org/packages/devdocs-0.7.tar";
+        sha256 = "0jwhfmllfbmv2xhkpicyg7mmj7vl9x5pld4vmv66rrl0ha47ahgr";
       };
-      packageRequires = [ ];
+      packageRequires = [ compat ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/devdocs.html";
         license = lib.licenses.free;
@@ -2273,10 +2274,10 @@
     elpaBuild {
       pname = "dicom";
       ename = "dicom";
-      version = "1.0";
+      version = "1.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/dicom-1.0.tar";
-        sha256 = "05v20pac5xgcmcqn6hw0f3n8dlz3nr178044y2xry6zz0psc3vx0";
+        url = "https://elpa.gnu.org/packages/dicom-1.2.tar";
+        sha256 = "1k1n7i2nzbcs8jqnhiksh79xyp80x94h18jwgl7s0c0akcp8365n";
       };
       packageRequires = [ compat ];
       meta = {
@@ -2619,10 +2620,10 @@
     elpaBuild {
       pname = "doric-themes";
       ename = "doric-themes";
-      version = "0.4.0";
+      version = "0.5.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/doric-themes-0.4.0.tar";
-        sha256 = "0dh5gib95fqfqdlk493y8dpdln2bqs2v5gg4gghy4rhgg79six5j";
+        url = "https://elpa.gnu.org/packages/doric-themes-0.5.0.tar";
+        sha256 = "11889xskdp42ckbk75wiy1f5sdy1ia04ndn48vn2dw57pcgmjcnw";
       };
       packageRequires = [ ];
       meta = {
@@ -2641,10 +2642,10 @@
     elpaBuild {
       pname = "drepl";
       ename = "drepl";
-      version = "0.3";
+      version = "0.4";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/drepl-0.3.tar";
-        sha256 = "0dy8xvx5nwibiyhddm6nhcw384vhkhsbbxcs4hah0yxwajfm8yds";
+        url = "https://elpa.gnu.org/packages/drepl-0.4.tar";
+        sha256 = "161aga6jviba7h8iaid8dkrgli0wikm2zl9dfkzmj4xms3czgl24";
       };
       packageRequires = [ comint-mime ];
       meta = {
@@ -2821,10 +2822,10 @@
     elpaBuild {
       pname = "eev";
       ename = "eev";
-      version = "20250914";
+      version = "20251123";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/eev-20250914.tar";
-        sha256 = "1bn7nv42pkd910s47if2jzrzfd10s2nbhid3adh96p9bpy46k639";
+        url = "https://elpa.gnu.org/packages/eev-20251123.tar";
+        sha256 = "02vnijm7av43dlnwkg8ss96vqzl8k92b1m4mn7mjnv60zcxscxf6";
       };
       packageRequires = [ ];
       meta = {
@@ -2838,16 +2839,17 @@
       elpaBuild,
       fetchurl,
       lib,
+      modus-themes,
     }:
     elpaBuild {
       pname = "ef-themes";
       ename = "ef-themes";
-      version = "1.11.0";
+      version = "2.0.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/ef-themes-1.11.0.tar";
-        sha256 = "086d2fmgzgnjil97zjn2i0ii81dq9l8rr859j0kyaxiy83r27rqb";
+        url = "https://elpa.gnu.org/packages/ef-themes-2.0.1.tar";
+        sha256 = "039jhc3lwwp7s420078zr65k4l611n5x9bxhj2klqyzixsw4w64n";
       };
-      packageRequires = [ ];
+      packageRequires = [ modus-themes ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/ef-themes.html";
         license = lib.licenses.free;
@@ -2856,7 +2858,6 @@
   ) { };
   eglot = callPackage (
     {
-      compat,
       eldoc,
       elpaBuild,
       external-completion,
@@ -2866,26 +2867,23 @@
       lib,
       project,
       seq,
-      track-changes,
       xref,
     }:
     elpaBuild {
       pname = "eglot";
       ename = "eglot";
-      version = "1.18";
+      version = "1.19";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/eglot-1.18.tar";
-        sha256 = "1zqs498yn3i8wn045jgq9nw4pddiyrwwgyq39mndzvgvi1j6a431";
+        url = "https://elpa.gnu.org/packages/eglot-1.19.tar";
+        sha256 = "0bsz3grw41nh5r76brfdb4gb3hncs5chlhwsqm6qqg0ach69m7zi";
       };
       packageRequires = [
-        compat
         eldoc
         external-completion
         flymake
         jsonrpc
         project
         seq
-        track-changes
         xref
       ];
       meta = {
@@ -3151,10 +3149,10 @@
     elpaBuild {
       pname = "ement";
       ename = "ement";
-      version = "0.16";
+      version = "0.17";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/ement-0.16.tar";
-        sha256 = "1c496sm9lad5m18pjfwnqf6l1kjrnyayip8flj1ijm13996c3mp3";
+        url = "https://elpa.gnu.org/packages/ement-0.17.tar";
+        sha256 = "1qihmk6f2chb8kfv9gr6kmxsayf7p161dihvfy5x176pc0l4capk";
       };
       packageRequires = [
         map
@@ -3183,10 +3181,10 @@
     elpaBuild {
       pname = "emms";
       ename = "emms";
-      version = "23";
+      version = "24";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/emms-23.tar";
-        sha256 = "08s04cqk9p0srcxffvpdf67fajv130sfyah6yd13mj7am9r1ak9d";
+        url = "https://elpa.gnu.org/packages/emms-24.tar";
+        sha256 = "1nl152v27ryxq3g2dzg52xv3znw08wh486ax5dxkd2wvj6rv0dbg";
       };
       packageRequires = [
         cl-lib
@@ -3272,10 +3270,10 @@
     elpaBuild {
       pname = "erc";
       ename = "erc";
-      version = "5.6";
+      version = "5.6.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/erc-5.6.tar";
-        sha256 = "16qyfsa2q297xcfjiacjms9v14kjwwrsp3m8kcs5s50aavzfvc1s";
+        url = "https://elpa.gnu.org/packages/erc-5.6.1.tar";
+        sha256 = "13dzip6xhj0mf8hs8wk08pfxny5gwpbzfsqkmz146xvl2d8m621x";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3567,10 +3565,10 @@
     elpaBuild {
       pname = "flymake";
       ename = "flymake";
-      version = "1.4.1";
+      version = "1.4.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/flymake-1.4.1.tar";
-        sha256 = "0l20gxzlvpl0d3wvvsam3mda5hdlag4anplx3fd4xksbvfhndzlk";
+        url = "https://elpa.gnu.org/packages/flymake-1.4.3.tar";
+        sha256 = "0jg0lbj861smycmya626b54hy9lh4xfqpjwzf28i2vnf9wy6q840";
       };
       packageRequires = [
         eldoc
@@ -4125,10 +4123,10 @@
     elpaBuild {
       pname = "greader";
       ename = "greader";
-      version = "0.12.7";
+      version = "0.13.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/greader-0.12.7.tar";
-        sha256 = "05i6fmfs9lvffhm54lkw97x7vxlw7x30ka6xrpxh827qml3m7z3q";
+        url = "https://elpa.gnu.org/packages/greader-0.13.1.tar";
+        sha256 = "0av55fk2r1bqsb8dp17y3cka46hda29x16y763az0lwga33ssz89";
       };
       packageRequires = [
         compat
@@ -4170,10 +4168,10 @@
     elpaBuild {
       pname = "gtags-mode";
       ename = "gtags-mode";
-      version = "1.9.3";
+      version = "1.9.4";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/gtags-mode-1.9.3.tar";
-        sha256 = "1cvmb6pnn4wpqna2h0a19m5yilh1jrzah61xzspwrdv2djf8zrlb";
+        url = "https://elpa.gnu.org/packages/gtags-mode-1.9.4.tar";
+        sha256 = "01bpgw839gkvy8258kc5p0zy8xv9rh4hpzb0h1hlxcllkir6idgg";
       };
       packageRequires = [ ];
       meta = {
@@ -4789,10 +4787,10 @@
     elpaBuild {
       pname = "jinx";
       ename = "jinx";
-      version = "2.3";
+      version = "2.4";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/jinx-2.3.tar";
-        sha256 = "0sm6yrh70qy6w7v1ljr02rfj10kyixnghk1aigizc4rgpr4b8azp";
+        url = "https://elpa.gnu.org/packages/jinx-2.4.tar";
+        sha256 = "052wax7k9wkl8g0c6v1cjhdpvhw89byykv43gyxl3c9a6garllrm";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4811,10 +4809,10 @@
     elpaBuild {
       pname = "jit-spell";
       ename = "jit-spell";
-      version = "0.4";
+      version = "0.5";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/jit-spell-0.4.tar";
-        sha256 = "0p9nf2n0x6c6xl32aczghzipx8n5aq7a1x6r2s78xvpwr299k998";
+        url = "https://elpa.gnu.org/packages/jit-spell-0.5.tar";
+        sha256 = "0xdn4hm4d26vmqh75i2ghyissm2s2szgynwynpgmlvhr4q5nkswf";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4875,10 +4873,10 @@
     elpaBuild {
       pname = "jsonrpc";
       ename = "jsonrpc";
-      version = "1.0.25";
+      version = "1.0.26";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/jsonrpc-1.0.25.tar";
-        sha256 = "18f0g8j1rd2fpa707w6fll6ryj7mg6hbcy2pc3xff2a4ps8zv12b";
+        url = "https://elpa.gnu.org/packages/jsonrpc-1.0.26.tar";
+        sha256 = "0lsm17kak4wb9anplqlyqfy0527akb8vp2gl3lszbxh281kjg1qx";
       };
       packageRequires = [ ];
       meta = {
@@ -5241,10 +5239,10 @@
     elpaBuild {
       pname = "llm";
       ename = "llm";
-      version = "0.27.2";
+      version = "0.27.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/llm-0.27.2.tar";
-        sha256 = "0wkz4l2ica2wrmb30yylqdbdp1q2xflarcdl0z399lh315jdbypg";
+        url = "https://elpa.gnu.org/packages/llm-0.27.3.tar";
+        sha256 = "0187msn4wfgnc9rbnqrjzwazzk41d6vb8s1xwd7ynfkibfv1jkya";
       };
       packageRequires = [
         compat
@@ -5479,10 +5477,10 @@
     elpaBuild {
       pname = "marginalia";
       ename = "marginalia";
-      version = "2.3";
+      version = "2.5";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/marginalia-2.3.tar";
-        sha256 = "0k2ndssravhd94b63fyiv2h7rvny2fik988w1dnpdy6q9vj2vdgw";
+        url = "https://elpa.gnu.org/packages/marginalia-2.5.tar";
+        sha256 = "0qjb7nznr08nps9drkfpmkwl59cfzrgyfzmqsmhgbrmaa79qly84";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5585,10 +5583,10 @@
     elpaBuild {
       pname = "matlab-mode";
       ename = "matlab-mode";
-      version = "7.1.1";
+      version = "7.4.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/matlab-mode-7.1.1.tar";
-        sha256 = "0axqvarxnvn02pcqmqf9sf6kg0xfz5a8wfzjw8if6xsbk45krlcz";
+        url = "https://elpa.gnu.org/packages/matlab-mode-7.4.1.tar";
+        sha256 = "14y8hbkk7cz5s1kpv9id5i4kp4y36zvdznjygqp6yp0b6d3w3kc8";
       };
       packageRequires = [ ];
       meta = {
@@ -5746,6 +5744,27 @@
       };
     }
   ) { };
+  minimail = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "minimail";
+      ename = "minimail";
+      version = "0.3";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/minimail-0.3.tar";
+        sha256 = "1p8vk9z34ylzg9hvs88wik07m5mr72bqkh19kngw7gqlg0m2ydfp";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/minimail.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   minimap = callPackage (
     {
       elpaBuild,
@@ -5824,10 +5843,10 @@
     elpaBuild {
       pname = "modus-themes";
       ename = "modus-themes";
-      version = "4.8.1";
+      version = "5.1.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/modus-themes-4.8.1.tar";
-        sha256 = "1xax6pfq8xlybwid3sgzm82az4p1blm217qp1bvy0fjf5qcand5i";
+        url = "https://elpa.gnu.org/packages/modus-themes-5.1.0.tar";
+        sha256 = "0n7mhf3zp96srm7d0i87ps18h08k3pap904y78xz22xhm98ljsnl";
       };
       packageRequires = [ ];
       meta = {
@@ -6226,10 +6245,10 @@
     elpaBuild {
       pname = "oauth2";
       ename = "oauth2";
-      version = "0.18.3";
+      version = "0.18.4";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/oauth2-0.18.3.tar";
-        sha256 = "1xn9jkf55b9sc6fidzn6p1falvvgvpc08iz53fvmmp7fandgwbxi";
+        url = "https://elpa.gnu.org/packages/oauth2-0.18.4.tar";
+        sha256 = "1hhfk7glp3m9f4aqf1dvqs5f7qp4s2gvbxamyxjalw3sj6pbv92n";
       };
       packageRequires = [ ];
       meta = {
@@ -6376,10 +6395,10 @@
     elpaBuild {
       pname = "org";
       ename = "org";
-      version = "9.7.34";
+      version = "9.7.38";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/org-9.7.34.tar";
-        sha256 = "0jd9bhymcjxkf04vygl32mnqvbsgjqqp48axv3pm2s614vw23qsp";
+        url = "https://elpa.gnu.org/packages/org-9.7.38.tar";
+        sha256 = "1y752wx4hhfgwkn9i9rrl6hjgpwb38g0zanpvyxxkzxy3n2fv079";
       };
       packageRequires = [ ];
       meta = {
@@ -6495,10 +6514,10 @@
     elpaBuild {
       pname = "org-modern";
       ename = "org-modern";
-      version = "1.9";
+      version = "1.10";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/org-modern-1.9.tar";
-        sha256 = "09lgmng1g6l29alnwmxqk2qq0gx2vv5nrrmrxdzlrknkd8f07nl1";
+        url = "https://elpa.gnu.org/packages/org-modern-1.10.tar";
+        sha256 = "07fn1milsx61slc3pg065027w8jp17ab07h2n3qg3rl5zq4l7qpl";
       };
       packageRequires = [
         compat
@@ -6675,10 +6694,10 @@
     elpaBuild {
       pname = "osm";
       ename = "osm";
-      version = "1.7";
+      version = "1.9";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/osm-1.7.tar";
-        sha256 = "1iqg0cjqq2fzrimzgxqa7jsvhzajycl4nq1c7fsr3pd5yjp8d4z8";
+        url = "https://elpa.gnu.org/packages/osm-1.9.tar";
+        sha256 = "0ankxndigmjwxad3ryrlkc99pqgja7wywf3b77j5y5sph0zyc0hs";
       };
       packageRequires = [ compat ];
       meta = {
@@ -6888,10 +6907,10 @@
     elpaBuild {
       pname = "persist";
       ename = "persist";
-      version = "0.7";
+      version = "0.8";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/persist-0.7.tar";
-        sha256 = "0g38vf4a4f4b8cp35qc7pwzj1qwrnw6dd6mc83mrjs35fx43lpjn";
+        url = "https://elpa.gnu.org/packages/persist-0.8.tar";
+        sha256 = "0lx4phndjr6x2bwlak0z232968vnzhnivq25531ykv4c4f45qyhj";
       };
       packageRequires = [ compat ];
       meta = {
@@ -7144,10 +7163,10 @@
     elpaBuild {
       pname = "posframe";
       ename = "posframe";
-      version = "1.4.4";
+      version = "1.5.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/posframe-1.4.4.tar";
-        sha256 = "18cvfr2jxwsnsdg9f8wr0g64rkk6q1cc4gchrw76lnnknanidpk7";
+        url = "https://elpa.gnu.org/packages/posframe-1.5.0.tar";
+        sha256 = "0yk38fc08fgxwai6dn6da9yykcmq3bd4x7msfnlrg081b15q9a32";
       };
       packageRequires = [ ];
       meta = {
@@ -7317,10 +7336,10 @@
     elpaBuild {
       pname = "pyim";
       ename = "pyim";
-      version = "5.3.4";
+      version = "5.3.5";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/pyim-5.3.4.tar";
-        sha256 = "0axi8vizr2pdswdnnkr409k926h9k7w3c18nbmb9j3pfc32inkjs";
+        url = "https://elpa.gnu.org/packages/pyim-5.3.5.tar";
+        sha256 = "1s452swgbkbnpfhiwmipmvbqn6wkf6f7dq63gr349h7n29nbnnnk";
       };
       packageRequires = [
         async
@@ -8612,16 +8631,17 @@
       elpaBuild,
       fetchurl,
       lib,
+      modus-themes,
     }:
     elpaBuild {
       pname = "standard-themes";
       ename = "standard-themes";
-      version = "2.2.0";
+      version = "3.0.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/standard-themes-2.2.0.tar";
-        sha256 = "0qdld75vcfhsn2l0xips52vrlp5q7ss3973hd722h2gp1wddn5f7";
+        url = "https://elpa.gnu.org/packages/standard-themes-3.0.2.tar";
+        sha256 = "071k6cxfb5ccipvb0059wcs9fq4pzywyahqwjrl4cbidv6dnvzcm";
       };
-      packageRequires = [ ];
+      packageRequires = [ modus-themes ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/standard-themes.html";
         license = lib.licenses.free;
@@ -8964,10 +8984,10 @@
     elpaBuild {
       pname = "tempel";
       ename = "tempel";
-      version = "1.6";
+      version = "1.8";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/tempel-1.6.tar";
-        sha256 = "1h5k3cc5kl4g11chrfjgnhr1vg29fj3qz706rimilki367n2sra5";
+        url = "https://elpa.gnu.org/packages/tempel-1.8.tar";
+        sha256 = "16ghnb1blr04xc084dzafp3lfkcsydn554j39kpfizdxlr4r9zzv";
       };
       packageRequires = [ compat ];
       meta = {
@@ -9007,10 +9027,10 @@
     elpaBuild {
       pname = "test-simple";
       ename = "test-simple";
-      version = "1.3.0";
+      version = "1.3.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/test-simple-1.3.0.tar";
-        sha256 = "065jfps5ixpy5d4l2xgwhkpafdwiziqh4msbjcascwpac3j5c5yp";
+        url = "https://elpa.gnu.org/packages/test-simple-1.3.1.tar";
+        sha256 = "11sgc7187l1a4f1x1f6z58dy7pc7n1999id50rjifkvk901x0qd1";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -9155,10 +9175,10 @@
     elpaBuild {
       pname = "tmr";
       ename = "tmr";
-      version = "1.2.0";
+      version = "1.2.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/tmr-1.2.0.tar";
-        sha256 = "0ywy3wz6km4smp7igzn44fwincc79nwzm0a55jv7hyz6bv78n8xr";
+        url = "https://elpa.gnu.org/packages/tmr-1.2.1.tar";
+        sha256 = "1jx3j9pgr4z5f70jr5byq9b27z4l6q7r4pjzq9dzw6q30wk2kv8p";
       };
       packageRequires = [ ];
       meta = {
@@ -9244,10 +9264,10 @@
     elpaBuild {
       pname = "tramp";
       ename = "tramp";
-      version = "2.8.0.3";
+      version = "2.8.0.4";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/tramp-2.8.0.3.tar";
-        sha256 = "1qszpb4qywpnx5x7ynx8srq6m6aiygdimffghihxcviv1r1mxs53";
+        url = "https://elpa.gnu.org/packages/tramp-2.8.0.4.tar";
+        sha256 = "07zc1w4w1kkybkfydxwhv84rwxgz9zsz7n31hlcyw5x58624x4h2";
       };
       packageRequires = [ ];
       meta = {
@@ -9322,6 +9342,7 @@
   transient = callPackage (
     {
       compat,
+      cond-let,
       elpaBuild,
       fetchurl,
       lib,
@@ -9330,13 +9351,14 @@
     elpaBuild {
       pname = "transient";
       ename = "transient";
-      version = "0.10.1";
+      version = "0.11.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/transient-0.10.1.tar";
-        sha256 = "1qxml619jpjp2an4iiq7c2n0vy0xam73rjl6076lialfwsa05hqd";
+        url = "https://elpa.gnu.org/packages/transient-0.11.0.tar";
+        sha256 = "09rdjkmmg7b3r2d55ff2r11hklglq14xknmn2ywc53qglxxsn0im";
       };
       packageRequires = [
         compat
+        cond-let
         seq
       ];
       meta = {
@@ -9841,10 +9863,10 @@
     elpaBuild {
       pname = "vecdb";
       ename = "vecdb";
-      version = "0.2";
+      version = "0.2.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/vecdb-0.2.tar";
-        sha256 = "10p5nhk4v4j05k9cz9br5ninycpp7spgby9mrr9z8bsy2g0j0il2";
+        url = "https://elpa.gnu.org/packages/vecdb-0.2.2.tar";
+        sha256 = "0nzaga79yls0x7hcrfvk6zic4a4pm5h10sav0f1pxccx1scsrzfn";
       };
       packageRequires = [
         pg
@@ -9865,10 +9887,10 @@
     elpaBuild {
       pname = "verilog-mode";
       ename = "verilog-mode";
-      version = "2025.1.1.100165202";
+      version = "2025.11.8.248496848";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/verilog-mode-2025.1.1.100165202.tar";
-        sha256 = "1cgv081dlarc0b4s6rjkqbvs4fa9npyq9pjxj7173vmgkfdwmkp5";
+        url = "https://elpa.gnu.org/packages/verilog-mode-2025.11.8.248496848.tar";
+        sha256 = "0w10f8gh2adabd5phgqqka4i0jq1g86bvq9yv3whnaxwiyf0m676";
       };
       packageRequires = [ ];
       meta = {
@@ -9887,10 +9909,10 @@
     elpaBuild {
       pname = "vertico";
       ename = "vertico";
-      version = "2.5";
+      version = "2.6";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/vertico-2.5.tar";
-        sha256 = "06yj03x61406zfs75q4blh9fav284psnigsy3g5wpqrv3p79b89s";
+        url = "https://elpa.gnu.org/packages/vertico-2.6.tar";
+        sha256 = "11lm8bqk0scpa4szlmsrhv8k3ll57a6jhbiimvbm44l8jh3qkk9c";
       };
       packageRequires = [ compat ];
       meta = {
@@ -10384,10 +10406,10 @@
     elpaBuild {
       pname = "xelb";
       ename = "xelb";
-      version = "0.21";
+      version = "0.22";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/xelb-0.21.tar";
-        sha256 = "0fmms4dy5b9l6qlf246p61v3k8szm7qhl60lf84wc0xpa6ah2698";
+        url = "https://elpa.gnu.org/packages/xelb-0.22.tar";
+        sha256 = "0vd0dsigr2lvwvvm32kf20dyg5bvafinb2xhz491f8wj2w99fjx4";
       };
       packageRequires = [ compat ];
       meta = {
@@ -10494,10 +10516,10 @@
     elpaBuild {
       pname = "yaml";
       ename = "yaml";
-      version = "1.2.0";
+      version = "1.2.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/yaml-1.2.0.tar";
-        sha256 = "1j1shz85vdj7w7bslpmpfws92fi3afp44533irq8caf7zj9masph";
+        url = "https://elpa.gnu.org/packages/yaml-1.2.1.tar";
+        sha256 = "14asp31dba2ab1hjvxjqdk99kzl82r7yjmrw6nk65i1wsnk14a6i";
       };
       packageRequires = [ ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -1249,7 +1249,7 @@ let
           # TODO report to upstream
           global-tags = addPackageRequires super.global-tags [ self.s ];
 
-          gnosis = mkHome super.gnosis;
+          gnosis = ignoreCompilationError (mkHome super.gnosis); # doing db stuff when compiling
 
           go = ignoreCompilationError super.go; # elisp error
 

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -1667,18 +1667,6 @@ let
 
           scad-preview = ignoreCompilationError super.scad-preview; # elisp error
 
-          sdml-mode = super.sdml-mode.overrideAttrs (
-            finalAttrs: previousAttrs: {
-              patches = previousAttrs.patches or [ ] ++ [
-                (pkgs.fetchpatch {
-                  name = "make-pretty-hydra-optional.patch";
-                  url = "https://github.com/sdm-lang/emacs-sdml-mode/pull/3/commits/2368afe31c72073488411540e212c70aae3dd468.patch";
-                  hash = "sha256-Wc4pquKV9cTRey9SdjY++UgcP+pGI0hVOOn1Cci8dpk=";
-                })
-              ];
-            }
-          );
-
           # https://github.com/wanderlust/semi/pull/29
           # missing optional dependencies
           semi = addPackageRequires super.semi [ self.bbdb-vcard ];

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -1456,6 +1456,8 @@ let
 
           mu4e-views = addPackageRequires super.mu4e-views [ self.mu4e ];
 
+          mu4e-walk = addPackageRequires super.mu4e-walk [ self.mu4e ];
+
           # https://github.com/magnars/multifiles.el/issues/9
           multifiles = addPackageRequires super.multifiles [ self.dash ];
 

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -1761,6 +1761,14 @@ let
 
           workgroups2 = ignoreCompilationError super.workgroups2; # elisp error
 
+          ws-butler = super.ws-butler.overrideAttrs (old: {
+            # work around https://github.com/NixOS/nixpkgs/issues/436534
+            src = pkgs.fetchFromSavannah {
+              repo = "emacs/nongnu";
+              inherit (old.src) rev outputHash outputHashAlgo;
+            };
+          });
+
           # https://github.com/nicklanasa/xcode-mode/issues/28
           xcode-mode = addPackageRequires super.xcode-mode [ self.hydra ];
 

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-devel-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-devel-generated.nix
@@ -54,10 +54,10 @@
     elpaBuild {
       pname = "aidermacs";
       ename = "aidermacs";
-      version = "1.5.0.20250927.10200";
+      version = "1.6.0.20251122.154759";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/aidermacs-1.5.0.20250927.10200.tar";
-        sha256 = "1sf2h2d7g1jf60vm6s5j6la27q43ckpz7b3pnyxka9rpy51ffnfr";
+        url = "https://elpa.nongnu.org/nongnu-devel/aidermacs-1.6.0.20251122.154759.tar";
+        sha256 = "17l9jdmdlhkwimgmggicp5vqh6ly24g498g9mbfknq61i1g7pl72";
       };
       packageRequires = [
         compat
@@ -79,10 +79,10 @@
     elpaBuild {
       pname = "alect-themes";
       ename = "alect-themes";
-      version = "0.10.0.20211022.165129";
+      version = "0.11.0.20251129.73827";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/alect-themes-0.10.0.20211022.165129.tar";
-        sha256 = "1p9p5p58cyz5m1bsrm4icazm049n4q72mwawp0zlibsdqywjliqj";
+        url = "https://elpa.nongnu.org/nongnu-devel/alect-themes-0.11.0.20251129.73827.tar";
+        sha256 = "1byaxbs7k6r2jbssdpf0siwryzrxrv0x8ds11wxpcg7v0kiihmaz";
       };
       packageRequires = [ ];
       meta = {
@@ -121,10 +121,10 @@
     elpaBuild {
       pname = "annotate";
       ename = "annotate";
-      version = "2.4.2.0.20250515.142850";
+      version = "2.4.5.0.20251111.163545";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/annotate-2.4.2.0.20250515.142850.tar";
-        sha256 = "0g30jcpb44vdb43msn93w8j4f2zk0zm7n3l2ghndvm31qc3qr1k8";
+        url = "https://elpa.nongnu.org/nongnu-devel/annotate-2.4.5.0.20251111.163545.tar";
+        sha256 = "09jghlf5bjiiah1qqvr1s3lkjqzywf9cxrfzpfq192ms1hzs1wmd";
       };
       packageRequires = [ ];
       meta = {
@@ -184,10 +184,10 @@
     elpaBuild {
       pname = "apache-mode";
       ename = "apache-mode";
-      version = "2.2.0.0.20250811.194318";
+      version = "2.2.0.0.20251120.174624";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/apache-mode-2.2.0.0.20250811.194318.tar";
-        sha256 = "16hpfjy2998i289gd95f61fj95g798z99kwlv3mh8a57sj1da0fz";
+        url = "https://elpa.nongnu.org/nongnu-devel/apache-mode-2.2.0.0.20251120.174624.tar";
+        sha256 = "0f536bc064ykjajsgyxcbdjxch14wi2kkxhva9szi802l78zkdhh";
       };
       packageRequires = [ ];
       meta = {
@@ -205,10 +205,10 @@
     elpaBuild {
       pname = "apropospriate-theme";
       ename = "apropospriate-theme";
-      version = "0.2.0.0.20250724.72226";
+      version = "0.2.0.0.20251009.212150";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/apropospriate-theme-0.2.0.0.20250724.72226.tar";
-        sha256 = "10z6ifrfg0dxjjvk8lhw7a2w041wbfvfik9jvz8m7sl6k6pl8bsi";
+        url = "https://elpa.nongnu.org/nongnu-devel/apropospriate-theme-0.2.0.0.20251009.212150.tar";
+        sha256 = "0nz35vvlysqpsvghkkf4ysw8dich809ag2brdlz9jcw52j2haxyi";
       };
       packageRequires = [ ];
       meta = {
@@ -270,10 +270,10 @@
     elpaBuild {
       pname = "autothemer";
       ename = "autothemer";
-      version = "0.2.18.0.20250421.72550";
+      version = "0.2.18.0.20251114.41509";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/autothemer-0.2.18.0.20250421.72550.tar";
-        sha256 = "0y6k0ysy4z7am8zapp1gynr3rjm9vwggi8syc1a19niaqvzm80c4";
+        url = "https://elpa.nongnu.org/nongnu-devel/autothemer-0.2.18.0.20251114.41509.tar";
+        sha256 = "0ix8byl6fa2qpcjvcf93afbsk2f9frnsbq9mcnhxmx17l48fzl06";
       };
       packageRequires = [ dash ];
       meta = {
@@ -333,10 +333,10 @@
     elpaBuild {
       pname = "beancount";
       ename = "beancount";
-      version = "0.9.0.0.20250616.105101";
+      version = "0.9.0.0.20251027.80859";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/beancount-0.9.0.0.20250616.105101.tar";
-        sha256 = "1h1hy46xqm70nilqx1z5v4a81y59j7ywikckw2xslilkrniw6wj5";
+        url = "https://elpa.nongnu.org/nongnu-devel/beancount-0.9.0.0.20251027.80859.tar";
+        sha256 = "19lklnmqpxzxgwdjb3wzaarkklxqswnl9ff11pg854rr7kivlmwl";
       };
       packageRequires = [ ];
       meta = {
@@ -375,10 +375,10 @@
     elpaBuild {
       pname = "bind-map";
       ename = "bind-map";
-      version = "1.1.2.0.20250308.71029";
+      version = "1.1.2.0.20251118.210127";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/bind-map-1.1.2.0.20250308.71029.tar";
-        sha256 = "0z0dzlxj011nggzgzk5g4dwc1c2z78264pggj8li0h15216yq3ll";
+        url = "https://elpa.nongnu.org/nongnu-devel/bind-map-1.1.2.0.20251118.210127.tar";
+        sha256 = "1qwbyg84a6xkbzk5wzjd26ih3kypdivb4isvyx8hb6cc9q276m7w";
       };
       packageRequires = [ ];
       meta = {
@@ -572,10 +572,10 @@
     elpaBuild {
       pname = "cider";
       ename = "cider";
-      version = "1.20.0snapshot0.20250902.153000";
+      version = "1.20.0.0.20251105.93303";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/cider-1.20.0snapshot0.20250902.153000.tar";
-        sha256 = "04rgbpa53mzpbfhaj8y4yczv189i9v571xbq60lvxj3sy7lvbjkm";
+        url = "https://elpa.nongnu.org/nongnu-devel/cider-1.20.0.0.20251105.93303.tar";
+        sha256 = "17gkyg3zpj3941h1cs1chdf2hg0slpwla4r91xhxz3akfjrjmq80";
       };
       packageRequires = [
         clojure-mode
@@ -622,10 +622,10 @@
     elpaBuild {
       pname = "clojure-ts-mode";
       ename = "clojure-ts-mode";
-      version = "0.6.0snapshot0.20251003.205157";
+      version = "0.6.0snapshot0.20251120.73520";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/clojure-ts-mode-0.6.0snapshot0.20251003.205157.tar";
-        sha256 = "0cx9w4nj9v373yhz1ydrqh747xqjfsjjn08fd1s4byrkw6ll7d83";
+        url = "https://elpa.nongnu.org/nongnu-devel/clojure-ts-mode-0.6.0snapshot0.20251120.73520.tar";
+        sha256 = "1xpq94a1lsppsjsb5bv05ij67gx1i256lfaz6mlqrikq317x0gfz";
       };
       packageRequires = [ ];
       meta = {
@@ -664,10 +664,10 @@
     elpaBuild {
       pname = "cond-let";
       ename = "cond-let";
-      version = "0.1.1.0.20250903.164604";
+      version = "0.2.0.0.20251101.194229";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/cond-let-0.1.1.0.20250903.164604.tar";
-        sha256 = "1h6hb7wwwvcvxzykyh68a4ayjdrmc0dav8fb3s5y9wp3b9r8wvjx";
+        url = "https://elpa.nongnu.org/nongnu-devel/cond-let-0.2.0.0.20251101.194229.tar";
+        sha256 = "07dsv5nflh8izy93b1pjq1l0ya7yalxjv45y958a2c88jdwk32h3";
       };
       packageRequires = [ ];
       meta = {
@@ -844,10 +844,10 @@
     elpaBuild {
       pname = "dart-mode";
       ename = "dart-mode";
-      version = "1.0.7.0.20250811.110356";
+      version = "1.0.7.0.20251121.124027";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/dart-mode-1.0.7.0.20250811.110356.tar";
-        sha256 = "0xispkk8chgahkw4pgn70scx0nnsrlnvvskrgfisr9ih5rlbhvi1";
+        url = "https://elpa.nongnu.org/nongnu-devel/dart-mode-1.0.7.0.20251121.124027.tar";
+        sha256 = "07bc7m8n76ric6gwy85r91wc52rmj8sa31fl89v41d9p1vq545ww";
       };
       packageRequires = [ ];
       meta = {
@@ -951,10 +951,10 @@
     elpaBuild {
       pname = "diff-ansi";
       ename = "diff-ansi";
-      version = "0.2.0.20250913.225150";
+      version = "0.2.0.20251126.113407";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/diff-ansi-0.2.0.20250913.225150.tar";
-        sha256 = "0i6147bhn1wl46d13wni1frbkg2zxccb46yp2wgs6vxgsvn8fikl";
+        url = "https://elpa.nongnu.org/nongnu-devel/diff-ansi-0.2.0.20251126.113407.tar";
+        sha256 = "1018a6finysf24xvfyhv9x6001kz9hn9lzvp1dy8ywv2pd9bb9g3";
       };
       packageRequires = [ ];
       meta = {
@@ -994,10 +994,10 @@
     elpaBuild {
       pname = "doc-show-inline";
       ename = "doc-show-inline";
-      version = "0.1.0.20250913.225149";
+      version = "0.1.0.20251126.114419";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/doc-show-inline-0.1.0.20250913.225149.tar";
-        sha256 = "0rfpjmgkd76k2q9bxpv0q9vipzvrydyxvpd9ia8b9bwzaszdw8x2";
+        url = "https://elpa.nongnu.org/nongnu-devel/doc-show-inline-0.1.0.20251126.114419.tar";
+        sha256 = "0r1ly44d1ysqhns72r1mzss6g9ng2300mdqxkqgbb9i0is0nwxql";
       };
       packageRequires = [ ];
       meta = {
@@ -1143,10 +1143,10 @@
     elpaBuild {
       pname = "editorconfig";
       ename = "editorconfig";
-      version = "0.11.0.0.20250905.2405";
+      version = "0.11.0.0.20251127.151047";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/editorconfig-0.11.0.0.20250905.2405.tar";
-        sha256 = "06gwq2fr79l1abcxg2fqyqrkadg35fn6zm30bv6d8nvz7f1msfzq";
+        url = "https://elpa.nongnu.org/nongnu-devel/editorconfig-0.11.0.0.20251127.151047.tar";
+        sha256 = "1pz7f850zl1pd3c26gs5w3y1vhm5k3w7g8nr0xpqvhgfp4vj7sak";
       };
       packageRequires = [ ];
       meta = {
@@ -1248,10 +1248,10 @@
     elpaBuild {
       pname = "emacsql";
       ename = "emacsql";
-      version = "4.3.2.0.20250901.154446";
+      version = "4.3.3.0.20251116.165511";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/emacsql-4.3.2.0.20250901.154446.tar";
-        sha256 = "1jj49nx5id54xxxzr3nr1xgzymwxa5mrdlf4a4n07bp4xn2jgwhi";
+        url = "https://elpa.nongnu.org/nongnu-devel/emacsql-4.3.3.0.20251116.165511.tar";
+        sha256 = "12v0lgadvg1s72pvlqxgicnj6fl012fb7x69i5sly180b0q4iwvr";
       };
       packageRequires = [ ];
       meta = {
@@ -1293,10 +1293,10 @@
     elpaBuild {
       pname = "evil";
       ename = "evil";
-      version = "1.15.0.0.20250929.165020";
+      version = "1.15.0.0.20251108.13841";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/evil-1.15.0.0.20250929.165020.tar";
-        sha256 = "0qq60l5wy38izbixv4ymga32wvvl0fmxy2lc56s55fcg0safiwmc";
+        url = "https://elpa.nongnu.org/nongnu-devel/evil-1.15.0.0.20251108.13841.tar";
+        sha256 = "0vh9pmwsapdg2pn1cnp03jv9y35ddi57niwacrikn12g7niwh8jn";
       };
       packageRequires = [
         cl-lib
@@ -1654,10 +1654,10 @@
     elpaBuild {
       pname = "exec-path-from-shell";
       ename = "exec-path-from-shell";
-      version = "2.2.0.20250922.141302";
+      version = "2.2.0.20251113.132402";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/exec-path-from-shell-2.2.0.20250922.141302.tar";
-        sha256 = "1g70dg5ssw3k4jxcqqpi76qlckcl5n5rn7x812bm6xs9xp6izg1z";
+        url = "https://elpa.nongnu.org/nongnu-devel/exec-path-from-shell-2.2.0.20251113.132402.tar";
+        sha256 = "0brfbnxa36rvql03l7pq8wja520yjzmayhfxzh94sirs4f3s5yhl";
       };
       packageRequires = [ ];
       meta = {
@@ -1683,6 +1683,58 @@
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu-devel/extmap.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  fedi = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+      markdown-mode,
+    }:
+    elpaBuild {
+      pname = "fedi";
+      ename = "fedi";
+      version = "0.2.0.20250812.64538";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu-devel/fedi-0.2.0.20250812.64538.tar";
+        sha256 = "11s2l27vkzyrng931r5835xvh7jkq0vp30fpwihzsgq17g53h3i6";
+      };
+      packageRequires = [ markdown-mode ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu-devel/fedi.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  fj = callPackage (
+    {
+      elpaBuild,
+      fedi,
+      fetchurl,
+      lib,
+      magit,
+      tp,
+      transient,
+    }:
+    elpaBuild {
+      pname = "fj";
+      ename = "fj";
+      version = "0.28.0.20251030.134543";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu-devel/fj-0.28.0.20251030.134543.tar";
+        sha256 = "1fihl80jlsyb9w1f6dwd5rsrzaaxazb1cj8cp8yj4cajh4gmf8ms";
+      };
+      packageRequires = [
+        fedi
+        magit
+        tp
+        transient
+      ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu-devel/fj.html";
         license = lib.licenses.free;
       };
     }
@@ -1740,16 +1792,17 @@
       elpaBuild,
       fetchurl,
       lib,
+      seq,
     }:
     elpaBuild {
       pname = "flycheck";
       ename = "flycheck";
-      version = "35.0.0.20250814.121325";
+      version = "35.0.0.20251128.170639";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/flycheck-35.0.0.20250814.121325.tar";
-        sha256 = "1w2hzzdz4bb982dj1632lg1fhi69hxy2244nmc5g19qk799cvgwc";
+        url = "https://elpa.nongnu.org/nongnu-devel/flycheck-35.0.0.20251128.170639.tar";
+        sha256 = "1r0mjdnwb52jx2by1adkv3lxm24i42lpsr2lkmp5fmsxqn34pr7q";
       };
-      packageRequires = [ ];
+      packageRequires = [ seq ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu-devel/flycheck.html";
         license = lib.licenses.free;
@@ -1836,10 +1889,10 @@
     elpaBuild {
       pname = "flymake-pyrefly";
       ename = "flymake-pyrefly";
-      version = "0.1.8.0.20251007.82059";
+      version = "0.1.8.0.20251120.306";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/flymake-pyrefly-0.1.8.0.20251007.82059.tar";
-        sha256 = "08120i69qmf25s84kdpxq9rp25v9ivyly1gg7pi5fsaiprf84pk4";
+        url = "https://elpa.nongnu.org/nongnu-devel/flymake-pyrefly-0.1.8.0.20251120.306.tar";
+        sha256 = "0mjgy6x6z9i471krijd2f00rsyjg5yrakyvzv9w5xaqk7bjzhzhy";
       };
       packageRequires = [ ];
       meta = {
@@ -1880,10 +1933,10 @@
     elpaBuild {
       pname = "forth-mode";
       ename = "forth-mode";
-      version = "0.2.0.20231206.112722";
+      version = "0.2.0.20251027.73009";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/forth-mode-0.2.0.20231206.112722.tar";
-        sha256 = "0vx3ic6xjpw6xfxb42n7fipkrxfbn1z86hngzg1yz77mig0fvw3n";
+        url = "https://elpa.nongnu.org/nongnu-devel/forth-mode-0.2.0.20251027.73009.tar";
+        sha256 = "1h7vvigb98z1bj9s6j34jw8kwlg71agi92plxsbk89cpdx8w9xki";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -2221,10 +2274,10 @@
     elpaBuild {
       pname = "git-modes";
       ename = "git-modes";
-      version = "1.4.6.0.20250901.160839";
+      version = "1.4.7.0.20251101.201726";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/git-modes-1.4.6.0.20250901.160839.tar";
-        sha256 = "146x7r2dhj4smanpwlbvdwg4229kshcd4lshlpzzmqn1xk6z8yga";
+        url = "https://elpa.nongnu.org/nongnu-devel/git-modes-1.4.7.0.20251101.201726.tar";
+        sha256 = "1kr6fqj4invd594ig0s04dyn78y7xaafpqsry9y32ld1psa17pyv";
       };
       packageRequires = [ compat ];
       meta = {
@@ -2246,10 +2299,10 @@
     elpaBuild {
       pname = "gnosis";
       ename = "gnosis";
-      version = "0.5.5.0.20251001.70740";
+      version = "0.5.8.0.20251108.184759";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/gnosis-0.5.5.0.20251001.70740.tar";
-        sha256 = "05x98zgr6lxaxxsy76yxb15h5mwihp5xk2ppsrl9csc26sv3z2d6";
+        url = "https://elpa.nongnu.org/nongnu-devel/gnosis-0.5.8.0.20251108.184759.tar";
+        sha256 = "1v2v2mhragjxr74c323jr5bgxl267n0khyzcm7qj9z39v0lq6xzx";
       };
       packageRequires = [
         compat
@@ -2422,10 +2475,10 @@
     elpaBuild {
       pname = "gptel";
       ename = "gptel";
-      version = "0.9.9.0.20251006.195737";
+      version = "0.9.9.3.0.20251128.336";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/gptel-0.9.9.0.20251006.195737.tar";
-        sha256 = "0sfwlcg103zgm1f12slc2q2lygxcp92bvb7iddn79609hh1gg9ww";
+        url = "https://elpa.nongnu.org/nongnu-devel/gptel-0.9.9.3.0.20251128.336.tar";
+        sha256 = "0xbw2n4z7kpjw2b9flw2vijzfc0y51c3jbwpx9v927gd5kn73hbx";
       };
       packageRequires = [
         compat
@@ -2553,10 +2606,10 @@
     elpaBuild {
       pname = "haskell-mode";
       ename = "haskell-mode";
-      version = "17.5.0.20250930.172812";
+      version = "17.5.0.20251121.55413";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/haskell-mode-17.5.0.20250930.172812.tar";
-        sha256 = "0wjqyxnjvdxzfaipax3bbm8yjrmxkq54zhm78mr13gx3p1awz0id";
+        url = "https://elpa.nongnu.org/nongnu-devel/haskell-mode-17.5.0.20251121.55413.tar";
+        sha256 = "191bcwnj5bf1yvg7a6cwhhjljzkgrbis56gq3jn9c79dm4zffmkq";
       };
       packageRequires = [ ];
       meta = {
@@ -2596,10 +2649,10 @@
     elpaBuild {
       pname = "haskell-ts-mode";
       ename = "haskell-ts-mode";
-      version = "1.3.4.0.20250922.153032";
+      version = "1.3.5.0.20251127.100217";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/haskell-ts-mode-1.3.4.0.20250922.153032.tar";
-        sha256 = "0glcsp3kvnmqxcydj154shwgyamial6y987z1i0y5jz9rgn9zz7w";
+        url = "https://elpa.nongnu.org/nongnu-devel/haskell-ts-mode-1.3.5.0.20251127.100217.tar";
+        sha256 = "1jpz4l779h2njz4mjj2np0lq628vnlnv853vaha37bhy6yqrabzm";
       };
       packageRequires = [ ];
       meta = {
@@ -2619,10 +2672,10 @@
     elpaBuild {
       pname = "helm";
       ename = "helm";
-      version = "4.0.6.0.20251005.61450";
+      version = "4.0.6.0.20251115.145048";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/helm-4.0.6.0.20251005.61450.tar";
-        sha256 = "1m1qx22gcz5vgnji8qys1vkmsck9rz830fpc2kany6nzr7z2v8mm";
+        url = "https://elpa.nongnu.org/nongnu-devel/helm-4.0.6.0.20251115.145048.tar";
+        sha256 = "04rir4l25351zzf274z1nqmpvkqv0v48yqimy7ikki8mzniyyg4k";
       };
       packageRequires = [
         helm-core
@@ -2644,10 +2697,10 @@
     elpaBuild {
       pname = "helm-core";
       ename = "helm-core";
-      version = "4.0.6.0.20251005.61450";
+      version = "4.0.6.0.20251115.145048";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/helm-core-4.0.6.0.20251005.61450.tar";
-        sha256 = "0cv2lqibs6as1b8zfqwz9wlg4cfxbljd7mld1qa51p7nmxm3rzjw";
+        url = "https://elpa.nongnu.org/nongnu-devel/helm-core-4.0.6.0.20251115.145048.tar";
+        sha256 = "0pnrqmpsw3yd1i9xdsvh7f5xw5jhz3kk487ih2qw4rn0yalxck96";
       };
       packageRequires = [ async ];
       meta = {
@@ -2665,10 +2718,10 @@
     elpaBuild {
       pname = "hideshowvis";
       ename = "hideshowvis";
-      version = "0.8.0.20250225.175051";
+      version = "0.9.0.20251119.95800";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/hideshowvis-0.8.0.20250225.175051.tar";
-        sha256 = "1f0p5ir99n5m41habjkhy2c2nj7infianp6zy0d6i8493gxcxay4";
+        url = "https://elpa.nongnu.org/nongnu-devel/hideshowvis-0.9.0.20251119.95800.tar";
+        sha256 = "0x31p9ilpr60l9shddarimms3r7znipnic2aahd165xfx33h3jnf";
       };
       packageRequires = [ ];
       meta = {
@@ -2707,10 +2760,10 @@
     elpaBuild {
       pname = "hl-block-mode";
       ename = "hl-block-mode";
-      version = "0.2.0.20250913.225150";
+      version = "0.2.0.20251126.113654";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/hl-block-mode-0.2.0.20250913.225150.tar";
-        sha256 = "1zwgalb0s1jprfyfldxin9a4gqwjngqf46k24gnxxpw7039gszyw";
+        url = "https://elpa.nongnu.org/nongnu-devel/hl-block-mode-0.2.0.20251126.113654.tar";
+        sha256 = "1jn3gl3i77zhh62yzax40qh1ralvrdjpq4ivlvhqspf2nbsqgqdw";
       };
       packageRequires = [ ];
       meta = {
@@ -2777,10 +2830,10 @@
     elpaBuild {
       pname = "hyperdrive";
       ename = "hyperdrive";
-      version = "0.6pre0.20250406.152517";
+      version = "0.6pre0.20251120.145618";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/hyperdrive-0.6pre0.20250406.152517.tar";
-        sha256 = "190cj2hflahfg592w6g9h24m5pa62dn7jc38lrf5qabgpbrk5ksb";
+        url = "https://elpa.nongnu.org/nongnu-devel/hyperdrive-0.6pre0.20251120.145618.tar";
+        sha256 = "1s57c6m6fh593b9ax5skc5v1k3l0w983iq6mp3vx2a6g276qa44l";
       };
       packageRequires = [
         compat
@@ -2832,10 +2885,10 @@
     elpaBuild {
       pname = "idle-highlight-mode";
       ename = "idle-highlight-mode";
-      version = "1.1.4.0.20250922.133045";
+      version = "1.1.4.0.20251126.113001";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/idle-highlight-mode-1.1.4.0.20250922.133045.tar";
-        sha256 = "004axcdjrp10pflhx1s58ygjic0kcq17l2dg01sj6r8lck89gin9";
+        url = "https://elpa.nongnu.org/nongnu-devel/idle-highlight-mode-1.1.4.0.20251126.113001.tar";
+        sha256 = "0qv1m4dvy7akywjjyjpa1l8xxwwmc2v7ycvqcr2sknlyk9hsi5pz";
       };
       packageRequires = [ ];
       meta = {
@@ -2855,10 +2908,10 @@
     elpaBuild {
       pname = "idris-mode";
       ename = "idris-mode";
-      version = "1.1.0.0.20251006.81904";
+      version = "1.1.0.0.20251128.160804";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/idris-mode-1.1.0.0.20251006.81904.tar";
-        sha256 = "0yga8jfw275c6vkr1dz23d9bm5jshqidzg0fhakpxrl2aiyd8qkh";
+        url = "https://elpa.nongnu.org/nongnu-devel/idris-mode-1.1.0.0.20251128.160804.tar";
+        sha256 = "091aa1vk2f6g2xj1yfkxkbx7x15s13iv8awzvqyjfqsbbkc6qyw6";
       };
       packageRequires = [
         cl-lib
@@ -2879,10 +2932,10 @@
     elpaBuild {
       pname = "iedit";
       ename = "iedit";
-      version = "0.9.9.9.9.0.20220216.75011";
+      version = "0.9.9.9.9.0.20251013.114841";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/iedit-0.9.9.9.9.0.20220216.75011.tar";
-        sha256 = "0q31dfsh3ay2ls7f4i2f52zzjz62glwnccqmxww938hayn23lfg2";
+        url = "https://elpa.nongnu.org/nongnu-devel/iedit-0.9.9.9.9.0.20251013.114841.tar";
+        sha256 = "1kczx43d3f63bhgyw6xsyd0spf7jgw424sncaiqxgnmcfhabrc03";
       };
       packageRequires = [ ];
       meta = {
@@ -2951,6 +3004,27 @@
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu-devel/inkpot-theme.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  isl = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "isl";
+      ename = "isl";
+      version = "1.6.0.20251120.44129";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu-devel/isl-1.6.0.20251120.44129.tar";
+        sha256 = "0zql7y0r33k503qdr4wbbkvjkgb3b71kx2qd0frw91iy5y9w41k2";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu-devel/isl.html";
         license = lib.licenses.free;
       };
     }
@@ -3075,10 +3149,10 @@
     elpaBuild {
       pname = "keycast";
       ename = "keycast";
-      version = "1.4.5.0.20250901.161025";
+      version = "1.4.6.0.20251101.202141";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/keycast-1.4.5.0.20250901.161025.tar";
-        sha256 = "0dj814wrkb24hr5dfghviqnl9c1pnwzw600dx4d00gfy93mpfsq2";
+        url = "https://elpa.nongnu.org/nongnu-devel/keycast-1.4.6.0.20251101.202141.tar";
+        sha256 = "1k6rzb0b6x01l8rsqmw3i340bb8qqcxaqk70pbjjrihaf4nqjba9";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3108,6 +3182,32 @@
       };
     }
   ) { };
+  lem = callPackage (
+    {
+      elpaBuild,
+      fedi,
+      fetchurl,
+      lib,
+      markdown-mode,
+    }:
+    elpaBuild {
+      pname = "lem";
+      ename = "lem";
+      version = "0.24.0.20250806.92416";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu-devel/lem-0.24.0.20250806.92416.tar";
+        sha256 = "0hamh1xvwir0dhf91vn0fch39hxs7k443q4x9anfv44006fsgd3f";
+      };
+      packageRequires = [
+        fedi
+        markdown-mode
+      ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu-devel/lem.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   llama = callPackage (
     {
       compat,
@@ -3118,10 +3218,10 @@
     elpaBuild {
       pname = "llama";
       ename = "llama";
-      version = "1.0.1.0.20250901.154405";
+      version = "1.0.2.0.20251101.200220";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/llama-1.0.1.0.20250901.154405.tar";
-        sha256 = "1qksx33xaavzqd8ywiyb412bi6ykqlyxxk28k4zgkak6sxwrn2jd";
+        url = "https://elpa.nongnu.org/nongnu-devel/llama-1.0.2.0.20251101.200220.tar";
+        sha256 = "1jrn6scffp74zlf73zjvbzw2k9p153bfd2sp98489kk0996wfp38";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3142,10 +3242,10 @@
     elpaBuild {
       pname = "logview";
       ename = "logview";
-      version = "0.19.3snapshot0.20250401.172309";
+      version = "0.19.4snapshot0.20251104.172505";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/logview-0.19.3snapshot0.20250401.172309.tar";
-        sha256 = "0vr34ixpidz1lp6y87axlvi0pac11lfkm5g0d310wphihnjmyssr";
+        url = "https://elpa.nongnu.org/nongnu-devel/logview-0.19.4snapshot0.20251104.172505.tar";
+        sha256 = "1j1sy2z3w9k6h5b9dszshfy2l34v73qyr3y9l11zf2yzzm90lwz1";
       };
       packageRequires = [
         compat
@@ -3171,10 +3271,10 @@
     elpaBuild {
       pname = "loopy";
       ename = "loopy";
-      version = "0.14.0.0.20251008.15638";
+      version = "0.15.0.0.20251116.1315";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/loopy-0.14.0.0.20251008.15638.tar";
-        sha256 = "1jmlrbac8psymd17v6hhks7ldqzik99g32cqc756gp5gj9ixdxyf";
+        url = "https://elpa.nongnu.org/nongnu-devel/loopy-0.15.0.0.20251116.1315.tar";
+        sha256 = "1iw2a0diz0x1r9gilhh9zdymw6ga9lsvyd314vcmbm8vcrp7lyiq";
       };
       packageRequires = [
         compat
@@ -3298,10 +3398,10 @@
     elpaBuild {
       pname = "magit";
       ename = "magit";
-      version = "4.4.2.0.20251006.184033";
+      version = "4.4.2.0.20251125.10143";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/magit-4.4.2.0.20251006.184033.tar";
-        sha256 = "1jl4wnxca90vfr42v5wl66arrh8c8ybxcr18lgq4af32shcpz758";
+        url = "https://elpa.nongnu.org/nongnu-devel/magit-4.4.2.0.20251125.10143.tar";
+        sha256 = "0szm0200bw2b5y8niqndwnlhym2w9rllhjqb3l1038lm6d1bd7j0";
       };
       packageRequires = [
         compat
@@ -3331,10 +3431,10 @@
     elpaBuild {
       pname = "magit-section";
       ename = "magit-section";
-      version = "4.4.2.0.20251006.184033";
+      version = "4.4.2.0.20251125.10143";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/magit-section-4.4.2.0.20251006.184033.tar";
-        sha256 = "1lb6lm7fq0svjrfk6h7x45rhbwfspri46rfsnz2rv54l7jxzb7dh";
+        url = "https://elpa.nongnu.org/nongnu-devel/magit-section-4.4.2.0.20251125.10143.tar";
+        sha256 = "0hns2nn9hhirlxlvnhswra5snl5hiigjpddnrxjpxflz6gbqnflv";
       };
       packageRequires = [
         compat
@@ -3357,10 +3457,10 @@
     elpaBuild {
       pname = "markdown-mode";
       ename = "markdown-mode";
-      version = "2.8alpha0.20250812.42301";
+      version = "2.8alpha0.20251028.41247";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/markdown-mode-2.8alpha0.20250812.42301.tar";
-        sha256 = "1ckl1ykijnahld1fwd6mp04j1hwdq1acdbi9wrnwzizizrfisbjp";
+        url = "https://elpa.nongnu.org/nongnu-devel/markdown-mode-2.8alpha0.20251028.41247.tar";
+        sha256 = "09f9h6x9p56x9ljfqgalvh0l8lpzpx4zy6j8vmh3cz00ib6nn83v";
       };
       packageRequires = [ ];
       meta = {
@@ -3380,10 +3480,10 @@
     elpaBuild {
       pname = "mastodon";
       ename = "mastodon";
-      version = "2.0.3.0.20251006.174033";
+      version = "2.0.7.0.20251117.145845";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/mastodon-2.0.3.0.20251006.174033.tar";
-        sha256 = "1b0wxpzgi5g5n8n3kxsxshfpx7nb8xywc0a2qk8qjarii2dlm6wc";
+        url = "https://elpa.nongnu.org/nongnu-devel/mastodon-2.0.7.0.20251117.145845.tar";
+        sha256 = "1ar3yb71gnm6gl6h44r23y8bzv03jpcxkn6jsm1hyv779xjrnpg3";
       };
       packageRequires = [
         persist
@@ -3715,10 +3815,10 @@
     elpaBuild {
       pname = "org-contrib";
       ename = "org-contrib";
-      version = "0.6.0.20250227.181559";
+      version = "0.7.0.20251011.144539";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/org-contrib-0.6.0.20250227.181559.tar";
-        sha256 = "15cc87skz34cw9zrg055jmqnjqpbwl06mfvqblzg3x5irjgghkfi";
+        url = "https://elpa.nongnu.org/nongnu-devel/org-contrib-0.7.0.20251011.144539.tar";
+        sha256 = "02v12mhpfd7i0m7y5cij6zq8lqamrplc4ybdkya66zw8dwh5y1mn";
       };
       packageRequires = [ org ];
       meta = {
@@ -3786,10 +3886,10 @@
     elpaBuild {
       pname = "org-mime";
       ename = "org-mime";
-      version = "0.3.4.0.20250318.215555";
+      version = "0.3.4.0.20251129.11105";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/org-mime-0.3.4.0.20250318.215555.tar";
-        sha256 = "0plqmcyszpc1x35v691zlgxmnbga80yxxcjyb5mvxdri45z4458d";
+        url = "https://elpa.nongnu.org/nongnu-devel/org-mime-0.3.4.0.20251129.11105.tar";
+        sha256 = "0kjmwsayg5rkvvpysvf1lhvfayg6g9fdfvhr10dwd30qj4hchgrm";
       };
       packageRequires = [ ];
       meta = {
@@ -3892,6 +3992,7 @@
   orgit = callPackage (
     {
       compat,
+      cond-let,
       elpaBuild,
       fetchurl,
       lib,
@@ -3901,13 +4002,14 @@
     elpaBuild {
       pname = "orgit";
       ename = "orgit";
-      version = "2.0.5.0.20250901.181058";
+      version = "2.1.0.0.20251123.180141";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/orgit-2.0.5.0.20250901.181058.tar";
-        sha256 = "1cisgrfca4ry2fayl55swp2h9nr3nxngjyvfdm79z6lv5rciinr1";
+        url = "https://elpa.nongnu.org/nongnu-devel/orgit-2.1.0.0.20251123.180141.tar";
+        sha256 = "0hliymdwdbkzdv8ckfm162nlb6b3p321xds5i11783y4flvr5f6b";
       };
       packageRequires = [
         compat
+        cond-let
         magit
         org
       ];
@@ -3948,10 +4050,10 @@
     elpaBuild {
       pname = "package-lint";
       ename = "package-lint";
-      version = "0.26.0.20250828.150659";
+      version = "0.26.0.20251121.93117";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/package-lint-0.26.0.20250828.150659.tar";
-        sha256 = "0lm66fw4qf5i2jndfpbpglgh8k9hs15fq08vxwmf19sg2mgi8c8l";
+        url = "https://elpa.nongnu.org/nongnu-devel/package-lint-0.26.0.20251121.93117.tar";
+        sha256 = "0nlk67wq5aq3mbya1icgzi95lmwbg73lxcz743606b13hdwn6qkw";
       };
       packageRequires = [ let-alist ];
       meta = {
@@ -3991,10 +4093,10 @@
     elpaBuild {
       pname = "page-break-lines";
       ename = "page-break-lines";
-      version = "0.15.0.20250812.113016";
+      version = "0.15.0.20251121.212752";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/page-break-lines-0.15.0.20250812.113016.tar";
-        sha256 = "08v3pdy4p4qw8dcss4246r7lajcabs37ah4vngyniip331qnf8ja";
+        url = "https://elpa.nongnu.org/nongnu-devel/page-break-lines-0.15.0.20251121.212752.tar";
+        sha256 = "0jzga42sd4p4nibbypi0f6427pfibdmpdjrcxnygvj8rc3wk1qv6";
       };
       packageRequires = [ ];
       meta = {
@@ -4149,10 +4251,10 @@
     elpaBuild {
       pname = "pg";
       ename = "pg";
-      version = "0.60.0.20250928.144633";
+      version = "0.61.0.20251126.143425";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/pg-0.60.0.20250928.144633.tar";
-        sha256 = "0899g9r151ymhimlv40pnb4mx5kqyizbwa1ml6pnqk3as6lld0bj";
+        url = "https://elpa.nongnu.org/nongnu-devel/pg-0.61.0.20251126.143425.tar";
+        sha256 = "0g96hx5h7b2vsj9il403m4lnjdxbl716hyg813adc3q2527cwdlf";
       };
       packageRequires = [ peg ];
       meta = {
@@ -4170,10 +4272,10 @@
     elpaBuild {
       pname = "php-mode";
       ename = "php-mode";
-      version = "1.26.1.0.20250928.131854";
+      version = "1.26.1.0.20251112.64638";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/php-mode-1.26.1.0.20250928.131854.tar";
-        sha256 = "10px7l5j7z0zxzviccng3snp5j8ha7k1vzapmd0dvagjwn6l6dcp";
+        url = "https://elpa.nongnu.org/nongnu-devel/php-mode-1.26.1.0.20251112.64638.tar";
+        sha256 = "1vh7ynpbpps46jw5g9qwzzhyb4kll0dpppj5493kpjj3d87xclir";
       };
       packageRequires = [ ];
       meta = {
@@ -4212,14 +4314,35 @@
     elpaBuild {
       pname = "popup";
       ename = "popup";
-      version = "0.5.9.0.20250812.70240";
+      version = "0.5.9.0.20251120.211937";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/popup-0.5.9.0.20250812.70240.tar";
-        sha256 = "1csszznlk47jxzbsw2rayf0mwnxk4r2abc95sb7nzf30bibgwymg";
+        url = "https://elpa.nongnu.org/nongnu-devel/popup-0.5.9.0.20251120.211937.tar";
+        sha256 = "1f6rl4prpsp77khcc8j5vbq5qnnpf16g5n82h0dc9z6chdb2y9xs";
       };
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu-devel/popup.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  powershell = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "powershell";
+      ename = "powershell";
+      version = "0.4.0.20251122.143018";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu-devel/powershell-0.4.0.20251122.143018.tar";
+        sha256 = "1zd7cywmgsz59k80jkgnzhazpfijv26fx81l3nfnlkznfy0zgmxd";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu-devel/powershell.html";
         license = lib.licenses.free;
       };
     }
@@ -4254,10 +4377,10 @@
     elpaBuild {
       pname = "proof-general";
       ename = "proof-general";
-      version = "4.6snapshot0.20250915.103850";
+      version = "4.6snapshot0.20251120.174626";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/proof-general-4.6snapshot0.20250915.103850.tar";
-        sha256 = "0kanqrxdv0ayf5q6i3wj5xbc2nb7abhvw3sssn2nhn9kzy2yip1m";
+        url = "https://elpa.nongnu.org/nongnu-devel/proof-general-4.6snapshot0.20251120.174626.tar";
+        sha256 = "1ayyczx5n1rccmd29aa0pn49i008jjiakgq8qxz0imkn1ri5g1kv";
       };
       packageRequires = [ ];
       meta = {
@@ -4298,10 +4421,10 @@
     elpaBuild {
       pname = "racket-mode";
       ename = "racket-mode";
-      version = "1.0.20250830.122523";
+      version = "1.0.20251106.215641";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/racket-mode-1.0.20250830.122523.tar";
-        sha256 = "01nqdsblxn2l7c2yv91d7phdpfasz6k4ifsk05647ccjqbvqsr45";
+        url = "https://elpa.nongnu.org/nongnu-devel/racket-mode-1.0.20251106.215641.tar";
+        sha256 = "1kkmb5b64h7az0nc22xrbrwb55l8bvw13xq7s5kqwx0xikj9q9yl";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4382,10 +4505,10 @@
     elpaBuild {
       pname = "recomplete";
       ename = "recomplete";
-      version = "0.2.0.20250913.225149";
+      version = "0.2.0.20251126.51858";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/recomplete-0.2.0.20250913.225149.tar";
-        sha256 = "0ghkkigd0kh4kwf8wlviaxcmbzvgdbz67vd8qhlm978b48pqpbb5";
+        url = "https://elpa.nongnu.org/nongnu-devel/recomplete-0.2.0.20251126.51858.tar";
+        sha256 = "1kg9gm95qj2dzlk99rx2zrz6lrgcmm8fp3j5qxnmncsda6caw4p5";
       };
       packageRequires = [ ];
       meta = {
@@ -4403,10 +4526,10 @@
     elpaBuild {
       pname = "reformatter";
       ename = "reformatter";
-      version = "0.8.0.20250812.113040";
+      version = "0.8.0.20251121.93526";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/reformatter-0.8.0.20250812.113040.tar";
-        sha256 = "1x8n1i974cnmjccz4142nr4p8yic9szfpsmnxm9gg4mnvrlnjzwv";
+        url = "https://elpa.nongnu.org/nongnu-devel/reformatter-0.8.0.20251121.93526.tar";
+        sha256 = "11s23mply7aaa68y6miwzn6bld5m1rynk19l5jj2i1mwjk2plrlk";
       };
       packageRequires = [ ];
       meta = {
@@ -4508,10 +4631,10 @@
     elpaBuild {
       pname = "rust-mode";
       ename = "rust-mode";
-      version = "1.0.6.0.20250816.40724";
+      version = "1.0.6.0.20251120.211427";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/rust-mode-1.0.6.0.20250816.40724.tar";
-        sha256 = "1w45rp9ppw8sr2pprzfy2bglmd2x47frhz5kfmf07ch3prdbynp7";
+        url = "https://elpa.nongnu.org/nongnu-devel/rust-mode-1.0.6.0.20251120.211427.tar";
+        sha256 = "1jif5r4r7s991kr4x381ipqnhivi96il7vq9c26f4vc16nrm6imm";
       };
       packageRequires = [ ];
       meta = {
@@ -4619,10 +4742,10 @@
     elpaBuild {
       pname = "scroll-on-jump";
       ename = "scroll-on-jump";
-      version = "0.2.0.20250913.225149";
+      version = "0.2.0.20251126.51435";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/scroll-on-jump-0.2.0.20250913.225149.tar";
-        sha256 = "057pc5rfd6ighm87jsgbivlgs52vhczp6c1bz6rjrhfqrajhdw6c";
+        url = "https://elpa.nongnu.org/nongnu-devel/scroll-on-jump-0.2.0.20251126.51435.tar";
+        sha256 = "0zfag8ad4c75x8b498rxf71yr7rr2nym2yh6592whkkvy75hihlc";
       };
       packageRequires = [ ];
       meta = {
@@ -4683,10 +4806,10 @@
     elpaBuild {
       pname = "slime";
       ename = "slime";
-      version = "2.31snapshot0.20250918.225852";
+      version = "2.31snapshot0.20251122.135227";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/slime-2.31snapshot0.20250918.225852.tar";
-        sha256 = "0bpn15a6a8fvr3ycjngqkg5wqkcv95fbkf8s3zr72xv8ys5zlk61";
+        url = "https://elpa.nongnu.org/nongnu-devel/slime-2.31snapshot0.20251122.135227.tar";
+        sha256 = "189jfp545fvddp24gdk5kd1x07arnl509bdl2v2nmrrqahb2hmwc";
       };
       packageRequires = [ macrostep ];
       meta = {
@@ -4704,10 +4827,10 @@
     elpaBuild {
       pname = "sly";
       ename = "sly";
-      version = "1.0.43.0.20250930.91309";
+      version = "1.0.43.0.20251125.3152";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/sly-1.0.43.0.20250930.91309.tar";
-        sha256 = "0fg0prfy7jp0g5cs0czv8a6i4n29lbz8961h7ybpdn8i5s2mpasd";
+        url = "https://elpa.nongnu.org/nongnu-devel/sly-1.0.43.0.20251125.3152.tar";
+        sha256 = "1dcdv3k19xr36ygzcdx4m26z3j36rjmjh5mh195y3hqzqcaflmyf";
       };
       packageRequires = [ ];
       meta = {
@@ -4768,10 +4891,10 @@
     elpaBuild {
       pname = "spacemacs-theme";
       ename = "spacemacs-theme";
-      version = "0.2.0.20250613.211345";
+      version = "0.2.0.20251015.182334";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/spacemacs-theme-0.2.0.20250613.211345.tar";
-        sha256 = "0a2rf7kdwjnz8y90018f3ajmy9pd1iz5aq36s74l10fzd08ccqpj";
+        url = "https://elpa.nongnu.org/nongnu-devel/spacemacs-theme-0.2.0.20251015.182334.tar";
+        sha256 = "00jgpmnb6x78rzxcwbcgy8mkxkq5gkm346fb0wc96xhhmifs7824";
       };
       packageRequires = [ ];
       meta = {
@@ -4789,10 +4912,10 @@
     elpaBuild {
       pname = "spell-fu";
       ename = "spell-fu";
-      version = "0.3.0.20250913.225149";
+      version = "0.3.0.20251126.52910";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/spell-fu-0.3.0.20250913.225149.tar";
-        sha256 = "03c7ivc3wmcbwhwyca52naxjwlbsnzzwws8x4cfpydngfrbrfgrb";
+        url = "https://elpa.nongnu.org/nongnu-devel/spell-fu-0.3.0.20251126.52910.tar";
+        sha256 = "1ljqxf86zwvld6963a6cf3mri5x1x40g371jdfr42wcvjpp72wdc";
       };
       packageRequires = [ ];
       meta = {
@@ -4810,10 +4933,10 @@
     elpaBuild {
       pname = "sqlite3";
       ename = "sqlite3";
-      version = "0.17.0.20231124.132621";
+      version = "0.17.0.20251014.53705";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/sqlite3-0.17.0.20231124.132621.tar";
-        sha256 = "10mgf69dvvglf067n59w3dy08jc245rhbqqjbfr27ff9xjrklvfh";
+        url = "https://elpa.nongnu.org/nongnu-devel/sqlite3-0.17.0.20251014.53705.tar";
+        sha256 = "0q849fac1h7vci1mclh3l0w7zg6150w95fbzfk0aq7nldir6mizy";
       };
       packageRequires = [ ];
       meta = {
@@ -4894,10 +5017,10 @@
     elpaBuild {
       pname = "subed";
       ename = "subed";
-      version = "1.2.25.0.20250128.122549";
+      version = "1.2.25.0.20251010.214554";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/subed-1.2.25.0.20250128.122549.tar";
-        sha256 = "0h53z43vxyn03sa621ajig637akyjijbby3nrkjibhz47gc2nyyn";
+        url = "https://elpa.nongnu.org/nongnu-devel/subed-1.2.25.0.20251010.214554.tar";
+        sha256 = "1c2n4vn4mxblfjgphhp5f9987j8pj8kj8qrh7lidpgcl0hjnbm8l";
       };
       packageRequires = [ ];
       meta = {
@@ -4937,10 +5060,10 @@
     elpaBuild {
       pname = "swift-mode";
       ename = "swift-mode";
-      version = "9.4.0.0.20250922.71205";
+      version = "9.4.0.0.20251122.85713";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/swift-mode-9.4.0.0.20250922.71205.tar";
-        sha256 = "1ydsnrdschridpm72228v690024l95bl97hp1l8x5qyxhyg147js";
+        url = "https://elpa.nongnu.org/nongnu-devel/swift-mode-9.4.0.0.20251122.85713.tar";
+        sha256 = "1sn7lm6srrlnbxfdjpqdr503plkml61bz79ivwgz9rs9fqkbrvgg";
       };
       packageRequires = [ ];
       meta = {
@@ -5199,10 +5322,10 @@
     elpaBuild {
       pname = "treesit-fold";
       ename = "treesit-fold";
-      version = "0.2.1.0.20250911.3703";
+      version = "0.2.1.0.20251121.62118";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/treesit-fold-0.2.1.0.20250911.3703.tar";
-        sha256 = "06wjzpgd0525xb8xq968p78y319hy4jxk97kxjdy3cbcf368s58w";
+        url = "https://elpa.nongnu.org/nongnu-devel/treesit-fold-0.2.1.0.20251121.62118.tar";
+        sha256 = "0czbmrb3g34m1qfnkkm4my62lv2z3wzvjm0gl7qz4vnzzq8ald41";
       };
       packageRequires = [ ];
       meta = {
@@ -5263,10 +5386,10 @@
     elpaBuild {
       pname = "typescript-mode";
       ename = "typescript-mode";
-      version = "0.4.0.20250118.205614";
+      version = "0.4.0.20251127.204054";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/typescript-mode-0.4.0.20250118.205614.tar";
-        sha256 = "0aj776mj89brr0210ilwiaj40x834a1r39fg9f4gy3a7immkpisd";
+        url = "https://elpa.nongnu.org/nongnu-devel/typescript-mode-0.4.0.20251127.204054.tar";
+        sha256 = "128xgfj0b5lxm06ddlhd1bl5mqy828yphgq07q2mgxprgv58c3xw";
       };
       packageRequires = [ ];
       meta = {
@@ -5284,10 +5407,10 @@
     elpaBuild {
       pname = "typst-ts-mode";
       ename = "typst-ts-mode";
-      version = "0.12.2.0.20250906.143855";
+      version = "0.12.2.0.20251026.52820";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/typst-ts-mode-0.12.2.0.20250906.143855.tar";
-        sha256 = "1qi73s1r6ld6l31xf3sa9ml52zlcpwp2wr5m2w76i1bcwylgnaad";
+        url = "https://elpa.nongnu.org/nongnu-devel/typst-ts-mode-0.12.2.0.20251026.52820.tar";
+        sha256 = "002ry7lgc61w1appzw33xgavsgc34wxjahbpjqba3rp53qmkk0m8";
       };
       packageRequires = [ ];
       meta = {
@@ -5326,10 +5449,10 @@
     elpaBuild {
       pname = "undo-fu";
       ename = "undo-fu";
-      version = "0.5.0.20250611.233145";
+      version = "0.5.0.20251126.50949";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/undo-fu-0.5.0.20250611.233145.tar";
-        sha256 = "043c0lswp9684naqka6j3jmqygrki2ylr4q7b3x8r8bi9xmdspb0";
+        url = "https://elpa.nongnu.org/nongnu-devel/undo-fu-0.5.0.20251126.50949.tar";
+        sha256 = "0l14yi8ls2gqj66yqxrdzkyv7zyb1zh3jfksarn6c63v1lqpx1rx";
       };
       packageRequires = [ ];
       meta = {
@@ -5347,10 +5470,10 @@
     elpaBuild {
       pname = "undo-fu-session";
       ename = "undo-fu-session";
-      version = "0.7.0.20250918.1702";
+      version = "0.7.0.20251126.114300";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/undo-fu-session-0.7.0.20250918.1702.tar";
-        sha256 = "19ir40rg2zrmr2f1dfkxk304vhg1rv9bg8g5a0pn5j2qlgwcn5kb";
+        url = "https://elpa.nongnu.org/nongnu-devel/undo-fu-session-0.7.0.20251126.114300.tar";
+        sha256 = "0m3h4pa1vq041l1kq5s0pgbbvx4cjh2narj2igp9lybff2ywxp14";
       };
       packageRequires = [ ];
       meta = {
@@ -5410,10 +5533,10 @@
     elpaBuild {
       pname = "visual-fill-column";
       ename = "visual-fill-column";
-      version = "2.7.0.0.20250925.121619";
+      version = "2.7.1.0.20251110.104539";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/visual-fill-column-2.7.0.0.20250925.121619.tar";
-        sha256 = "0ymr57mwd6k9xia62dqwjxmywlhc5y7vnfc5ag8z9j232znshllp";
+        url = "https://elpa.nongnu.org/nongnu-devel/visual-fill-column-2.7.1.0.20251110.104539.tar";
+        sha256 = "18gm23pmkn6h9jajn50mczip0680jcx6v72mhi99lmnvjbvwbxb8";
       };
       packageRequires = [ ];
       meta = {
@@ -5429,18 +5552,20 @@
       fetchurl,
       lib,
       nadvice,
+      vcard,
     }:
     elpaBuild {
       pname = "vm";
       ename = "vm";
-      version = "8.3.0snapshot0.20250922.112745";
+      version = "8.3.0snapshot0.20251121.52349";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/vm-8.3.0snapshot0.20250922.112745.tar";
-        sha256 = "1p1jyqwb1m0rxkpyr69yzkjjfv4yj1x3gfk8h5xizjcqisxckpaa";
+        url = "https://elpa.nongnu.org/nongnu-devel/vm-8.3.0snapshot0.20251121.52349.tar";
+        sha256 = "0vgfx1qwdkwlwg38si4sjzazh26fkw3aljzil63ksi0yn20wqs42";
       };
       packageRequires = [
         cl-lib
         nadvice
+        vcard
       ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu-devel/vm.html";
@@ -5568,10 +5693,10 @@
     elpaBuild {
       pname = "with-editor";
       ename = "with-editor";
-      version = "3.4.6.0.20250901.161817";
+      version = "3.4.7.0.20251115.121304";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/with-editor-3.4.6.0.20250901.161817.tar";
-        sha256 = "1387wiakkxw2vpdp07sj1d3dy8vbk1113jmmp980swpd1gm4hfmy";
+        url = "https://elpa.nongnu.org/nongnu-devel/with-editor-3.4.7.0.20251115.121304.tar";
+        sha256 = "0hkjxmcs5pj82zdgk8lzbpsbcn31d7kz8qb6aw5y0g76g3id8wmw";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5678,10 +5803,10 @@
     elpaBuild {
       pname = "xah-fly-keys";
       ename = "xah-fly-keys";
-      version = "28.7.20250917123258.0.20250917.123752";
+      version = "28.11.20251125073911.0.20251125.74100";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/xah-fly-keys-28.7.20250917123258.0.20250917.123752.tar";
-        sha256 = "03hx3z023xv467zwmgz9g2k0ps2vvd95fs1n6f8msdv5f2sxysx9";
+        url = "https://elpa.nongnu.org/nongnu-devel/xah-fly-keys-28.11.20251125073911.0.20251125.74100.tar";
+        sha256 = "19ksi2y9zjql4r48qalp5gb3scvzpchg25pjsc3wj1qnc5i1dy6v";
       };
       packageRequires = [ ];
       meta = {
@@ -5721,10 +5846,10 @@
     elpaBuild {
       pname = "xml-rpc";
       ename = "xml-rpc";
-      version = "1.6.17.0.20250812.100619";
+      version = "1.6.17.0.20251122.185743";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/xml-rpc-1.6.17.0.20250812.100619.tar";
-        sha256 = "0l4amp36zazwgnm7gvlyqfqjycj3c9vbdr1hdhf8jxyrikr9p12a";
+        url = "https://elpa.nongnu.org/nongnu-devel/xml-rpc-1.6.17.0.20251122.185743.tar";
+        sha256 = "1sshmzg6v27v8l0q3lq2apfvpbkkg71dyn7mk99a56qab4ajm6zs";
       };
       packageRequires = [ ];
       meta = {
@@ -5764,10 +5889,10 @@
     elpaBuild {
       pname = "yasnippet-snippets";
       ename = "yasnippet-snippets";
-      version = "1.0.0.20250808.81958";
+      version = "1.0.0.20251010.101816";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/yasnippet-snippets-1.0.0.20250808.81958.tar";
-        sha256 = "067jidwz1xn13fxcnwdrh0bnr93bndwjs1yznn483xdw9fcgyz05";
+        url = "https://elpa.nongnu.org/nongnu-devel/yasnippet-snippets-1.0.0.20251010.101816.tar";
+        sha256 = "02acz3l84sprs79iq3fxqrk0579pz31l0i1f1fiszjpn8hiixgbp";
       };
       packageRequires = [ yasnippet ];
       meta = {
@@ -5785,10 +5910,10 @@
     elpaBuild {
       pname = "zenburn-theme";
       ename = "zenburn-theme";
-      version = "2.9.0snapshot0.20250213.141810";
+      version = "2.9.0snapshot0.20251028.122652";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/zenburn-theme-2.9.0snapshot0.20250213.141810.tar";
-        sha256 = "165sy1df0cil2m63nnsxnmvvp7v2yh31lxzpdbzz6vwx6br4nl84";
+        url = "https://elpa.nongnu.org/nongnu-devel/zenburn-theme-2.9.0snapshot0.20251028.122652.tar";
+        sha256 = "00y5qix2znxz7c3g780h56ssmqjj801s7ig43gsk84rhr6h67wy5";
       };
       packageRequires = [ ];
       meta = {
@@ -5807,10 +5932,10 @@
     elpaBuild {
       pname = "zig-mode";
       ename = "zig-mode";
-      version = "0.0.8.0.20250915.80705";
+      version = "0.0.8.0.20251121.92826";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/zig-mode-0.0.8.0.20250915.80705.tar";
-        sha256 = "0dz5gaja4zkq2vdamq2msqyxp8j59m131cm8mgjwz4jikcxg600b";
+        url = "https://elpa.nongnu.org/nongnu-devel/zig-mode-0.0.8.0.20251121.92826.tar";
+        sha256 = "1bca96i1iiayw0i0van0xrs9hxzdzr6219a1ax9vr8khbi8a1asa";
       };
       packageRequires = [ reformatter ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
@@ -54,10 +54,10 @@
     elpaBuild {
       pname = "aidermacs";
       ename = "aidermacs";
-      version = "1.5";
+      version = "1.6";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/aidermacs-1.5.tar";
-        sha256 = "1gfgk4g1942xjqr3g1q6rw330wgxlsm35p3vsiixszxcs0xh55sj";
+        url = "https://elpa.nongnu.org/nongnu/aidermacs-1.6.tar";
+        sha256 = "07ql2kv7naza7jigmsw9x1k3md0hz2c302qrc0cy1a1h07567nli";
       };
       packageRequires = [
         compat
@@ -79,10 +79,10 @@
     elpaBuild {
       pname = "alect-themes";
       ename = "alect-themes";
-      version = "0.10";
+      version = "0.11";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/alect-themes-0.10.tar";
-        sha256 = "0pagkf0bb85sr3mvg8z6h6akb9hjmvfqmpiaiz121ys0r92m6nb7";
+        url = "https://elpa.nongnu.org/nongnu/alect-themes-0.11.tar";
+        sha256 = "1ij0c321gi3vqcw0pzzsi02b3370l2ynijq0999j1jxrillc9h2l";
       };
       packageRequires = [ ];
       meta = {
@@ -121,10 +121,10 @@
     elpaBuild {
       pname = "annotate";
       ename = "annotate";
-      version = "2.4.2";
+      version = "2.4.5";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/annotate-2.4.2.tar";
-        sha256 = "12510awgjx14kcz88a66walybvxqf7whbb0gckxj1dxsn0r1spfa";
+        url = "https://elpa.nongnu.org/nongnu/annotate-2.4.5.tar";
+        sha256 = "0pdhwlz792sf5zipv8s449bah7xm9klbpicx9203fhsc0ad82d0j";
       };
       packageRequires = [ ];
       meta = {
@@ -572,10 +572,10 @@
     elpaBuild {
       pname = "cider";
       ename = "cider";
-      version = "1.19.0";
+      version = "1.20.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/cider-1.19.0.tar";
-        sha256 = "04jz9cjdrx7i8p8zb7yavapz2yl8nlv7jczvmph2bpyxff2fimcf";
+        url = "https://elpa.nongnu.org/nongnu/cider-1.20.0.tar";
+        sha256 = "1s1jw1dc8r7aqjc4vkgcsz193fnhrd6lrz54bim839sfyfv2rhb8";
       };
       packageRequires = [
         clojure-mode
@@ -687,10 +687,10 @@
     elpaBuild {
       pname = "cond-let";
       ename = "cond-let";
-      version = "0.1.1";
+      version = "0.2.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/cond-let-0.1.1.tar";
-        sha256 = "1s1gzmn2xa76hbk0q60gznsj0p8kfn1b4fzijdkqdrvindmc4ymw";
+        url = "https://elpa.nongnu.org/nongnu/cond-let-0.2.0.tar";
+        sha256 = "1vycjql5i9k9k8nmrpjx393qaw5vh9jy9f7riggsxgd80xky35zi";
       };
       packageRequires = [ ];
       meta = {
@@ -1272,10 +1272,10 @@
     elpaBuild {
       pname = "emacsql";
       ename = "emacsql";
-      version = "4.3.2";
+      version = "4.3.3";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/emacsql-4.3.2.tar";
-        sha256 = "0yl5j35r3s3z4pnxpk6hx2a8piw110rgc67zz3nmkp8ppzkz9h86";
+        url = "https://elpa.nongnu.org/nongnu/emacsql-4.3.3.tar";
+        sha256 = "0j1q33wfyqrif7zf9qzvh74yxpsqvp800nm0blkr745881k6cmwr";
       };
       packageRequires = [ ];
       meta = {
@@ -1701,6 +1701,58 @@
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu/extmap.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  fedi = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+      markdown-mode,
+    }:
+    elpaBuild {
+      pname = "fedi";
+      ename = "fedi";
+      version = "0.2";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu/fedi-0.2.tar";
+        sha256 = "1vhv72s988xvwq14w9xhzqq7hpsjidh2hsii97q9bakh00k5zdra";
+      };
+      packageRequires = [ markdown-mode ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu/fedi.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  fj = callPackage (
+    {
+      elpaBuild,
+      fedi,
+      fetchurl,
+      lib,
+      magit,
+      tp,
+      transient,
+    }:
+    elpaBuild {
+      pname = "fj";
+      ename = "fj";
+      version = "0.28";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu/fj-0.28.tar";
+        sha256 = "0smmz9iig83yckcgmd9jd45kkklfywk7nw4jl98wxm4mqwmy1f5l";
+      };
+      packageRequires = [
+        fedi
+        magit
+        tp
+        transient
+      ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu/fj.html";
         license = lib.licenses.free;
       };
     }
@@ -2238,10 +2290,10 @@
     elpaBuild {
       pname = "git-modes";
       ename = "git-modes";
-      version = "1.4.6";
+      version = "1.4.7";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/git-modes-1.4.6.tar";
-        sha256 = "0hxvdm8578pl5f7fb2xi46a9arfr97cyybizk6yi17p82nz6s9g7";
+        url = "https://elpa.nongnu.org/nongnu/git-modes-1.4.7.tar";
+        sha256 = "1rg38m9mx0vrbyn0d05n3zk2pnkp7122s33nlcj33xr7kslv46ci";
       };
       packageRequires = [ compat ];
       meta = {
@@ -2263,10 +2315,10 @@
     elpaBuild {
       pname = "gnosis";
       ename = "gnosis";
-      version = "0.5.5";
+      version = "0.5.8";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/gnosis-0.5.5.tar";
-        sha256 = "0na35233h87yk8h300g4vcfc5w4ckd09y8y7hwj7n3y725wi964h";
+        url = "https://elpa.nongnu.org/nongnu/gnosis-0.5.8.tar";
+        sha256 = "00halz9fmgccgc7px2zqp6q2js4ab60fixqbr15sdqbygmlwvhh7";
       };
       packageRequires = [
         compat
@@ -2439,10 +2491,10 @@
     elpaBuild {
       pname = "gptel";
       ename = "gptel";
-      version = "0.9.9";
+      version = "0.9.9.3";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/gptel-0.9.9.tar";
-        sha256 = "1vnnizqb60sipim7fllv5hvwd9xjsp08wyn1gnhn8j91yv90hlqb";
+        url = "https://elpa.nongnu.org/nongnu/gptel-0.9.9.3.tar";
+        sha256 = "19wwjjlpfa5ngmfj8v3hzf2ndr355s5vg9nzg8qmx3ni61jb08n7";
       };
       packageRequires = [
         compat
@@ -2612,10 +2664,10 @@
     elpaBuild {
       pname = "haskell-ts-mode";
       ename = "haskell-ts-mode";
-      version = "1.3.4";
+      version = "1.3.5";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/haskell-ts-mode-1.3.4.tar";
-        sha256 = "1z0bl88w9gf53cfmnfq0iqq2hqm2bmy6wl8fwydvayn77lr5x72h";
+        url = "https://elpa.nongnu.org/nongnu/haskell-ts-mode-1.3.5.tar";
+        sha256 = "19cy20wh2al1akgyx24jkks1hmfrhdrbw4h7a9g1nxsn7bw88lqy";
       };
       packageRequires = [ ];
       meta = {
@@ -2681,10 +2733,10 @@
     elpaBuild {
       pname = "hideshowvis";
       ename = "hideshowvis";
-      version = "0.8";
+      version = "0.9";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/hideshowvis-0.8.tar";
-        sha256 = "0xx2jjv95r1nhlf729y0zplfpjlh46nfnixmd3f5jc3z2pc6zf5b";
+        url = "https://elpa.nongnu.org/nongnu/hideshowvis-0.9.tar";
+        sha256 = "0yi9qcbacn97gl9y3zmvzr1b48hhx6h1yjcwllficahiq39fs0h8";
       };
       packageRequires = [ ];
       meta = {
@@ -2971,6 +3023,27 @@
       };
     }
   ) { };
+  isl = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "isl";
+      ename = "isl";
+      version = "1.6";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu/isl-1.6.tar";
+        sha256 = "1bsqq3i7flpbihvcmvcwb1s3gabq6wslwpamcqhcf15j30znwhb1";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu/isl.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   iwindow = callPackage (
     {
       compat,
@@ -3091,10 +3164,10 @@
     elpaBuild {
       pname = "keycast";
       ename = "keycast";
-      version = "1.4.5";
+      version = "1.4.6";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/keycast-1.4.5.tar";
-        sha256 = "0c847ailkfa46f6p4d9j6fg485cj8pwd208ynxz5sx5my4gqfnbw";
+        url = "https://elpa.nongnu.org/nongnu/keycast-1.4.6.tar";
+        sha256 = "0vvkcvir2wqgn6wl8yw689f7sx1qqvcynyyvd61b9c1jf8av90cd";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3124,6 +3197,32 @@
       };
     }
   ) { };
+  lem = callPackage (
+    {
+      elpaBuild,
+      fedi,
+      fetchurl,
+      lib,
+      markdown-mode,
+    }:
+    elpaBuild {
+      pname = "lem";
+      ename = "lem";
+      version = "0.24";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu/lem-0.24.tar";
+        sha256 = "1ykyahpd7y43lf3vk3a0w9rjim4lsm35mlw1qqljbixci2izk797";
+      };
+      packageRequires = [
+        fedi
+        markdown-mode
+      ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu/lem.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   llama = callPackage (
     {
       compat,
@@ -3134,10 +3233,10 @@
     elpaBuild {
       pname = "llama";
       ename = "llama";
-      version = "1.0.1";
+      version = "1.0.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/llama-1.0.1.tar";
-        sha256 = "1aldq3waibplzc2m1qfhf58rmi6h3wfgghmdk6q5ixx2y1gml1vq";
+        url = "https://elpa.nongnu.org/nongnu/llama-1.0.2.tar";
+        sha256 = "10dvvw6w082gdhq7an4z3krl94q0910fvap3p39gs8pmd898a9f7";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3158,10 +3257,10 @@
     elpaBuild {
       pname = "logview";
       ename = "logview";
-      version = "0.19.2";
+      version = "0.19.3";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/logview-0.19.2.tar";
-        sha256 = "0jcc726fh6lq9x6hhl9cm4i98irf5z3pz1lchkwwy21jippxwj2i";
+        url = "https://elpa.nongnu.org/nongnu/logview-0.19.3.tar";
+        sha256 = "1ldcjf0p8m0qnhqc98f5hi5kk05adl3j21b7nkc0b879v9bc9in9";
       };
       packageRequires = [
         compat
@@ -3187,10 +3286,10 @@
     elpaBuild {
       pname = "loopy";
       ename = "loopy";
-      version = "0.14.0";
+      version = "0.15.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/loopy-0.14.0.tar";
-        sha256 = "0kfa4rqmnc26nzwff4bd50rkpclmxpmw9r5hhnfasmm6k2m7fmpj";
+        url = "https://elpa.nongnu.org/nongnu/loopy-0.15.0.tar";
+        sha256 = "18l1bml8xiji0mgmm6fb669iwyidg7pay231kv14kbv1agiwfkbp";
       };
       packageRequires = [
         compat
@@ -3396,10 +3495,10 @@
     elpaBuild {
       pname = "mastodon";
       ename = "mastodon";
-      version = "2.0.3";
+      version = "2.0.7";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/mastodon-2.0.3.tar";
-        sha256 = "07snrvsbwvzky8b8whwy3qwwdzj84bfr23c2m11b5sskkgjykvy0";
+        url = "https://elpa.nongnu.org/nongnu/mastodon-2.0.7.tar";
+        sha256 = "1sk58jd9s623n86wb0gsl80dprfjll5c0rqc41naprrbcjfqfgzn";
       };
       packageRequires = [
         persist
@@ -3738,10 +3837,10 @@
     elpaBuild {
       pname = "org-contrib";
       ename = "org-contrib";
-      version = "0.6";
+      version = "0.7";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/org-contrib-0.6.tar";
-        sha256 = "02rpy7psjp1mj2nbzzbc06i4961m83hkq5ndks56mfkcz4hdhj2m";
+        url = "https://elpa.nongnu.org/nongnu/org-contrib-0.7.tar";
+        sha256 = "1v9sphc2jwccdix74ry3wblkkp9majk7n7c9ic1bsq9caj4i9n5r";
       };
       packageRequires = [ org ];
       meta = {
@@ -3924,10 +4023,10 @@
     elpaBuild {
       pname = "orgit";
       ename = "orgit";
-      version = "2.0.5";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/orgit-2.0.5.tar";
-        sha256 = "0k24rg1pfajqnagd2yljsccs66si56d7s4aybq9jd086f4wx3fcq";
+        url = "https://elpa.nongnu.org/nongnu/orgit-2.1.0.tar";
+        sha256 = "1wncvmg6x6w0pw9d2xl7i3m621q7jmx7sl76llnf29vbrdq7yiq9";
       };
       packageRequires = [
         compat
@@ -4172,10 +4271,10 @@
     elpaBuild {
       pname = "pg";
       ename = "pg";
-      version = "0.60";
+      version = "0.61";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/pg-0.60.tar";
-        sha256 = "06jlr38jbxnmmgqqic1n6d22sx0kfszv9awh3597lsvx044ix48j";
+        url = "https://elpa.nongnu.org/nongnu/pg-0.61.tar";
+        sha256 = "0vzx2nsxvl9a77mfri1cqmxibd15c4is61lazs2hl8cqzw7msxjl";
       };
       packageRequires = [ peg ];
       meta = {
@@ -4243,6 +4342,27 @@
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu/popup.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  powershell = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "powershell";
+      ename = "powershell";
+      version = "0.4";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu/powershell-0.4.tar";
+        sha256 = "13f7rfjcip64if7mxd12pnrw409xdmxblddri49laacvi1qhlj9k";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu/powershell.html";
         license = lib.licenses.free;
       };
     }
@@ -4321,10 +4441,10 @@
     elpaBuild {
       pname = "racket-mode";
       ename = "racket-mode";
-      version = "1.0.20250830.122523";
+      version = "1.0.20251106.215641";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/racket-mode-1.0.20250830.122523.tar";
-        sha256 = "0bxinraaj2cnhd6x1sgps36k5vir57l4jn0x5rlndv4lsb2bp18c";
+        url = "https://elpa.nongnu.org/nongnu/racket-mode-1.0.20251106.215641.tar";
+        sha256 = "0jrz8c3ni81cczai01j1359m8j3pp620lirx1j534jn52b7xqy0q";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5452,10 +5572,10 @@
     elpaBuild {
       pname = "visual-fill-column";
       ename = "visual-fill-column";
-      version = "2.7.0";
+      version = "2.7.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/visual-fill-column-2.7.0.tar";
-        sha256 = "1xv42kzmizhr7k35xw08zib71anrif3gsbzc566gvl7yqpjd30zm";
+        url = "https://elpa.nongnu.org/nongnu/visual-fill-column-2.7.1.tar";
+        sha256 = "0c5vammsvj0cx343s9nncdmcrpbaqiwk276clqkib594g74rjnmd";
       };
       packageRequires = [ ];
       meta = {
@@ -5584,10 +5704,10 @@
     elpaBuild {
       pname = "with-editor";
       ename = "with-editor";
-      version = "3.4.6";
+      version = "3.4.7";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/with-editor-3.4.6.tar";
-        sha256 = "1l3sdfd6k6baw87jgz25f7rlgwgi15f2nj51cfgjy6kkgf5ag48s";
+        url = "https://elpa.nongnu.org/nongnu/with-editor-3.4.7.tar";
+        sha256 = "06z64yp4dxwnrz5n6bwd3yf2h0502f2gx6zgnzsni8pk6zsb1l22";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5694,10 +5814,10 @@
     elpaBuild {
       pname = "xah-fly-keys";
       ename = "xah-fly-keys";
-      version = "28.7.20250917123258";
+      version = "28.11.20251125073911";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/xah-fly-keys-28.7.20250917123258.tar";
-        sha256 = "1d4r112via671f2x0db1ssxsbhi1w24zklgik3wgz619ng7al2ry";
+        url = "https://elpa.nongnu.org/nongnu/xah-fly-keys-28.11.20251125073911.tar";
+        sha256 = "0qkgbi1637nxvkx7cpycx80lywcwnld3x4y77mksx9z1v6pyhrd7";
       };
       packageRequires = [ ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
@@ -1591,6 +1591,30 @@
   }
  },
  {
+  "ename": "acp",
+  "commit": "c925f259e6acf131e3008c0635edeeca66a0a9d0",
+  "sha256": "1mlx24yva1kzdrrhl3vg4nb6wyws88y131xp6gvjg0hgrigwbqq4",
+  "fetcher": "github",
+  "repo": "xenodium/acp.el",
+  "unstable": {
+   "version": [
+    20251127,
+    1649
+   ],
+   "commit": "8f82c9a65bb44ba2aad452bfa2a62c443bc12fb1",
+   "sha256": "0kgb7ir65kh2112i0gsanhniqk5li021p4g2fs6w3vis8ygsz2wc"
+  },
+  "stable": {
+   "version": [
+    0,
+    7,
+    1
+   ],
+   "commit": "f9dd828c7bfb209523e907cc947668924ff9f1bf",
+   "sha256": "04sd5qwfd3cgb8anfa7ygs4pjl1k9d0crf033cs3ymhi2lfmiq8i"
+  }
+ },
+ {
   "ename": "act-mode",
   "commit": "cf407f944186776070ec6900d1bb8846cb3b8e57",
   "sha256": "01nybw8gz2fk4938nkb68znbgcpw1ik31kqc2h6iwn6kvnchpw26",
@@ -1703,11 +1727,20 @@
   "repo": "brownts/ada-ts-mode",
   "unstable": {
    "version": [
-    20250309,
-    1743
+    20251125,
+    2018
    ],
-   "commit": "d0c1c124b236b402b884188948cb1f3502ef8779",
-   "sha256": "0ilyhvg6ik98rsl9yim8jb3nkfwi8yh9i6nh5wprbmqrmmk63dr6"
+   "commit": "52e0fd11604ab1d51a34c89e05692446d9dc5ecb",
+   "sha256": "064lbyywnlcgjfz86bwhk13waqsc651jrnpf9liqc55r8i97igxi"
+  },
+  "stable": {
+   "version": [
+    0,
+    8,
+    3
+   ],
+   "commit": "52e0fd11604ab1d51a34c89e05692446d9dc5ecb",
+   "sha256": "064lbyywnlcgjfz86bwhk13waqsc651jrnpf9liqc55r8i97igxi"
   }
  },
  {
@@ -1802,11 +1835,11 @@
   "repo": "thierryvolpiatto/addressbook-bookmark",
   "unstable": {
    "version": [
-    20250803,
-    408
+    20251106,
+    1903
    ],
-   "commit": "09936ea4dd490ffcc4d63a89a4eb4c321b587703",
-   "sha256": "1872yba5xjh3qsaq4zn4k9wnw213rsj75f6mj2qmmzdpr85sja38"
+   "commit": "a93118ce6cb69c5766f5f74fab32b0108d410827",
+   "sha256": "0j0v3vixa9wji2jyh5l55fdw6dgs2w9688lgvj8wfhnb0pq7r0sn"
   },
   "stable": {
    "version": [
@@ -2034,6 +2067,21 @@
   }
  },
  {
+  "ename": "agda-lib-mode",
+  "commit": "e729950f9bad335dee314ac897d5b5592da4a035",
+  "sha256": "0226wnpbh0sr565n90p0ymplxb4v6hdd7x66pg32x2shvwajxcic",
+  "fetcher": "codeberg",
+  "repo": "heraplem/agda-lib-mode",
+  "unstable": {
+   "version": [
+    20251013,
+    2307
+   ],
+   "commit": "1cf7d486753887736eef6cae2688b2a05f9c1854",
+   "sha256": "0lvzjpprvyc040gvqnz8bab04q2kl0yplr44h09v2zk6iz7rhqsy"
+  }
+ },
+ {
   "ename": "age",
   "commit": "50eee72024c2c915022c12c713cab3ac7e2c68f0",
   "sha256": "1h3qc46z9lw62h2n501drx18kx2zm437vrfn33vg9la4fd3phl59",
@@ -2078,6 +2126,38 @@
    ],
    "commit": "36ad60f0b7f2a12b730c6f568fcfd4daf2581158",
    "sha256": "17l6j83i2xm3agrrbmg2pwccim6y9f65b1vsripv95fyxhp6l1mm"
+  }
+ },
+ {
+  "ename": "agent-shell",
+  "commit": "1895e21adfb5e4dfccb4d4db49c213c77fc57727",
+  "sha256": "1s3nq2q47zagyzsl8pbhqmk0c1c4549hm37r78b2hqg9lqwkqb8y",
+  "fetcher": "github",
+  "repo": "xenodium/agent-shell",
+  "unstable": {
+   "version": [
+    20251128,
+    1431
+   ],
+   "deps": [
+    "acp",
+    "shell-maker"
+   ],
+   "commit": "17aa148caa685b0a23c978098ffdeb59fe2c2682",
+   "sha256": "0drvxr9s4d33x8vwig5kwsjc85xs4ar59g46ra94a3fy1jc59dqq"
+  },
+  "stable": {
+   "version": [
+    0,
+    18,
+    1
+   ],
+   "deps": [
+    "acp",
+    "shell-maker"
+   ],
+   "commit": "3803449d80318bb4005fd9509ebc8a669750ceea",
+   "sha256": "0876j6a9wwcg6n7giwbvnyxfjka42b5vadnnbrvxv8vkxf6nsrj0"
   }
  },
  {
@@ -2223,8 +2303,8 @@
   "repo": "tninja/aider.el",
   "unstable": {
    "version": [
-    20250910,
-    525
+    20251125,
+    23
    ],
    "deps": [
     "magit",
@@ -2232,14 +2312,14 @@
     "s",
     "transient"
    ],
-   "commit": "7fc7041524f960bac46098dfcd23d096f8c7f0b9",
-   "sha256": "1cwhmizknq31v5mdj173wsqzvf4cp272hff93mwiq21xc4dqsca6"
+   "commit": "6f6472586413f59cce992ecaa79276e3b56212ca",
+   "sha256": "1932ghif057mxm9nz1213gf8j26ispl6ikfr90hrlag168c2f630"
   },
   "stable": {
    "version": [
     0,
     13,
-    1
+    2
    ],
    "deps": [
     "magit",
@@ -2247,8 +2327,8 @@
     "s",
     "transient"
    ],
-   "commit": "19adf3246aac61fca6ec11b5c8967e52fd7a7f63",
-   "sha256": "19y8s0gmfxp4m5508jkmw8wmb9z9xsrjm55r5bja2kl6c1i6xx57"
+   "commit": "6f6472586413f59cce992ecaa79276e3b56212ca",
+   "sha256": "1932ghif057mxm9nz1213gf8j26ispl6ikfr90hrlag168c2f630"
   }
  },
  {
@@ -2259,29 +2339,29 @@
   "repo": "MatthewZMD/aidermacs",
   "unstable": {
    "version": [
-    20250927,
-    502
+    20251122,
+    1547
    ],
    "deps": [
     "compat",
     "markdown-mode",
     "transient"
    ],
-   "commit": "c6cb54d58aa5434ee39db77fde3945e078559f00",
-   "sha256": "0lknlkjrpml5pgkj84qc9bdyc3yh5ii85cffswsawb13xgbvww0x"
+   "commit": "1158314ef4319fd7f0c0eb84a1d17250a6b5648f",
+   "sha256": "13kzhv3fn4161b2wcdg09ynzcg6siyymqchj6fgav0kg41aicyz5"
   },
   "stable": {
    "version": [
     1,
-    5
+    6
    ],
    "deps": [
     "compat",
     "markdown-mode",
     "transient"
    ],
-   "commit": "5084913506b8b243c732a77b6de4768f18edcff3",
-   "sha256": "0p24acxdskc9khkk79aj216fn2sdwlbwsnw7q0jvsdxfi1ryymbj"
+   "commit": "9cd6796833b7f830b55d2e3dcc6ef05693bed61b",
+   "sha256": "0fbhigzba5mj9303bvwn999dain916zqc59hvl2gk7v2i5gr1wmb"
   }
  },
  {
@@ -2334,19 +2414,19 @@
   "repo": "skeeto/emacs-aio",
   "unstable": {
    "version": [
-    20200610,
-    1904
+    20251117,
+    644
    ],
-   "commit": "da93523e235529fa97d6f251319d9e1d6fc24a41",
-   "sha256": "0hnxbz5pxlrgxhjr5gnhf06qwg67g5pd87xkp0smmagsh18pnf76"
+   "commit": "58157e51e7eb7a4b954894ee4182564c507a2f01",
+   "sha256": "10m6kkcb2gk0vaj6z3d8kcf72zqmi8mw4bx39nvkx4c2ssx5k66g"
   },
   "stable": {
    "version": [
     1,
-    0
+    1
    ],
-   "commit": "077722896e649e7a33dcafbc4585686a29423979",
-   "sha256": "1y7j10j74r3fy0rcb8g3cm9nlls34qb0pz9xkia7psp77syrlz54"
+   "commit": "e0105f8ec8c47c12c0958442d0eaef72c94e8747",
+   "sha256": "15pyqf0k3k1z2p97zz86xqbjd28i3qmrb6ypdvflfs5zrmxs16hb"
   }
  },
  {
@@ -2522,11 +2602,11 @@
   "repo": "alezost/alect-themes",
   "unstable": {
    "version": [
-    20211022,
-    1651
+    20251109,
+    1013
    ],
-   "commit": "89560047934c236d05ea6b911c0c63702a8e06f3",
-   "sha256": "190clnm5x4hpzrq2wp18vxg6614ly3ciyv0y1sm9rfr9w9z5i0ya"
+   "commit": "cd188417e66d29ac79235e40f745fa160e2b9421",
+   "sha256": "0a6mm3vhfqxdi04y60bfjlsyv9b12p0fwwzz00q8y4gdzxadk79d"
   },
   "stable": {
    "version": [
@@ -3378,11 +3458,11 @@
   "repo": "anki-editor/anki-editor",
   "unstable": {
    "version": [
-    20250930,
-    1609
+    20251107,
+    1231
    ],
-   "commit": "17d56b130e7422054a84e4d286b315801d9cc4f0",
-   "sha256": "0ipknpb1wnh3gzqd4h5hy1a407b74791v4qkh5h1mq13fqlgx04b"
+   "commit": "9289601129d42c4621a87fde856e077847314dcc",
+   "sha256": "1rxmj3mxvqcxqkgd4qvh6fa9asd4iqd3qvk07vm8bff7253mzsci"
   }
  },
  {
@@ -3493,11 +3573,11 @@
   "repo": "bastibe/annotate.el",
   "unstable": {
    "version": [
-    20250515,
-    1428
+    20251111,
+    1635
    ],
-   "commit": "dc6e884265c9de5b0e486b9f6bd9509a14b85c94",
-   "sha256": "07jbi3ripkmbsx51w57qiwi9pi2bd1a05rd627vg99avv9j00mj5"
+   "commit": "9c80b465297dce20901abaf0389a48951b6e030f",
+   "sha256": "04d8737kjqavg8j062wf6z1fd7k8l25bcc7h82fgg9w485c953qk"
   },
   "stable": {
    "version": [
@@ -3583,14 +3663,14 @@
   "repo": "rejeep/ansi.el",
   "unstable": {
    "version": [
-    20230306,
-    1823
+    20251118,
+    230
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "c79806eacdf96e061abf5334f4c3364a995705d4",
-   "sha256": "0y4jifvy1jrc20q10dnh0fkzjxj6y2af4nr07k0047c2mfz69fmv"
+   "commit": "a3aa9daa37a75fec22186399014a790a6c554311",
+   "sha256": "0p2p28kpzv7l3dbgcyyd9yc6yrxh48x5khqdj4m07a39r2pp2p9l"
   },
   "stable": {
    "version": [
@@ -3669,35 +3749,35 @@
   "repo": "freehck/ansible-vault-mode",
   "unstable": {
    "version": [
-    20250331,
-    2155
+    20251029,
+    2146
    ],
-   "commit": "f0fab5d8d56e4c16f9fa85f22635cb0cec3637e1",
-   "sha256": "15imwyq8zm0s3ccycdrmwfqcb124lz7xrymjmvz67ynsvzh1lcmp"
+   "commit": "74f96ce226f51bec203af343f73182ea132749a6",
+   "sha256": "1mj07znw8chdxcg0hi07mgay0i9p55sy8fwaw1waxfp47izqvq1x"
   },
   "stable": {
    "version": [
     0,
-    5,
-    4
+    6,
+    1
    ],
-   "commit": "206801defa0058da0ab6ed4d58daff0e3ededcb7",
-   "sha256": "0xi263bz2jf9fpbmn2n2vplrhxw49xrg8msg1fnxbr8bcl4612z8"
+   "commit": "74f96ce226f51bec203af343f73182ea132749a6",
+   "sha256": "1mj07znw8chdxcg0hi07mgay0i9p55sy8fwaw1waxfp47izqvq1x"
   }
  },
  {
   "ename": "ansilove",
-  "commit": "8f0e33e241bbdbac9847f4acfe11f255e20c9c67",
-  "sha256": "05h5r66aq4nbrfgqp39pa6p0zjbzki963yc6ii5jyybllh6x4bis",
+  "commit": "dcf3a770af51d6cb3a45b85d81d4a517f7d91959",
+  "sha256": "0nfm7s590q4sz3lqkl48knbi0sa7kzh7hwwf7j0rrhg7qwkiwlma",
   "fetcher": "gitlab",
-  "repo": "xgqt/emacs-ansilove",
+  "repo": "xgqt/xgqt-elisp-lib-ansilove",
   "unstable": {
    "version": [
-    20230210,
-    1338
+    20250105,
+    1853
    ],
-   "commit": "abd64819dc67e1ababd38d39c7c7f6a2459987c0",
-   "sha256": "05q548dyb620kg12mgkmw6jpwbr2y2aqs5p7314y2c37khvw5irg"
+   "commit": "a75eb6c89a1d96e1b4fa028ecca9be8b13c95230",
+   "sha256": "0m4iqmijn7zpgw0d7lgpa5k6w1azlik12pwdb0bzsprwwync5g2d"
   },
   "stable": {
    "version": [
@@ -3911,20 +3991,20 @@
   "repo": "radian-software/apheleia",
   "unstable": {
    "version": [
-    20250807,
-    2320
+    20251128,
+    1951
    ],
-   "commit": "f1d36031fc162f541f77d4f6c6c0fd6197aba077",
-   "sha256": "02l36zd37lrdxvv82j1hq7wn07nddw6569ni60y5pbcg22fzsbq6"
+   "commit": "436cd94b3e01c8c4314645417ce40b1acdb5d2cb",
+   "sha256": "0ddaplrzkcp26b5bni3l8np7gn623ijdak8fd0ifrnxnga6i3hdl"
   },
   "stable": {
    "version": [
     4,
     4,
-    1
+    2
    ],
-   "commit": "82cbb665bc6a62de59e00aa76dcef29ef3a6c3a2",
-   "sha256": "06zbl4syvk05qh57mlzwyw9avyag26yirw99b9l3z0fxcmyn8l39"
+   "commit": "5e5969d7c8afa4c40948d95dc41fe66e30f3a282",
+   "sha256": "1ldj6cny88b7j0jspv68sw5z9jpfpqimavmbnhcbq7gmc6xlbmvz"
   }
  },
  {
@@ -4064,11 +4144,11 @@
   "repo": "waymondo/apropospriate-theme",
   "unstable": {
    "version": [
-    20250724,
-    1422
+    20251010,
+    121
    ],
-   "commit": "4457fb40db9893fe92f4afcd9420c37c503701f0",
-   "sha256": "1wq0hm05v22r7ksxlyxklm4pldbybd4608ilvpc2gmhckbig0b61"
+   "commit": "2b26eed7e2063ca93998a6807f5a4e602483a23d",
+   "sha256": "0sdqy1vkvnkhxwfdpsrq0y2npr6w617fgv1bw7y7rm18vpw8mmri"
   },
   "stable": {
    "version": [
@@ -5322,20 +5402,20 @@
   "repo": "emacscollective/auto-compile",
   "unstable": {
    "version": [
-    20250901,
-    1341
+    20251111,
+    1802
    ],
-   "commit": "20744a681ba5f0584695973a5ece3a794026ff76",
-   "sha256": "10kjl3cvkq024a3kh30s6l0x326cbm6nz6904zkafxjz4lbrryln"
+   "commit": "7d314cc13515a1bd6ded29e69a9d4be4aff205c3",
+   "sha256": "1qdg4acschcjp3z7bqwafjcc819kmy1h2mfmap15qp92mlb1w1cn"
   },
   "stable": {
    "version": [
     2,
     1,
-    0
+    1
    ],
-   "commit": "20744a681ba5f0584695973a5ece3a794026ff76",
-   "sha256": "10kjl3cvkq024a3kh30s6l0x326cbm6nz6904zkafxjz4lbrryln"
+   "commit": "37b0394b1ed61650df269ab82b2ed09a5a86454c",
+   "sha256": "12knl2m3zww2ayl4fmpvwdjpd0qjfzlfmjslb0r6pfkwj7ixy1da"
   }
  },
  {
@@ -5346,14 +5426,14 @@
   "repo": "auto-complete/auto-complete",
   "unstable": {
    "version": [
-    20250101,
-    843
+    20251123,
+    1919
    ],
    "deps": [
     "popup"
    ],
-   "commit": "01bbfdf12b34ad04d0a44c98c1385df6ef0db449",
-   "sha256": "0vzq2wlyd0n4cs6krx0350992hpf4xn55wrwj6jsqjlxpphx3bjz"
+   "commit": "1dbfb343412f9444dcd2d9a08b7b42c7270c9547",
+   "sha256": "1yvqswh481arfjc1ylvyfrdr4klqwwj0rk50l33b0q1mrp98cx1j"
   },
   "stable": {
    "version": [
@@ -5883,6 +5963,30 @@
   }
  },
  {
+  "ename": "auto-save-visited-local-mode",
+  "commit": "479465bc342df072570b15aaef2a8422d716603f",
+  "sha256": "1rwwi86azzwrzm52a7rql1q6ja3bv5jh0s857f9vyz9a5gyyn3l1",
+  "fetcher": "github",
+  "repo": "pierrelegall/auto-save-visited-local-mode",
+  "unstable": {
+   "version": [
+    20251021,
+    1126
+   ],
+   "commit": "78a46d8a02360b4c63e45496bd32efe351459c81",
+   "sha256": "1nr9nl1lwwdwd0bgd1sihgf549yj6p25kfa10igqzrricjfhq40s"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    2
+   ],
+   "commit": "78a46d8a02360b4c63e45496bd32efe351459c81",
+   "sha256": "1nr9nl1lwwdwd0bgd1sihgf549yj6p25kfa10igqzrricjfhq40s"
+  }
+ },
+ {
   "ename": "auto-shell-command",
   "commit": "ea710bfa77fee7c2688eea8258ca9d2105d1896e",
   "sha256": "1i78fh72i8yv91rnabf0vs78r43qrjkr36hndmn5ya2xs3b1g41j",
@@ -6198,26 +6302,26 @@
   "repo": "jasonm23/autothemer",
   "unstable": {
    "version": [
-    20230414,
-    1419
+    20251114,
+    415
    ],
    "deps": [
     "dash"
    ],
-   "commit": "8f72afc6dba5ad7cc3a201a084fd20571f945d2e",
-   "sha256": "15f7i39937riswpwjpc1ryg2v0rqj944pwf7rp2ry56rbx4vgl97"
+   "commit": "e62bf83414abd8b1cefafb7480612faa30ed7878",
+   "sha256": "0w7qrfl38qc64a6bansrmvzxcdrlfpkd4l41scgr242dgy4dnq45"
   },
   "stable": {
    "version": [
     0,
     2,
-    17
+    18
    ],
    "deps": [
     "dash"
    ],
-   "commit": "d4bd4427f541b7a0803a9ef849cc935c0f86df17",
-   "sha256": "13lj0igrsdycsr8ldv2hilj2x79c888g4lx2ixqn7w29lw6cb44g"
+   "commit": "0d3ed8d74cdf9be90492999217db1bc7ba866607",
+   "sha256": "06xsj7yvcwgl8pxi3cr17fprpbi12csbk9r6nmm75wqys8yywld5"
   }
  },
  {
@@ -6303,14 +6407,14 @@
   "repo": "nameiwillforget/avy-act",
   "unstable": {
    "version": [
-    20250727,
-    1603
+    20251104,
+    1920
    ],
    "deps": [
     "avy"
    ],
-   "commit": "6e60b4bac5501e29e12daccea15594755c847295",
-   "sha256": "1kkchn6qq318a2a1i80inckxh10ziqg6w6pvjlhh3y2gslq93yxj"
+   "commit": "61b0bf036da3755ded04f8bc295a8a54407ea758",
+   "sha256": "13gcjbf4i1vfwx5ga95xixld8jx0gjr1nvdkxpk9rdplqzjwnx2l"
   }
  },
  {
@@ -6727,28 +6831,28 @@
   "repo": "tarsius/backline",
   "unstable": {
    "version": [
-    20250901,
-    1339
+    20251101,
+    1936
    ],
    "deps": [
     "compat",
     "outline-minor-faces"
    ],
-   "commit": "49ff6466633d14850a7d58eaa4c026c7764cd424",
-   "sha256": "08fzzm69rym32jnfb4k4rwp9sv64jcyxj8rf313i7pjqkzn3czd3"
+   "commit": "821dab84aba746247be184066b2a69a6545ed346",
+   "sha256": "0ap3vfrxpvxgg0lv0blwkqnyv8rfwfl6zazky2nsg22kp3wd1ij4"
   },
   "stable": {
    "version": [
     1,
     2,
-    0
+    1
    ],
    "deps": [
     "compat",
     "outline-minor-faces"
    ],
-   "commit": "49ff6466633d14850a7d58eaa4c026c7764cd424",
-   "sha256": "08fzzm69rym32jnfb4k4rwp9sv64jcyxj8rf313i7pjqkzn3czd3"
+   "commit": "821dab84aba746247be184066b2a69a6545ed346",
+   "sha256": "0ap3vfrxpvxgg0lv0blwkqnyv8rfwfl6zazky2nsg22kp3wd1ij4"
   }
  },
  {
@@ -6992,11 +7096,11 @@
   "repo": "tinted-theming/base16-emacs",
   "unstable": {
    "version": [
-    20250914,
-    123
+    20251123,
+    144
    ],
-   "commit": "3c41bbd9bb315d39a56b9ab4fa7dc06c7a8a8639",
-   "sha256": "0ljk7vhzisjr1if8lilvy07wi91jnfsdxi4lgk945kzdgmbwxcja"
+   "commit": "94505fbd01acb4af3f742a584aea6203dd7d5029",
+   "sha256": "1yi2fd6rpb81gzkd2hlwsrsgk21lqilb8ii1hdz3za63afy95hhc"
   },
   "stable": {
    "version": [
@@ -7748,11 +7852,11 @@
   "repo": "technomancy/better-defaults",
   "unstable": {
    "version": [
-    20241028,
-    4
+    20251012,
+    2227
    ],
-   "commit": "fde8d8f9cf8c038c8ef902d939df4745e88fac88",
-   "sha256": "1kdin9c9lnzfy096l3hf3g54czpds4kgg13drj0d6aa2i0d6n78l"
+   "commit": "b4e566ddd368609c7df711c4f0d9cc345455aa0f",
+   "sha256": "1jn2cp2hj62yl3ari0q7jdjw0cmnwzidd9xd1d2w3xwc998j8har"
   }
  },
  {
@@ -8142,26 +8246,26 @@
   "repo": "tarsius/bicycle",
   "unstable": {
    "version": [
-    20250601,
-    1007
+    20251101,
+    1937
    ],
    "deps": [
     "compat"
    ],
-   "commit": "8d20cb42dc44080f3af4d712e54ae34d9a6b5e62",
-   "sha256": "0yly5hlfjr331p5pc7dpdwsvx45j9lg2hw98bzvh1j0nvi35siz4"
+   "commit": "baeb42c79fa213c1e47ab1158c01abdf0a4c54d3",
+   "sha256": "0mihvfhs3klm3ydc9zicfs4cpbyg48wdkw0wp7nk6bifa8a28j7s"
   },
   "stable": {
    "version": [
     1,
-    0,
-    2
+    1,
+    1
    ],
    "deps": [
     "compat"
    ],
-   "commit": "8d20cb42dc44080f3af4d712e54ae34d9a6b5e62",
-   "sha256": "0yly5hlfjr331p5pc7dpdwsvx45j9lg2hw98bzvh1j0nvi35siz4"
+   "commit": "baeb42c79fa213c1e47ab1158c01abdf0a4c54d3",
+   "sha256": "0mihvfhs3klm3ydc9zicfs4cpbyg48wdkw0wp7nk6bifa8a28j7s"
   }
  },
  {
@@ -8315,11 +8419,11 @@
   "repo": "justbur/emacs-bind-map",
   "unstable": {
    "version": [
-    20250308,
-    1210
+    20251119,
+    201
    ],
-   "commit": "f23cfc13222a39e686d28a83ff83e9901d8908b2",
-   "sha256": "1a05nxm0iadvqy3wlz58f7c4g0lvip3n8dwkn1fr14dyl1vssgar"
+   "commit": "75aac732c10d97bc8dc49196c6623a09faf30d37",
+   "sha256": "16s8n5a85x512fizaa61p6sls9dakmvv9wlq4qfgns7gjykkcigy"
   },
   "stable": {
    "version": [
@@ -8926,14 +9030,14 @@
   "repo": "lapislazuli/blue.el",
   "unstable": {
    "version": [
-    20251010,
-    1137
+    20251119,
+    2110
    ],
    "deps": [
     "magit-section"
    ],
-   "commit": "6f2162a0a8a94f76c22beeffa8b10f36579cc0d0",
-   "sha256": "1viiqaij9dbkn3qnbnwvq660swgzhnf2cn0rc662zk4ldhb88vqx"
+   "commit": "9aaf48ee5cb9731c0bfcc5368da3ba1a6fc06804",
+   "sha256": "1mk7hlcxsa6ssh0aixskf00h86d6xyrvncnhxzdia9xjp28lgkaw"
   }
  },
  {
@@ -8944,19 +9048,19 @@
   "repo": "rwv/bluesound-el",
   "unstable": {
    "version": [
-    20231124,
-    1347
+    20251022,
+    1406
    ],
-   "commit": "92f6ebacfa20e89ccd10d27bdb84c74b6413cc68",
-   "sha256": "1ffhdh7jryzpbzn2bcgxn06pi431dg5n4zjg06qkshydj580gwck"
+   "commit": "60d7f422483bd7f3cf23983160e28ecff9c14b38",
+   "sha256": "1bg2y0ny4yszs03hj7aiq8mm57zbind5i0pk17bms12sl2ahkm82"
   },
   "stable": {
    "version": [
     0,
-    2
+    3
    ],
-   "commit": "416b9825db5feea326388ca1bec2614046522006",
-   "sha256": "1a2zwc185nzj3qa59xlxvnlngsk2y1kxsqr6m4j20p5l8vd1wgcp"
+   "commit": "60d7f422483bd7f3cf23983160e28ecff9c14b38",
+   "sha256": "1bg2y0ny4yszs03hj7aiq8mm57zbind5i0pk17bms12sl2ahkm82"
   }
  },
  {
@@ -9249,11 +9353,11 @@
   "repo": "ideasman42/emacs-bookmark-in-project",
   "unstable": {
    "version": [
-    20250921,
-    813
+    20251126,
+    519
    ],
-   "commit": "a15821d3acb5c010a0a309ddd5d957ea6a56a4e4",
-   "sha256": "0mmvxhk2gck861hs85883s43gfi7mc4az8f6c6z4gz41whdhwy71"
+   "commit": "9602be7da3fbd78ca6a94ca28f67ace08d82d497",
+   "sha256": "15pbwq84nv4rl2lxbpclnwwq0c5nc941z243akb11kd0yxrqapr9"
   }
  },
  {
@@ -9336,28 +9440,28 @@
   "repo": "emacscollective/borg",
   "unstable": {
    "version": [
-    20251006,
-    1814
+    20251119,
+    1634
    ],
    "deps": [
     "epkg",
     "magit"
    ],
-   "commit": "5b192d8d1a426402b98a2e2e3342c4b73477fbcc",
-   "sha256": "1ppys1bc24ia4qq608wn93w13489a558ia87bz32biiqj4yhmpqg"
+   "commit": "2669e518b176dc3abc0b40d9557e3f8356cda87c",
+   "sha256": "01gayd8wn7ac9hliy1vy9ckspy0xsir57xi036nypq88gdwvj89a"
   },
   "stable": {
    "version": [
     4,
-    2,
-    2
+    3,
+    0
    ],
    "deps": [
     "epkg",
     "magit"
    ],
-   "commit": "5b192d8d1a426402b98a2e2e3342c4b73477fbcc",
-   "sha256": "1ppys1bc24ia4qq608wn93w13489a558ia87bz32biiqj4yhmpqg"
+   "commit": "28e6ba50fab83ffbcb0484dbdb1d5c180537235a",
+   "sha256": "0mwl0k98bidg7klays3ir7yag9q98f23sasias1f4phk7qxmb6sc"
   }
  },
  {
@@ -9515,11 +9619,11 @@
   "repo": "tarsius/paren-face",
   "unstable": {
    "version": [
-    20250822,
-    1936
+    20251101,
+    2048
    ],
-   "commit": "88cbcf779d3c382cf785a540a2134a663b753d7b",
-   "sha256": "0rxrcnpsar1550ihfr6a8qf0cx1p5va14cdx70ykqzfpvcbg5rdw"
+   "commit": "b121bc08ecb0c11a89705ed9f77c5343e2baec04",
+   "sha256": "0bs5hdn7agyr0r0ywblpihp4x3gn89xdfvzsb8wlyd0gvc2rx6g9"
   }
  },
  {
@@ -9563,11 +9667,11 @@
   "repo": "ideasman42/emacs-bray",
   "unstable": {
    "version": [
-    20250920,
-    932
+    20251012,
+    25
    ],
-   "commit": "75e671b07a501889b7d68da3c81d6bd86b817614",
-   "sha256": "03szhjpbxch22xxyhppfl00p5s17bbx23pmkwgcv7hihkncnvi64"
+   "commit": "d17c245a15bae1ba8aa83bb1fb71508e04ac1258",
+   "sha256": "0rlf3afq661aaj9pbzd4nmmzj5nd35y6kg2wv3d449fbfhpy11nx"
   }
  },
  {
@@ -10051,11 +10155,11 @@
   "repo": "ideasman42/emacs-buffer-name-relative",
   "unstable": {
    "version": [
-    20250913,
-    2251
+    20251016,
+    2312
    ],
-   "commit": "f59cd8c0ecf6670da1d2a1468240d3f81663884b",
-   "sha256": "04iqprrb1s2m9v958g26s5dm8b9p15aqai2941hbw7ffj91b5zx8"
+   "commit": "089ef7a1ea3156f900aeb7e0674e780fd230ecda",
+   "sha256": "0apz4z6hzy8nnsvsra316nsw5xqxd3j9dqf9zq799vqv4diswa9c"
   }
  },
  {
@@ -10245,11 +10349,11 @@
   "repo": "jamescherti/bufferfile.el",
   "unstable": {
    "version": [
-    20250822,
-    1931
+    20251011,
+    1158
    ],
-   "commit": "5f169b301e04d183500261825bb7af76a35b7ad0",
-   "sha256": "1v3i9fzklq7j5440xb9jsgrbywzkdsrx3pih328ba44d4h7sj4yq"
+   "commit": "e4e5c46fcf656fa06f7388b514fbf17636bba424",
+   "sha256": "0g5fmmfh5l9zraw05hws4kwfzrbj4b5qfl178nph6lzw39dzc953"
   },
   "stable": {
    "version": [
@@ -10455,37 +10559,6 @@
    ],
    "commit": "c29a0146c5d0be274f5e17921e01698f572c23a1",
    "sha256": "03f0h7sp0sr9kjyhvcx7i34lvc26f5x8nikfidihgzhrqpprv2b6"
-  }
- },
- {
-  "ename": "bundler",
-  "commit": "3416586d4d782cdd61a56159c5f80a0ca9b3ddf4",
-  "sha256": "1jvcrxwsf9yd5vhirfdmjl52n6hffr1vikd386qbn32vgqcsba7a",
-  "fetcher": "github",
-  "repo": "endofunky/bundler.el",
-  "unstable": {
-   "version": [
-    20200129,
-    1338
-   ],
-   "deps": [
-    "cl-lib",
-    "inf-ruby"
-   ],
-   "commit": "43efb6be4ed118b06d787ce7fbcffd68a31732a7",
-   "sha256": "1r7x3xw4l5bp4dfqk2v2nrd2yl0rs064gw75nx99ifm92n7nkmgh"
-  },
-  "stable": {
-   "version": [
-    1,
-    1,
-    0
-   ],
-   "deps": [
-    "inf-ruby"
-   ],
-   "commit": "4cb4fafe092d587cc9e58ff61cf900fb7f409adf",
-   "sha256": "18d74nwcpk1i8adxzfwz1lgqqcxsc4wkrb490v64pph79dxsi80h"
   }
  },
  {
@@ -10815,6 +10888,21 @@
   }
  },
  {
+  "ename": "cabal-mode",
+  "commit": "8116eb6af6928e34167cf0825f293471ceeb7e30",
+  "sha256": "1n6vdflrfm4n4lmh5y46jpc4mh8dr0hikawvgdmiyyakz4mf023i",
+  "fetcher": "github",
+  "repo": "webdevred/cabal-mode",
+  "unstable": {
+   "version": [
+    20251119,
+    1602
+   ],
+   "commit": "14183916674121ce49bff129c5c1f4f49092ee2c",
+   "sha256": "0gwis3msy8qd4c778h95ndb3zg8w7jyn9vnaf548lj40yszaapp6"
+  }
+ },
+ {
   "ename": "cabledolphin",
   "commit": "0c8bd2715aec4793abc37d6899adabd568955a08",
   "sha256": "04slrx0vkcm66q59158limn0cpxn18ghlqyx7z8nrn7frrc03z03",
@@ -10840,11 +10928,11 @@
   "repo": "Michael-Garibaldi/cacao-theme",
   "unstable": {
    "version": [
-    20250928,
-    1909
+    20251104,
+    2135
    ],
-   "commit": "50d2e703e316fc04ed4e2205f3ef99621fc4ff31",
-   "sha256": "1sxmav51827x5zyllqwkh9z1rd19a1sajsh2pd0j01mfqh27z107"
+   "commit": "72c1cff056fcfbada298d32811b14988dff1cf6d",
+   "sha256": "1xx5zqppl91bj9flrphr215i62z7zw3lcq2iar0l452q5jqxyygd"
   }
  },
  {
@@ -11015,6 +11103,29 @@
   }
  },
  {
+  "ename": "calctape",
+  "commit": "fad9cc1c4c3bfe1daebee6ccde16d372f86f8f82",
+  "sha256": "1hc86d2d4mvk62p1p96g24n21wwgdcv4pfbzsvdk59a5dmw1bhsv",
+  "fetcher": "github",
+  "repo": "Boruch-Baum/emacs-calctape",
+  "unstable": {
+   "version": [
+    20251016,
+    857
+   ],
+   "commit": "4fe05aa8d0071c7e057cec9985dd5bab65c3380c",
+   "sha256": "016n7nmi093hfmddqr1b9wcc0wrhnnfky77chsfaa4mkax2zbhvh"
+  },
+  "stable": {
+   "version": [
+    1,
+    0
+   ],
+   "commit": "783be1a28ea24e63f7438210aedc9e750439c925",
+   "sha256": "1m2b8643sv73hiq53vdxckqrsslnpqm2xbcj3x9qrlfw6c7mh1s3"
+  }
+ },
+ {
   "ename": "calendar-norway",
   "commit": "c5d01230027d5cec9da2545a9ce9270a611f6567",
   "sha256": "1i23ks0bnq62bvn3szvqf0ikcam4s92yvr998mkjxhdhc94zd19c",
@@ -11040,48 +11151,54 @@
  },
  {
   "ename": "calfw",
-  "commit": "cc64274abdc7c8fb904b43d2d036aac98e738131",
-  "sha256": "0am1nafc16zax8082gjlz0pi85lryjhrx0v80nzgr23iybj5mfx4",
+  "commit": "0550a82710786718438e8c17a07e4ec1cca05a2e",
+  "sha256": "1zxvvqsp9lqjg7zvj3kq2d48ypjfv9g85cyarz5j4567y5mr11ni",
   "fetcher": "github",
   "repo": "kiwanami/emacs-calfw",
   "unstable": {
    "version": [
-    20180118,
-    45
+    20251031,
+    1110
    ],
-   "commit": "03abce97620a4a7f7ec5f911e669da9031ab9088",
-   "sha256": "0wiggihw9ackjdssqgp2cqccd3sil13n3pfn33d3r320fmxfjbch"
+   "commit": "36846cdca91794cf38fa171d5a3ac291d3ebc060",
+   "sha256": "02s37k0d9pp8d0a3lbq5dy1dwjw53q7scyrrirqiyj11h4qwia72"
   },
   "stable": {
    "version": [
-    1,
-    6
+    2,
+    0
    ],
-   "commit": "c538d3746449b4f0e16b16aad3073d4f7379d805",
-   "sha256": "0r42cagvmvvib76kd15nd9ix55ys6i549vxnls4z16s864695zpa"
+   "commit": "9cce503eb0e998389485a74b956884d218a960e2",
+   "sha256": "0vmd9dl1hnmwjfr9gy8n91724bl05walhjx2myszh6qs28xay0z4"
   }
  },
  {
   "ename": "calfw-cal",
-  "commit": "cc64274abdc7c8fb904b43d2d036aac98e738131",
-  "sha256": "1wylkd7jl1ifq56jj04l5b9wfrjkhwncxzrjgnbgg1cl2klf6v4m",
+  "commit": "0550a82710786718438e8c17a07e4ec1cca05a2e",
+  "sha256": "1b7scf9yviyfmi3cvcj7bj2vmn77imk28zzq1va42040pm4gvc54",
   "fetcher": "github",
   "repo": "kiwanami/emacs-calfw",
   "unstable": {
    "version": [
-    20170411,
-    220
+    20251030,
+    845
    ],
-   "commit": "c538d3746449b4f0e16b16aad3073d4f7379d805",
-   "sha256": "0r42cagvmvvib76kd15nd9ix55ys6i549vxnls4z16s864695zpa"
+   "deps": [
+    "calfw"
+   ],
+   "commit": "57be107b20625c13ed010cb0f70a603a61d47629",
+   "sha256": "0hr55mwqk8h2hx2lwdlwrwq2hjwrxvjjbnwzzv4rr0ywqpxf6g5r"
   },
   "stable": {
    "version": [
-    1,
-    6
+    2,
+    0
    ],
-   "commit": "c538d3746449b4f0e16b16aad3073d4f7379d805",
-   "sha256": "0r42cagvmvvib76kd15nd9ix55ys6i549vxnls4z16s864695zpa"
+   "deps": [
+    "calfw"
+   ],
+   "commit": "9cce503eb0e998389485a74b956884d218a960e2",
+   "sha256": "0vmd9dl1hnmwjfr9gy8n91724bl05walhjx2myszh6qs28xay0z4"
   }
  },
  {
@@ -11101,71 +11218,92 @@
  },
  {
   "ename": "calfw-howm",
-  "commit": "cc64274abdc7c8fb904b43d2d036aac98e738131",
-  "sha256": "08cv16cq211sy2v1i0gk7d81f0gyywv0i9szmamnrbjif3rrv2m0",
+  "commit": "0550a82710786718438e8c17a07e4ec1cca05a2e",
+  "sha256": "0xgyzx5fwkzsy3d572m1mm9yihjd06d0k54qj510ba1f06rrcd19",
   "fetcher": "github",
   "repo": "kiwanami/emacs-calfw",
   "unstable": {
    "version": [
-    20170704,
-    4
+    20251030,
+    1600
    ],
-   "commit": "bcfc0c546c3c58e1f635a9a29efdf56c9421a3ce",
-   "sha256": "0n7kn0g7mxylp28w5llrz22w12qjvypa1g82660qr2d9ga9mb0v9"
+   "deps": [
+    "calfw",
+    "howm"
+   ],
+   "commit": "c34b6afaee33392e0bcd18441588e9a502f368eb",
+   "sha256": "09g574sm7zwj016z8gmv865f7s52i7vb1l2kclpnf22dkq0xwz1w"
   },
   "stable": {
    "version": [
-    1,
-    6
+    2,
+    0
    ],
-   "commit": "c538d3746449b4f0e16b16aad3073d4f7379d805",
-   "sha256": "0r42cagvmvvib76kd15nd9ix55ys6i549vxnls4z16s864695zpa"
+   "deps": [
+    "calfw",
+    "howm"
+   ],
+   "commit": "9cce503eb0e998389485a74b956884d218a960e2",
+   "sha256": "0vmd9dl1hnmwjfr9gy8n91724bl05walhjx2myszh6qs28xay0z4"
   }
  },
  {
   "ename": "calfw-ical",
-  "commit": "cc64274abdc7c8fb904b43d2d036aac98e738131",
-  "sha256": "1bh9ahwp9b5knjxph79kl19fgs48x3w7dga299l0xvbxq2jhs95q",
+  "commit": "0550a82710786718438e8c17a07e4ec1cca05a2e",
+  "sha256": "1d0amrfv8lidwkhix1q9f9sznapb99brwwldzmk4b8slhswgv702",
   "fetcher": "github",
   "repo": "kiwanami/emacs-calfw",
   "unstable": {
    "version": [
-    20170411,
-    220
+    20251030,
+    845
    ],
-   "commit": "c538d3746449b4f0e16b16aad3073d4f7379d805",
-   "sha256": "0r42cagvmvvib76kd15nd9ix55ys6i549vxnls4z16s864695zpa"
+   "deps": [
+    "calfw"
+   ],
+   "commit": "57be107b20625c13ed010cb0f70a603a61d47629",
+   "sha256": "0hr55mwqk8h2hx2lwdlwrwq2hjwrxvjjbnwzzv4rr0ywqpxf6g5r"
   },
   "stable": {
    "version": [
-    1,
-    6
+    2,
+    0
    ],
-   "commit": "c538d3746449b4f0e16b16aad3073d4f7379d805",
-   "sha256": "0r42cagvmvvib76kd15nd9ix55ys6i549vxnls4z16s864695zpa"
+   "deps": [
+    "calfw"
+   ],
+   "commit": "9cce503eb0e998389485a74b956884d218a960e2",
+   "sha256": "0vmd9dl1hnmwjfr9gy8n91724bl05walhjx2myszh6qs28xay0z4"
   }
  },
  {
   "ename": "calfw-org",
-  "commit": "cc64274abdc7c8fb904b43d2d036aac98e738131",
-  "sha256": "1cfpjh08djz3k067w3580yb15p1csks3gzch9c4cbrbcjvg8inh5",
+  "commit": "0550a82710786718438e8c17a07e4ec1cca05a2e",
+  "sha256": "1f0nlwm19w76y2v4fc8p6mxnjzg6g2a9ycpvm87hrkc0b4rxah9i",
   "fetcher": "github",
   "repo": "kiwanami/emacs-calfw",
   "unstable": {
    "version": [
-    20170411,
-    220
+    20251030,
+    845
    ],
-   "commit": "c538d3746449b4f0e16b16aad3073d4f7379d805",
-   "sha256": "0r42cagvmvvib76kd15nd9ix55ys6i549vxnls4z16s864695zpa"
+   "deps": [
+    "calfw",
+    "org"
+   ],
+   "commit": "57be107b20625c13ed010cb0f70a603a61d47629",
+   "sha256": "0hr55mwqk8h2hx2lwdlwrwq2hjwrxvjjbnwzzv4rr0ywqpxf6g5r"
   },
   "stable": {
    "version": [
-    1,
-    6
+    2,
+    0
    ],
-   "commit": "c538d3746449b4f0e16b16aad3073d4f7379d805",
-   "sha256": "0r42cagvmvvib76kd15nd9ix55ys6i549vxnls4z16s864695zpa"
+   "deps": [
+    "calfw"
+   ],
+   "commit": "9cce503eb0e998389485a74b956884d218a960e2",
+   "sha256": "0vmd9dl1hnmwjfr9gy8n91724bl05walhjx2myszh6qs28xay0z4"
   }
  },
  {
@@ -11251,20 +11389,20 @@
   "repo": "kickingvegas/calle24",
   "unstable": {
    "version": [
-    20250625,
-    2010
+    20251111,
+    1755
    ],
-   "commit": "34a9821ec8877945518ddab61fa8b93c2e9b1e79",
-   "sha256": "1sshsiii1b73f2md4gwrw04l97z5j1z4x9961q9nxs7jnj40ar99"
+   "commit": "a0b3ff3333fcc44f332ea0e3e04d0392bec2991e",
+   "sha256": "0yj7q7539b958k4c2d642vmmxg498npw9y80sl5bnlnwvrnli3qn"
   },
   "stable": {
    "version": [
     1,
-    0,
-    10
+    1,
+    2
    ],
-   "commit": "34a9821ec8877945518ddab61fa8b93c2e9b1e79",
-   "sha256": "1sshsiii1b73f2md4gwrw04l97z5j1z4x9961q9nxs7jnj40ar99"
+   "commit": "a0b3ff3333fcc44f332ea0e3e04d0392bec2991e",
+   "sha256": "0yj7q7539b958k4c2d642vmmxg498npw9y80sl5bnlnwvrnli3qn"
   }
  },
  {
@@ -11378,25 +11516,25 @@
   "repo": "minad/cape",
   "unstable": {
    "version": [
-    20250920,
-    843
+    20251115,
+    1822
    ],
    "deps": [
     "compat"
    ],
-   "commit": "e687d4dbf4a8d07a2f1a19b5ca676828038eff31",
-   "sha256": "1b511xh76br5ycq6z3yjs4la96vpyjjcndkf5gnv27w9pm938clv"
+   "commit": "a3f190328df26f89046b9bfd2ae0adb859c102bd",
+   "sha256": "1hvdqrr0nbgimzx74srkmfk9fqgh44hvgfph048mrr0saf4mv4qj"
   },
   "stable": {
    "version": [
     2,
-    1
+    3
    ],
    "deps": [
     "compat"
    ],
-   "commit": "c9191ee9e13e86a7b40c3d25c8bf7907c085a1cf",
-   "sha256": "0jdlk2i4mksp7dh71hvz93125z9y1vrfq78jiazzmwyimnawq5zh"
+   "commit": "a3f190328df26f89046b9bfd2ae0adb859c102bd",
+   "sha256": "1hvdqrr0nbgimzx74srkmfk9fqgh44hvgfph048mrr0saf4mv4qj"
   }
  },
  {
@@ -11706,26 +11844,28 @@
   "repo": "kickingvegas/casual",
   "unstable": {
    "version": [
-    20251006,
-    2105
+    20251121,
+    2150
    ],
    "deps": [
+    "csv-mode",
     "transient"
    ],
-   "commit": "f0ec7e600db38e9e7c0b46de48eac032dbf9845d",
-   "sha256": "18j89l5ivrv1aki4kyc9ww2gm5h5wzx79c2f84k7v9hxvh46d9n8"
+   "commit": "9b0a3e60e9dac97fcb0a3a937d4c1f0c637e15b8",
+   "sha256": "1arxmcgibrpb8wr0y8s9wyas07g9n3zf4w3f17a3zmbjn0xjdqkm"
   },
   "stable": {
    "version": [
     2,
-    9,
+    11,
     1
    ],
    "deps": [
+    "csv-mode",
     "transient"
    ],
-   "commit": "f0ec7e600db38e9e7c0b46de48eac032dbf9845d",
-   "sha256": "18j89l5ivrv1aki4kyc9ww2gm5h5wzx79c2f84k7v9hxvh46d9n8"
+   "commit": "9b0a3e60e9dac97fcb0a3a937d4c1f0c637e15b8",
+   "sha256": "1arxmcgibrpb8wr0y8s9wyas07g9n3zf4w3f17a3zmbjn0xjdqkm"
   }
  },
  {
@@ -12347,16 +12487,16 @@
   "repo": "worr/cfn-mode",
   "unstable": {
    "version": [
-    20250921,
-    807
+    20251123,
+    907
    ],
    "deps": [
     "f",
     "s",
     "yaml-mode"
    ],
-   "commit": "b8f914d1d5f0b0343e44a50a44c2a0520a90628a",
-   "sha256": "1j0idikby2s23xyg016vhn5y4jzxhk34vck2v3bk95mf3rsjpn11"
+   "commit": "346324ff624b68bc478204c1ae909147346ba701",
+   "sha256": "0gyin25kwckhz4vkg45kirscwrj2hpj8dz9nql51dff72sf6r541"
   },
   "stable": {
    "version": [
@@ -12620,15 +12760,15 @@
   "repo": "xenodium/chatgpt-shell",
   "unstable": {
    "version": [
-    20251005,
-    1215
+    20251119,
+    744
    ],
    "deps": [
     "shell-maker",
     "transient"
    ],
-   "commit": "1a86193a519b1429b14972da49be20beb446affc",
-   "sha256": "1x4f7cis50vsvhmwrkg89l2vjs22pzcy9lwr5jslw0ms3hdzky1n"
+   "commit": "83b327ba55cd116d892a9b44f00bc65543b7c22e",
+   "sha256": "15rsnmb3k1rf9g3dkmc900mzsanfvjmbpg3774gsbb4h278c01jl"
   },
   "stable": {
    "version": [
@@ -12652,15 +12792,15 @@
   "repo": "kimim/chatu",
   "unstable": {
    "version": [
-    20250425,
-    645
+    20251113,
+    2350
    ],
    "deps": [
     "org",
     "plantuml-mode"
    ],
-   "commit": "5324662e8dc3b16cdd7e596c98832f427962c223",
-   "sha256": "040y0kkz4a094ka29lb988209ihxmrhki8jnbsbcyldmnxhp9l18"
+   "commit": "54fde21a03de78fc234ff3ce25a84fc4833adbca",
+   "sha256": "0ab2h59d4vampalp1mx6mzlyjap9azc9b39qid3br89m4w2qkikf"
   }
  },
  {
@@ -13307,8 +13447,8 @@
   "repo": "clojure-emacs/cider",
   "unstable": {
    "version": [
-    20250902,
-    1530
+    20251105,
+    925
    ],
    "deps": [
     "clojure-mode",
@@ -13319,13 +13459,13 @@
     "spinner",
     "transient"
    ],
-   "commit": "af63db156a89fc77a35b0f8a3c1ccddcfbf9af84",
-   "sha256": "16l6d0iznmxdpwifdm2xsdnbg74w4jshaj82x5qw1k4cncfyna0d"
+   "commit": "8e3091e8c427cc18f1cc511d5d5aa15424cddb62",
+   "sha256": "08hd281ybskkhir170hr3xpga1b1hwpph7rd0fk6fvm0ngdgxazs"
   },
   "stable": {
    "version": [
     1,
-    19,
+    20,
     0
    ],
    "deps": [
@@ -13337,8 +13477,8 @@
     "spinner",
     "transient"
    ],
-   "commit": "b5a6ffc97e3c76957721f71280ea5f49fd29d7a3",
-   "sha256": "0limw27arkc8bn0zzj0jzhdsax78qm1lz5jfgy8zgf971llhf5qc"
+   "commit": "8e3091e8c427cc18f1cc511d5d5aa15424cddb62",
+   "sha256": "08hd281ybskkhir170hr3xpga1b1hwpph7rd0fk6fvm0ngdgxazs"
   }
  },
  {
@@ -13541,14 +13681,14 @@
   "repo": "emacs-circe/circe",
   "unstable": {
    "version": [
-    20250929,
-    1724
+    20251013,
+    1911
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "754a59fa06bdbf03cc47567c04c97ee49d8aa1f1",
-   "sha256": "1x7rq9pc8xg2c72fyvifpj2zimcqzfrxqprhw60hk1g4x2ygvk99"
+   "commit": "e909ff49e59c396b19564855a3f282684a4e716e",
+   "sha256": "09ziy6q2m1sz6da9jnny4yacnypylgmjbyi7qiiq7qwx6mgkc3zm"
   },
   "stable": {
    "version": [
@@ -13634,16 +13774,17 @@
   "repo": "emacs-citar/citar",
   "unstable": {
    "version": [
-    20250113,
-    1556
+    20251109,
+    1138
    ],
    "deps": [
     "citeproc",
+    "compat",
     "org",
     "parsebib"
    ],
-   "commit": "ce5e9644ed02cc1ed4a905e0436a1be8f8ccab57",
-   "sha256": "1ap840f2pv3h6jg9f2bxvg9f3nysf1dvghawzsrhjp1syg3ilara"
+   "commit": "dc7018eb36fb3540cb5b7fc526d6747144437eef",
+   "sha256": "1fbzm5ipsf6rjsq4jvrrv62dwfr30jkqqf5k62ba5l7yzqas4hsa"
   },
   "stable": {
    "version": [
@@ -13702,15 +13843,15 @@
   "repo": "emacs-citar/citar",
   "unstable": {
    "version": [
-    20231122,
-    1548
+    20251027,
+    1830
    ],
    "deps": [
     "citar",
     "embark"
    ],
-   "commit": "572b7b6e569e9423dd948539fa48d3f53ceffe57",
-   "sha256": "17qfkiwy2mvyp6rwkxwxhlx2lxw5j2rb7n15c3dyzvfdphxjfikd"
+   "commit": "a71ec7c3f02e8d4051fb608d9c4918de5a8ba4e6",
+   "sha256": "12hh22jb5ikkzsp6s571fmp778ndiszw3fpr8k099fnvzrqz7s98"
   },
   "stable": {
    "version": [
@@ -13800,8 +13941,8 @@
   "repo": "andras-simonyi/citeproc-el",
   "unstable": {
    "version": [
-    20250912,
-    1154
+    20251103,
+    716
    ],
    "deps": [
     "compat",
@@ -13813,8 +13954,8 @@
     "s",
     "string-inflection"
    ],
-   "commit": "9f16f2eee4586404b88a7b8cf46e1c158477bc33",
-   "sha256": "1nabgdifrbdn5mj7srjqz1slsfccjh22zjaz9bmkdr1x859b0gaj"
+   "commit": "a3d62ab8e40a75fcfc6e4c0c107e3137b4db6db8",
+   "sha256": "1ffxh22xhzg582hbpsxr6cyjfyvvv5yqn3k39qxmkxbxk0g6hair"
   },
   "stable": {
    "version": [
@@ -13882,11 +14023,11 @@
   "repo": "universal-ctags/citre",
   "unstable": {
    "version": [
-    20250411,
-    1406
+    20251015,
+    220
    ],
-   "commit": "3e3c6e539c41c880f9d10ef7424cd0d2adcf3151",
-   "sha256": "0p2iifiadxpa2q75zk45gqj8bwa3wx9gcs82p5b303lrzid9mrga"
+   "commit": "300596a34b61b486530ce3759e8fb722d9534325",
+   "sha256": "0nhyshjiy7amncxisnm8ra462xhmq351zrrv0ah3ym3v99vlsgn7"
   },
   "stable": {
    "version": [
@@ -13947,10 +14088,10 @@
  },
  {
   "ename": "clang-capf",
-  "commit": "a3645b08cb46e3d91081da7baa982b5283918447",
-  "sha256": "0mmn8m0ahkpm7gxw3lj3mjcmxi0c7h666kv62skwbjmfn6349k21",
-  "fetcher": "sourcehut",
-  "repo": "pkal/clang-capf",
+  "commit": "c4db3820d23067e878144c9ad3a8ac2693bf8d71",
+  "sha256": "00y2hhah5q68f5dh0a2hnkxiv8vi4667gsnqrfndvr1g3rh4gxj8",
+  "fetcher": "codeberg",
+  "repo": "pkal/clang-capf.el",
   "unstable": {
    "version": [
     20221030,
@@ -14864,11 +15005,11 @@
   "repo": "clojure-emacs/clojure-ts-mode",
   "unstable": {
    "version": [
-    20251003,
-    2051
+    20251112,
+    927
    ],
-   "commit": "08b1c3b961f4284d9718dfcdaa9cb7e8b5b42b27",
-   "sha256": "0ffdycwz6nsckhx6wbdzg6kp3m283y1cfy02hcxwhswcmj0r56lr"
+   "commit": "31f12ea1e386fe0e8eb3641e8b55bd0103eeb111",
+   "sha256": "1i8lcbycxkhmhckwydx1p27alsb8844vqvcsgg1bvjkgvk986ynr"
   },
   "stable": {
    "version": [
@@ -14923,28 +15064,28 @@
   "repo": "magit/closql",
   "unstable": {
    "version": [
-    20250913,
-    1926
+    20251101,
+    1940
    ],
    "deps": [
     "compat",
     "emacsql"
    ],
-   "commit": "f5dd024c47b792dac499dac94c906af60044d2ad",
-   "sha256": "0b0a9x669148l83s54jkb0vvwqch1dhfg917f80b1rmqn8nx9rd4"
+   "commit": "4a60723ae4bfe809a9affcf3306cb40e0ca1ca6c",
+   "sha256": "110xlykmgd77z908l54kws7qcgj9hk7r33zmbk13dabl3wf8yzzk"
   },
   "stable": {
    "version": [
     2,
     3,
-    0
+    2
    ],
    "deps": [
     "compat",
     "emacsql"
    ],
-   "commit": "80e91c557331225b5c4b420ec6f283ac3c40bbac",
-   "sha256": "1vfanw02di8lgvbiijzbgm5rd8w1yzfd81srygacfbzp34diqvcy"
+   "commit": "4a60723ae4bfe809a9affcf3306cb40e0ca1ca6c",
+   "sha256": "110xlykmgd77z908l54kws7qcgj9hk7r33zmbk13dabl3wf8yzzk"
   }
  },
  {
@@ -15117,20 +15258,20 @@
   "url": "https://gitlab.kitware.com/cmake/cmake.git",
   "unstable": {
    "version": [
-    20250930,
-    1448
+    20251119,
+    1357
    ],
-   "commit": "11f3f34077ba6fc1a2be6fe0f1ae542ebf884675",
-   "sha256": "092vx75c232y8yng0j97xds0f8lhiw98b18jz3cj1s67kjhf0fsd"
+   "commit": "a0c7f1d29c77fd5c862b087f9d2442c84798a4b6",
+   "sha256": "105j8a74n712p9vzqcxb5ckap5vwpxfxv95xd9prwicjpbv0mij7"
   },
   "stable": {
    "version": [
     4,
-    1,
-    2
+    2,
+    0
    ],
-   "commit": "11f3f34077ba6fc1a2be6fe0f1ae542ebf884675",
-   "sha256": "092vx75c232y8yng0j97xds0f8lhiw98b18jz3cj1s67kjhf0fsd"
+   "commit": "a0c7f1d29c77fd5c862b087f9d2442c84798a4b6",
+   "sha256": "105j8a74n712p9vzqcxb5ckap5vwpxfxv95xd9prwicjpbv0mij7"
   }
  },
  {
@@ -15290,6 +15431,21 @@
    ],
    "commit": "1ad9af6679d0294c3056eab9cad673f29c562721",
    "sha256": "0s0zakrmbx9gr7ippnyqngc09xj9f7bsv0mv11p062a8pkilg219"
+  }
+ },
+ {
+  "ename": "code-awareness",
+  "commit": "1d5b6a9073ab474cf66b283bf996fdd9fc017b7b",
+  "sha256": "1k9x0xa9jz2azc65zwcy182dakz201hkxkry5idz79fd424sy5jf",
+  "fetcher": "github",
+  "repo": "codeawareness/kawa.emacs",
+  "unstable": {
+   "version": [
+    20251117,
+    617
+   ],
+   "commit": "16b700570ea8902830607575f3418f970dffe4c0",
+   "sha256": "0qw337f7p6ckdzycaacfsn0k7iigc7bs1ahkmhh14w7za5x4glw7"
   }
  },
  {
@@ -15799,11 +15955,11 @@
   "repo": "purcell/color-theme-sanityinc-tomorrow",
   "unstable": {
    "version": [
-    20250401,
-    1320
+    20251107,
+    1433
    ],
-   "commit": "f3a993da26b3b6f778f5943e095e8b2816a6475c",
-   "sha256": "0r8q6ld2zma1bqq5pv61gpy99a4vx6bwx4v820ijzbymmi62vv3z"
+   "commit": "f3f05e31cd9fd2e99e8d7859a8d46a549fac9537",
+   "sha256": "0b719v2k58iac24gbzx2cvl0f608i4zlabzqxpr05hyaayl92jjn"
   },
   "stable": {
    "version": [
@@ -15971,14 +16127,14 @@
   "repo": "NicholasBHubbard/comint-histories",
   "unstable": {
    "version": [
-    20250825,
-    1935
+    20251116,
+    1248
    ],
    "deps": [
     "f"
    ],
-   "commit": "85a91700216524aec0e4c92c123faabff27e69e8",
-   "sha256": "1bsd51j3aclw8nlv10q57c30zf0fix28v5iilz92ci7iaf6j79yj"
+   "commit": "36f37760a85bc5e8535180d9481c856768ea356d",
+   "sha256": "1rh36m9d4pm4lhdlwyw77h6k2gnwz69bayh270aslv269j1g96xk"
   }
  },
  {
@@ -16286,11 +16442,11 @@
   "repo": "company-mode/company-mode",
   "unstable": {
    "version": [
-    20250911,
-    129
+    20251021,
+    2211
    ],
-   "commit": "03bedfce7623c69dde08d85abdf0ceb2a89a274c",
-   "sha256": "19h05cc0vvzzia1czn341a3yrg3nygjxhf4d67p7lz66bz7ks3zp"
+   "commit": "4ff89f7369227fbb89fe721d1db707f1af74cd0f",
+   "sha256": "054k6xwh8vkbj0j8jj6wnkh12fnqhdkcw5djqz05x1pm413zyixl"
   },
   "stable": {
    "version": [
@@ -16819,15 +16975,16 @@
   "repo": "pkryger/company-forge.el",
   "unstable": {
    "version": [
-    20250815,
-    1339
+    20251101,
+    1346
    ],
    "deps": [
     "company",
-    "forge"
+    "forge",
+    "ghub"
    ],
-   "commit": "7361b40a814cc61e543db6462e58e701ac1afca7",
-   "sha256": "1p2adrpjki0j0ggq254xkzgqzyzqv5f3sd5c1zxxpy91lhnnv51v"
+   "commit": "17f20cf41bd8711e1e8d9c93a7385dad55754ff0",
+   "sha256": "1ig8a8qsyxlx0ch8m7gx2fw8rflkr7xsg4frzghl14lk4wf0r65l"
   }
  },
  {
@@ -18183,20 +18340,20 @@
   "repo": "jamescherti/compile-angel.el",
   "unstable": {
    "version": [
-    20250905,
-    2104
+    20251116,
+    2222
    ],
-   "commit": "59b03b6ff55b3f07d9b42739cf35ac0de7775a99",
-   "sha256": "1jiwv7jxr92x832z76mpfhxahmxrb84kfc1j7478y064vk55axya"
+   "commit": "95a0d01dc9c6eeac5023465fadf8ab82726df097",
+   "sha256": "0c5n6qwjjv3wn2cdmh31zgpwzz3vkdq2jmzyals7h2ag1s7cxq4r"
   },
   "stable": {
    "version": [
     1,
     1,
-    2
+    3
    ],
-   "commit": "c8475c2445913765ed5b9928045e62345ee866c6",
-   "sha256": "1bkws8303qligshrlndj7dh6m3s3qpj5smfgy5bv7f7lnbn0ps1l"
+   "commit": "95a0d01dc9c6eeac5023465fadf8ab82726df097",
+   "sha256": "0c5n6qwjjv3wn2cdmh31zgpwzz3vkdq2jmzyals7h2ag1s7cxq4r"
   }
  },
  {
@@ -18319,8 +18476,8 @@
   "repo": "mkcms/compiler-explorer.el",
   "unstable": {
    "version": [
-    20250928,
-    1426
+    20251020,
+    1212
    ],
    "deps": [
     "eldoc",
@@ -18328,8 +18485,8 @@
     "plz",
     "seq"
    ],
-   "commit": "9e32e10b13a53b1fbf5471c34e4c0ea7a5db9057",
-   "sha256": "0gmf0q8s4n4x5v3nj0yanmc5nrjcca4049h7xg5dvd3250y0a1ar"
+   "commit": "efad3b9f92098d2eb28d6ae47b71e8853f6dfb49",
+   "sha256": "1j1pkz8pq035s20bwi0biqbjs3wnm0azddqscsld0kxmgcgqf082"
   },
   "stable": {
    "version": [
@@ -18480,20 +18637,20 @@
   "repo": "tarsius/cond-let",
   "unstable": {
    "version": [
-    20250903,
-    1646
+    20251101,
+    1942
    ],
-   "commit": "79a16e1f2428f0f79f03250b987bc79cd37a029e",
-   "sha256": "1hsxl42dysbrkmgnbd954zjv28cms73r7nask5ip4f07qzgaj1gi"
+   "commit": "288b7d36563223ebaf64cb220a3b270bdffb63f1",
+   "sha256": "0jdhdngczdwj44wk3zsb9ab5dv5j9bflfwg22hay1rrzq5jiihyw"
   },
   "stable": {
    "version": [
     0,
-    1,
-    1
+    2,
+    0
    ],
-   "commit": "79a16e1f2428f0f79f03250b987bc79cd37a029e",
-   "sha256": "1hsxl42dysbrkmgnbd954zjv28cms73r7nask5ip4f07qzgaj1gi"
+   "commit": "288b7d36563223ebaf64cb220a3b270bdffb63f1",
+   "sha256": "0jdhdngczdwj44wk3zsb9ab5dv5j9bflfwg22hay1rrzq5jiihyw"
   }
  },
  {
@@ -18727,25 +18884,25 @@
   "repo": "minad/consult",
   "unstable": {
    "version": [
-    20251006,
-    1037
+    20251123,
+    1137
    ],
    "deps": [
     "compat"
    ],
-   "commit": "ce965a04223336665fa82df797455b7317181fc6",
-   "sha256": "059ijmf0v1mbkg4g6n0c878lh4rad4mzy831dqdws9p2h1aq1pi8"
+   "commit": "e82f398a702a55b081e36e49b38fce6edf39be54",
+   "sha256": "0dcvj9v57zck6xc47ga6ybv0gv1j2nvs35y89cp6lrpgylzrlj7l"
   },
   "stable": {
    "version": [
-    2,
-    8
+    3,
+    0
    ],
    "deps": [
     "compat"
    ],
-   "commit": "098462a6321a15afd4ae33fa8083658145332d9c",
-   "sha256": "0yvb73d2rp728pkaz6d9k1ka64za47bx7jrnx6isf057g17p9di7"
+   "commit": "f2965873f94815c6a7e742bf2303135a6f59b24e",
+   "sha256": "0m4fsvz73pfbi4cglihvv6h19zx1iwdx3cqs2wfnxqh589vrkmr4"
   }
  },
  {
@@ -18884,14 +19041,15 @@
   "repo": "karthink/consult-dir",
   "unstable": {
    "version": [
-    20250313,
-    359
+    20251020,
+    416
    ],
    "deps": [
-    "consult"
+    "consult",
+    "project"
    ],
-   "commit": "4532b8d215d16b0159691ce4dee693e72d71e0ff",
-   "sha256": "1yv6sssg8fddi9g44c7x026z7ajgzsc351lvf7sp79il0hqjg0nm"
+   "commit": "1497b46d6f48da2d884296a1297e5ace1e050eb5",
+   "sha256": "0s77s223qkp0qpmv83zn4wvym90gjnrrhy9a4agal8iiwsgv7k62"
   },
   "stable": {
    "version": [
@@ -19312,16 +19470,16 @@
   "repo": "gagbo/consult-lsp",
   "unstable": {
    "version": [
-    20250121,
-    707
+    20251025,
+    719
    ],
    "deps": [
     "consult",
     "f",
     "lsp-mode"
    ],
-   "commit": "aef321d03907ca6926b0cf20ca85f672c4744000",
-   "sha256": "1rai69yfcild5qxrl1rsz7jpviy89yysk38vwbj32fh3mr26hv90"
+   "commit": "d11102c9db33c4ca7817296a2edafc3e26a61117",
+   "sha256": "1lswbg18f1f3xg25hlgbn4rrlm4h4p5y27msx2g2gm49bk6ybfdi"
   },
   "stable": {
    "version": [
@@ -19345,16 +19503,16 @@
   "repo": "mclear-tools/consult-notes",
   "unstable": {
    "version": [
-    20241213,
-    1718
+    20251117,
+    1511
    ],
    "deps": [
     "consult",
     "dash",
     "s"
    ],
-   "commit": "7c9cd970c75fae9a6140ca1beefed9532d8e1b96",
-   "sha256": "1lccpnqqaai6vsjn9v65xhpzs0bmhrsyflaxg3n3iszigmsxrfaz"
+   "commit": "3c11379514718db365a377ac8e4503d1ea4674a8",
+   "sha256": "096ppagkdr8ji3cfkmgh0jnlwzccc89rcdqc1pp9mf2yq6phbxfh"
   }
  },
  {
@@ -19397,15 +19555,15 @@
   "repo": "jgru/consult-org-roam",
   "unstable": {
    "version": [
-    20240217,
-    1442
+    20251116,
+    1230
    ],
    "deps": [
     "consult",
     "org-roam"
    ],
-   "commit": "a6dec09dcd06a3014409044399c4f8860ca45ef1",
-   "sha256": "0121kcxmkb6n880nrnv23amdx05kvnv1p0j27y4aypg12s0fppqr"
+   "commit": "7d825fffd6f990b800485376f62dd9b277991709",
+   "sha256": "1icr16lq7ns9ml8sl6zxbv68zvwb1b1w4vq0x7dr1qrcvgzpsgr8"
   }
  },
  {
@@ -19777,30 +19935,32 @@
   "repo": "copilot-emacs/copilot.el",
   "unstable": {
    "version": [
-    20250916,
-    500
+    20251117,
+    510
    ],
    "deps": [
     "editorconfig",
     "f",
-    "jsonrpc"
+    "jsonrpc",
+    "track-changes"
    ],
-   "commit": "c42c18e346e1ff8399eb30d40527e593f614e4d3",
-   "sha256": "0rnk2nk1qq6pky40g2wjbm1qhcvbgdfamvryfs74rdm57cvarwf1"
+   "commit": "8e43edf1f3efe094ea42a21863b3b742a339742c",
+   "sha256": "00lqpjb0qxh9pzh0vd579s21hmq1gvnln0r942aml2y9zibn0gqx"
   },
   "stable": {
    "version": [
     0,
-    2,
+    3,
     0
    ],
    "deps": [
     "editorconfig",
     "f",
-    "jsonrpc"
+    "jsonrpc",
+    "track-changes"
    ],
-   "commit": "11b0739da1f74285dd661914c0ef92e24f9c4aa7",
-   "sha256": "1pf5j3xhhcrv4dj2cgp7627s67wsw4hm308szqyr4f58snlkx044"
+   "commit": "b98754712ad05282e1bb392bb35e5918ed35c9b6",
+   "sha256": "0n1kpjkr6vdfpb20x28bsg14piqv9vl0iz0jswc5qm0qgdmi23ah"
   }
  },
  {
@@ -19811,8 +19971,8 @@
   "repo": "chep/copilot-chat.el",
   "unstable": {
    "version": [
-    20250909,
-    1505
+    20251112,
+    1222
    ],
    "deps": [
     "aio",
@@ -19824,8 +19984,8 @@
     "shell-maker",
     "transient"
    ],
-   "commit": "15cf30010274f48a18fbacdc79062c06901a227e",
-   "sha256": "1s7401wbwfljk5yq82vxxaianq8r3qga9f4gn4dbfb3ikcnm7pvr"
+   "commit": "1bded1dbe4e8044913fec3db5cc68bc710d55344",
+   "sha256": "1n1v6199cgh1g3i7vfzj2nh50phy9zidqv76cs9mrpr4jxjvgq8r"
   },
   "stable": {
    "version": [
@@ -19996,25 +20156,25 @@
   "repo": "minad/corfu",
   "unstable": {
    "version": [
-    20250923,
-    1250
+    20251116,
+    1939
    ],
    "deps": [
     "compat"
    ],
-   "commit": "d6cc682c15b594f2bc9f55196a382a5fda7a7fc6",
-   "sha256": "1rllxij3nhy9did3nyxy52dy5isvapgj9s20mfs8k5nfca27l86z"
+   "commit": "d9f88cbdb8de0cdca8b234a99949931b42f2cf83",
+   "sha256": "05yj2if0r923c5jk90jm77bs6z8324zfg720lqfygvyd6a23dwxr"
   },
   "stable": {
    "version": [
     2,
-    3
+    5
    ],
    "deps": [
     "compat"
    ],
-   "commit": "53aa6c85be72ce220a4321487c535295b0de0488",
-   "sha256": "1f2hz1970f5ifd5p6lbxdi4krgxgvxrr477f6vbqakqj07bk9jps"
+   "commit": "2d7d5d25a9003077329d3469b64d81a60a629aba",
+   "sha256": "14ddl6dby5hlphpcsnwxkvw61hh1cyhilpgsyj17fzw9xwpp4q9w"
   }
  },
  {
@@ -21129,11 +21289,26 @@
   }
  },
  {
-  "ename": "create-link",
-  "commit": "80b967b973240c5124957180819aeacac66271bb",
-  "sha256": "0ypj1sd9jabr5mmrpwibsahrchxs28kp4xv1yjk5pqwyz0r08a8b",
+  "ename": "creamy-theme",
+  "commit": "ce6c430561e8dfc4afd70fd28e13bab310a403e9",
+  "sha256": "0lgf9ci0acwrasmrc8ngzwpf36f6aw8b6lp6kr635ccnmn3j4lr2",
   "fetcher": "github",
-  "repo": "kijimaD/create-link",
+  "repo": "smallwat3r/emacs-creamy-theme",
+  "unstable": {
+   "version": [
+    20251030,
+    1829
+   ],
+   "commit": "3bceabac758378d91d07ba39b855e744be7e3c54",
+   "sha256": "135v8qcx2cwjj68q9zwxiy4jgmyl6pwvc4dkwi4z6r4wy7g306sl"
+  }
+ },
+ {
+  "ename": "create-link",
+  "commit": "d97a46b9b446c8fc0ad17d80163a7e0be6822b61",
+  "sha256": "1x7b2p4sw6niyxzp43pkgmsg67i0k0bqiv21yb69bx0mc7s593z9",
+  "fetcher": "github",
+  "repo": "kijimad/create-link",
   "unstable": {
    "version": [
     20220621,
@@ -21405,14 +21580,14 @@
   "repo": "jasonrobot/crystal-playground",
   "unstable": {
    "version": [
-    20180830,
-    501
+    20251026,
+    2240
    ],
    "deps": [
     "crystal-mode"
    ],
-   "commit": "532dc7e4239eb4bdd241bc4347d34760344c1ebb",
-   "sha256": "06vrmxikqi36wbnm66r5s5fxhkdlz76fjb3nhlighbqlym4bxpl1"
+   "commit": "9920cab99b02c6da70dfe1c3325146d062c14288",
+   "sha256": "14jwmii9nilzd8l3pgjsxym6r0666s25cjaxc1in7hf56dwwvyhb"
   }
  },
  {
@@ -22011,10 +22186,10 @@
  },
  {
   "ename": "current-word-highlight",
-  "commit": "02d60c15b4624735ba7e62f7c27a27487f1c7caf",
-  "sha256": "0jrcgvc60hzcnd66b0na4rd0lnr92pgfrkwwfvih2qjzxf5lpl72",
+  "commit": "669877595d3bd05721478de09eb3d1a1a4fc681e",
+  "sha256": "0b6csbh9h5agff281rrjhph6l6wyqhj41nzihf6pjj7l4dyzsnb2",
   "fetcher": "github",
-  "repo": "kijimaD/current-word-highlight",
+  "repo": "kijimad/current-word-highlight",
   "unstable": {
    "version": [
     20210323,
@@ -22460,6 +22635,25 @@
   }
  },
  {
+  "ename": "dag-draw",
+  "commit": "5530f13a15c53a19cda2dcde2e48bded78bda768",
+  "sha256": "10y5mi4487vjkms759vv3l5yi9n5cl32blcz3ag4xc9yvy25sva5",
+  "fetcher": "codeberg",
+  "repo": "trevoke/dag-draw.el",
+  "unstable": {
+   "version": [
+    20251121,
+    1936
+   ],
+   "deps": [
+    "dash",
+    "ht"
+   ],
+   "commit": "056b9ac9c8ed8fd06bd1bb55a60cadd1370ba949",
+   "sha256": "1r8djlf51ygafyp65cakqmfd5mw75c27cp9b6y0fikp1jlv535g7"
+  }
+ },
+ {
   "ename": "dakrone-light-theme",
   "commit": "f3a88022a5f68d2fe01e08c2e99cfe380e3697b7",
   "sha256": "1njlpvfa4ar14zn51fdmby55vjgfkpskizg5rif2f3zn6y4np2xw",
@@ -22623,8 +22817,8 @@
   "repo": "emacs-lsp/dap-mode",
   "unstable": {
    "version": [
-    20251004,
-    452
+    20251105,
+    2320
    ],
    "deps": [
     "bui",
@@ -22637,8 +22831,8 @@
     "posframe",
     "s"
    ],
-   "commit": "6c74027e39fca229eeb1d0d59698219ae7d0aa41",
-   "sha256": "0pja86dc2dsk18vh5bqsrv9f7g1yl73cqp5sgdwdgr5zpbsxkc94"
+   "commit": "ab96fc8e8df4ae23eb895aea6bed5b2a329d5f23",
+   "sha256": "10h2xscf4zb94r5hk9sjfgs9jfb3m06w3acv91b3v4pknamx3qid"
   },
   "stable": {
    "version": [
@@ -22677,10 +22871,10 @@
  },
  {
   "ename": "darcula-theme",
-  "commit": "23c8f10205187babb17e3abc3dc40eb1938e6640",
-  "sha256": "1n9mpkdyf5jpxc5azfs38ccp9p0b5ii87sz4c7z4khs94y0gxqh3",
-  "fetcher": "gitlab",
-  "repo": "fommil/emacs-darcula-theme",
+  "commit": "089a576e7f4d7d609c7cdcf3009f3c9fd3408e4f",
+  "sha256": "0pgwpxa1lbb3b56cdflrm9kvy0j2s82f8n6dhyijk4y8654p65d4",
+  "fetcher": "github",
+  "repo": "fommil/darcula-theme.el",
   "unstable": {
    "version": [
     20171227,
@@ -22805,26 +22999,26 @@
   "repo": "emacsfodder/emacs-theme-darktooth",
   "unstable": {
    "version": [
-    20231011,
-    427
+    20251019,
+    304
    ],
    "deps": [
     "autothemer"
    ],
-   "commit": "2358dd334b5dcb6dc9828422bd7bd1e4da556819",
-   "sha256": "0ivdwypamhnipfh5qg71icf1bbd0nqp17xpj31cs0iaik1s9pj8h"
+   "commit": "998639b2ce629dbdc0901ed560371f82de7af490",
+   "sha256": "05xaxxf81x5fsysj6a9818va03cfc0ifwfjcaznzp168svk5kiyg"
   },
   "stable": {
    "version": [
     1,
     0,
-    2
+    3
    ],
    "deps": [
     "autothemer"
    ],
-   "commit": "6910ebd3ec2441487a730ef98df591d6b1e0c671",
-   "sha256": "03jrdyvna5nbs3787dgiija4va7r6z7ynmdd0bg8isfpn2nnspzh"
+   "commit": "998639b2ce629dbdc0901ed560371f82de7af490",
+   "sha256": "05xaxxf81x5fsysj6a9818va03cfc0ifwfjcaznzp168svk5kiyg"
   }
  },
  {
@@ -22835,11 +23029,11 @@
   "repo": "emacsorphanage/dart-mode",
   "unstable": {
    "version": [
-    20231002,
-    1138
+    20251105,
+    543
    ],
-   "commit": "61e01142352f6813aca6512bedadb5007de3a0b9",
-   "sha256": "1pvyv1m2nk0hx05zjrphw7ad9y6xsixhjhm4gygpjjv99qbx4njc"
+   "commit": "22288d0bb374f6880ffc211ce87c302acb3421e7",
+   "sha256": "0z1j0v5h5472r04bl9c7hwr0l9mjhp48kcyqgdrb3rx7z0id7052"
   },
   "stable": {
    "version": [
@@ -22895,11 +23089,11 @@
   "repo": "nameiwillforget/d-emacs",
   "unstable": {
    "version": [
-    20250915,
-    2057
+    20251107,
+    1324
    ],
-   "commit": "6dca1e898050d517ad55732b2600f98f5004fa42",
-   "sha256": "14hgw0crbql7bbib1s1911plpkyspqh3mxsxwga4wfsp1x8hnqkf"
+   "commit": "ae3135b143027d857b3581dc93a4eb77773f1e67",
+   "sha256": "0shywyniid34psk1jp5x7sa9xh6z73lpg3ns8820qncn29dldwy9"
   }
  },
  {
@@ -23699,11 +23893,11 @@
   "repo": "ideasman42/emacs-default-font-presets",
   "unstable": {
    "version": [
-    20250921,
-    944
+    20251126,
+    350
    ],
-   "commit": "02175c87d908e2fc0860dae7eacf4a2ffbe80f27",
-   "sha256": "09qgwrky5wqpmfm4q0m27a4gfd246bjdw02cr7frhib3ppnvkaz3"
+   "commit": "0ac18ca47b80934fe0c8beffcbafac3312c8a12f",
+   "sha256": "0krcrqyssfrbyaa99ij0fq7z1vindkj2var6dw8cq503gzznbcvd"
   }
  },
  {
@@ -24117,16 +24311,16 @@
   "repo": "pprevos/denote-explore",
   "unstable": {
    "version": [
-    20251005,
-    853
+    20251027,
+    911
    ],
    "deps": [
     "dash",
     "denote",
     "denote-regexp"
    ],
-   "commit": "dad35045cf5f30e5ecce1c87b5241ce27793936d",
-   "sha256": "1vbjs7h5rdfsll2qzvbpk3kk3pklpjh0wwh2i1c0zm730pzgg5mg"
+   "commit": "3adc8b4d342bbc411d667f93dbc1f1468a245e04",
+   "sha256": "12b0bxvz01za3bxs66n63l6fyffnhq1br5fz0nf28839gvi80npg"
   },
   "stable": {
    "version": [
@@ -24435,15 +24629,14 @@
   "repo": "astoff/devdocs.el",
   "unstable": {
    "version": [
-    20250608,
-    1414
+    20251022,
+    1255
    ],
    "deps": [
-    "compat",
-    "mathjax"
+    "compat"
    ],
-   "commit": "4023409017d37dc2d6c230fe010fadb917b4395b",
-   "sha256": "0dmy4s58cf2dj4k8w12yh7x1dy290454r2q8nywdw9qla74qfp04"
+   "commit": "25c746024ddf73570195bf42b841f761a2fee10c",
+   "sha256": "1q63bch5jazvf0y76847s2j73f48n4gdr9ac4aaal9z5nidxv1hz"
   }
  },
  {
@@ -24454,11 +24647,11 @@
   "repo": "blahgeek/emacs-devdocs-browser",
   "unstable": {
    "version": [
-    20250319,
-    240
+    20251129,
+    225
    ],
-   "commit": "e6ccbaafc795e8be54762b2e930ada2967cec08b",
-   "sha256": "09clfa4ngs86chbfmgzv7s896xvw0wgd0ir56b2zmpra8a9hrln9"
+   "commit": "f6c3b96748cb4e6d3022a2cece15d0d0fc437cd6",
+   "sha256": "0w4ad054kd5g4qk7m26rsm9fvarrfaq3psds0hflsf6pc5k6xcmg"
   }
  },
  {
@@ -24593,25 +24786,25 @@
   "repo": "minad/dicom",
   "unstable": {
    "version": [
-    20251008,
-    1041
+    20251115,
+    1813
    ],
    "deps": [
     "compat"
    ],
-   "commit": "df5acfbb5d1211515d2dfec141fd063be35bff16",
-   "sha256": "1fbiajyp5d074kg48w2kg30wz8png0b9scgabbplkmjsm3swnpyw"
+   "commit": "161d7b6b990cf608f5f71b4a6c840cfa57107d35",
+   "sha256": "1inmzamm88zzq98x5xjc97c0kk9mgdmj9jw6vklmhiady2v8jy6y"
   },
   "stable": {
    "version": [
     1,
-    0
+    2
    ],
    "deps": [
     "compat"
    ],
-   "commit": "3c5e750ff63cbd80d328738f93975eee4b537505",
-   "sha256": "15xi5c6qp6k941zh0axb0xlgb596mqf52gvd23r50s4njpllbsqz"
+   "commit": "161d7b6b990cf608f5f71b4a6c840cfa57107d35",
+   "sha256": "1inmzamm88zzq98x5xjc97c0kk9mgdmj9jw6vklmhiady2v8jy6y"
   }
  },
  {
@@ -24684,11 +24877,11 @@
   "repo": "kisaragi-hiu/didyoumean.el",
   "unstable": {
    "version": [
-    20240229,
-    1807
+    20251103,
+    1002
    ],
-   "commit": "fc12bd33c7b4f6dc74e49735c269ff75c72227a1",
-   "sha256": "1fc0bmhvhmhnvqsp5j3dwhsi355aarrxcs5jgnjp7y26wi6ijn4h"
+   "commit": "398fc3bf8ea520cd0517076bdc9b609cc6858c80",
+   "sha256": "1kgxck5b40mhi6v6jw5knjcj4hv9hv1kgsj053j3ih4mndjpiyj0"
   },
   "stable": {
    "version": [
@@ -24708,11 +24901,11 @@
   "repo": "ideasman42/emacs-diff-ansi",
   "unstable": {
    "version": [
-    20250913,
-    2251
+    20251126,
+    1134
    ],
-   "commit": "1ae63be2381d97afcf63c5dbf07ed9310aa3d707",
-   "sha256": "12gpq6ga2977lh5h1x37qwc97vwq8qk6m4izq6ja762iq6wqp12g"
+   "commit": "5db2c410fc754a919b5b6811277646da5a26778c",
+   "sha256": "0zvbvwzrx05p6xgpndsil215rmgvcmrnfk77xxknllvk15isqqfj"
   }
  },
  {
@@ -24738,14 +24931,14 @@
   "repo": "dgutov/diff-hl",
   "unstable": {
    "version": [
-    20251008,
-    2241
+    20251126,
+    112
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "74bfb7069dd51d2df57ff7ab6686b40e36bb0ed0",
-   "sha256": "0mni00skryyyjky5a467bz7bm4c1lkwsmc2n4yfp3r2xn0mp4h78"
+   "commit": "685ea2d50607a9902f1c6c141ee6268d759b9b25",
+   "sha256": "0mb2b3rrv349fx4sa6q4kvf6xfr601b4fhlhrac519x0a0kbg1q6"
   },
   "stable": {
    "version": [
@@ -24861,16 +25054,16 @@
   "repo": "pkryger/difftastic.el",
   "unstable": {
    "version": [
-    20250930,
-    718
+    20251021,
+    1320
    ],
    "deps": [
     "compat",
     "magit",
     "transient"
    ],
-   "commit": "63d31f62617da25b9c77afd0fe88b26e095d506d",
-   "sha256": "105q2477lwhfzhrgpc6nhjxax868nv28k8kif2q27djsh9i37wh4"
+   "commit": "9cb89fcff94f68b869e214b08d7af7265b78ecbd",
+   "sha256": "158qb1ymgfqkxnj02lgairgcwzd10m3l5inqbhsr0202jcmijr8a"
   }
  },
  {
@@ -25037,26 +25230,26 @@
   "repo": "tarsius/dim-autoload",
   "unstable": {
    "version": [
-    20250801,
-    945
+    20251101,
+    2000
    ],
    "deps": [
     "compat"
    ],
-   "commit": "31ba7cf40f5da6b6157c71917599cf718fd68936",
-   "sha256": "0gkpmssr4f5wz6qxapyz66j5wixg4jxs4dslk85nqlhhlpn2vnsc"
+   "commit": "793b259f6ad2c1b47152986ec2d39622792fb3d2",
+   "sha256": "077p2xxmjji9ngdm39cv1lc8nd6vby1fxbmha7xmzq7z7xsib340"
   },
   "stable": {
    "version": [
     2,
     1,
-    0
+    1
    ],
    "deps": [
     "compat"
    ],
-   "commit": "31ba7cf40f5da6b6157c71917599cf718fd68936",
-   "sha256": "0gkpmssr4f5wz6qxapyz66j5wixg4jxs4dslk85nqlhhlpn2vnsc"
+   "commit": "793b259f6ad2c1b47152986ec2d39622792fb3d2",
+   "sha256": "077p2xxmjji9ngdm39cv1lc8nd6vby1fxbmha7xmzq7z7xsib340"
   }
  },
  {
@@ -25208,11 +25401,11 @@
   "repo": "jamescherti/dir-config.el",
   "unstable": {
    "version": [
-    20250330,
-    2325
+    20251103,
+    1431
    ],
-   "commit": "985e86dd79cd661493f3858d172d7452c6fb440e",
-   "sha256": "0bj0767ri5bivk8005cdyzw6lwq42l8z2z3ad80scw7myc04s6q2"
+   "commit": "727e34c77b2b43c6b0d0bc10556ece8c21bd1f9e",
+   "sha256": "18r6qk706yajv646g1jglhv5gncm0yp6r9f5fgavjikzf6gzwdlg"
   },
   "stable": {
    "version": [
@@ -25619,11 +25812,11 @@
   "repo": "Anoncheg1/dired-hist",
   "unstable": {
    "version": [
-    20240405,
-    2347
+    20251110,
+    1828
    ],
-   "commit": "bcbfa60e2de0d86a38740d72bea7e4f25ccc35c8",
-   "sha256": "06vjlijvicgszpfb09gpwhb2cczajn5hjp9a5vzf5yn9h76rhjkk"
+   "commit": "8cca7292086b849ef170d17bc6beafbc2d3228b6",
+   "sha256": "1mgn860srj3jw8ifnvfmpq726xwq4b4yc6pns9b2y2hwyvc2k7qh"
   },
   "stable": {
    "version": [
@@ -26171,14 +26364,14 @@
   "repo": "Boruch-Baum/emacs-diredc",
   "unstable": {
    "version": [
-    20250928,
-    618
+    20251124,
+    1412
    ],
    "deps": [
     "key-assist"
    ],
-   "commit": "009558fcce67bd1120b9285cceae15bdc6dfcef2",
-   "sha256": "0xj6zn08d30nm9lbmnv6192ywnxl7nlvp4y8cndgsqzncahfv3c6"
+   "commit": "11ffa50763ac06a4aa356ba27f8ce5b57a0ac36c",
+   "sha256": "1a5zzhzm1ia6f3ri4j1sgja404y3zc0rdm4dy3sl8rsrgv8k3307"
   },
   "stable": {
    "version": [
@@ -27113,11 +27306,11 @@
   "repo": "ideasman42/emacs-doc-show-inline",
   "unstable": {
    "version": [
-    20250913,
-    2251
+    20251126,
+    1144
    ],
-   "commit": "4c43aac0867af455d9aee341480725e8bbcd7569",
-   "sha256": "01id3zxbsa0lc37q0ipr789570qnrn352wrr8prf8yi7zk36qkf6"
+   "commit": "87993d064d02dcdbb3dcfd883e4a0b498b0978d8",
+   "sha256": "1cv4iikmzgydzsjmm2jayyaims2cnijjfhc931q24p7dc6p3fr8l"
   }
  },
  {
@@ -27180,8 +27373,8 @@
   "repo": "Silex/docker.el",
   "unstable": {
    "version": [
-    20250715,
-    835
+    20251028,
+    1026
    ],
    "deps": [
     "aio",
@@ -27190,14 +27383,14 @@
     "tablist",
     "transient"
    ],
-   "commit": "91233a7c559d87c47de6193a64913732756f0799",
-   "sha256": "10dfxqslvdmzni9ifjcqx6kd5r0h991h204x2zm2ng9nv0hs4sg4"
+   "commit": "375e0ed45bb1edc655d9ae2943a09864bec1fcba",
+   "sha256": "102hn0m91shyiz25x2c5ihhzbc8a3i9vnlkfcb3xm3w3nrqa5w64"
   },
   "stable": {
    "version": [
     2,
-    3,
-    1
+    4,
+    0
    ],
    "deps": [
     "aio",
@@ -27206,8 +27399,8 @@
     "tablist",
     "transient"
    ],
-   "commit": "2def2ab7fa04ed14403d00e3547a94c3822302cb",
-   "sha256": "13927ns3393q40gxrfzyqh6ajxzfjg14d0srfxi6ild3pmaz0460"
+   "commit": "375e0ed45bb1edc655d9ae2943a09864bec1fcba",
+   "sha256": "102hn0m91shyiz25x2c5ihhzbc8a3i9vnlkfcb3xm3w3nrqa5w64"
   }
  },
  {
@@ -27581,30 +27774,30 @@
   "repo": "seagle0128/doom-modeline",
   "unstable": {
    "version": [
-    20250925,
-    241
+    20251126,
+    1552
    ],
    "deps": [
     "compat",
     "nerd-icons",
     "shrink-path"
    ],
-   "commit": "1efbd4f784a13e4ada0ddbf2b4c68b57c03b4f4d",
-   "sha256": "1qdzgl5vvil1lfvarv931762vy9bv3kq4v8fa16rk34rdb93wk79"
+   "commit": "85dc5f033e057135a90958f258c5c6362c5497de",
+   "sha256": "1zxxr86ga30m062s3vh1gh95fyc2dpm712md7k8flxmd0f83dsn2"
   },
   "stable": {
    "version": [
     4,
     2,
-    0
+    1
    ],
    "deps": [
     "compat",
     "nerd-icons",
     "shrink-path"
    ],
-   "commit": "14b09e0b20f0e210be54167b12c3b5a201eb0327",
-   "sha256": "093faiamd6lk2abk5n61i86drawqb00v319yg9vv95an6silcmmg"
+   "commit": "2f6112cba40df55042d577c3810df7d4be2577a8",
+   "sha256": "1v0jm217sx4bjjp60ipqzdqh4vj7rcqbpz43ph3n2cj886gybh7b"
   }
  },
  {
@@ -27874,6 +28067,30 @@
   }
  },
  {
+  "ename": "doxymin",
+  "commit": "b671c4ffa74bd1704ceaf1414ecc326dae935bf1",
+  "sha256": "06kn8chzxl0256fk37v069al7aph5mcahaxw0qy64dr6d444k95y",
+  "fetcher": "gitlab",
+  "repo": "L0ren2/doxymin",
+  "unstable": {
+   "version": [
+    20251122,
+    1103
+   ],
+   "commit": "1de66de7bf4b0c3f6d09eaf461337840bd28715e",
+   "sha256": "055wff4hdry0pigl7b1vrn06gg08hn4rmpw9g477xbmhybk9f95z"
+  },
+  "stable": {
+   "version": [
+    0,
+    0,
+    4
+   ],
+   "commit": "1de66de7bf4b0c3f6d09eaf461337840bd28715e",
+   "sha256": "055wff4hdry0pigl7b1vrn06gg08hn4rmpw9g477xbmhybk9f95z"
+  }
+ },
+ {
   "ename": "dpaste",
   "commit": "855ea20024b606314f8590129259747cac0bcc97",
   "sha256": "0wrfy9w0yf5m15vmhg4l880v92cy557g332xniqs77ab0sga4vgc",
@@ -27914,14 +28131,14 @@
   "url": "https://salsa.debian.org/emacsen-team/dpkg-dev-el.git",
   "unstable": {
    "version": [
-    20250912,
-    823
+    20251025,
+    1006
    ],
    "deps": [
     "debian-el"
    ],
-   "commit": "38f1fb20892dbb7c0e5ab6e23b7dee1f3fd926b3",
-   "sha256": "1w0q1j4l0ajyil39hy0w6cppn7nksif04wqw6wi9wk8jdxvqy9nl"
+   "commit": "314f0dbbbb6410e8ebcdb99de34e345fc12e40fb",
+   "sha256": "0q4jh8jn9nsfv2i3q5libcig0jnvp0r8fbim4q6mywb0jq4zp4sx"
   },
   "stable": {
    "version": [
@@ -28284,19 +28501,19 @@
   "repo": "jscheid/dtrt-indent",
   "unstable": {
    "version": [
-    20250716,
-    2128
+    20251102,
+    857
    ],
-   "commit": "9108979357e8c9a1015baa5d37c0b596e2dda11b",
-   "sha256": "1fk88rjv8shdpmnbhc4fy52anf18w7xl9z2fi6bnpjawi9hn9c94"
+   "commit": "7c372bec8d84c247e4bd0d5599024d66ee300429",
+   "sha256": "04p6avj8d15i6qswdfpgvdil5c13rcfmc4n2jili485zgpw14j81"
   },
   "stable": {
    "version": [
     1,
-    25
+    26
    ],
-   "commit": "9108979357e8c9a1015baa5d37c0b596e2dda11b",
-   "sha256": "1fk88rjv8shdpmnbhc4fy52anf18w7xl9z2fi6bnpjawi9hn9c94"
+   "commit": "7c372bec8d84c247e4bd0d5599024d66ee300429",
+   "sha256": "04p6avj8d15i6qswdfpgvdil5c13rcfmc4n2jili485zgpw14j81"
   }
  },
  {
@@ -28434,11 +28651,11 @@
   "repo": "ocaml/dune",
   "unstable": {
    "version": [
-    20240427,
-    1346
+    20250903,
+    1130
    ],
-   "commit": "5554158af27ead066fbb3c009e780c930958613c",
-   "sha256": "1wilcgji9nw2lwvb4zkhikb0wkpyzj3070czhvvlclxx5ispxh9g"
+   "commit": "1e54fd3f450aae7fb41ffb6b7c8b7a5aed754777",
+   "sha256": "1z4ji0jwwwxsx0ffw0klnkvaql8m2mqyi9h308y23waaf8dr3g94"
   },
   "stable": {
    "version": [
@@ -28601,11 +28818,11 @@
   "repo": "xenodium/dwim-shell-command",
   "unstable": {
    "version": [
-    20251008,
-    1304
+    20251028,
+    1030
    ],
-   "commit": "1f40c468fd5bf5241276347ea785b7f3082d8260",
-   "sha256": "1imybvlr2wc6zg9r8c8bymra9l2089db2pjlb6lbri59g2byi79f"
+   "commit": "44b35c8af2e1c5ba156a7a4d1766c3b6e55611ad",
+   "sha256": "0861180d26g1kwivg1jbhm05wm1bhc9y1q264vyrgw11976xkm8j"
   },
   "stable": {
    "version": [
@@ -28615,6 +28832,36 @@
    ],
    "commit": "7d1c45aa2bc782c448cadd989dc776c2e5f83514",
    "sha256": "0iy4pg86sl1z3mwnfm6nsy9gjanddbpyg9w099wvflpq0l54lm0g"
+  }
+ },
+ {
+  "ename": "dwin",
+  "commit": "34407dd667401c885f85e5ca6c87d74edcc297d6",
+  "sha256": "1nayvd95rsxlkp00ddbp6zxslnr7r33bvh0j166gwcy4xfgdk64q",
+  "fetcher": "github",
+  "repo": "lsth/dwin",
+  "unstable": {
+   "version": [
+    20251128,
+    2028
+   ],
+   "deps": [
+    "compat"
+   ],
+   "commit": "ed1ca4f2b9ba148f6075896ca113548811ef6b80",
+   "sha256": "0fhkzlbigqvbasb28lbm7j4fbh0xk2kc0a4pssr35z2ryay3hl8j"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    0
+   ],
+   "deps": [
+    "compat"
+   ],
+   "commit": "aed6438f22783c5590ad5e3ac71575b70a9d64ed",
+   "sha256": "0fc6610ljk2bnvcdyxzrd0zrp7k6yhgfcwnk8rqxjk8yfv92nam4"
   }
  },
  {
@@ -28764,11 +29011,11 @@
   "repo": "countvajhula/dynaring",
   "unstable": {
    "version": [
-    20250617,
-    43
+    20251104,
+    1606
    ],
-   "commit": "a02e2aa5b4964c9715e9f0634a7c60698fc6d2c9",
-   "sha256": "0am496m8k6dvyfzh3ri7152fkx2bgfr6v2g05g8ldim2cpgqm6cz"
+   "commit": "d74e4f36da97a64baa023e5b2519bfaac7d8b02b",
+   "sha256": "0nmjgc21hzfhjcrzm7n82c84si400l9jdw0p3khdifgr39avcb6d"
   },
   "stable": {
    "version": [
@@ -29114,11 +29361,11 @@
   "repo": "emacs-eask/eask",
   "unstable": {
    "version": [
-    20250801,
-    1115
+    20251115,
+    2211
    ],
-   "commit": "6125fc4782a388a387f787108850074db5381ab5",
-   "sha256": "1gbijxcfcqfgy8aas612xnyhyps28nivcb79ma1k5j7ybb6d3za5"
+   "commit": "6b0c7c46e686afb559f52974be6be9a21763398d",
+   "sha256": "16f7cbzld21waqmh6152i7v03csv8ym2z8ksv4ans4vkgk9v0895"
   },
   "stable": {
    "version": [
@@ -29394,6 +29641,21 @@
   }
  },
  {
+  "ename": "easy-theme-preview",
+  "commit": "3280d652d017a16eedcd87b2788b6db49dcc17ee",
+  "sha256": "007175i96slhnvfhr804gznpf4kyn63xiq1k8xkd8ww38vkjc4m6",
+  "fetcher": "github",
+  "repo": "ayys/easy-theme-preview.el",
+  "unstable": {
+   "version": [
+    20251123,
+    1604
+   ],
+   "commit": "999d89d88634e2eedcc82ac56fa54ed92ce38614",
+   "sha256": "186dhpla0rcb1dqmqyhfapw84kcarsffclis2pg3wfh7r6d2v2jj"
+  }
+ },
+ {
   "ename": "easysession",
   "commit": "983fd80302a8a75c2ba5e00a919ae3ff51bd24b6",
   "sha256": "01p8cc34w7wqvr8dpcb120gjqv9br1wnyy0ha99x8c0yas587k2j",
@@ -29401,20 +29663,20 @@
   "repo": "jamescherti/easysession.el",
   "unstable": {
    "version": [
-    20250911,
-    225
+    20251113,
+    1422
    ],
-   "commit": "3a7e3882bb0a09f58aebfdc16c53924d5f8b66a5",
-   "sha256": "0ffrcls3wnviam2fh7dyyhlzkb09jqapclq153sjb57j950b8ajs"
+   "commit": "f30ffdf6e270e0420df99b1265081800a36ca4d5",
+   "sha256": "1vv55xbvfir7x1iilsrwrxl1jgz1929zwqygwms48pf835rh24gl"
   },
   "stable": {
    "version": [
     1,
     1,
-    4
+    7
    ],
-   "commit": "b28881254c639f5e6a34e4ab46ba1d84e2a8d225",
-   "sha256": "1g658l2vpk09j6mc0q6z1z2lqv1gcr0xvkxf7i1g3101ck72ynrz"
+   "commit": "f30ffdf6e270e0420df99b1265081800a36ca4d5",
+   "sha256": "1vv55xbvfir7x1iilsrwrxl1jgz1929zwqygwms48pf835rh24gl"
   }
  },
  {
@@ -29425,28 +29687,28 @@
   "repo": "swflint/emacs-universal-sidecar",
   "unstable": {
    "version": [
-    20250704,
-    342
+    20251029,
+    1934
    ],
    "deps": [
     "ebdb",
     "universal-sidecar"
    ],
-   "commit": "c7f17d5377c8d97a72f6548a82d6b259dfc8fc07",
-   "sha256": "0pjvqrjmb616x9jc1zzwvrnlnsyws6acm1c4z6hs2c6nlh18ypnk"
+   "commit": "01b12aecca0ce66f5427e7fe65012d37e7e128b2",
+   "sha256": "1gm5337d87mm3y41f787wadk7kmkdrw4rq9anb3wqhx8sn6j63gh"
   },
   "stable": {
    "version": [
     1,
-    7,
+    9,
     0
    ],
    "deps": [
     "ebdb",
     "universal-sidecar"
    ],
-   "commit": "c7f17d5377c8d97a72f6548a82d6b259dfc8fc07",
-   "sha256": "0pjvqrjmb616x9jc1zzwvrnlnsyws6acm1c4z6hs2c6nlh18ypnk"
+   "commit": "01b12aecca0ce66f5427e7fe65012d37e7e128b2",
+   "sha256": "1gm5337d87mm3y41f787wadk7kmkdrw4rq9anb3wqhx8sn6j63gh"
   }
  },
  {
@@ -29522,8 +29784,8 @@
   "repo": "swflint/emacs-universal-sidecar",
   "unstable": {
    "version": [
-    20250704,
-    342
+    20251029,
+    1934
    ],
    "deps": [
     "citeproc",
@@ -29531,13 +29793,13 @@
     "universal-sidecar",
     "universal-sidecar-citeproc"
    ],
-   "commit": "c7f17d5377c8d97a72f6548a82d6b259dfc8fc07",
-   "sha256": "0pjvqrjmb616x9jc1zzwvrnlnsyws6acm1c4z6hs2c6nlh18ypnk"
+   "commit": "01b12aecca0ce66f5427e7fe65012d37e7e128b2",
+   "sha256": "1gm5337d87mm3y41f787wadk7kmkdrw4rq9anb3wqhx8sn6j63gh"
   },
   "stable": {
    "version": [
     1,
-    7,
+    9,
     0
    ],
    "deps": [
@@ -29546,8 +29808,8 @@
     "universal-sidecar",
     "universal-sidecar-citeproc"
    ],
-   "commit": "c7f17d5377c8d97a72f6548a82d6b259dfc8fc07",
-   "sha256": "0pjvqrjmb616x9jc1zzwvrnlnsyws6acm1c4z6hs2c6nlh18ypnk"
+   "commit": "01b12aecca0ce66f5427e7fe65012d37e7e128b2",
+   "sha256": "1gm5337d87mm3y41f787wadk7kmkdrw4rq9anb3wqhx8sn6j63gh"
   }
  },
  {
@@ -29588,8 +29850,8 @@
   "repo": "editor-code-assistant/eca-emacs",
   "unstable": {
    "version": [
-    20251009,
-    1404
+    20251124,
+    2208
    ],
    "deps": [
     "compat",
@@ -29597,8 +29859,8 @@
     "f",
     "markdown-mode"
    ],
-   "commit": "a7e9fe25af8fd8827399f2a83744a00156cbc256",
-   "sha256": "00smlfls8zdmlgcb55wn65afd68gyrn91szp4r4vc2mbmcqla04j"
+   "commit": "acc209e697060f0d022a515141eeda332661b557",
+   "sha256": "1dngysa3gi50b4z992hn95x919sbg8djjgbpvy1zikggyxb3q0zb"
   },
   "stable": {
    "version": [
@@ -29624,11 +29886,11 @@
   "repo": "ecb-org/ecb",
   "unstable": {
    "version": [
-    20250930,
-    1739
+    20251014,
+    1427
    ],
-   "commit": "a1694bb856784fcd9edf1020ca3a40a924a403f5",
-   "sha256": "1nvcbi3gp4h4pm88b4938pp3d7qklsxcqqvl1s62lv05dwvraczn"
+   "commit": "2f9028aa1d8791720e809954016dbc84fe8fc864",
+   "sha256": "1gvqayfp8a5fjd6clibj4fn4algy921ck0ifa61g3gykhkmj1jhi"
   },
   "stable": {
    "version": [
@@ -30000,10 +30262,10 @@
  },
  {
   "ename": "edit-list",
-  "commit": "6c8aa348ce5289a8b1238f186affac1d544af755",
-  "sha256": "0mi12jfgx06i0yr8k5nk80xryqszjv0xykdnri505862rb90xakv",
+  "commit": "268636da24129c47d0fcf15127aef241191ac644",
+  "sha256": "1z5j6m6bwlcvdldx30dz893is0n0ngq5pcrz4vq52gvp38b7vymi",
   "fetcher": "github",
-  "repo": "emacsmirror/edit-list",
+  "repo": "emacsattic/edit-list",
   "unstable": {
    "version": [
     20100930,
@@ -30070,11 +30332,11 @@
   "repo": "editorconfig/editorconfig-emacs",
   "unstable": {
    "version": [
-    20250905,
-    724
+    20251127,
+    2310
    ],
-   "commit": "4af10445fcdf1c9dfa7af4f9e5bec59e8a759d6f",
-   "sha256": "1lik1xwq5jlmrnyk03zmladkqk9mmxbrgxn25rzhm51idylfgvqf"
+   "commit": "5be6d1b972197d4a398962841c1e6b6993ad5c78",
+   "sha256": "0gbb7wfp96f9b42cnfcydmg8abfplxlam5f75vz2zs17iqgw5hmn"
   },
   "stable": {
    "version": [
@@ -30213,11 +30475,11 @@
   "repo": "sinic/ednc",
   "unstable": {
    "version": [
-    20241129,
-    1636
+    20251104,
+    1820
    ],
-   "commit": "e181e0bbf12b6516afba3785192d88432d8ebc6c",
-   "sha256": "1b545ibacpvjvwh0lhyx6g483xkdf8lqiiddddch3pq3dnm38yzg"
+   "commit": "638d73e7c3fe4ffe86199e33fb85fbaa4cf1ab7f",
+   "sha256": "13q8w4xn1i4syz5rjjnygarw1i9x3rg2dkivighbnv0d20nvjr1d"
   },
   "stable": {
    "version": [
@@ -30703,20 +30965,20 @@
   "url": "https://forge.tedomum.net/hjuvi/eide.git",
   "unstable": {
    "version": [
-    20251003,
-    1847
+    20251122,
+    2140
    ],
-   "commit": "0f0ebce80f0feb718b84115b05ed45ec5dfe5b81",
-   "sha256": "1wxl9d9gk5ssdglsd35j0xv0arv3jd050pkna5q5f4vs8464gxl5"
+   "commit": "e3aeed7fcd2892b0d3d3b8f29743ec864ab7466d",
+   "sha256": "1xcbfbi9dgajsxg4ccxxyfd2k2srqjg1wlmb0hyq40b95h45y7m4"
   },
   "stable": {
    "version": [
     2,
     3,
-    3
+    4
    ],
-   "commit": "0e41fa0315b2e499dd0947cdda05d9a2e1aa2203",
-   "sha256": "0pjp51di1jv7ziq4sf0q526jjjizvrd8xw5qlzjd2pz7gsz754rc"
+   "commit": "a5b47c5d0a19441359e0ad0de5f2fe3f61f671fa",
+   "sha256": "0n71kldig62h2vf44kk143dzp82fnq9d1bzxy7ahrhg00z3i2cby"
   }
  },
  {
@@ -30840,15 +31102,15 @@
   "repo": "ahyatt/ekg",
   "unstable": {
    "version": [
-    20251006,
-    437
+    20251110,
+    242
    ],
    "deps": [
     "llm",
     "triples"
    ],
-   "commit": "48f6188a6c7661ef8b5094d434b8c6b442d8d7de",
-   "sha256": "13j6y37aksfdpdckw166im0fh45jv9vv9kxjs6248nmcxy0vc1ya"
+   "commit": "70036806b488d3c933e95334c99866532e21944f",
+   "sha256": "1whz361xh0ims2kwhpahpgslcr4q2v64cx4wki4gi5llnbg2sr7c"
   },
   "stable": {
    "version": [
@@ -30889,26 +31151,26 @@
  },
  {
   "ename": "el-fetch",
-  "commit": "a6ff6bbfa11f08647bf17afe75bfb4dcafd86683",
-  "sha256": "0dkynd8wp687vddjdggsafqfxmpm51gwhr92v9n6w9zqgvhcn2k7",
+  "commit": "dcf3a770af51d6cb3a45b85d81d4a517f7d91959",
+  "sha256": "15vypaassdchzb7390sfxjbwiil2ha62h69w9abrbgw6a05w7r13",
   "fetcher": "gitlab",
-  "repo": "xgqt/emacs-el-fetch",
+  "repo": "xgqt/xgqt-elisp-app-el-fetch",
   "unstable": {
    "version": [
-    20230624,
-    2
+    20250105,
+    2335
    ],
-   "commit": "7907fd7829ca55b21a62d23c17066fdfde9cd07c",
-   "sha256": "0b2z767j9cdv2a7n0g5x4zxjp9jim9q2lwcvyxddq82lrqy75ych"
+   "commit": "a1ae3704de96e6d622a67faacfae7a5993f96699",
+   "sha256": "122nn7qvsqr92ra06kfgfzxma3mljzx18c4l8fsa66lbwjgrxfmp"
   },
   "stable": {
    "version": [
-    3,
-    3,
+    4,
+    0,
     0
    ],
-   "commit": "0142f58f075ea39aa6cc7ed35dd599afc4b6b450",
-   "sha256": "0d15zpbymi8k5bacgl6iyy60vzx2783qqn72cd7gszyxf6kz2695"
+   "commit": "a1ae3704de96e6d622a67faacfae7a5993f96699",
+   "sha256": "122nn7qvsqr92ra06kfgfzxma3mljzx18c4l8fsa66lbwjgrxfmp"
   }
  },
  {
@@ -30934,11 +31196,11 @@
   "repo": "dimitri/el-get",
   "unstable": {
    "version": [
-    20240408,
-    837
+    20251110,
+    758
    ],
-   "commit": "1c5b0eb7fa162523183a96e409e4e3ae6b5cc3a0",
-   "sha256": "1dw13jpls9rm4xli52ry3g966hji92s8kysyn7p1rcxbygvqwyw2"
+   "commit": "64112351b1f58c77463b8802ddd7f78964c9c5ca",
+   "sha256": "0lj83i7qxsy1lm5fc639y1mbxk1krhbhr1ig4gsfwxqyq2v4bqq0"
   },
   "stable": {
    "version": [
@@ -31455,11 +31717,11 @@
   "repo": "vilij/slurpbarf-elcute",
   "unstable": {
    "version": [
-    20251009,
-    1510
+    20251018,
+    1822
    ],
-   "commit": "cc3237983a9cbd2f1af20c5ae99ecb0a77f42361",
-   "sha256": "15m2580y6dyxa88b17jv22b1iqijibkspajsbk2s4gchid89rhy2"
+   "commit": "f590cc7f9308c37231693e41bf773da002542d51",
+   "sha256": "09m7s1xmb35q9i4969x3150d6ml1pap22vpjywdzw3s7gpkm8nxx"
   }
  },
  {
@@ -31494,11 +31756,11 @@
   "repo": "casouri/eldoc-box",
   "unstable": {
    "version": [
-    20250920,
-    125
+    20251111,
+    2306
    ],
-   "commit": "fead2cef661790417267e5498d4d14806e020f99",
-   "sha256": "0nxc0qyx1lz8z9qhkchhmb1n4sfwxi86flwylmxrjq4dvza2p072"
+   "commit": "84bff3a1da2db9e5451e06241642b6f7216f09f8",
+   "sha256": "02ni8jihl3ig2jbrd2dix41j3373nvsjp3fm43piwi7q75m8j1zz"
   },
   "stable": {
    "version": [
@@ -31576,6 +31838,37 @@
    ],
    "commit": "deca5e39f31282a06531002d289258cd099433c0",
    "sha256": "1fh9dx669czkwy4msylcg64azz3az27akx55ipnazb5ghmsi7ivk"
+  }
+ },
+ {
+  "ename": "eldoc-mouse",
+  "commit": "9df97bcc0b9505df4dafdc65afc730b822e2ec47",
+  "sha256": "14ywf67kndd1hqvprqxig30rsqwx5nlaqcmmq5ghyi9sqp2hai5z",
+  "fetcher": "github",
+  "repo": "huangfeiyu/eldoc-mouse",
+  "unstable": {
+   "version": [
+    20251126,
+    1410
+   ],
+   "deps": [
+    "eglot",
+    "posframe"
+   ],
+   "commit": "2c76900a95cbc90eacd914b4231282c9370dab23",
+   "sha256": "0cdws6rcfc371nxzkaz7qm1n4xgdc9v99p3mpr1012kr3aw7n3qc"
+  },
+  "stable": {
+   "version": [
+    3,
+    0
+   ],
+   "deps": [
+    "eglot",
+    "posframe"
+   ],
+   "commit": "0b84d1bb46992680181cf67b8f8aeaff3be5620b",
+   "sha256": "1lg1kbfshi99jy4a9wcaiw60rd2356skdvlk9cqsay69vh5ygba9"
   }
  },
  {
@@ -31914,26 +32207,26 @@
   "repo": "rnadler/elfeed-curate",
   "unstable": {
    "version": [
-    20231119,
-    32
+    20251026,
+    311
    ],
    "deps": [
     "elfeed"
    ],
-   "commit": "195ee944a1dd95380c680d886e15a8aadab50b8e",
-   "sha256": "052wz0aw9mwfzs34pa6wf1kh5fwp155pnp4b4f159nj0w6ih9mk6"
+   "commit": "c91caf36cefadd818c893ac219265367f9f7945d",
+   "sha256": "0sc5x1h7vq41gny9hy3mpysnrisyy7972jqrh56xdk3l37f5xj7x"
   },
   "stable": {
    "version": [
     0,
-    2,
-    1
+    3,
+    0
    ],
    "deps": [
     "elfeed"
    ],
-   "commit": "195ee944a1dd95380c680d886e15a8aadab50b8e",
-   "sha256": "052wz0aw9mwfzs34pa6wf1kh5fwp155pnp4b4f159nj0w6ih9mk6"
+   "commit": "c91caf36cefadd818c893ac219265367f9f7945d",
+   "sha256": "0sc5x1h7vq41gny9hy3mpysnrisyy7972jqrh56xdk3l37f5xj7x"
   }
  },
  {
@@ -32035,26 +32328,26 @@
   "repo": "sp1ff/elfeed-score",
   "unstable": {
    "version": [
-    20250217,
-    337
+    20251012,
+    2253
    ],
    "deps": [
     "elfeed"
    ],
-   "commit": "5ab2382d54baa4ee54b2fc54d7de54ec6e488c74",
-   "sha256": "16dsv9nqc71hpdxcy8xspy6ji32q8j38ikq57kxrvkysv2zsjzy6"
+   "commit": "9e9874dc4f2a6b01199e0834ba52665d8383ad9f",
+   "sha256": "14f5m81ik8w3yi2dc3mff88v63abkcjs5fcp5d2zbg35adbqrb7l"
   },
   "stable": {
    "version": [
     1,
     2,
-    9
+    10
    ],
    "deps": [
     "elfeed"
    ],
-   "commit": "5ab2382d54baa4ee54b2fc54d7de54ec6e488c74",
-   "sha256": "16dsv9nqc71hpdxcy8xspy6ji32q8j38ikq57kxrvkysv2zsjzy6"
+   "commit": "9e9874dc4f2a6b01199e0834ba52665d8383ad9f",
+   "sha256": "14f5m81ik8w3yi2dc3mff88v63abkcjs5fcp5d2zbg35adbqrb7l"
   }
  },
  {
@@ -32273,11 +32566,11 @@
   "repo": "ideasman42/emacs-elisp-autofmt",
   "unstable": {
    "version": [
-    20251002,
-    1141
+    20251126,
+    531
    ],
-   "commit": "6f5936074bb3e44437957cef1f5405898a60309c",
-   "sha256": "1vchi3qf3w0fdxy8nim3gpzn6zlaxma7v05n2y7kwmxd1i7iy7cq"
+   "commit": "35acb57405af8768569a80205b161c806816f2a3",
+   "sha256": "038fkrbp1yy9jr8wqxki83cka7hjqskbljfpr74l8957cv7w1zpx"
   }
  },
  {
@@ -32345,11 +32638,11 @@
   "repo": "emacsorphanage/elisp-depend",
   "unstable": {
    "version": [
-    20190325,
-    1114
+    20251121,
+    2039
    ],
-   "commit": "6679da9a6be5a845bb4804224c8394a9bc62168f",
-   "sha256": "09xbrk1li76fwa85kvd5xpr0zswrkh51p7a62sb8g422wpaqxiwx"
+   "commit": "c604eee1a86a297cd13c0235ebde1431dcad59d2",
+   "sha256": "0gxv85hxrcrf7xlamr3znkarxv05hfcsdl742ymim0xrh71gyi34"
   }
  },
  {
@@ -32360,11 +32653,14 @@
   "repo": "mtekman/elisp-depmap.el",
   "unstable": {
    "version": [
-    20250919,
-    1240
+    20251029,
+    1438
    ],
-   "commit": "65afa5316506666888c0fb073505eb7e7c62c893",
-   "sha256": "0758c9v1fz9lcfhwlj47z64s2m256av56klh6ly8sjprdx7jrnjk"
+   "deps": [
+    "dash"
+   ],
+   "commit": "c87e9ecae624b09d113c25b7ad1317d97eb2f434",
+   "sha256": "0z6ikfz2br1786gqaklb0l0vydh4zyvqnmv3q60k47x99rjqrhhy"
   }
  },
  {
@@ -33410,28 +33706,28 @@
   "repo": "emacscollective/elx",
   "unstable": {
    "version": [
-    20250901,
-    1600
+    20251101,
+    2004
    ],
    "deps": [
     "compat",
     "llama"
    ],
-   "commit": "fc2d5a232c1efca8a35b086d4f94a7bd8ca290c2",
-   "sha256": "1dw470giapm07k9gw7xi2xl2r7rz930h2fjx247vmyyh1d1ndv6q"
+   "commit": "0fb0bc2c33a0bff2d02848c70f17f3060810a114",
+   "sha256": "01iqjy7lzvyzb87v7hqrmcs0yp280vhb3xvlwysilm1w8qv3bqsn"
   },
   "stable": {
    "version": [
     2,
     3,
-    0
+    1
    ],
    "deps": [
     "compat",
     "llama"
    ],
-   "commit": "fc2d5a232c1efca8a35b086d4f94a7bd8ca290c2",
-   "sha256": "1dw470giapm07k9gw7xi2xl2r7rz930h2fjx247vmyyh1d1ndv6q"
+   "commit": "0fb0bc2c33a0bff2d02848c70f17f3060810a114",
+   "sha256": "01iqjy7lzvyzb87v7hqrmcs0yp280vhb3xvlwysilm1w8qv3bqsn"
   }
  },
  {
@@ -33472,11 +33768,11 @@
   "repo": "tecosaur/emacs-everywhere",
   "unstable": {
    "version": [
-    20250925,
-    1637
+    20251028,
+    1701
    ],
-   "commit": "10bf72a616eae8c4c89025bfebb062f761c869f7",
-   "sha256": "0scl2kjgyxr0clbhnwkbwgmygngli641a7gk2vm0hrb3dqbxbf6h"
+   "commit": "09a6a64dd07a712aad8ef1d0b99c086f025540d3",
+   "sha256": "13x91s0s78yqsyycw1gl6n1vzah8q8a73gp84wlksn3dpqip54mg"
   }
  },
  {
@@ -33526,20 +33822,20 @@
   "repo": "magit/emacsql",
   "unstable": {
    "version": [
-    20250901,
-    1544
+    20251116,
+    1655
    ],
-   "commit": "3e015ab99e061f3967a154683f068ce6553f168a",
-   "sha256": "0j2x6incalwfzwri3lisw5by78w3k2vfhmpdhclq5qzjw7bm126v"
+   "commit": "e1908de2cf2c7b77798ef6645d514dded1d7f8a4",
+   "sha256": "0p69p0dqnp3bkgrbpl2v9q9qr5rh7bf9hbd1lb7cbq5pc93vqrkv"
   },
   "stable": {
    "version": [
     4,
     3,
-    2
+    3
    ],
-   "commit": "3e015ab99e061f3967a154683f068ce6553f168a",
-   "sha256": "0j2x6incalwfzwri3lisw5by78w3k2vfhmpdhclq5qzjw7bm126v"
+   "commit": "138fae5c3f55c81a4eded42eabe4e33483de567e",
+   "sha256": "1vgdmsv6ljamz0bcm3q7mx1f3izcj90vk2w9ms1j4s3fvda4qkir"
   }
  },
  {
@@ -33646,14 +33942,14 @@
   "repo": "oantolin/embark",
   "unstable": {
    "version": [
-    20250825,
-    1352
+    20251118,
+    111
    ],
    "deps": [
     "compat"
    ],
-   "commit": "1371a1e33e3a3d96557beb28dccf1fa762f6ae22",
-   "sha256": "1si8c5p3pqn4295zrpb8gdglzrhz6zc1xlyh7lny1nkvcqvrx2vc"
+   "commit": "7b3b2fa239c34c2e304eab4367a4f5924c047e2b",
+   "sha256": "1hn4x5smylqviaqw35j9wccffsvfxp0q5jlnw0ynxny5c7pnp66l"
   },
   "stable": {
    "version": [
@@ -33842,14 +34138,14 @@
   "repo": "marcoxa/emc",
   "unstable": {
    "version": [
-    20251001,
-    1740
+    20251014,
+    1710
    ],
    "deps": [
     "delight"
    ],
-   "commit": "03c991ccc940c8b744f3a08b962f67eef33e6a4c",
-   "sha256": "1vvpmy42k8rgc533n1d3bqgim1vnay0cvd19w311024rvzbpj8rf"
+   "commit": "f788e164056801059b5821a64909d49472d0e77e",
+   "sha256": "0hc61haiyhrzfm44b17ndqdbyq5vgy4g2v4da87scvkaxnsj8vbq"
   }
  },
  {
@@ -33917,8 +34213,20 @@
   "url": "https://git.savannah.gnu.org/git/emms.git",
   "unstable": {
    "version": [
-    20251002,
-    1442
+    20251125,
+    1121
+   ],
+   "deps": [
+    "cl-lib",
+    "nadvice",
+    "seq"
+   ],
+   "commit": "2b652057ca75b99fab6fb8da90ead645b4a6af13",
+   "sha256": "1lvc9p9skx7x1x07i7h7ga593c60bh32n7lzdf1v9n1i706b8xqv"
+  },
+  "stable": {
+   "version": [
+    24
    ],
    "deps": [
     "cl-lib",
@@ -33927,18 +34235,6 @@
    ],
    "commit": "99ebaae9f180dd6b2e5be363e709efa1da0014d6",
    "sha256": "1x0lja7k2vn3dhnmhg3gvhiv6yid899k26f79c7slwfs0sl680yc"
-  },
-  "stable": {
-   "version": [
-    23
-   ],
-   "deps": [
-    "cl-lib",
-    "nadvice",
-    "seq"
-   ],
-   "commit": "09f829b04804af37d00280e31a0e0257bcd2329e",
-   "sha256": "0d1cjfva0ddpg1s884ybxv7gwgxg8qqnyd8m6z9yyrkizn445gsy"
   }
  },
  {
@@ -34328,28 +34624,28 @@
   "repo": "isamert/empv.el",
   "unstable": {
    "version": [
-    20250907,
-    1847
+    20251116,
+    2314
    ],
    "deps": [
     "compat",
     "s"
    ],
-   "commit": "731b986bb2181f7376ab1a8f01abfd3affb5e20d",
-   "sha256": "0knqzgmh76w1cp6cgxnbpk54bb1saf31myai3kznyx9k7ir4hmhb"
+   "commit": "6b40d9e6f8d479eb22a8649fb92de513d3fc2b44",
+   "sha256": "1jcs9hyqv5gwfjrd2j6rm7blhcafb9fx32crzcy40i0k78r5qdjh"
   },
   "stable": {
    "version": [
     5,
-    0,
+    1,
     0
    ],
    "deps": [
     "compat",
     "s"
    ],
-   "commit": "825d4e87176c5fc9d1bf099926f4514c9d06e69d",
-   "sha256": "02qvac61v6fxgv8pjbbakn3z3xf1x6358gca7nil9k9jv9xq12ng"
+   "commit": "8de3e5abcdf99f76a339a386855d6c2ddd38b178",
+   "sha256": "0in9yyssahrp0qfbwziymg85bmysxlzr58vycb13k4m4g9i4s3r7"
   }
  },
  {
@@ -34516,28 +34812,28 @@
   "repo": "jamescherti/enhanced-evil-paredit.el",
   "unstable": {
    "version": [
-    20250909,
-    2222
+    20251016,
+    1351
    ],
    "deps": [
     "evil",
     "paredit"
    ],
-   "commit": "995b37e0eb5d4993c1491a8b80dd2d1094eaccfc",
-   "sha256": "1a76vdn0wfk7nvmnj2fl9rbg888y2r6956b4j1rmzjq0hsrfr8hf"
+   "commit": "58f607ded07383cd6db5a6a39cc0f76dea61c4f7",
+   "sha256": "1wqcs316amspqjgikaci9125rs27bkgck7w2658aacsghmd49y17"
   },
   "stable": {
    "version": [
     1,
     0,
-    2
+    4
    ],
    "deps": [
     "evil",
     "paredit"
    ],
-   "commit": "5cef5a157e2223552742a16335841e713cf0b277",
-   "sha256": "142sx7c0j7f9i19bb87lcdsqanhhqqcg863zw9lqslnndsnypczg"
+   "commit": "7ca82138881a5efacacf0494b898fb1201311fc8",
+   "sha256": "0kkfnnqd2pzzm92pi13ngh63frp33z2mfb1prkqaw62nq4yrw6d8"
   }
  },
  {
@@ -34837,8 +35133,8 @@
   "repo": "emacscollective/epkg",
   "unstable": {
    "version": [
-    20250901,
-    1551
+    20251108,
+    1325
    ],
    "deps": [
     "closql",
@@ -34846,14 +35142,14 @@
     "emacsql",
     "llama"
    ],
-   "commit": "b6922f112dd0b523df0e2da49b4cc9327b1085ba",
-   "sha256": "0j3abhk3vhbpx2m2hgsafij24a9f55kza9fcy54vh81rh3c15q97"
+   "commit": "a4c8dc4e760ff9d0079e25fa9000b06791ed009b",
+   "sha256": "12m0isjl74i5sflx2rij46838rdai4zdm725wg76234vb6j248xr"
   },
   "stable": {
    "version": [
     4,
     1,
-    0
+    1
    ],
    "deps": [
     "closql",
@@ -34861,8 +35157,8 @@
     "emacsql",
     "llama"
    ],
-   "commit": "b6922f112dd0b523df0e2da49b4cc9327b1085ba",
-   "sha256": "0j3abhk3vhbpx2m2hgsafij24a9f55kza9fcy54vh81rh3c15q97"
+   "commit": "6aabd58170b5385fecc873a9ea53432eb24cc993",
+   "sha256": "06dmsmjgqj5rfy72lkswba02w4rmfaj212qgdw9i8pw7s3fd4f37"
   }
  },
  {
@@ -34873,30 +35169,30 @@
   "repo": "emacscollective/epkg-marginalia",
   "unstable": {
    "version": [
-    20250901,
-    1606
+    20251101,
+    2117
    ],
    "deps": [
     "compat",
     "epkg",
     "marginalia"
    ],
-   "commit": "9c588b4f678f488826fc2707ebdae1ae297f1b76",
-   "sha256": "18hx3909cirrqq4nnxl4zyr322131ybm10lqbacgxlxcvbb8v6j1"
+   "commit": "681295f585efdc3f615ba4be90a246eb46ef4018",
+   "sha256": "0kwqbvkyzwlpvlrp1lcr5fsn2q0h215q1wxa4hcv1bbbbla7kjhz"
   },
   "stable": {
    "version": [
     1,
     1,
-    0
+    1
    ],
    "deps": [
     "compat",
     "epkg",
     "marginalia"
    ],
-   "commit": "9c588b4f678f488826fc2707ebdae1ae297f1b76",
-   "sha256": "18hx3909cirrqq4nnxl4zyr322131ybm10lqbacgxlxcvbb8v6j1"
+   "commit": "681295f585efdc3f615ba4be90a246eb46ef4018",
+   "sha256": "0kwqbvkyzwlpvlrp1lcr5fsn2q0h215q1wxa4hcv1bbbbla7kjhz"
   }
  },
  {
@@ -34936,15 +35232,15 @@
   "repo": "GioBo/eplotly",
   "unstable": {
    "version": [
-    20250910,
-    2140
+    20251118,
+    2156
    ],
    "deps": [
     "f",
     "jack"
    ],
-   "commit": "2b509457bd8bfeea1e906f8db222f9e1fe8e4c4e",
-   "sha256": "1ma3cwfa0zlc567clf4z0pfxz8l3q0lys43ly4rzp47f9lzd4qar"
+   "commit": "dd8165b20726a53fd90ce2499105842ce71211bf",
+   "sha256": "0iji8vgb2ilb424v3j81nig9p3cv01a82hbd4ippj1si5sjxjz1y"
   }
  },
  {
@@ -35123,14 +35419,14 @@
   "repo": "atomontage/erc-crypt",
   "unstable": {
    "version": [
-    20200516,
-    2054
+    20251128,
+    1224
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "aea33aed864dca2866ae951161d15de0b2366e99",
-   "sha256": "05h7bzggzs44m5zbm6pkx0wrnq8mnjyjj9byq2msij8a7kvnnrdc"
+   "commit": "fc7eb4896310cc274ab7d035a1daf6a2a608a1e1",
+   "sha256": "18n0z7nyc4km9xwby7xfa3wgqxkphi5hnblymi5nyiqrsccfnr6b"
   },
   "stable": {
    "version": [
@@ -35623,10 +35919,10 @@
   "stable": {
    "version": [
     28,
-    1
+    2
    ],
-   "commit": "34316363201de07437e14e79ef559fde7becb0ee",
-   "sha256": "1aby8zips3s7x2h6pjndvx0dasdccnrq81sgxdgy7nfw7rkga7dd"
+   "commit": "dff037f64e8eaa0a591866e967ee2b7164329376",
+   "sha256": "128pmwgbjb138pkw78pklh7myzlbrlnkjl55vsrsj3p3k96i9lp7"
   }
  },
  {
@@ -35637,25 +35933,25 @@
   "repo": "erlang/emacs-erlang-ts",
   "unstable": {
    "version": [
-    20250202,
-    1841
+    20251107,
+    814
    ],
    "deps": [
     "erlang"
    ],
-   "commit": "eb579dd55fbb2cf721290939e7b3a50be19c0305",
-   "sha256": "055gmrlx30jm9wzgbkqpf0z9bsmaqgywxxnw41w7ia00wwfwh562"
+   "commit": "959907d26d32f7d23bdcbb6f9d06ccb2a5db54c3",
+   "sha256": "11qncwybc4ph4pjjlr8mw46z7i7n7vb37bw2pjr3xb629kgv2hmn"
   },
   "stable": {
    "version": [
     0,
-    2
+    3
    ],
    "deps": [
     "erlang"
    ],
-   "commit": "eb579dd55fbb2cf721290939e7b3a50be19c0305",
-   "sha256": "055gmrlx30jm9wzgbkqpf0z9bsmaqgywxxnw41w7ia00wwfwh562"
+   "commit": "bf5adaa17a55a8a0d21c30de949d6074731711a0",
+   "sha256": "01sl1162w9qx10yl1c8k5a5gskflpd47ky7qsh5zln9qyrqpr5bw"
   }
  },
  {
@@ -36719,11 +37015,11 @@
   "repo": "emacs-ess/ESS",
   "unstable": {
    "version": [
-    20251003,
-    2044
+    20251015,
+    1619
    ],
-   "commit": "282d1cd6b401183cd0f50f5336140a03a1193300",
-   "sha256": "1x5qjrj816sbjnfz10zms3ay2cgg0mxmj7mlm3k5zmng10wqxy4f"
+   "commit": "a7d685bd9a3dbc8540edf86318012a0a0528e49e",
+   "sha256": "0cigas5ixhkly1vkrgrd5dw45haj629xrfsxql2q2pxm2rjfg2ir"
   },
   "stable": {
    "version": [
@@ -37423,16 +37719,16 @@
   "repo": "emacs-evil/evil",
   "unstable": {
    "version": [
-    20250929,
-    1650
+    20251108,
+    138
    ],
    "deps": [
     "cl-lib",
     "goto-chg",
     "nadvice"
    ],
-   "commit": "b06f644bdb5b06c6ac46c11b0259f15ac9ffd5da",
-   "sha256": "0cpavshhfh1xhq611qjmb8svhz9lf0qbvqjhc5s2v8i11yh48mdw"
+   "commit": "729d9a58b387704011a115c9200614e32da3cefc",
+   "sha256": "0scdws40fg4k9lqyznjghnn8svn7l0c6mq7h2aq5pzkm6hanzqn3"
   },
   "stable": {
    "version": [
@@ -37625,15 +37921,15 @@
   "repo": "emacs-evil/evil-collection",
   "unstable": {
    "version": [
-    20251007,
-    813
+    20251024,
+    2337
    ],
    "deps": [
     "annalist",
     "evil"
    ],
-   "commit": "00e71118ab43d8eebf619c8ac00d165b21b9c1e7",
-   "sha256": "16yrp140hnij647jnqxi73ny7y78qnasf2ihgdr6bf43vpzkzw13"
+   "commit": "092408dcf7655c299d69b8cacb85bdea59598196",
+   "sha256": "1pqh5g4wzs60p642h85h71vgwgpc46a0wxih2db7d57acivh1czf"
   },
   "stable": {
    "version": [
@@ -37937,15 +38233,15 @@
   "repo": "jam1015/evil-god-toggle",
   "unstable": {
    "version": [
-    20251006,
-    2259
+    20251031,
+    2050
    ],
    "deps": [
     "evil",
     "god-mode"
    ],
-   "commit": "ea5f09b8903fcc111f986b87b5b6b25af8c496a0",
-   "sha256": "1c0x5y70fzwj7389vgaajkb0wj0ganddlamnfb2sygmh4k6b83i7"
+   "commit": "5f61e718133c86db3ddc0532cc0e1d4f80b967cb",
+   "sha256": "1l7mj3lndk4lzn8min1cncqs7kdyzjd750i5m6dk9q1llnfnbn3d"
   },
   "stable": {
    "version": [
@@ -39250,11 +39546,11 @@
   "repo": "meain/evil-textobj-tree-sitter",
   "unstable": {
    "version": [
-    20250908,
-    352
+    20251118,
+    341
    ],
-   "commit": "211525baed0ee02201a56bc35cc4366d8e23cc35",
-   "sha256": "06szqafqj71vwirid1sza6p7z8c87pj86pbfim99vsalgp9mq2cl"
+   "commit": "d0d088c781b54534b49880819a40575b203dc6c8",
+   "sha256": "1g6zdpf5djalckn7kdhmvvzv3jlrh8pnf91w15aj0gzx6lgppykv"
   },
   "stable": {
    "version": [
@@ -39629,6 +39925,24 @@
   }
  },
  {
+  "ename": "ewm",
+  "commit": "1b7a377be4773a5a67cfd172edba7c78650e0af0",
+  "sha256": "1i2qpffz3fklzaiygwnajr4bny93rrjz46k6z8700qcqfx1s2nap",
+  "fetcher": "github",
+  "repo": "laluxx/ewm",
+  "unstable": {
+   "version": [
+    20251021,
+    30
+   ],
+   "deps": [
+    "eyebrowse"
+   ],
+   "commit": "aed05324efc290a1674eceb2018f8e2a7e4480d5",
+   "sha256": "073jykzngzchjhpwssz0c5fmy1svb39860svpf7n9q7h5yj4g7mj"
+  }
+ },
+ {
   "ename": "ewmctrl",
   "commit": "b2a7679f0961b171bf23080e628ae80f50c446e4",
   "sha256": "1w60pb7szai1kh06jd3qvgpzq3z1ci4a77ysnpqjfk326s6zv7hl",
@@ -39728,11 +40042,11 @@
   "repo": "purcell/exec-path-from-shell",
   "unstable": {
    "version": [
-    20250922,
-    1413
+    20251113,
+    1324
    ],
-   "commit": "59631fc475678ca299cc9503c1e48e87404b0b80",
-   "sha256": "1ijdzdml1fk6dmq8knb3xdfaxfgnfjd70im01076wv326wh0ajc1"
+   "commit": "7552abf032a383ff761e7d90e6b5cbb4658a728a",
+   "sha256": "1yhgn3va4pm1bfs32yf2z6m23p7s9gdi9kbgj3hycb0h308hxfg6"
   },
   "stable": {
    "version": [
@@ -40051,8 +40365,8 @@
   "repo": "ananthakumaran/exunit.el",
   "unstable": {
    "version": [
-    20250824,
-    318
+    20251101,
+    1233
    ],
    "deps": [
     "f",
@@ -40060,8 +40374,8 @@
     "s",
     "transient"
    ],
-   "commit": "9a7cfc3d7893cba3b2955be7399a2158bbed4d8b",
-   "sha256": "0k22j5hda2wczvnszgm3iy4kxl1cxkrvqgsjc9awaazpzmylgmd6"
+   "commit": "632298249150f8e6cf83175edcb0a13158deabc2",
+   "sha256": "1bcrxzk9jpvj2wx3wx3z048xi2pplcay4ljg6bahmgf178lc36sv"
   }
  },
  {
@@ -40087,14 +40401,14 @@
   "repo": "walseb/exwm-firefox-core",
   "unstable": {
    "version": [
-    20190812,
-    2110
+    20251107,
+    2150
    ],
    "deps": [
     "exwm"
    ],
-   "commit": "e2fe2a895e8f973307ef52f8c9976b26e701cbd0",
-   "sha256": "0k5jkjzx6f8nfmbkc61raj585p9pymycgzv7rr3fhv2drgkaa4yi"
+   "commit": "d8e599b7584f5570f3e50e111248d1d857cd5641",
+   "sha256": "0brxfxprwinfqi98lswn68vg2ipca6lziqy35l6r0dz0s9y4q5si"
   }
  },
  {
@@ -40515,19 +40829,19 @@
   "repo": "WJCFerguson/emacs-faff-theme",
   "unstable": {
    "version": [
-    20250416,
-    1410
+    20251120,
+    1400
    ],
-   "commit": "7936ff70dfcdd919e525b275533612f5f267b4a4",
-   "sha256": "04zxwlfpf4jljhdaii3v0b6svqwbjwdzk7n3krkpda9dh381lrlk"
+   "commit": "e8b6b4b5669fb41f0dd4fdcbcb88b5b9ab803f53",
+   "sha256": "0m4li4qhxp5ay0zs6dgsqj7llh8kv4gmcs5jbdswcr631b2a4ax7"
   },
   "stable": {
    "version": [
     3,
-    7
+    8
    ],
-   "commit": "1ef3ec33c7605895d1fdd4755640ce929a778c81",
-   "sha256": "12y4l4q7kmknqckcc4j6rj681271q6agnd85zv4x885pizdy49fm"
+   "commit": "e8b6b4b5669fb41f0dd4fdcbcb88b5b9ab803f53",
+   "sha256": "0m4li4qhxp5ay0zs6dgsqj7llh8kv4gmcs5jbdswcr631b2a4ax7"
   }
  },
  {
@@ -40581,11 +40895,11 @@
   "repo": "ideasman42/emacs-fancy-compilation",
   "unstable": {
    "version": [
-    20250629,
-    329
+    20251030,
+    2357
    ],
-   "commit": "51f6945c84e6d0e09d45698f1b9056e73fd79fa9",
-   "sha256": "091x4h8ly38cy1hq3ypk2k1l1qhqykgyjmjyjxd9h6k0cfng2922"
+   "commit": "7a2ea9eb09563f392e37a0b6860fb7ae96e9e8dd",
+   "sha256": "1ng9bxxxk9n3a0rn34jssgsq0cwfgk7l3ybgy2kcl14nkb6a8scv"
   }
  },
  {
@@ -40979,11 +41293,11 @@
   "repo": "freesteph/cucumber.el",
   "unstable": {
    "version": [
-    20250401,
-    1008
+    20251015,
+    2134
    ],
-   "commit": "b788d49624c7a4eb4a3bce475cd4ce1e08d5193d",
-   "sha256": "0lb3s4phqfb5w54zy725lz6j4214nl57x8lkbrfs2zhjdiscbbnr"
+   "commit": "8d43c37ddf986af769870da27c31c1911f35b205",
+   "sha256": "00jv309v4g29j3sji4i715wl3k1mj9dzkg9q256hsvbp0f6zvna4"
   },
   "stable": {
    "version": [
@@ -41100,11 +41414,11 @@
   "repo": "technomancy/fennel-mode",
   "unstable": {
    "version": [
-    20250906,
-    306
+    20251028,
+    2216
    ],
-   "commit": "2624b5cd6dc8b9b535d031f8c256081271245c62",
-   "sha256": "0703sps6sa5jf0hxwsxadlcmcr80bjvm3y9n894lqd6qw07zdjrm"
+   "commit": "c1bccdec9e8923247c9b1a5ffcf14039d2ddb227",
+   "sha256": "0ylhffwiww03my7qaysklz7mx4jh530hgv5zgv78v4fbxsqwp02n"
   },
   "stable": {
    "version": [
@@ -41235,15 +41549,15 @@
   "repo": "Artawower/file-info.el",
   "unstable": {
    "version": [
-    20250930,
-    920
+    20251107,
+    1738
    ],
    "deps": [
     "browse-at-remote",
     "hydra"
    ],
-   "commit": "ac8c0fecde9491d8626d54667c99e4e5dcfa4128",
-   "sha256": "1kq38zj71svvh319a3sif8nckj6phxb06733gg11aax04kygwb5l"
+   "commit": "5d8c5158a57e0077410bcdb802c344f5e8da4aca",
+   "sha256": "1ap8ms7vrv0hnra0mcxpkf364j3ql5s9j40fmqqi84djr6w0abn6"
   },
   "stable": {
    "version": [
@@ -42004,6 +42318,41 @@
   }
  },
  {
+  "ename": "fj",
+  "commit": "35fa3c23067eec0bed74d227c16ff598e70fc9ef",
+  "sha256": "02km4hll3bk6hd0zmcpsy8q2vbkdz6z7n0kpr2x60vrdp31ys5x2",
+  "fetcher": "codeberg",
+  "repo": "martianh/fj.el",
+  "unstable": {
+   "version": [
+    20251030,
+    1345
+   ],
+   "deps": [
+    "fedi",
+    "magit",
+    "tp",
+    "transient"
+   ],
+   "commit": "79a1ef1006f6f8da6bbdcaf05ae8888a79f6887e",
+   "sha256": "0wjycqxknvim5x0xbwjkbpvzaplikzxpiw33dsv7ly8c71nbr4i4"
+  },
+  "stable": {
+   "version": [
+    0,
+    27
+   ],
+   "deps": [
+    "fedi",
+    "magit",
+    "tp",
+    "transient"
+   ],
+   "commit": "eeba4f379b957864e5b7b16f7f5b98c5f75614b5",
+   "sha256": "1hp8xaggb6fclgdjh7jz97rn248xbl8qy88a8c7xx3gvv2x7ahgx"
+  }
+ },
+ {
   "ename": "flame",
   "commit": "b7a14c14368de722855286c088020a5657f7cf8b",
   "sha256": "1br9c48anscq9vbssr0gq8f5kbq755hjaglbljwwh9nd5riycv5v",
@@ -42208,28 +42557,28 @@
   "repo": "plandes/flex-compile",
   "unstable": {
    "version": [
-    20250820,
-    1557
+    20251123,
+    2259
    ],
    "deps": [
     "buffer-manage",
     "dash"
    ],
-   "commit": "982b20bf03df82cbd462d119f1101ce542d887c3",
-   "sha256": "17q8bhnwi87zb67mzwdhdibnvypzfyc00iba98zy45fhlbs2l0zg"
+   "commit": "4e1057bb8f2430015a8912d05763d971c843f43c",
+   "sha256": "1x3fz0gjm6c7pdypja6rry3441z74nhiyhhxdz9mljzaq0j9ksiv"
   },
   "stable": {
    "version": [
     1,
-    6,
+    7,
     0
    ],
    "deps": [
     "buffer-manage",
     "dash"
    ],
-   "commit": "00c23361b73f3b3c1656a205ec31943d40867cff",
-   "sha256": "12g69mcjrvippgvyhjk2z9zc4377sri1kj1v4h6y2fgggkd6gmg7"
+   "commit": "4e1057bb8f2430015a8912d05763d971c843f43c",
+   "sha256": "1x3fz0gjm6c7pdypja6rry3441z74nhiyhhxdz9mljzaq0j9ksiv"
   }
  },
  {
@@ -42270,15 +42619,15 @@
   "repo": "emacsmirror/flim",
   "unstable": {
    "version": [
-    20251004,
-    2059
+    20251102,
+    2052
    ],
    "deps": [
     "apel",
     "oauth2"
    ],
-   "commit": "b16b10600efb518425ec796bbf15f64aaa97d998",
-   "sha256": "1phfmmmm9bmapk36m7h800iq3bvfxpg76h9dq8z45q4n6kalmadn"
+   "commit": "b7265bae4b11a1434f5c0acf78ba13580bf00cfc",
+   "sha256": "176zlmwikm5fcvlb2dpx7yxmd31fzpa94hj2lmygy28wnxvs0ak2"
   }
  },
  {
@@ -42571,11 +42920,14 @@
   "repo": "flycheck/flycheck",
   "unstable": {
    "version": [
-    20250527,
-    907
+    20251128,
+    1706
    ],
-   "commit": "a4d782e7af12e20037c0cecf0d4386cd2676c085",
-   "sha256": "0vhilah2gnmifv9hk7whcdcbcfzw0yxhfhwa8xka1fdlr0g23hws"
+   "deps": [
+    "seq"
+   ],
+   "commit": "62570fafbedb8fa3f7d75a50a9364feca3b294ef",
+   "sha256": "18068n5mqb1k54hjgfifhvghkm3adbh498dbj8xms0i1bi1ld8c7"
   },
   "stable": {
    "version": [
@@ -43416,27 +43768,27 @@
   "repo": "flycheck/flycheck-eldev",
   "unstable": {
    "version": [
-    20230905,
-    1754
+    20251025,
+    1350
    ],
    "deps": [
     "dash",
     "flycheck"
    ],
-   "commit": "e3d5cdaf8183bd9d1cf66857d21bf86052b1d703",
-   "sha256": "0fikkqgclf86whagjmda86qvanvk631np97fivaj9d8ry6sqrnyy"
+   "commit": "ad9e367c0caf75195e7443b666adcddf98576724",
+   "sha256": "0rfr7wm2fx5ffiqk5b8bvdpxb4bmqc7363g8ifdxk22bqq72ljm0"
   },
   "stable": {
    "version": [
     1,
-    1
+    2
    ],
    "deps": [
     "dash",
     "flycheck"
    ],
-   "commit": "d222ce6a8e59385ffeeee7c3a36ee41cf9a8561e",
-   "sha256": "0lipvy48ilc8cxkzk64j7384rx0w57hjcgxbn9dp31c8i5pygj6y"
+   "commit": "8a6ef42f38208e27d55771459ad884ced0d35b6a",
+   "sha256": "1xni21nq7agdsadamij0mn71i1g9fh3lc7cj2cqi9f5j4g1ywskb"
   }
  },
  {
@@ -45410,20 +45762,20 @@
   "repo": "jamescherti/flymake-ansible-lint.el",
   "unstable": {
    "version": [
-    20250920,
-    1926
+    20251019,
+    1945
    ],
-   "commit": "fcd15eafd96afa35f4b3d52f320d949d110bf573",
-   "sha256": "0gan9yanaa6s4llxgqibx4wr04s4kdbxkippndsjcv9q9n9dpdqh"
+   "commit": "c5375aea83586e1ae97e6c2fa74ea61cf44d98f4",
+   "sha256": "1w34h714q7gvhpazbqfh0b6vgm0sy7h5xkhsksdqy144agj7jja3"
   },
   "stable": {
    "version": [
     1,
     0,
-    4
+    5
    ],
-   "commit": "fcd15eafd96afa35f4b3d52f320d949d110bf573",
-   "sha256": "0gan9yanaa6s4llxgqibx4wr04s4kdbxkippndsjcv9q9n9dpdqh"
+   "commit": "c5375aea83586e1ae97e6c2fa74ea61cf44d98f4",
+   "sha256": "1w34h714q7gvhpazbqfh0b6vgm0sy7h5xkhsksdqy144agj7jja3"
   }
  },
  {
@@ -46237,14 +46589,14 @@
   "repo": "emacs-languagetool/flymake-languagetool",
   "unstable": {
    "version": [
-    20250101,
-    852
+    20251107,
+    2140
    ],
    "deps": [
     "compat"
    ],
-   "commit": "c9b6749c5b17a8e58931cf2ce3ab5cbb855ae75d",
-   "sha256": "12sjiwxngv069c08vz2x8n49kcpwf7qc679lf7gh44dmyj0fs8fw"
+   "commit": "a697dccf2d537e7efd92fd80e6b480bacbd1b821",
+   "sha256": "1jhazxn8728fncvwa8rby99yaf65h2qx7728vrf3c36g052a364m"
   },
   "stable": {
    "version": [
@@ -46853,6 +47205,36 @@
    ],
    "commit": "e9c6038f69ad1523e603026155d9acd5fc3d5aac",
    "sha256": "1k0ayc38kjwciq7dj2zlq2y1kfvgdj55yl6xn1mwafxy7kywgplg"
+  }
+ },
+ {
+  "ename": "flymake-x",
+  "commit": "015ab56dacbd76e023561d16dbb702ac651ca7df",
+  "sha256": "18y1g56w6a4mb1cgf32agvna26m8m8dkv3zycn0xm09yz3gksr2d",
+  "fetcher": "github",
+  "repo": "mkcms/flymake-x",
+  "unstable": {
+   "version": [
+    20251020,
+    2034
+   ],
+   "deps": [
+    "flymake"
+   ],
+   "commit": "5476c4d1ff2539da0f9335615678f938b4da95df",
+   "sha256": "1v0v4vxhkg7vr6lpqq0rbs86v5ckdnc6md5gvys4y2ss4l0zn4im"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "deps": [
+    "flymake"
+   ],
+   "commit": "2f31aae3548ab2575f55e4cead5a4be964fe8f38",
+   "sha256": "11dn3bq362dpr3d64hgpbklnqh877ghb3wn5rj74b49c4c0sdk7g"
   }
  },
  {
@@ -47488,11 +47870,11 @@
   "repo": "Fuco1/fontify-face",
   "unstable": {
    "version": [
-    20210503,
-    1956
+    20251111,
+    1121
    ],
-   "commit": "d1386c88ccc77ccfb40b888ff90d6181325d14f8",
-   "sha256": "1fi8sa7d6p6zgpvrnmpl85jfxqnl43053krb4h2lw0cgxd2wbd1v"
+   "commit": "b975c764b6e9e070c7673317146b4d345ec83ef8",
+   "sha256": "1sv6fw4vcxmwwsjris8i0lk2k68cszysg1qh9pvkhcnggsf0h42p"
   },
   "stable": {
    "version": [
@@ -47654,8 +48036,8 @@
   "repo": "magit/forge",
   "unstable": {
    "version": [
-    20251007,
-    1152
+    20251113,
+    2133
    ],
    "deps": [
     "closql",
@@ -47670,14 +48052,14 @@
     "transient",
     "yaml"
    ],
-   "commit": "54a33e91aed1ce30f083b01b2ffee54ec1311313",
-   "sha256": "0hd8gllkmbn6ac2dk0ilfd43nl3l7sdsf3x7jkl07algnskngr2j"
+   "commit": "37b4b2bf8f946db588b51fbaf5f27662739fdfe8",
+   "sha256": "02mkl5j6ykzyh8dzdkswfkr96c9ay0d75hh5qxapqacn3q2nsq5w"
   },
   "stable": {
    "version": [
     0,
     6,
-    1
+    2
    ],
    "deps": [
     "closql",
@@ -47692,8 +48074,8 @@
     "transient",
     "yaml"
    ],
-   "commit": "34e7b77602b2018f64bd7e38314a0a2cb4a32227",
-   "sha256": "18ayhf3q433abkp2dwyc3arlbvadsr7bjh3j52figy0k2bi3ixhh"
+   "commit": "71910a26e360bfe88eb81b47f377f7694161fe9b",
+   "sha256": "05clfk3w81p36v86bc169am6kp6k61phrh8pwvmzhknmar1lspln"
   }
  },
  {
@@ -47847,14 +48229,14 @@
   "repo": "larsbrinkhoff/forth-mode",
   "unstable": {
    "version": [
-    20231206,
-    1127
+    20251027,
+    730
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "59c5ea89ca7593bd49cdde6caefa0893a8780105",
-   "sha256": "1l82hsrg7n7xvi6bd6sdcwvxc9g5qnh84lcmb274myldjzlvyy93"
+   "commit": "8f526ed38b52404c0ce55df6df5c8cbbc8f1de69",
+   "sha256": "17n7mcixa4glcz1pfrb1jrx470zx3bjdxfp5bnvgyrm1gg7pgnzz"
   }
  },
  {
@@ -47940,11 +48322,11 @@
   "repo": "gmlarumbe/fpga",
   "unstable": {
    "version": [
-    20251002,
-    1238
+    20251119,
+    2304
    ],
-   "commit": "8e5f44d73d9bec693b9882113fa34827a5b4c2b1",
-   "sha256": "0n7l45gyi7a048vh3bp1692z596yqk6f0yz0lvfqpvldnrgf9n54"
+   "commit": "48ec1572ab3c96cbc20d0c542cfe56124e05d48b",
+   "sha256": "0j1573m59iadip4qpg457jdl22gdgx1w41irdd0s300yqsrjxyms"
   },
   "stable": {
    "version": [
@@ -48094,26 +48476,26 @@
   "repo": "tarsius/frameshot",
   "unstable": {
    "version": [
-    20250901,
-    1607
+    20251101,
+    2212
    ],
    "deps": [
     "compat"
    ],
-   "commit": "f65d85397d6a87c4d5ef42a4c6c78cbfafe9d12d",
-   "sha256": "0nnncybd3hcz87m61fdnkvyw6akglsyyna6xxsbxwbjp4skqybbr"
+   "commit": "89ca25879b4c55da049f771870926a27bbfb1066",
+   "sha256": "0l10j1zb2fyy1j4xxks1r8hyx9vrjqd26llwc3x7chb2r2x5wyla"
   },
   "stable": {
    "version": [
     1,
-    1,
+    2,
     0
    ],
    "deps": [
     "compat"
    ],
-   "commit": "f65d85397d6a87c4d5ef42a4c6c78cbfafe9d12d",
-   "sha256": "0nnncybd3hcz87m61fdnkvyw6akglsyyna6xxsbxwbjp4skqybbr"
+   "commit": "89ca25879b4c55da049f771870926a27bbfb1066",
+   "sha256": "0l10j1zb2fyy1j4xxks1r8hyx9vrjqd26llwc3x7chb2r2x5wyla"
   }
  },
  {
@@ -48228,30 +48610,6 @@
    ],
    "commit": "cf8bf0359cf6c77848facbd24b764b3e111b4c2d",
    "sha256": "0ggkflx4lhyxqr7sgf1f3z0i3glmqyvl4bn16clh9ybl14q22rli"
-  }
- },
- {
-  "ename": "freeze-it",
-  "commit": "0b50aa7ce66a827ddd975eddf8e95ba655e05239",
-  "sha256": "03wnmp6m9ss3vvzibajjdvzbgh2ydvq95xk9k2rhrgjj9pdz5ml8",
-  "fetcher": "github",
-  "repo": "rnkn/freeze-it",
-  "unstable": {
-   "version": [
-    20240630,
-    730
-   ],
-   "commit": "0d0b6c425769a602ab18d41927feb8c0e22e214b",
-   "sha256": "0zs0d7r14yzw7nihw5v24drwbv1pf8ldrgfackkdkhxh1x6laqqm"
-  },
-  "stable": {
-   "version": [
-    0,
-    2,
-    2
-   ],
-   "commit": "6891d3b7a85da13e6d5982ac6b9588473941ec98",
-   "sha256": "0bwd3hw5qdijmvbfm69iyhijjx12yqvsa8n08cawxfa26cs6hi1g"
   }
  },
  {
@@ -48594,11 +48952,11 @@
   "repo": "open-spaced-repetition/lisp-fsrs",
   "unstable": {
    "version": [
-    20250712,
-    511
+    20251119,
+    1629
    ],
-   "commit": "7c70543ba4d3ac11d973a3595964f156c416146f",
-   "sha256": "1cwq2sl6s1bmhw3kcanz6qkppv76lw4ddanw9mvbs9rj4vxh7mhv"
+   "commit": "3260544388b9239dc3710eb16ff202a279391260",
+   "sha256": "06a8yww5hhq7i83n8h25zgxybzndg1ns6mvml3bwh7c9n1zbv44s"
   }
  },
  {
@@ -48895,6 +49253,21 @@
   }
  },
  {
+  "ename": "fuzzy-clock",
+  "commit": "dda4bb92a9420f4d88f37ca728da68b42c6a3f31",
+  "sha256": "0cxkqn4j99v9d9z2210ysbpl7jrdqijxva578y67j9qacrwahny1",
+  "fetcher": "github",
+  "repo": "Trevoke/fuzzy-clock.el",
+  "unstable": {
+   "version": [
+    20251109,
+    17
+   ],
+   "commit": "6b1a33296d856aeee0b29cdf65a9e614054ef94a",
+   "sha256": "03vpk4hffczjy882inxs6aybz30scrjv1g13iksfzry63kx877wa"
+  }
+ },
+ {
   "ename": "fuzzy-finder",
   "commit": "e217226f37d9184b175d7e36902b4977fce8a5bf",
   "sha256": "0irwkc59c66wqhr6vmmdczj678224lng4qjhw9yv4lz3dn06n5i3",
@@ -48950,26 +49323,26 @@
   "repo": "tarsius/fwb-cmds",
   "unstable": {
    "version": [
-    20250531,
-    2217
+    20251101,
+    2015
    ],
    "deps": [
     "compat"
    ],
-   "commit": "252a3a9d5420ac5db477047aa5c6a2c668b317b7",
-   "sha256": "07d85n11455pl8rnpcdd1s8jc2ii153wa5igp92mzm8v75pym4fy"
+   "commit": "2c36c716a5cf86e790ad1acbd2a062230c78eec2",
+   "sha256": "0sp41dsqm8n2m8yc4y4nr7r6qqkc261jz75gi0vgf9pjx0qc8iys"
   },
   "stable": {
    "version": [
     2,
     0,
-    3
+    4
    ],
    "deps": [
     "compat"
    ],
-   "commit": "252a3a9d5420ac5db477047aa5c6a2c668b317b7",
-   "sha256": "07d85n11455pl8rnpcdd1s8jc2ii153wa5igp92mzm8v75pym4fy"
+   "commit": "2c36c716a5cf86e790ad1acbd2a062230c78eec2",
+   "sha256": "0sp41dsqm8n2m8yc4y4nr7r6qqkc261jz75gi0vgf9pjx0qc8iys"
   }
  },
  {
@@ -49090,19 +49463,19 @@
   "repo": "ShiroTakeda/gams-mode",
   "unstable": {
    "version": [
-    20250127,
-    1458
+    20251124,
+    1517
    ],
-   "commit": "638656ed0c3a87c68d4afefe7686fa061bbcc0cf",
-   "sha256": "1kvl694h81f0dc97y9vgl8w1fspz6rivis8b6blcinnqr3622r1y"
+   "commit": "dfab98a2ef847bae4bc3ae3abdf638355efd73db",
+   "sha256": "0y5phgla7s9cxb4rwn9kc092wl55knv4iyf5621bc87b7ybma4q8"
   },
   "stable": {
    "version": [
-    6,
-    16
+    7,
+    1
    ],
-   "commit": "6fb90d9c83747ac020743cd7a8c2efda0c5936eb",
-   "sha256": "09ldm491m1zf47x6gwdylilc5slcwzsbl498axlpzy723ysf916y"
+   "commit": "c01474a5bbf4fa11564579f258e97941c85980d1",
+   "sha256": "15aqvzy71fk4crvvk06mgijkwnai3w12968r3krldb247drw1icd"
   }
  },
  {
@@ -49197,11 +49570,11 @@
   "repo": "pastor/gdb-x",
   "unstable": {
    "version": [
-    20250213,
-    2057
+    20251107,
+    1256
    ],
-   "commit": "9db6e02cc101f21fea778879a4420bfe1af91096",
-   "sha256": "08ibkm959kdqay92q662px38baz9avmq7dszpr1pvs2nzfwbf272"
+   "commit": "7e03680f7b5a001341d1892daa69bc32fcf75113",
+   "sha256": "09b4xkpa1gcjlxaw8mxlamczq26pfwr2k7lbh3ysnqrk4vck832x"
   }
  },
  {
@@ -49212,11 +49585,11 @@
   "repo": "godotengine/emacs-gdscript-mode",
   "unstable": {
    "version": [
-    20250420,
-    1418
+    20251104,
+    1437
    ],
-   "commit": "1938aa7e2d1aac1d111b1c3d55e3cf932ae63cc4",
-   "sha256": "1b7qa01ivj9n3k4hn1qvgr7h0hdc7v3hfjdxr88am1gp6p10amf0"
+   "commit": "e94dfd9dc7a50261b2c41ae3daa05043331a54a8",
+   "sha256": "18f7y7cnsr0kc6h0f286x6557f6mp69v17b98i4mg4my2ah6gszi"
   },
   "stable": {
    "version": [
@@ -49867,16 +50240,16 @@
   "repo": "twmr/gerrit.el",
   "unstable": {
    "version": [
-    20250112,
-    802
+    20251105,
+    2119
    ],
    "deps": [
     "dash",
     "magit",
     "s"
    ],
-   "commit": "69e12cee9da6b08a87039e247c069a099539cb19",
-   "sha256": "1bv76q574gpfnqzmb3z99xzfbkpndkvmq0fyd80y07ply9w9mb95"
+   "commit": "e89b21d2f464ead98a60d8ecc79c359be886b232",
+   "sha256": "19wz4vgm0bjk87rn0x6ykj612rh4b3idaig6adn6yns77danrs60"
   }
  },
  {
@@ -50018,28 +50391,28 @@
   "repo": "anticomputer/gh-notify",
   "unstable": {
    "version": [
-    20251002,
-    1943
+    20251103,
+    133
    ],
    "deps": [
     "forge",
     "magit"
    ],
-   "commit": "63ebc8c2127fac5fd69b5aa293f558ede82b3c5a",
-   "sha256": "1fihyswz4zp0ddby6wsv08q8n65nplhjmbxcgnynkbp2k0b3zh2n"
+   "commit": "c992d7f4b9cc2bcdc27a8f61bc77cc09e85dc7cd",
+   "sha256": "1b9fhrd5kcsxvwdic3v2fa7fcjig6cc3kfy8w28gi124c06wsmgs"
   },
   "stable": {
    "version": [
     2,
     1,
-    5
+    7
    ],
    "deps": [
     "forge",
     "magit"
    ],
-   "commit": "63ebc8c2127fac5fd69b5aa293f558ede82b3c5a",
-   "sha256": "1fihyswz4zp0ddby6wsv08q8n65nplhjmbxcgnynkbp2k0b3zh2n"
+   "commit": "c992d7f4b9cc2bcdc27a8f61bc77cc09e85dc7cd",
+   "sha256": "1b9fhrd5kcsxvwdic3v2fa7fcjig6cc3kfy8w28gi124c06wsmgs"
   }
  },
  {
@@ -50157,30 +50530,30 @@
   "repo": "magit/ghub",
   "unstable": {
    "version": [
-    20251006,
-    1821
+    20251113,
+    2133
    ],
    "deps": [
     "compat",
     "llama",
     "treepy"
    ],
-   "commit": "6dc4ff700fc515157131b2106a17bb667579d449",
-   "sha256": "1p88q8g3a0qqd2rakpg03p945y88cmb9c93sihh77ya5r477glh0"
+   "commit": "423c0838c15a55208d4475e05aaaac85a6461b22",
+   "sha256": "1hhkdlbfy4pnr2nhw0cp0wg8l50318hn41iv05ydrykj3v9a2zky"
   },
   "stable": {
    "version": [
     5,
     0,
-    1
+    2
    ],
    "deps": [
     "compat",
     "llama",
     "treepy"
    ],
-   "commit": "6dc4ff700fc515157131b2106a17bb667579d449",
-   "sha256": "1p88q8g3a0qqd2rakpg03p945y88cmb9c93sihh77ya5r477glh0"
+   "commit": "447cb51fa7d19e1fb3844acdd2c540be04299ffb",
+   "sha256": "16ikjhps2ha23ab3w43vsz38l1hbjvwhk2dhajv6853gpx4xaipm"
   }
  },
  {
@@ -50843,20 +51216,20 @@
   "repo": "sshaw/git-link",
   "unstable": {
    "version": [
-    20250812,
-    1427
+    20251116,
+    105
    ],
-   "commit": "e4cfed05d110a6af07543d069f12e1894f553c2e",
-   "sha256": "0zg3vkj1zgcyci7ql47qqraz44vv59qjpclg7d08q1wj770ilmn3"
+   "commit": "12caebc0982d3401a0b74ccddc2d5a651122de8a",
+   "sha256": "14nmiybixnn3cvvdyp0b7yimhqmj41q3g0c6nz0x4lwjfhl5w7nc"
   },
   "stable": {
    "version": [
     0,
-    9,
-    2
+    10,
+    0
    ],
-   "commit": "f66d1f3cdc2c99a2a5c193a6e2521118807f59e8",
-   "sha256": "1z7m7xl72x7as3d9l3zspac53kyij7hixpz1y2aq5gqpa7wzh87z"
+   "commit": "67b02cf0df4e789771f2344b4dd77c85334a0f9f",
+   "sha256": "1cq456q908nmbz2br578fhi8vq2jh11nf0axxa7913gd7dhmqklg"
   }
  },
  {
@@ -50896,26 +51269,26 @@
   "repo": "magit/git-modes",
   "unstable": {
    "version": [
-    20250901,
-    1608
+    20251101,
+    2017
    ],
    "deps": [
     "compat"
    ],
-   "commit": "7063d66857023e6c010cecac52de67c0baa77fb7",
-   "sha256": "0k73855kzl2hj0lsr68gmbmabxjm5pxwciybbz0pr3j67s3i7r82"
+   "commit": "dfc450d79498b7997b1155ac76629ab01f7ef355",
+   "sha256": "0pjsxw5ni47c8mfd40l9x5fnpi1423djhxxr2ixvk81p7xcrcsyi"
   },
   "stable": {
    "version": [
     1,
     4,
-    6
+    7
    ],
    "deps": [
     "compat"
    ],
-   "commit": "7063d66857023e6c010cecac52de67c0baa77fb7",
-   "sha256": "0k73855kzl2hj0lsr68gmbmabxjm5pxwciybbz0pr3j67s3i7r82"
+   "commit": "dfc450d79498b7997b1155ac76629ab01f7ef355",
+   "sha256": "0pjsxw5ni47c8mfd40l9x5fnpi1423djhxxr2ixvk81p7xcrcsyi"
   }
  },
  {
@@ -51701,15 +52074,15 @@
   "repo": "Kinneyzhang/gkroam",
   "unstable": {
    "version": [
-    20220923,
-    1018
+    20251114,
+    648
    ],
    "deps": [
     "company",
     "db"
    ],
-   "commit": "7a6f2899e676ce4720b102cd9eb4410e05613958",
-   "sha256": "0r26lmi0r847klx246i35banb55m1ll8ng0dk0j7q92yikb7v3jf"
+   "commit": "b2b580731ce5c92d6682cfbd17361129a5cea4ca",
+   "sha256": "0ficc91jxv10bdrhlna05rifr1ba7c4905is3npb9iw2qphc9nin"
   },
   "stable": {
    "version": [
@@ -51798,11 +52171,20 @@
   "repo": "gleam-lang/gleam-mode",
   "unstable": {
    "version": [
-    20251006,
-    1500
+    20251106,
+    221
    ],
-   "commit": "bd4a0ea995cab2bd2676d04ff155eccd306f835d",
-   "sha256": "0xlkk8akh2jycs5ja91mzgcigngk1c6cb33lk4i9dnyy51mbw9rl"
+   "commit": "91cf073c5fb889c091b1797f44cc52419b7c9ae2",
+   "sha256": "0dd7qylvhrqlxnbvvkb3f03gz14v0sjg9fhiymfhw7p571bq8nqi"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "commit": "91cf073c5fb889c091b1797f44cc52419b7c9ae2",
+   "sha256": "0dd7qylvhrqlxnbvvkb3f03gz14v0sjg9fhiymfhw7p571bq8nqi"
   }
  },
  {
@@ -52056,8 +52438,8 @@
   "url": "https://git.thanosapollo.org/gnosis",
   "unstable": {
    "version": [
-    20251001,
-    707
+    20251108,
+    939
    ],
    "deps": [
     "compat",
@@ -52065,14 +52447,14 @@
     "org-gnosis",
     "transient"
    ],
-   "commit": "e8b36d20064b5e4337083d6ee90e4513fcd7790e",
-   "sha256": "1bz5pgpp4visd7xspmn2ig1kqvv3wz20d2k4vcnsk75b1akfmzks"
+   "commit": "43b8ba93a7173543d16e08ebc30ce8ed3f793b7f",
+   "sha256": "0zlcw3qqpxar9sapds38w38yhxmndv7zb59xh206c0fwvymjfc1d"
   },
   "stable": {
    "version": [
     0,
     5,
-    4
+    8
    ],
    "deps": [
     "compat",
@@ -52080,8 +52462,8 @@
     "org-gnosis",
     "transient"
    ],
-   "commit": "c302df0656f0a6fce69cc2e90c543514a896c75a",
-   "sha256": "1agb0aqgr3zs27bfwz3sknlg17knl9sxjp3vkakmaqgjrrr8jwdh"
+   "commit": "43b8ba93a7173543d16e08ebc30ce8ed3f793b7f",
+   "sha256": "0zlcw3qqpxar9sapds38w38yhxmndv7zb59xh206c0fwvymjfc1d"
   }
  },
  {
@@ -53726,11 +54108,11 @@
   "repo": "stuhlmueller/gpt.el",
   "unstable": {
    "version": [
-    20250929,
-    1735
+    20251125,
+    1824
    ],
-   "commit": "bd10b618af9b50a678bd992eb8a22a64053e2134",
-   "sha256": "0cbaclbycg2ng03c4h3zlg3x43q9b1985cpknjbyqnhb81zl059m"
+   "commit": "b7df9de71227dc2b91d4953a46994ab42301c935",
+   "sha256": "1rjazqd1d2skjjd2qd837651ydnc0vlkxylq11dnfj3rwm7b6wry"
   }
  },
  {
@@ -53797,28 +54179,50 @@
   "repo": "karthink/gptel",
   "unstable": {
    "version": [
-    20251007,
-    257
+    20251128,
+    803
    ],
    "deps": [
     "compat",
     "transient"
    ],
-   "commit": "4275350d7769fb8fdd09353e3e6d991b05c7a673",
-   "sha256": "1iil8q9nhm34dsf31qm83v3lv9rij3rcaakma9hpnphipzzws7hi"
+   "commit": "73144b7345693b046174364edb68e1a5f5a3c7ed",
+   "sha256": "0bkfzyhgk1ddsqr4ycx6lh6i6ircvs6gvgajqd7p796h79rl5rrf"
   },
   "stable": {
    "version": [
     0,
     9,
-    9
+    9,
+    3
    ],
    "deps": [
     "compat",
     "transient"
    ],
-   "commit": "81618f24e2190568ea745dca82ba50267eed321a",
-   "sha256": "00f391gaf0pnin6qncpnxl5yj0j089d1rdblwgv5cf3mkid9w8gj"
+   "commit": "d0c392bbb0a1f7775d3a1e98220f4bdc043ab63b",
+   "sha256": "080dk0101imvfkxcqlqhy8wf1wc8p2vqyp3cwdi48wn44y1csqy9"
+  }
+ },
+ {
+  "ename": "gptel-agent",
+  "commit": "f321418abe82e755f55a6144fd89ce93fd1a7615",
+  "sha256": "0g5gh7ljs47ivw0iifb4xxb06724vcw83drm732k9vk39rnk8ilk",
+  "fetcher": "github",
+  "repo": "karthink/gptel-agent",
+  "unstable": {
+   "version": [
+    20251126,
+    723
+   ],
+   "deps": [
+    "compat",
+    "gptel",
+    "orderless",
+    "yaml"
+   ],
+   "commit": "320c6327a16d0792409f6901234dbdf9611cc613",
+   "sha256": "13a8bvqdgzxsgilvjg5np4c2iq1rl5nkhf65i9qbghb8wqqvdpwz"
   }
  },
  {
@@ -54389,15 +54793,15 @@
   "repo": "michelangelo-rodriguez/greader",
   "unstable": {
    "version": [
-    20250722,
-    520
+    20251125,
+    859
    ],
    "deps": [
     "compat",
     "seq"
    ],
-   "commit": "bc7702a53db6aae35187b83e23b1f56342a16252",
-   "sha256": "0nqg9xy0qfg92ycfrxhwnd6mv6zv6aqh2z1pvk0a6klxy9bb179n"
+   "commit": "b25974aeae49f11b91bb78d94ab51913fdfcdc05",
+   "sha256": "1qkszb4yrfnzb2rqkf6vmzca53w68p78zb58frcxslxn7s5l7ih1"
   }
  },
  {
@@ -54909,6 +55313,30 @@
    ],
    "commit": "f9febd8583ea482f72139e02f440f3972502f5a2",
    "sha256": "1z9rvk9ksva2xpwgb7bgw9zy0lv9sr7sq77f6dpm9fkdwzpj38mi"
+  }
+ },
+ {
+  "ename": "gtasks",
+  "commit": "883d8c8b2d10353d738218c80049d49448aa6ff7",
+  "sha256": "0issrh5fn8csykj2l8p0m8dgm0vhqpd86iylci0iizksc64vzhnq",
+  "fetcher": "github",
+  "repo": "thndrbrrr/gtasks",
+  "unstable": {
+   "version": [
+    20251028,
+    336
+   ],
+   "commit": "574205a511b5788e3711f86a438573a62a08c472",
+   "sha256": "1z4pxls40lzr9hacx6vwa8akqn5yr75nfczds0ys2l80ljz57gl5"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    2
+   ],
+   "commit": "1b5aba8ee152d9646fd6062f45824cb5fa4b127b",
+   "sha256": "1sqnrbhqf6pkf8hqqlw5aqq6z05wddjs4jib5znd637j9ksd546n"
   }
  },
  {
@@ -56221,11 +56649,11 @@
   "repo": "mgmarlow/helix-mode",
   "unstable": {
    "version": [
-    20250921,
-    1802
+    20251125,
+    2011
    ],
-   "commit": "1b78a854a2181bbfac8296433c606b2419ded77c",
-   "sha256": "1x5c5zrc7xrxjwpdn61hfy49s7cxqxm87i3a73m5056bp6gpi30r"
+   "commit": "95720173db4b0d4a4fab17aa8413700484c92a77",
+   "sha256": "17migiz73riw4xyq2hl6i8fn0v3gzb30vh7djd3cvqw3z3wslp73"
   },
   "stable": {
    "version": [
@@ -56260,15 +56688,15 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20251005,
-    614
+    20251115,
+    1450
    ],
    "deps": [
     "helm-core",
     "wfnames"
    ],
-   "commit": "ea0dd8639bd6dcac3b1c34228598f3d4555115a0",
-   "sha256": "0lzpx4l9lcdkpacpqnhaahsj1r9i3jgagjlb1biwbv827z46ayl9"
+   "commit": "9540c7e7230c4743b4b7cb2449faa1aebb216baf",
+   "sha256": "0d2ajz2nqrskqkfa6gnpnxk8mqwd4hrhzqpadqca7sdnlrwy67c8"
   },
   "stable": {
    "version": [
@@ -57071,14 +57499,14 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20251005,
-    539
+    20251031,
+    1743
    ],
    "deps": [
     "async"
    ],
-   "commit": "193164eb010d133185d737784f9451be3ca8e578",
-   "sha256": "1f775ykxckcnax5zf3gzl00kd0y71zwrk2slcpynw1gpcw3fd9ml"
+   "commit": "23fb3c57b919b942e670cf2bb287618b379627dd",
+   "sha256": "1j2r4p0rwxxyf7hihz1r044z858h4dx7aqk516l643dcrc62zjnc"
   },
   "stable": {
    "version": [
@@ -57311,6 +57739,25 @@
    ],
    "commit": "7ba83bd8924cec66fe3ede3334e98b1845e6852e",
    "sha256": "0icf0jdyd86w2sfkv499gbc579zypyc8lh9dgh3vcm6jp9fk0sc2"
+  }
+ },
+ {
+  "ename": "helm-elfeed",
+  "commit": "79a43fffadf3e0116a5628b37157d7b67a2266b2",
+  "sha256": "09zgkwvnpswk03779161ljwnz7icdyc6kf39zgs45nbhg78d0x90",
+  "fetcher": "codeberg",
+  "repo": "timmli/helm-elfeed",
+  "unstable": {
+   "version": [
+    20251013,
+    1740
+   ],
+   "deps": [
+    "elfeed",
+    "helm"
+   ],
+   "commit": "4d1c853548e3425bc72a0c2fd4be9a3672382d51",
+   "sha256": "1izmxkrvxjxliwib92n7npxmagv15x1w9kgl0ibp2jvsyykzdriy"
   }
  },
  {
@@ -58412,14 +58859,14 @@
   "repo": "emacs-helm/helm-ls-git",
   "unstable": {
    "version": [
-    20250916,
-    1233
+    20251026,
+    714
    ],
    "deps": [
     "helm"
    ],
-   "commit": "fcf49200204c90444e2938f00fd147a4a1e89f4a",
-   "sha256": "179dy6772ns9mhil6bfcwdcl6xdyb12zwhk8jlq7l3yiv6kcpgjw"
+   "commit": "d72786b5a87950a4d125456ff64a258a8388bf19",
+   "sha256": "18700qfy7p2vfhz7x3rkph2d285lqh0cazrzayg08pxd8nh8l2mc"
   },
   "stable": {
    "version": [
@@ -58649,14 +59096,14 @@
   "repo": "emacs-helm/helm-mu",
   "unstable": {
    "version": [
-    20240910,
-    854
+    20251128,
+    1556
    ],
    "deps": [
     "helm"
    ],
-   "commit": "d0bbc46338337d92b58708b906b40d0e12ae8006",
-   "sha256": "0l7cysci0cmg0mg64gjxismkwqc3rfwl4ixjz5a0434zc1pg502j"
+   "commit": "8275efff2c5e41da1264f9b261b93afc116c32a5",
+   "sha256": "0jmlnhxddb4csgmnlxgry2q6v2pdk4bzg8ihxbv1qrfdz7mbf0a8"
   }
  },
  {
@@ -60064,15 +60511,15 @@
   "repo": "emacs-helm/helm-system-packages",
   "unstable": {
    "version": [
-    20220515,
-    812
+    20251124,
+    1134
    ],
    "deps": [
     "helm",
     "seq"
    ],
-   "commit": "e93f4aeaa77b73c6e529141c3fa0ac49b40b6306",
-   "sha256": "1i5dy2hi5xiyb2p2795pk24h8kzmd38pasd51azyx5d0qmjjvb8m"
+   "commit": "0ae4ab08443c269150350960d151c44642a07b7a",
+   "sha256": "13z1xch0d14zb4bsv1cka94p7x5aiid5nqnr17151p61frjlry2g"
   },
   "stable": {
    "version": [
@@ -61544,11 +61991,11 @@
   "repo": "ideasman42/emacs-hl-block-mode",
   "unstable": {
    "version": [
-    20250913,
-    2251
+    20251126,
+    1136
    ],
-   "commit": "fdb50b4d2048e238d1e039969ff40de00118bf77",
-   "sha256": "0w51sq8x32y1rf49cns3q0c1nzvdln1wjq7mm5hpp7xljygm7c6v"
+   "commit": "8dbab7b71ee959e4e57f609a2483481603a97f71",
+   "sha256": "11mfhz2829qnm62v8kqvk2zn6yxdx3mpkc7vjz002nryqi14s3vd"
   }
  },
  {
@@ -61577,11 +62024,11 @@
   "repo": "ideasman42/emacs-hl-indent-scope",
   "unstable": {
    "version": [
-    20250918,
-    35
+    20251126,
+    1145
    ],
-   "commit": "a6511fde03b771a89f949b05e7eecd751cd261f8",
-   "sha256": "0f8jwl60wbh6rq2dzjli2lhqsifpyp0ggavzkvld82gnvnzy9vxj"
+   "commit": "b099b553d6a1a797a57a83203e41819718e24ca2",
+   "sha256": "1798pc52y9v3nf9d6frz9w4fv9h6mwy5kjzb07albbpp8gs8j9hk"
   }
  },
  {
@@ -61610,11 +62057,11 @@
   "repo": "ideasman42/emacs-hl-prog-extra",
   "unstable": {
    "version": [
-    20250923,
-    2251
+    20251126,
+    1139
    ],
-   "commit": "51a78d2e19899e981b041023157e1aa2c15138ed",
-   "sha256": "0xzc5lbmagkqhr36p9nfqxsshckrbd04d0jzgx29yxji8q9z4mgg"
+   "commit": "c9cd44cc8346f9a044165658a13931f0304ae293",
+   "sha256": "01bvb07x3nslfcjvci7vfi4np3srn0chdwy02qcpvs07fwdmbwfn"
   }
  },
  {
@@ -61647,26 +62094,26 @@
   "repo": "tarsius/hl-todo",
   "unstable": {
    "version": [
-    20251006,
-    1811
+    20251101,
+    2019
    ],
    "deps": [
     "compat"
    ],
-   "commit": "2e9504511aa393686f44a36716c1d2ebdc5def1f",
-   "sha256": "1gzrlf151hbascalch8mar2l7ppgax7l6633ikw79g3ygf37fbrd"
+   "commit": "94893087e0aca6642a3ebf11f46b3d5f47c1eb22",
+   "sha256": "1ym4al62ljnpr6zk459qwl1as8hf8grvigh28h635bc5mv6qnaj3"
   },
   "stable": {
    "version": [
     3,
     9,
-    1
+    2
    ],
    "deps": [
     "compat"
    ],
-   "commit": "2e9504511aa393686f44a36716c1d2ebdc5def1f",
-   "sha256": "1gzrlf151hbascalch8mar2l7ppgax7l6633ikw79g3ygf37fbrd"
+   "commit": "94893087e0aca6642a3ebf11f46b3d5f47c1eb22",
+   "sha256": "1ym4al62ljnpr6zk459qwl1as8hf8grvigh28h635bc5mv6qnaj3"
   }
  },
  {
@@ -61677,16 +62124,16 @@
   "repo": "narendraj9/hledger-mode",
   "unstable": {
    "version": [
-    20240415,
-    1812
+    20251023,
+    1834
    ],
    "deps": [
     "async",
     "htmlize",
     "popup"
    ],
-   "commit": "5492509a23047f0a1f05a112b47fa34eba7c5e1d",
-   "sha256": "1kwg5bi4290ak6zvnv85rhqim0jiyx49x0nzjhj09863p7fn4l1h"
+   "commit": "77766869e03ce1ab0d810d8c6fb5d482a3017854",
+   "sha256": "0a11as90j49g9f8kwaah94i454mlx30hhc5kz4dwqv4f9qmv69b9"
   }
  },
  {
@@ -61767,17 +62214,17 @@
  },
  {
   "ename": "hoa-mode",
-  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
-  "sha256": "1j8fi6bv25lgj8n6ykki2n1k9hbwbm7gw9g5jh2ds5n475291gcj",
+  "commit": "07e85198e461f6a5e440ec95f7a5e93dd624205c",
+  "sha256": "017vq9rwnk5wy3svhjnssr3qf94qfaxrn31m2j0rb9p0rd49dr6b",
   "fetcher": "git",
-  "url": "https://gitlab.lrde.epita.fr/spot/emacs-modes.git",
+  "url": "https://gitlab.lre.epita.fr/spot/emacs-modes.git",
   "unstable": {
    "version": [
-    20200610,
-    1339
+    20251027,
+    1528
    ],
-   "commit": "18f5c981e256f867f29a93376ccdc04717b159cd",
-   "sha256": "1814si09xjimmn1a8yp6q13lz1lr6cwnaz7fqfszqcil8lldcwvx"
+   "commit": "10446387fda1d59d7ef9765d67b8022543697e62",
+   "sha256": "1690ailrnzhn06av7dcsq9kaia4ancab02sybxwfpcl589ykvqa7"
   }
  },
  {
@@ -61929,11 +62376,11 @@
   "repo": "j-hotlink/hotdesk",
   "unstable": {
    "version": [
-    20250825,
-    2217
+    20251125,
+    2349
    ],
-   "commit": "5fa4c4b1a05fbf9737eeedc7d46ce8f374c92471",
-   "sha256": "0djq1ig5sk18d86syfxgm6wv2lm3p7fsxrvavjrr2piv2v984za3"
+   "commit": "8d20f38edb3f7e53ee86bb408e020f4dc35c6c70",
+   "sha256": "184mikvdv84lxz9q6x9ribsamj9bz38mh6liin1grfj6a0kj1dh0"
   }
  },
  {
@@ -62448,11 +62895,11 @@
   "repo": "humanoid-colors/emacs-humanoid-themes",
   "unstable": {
    "version": [
-    20250701,
-    855
+    20251106,
+    1956
    ],
-   "commit": "ea7c03ba933be01b0bab2fe3ca52063903385c17",
-   "sha256": "01v9xfn76p257bx5g9gx46qns6vldgkrbdwz6ahgpn83gk5aism3"
+   "commit": "4adf696a5d9968f6328f488a1f606558cfc8f940",
+   "sha256": "05qlklryx560sln5ziz129dkdlza5jv2a17y07p0cjr2913sm62s"
   },
   "stable": {
    "version": [
@@ -62691,11 +63138,11 @@
   "url": "https://git.savannah.gnu.org/git/hyperbole.git",
   "unstable": {
    "version": [
-    20251007,
-    2220
+    20251126,
+    227
    ],
-   "commit": "4b58147274b7488322873da47951c2d8d57b006a",
-   "sha256": "0b04vqj9xmh3h2c2aw8x7kbam8pr6smjsriyx27gnfjajaw2bx1q"
+   "commit": "028402df7bb32b7ef471e6bfb32725ae27c318a1",
+   "sha256": "0ghwr8gjid47ff3i2i9ssx0qmsjd194l8s1jjx07wfrvb6fqz981"
   },
   "stable": {
    "version": [
@@ -62715,8 +63162,8 @@
   "repo": "ushin/hyperdrive.el",
   "unstable": {
    "version": [
-    20250406,
-    2225
+    20251120,
+    1454
    ],
    "deps": [
     "compat",
@@ -62727,8 +63174,8 @@
     "taxy-magit-section",
     "transient"
    ],
-   "commit": "42048ef8bc7e568f9f1e1fa82c9f70b06a4d574d",
-   "sha256": "07fvdzd93836msaxpw9rk0sdrxpm29fn2zk22ln91v7s9aazjd3w"
+   "commit": "cb4974672b4271004ddd5eea1962216752b730ab",
+   "sha256": "1rabx68x7s083qs5yg88yv2mc6xr5vv4baagz0dmzgjp20g7cidi"
   },
   "stable": {
    "version": [
@@ -62984,17 +63431,17 @@
  },
  {
   "ename": "ialign",
-  "commit": "072f1f7ce17e2972863bce10af9c52b3c6502eab",
-  "sha256": "070a0fa2vbdfvbnpbzv4z0c7311lf8sy2zw2ifn9k548n4l8k62j",
+  "commit": "df6c4ed7ec2bd9fabaed36895b958d615e6c2461",
+  "sha256": "18p2aqf8s1ybkkp91s5k2jvba2sdg3afd29hvbrs8rxg79m9xgk4",
   "fetcher": "github",
-  "repo": "mkcms/interactive-align",
+  "repo": "mkcms/ialign",
   "unstable": {
    "version": [
-    20240925,
-    654
+    20251102,
+    1056
    ],
-   "commit": "fd1ad6bae74961e0b6bdf0bd15e6d9679186aaed",
-   "sha256": "0aanl83k66nbp5dpsckmj4dgkclkr208nrbl7wmjnqlkg0qzgifz"
+   "commit": "2a7472bdb782f5af021bfbdc4c32424d54c005dd",
+   "sha256": "0za7pn6rxn15bsmmrppzisfwg3g7ji2szawfj59p0dx1hrsny2lw"
   },
   "stable": {
    "version": [
@@ -63208,11 +63655,11 @@
   "repo": "haji-ali/maccalfw",
   "unstable": {
    "version": [
-    20250921,
-    1717
+    20251106,
+    746
    ],
-   "commit": "af8eb956f0e6e10cc209c6d663d28d35cbfb6344",
-   "sha256": "1i6ihqpws0s7knx68r0cs8z99apyljlqzmv5zzbvbrqj7srwq8d3"
+   "commit": "fce42746bdaa1f5770282dfc4ec85241c2f5bdd7",
+   "sha256": "1yhiddpskk0f4g7xjpnmxg323r3r7irb071vls42fflzhdnh5agv"
   }
  },
  {
@@ -63400,11 +63847,11 @@
   "repo": "ideasman42/emacs-idle-highlight-mode",
   "unstable": {
    "version": [
-    20250922,
-    1330
+    20251126,
+    1130
    ],
-   "commit": "6fa320d2cc67786c72d82e0372089087bdd74938",
-   "sha256": "1zzg11kdmpprljjr46lkf844hxi0hswqvyaqsbgr20ks4cm8812z"
+   "commit": "4f5183c480c3cfa32175624f6845e8f19211553a",
+   "sha256": "0kyw1hlglrnndk8cvbwnh65w2ssmgvkrs5wc51gmhp6cxys5kja7"
   }
  },
  {
@@ -63818,15 +64265,15 @@
   "repo": "idris-hackers/idris-mode",
   "unstable": {
    "version": [
-    20251006,
-    819
+    20251128,
+    1608
    ],
    "deps": [
     "cl-lib",
     "prop-menu"
    ],
-   "commit": "ca1e5fdca371650cd8efcb2762e07b27fe4c1b90",
-   "sha256": "1y3z5avc9j2p6cb8r24gijl9vx0l2s2xwfmma6k535bfym863567"
+   "commit": "9b743421cd530ebc52efd36619dc35b1c2dbb953",
+   "sha256": "0nxcrgg442cnmg3vmv4sa70359ni7s8grk02qxss40bzrsl5va6l"
   },
   "stable": {
    "version": [
@@ -63864,11 +64311,11 @@
   "repo": "victorhge/iedit",
   "unstable": {
    "version": [
-    20220216,
-    717
+    20251017,
+    410
    ],
-   "commit": "dd5d75b38ee0c52ad81245a8e5c932d3f5c4772d",
-   "sha256": "0sm99030f4qzgqfpm0rzzd0sji4x8fqvrzlhkxyhs7j7mi4hls11"
+   "commit": "7e513d573c6a5dd2a01aeeb1d8587d74630a2f80",
+   "sha256": "1bi2c3ckrs3a667kk54ai97d6ikpjiw0k0n790gkb5jda7ibwx1l"
   },
   "stable": {
    "version": [
@@ -63928,28 +64375,28 @@
   "repo": "KarimAziev/igist",
   "unstable": {
    "version": [
-    20250313,
-    1020
+    20251023,
+    848
    ],
    "deps": [
     "ghub",
     "transient"
    ],
-   "commit": "bf7e7abea93e6d16853f7714a98406dc34964f88",
-   "sha256": "0nssjv0mfxy34mbfv3c4bnszbc4ryqqs9pclbyg3spplfpvbxy97"
+   "commit": "badbc1302e6f83cfebd304c6332b321ca3313f21",
+   "sha256": "0s96wv35dax1j4qa0c72l658317r34xbgmhvvl3lz6khac64k8s5"
   },
   "stable": {
    "version": [
     1,
-    7,
+    8,
     0
    ],
    "deps": [
     "ghub",
     "transient"
    ],
-   "commit": "c0d50e690bdc42efcc49fb2daa1fa76684f972b6",
-   "sha256": "1h9nnrw0ilj9s8c2ad5wdvhjsl53bl3j4f39kl4clr58xb68ww3l"
+   "commit": "badbc1302e6f83cfebd304c6332b321ca3313f21",
+   "sha256": "0s96wv35dax1j4qa0c72l658317r34xbgmhvvl3lz6khac64k8s5"
   }
  },
  {
@@ -64104,50 +64551,26 @@
   "repo": "tarsius/imake",
   "unstable": {
    "version": [
-    20250531,
-    2218
+    20251101,
+    2020
    ],
    "deps": [
     "compat"
    ],
-   "commit": "151c0f14dee48f43582a21df3812e2f9a33ff05d",
-   "sha256": "1r5g9vvr27idka3x3mdl22mxxp3nxljkbaqx6fdr9nypmv5cww2y"
+   "commit": "6a0bfeddb1565b4215c9228635c5897b487adb26",
+   "sha256": "0c12x1ycjk2bcigyw3fxa87hjkc5axa3zyxa02l5w0xfak0w76zb"
   },
   "stable": {
    "version": [
     1,
     2,
-    4
+    5
    ],
    "deps": [
     "compat"
    ],
-   "commit": "151c0f14dee48f43582a21df3812e2f9a33ff05d",
-   "sha256": "1r5g9vvr27idka3x3mdl22mxxp3nxljkbaqx6fdr9nypmv5cww2y"
-  }
- },
- {
-  "ename": "imapfilter",
-  "commit": "2415894afa3404fbd73c84c58f8b8267187d6d86",
-  "sha256": "0i893kqj6yzadhza800r6ri7fihl01r57z8yrzzh3d09qaias5vz",
-  "fetcher": "github",
-  "repo": "tarsius/imapfilter",
-  "unstable": {
-   "version": [
-    20180318,
-    2222
-   ],
-   "commit": "79bbbe918319bc1e8f42a0bef53dc7c77fe868ea",
-   "sha256": "0lqhwh8kav7f526a40rjdy2hzarzph1i3ig2dmbf02gp32sl7rg9"
-  },
-  "stable": {
-   "version": [
-    1,
-    0,
-    3
-   ],
-   "commit": "79bbbe918319bc1e8f42a0bef53dc7c77fe868ea",
-   "sha256": "0lqhwh8kav7f526a40rjdy2hzarzph1i3ig2dmbf02gp32sl7rg9"
+   "commit": "6a0bfeddb1565b4215c9228635c5897b487adb26",
+   "sha256": "0c12x1ycjk2bcigyw3fxa87hjkc5axa3zyxa02l5w0xfak0w76zb"
   }
  },
  {
@@ -64700,11 +65123,11 @@
   "repo": "xendk/indentinator.el",
   "unstable": {
    "version": [
-    20250901,
-    1740
+    20251103,
+    2132
    ],
-   "commit": "65322a28f01485234a7489fe1267186b33c0a63e",
-   "sha256": "0vlz54iaw84vr628nr8b8hpwffzmdvr9hncjq43wpvzkib1apnhs"
+   "commit": "79ddeb38d9679616b7a843a88b22866f3b3cd9f6",
+   "sha256": "1arrc6djgh32q9qfjxx2lz4mij9vapg9f7rb6yqc7m6pj7a0ywrg"
   },
   "stable": {
    "version": [
@@ -64871,11 +65294,11 @@
   "repo": "J3RN/inf-elixir",
   "unstable": {
    "version": [
-    20231229,
-    1939
+    20251106,
+    2146
    ],
-   "commit": "857210b83f3c6a68673222c1271c40cb0b5641bc",
-   "sha256": "1sdi37d8s9i767n8yvqq1prwbgnzmxg3phkbvdjjk9gnii2llns1"
+   "commit": "085f1c198a121c569a161f9fa71e6cce1998cd63",
+   "sha256": "1hrvam6ikl913ndcgf5929rsjwv5cnkf5s6ljrkcsimr0df3w0yj"
   },
   "stable": {
    "version": [
@@ -64885,21 +65308,6 @@
    ],
    "commit": "857210b83f3c6a68673222c1271c40cb0b5641bc",
    "sha256": "1sdi37d8s9i767n8yvqq1prwbgnzmxg3phkbvdjjk9gnii2llns1"
-  }
- },
- {
-  "ename": "inf-mongo",
-  "commit": "3416586d4d782cdd61a56159c5f80a0ca9b3ddf4",
-  "sha256": "0f12yb3dgkjnpr4d36jwfnncqzz7kl3bnnrmjw7hv223p2ryzwpx",
-  "fetcher": "github",
-  "repo": "endofunky/inf-mongo",
-  "unstable": {
-   "version": [
-    20180408,
-    1338
-   ],
-   "commit": "2e498d1c88bd1904eeec18ed06b1a0cf8bdc2a92",
-   "sha256": "1m6skisj6r3fbxadpwwgf3a3934b2qvwb7zj975qksxq56ij0wkq"
   }
  },
  {
@@ -65204,11 +65612,11 @@
   "repo": "jamescherti/inhibit-mouse.el",
   "unstable": {
    "version": [
-    20250920,
-    1803
+    20251103,
+    1432
    ],
-   "commit": "89e009898dca46e07fed5fb313eb7bcdeb9d9714",
-   "sha256": "01jcgrqlwwihvdv0bm1lddlm933czgdnas7rbxhr5zvdys9gfimz"
+   "commit": "442202e59d61b0f0c662f9dadfa8fd9ecc31991b",
+   "sha256": "17jkch53p0lk42mdg7119vzv68zdqpg7n1dr23sjxd6v8bg8rym7"
   },
   "stable": {
    "version": [
@@ -65529,10 +65937,10 @@
  },
  {
   "ename": "insert-kaomoji",
-  "commit": "a3645b08cb46e3d91081da7baa982b5283918447",
-  "sha256": "0rzn6l8xnp5afxl81jv6xwpnh667cvz59vglmkd1yhp2mlhq9dy8",
-  "fetcher": "sourcehut",
-  "repo": "pkal/insert-kaomoji",
+  "commit": "504262d43a4ba193260bd7af710aafa77e6f64ea",
+  "sha256": "0iqky1yl1lvj835dqc0dlm8yfwyrni9s26j4x1zc48pg6iz5z6x3",
+  "fetcher": "codeberg",
+  "repo": "pkal/insert-kaomoji.el",
   "unstable": {
    "version": [
     20220215,
@@ -65680,10 +66088,10 @@
  },
  {
   "ename": "intellij-theme",
-  "commit": "cfe86071b2e84929476a771da99341f4a73cfd06",
-  "sha256": "1g8cninmq840sl8fmhq2hcsmz7nccbjmprzcl8w1zdavfp86b97g",
-  "fetcher": "gitlab",
-  "repo": "fommil/emacs-intellij-theme",
+  "commit": "6e47cb7b6d5ea5fcf50f5b27f09d91a72f2e0cb0",
+  "sha256": "0w6a5i308dyca2n5j09kya1svy6wr5sjp9pl5717sy2pahyx07d7",
+  "fetcher": "github",
+  "repo": "fommil/intellij-theme.el",
   "unstable": {
    "version": [
     20171017,
@@ -65931,15 +66339,14 @@
   "repo": "emarsden/ipp-el",
   "unstable": {
    "version": [
-    20250720,
-    2029
+    20251124,
+    718
    ],
    "deps": [
-    "cl-lib",
     "plz"
    ],
-   "commit": "f1d4e4bdbc81de28ada2472e2a73fd9e96791b1d",
-   "sha256": "0dkdxbfp0cnhgk26fidv17c6j8cmhgv6yih129rpbqkzj73p4wax"
+   "commit": "8210d8a276ff4dfb67e3a2b4594a67be095edd45",
+   "sha256": "1l2hscbqk3bc6420h1l2ya36z52ckiyc1f1ykc72n7l53167pns2"
   },
   "stable": {
    "version": [
@@ -66245,26 +66652,20 @@
   "repo": "tomenzgg/emacs-iso-639",
   "unstable": {
    "version": [
-    20250303,
-    214
+    20251114,
+    1512
    ],
-   "deps": [
-    "levenshtein"
-   ],
-   "commit": "63e0788175da46c55562919c7fe7c4e43546752d",
-   "sha256": "1i07vi7lqvzfvnxlhx1bfh56b4csj8a9c2r8w3i6zl9vlvj2ryrv"
+   "commit": "d55dbbea5291dd41de4ccd9662f6dfd610feacb5",
+   "sha256": "1mkjavxq0zk0dkabzr5lvccsw5vizns8pa571ajab23p4942aax2"
   },
   "stable": {
    "version": [
     1,
-    0,
+    1,
     0
    ],
-   "deps": [
-    "levenshtein"
-   ],
-   "commit": "63e0788175da46c55562919c7fe7c4e43546752d",
-   "sha256": "1i07vi7lqvzfvnxlhx1bfh56b4csj8a9c2r8w3i6zl9vlvj2ryrv"
+   "commit": "d55dbbea5291dd41de4ccd9662f6dfd610feacb5",
+   "sha256": "1mkjavxq0zk0dkabzr5lvccsw5vizns8pa571ajab23p4942aax2"
   }
  },
  {
@@ -66431,11 +66832,11 @@
   "repo": "abo-abo/swiper",
   "unstable": {
    "version": [
-    20250417,
-    1209
+    20251123,
+    1023
    ],
-   "commit": "2529a23f9f510a94efa6c088bd14217aa764dafb",
-   "sha256": "1y53dg76vrc45z4qljn0cd5ycd4c9q1dwvhhii3j560hp88wkabi"
+   "commit": "ec9421340c88ebe08f05680e22308ed57ed68a3d",
+   "sha256": "1i3zpl8kldggvzbkzqmkld2j0cgdqc4wcid9gaz3l7dwmsanwbkp"
   },
   "stable": {
    "version": [
@@ -67238,10 +67639,10 @@
  },
  {
   "ename": "ivy-yasnippet",
-  "commit": "8c76857d716afab46f5efe46e353935921d5f217",
-  "sha256": "180q6hrsnkssbf9x9bj74dyy26kym4akbsjlj81x4193nnmc5w67",
+  "commit": "7f52201736a23f82c6adc0e8894a7f42bff214dc",
+  "sha256": "1gbssj4rdml1plxi43iwg0p67ybhlv6rx4vbs8jzyfc445ik8gqz",
   "fetcher": "github",
-  "repo": "mkcms/ivy-yasnippet",
+  "repo": "emacsattic/ivy-yasnippet",
   "unstable": {
    "version": [
     20200704,
@@ -67734,6 +68135,21 @@
   }
  },
  {
+  "ename": "jbeam-mode",
+  "commit": "bd344021bafae68f1e6ac8e446dd4f1051e4afec",
+  "sha256": "194rlihwd102mgiqhxl2q64h30f53c4pyzvn6lbwhr107r5ayaps",
+  "fetcher": "github",
+  "repo": "webdevred/jbeam-mode",
+  "unstable": {
+   "version": [
+    20251123,
+    2213
+   ],
+   "commit": "7c16b603cb8e342533d20069603373a63a3ca7ca",
+   "sha256": "0f7yswsb8a8p6gl8hz5w5sjrmsx5rd4p4p68ijy6wgb98crshnzy"
+  }
+ },
+ {
   "ename": "jbeans-theme",
   "commit": "6dd4bd78795ec7509d8744fec1e80426ce0557ec",
   "sha256": "0y7ccycfnpykgzr88968w7dl45qazf8b9zlf7ydw3ghkl4f6lbwl",
@@ -67964,15 +68380,15 @@
   "repo": "rmuslimov/jenkins.el",
   "unstable": {
    "version": [
-    20200524,
-    2016
+    20251022,
+    2050
    ],
    "deps": [
     "dash",
     "json"
    ],
-   "commit": "bd06cdc57c0cb9217d773eeba06ecc998f10033b",
-   "sha256": "0g99bi3i27ay8xhz409k9ska9yy77j3k687l817k1fyhlyy5lpjk"
+   "commit": "10197d13b491811d4e066003dfc83fedeb21dd90",
+   "sha256": "18w6rpmdpw4vs6h64g2xk1ddgn0bdgrs7svhbbdxisb2ljfdvfdz"
   }
  },
  {
@@ -68182,25 +68598,25 @@
   "repo": "minad/jinx",
   "unstable": {
    "version": [
-    20251007,
-    1659
+    20251129,
+    800
    ],
    "deps": [
     "compat"
    ],
-   "commit": "618e1a5c7ad8aa5a0b219436d3f998f3394415f5",
-   "sha256": "044kqnnpjkchi83jz4y3s2qici5p65yvy60wfiybj1an14vqb877"
+   "commit": "a678be8cf0888947789a10a493c8b1c3a7066f52",
+   "sha256": "1ql2gv9jrva5l16d9xm2fz77ganpri7p73br1k0sj9kvinkyqxyf"
   },
   "stable": {
    "version": [
     2,
-    3
+    4
    ],
    "deps": [
     "compat"
    ],
-   "commit": "214d98c18c01897eab108a880b18aa3b64632a03",
-   "sha256": "17pmj9dzyih4m06n7g357a0a8p6v8b216g33r5pcbqz8g0k40djw"
+   "commit": "e0ad6ea90e25c363a419eb5dbc378ae82252ed0a",
+   "sha256": "0gwq5fv84bdp0yrk853dxmfrw3az6gyjnfk9ckyja9cnqjlbh0d3"
   }
  },
  {
@@ -68211,8 +68627,8 @@
   "repo": "unmonoqueteclea/jira.el",
   "unstable": {
    "version": [
-    20251006,
-    1744
+    20251114,
+    1916
    ],
    "deps": [
     "magit-section",
@@ -68220,13 +68636,13 @@
     "tablist",
     "transient"
    ],
-   "commit": "865e97d9085be8fbb86e2c4ae749c72d8b79178e",
-   "sha256": "0zfv21249chxry5w72yhmmgk0ja0ljd8akzf9zlz0mn8zqqmsch3"
+   "commit": "227c59839f90d3426d1d94c906dee69dee62ca5b",
+   "sha256": "1kyyk76f6jmc70cq4bhhdasz8k00hcclc8b217amwandzi0hzw80"
   },
   "stable": {
    "version": [
     2,
-    10,
+    14,
     0
    ],
    "deps": [
@@ -68235,8 +68651,8 @@
     "tablist",
     "transient"
    ],
-   "commit": "865e97d9085be8fbb86e2c4ae749c72d8b79178e",
-   "sha256": "0zfv21249chxry5w72yhmmgk0ja0ljd8akzf9zlz0mn8zqqmsch3"
+   "commit": "227c59839f90d3426d1d94c906dee69dee62ca5b",
+   "sha256": "1kyyk76f6jmc70cq4bhhdasz8k00hcclc8b217amwandzi0hzw80"
   }
  },
  {
@@ -68342,11 +68758,11 @@
   "repo": "necaris/jjdescription.el",
   "unstable": {
    "version": [
-    20251007,
-    1951
+    20251011,
+    159
    ],
-   "commit": "883a3b9d5a400495f0b7ec87220633ad0502c894",
-   "sha256": "0mn0nl2mfh27hqr32z4zb5bc3k6j79vnrq1waqcip01v1g7p7hwp"
+   "commit": "cd2478f0e2f92cb823110caba22fe0eaafeed07e",
+   "sha256": "1y5r09mg9m6bma92q26gga68p2yc6mdj0578zyydcn4wh7vhk2wj"
   }
  },
  {
@@ -68694,11 +69110,11 @@
   "repo": "ovistoica/js-pkg-mode",
   "unstable": {
    "version": [
-    20250803,
-    534
+    20251017,
+    936
    ],
-   "commit": "4ada384f7f83e227b829223576f02ba51ba06fd1",
-   "sha256": "0lh0faxsmkcr3w9h2fbpvckpm4ab2ja4wq7q1cr6sfnxdj1w84zd"
+   "commit": "4d7248b829b62c7ed8509c13bd959e78466bef77",
+   "sha256": "12xwnacywrqb73w1r4hrcn5g33lkbv05cmhl5crkd0z999knb57i"
   }
  },
  {
@@ -68727,11 +69143,11 @@
   "repo": "jacksonrayhamilton/js-ts-defs",
   "unstable": {
    "version": [
-    20250713,
-    2216
+    20251118,
+    504
    ],
-   "commit": "ad1fe01406d58b3d13fd62ba8b76198cd18575a7",
-   "sha256": "0p1kqv9gy7fvgigpq69wmcf0n1n9nycafdg1spfyi8k16ai4hgpr"
+   "commit": "6e6d052855133534c9a175a813f01aea428a6a68",
+   "sha256": "0fx5j573dpkfxviirmsdsday9mvqckgg0560sf4vfbjscsjaf3bv"
   }
  },
  {
@@ -69050,14 +69466,14 @@
   "repo": "taku0/json-par",
   "unstable": {
    "version": [
-    20250713,
-    755
+    20250720,
+    619
    ],
    "deps": [
     "json-mode"
    ],
-   "commit": "f81ba61c2fe49b571be890708f3418165b3bbb74",
-   "sha256": "1s0fc9vzf34zpg7jznbkwvpr3qk2w1ls9fvlmsq0cvx43fiw1yr7"
+   "commit": "38a3f1f11dd2ab6d195a26818966a5a5e1f74448",
+   "sha256": "1nmkw76dzq5j5jvgdwql1sbzp1a5vl8hsb4pc1ic7ak8n51vqm4h"
   },
   "stable": {
    "version": [
@@ -69369,20 +69785,20 @@
   "repo": "llemaitre19/jtsx",
   "unstable": {
    "version": [
-    20250414,
-    2100
+    20251018,
+    1908
    ],
-   "commit": "f715f9b97d504492378a31004c40db3b661b15e1",
-   "sha256": "19w1ndnc1rivcl0z3frrykrjbq5683cg62mhsp7xjac5hglcd5km"
+   "commit": "61df071a7f4761ddb30c33c8225e78f72e68f7ae",
+   "sha256": "0h1f5g44lviv6z7pcssxm9p21r4hl6qq4w3rhnljqawbvf7vq18v"
   },
   "stable": {
    "version": [
     0,
-    6,
+    7,
     0
    ],
-   "commit": "4cf3bbbd3b7ca3687494169699140d39b1843d8b",
-   "sha256": "0m3drmx57mzqahjjxfb7vwz753hhdg45akcpyfaj92miljqds3v8"
+   "commit": "ec2617b8ebe6c7f8bc1fe1b1cb6ad0ea6421af52",
+   "sha256": "18h3hiq6pysn94lg07qkmgqpwa8h88xxd4h1lkv2k06fhihjc04a"
   }
  },
  {
@@ -69755,11 +70171,11 @@
   "repo": "leon-barrett/just-mode.el",
   "unstable": {
    "version": [
-    20250828,
-    1824
+    20251121,
+    1826
    ],
-   "commit": "310f437296173e4659c80490fcdb7ebafbac1665",
-   "sha256": "0bjpz0p13rgj3fmydxr34lghwd4vhcgkh7lxqp9a1rv2kdpar2qn"
+   "commit": "b6173c7bf4d8d28e0dbd80fa41b9c75626885b4e",
+   "sha256": "1czf779akdcx72ma7x9v70kjbic73312fi1czbzvlvxr01pjpyj0"
   },
   "stable": {
    "version": [
@@ -69779,11 +70195,11 @@
   "repo": "leon-barrett/just-ts-mode.el",
   "unstable": {
    "version": [
-    20250828,
-    1824
+    20251121,
+    1841
    ],
-   "commit": "f4fb841f93222fcefccabd641281553b4c8d9d6e",
-   "sha256": "1mmp6pkwcwmwfz2k5g19rbi9yfjrsih4yz4ajz63k1y0g7fxn8lb"
+   "commit": "9dd136bc809de85fa66a4665312eb0f55b1c8094",
+   "sha256": "0gmimdy2isfmyf622926y3w0a0fxm1q98ry0lbqjjvhfq9i2h3mc"
   }
  },
  {
@@ -69794,8 +70210,8 @@
   "repo": "psibi/justl.el",
   "unstable": {
    "version": [
-    20250909,
-    422
+    20251111,
+    948
    ],
    "deps": [
     "f",
@@ -69803,8 +70219,8 @@
     "s",
     "transient"
    ],
-   "commit": "8096ebd602f374936be2c14cbc6b2e7768c3fccf",
-   "sha256": "0mfp5aj6m2rmyfff3rw4rh1zgisphvz3lp8msx1pwznnfzab5wpi"
+   "commit": "3b11dd8ac7ebeaca5da6c80223254a9f0494b275",
+   "sha256": "1i5m8iqyw7pkc2cjkk6z0px6lqm0w0ad9r1f9i8dhi8v8v7lk70r"
   },
   "stable": {
    "version": [
@@ -69859,11 +70275,11 @@
   "repo": "joshbax189/jwt-el",
   "unstable": {
    "version": [
-    20241031,
-    2258
+    20251022,
+    2118
    ],
-   "commit": "d7deb62f8c2df58d5cfebf087a147c75207964e8",
-   "sha256": "01ngwb7xzzf6pdzv894dqwvmgj4nqkdjjnbmh67iv7xjd2m29dja"
+   "commit": "d6754f8fab6ff4041a7bece1963495e99ad9fe68",
+   "sha256": "0crqy2r2bx03f2z7pg1h2qm7csx3ncxqbya4bz976ssq0p7mljnv"
   },
   "stable": {
    "version": [
@@ -70480,40 +70896,39 @@
   "repo": "jinnovation/kele.el",
   "unstable": {
    "version": [
-    20250318,
-    226
+    20251129,
+    456
    ],
    "deps": [
     "async",
     "dash",
     "f",
-    "ht",
+    "magit-section",
     "memoize",
     "plz",
     "s",
     "yaml"
    ],
-   "commit": "9ad25a31103c6deea2dbea86f1f5f752cac3d622",
-   "sha256": "0b04dxzxnvh33zixvba7axdkwrw83688392h69gcn80bcamakj52"
+   "commit": "923d884728349e21372d4f65804bd5676b1cb73c",
+   "sha256": "1cvmy1nysc9v4fd2qafjb3nsy1df6c9xhg8yf885yr5ryn8bjrgn"
   },
   "stable": {
    "version": [
     0,
-    6,
+    7,
     0
    ],
    "deps": [
     "async",
     "dash",
     "f",
-    "ht",
     "memoize",
     "plz",
     "s",
     "yaml"
    ],
-   "commit": "beec4a76c090101d8a98e631c292207be3c3a6a1",
-   "sha256": "0h67jvvql9z969wzzxx8g2hnnzxw5p1wqc211258bgyxm6p25yzq"
+   "commit": "ddaae424cf142e1cb6c46824aede3cd0479f2669",
+   "sha256": "1df9b4ifav19b8724fpp35hpynkjadqxi5x7m0nj3kfyi46fl831"
   }
  },
  {
@@ -70684,41 +71099,41 @@
   "repo": "tarsius/keycast",
   "unstable": {
    "version": [
-    20250901,
-    1610
+    20251101,
+    2021
    ],
    "deps": [
     "compat"
    ],
-   "commit": "f23f6823710c4d194cbdb5f1a0532d1d6fe0d968",
-   "sha256": "0w8kvizrzml85j7m8c3nb8a9sp8nvx0l2xwv3f0zr2nald0vsd6c"
+   "commit": "090ade99c1c03830d45cc763e5733a1ca001c4e5",
+   "sha256": "1dnr2kfldbghq198bm5h784xmak6kybpfyq90bwwysd5dzli2i98"
   },
   "stable": {
    "version": [
     1,
     4,
-    5
+    6
    ],
    "deps": [
     "compat"
    ],
-   "commit": "f23f6823710c4d194cbdb5f1a0532d1d6fe0d968",
-   "sha256": "0w8kvizrzml85j7m8c3nb8a9sp8nvx0l2xwv3f0zr2nald0vsd6c"
+   "commit": "090ade99c1c03830d45cc763e5733a1ca001c4e5",
+   "sha256": "1dnr2kfldbghq198bm5h784xmak6kybpfyq90bwwysd5dzli2i98"
   }
  },
  {
   "ename": "keychain-environment",
-  "commit": "4382c9e7e8dee2cafea9ee49965d0952ca359dd5",
-  "sha256": "1w77cg00bwx68h0d6k6r1fzwdwz97q12ch2hmpzjnblqs0i4sv8v",
+  "commit": "b076512819264d79f0235f53faf26f2592480843",
+  "sha256": "13s6h2fj2qjzsbjl5dmdy2q386i0rb3dpf4li6254br70kd8iipc",
   "fetcher": "github",
-  "repo": "tarsius/keychain-environment",
+  "repo": "emacsorphanage/keychain-environment",
   "unstable": {
    "version": [
-    20180318,
-    2223
+    20251123,
+    46
    ],
-   "commit": "d3643196de6dc79ea77f9f4805028350fd76100b",
-   "sha256": "0wzs77nwal6apinc39d4arj3lralv2cb9aw9gkikk46fgk404hwj"
+   "commit": "d2fa34404fe3a58bd7e708e73b77be43f46eb4cc",
+   "sha256": "0di8lyqag0v7pb24nr4ixvfbb4vincqiqzq5sv2ab50glikmahvh"
   },
   "stable": {
    "version": [
@@ -70787,26 +71202,26 @@
   "repo": "tarsius/keymap-utils",
   "unstable": {
    "version": [
-    20250913,
-    1926
+    20251101,
+    2023
    ],
    "deps": [
     "compat"
    ],
-   "commit": "9b98459e39d5f9f8d14371c47f7070fc99dbbc68",
-   "sha256": "0s3dqqd2hxyb07lfpm5yd38ycr16m9nac8x3i5g6w1860q3357w4"
+   "commit": "b230f47067bd09d0c6ad783efcc763c2003f1617",
+   "sha256": "0hc99j6fcbfypaqp9ymv61d0swpx47m6qx4q77xlkrx58n2b7xnf"
   },
   "stable": {
    "version": [
     4,
-    0,
-    3
+    1,
+    1
    ],
    "deps": [
     "compat"
    ],
-   "commit": "5acd65f35aa12303e3ea1f205c368e82f0fa89c3",
-   "sha256": "100vc8a7llgpi350yldw1g00rymlda92ns1ljglpgvqkq4g1czib"
+   "commit": "b230f47067bd09d0c6ad783efcc763c2003f1617",
+   "sha256": "0hc99j6fcbfypaqp9ymv61d0swpx47m6qx4q77xlkrx58n2b7xnf"
   }
  },
  {
@@ -71033,15 +71448,15 @@
   "repo": "khoj-ai/khoj",
   "unstable": {
    "version": [
-    20250916,
-    917
+    20251118,
+    2330
    ],
    "deps": [
     "dash",
     "transient"
    ],
-   "commit": "6ac2280e4117421c1c162a4a0a2ecfa16351dc36",
-   "sha256": "148ixdxncw39nnagznvmiihzxj0vrcwjk5xrixgi6yk57qfyfvn6"
+   "commit": "043777c1bd73234aedf37d346bf007abef61cb5a",
+   "sha256": "0f9hmsq5cy1h79mwczyj66g0a5fr99ashd2rddl2iknfr1ywvhbs"
   },
   "stable": {
    "version": [
@@ -71177,30 +71592,6 @@
   }
  },
  {
-  "ename": "killer",
-  "commit": "bd8c3ec8fa272273128134dea96c0c999a524549",
-  "sha256": "10z4vqwrpss7mk0gq8xdsbsl0qibpp7s1g0l8wlmrsgn6kjkr2ma",
-  "fetcher": "github",
-  "repo": "tarsius/killer",
-  "unstable": {
-   "version": [
-    20190128,
-    10
-   ],
-   "commit": "ace0547944933440384ceeb5876b1f68c082d540",
-   "sha256": "06nzxd9nc1d569354xj7w88i0y5l99pyag691aribsh771rxbfz4"
-  },
-  "stable": {
-   "version": [
-    1,
-    0,
-    0
-   ],
-   "commit": "ace0547944933440384ceeb5876b1f68c082d540",
-   "sha256": "06nzxd9nc1d569354xj7w88i0y5l99pyag691aribsh771rxbfz4"
-  }
- },
- {
   "ename": "kite",
   "commit": "855ea20024b606314f8590129259747cac0bcc97",
   "sha256": "17bpk9ycx2xkwm3j1dxi5216lbzf5lgnscs8i4y0pkpicdn0wyr6",
@@ -71288,26 +71679,26 @@
   "repo": "mew/kixtart-mode",
   "unstable": {
    "version": [
-    20250916,
-    1957
+    20251011,
+    1421
    ],
    "deps": [
     "eldoc"
    ],
-   "commit": "863f0a42b6d865341cebb43fdcb3e0feb0048b5e",
-   "sha256": "0rida9ii6bis4rd8hknqilaijsbpcxi48amv2cb83bp7p98sqr4k"
+   "commit": "f1a713f812af49cd109efa30ad498008e31b87c6",
+   "sha256": "1p5m9m0wap7zbypfyizzhplxjrbrjb34x6rxji0hg3j6jpf986ji"
   },
   "stable": {
    "version": [
     1,
     4,
-    2
+    3
    ],
    "deps": [
     "eldoc"
    ],
-   "commit": "8a02eb6cbd99815b33352796a2a756a5d75edcae",
-   "sha256": "056g26j74cdjmmdz80cyd12fwmqnmsrg6jj94w8wfa1l8aksp9gb"
+   "commit": "f1a713f812af49cd109efa30ad498008e31b87c6",
+   "sha256": "1p5m9m0wap7zbypfyizzhplxjrbrjb34x6rxji0hg3j6jpf986ji"
   }
  },
  {
@@ -73938,15 +74329,11 @@
   "repo": "Judafa/linkin-org",
   "unstable": {
    "version": [
-    20251004,
-    1303
+    20251116,
+    1638
    ],
-   "deps": [
-    "dash",
-    "s"
-   ],
-   "commit": "7d18f48c611db1f97d8ef86a5efa23a76058bf5e",
-   "sha256": "0x92a64wd1qxhp9l0310ng1zaji03znx1z2x7290asvnzssmbr28"
+   "commit": "1ce63411cc48a89a5b430516f7670f8af208047d",
+   "sha256": "1vassrpml46ralpwx6cffffas2v95xj1qsbni92fzvjs5wiybxxi"
   }
  },
  {
@@ -74796,26 +75183,26 @@
   "repo": "tarsius/llama",
   "unstable": {
    "version": [
-    20250901,
-    1544
+    20251101,
+    2002
    ],
    "deps": [
     "compat"
    ],
-   "commit": "ec1d4ef02f5572fc5aff3f62d3e7ef791f444456",
-   "sha256": "13f5crs3sc0k5v64mhbg1415q9hm92f43ba53avacxjjzk7gzad4"
+   "commit": "e4803de8ab85991b6a944430bb4f543ea338636d",
+   "sha256": "0qrbw3asmwbqjpqpws8swvcjcmip89hanjmfczwcqassi5qa0h85"
   },
   "stable": {
    "version": [
     1,
     0,
-    1
+    2
    ],
    "deps": [
     "compat"
    ],
-   "commit": "ec1d4ef02f5572fc5aff3f62d3e7ef791f444456",
-   "sha256": "13f5crs3sc0k5v64mhbg1415q9hm92f43ba53avacxjjzk7gzad4"
+   "commit": "e4803de8ab85991b6a944430bb4f543ea338636d",
+   "sha256": "0qrbw3asmwbqjpqpws8swvcjcmip89hanjmfczwcqassi5qa0h85"
   }
  },
  {
@@ -74954,15 +75341,15 @@
   "repo": "tanrax/lobsters.el",
   "unstable": {
    "version": [
-    20250827,
-    2008
+    20251013,
+    656
    ],
    "deps": [
     "request",
     "visual-fill-column"
    ],
-   "commit": "d061e1b0d4fe27c7751509da61396681d335e69f",
-   "sha256": "042qhc3qg3lzcicq9b5z0b5650a9c3d71db5w2bnwbydph25m97h"
+   "commit": "a12d8a30307a5070bf222f9fa0d908b627a3908a",
+   "sha256": "0g9f7x4apq8c5w65fpjs0dqx5r1y7ppmyz0vd8msddn2s321yv5n"
   }
  },
  {
@@ -75280,30 +75667,30 @@
   "repo": "doublep/logview",
   "unstable": {
    "version": [
-    20250401,
-    1723
+    20251104,
+    1725
    ],
    "deps": [
     "compat",
     "datetime",
     "extmap"
    ],
-   "commit": "649d878f7e2aad0f938b2cf0a870f1968b4d5e30",
-   "sha256": "0jd9ym4hlj699a021xy3fhk2wr2pfkskw72ifzh5q50bz1nmiy3s"
+   "commit": "9c97221dd04d7398df098e9f942efff016b60bbf",
+   "sha256": "0rvm37j403x5ymd1n4s3xryl7cp7rpfsg11jbcajbpavdhk8nmq9"
   },
   "stable": {
    "version": [
     0,
     19,
-    2
+    3
    ],
    "deps": [
     "compat",
     "datetime",
     "extmap"
    ],
-   "commit": "e9b40730c6abea7d1e0235fa5ba790d175b008ef",
-   "sha256": "1dhs2l2lx1gvvwg840a9y4nf2zxk9nljpyr8xqzi3si8wa7b3jdj"
+   "commit": "93b744ac5d57d527b8ca625116c3206549b8231f",
+   "sha256": "0159sbb54qp5ri8317jyvrp1184zmrlrr3dvqm1vvc8vvkkfy4y8"
   }
  },
  {
@@ -75439,8 +75826,8 @@
   "repo": "okamsn/loopy",
   "unstable": {
    "version": [
-    20251008,
-    156
+    20251116,
+    13
    ],
    "deps": [
     "compat",
@@ -75448,13 +75835,13 @@
     "seq",
     "stream"
    ],
-   "commit": "218c241c5ef0742de89cc63258545dca84facf8e",
-   "sha256": "0dzrbf2xis2bczxd5ha9zabadh935c113lh527rh0gz2dm4qjw14"
+   "commit": "07a9952cd6c03e9573afecf95ffb4eed7521d559",
+   "sha256": "1g7cg7d16ww85jh08smprxnj0flhsqnl4qhi52vfcfrlmp90lrbn"
   },
   "stable": {
    "version": [
     0,
-    14,
+    15,
     0
    ],
    "deps": [
@@ -75463,8 +75850,8 @@
     "seq",
     "stream"
    ],
-   "commit": "36f76980ea52a31a4c7682f7bd26c4baa32a1d4c",
-   "sha256": "0a0yjn5g8bsaaamc5374jw2wvs6mi7i5p77rd48xn4vmrb24h3b9"
+   "commit": "1849c6c774332c6451288debd4c353449ee79a92",
+   "sha256": "0qpzg7p8qiggscddbbf85av7zp7b38jjib49jrzl9skliwc0klcr"
   }
  },
  {
@@ -75751,14 +76138,14 @@
   "repo": "emacs-lsp/lsp-haskell",
   "unstable": {
    "version": [
-    20250301,
-    213
+    20251121,
+    1710
    ],
    "deps": [
     "lsp-mode"
    ],
-   "commit": "cd0f5d251c14e90f2896d26d18de8ace462e011b",
-   "sha256": "181x8d13mmqlkhq0jdid7b1wx8r8gcfkvxinxf7898hvzvkqmzrr"
+   "commit": "871a0ef2e98b3a749d0b69d958698000ca5640d3",
+   "sha256": "0chk1nxagbf0n1xxl8namxj7z5bqhidgyp0nqynqbi8799v62aa7"
   }
  },
  {
@@ -75820,8 +76207,8 @@
   "repo": "emacs-lsp/lsp-java",
   "unstable": {
    "version": [
-    20250712,
-    2133
+    20251118,
+    1411
    ],
    "deps": [
     "dap-mode",
@@ -75833,8 +76220,8 @@
     "request",
     "treemacs"
    ],
-   "commit": "9230a0007c79a661028c142f35c7b8d1f9f55453",
-   "sha256": "098mzvn56r4zc0944bzwwnb57p3lv0z94m2kl7s8l629vk5qlkph"
+   "commit": "094593d9c13d6d0b03d526d46e7fb0ee28c29afc",
+   "sha256": "16xsxrjaznj9hki35v2z3i29ylbd9nk62km40spa10xrlljlwch5"
   },
   "stable": {
    "version": [
@@ -75945,28 +76332,28 @@
   "repo": "ROCKTAKEY/lsp-latex",
   "unstable": {
    "version": [
-    20250126,
-    1416
+    20251104,
+    1507
    ],
    "deps": [
     "consult",
     "lsp-mode"
    ],
-   "commit": "07741fe9a959bfd1f831eec15e1c5e1c6fe04794",
-   "sha256": "1772jjp4hfqan91ngx9dlgsah1z5bqqnwa52pgc82l1hv6izn82r"
+   "commit": "a9ac457141f0aa15505b61ded3f12d0ad477b771",
+   "sha256": "006a0z98flc3ygx4a5xw8ip5s27n5x7sclqf1cr28f46c0ngra6l"
   },
   "stable": {
    "version": [
     3,
-    10,
+    11,
     0
    ],
    "deps": [
     "consult",
     "lsp-mode"
    ],
-   "commit": "07741fe9a959bfd1f831eec15e1c5e1c6fe04794",
-   "sha256": "1772jjp4hfqan91ngx9dlgsah1z5bqqnwa52pgc82l1hv6izn82r"
+   "commit": "a9ac457141f0aa15505b61ded3f12d0ad477b771",
+   "sha256": "006a0z98flc3ygx4a5xw8ip5s27n5x7sclqf1cr28f46c0ngra6l"
   }
  },
  {
@@ -76053,8 +76440,8 @@
   "repo": "emacs-lsp/lsp-mode",
   "unstable": {
    "version": [
-    20251002,
-    2344
+    20251124,
+    1817
    ],
    "deps": [
     "dash",
@@ -76065,8 +76452,8 @@
     "markdown-mode",
     "spinner"
    ],
-   "commit": "aec6ae4186afec395d89008764dbccbb73633fd3",
-   "sha256": "118va4wc0yncr6a1qzw8w6vw5459w850wyz38krv6gmm5igcjccy"
+   "commit": "2b497a75132b9eb6758712318d60f5e929cb1172",
+   "sha256": "18c3aav8q32kk538f6ndd0j5lr0pbykjg624gf4m072ymnsn9r6g"
   },
   "stable": {
    "version": [
@@ -76095,8 +76482,8 @@
   "repo": "emacs-lsp/lsp-mssql",
   "unstable": {
    "version": [
-    20250825,
-    542
+    20251117,
+    1444
    ],
    "deps": [
     "dash",
@@ -76105,8 +76492,8 @@
     "lsp-mode",
     "lsp-treemacs"
    ],
-   "commit": "93d3adc9dc61156745ab1f7dc147af6070fdd25b",
-   "sha256": "0l85nqmdkr8132dqw8hf7dy2ds6bvcbdh936qsxp78di46ywcb7f"
+   "commit": "810d632bd4abc4f105681a674ebea5d09407a04e",
+   "sha256": "0v3csv4qgpkh3g7vwd4fxd35adjsz5g425m8972zixinshy2csk6"
   }
  },
  {
@@ -76813,6 +77200,25 @@
   }
  },
  {
+  "ename": "maccalfw",
+  "commit": "a372eab8e20d025d9e24bdc5cc595ed72530d634",
+  "sha256": "1z6i4lbkxnf14gma1qixcj8ap2hb41fmp4iqsj0pkqwhrr28j6qm",
+  "fetcher": "github",
+  "repo": "haji-ali/maccalfw",
+  "unstable": {
+   "version": [
+    20251104,
+    512
+   ],
+   "deps": [
+    "calfw",
+    "ical-form"
+   ],
+   "commit": "0a72897c02537948aecc6a65b30c91466c8adaa8",
+   "sha256": "0rkl26l2a82k9zhn9asaygyg2h1bpx40mwn1hlvw82vwx3hv6wqm"
+  }
+ },
+ {
   "ename": "maces-game",
   "commit": "2c9f33b926ecec48a43ba4f0484c687a7349ce50",
   "sha256": "0wz91dsa0w4xlkl5lbdr8k4pgkgalsqcy27sd0i8xswq3wwiy0ip",
@@ -77078,8 +77484,8 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20251006,
-    1840
+    20251125,
+    1404
    ],
    "deps": [
     "compat",
@@ -77090,8 +77496,8 @@
     "transient",
     "with-editor"
    ],
-   "commit": "b828afbb4b45641998fb6483a08effb1efb214e1",
-   "sha256": "0lsxldyjv2h69657pgrblhkxq8fvc0xdwlwpfmd09pb8zawygh2g"
+   "commit": "4800ace210d5eb82b00428f0ff74723c986181ba",
+   "sha256": "1fbyas1a674ir3a59j5gml54xyza6g04bfz682bg136jc99ddscy"
   },
   "stable": {
    "version": [
@@ -77150,14 +77556,14 @@
   "repo": "ideasman42/emacs-magit-commit-mark",
   "unstable": {
    "version": [
-    20250611,
-    2320
+    20251126,
+    1131
    ],
    "deps": [
     "magit"
    ],
-   "commit": "e4a6ea43206c1b640c125fb7e489b0522647b52e",
-   "sha256": "0wa4bzip2aj3mfl6vfypd92fs3czhkilwb64zb9nx3mxrm4sa55i"
+   "commit": "26db85085067c13d59e02742cc0e1232e1c3284f",
+   "sha256": "0rx1ahvxg4qilzkmmsrpdbv7kz7cscgnqddaqc84cr45fy6gqw18"
   }
  },
  {
@@ -77686,8 +78092,8 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20251006,
-    1840
+    20251125,
+    1404
    ],
    "deps": [
     "compat",
@@ -77695,8 +78101,8 @@
     "llama",
     "seq"
    ],
-   "commit": "b828afbb4b45641998fb6483a08effb1efb214e1",
-   "sha256": "0lsxldyjv2h69657pgrblhkxq8fvc0xdwlwpfmd09pb8zawygh2g"
+   "commit": "4800ace210d5eb82b00428f0ff74723c986181ba",
+   "sha256": "1fbyas1a674ir3a59j5gml54xyza6g04bfz682bg136jc99ddscy"
   },
   "stable": {
    "version": [
@@ -77805,14 +78211,14 @@
   "repo": "magit/magit-tbdiff",
   "unstable": {
    "version": [
-    20240811,
-    1938
+    20250915,
+    2109
    ],
    "deps": [
     "magit"
    ],
-   "commit": "03cb872f00dd7fc868de0c8d7661803b5d011aa0",
-   "sha256": "1xmkdd8fg3rw5xhxhrilll5fqzhb2xr15qrjrcbblpnzn9zl5rvk"
+   "commit": "f77cffb98dae726f011b133db8936df9ac4a657a",
+   "sha256": "1cl1y7bb9jsl02vhhgsbqrsbi447z0a21h9344r1zaxspaajal3p"
   },
   "stable": {
    "version": [
@@ -78040,19 +78446,19 @@
   "repo": "alezost/make-color.el",
   "unstable": {
    "version": [
-    20140625,
-    1150
+    20251106,
+    1219
    ],
-   "commit": "a1b34e95ccd3ebee4fba1489ab613d0b3078026d",
-   "sha256": "1ky3scyjb69wi76xg6a8qx4ja6lr6mk530bv5gmhj7fxbq8b3x5c"
+   "commit": "aac38ff562f8ba46917f8281ad79973caf379f49",
+   "sha256": "0iymb5nm0sijw7d7mfm0s0izk5kjra7psc646za21zqpymyqdsny"
   },
   "stable": {
    "version": [
     0,
-    4
+    5
    ],
-   "commit": "b19cb40c0619e267f2948ed37aff67b712a6deed",
-   "sha256": "0fp5gbin1sgsdz39spk74vadkzig3ydwhpzx9vg7f231kk5f6wzx"
+   "commit": "aac38ff562f8ba46917f8281ad79973caf379f49",
+   "sha256": "0iymb5nm0sijw7d7mfm0s0izk5kjra7psc646za21zqpymyqdsny"
   }
  },
  {
@@ -78396,66 +78802,6 @@
   }
  },
  {
-  "ename": "map-progress",
-  "commit": "5ed3335eaf0be7368059bcdb52c46f5e47c0c1a5",
-  "sha256": "0zc5vii72gbfwbb35w8m30c8r9zck971hwgcn1a4wjczgn4vkln7",
-  "fetcher": "github",
-  "repo": "tarsius/map-progress",
-  "unstable": {
-   "version": [
-    20190128,
-    16
-   ],
-   "deps": [
-    "cl-lib"
-   ],
-   "commit": "1fb916159cd054c233ce3c80d9d01adfae640297",
-   "sha256": "1hbk35l9aljp4jqg8cv67q6b2jbcx0g665j90fygxqibrf6r52a8"
-  },
-  "stable": {
-   "version": [
-    1,
-    0,
-    0
-   ],
-   "deps": [
-    "cl-lib"
-   ],
-   "commit": "1fb916159cd054c233ce3c80d9d01adfae640297",
-   "sha256": "1hbk35l9aljp4jqg8cv67q6b2jbcx0g665j90fygxqibrf6r52a8"
-  }
- },
- {
-  "ename": "map-regexp",
-  "commit": "927314443ecc00d94e7125de669e82832c5a125c",
-  "sha256": "0yiif0033lhaqggywzfizfia3siggwcz7yv4z7przhnr04akdmbj",
-  "fetcher": "github",
-  "repo": "tarsius/map-regexp",
-  "unstable": {
-   "version": [
-    20190128,
-    18
-   ],
-   "deps": [
-    "cl-lib"
-   ],
-   "commit": "ae2d1c22f786ad987aef3e319925e80160a887a0",
-   "sha256": "1ybhizafdhzm7fg8s6gm13fbrz1vnrc7ifq8gvrrm89wl3qi5z7f"
-  },
-  "stable": {
-   "version": [
-    1,
-    0,
-    0
-   ],
-   "deps": [
-    "cl-lib"
-   ],
-   "commit": "ae2d1c22f786ad987aef3e319925e80160a887a0",
-   "sha256": "1ybhizafdhzm7fg8s6gm13fbrz1vnrc7ifq8gvrrm89wl3qi5z7f"
-  }
- },
- {
   "ename": "marcopolo",
   "commit": "936a1cff601594575c5b550c5eb16e7dafc8a5ab",
   "sha256": "1nbck1m7lhync7n474578d2g1zc72c841hi236xjbdd2lnxz3zz0",
@@ -78499,25 +78845,25 @@
   "repo": "minad/marginalia",
   "unstable": {
    "version": [
-    20251006,
-    1126
+    20251123,
+    1133
    ],
    "deps": [
     "compat"
    ],
-   "commit": "18d2d02cdb6689d7d08cd6c41b497117eeeba728",
-   "sha256": "05cd4r1y13kidcavjzf543b3wq49i16qcy1jhdllmw1iva7b2d42"
+   "commit": "d38041df2c2d175040bbdb1df6e4cc75a75ca4f8",
+   "sha256": "180v5y24rjrbh4dk66x3xhx3vb52yj520d61bkxrx790555a0y8g"
   },
   "stable": {
    "version": [
     2,
-    3
+    5
    ],
    "deps": [
     "compat"
    ],
-   "commit": "cb3a69c039cf3b4ab007a72f802fc5f4699e8120",
-   "sha256": "1x4x0v0cqhk8kpp4nngkdavs383aacd5xxzc1pvgchvmqhck70hy"
+   "commit": "f4058af89839566495d6037d35489da6eee45250",
+   "sha256": "064kc6p8zh6vbrcg06jilc7s2zc2kb8bddbqxr0mdypm8pwvymg4"
   }
  },
  {
@@ -78641,11 +78987,11 @@
   "repo": "jrblevin/markdown-mode",
   "unstable": {
    "version": [
-    20250812,
-    423
+    20251028,
+    412
    ],
-   "commit": "d51c469133d220823cc6ab50ff8e8743ed6e42fb",
-   "sha256": "1cp4mqv8jnvwb0ph0f7wnxdv9ryrfl2wyljhixb1simwalkpn98f"
+   "commit": "b524618c3ed28906a7522482727f121428ce7e2e",
+   "sha256": "0x47v2gj9w8i4ffbxydvkfk5h0pwgzc0rlngk0aqqss8ash4wac4"
   },
   "stable": {
    "version": [
@@ -78994,6 +79340,24 @@
   }
  },
  {
+  "ename": "mason",
+  "commit": "7ac3767ca976c2820c07e0fc43168cdf71a1e875",
+  "sha256": "0q6b6kr9ysn14izc4ah7mbs1vxlpls9zdh5760mnif8a4qzs62a4",
+  "fetcher": "github",
+  "repo": "deirn/mason.el",
+  "unstable": {
+   "version": [
+    20251117,
+    1738
+   ],
+   "deps": [
+    "s"
+   ],
+   "commit": "27c86dc000966cac96d5f0fd265af17d5f53c9b1",
+   "sha256": "17wrgcldz7zd9x7n0lf13lpj8938adbm06flg9nyyfrwbynnhdgs"
+  }
+ },
+ {
   "ename": "mastodon",
   "commit": "962f7c87d0630399ea388f25ec5792fa2f2b4489",
   "sha256": "04r3gz156haimz916q229mvz0rdhlr6yljw66ql7q2pwhgc7w1ni",
@@ -79001,28 +79365,28 @@
   "repo": "martianh/mastodon.el",
   "unstable": {
    "version": [
-    20251006,
-    1740
+    20251117,
+    1458
    ],
    "deps": [
     "persist",
     "tp"
    ],
-   "commit": "9319d0647755e1d9dfc081241bfcb2ef3ec96be3",
-   "sha256": "1hyvbz0cxlqr1gpmjs4rh0cf3n7k66zhc2algrhhf5p5i21fp89h"
+   "commit": "1ac040c113c061c173206658657cdee708001471",
+   "sha256": "1yv9qvxbx1p62451mx6mbacy7a24pl91i778bwlgwfvkcyb0ihbp"
   },
   "stable": {
    "version": [
     2,
     0,
-    3
+    7
    ],
    "deps": [
     "persist",
     "tp"
    ],
-   "commit": "9319d0647755e1d9dfc081241bfcb2ef3ec96be3",
-   "sha256": "1hyvbz0cxlqr1gpmjs4rh0cf3n7k66zhc2algrhhf5p5i21fp89h"
+   "commit": "1ac040c113c061c173206658657cdee708001471",
+   "sha256": "1yv9qvxbx1p62451mx6mbacy7a24pl91i778bwlgwfvkcyb0ihbp"
   }
  },
  {
@@ -79160,20 +79524,20 @@
   "repo": "mathworks/Emacs-MATLAB-Mode",
   "unstable": {
    "version": [
-    20251001,
-    1413
+    20251127,
+    254
    ],
-   "commit": "aca9a75c24848e95a2f11894d4ef2efc539bf588",
-   "sha256": "0m9ryzigzlksc2h8vwvl2ahh92a1215apzlihlhbcsc4r9b1j738"
+   "commit": "debcd15126d1f1ce97325b8cffc6c79c81c63d66",
+   "sha256": "0yfbwn2icyfpwk7h88iabq6ql3k9gvg3pxzc2b8jk4bpgma807ph"
   },
   "stable": {
    "version": [
     7,
-    0,
-    1
+    4,
+    0
    ],
-   "commit": "243e9d42060fa3d6246de8c193ceb1766fcd2a96",
-   "sha256": "06xya55gd54bpggn4krgqszz3w8ahqbhv3a069xdzb156lpciziq"
+   "commit": "d49fa62458208140c67970e9c2ec7f5591f40b1c",
+   "sha256": "18akq8bwrxpcw5ajg0kqd3dq4qlv03j300spy6mw5cr66gfva2g9"
   }
  },
  {
@@ -79415,14 +79779,14 @@
   "repo": "lizqwerscott/mcp.el",
   "unstable": {
    "version": [
-    20250928,
-    1200
+    20251029,
+    1132
    ],
    "deps": [
     "jsonrpc"
    ],
-   "commit": "b9782bb80027c13a84ae3ffff1e363a674ed6cf1",
-   "sha256": "148lsxpcka4rf5z62y6wis91vdimbivsp0b2ia8kcym8d9k2jy3m"
+   "commit": "963b4af6ce743fbb6224f61bb61f05de1c37f511",
+   "sha256": "05k1j3xnzs4swl4xj2l5kpazq603jyqqq3iz7vf4f3iily81csfx"
   }
  },
  {
@@ -79433,20 +79797,20 @@
   "repo": "laurynas-biveinis/mcp-server-lib.el",
   "unstable": {
    "version": [
-    20251008,
-    1443
+    20251103,
+    541
    ],
-   "commit": "b4cba156e179b4c95aa18b965c48ef3de4838c63",
-   "sha256": "05v6nrj4j80vzx9aa4q9nicf09mn0hdfjljfxlm9c32b37hyhfn9"
+   "commit": "847bcb180b6c035ee07f497e0ffc8092b3e54c4a",
+   "sha256": "00jl2n0zj0x6gbxdx4q7abv5yn7x15ycc05mszdl1sx935k2z74q"
   },
   "stable": {
    "version": [
     0,
-    1,
+    2,
     0
    ],
-   "commit": "502f79d22fe565050adf7a6879a3f903708405f4",
-   "sha256": "1877rmb8qq5rwxlxx341rdkn1lc64dys9plqavjajng6n4jlf2hd"
+   "commit": "cfa2f2f3367b32429a06d2c401a2b791a896bba6",
+   "sha256": "0qn38iqf75xzz0vkgac2ngv49qv52rbbfpziczb052r5fnl0pzp0"
   }
  },
  {
@@ -79578,20 +79942,20 @@
   "repo": "hexmode/mediawiki-el",
   "unstable": {
    "version": [
-    20250914,
-    2305
+    20251123,
+    1653
    ],
-   "commit": "e0e45e73be527d75127b31746998824115dcf6a5",
-   "sha256": "1bp9120mbhn2x9636axpajijp878rj738aqynr1fq44a25afxyjz"
+   "commit": "cf091148fd8fcf17d81bc5ad556ae18c839f6507",
+   "sha256": "199vkks9adkw7rvac960sz2625n0pa7zr2bixrb552dvh29c1lxc"
   },
   "stable": {
    "version": [
     2,
     4,
-    8
+    10
    ],
-   "commit": "0bfeb0daba0c0b65281ae7e65b64ea5744d51626",
-   "sha256": "0qgydr8ll1g0d28yy7p8k2sij7769bxx4fhd7c0s5c8cg7mrl666"
+   "commit": "cf091148fd8fcf17d81bc5ad556ae18c839f6507",
+   "sha256": "199vkks9adkw7rvac960sz2625n0pa7zr2bixrb552dvh29c1lxc"
   }
  },
  {
@@ -79602,11 +79966,11 @@
   "repo": "ideasman42/emacs-meep",
   "unstable": {
    "version": [
-    20251008,
-    1123
+    20251126,
+    308
    ],
-   "commit": "d455ee7b2466054b1249e951b733f0fd14820bb8",
-   "sha256": "07gvvk19zs1l65wxaxbk8qmpbrc9zvr138flxzmaq3vy3whp4zf4"
+   "commit": "f03cb16f39174ee9b03c245193aee964d17eb53b",
+   "sha256": "0ggyvrhfldkk6v8w7gcas98dccrb080dgc2n2v4dzlfvh0krhsai"
   }
  },
  {
@@ -79836,26 +80200,26 @@
   "repo": "skissue/meow-tree-sitter",
   "unstable": {
    "version": [
-    20250513,
-    1948
+    20251118,
+    1939
    ],
    "deps": [
     "meow"
    ],
-   "commit": "b05d54a5e19f8ba0258b0bbf0ffcd4bc7bad112c",
-   "sha256": "05v3gi29rnl47fnq1l3yrarsdyrfir5bx42rh2kj93f180jjp3z2"
+   "commit": "ef69efbbc5a7d13c29ce871327a51622e03eafc7",
+   "sha256": "0zibaf43fzk1xrng9isrsfhw85wyh3aq7hn94gl29wjnzv01sc2a"
   },
   "stable": {
    "version": [
     2,
     0,
-    0
+    2
    ],
    "deps": [
     "meow"
    ],
-   "commit": "d8dce964fac631a6d44b650a733075e14854159c",
-   "sha256": "0fzj8hnf9qiylx2b2s2vj8js32rd79gnw0x2c6l35zs9mm9dxm2x"
+   "commit": "09181314c465e6536a282657704d4fc267304d0d",
+   "sha256": "1hpq3lj8k86318ikvaybl4mr886w8axc63l9dnn2n26f67pvijg0"
   }
  },
  {
@@ -80327,11 +80691,11 @@
   "repo": "kazu-yamamoto/Mew",
   "unstable": {
    "version": [
-    20251007,
-    3
+    20251104,
+    625
    ],
-   "commit": "3984ef39d4ed7bf763ab9d064a1a46fb9ba9db5a",
-   "sha256": "0vd26xpxb397qjdfqdjfhp0klk7dqam180hnppffmaq2rm6lbpdc"
+   "commit": "e50839aebada2eef2acefcadd1e5e68550dba672",
+   "sha256": "1zks12ga6jsprcrlrzljkfdbf2q1igm3a0wydiwympdam6vnag4b"
   },
   "stable": {
    "version": [
@@ -80406,20 +80770,20 @@
   "repo": "purpleidea/mgmt",
   "unstable": {
    "version": [
-    20250925,
-    516
+    20251028,
+    2100
    ],
-   "commit": "6a7b3d5fa9c50d923a088b1e353f975de5077e4d",
-   "sha256": "0vlm9xp670i8z0y0cnbj2bg0wbrvc2jzpf1h77bmyahfy2yg3yql"
+   "commit": "7079121217a345c45a31f4f75f6f3b1c0d92a84e",
+   "sha256": "1adzafq6ifpm9d51qvy1b5nkrd39s0f1z4lhlyaajfn5dj8llbs2"
   },
   "stable": {
    "version": [
     1,
     0,
-    0
+    1
    ],
-   "commit": "6a7b3d5fa9c50d923a088b1e353f975de5077e4d",
-   "sha256": "0vlm9xp670i8z0y0cnbj2bg0wbrvc2jzpf1h77bmyahfy2yg3yql"
+   "commit": "7079121217a345c45a31f4f75f6f3b1c0d92a84e",
+   "sha256": "1adzafq6ifpm9d51qvy1b5nkrd39s0f1z4lhlyaajfn5dj8llbs2"
   }
  },
  {
@@ -80870,6 +81234,21 @@
   }
  },
  {
+  "ename": "minimal-dashboard",
+  "commit": "221c437305babdae4988132cc6293af826563338",
+  "sha256": "00j6p0asi0sq28zpg8wmdzxr8l78gh1vhjgximj8a1rlkggnfc37",
+  "fetcher": "github",
+  "repo": "dheerajshenoy/minimal-dashboard.el",
+  "unstable": {
+   "version": [
+    20251102,
+    1952
+   ],
+   "commit": "b7dbce88a19777c0d33df025e2b830094e521af8",
+   "sha256": "0qa1sgijf8qywi8zxiv2bs6j526q5aankp6790q10p1r8d1vdhdp"
+  }
+ },
+ {
   "ename": "minimal-session-saver",
   "commit": "c9db386ab3910940addae6e925b2ac17e64e0f87",
   "sha256": "1ay7wvriga28bdmarpfwagqzmmk93ri9f3idhr6z6iivwggwyy2i",
@@ -80916,26 +81295,26 @@
   "repo": "tarsius/minions",
   "unstable": {
    "version": [
-    20250531,
-    2220
+    20251101,
+    2032
    ],
    "deps": [
     "compat"
    ],
-   "commit": "7aeabcab964fefacb15a72d983953c53e238d344",
-   "sha256": "0hlb0d4lhwclvng4kdzngk4i9d1nbylcrp1ninpjdn8k310ni728"
+   "commit": "7bd15dd0a12e898db6b24b03d4aa797f525fb0e8",
+   "sha256": "06s2gd47q2lp4lj0ycrjihhn41ws9d3mh6ap9a7gz3b0blifpb4i"
   },
   "stable": {
    "version": [
     1,
     1,
-    1
+    2
    ],
    "deps": [
     "compat"
    ],
-   "commit": "7aeabcab964fefacb15a72d983953c53e238d344",
-   "sha256": "0hlb0d4lhwclvng4kdzngk4i9d1nbylcrp1ninpjdn8k310ni728"
+   "commit": "7bd15dd0a12e898db6b24b03d4aa797f525fb0e8",
+   "sha256": "06s2gd47q2lp4lj0ycrjihhn41ws9d3mh6ap9a7gz3b0blifpb4i"
   }
  },
  {
@@ -81060,15 +81439,15 @@
   "repo": "milanglacier/minuet-ai.el",
   "unstable": {
    "version": [
-    20250915,
-    517
+    20251015,
+    1814
    ],
    "deps": [
     "dash",
     "plz"
    ],
-   "commit": "2d9d2ad7768adf26fa54a8fdd8f6d78197a259f1",
-   "sha256": "1577ikw6wwx3m07lwwx6rccyz563c4l82ygfnkndhrp38nmzrzfm"
+   "commit": "6d48b96f09ce3418971cd3ae8ff083b47e440047",
+   "sha256": "1bh31a3xapsggz4blpr5h0gmdcrkv50bpnv87p2xmkm31q9jkykm"
   },
   "stable": {
    "version": [
@@ -81617,26 +81996,26 @@
   "repo": "tarsius/mode-line-debug",
   "unstable": {
    "version": [
-    20250901,
-    1611
+    20251101,
+    2033
    ],
    "deps": [
     "compat"
    ],
-   "commit": "001f14805830a4f9bc9fc263a0487ebe5acc3e92",
-   "sha256": "1048ynr3j1f5pnwp61j506nv55ff09iq6nz15jpdgd6rwncwb4r7"
+   "commit": "f68cfa2ea28ce2dc6f40d4c93a44a701510e8e04",
+   "sha256": "07lh6nvhdayzpf9bhz9b9r25a9z14rqayjimr9wy557kg4iy8cqm"
   },
   "stable": {
    "version": [
     1,
     5,
-    0
+    1
    ],
    "deps": [
     "compat"
    ],
-   "commit": "001f14805830a4f9bc9fc263a0487ebe5acc3e92",
-   "sha256": "1048ynr3j1f5pnwp61j506nv55ff09iq6nz15jpdgd6rwncwb4r7"
+   "commit": "f68cfa2ea28ce2dc6f40d4c93a44a701510e8e04",
+   "sha256": "07lh6nvhdayzpf9bhz9b9r25a9z14rqayjimr9wy557kg4iy8cqm"
   }
  },
  {
@@ -81815,20 +82194,20 @@
   "repo": "protesilaos/modus-themes",
   "unstable": {
    "version": [
-    20251007,
-    415
+    20251129,
+    513
    ],
-   "commit": "cfa35451719e37ca07fb3734298eb0bbb569b377",
-   "sha256": "1x6xw7ab10i7b29vn5flny4vhhqcm3j2zk9pjxxkkcbk1da72c99"
+   "commit": "c41281151f71f76a50f463e041bd2298d78c5220",
+   "sha256": "17q56bf61hr0lf4dhkj0afifqvisb2vlrbq82jrrcwq9qknqjgly"
   },
   "stable": {
    "version": [
-    4,
-    8,
-    1
+    5,
+    1,
+    0
    ],
-   "commit": "2f19a515110f7fcc407fcc32b9cdfdb26a853eb5",
-   "sha256": "1ivgs7hqgw8ndx76qzqmdg35ga4bwqcph7z0khqsy8xzg5qr299g"
+   "commit": "4fd8cdfc552e7e1e6a96625a752ab612706b15e3",
+   "sha256": "1acabx4nkbkvm643fjjw2d4yv6h0vdz3rca814sc6wxjybqnvzac"
   }
  },
  {
@@ -82006,11 +82385,11 @@
   "repo": "ideasman42/emacs-mono-complete",
   "unstable": {
    "version": [
-    20250913,
-    2251
+    20251126,
+    1132
    ],
-   "commit": "6a641e3ece7286a4e84b29313b689b55379670ed",
-   "sha256": "0f1m2py1sgfga1h96q1x7s683ni0rzrbfdg60fxdcmrrk3rr2y6z"
+   "commit": "71d46dc015ccdb33b07b2ac31b6b433c651faa02",
+   "sha256": "19lf2sp20b0kflah00iwm7qki2y6lgdaq0ql6s04pb4ws0ps6gqr"
   }
  },
  {
@@ -82177,26 +82556,26 @@
   "repo": "tarsius/moody",
   "unstable": {
    "version": [
-    20250913,
-    1927
+    20251101,
+    2036
    ],
    "deps": [
     "compat"
    ],
-   "commit": "293036f57cc97aa7c085c8044d76fca481f0b54b",
-   "sha256": "1sfdjp1qri6gimvbcpk8nlk9r7mjjv8c7ivgaf70vpik2a8d0lrf"
+   "commit": "c88c360065ccb8371df2bbf12bffbd13afe60234",
+   "sha256": "0nay6mpphb8ri0b92jjj15h9dfff2nwl9rwsdjfay976qdnfffmi"
   },
   "stable": {
    "version": [
     1,
-    1,
-    5
+    2,
+    1
    ],
    "deps": [
     "compat"
    ],
-   "commit": "698376065e78201577b371ccd9a340b24cd59331",
-   "sha256": "1kkbsdw4xd3r81slfgqjrjm63qz3hz9a6v24zabs6rlpmlzmps72"
+   "commit": "c88c360065ccb8371df2bbf12bffbd13afe60234",
+   "sha256": "0nay6mpphb8ri0b92jjj15h9dfff2nwl9rwsdjfay976qdnfffmi"
   }
  },
  {
@@ -82304,20 +82683,20 @@
   "repo": "tarsius/morlock",
   "unstable": {
    "version": [
-    20250531,
-    2221
+    20251101,
+    2037
    ],
-   "commit": "d66b4d4e7f2239c2b4fc6e3ad19aa9ea7b3037c5",
-   "sha256": "1dnd834clqmi3gvanhaxl6mc5a86ixjwa6h6mv4qm3vh9in0bmkp"
+   "commit": "02759c4d05ef6ec6b05707dab5bfe9a148a2c5ac",
+   "sha256": "11xwiz5vbxjprnhi1glx7scpf7cdr6d7srvmyb1y1j0mxh0k5ijv"
   },
   "stable": {
    "version": [
     2,
     1,
-    1
+    2
    ],
-   "commit": "d66b4d4e7f2239c2b4fc6e3ad19aa9ea7b3037c5",
-   "sha256": "1dnd834clqmi3gvanhaxl6mc5a86ixjwa6h6mv4qm3vh9in0bmkp"
+   "commit": "02759c4d05ef6ec6b05707dab5bfe9a148a2c5ac",
+   "sha256": "11xwiz5vbxjprnhi1glx7scpf7cdr6d7srvmyb1y1j0mxh0k5ijv"
   }
  },
  {
@@ -82617,12 +82996,12 @@
   "stable": {
    "version": [
     2,
-    31,
-    5851,
+    32,
+    5994,
     102
    ],
-   "commit": "d703e617246b3916edcb5b95812badef1a2764bc",
-   "sha256": "15wjfmz7bjac9dcyvv1ndxcnskgaz5jn95rac5y43jwljvw3nnfx"
+   "commit": "d9c3f195582de6b0baa07ecb81a04e8902acf9af",
+   "sha256": "12mpqlw7msmy62mwyxc1jyc30777iy5nyij2sn90pvz6x8n2n94b"
   }
  },
  {
@@ -83072,16 +83451,16 @@
   "repo": "xzz53/mu4e-alert",
   "unstable": {
    "version": [
-    20240911,
-    1952
+    20251022,
+    2130
    ],
    "deps": [
     "alert",
     "ht",
     "s"
    ],
-   "commit": "d36eb0c1842dea51ee0465bb3751948c8886617c",
-   "sha256": "039kfpwgw0vi6fv2p4ixdh9qx9hdsahl48yl1niq00zmsp7rgg07"
+   "commit": "9f20f30b15a5f5cc43fe448684fe1d4b981639aa",
+   "sha256": "0qqky31590qdkg4743hrjsh768aw08n3d2x5xpdcfmlpzpjsdgfd"
   },
   "stable": {
    "version": [
@@ -83252,14 +83631,11 @@
   "repo": "timmli/mu4e-walk",
   "unstable": {
    "version": [
-    20250915,
-    637
+    20251128,
+    1525
    ],
-   "deps": [
-    "mu4e"
-   ],
-   "commit": "f062152e50b6354d122a763947acc6b305dc66ef",
-   "sha256": "0mm20air2k6s1p8ax85jkd3pl244xlhasfz52sadp4kk1aj4s7np"
+   "commit": "9fb9efd3b99a06ac75535a1cd6630515f1a632ca",
+   "sha256": "1szwnacn0bj82mp2bs88ss869jivwc03iz1nq5kh8hl37j5378v1"
   }
  },
  {
@@ -84568,26 +84944,26 @@
   "repo": "DamienCassou/navigel",
   "unstable": {
    "version": [
-    20240901,
-    1624
+    20251125,
+    1931
    ],
    "deps": [
     "tablist"
    ],
-   "commit": "5f2f2ecfbd91c35bfbe4946915462872acf58310",
-   "sha256": "0fszhjf6bj8frvlnim86sfv6sab3qyignxqh8x6i4bqgwnb6svkf"
+   "commit": "539fe2d9542b01824869b98cde000079a1159b9f",
+   "sha256": "15vzp5s52m5rj27bsxrz73v3vsjgk1n5rk2b68i5vfbbrxirh188"
   },
   "stable": {
    "version": [
     1,
-    0,
+    1,
     0
    ],
    "deps": [
     "tablist"
    ],
-   "commit": "5f2f2ecfbd91c35bfbe4946915462872acf58310",
-   "sha256": "0fszhjf6bj8frvlnim86sfv6sab3qyignxqh8x6i4bqgwnb6svkf"
+   "commit": "539fe2d9542b01824869b98cde000079a1159b9f",
+   "sha256": "15vzp5s52m5rj27bsxrz73v3vsjgk1n5rk2b68i5vfbbrxirh188"
   }
  },
  {
@@ -84767,11 +85143,11 @@
   "repo": "rainstormstudio/nerd-icons.el",
   "unstable": {
    "version": [
-    20251008,
-    1720
+    20251125,
+    1823
    ],
-   "commit": "418f137faac926b822582fbce55a74a26e891ec5",
-   "sha256": "0lmyz9qsyv0b1l8a2wjkwmbcx5vagl2widxpffwfziq34a7x3r1w"
+   "commit": "772987a28d6408f840331c52c91d04b623a87048",
+   "sha256": "0n3kjz3ir43ghs0pq86plcz5mpf3m0qn19ahi0705pv56hgvr0h8"
   },
   "stable": {
    "version": [
@@ -84791,15 +85167,15 @@
   "repo": "rainstormstudio/nerd-icons-completion",
   "unstable": {
    "version": [
-    20250925,
-    1420
+    20251029,
+    2106
    ],
    "deps": [
     "compat",
     "nerd-icons"
    ],
-   "commit": "63a6b3f1eb98bb381c86a1658ac401c8967079b8",
-   "sha256": "08p361rh5mv3ng10av1381kzl9s4msdjyca96hsgsh05qwq5pdrf"
+   "commit": "d09ea987ed3d2cc64137234f27851594050e2b64",
+   "sha256": "022yfkfvcywgjplvsj5xajmc24q1c7yx0l5mvnzagjfdg4iajidv"
   }
  },
  {
@@ -84840,14 +85216,14 @@
   "repo": "rainstormstudio/nerd-icons-dired",
   "unstable": {
    "version": [
-    20250827,
-    1819
+    20251106,
+    1840
    ],
    "deps": [
     "nerd-icons"
    ],
-   "commit": "adf9a2bb5f3f13be7a676923639337f3fcc5d8c3",
-   "sha256": "0x1xmwlfjgbk5kk4bxvgz4ykwwgiwmdbzhgsw49kpzz678a3qzrp"
+   "commit": "3265d6c4b552eae457d50d423adb10494113d70b",
+   "sha256": "1kkpw59xflz4i0jdg5rdw84lggjqjy2k03yilpa19a5allvar63s"
   }
  },
  {
@@ -84876,14 +85252,14 @@
   "repo": "seagle0128/nerd-icons-ibuffer",
   "unstable": {
    "version": [
-    20250307,
-    958
+    20251022,
+    42
    ],
    "deps": [
     "nerd-icons"
    ],
-   "commit": "46f57138e57329d841b1745e586b4f2c69f82b87",
-   "sha256": "020nl0q6ab08frbikd78lnk821wsv6r3i7p5g1jmfw05zywj2jyr"
+   "commit": "590bd834cf5f1898320f5f16ecbed0d5fd3167ed",
+   "sha256": "1yx5arpk2yi8x3sbvv6ax8faia060sa3k6803zbc5rmxp36s4q8m"
   },
   "stable": {
    "version": [
@@ -84998,11 +85374,11 @@
   "repo": "Feyorsh/nethack-el",
   "unstable": {
    "version": [
-    20250929,
-    1522
+    20251025,
+    1205
    ],
-   "commit": "8c60ea5891b52273309eb7a77c1230a361912ec5",
-   "sha256": "11xrbmy3gxhl6dqyj6271m1y4hwv6z5b44nlcwzwcj2fwx7sa38s"
+   "commit": "c3d4b8980fa812de2f07094e3d1aac90eed7d7a7",
+   "sha256": "03hqzs34098qnxsnwiklcwqx6b4d4z2lgz1vl0pdd04k3v2z24r3"
   }
  },
  {
@@ -85447,14 +85823,15 @@
   "repo": "ninetyfive-gg/ninetyfive.el",
   "unstable": {
    "version": [
-    20250829,
-    1430
+    20251125,
+    2223
    ],
    "deps": [
+    "async",
     "websocket"
    ],
-   "commit": "e330aa250b05dac98038fe794f9d34ee604f3a58",
-   "sha256": "1mxbw4pz4fmwqsn0ydvisrc7zggg1lzkxblbwngwmljdiy36jsaf"
+   "commit": "0d673ac905c68a91dadf7e9c2ff6fa9c6402034e",
+   "sha256": "1xxfgz97zcas50nsg848l1ish5fbj4xrmbd57slsrw02h7xm0m04"
   }
  },
  {
@@ -85633,20 +86010,20 @@
   "repo": "nix-community/nix-ts-mode",
   "unstable": {
    "version": [
-    20250819,
-    1504
+    20251114,
+    1500
    ],
-   "commit": "414b18a8a7c9335a1d67c87acc57d5ef2a06a30e",
-   "sha256": "0bv0lwgdhd1xj8cb7ql8pydinqafpnqc1v13cj4mi139ahz991cs"
+   "commit": "03c77fdbbd22d9b87a654169c26339b28c97d8cd",
+   "sha256": "1x8flq97vrxqvqmf25dr5wnmvwpa0l3zv5hyz2af3aj4yy1ic35n"
   },
   "stable": {
    "version": [
     0,
     1,
-    4
+    5
    ],
-   "commit": "49d890e86a4597911366208930af6457ce1d46e7",
-   "sha256": "1s2kcm8rg35cl3vgbqny0ac2l00nqj5xdpll4z0is7zbhib74ll5"
+   "commit": "03c77fdbbd22d9b87a654169c26339b28c97d8cd",
+   "sha256": "1x8flq97vrxqvqmf25dr5wnmvwpa0l3zv5hyz2af3aj4yy1ic35n"
   }
  },
  {
@@ -85908,26 +86285,26 @@
   "repo": "emacscollective/no-littering",
   "unstable": {
    "version": [
-    20251005,
-    1557
+    20251127,
+    229
    ],
    "deps": [
     "compat"
    ],
-   "commit": "d476ffe49674f5885b7d7889ed9fbcdf04685773",
-   "sha256": "1srmqffx5ccyck5aprggj8744g02g3cnj9qp1gk3zbj2lyvacwqp"
+   "commit": "5b568cab7f8340deecb02a5c59d55885fc7d147c",
+   "sha256": "0yf51ylz8w5v0jrj39c2nnvkxs656r59yx3xi66drf2prq9dqmsm"
   },
   "stable": {
    "version": [
     1,
     8,
-    0
+    2
    ],
    "deps": [
     "compat"
    ],
-   "commit": "6e641890cd334434d0a0b576401a0f905a5b2f25",
-   "sha256": "01g0f908cqhm87xvyafbjv5fr1cag8msg8cb1dwzrid98ay3f4pk"
+   "commit": "3bd74a519de3ef50a92b53f50b17398b5f328a9a",
+   "sha256": "1yi3nwivi39c744nbwhlgc0pkh5p9kdylwv3ca52r683fm63l7jb"
   }
  },
  {
@@ -86283,11 +86660,11 @@
   "repo": "ashton314/nordic-night",
   "unstable": {
    "version": [
-    20250624,
-    1732
+    20251129,
+    409
    ],
-   "commit": "a500ccc22fab22b291dfbddc8c534e665ae144f9",
-   "sha256": "03h3q9kwq3ss89hbs8ahl8xxafnx1fx3cdfidz3hbh5nm7ycz08l"
+   "commit": "5d35f9c9da0ab7138b0a4897daaf52d78f4a1a37",
+   "sha256": "1l2k4xd2bcnbsyj733ry2p8vqr39rrdypzapsrg8hcp86zcnvk1p"
   },
   "stable": {
    "version": [
@@ -86427,28 +86804,28 @@
   "repo": "tarsius/notmuch-addr",
   "unstable": {
    "version": [
-    20250531,
-    2222
+    20251101,
+    2052
    ],
    "deps": [
     "compat",
     "notmuch"
    ],
-   "commit": "29aed7910254dc43d4a2070eb6443d7c0b28ade9",
-   "sha256": "0z3445wnh0zjfwixzq0cqf0a0mzgpdgq6c5b6h6b4vfh9qwd5ra2"
+   "commit": "0883cd753f0a7a204f41c7311d3282ca3e53f869",
+   "sha256": "0cyi4x0zgvmz2kvrxkmdlgwv81qfq917i3shvml94rgxmk8calnz"
   },
   "stable": {
    "version": [
     1,
     1,
-    1
+    2
    ],
    "deps": [
     "compat",
     "notmuch"
    ],
-   "commit": "29aed7910254dc43d4a2070eb6443d7c0b28ade9",
-   "sha256": "0z3445wnh0zjfwixzq0cqf0a0mzgpdgq6c5b6h6b4vfh9qwd5ra2"
+   "commit": "0883cd753f0a7a204f41c7311d3282ca3e53f869",
+   "sha256": "0cyi4x0zgvmz2kvrxkmdlgwv81qfq917i3shvml94rgxmk8calnz"
   }
  },
  {
@@ -86519,28 +86896,28 @@
   "repo": "tarsius/notmuch-maildir",
   "unstable": {
    "version": [
-    20250701,
-    1221
+    20251101,
+    2053
    ],
    "deps": [
     "compat",
     "notmuch"
    ],
-   "commit": "1e52a31d2e9a7ae68e2d512fa82fc89437945809",
-   "sha256": "1b31qqbdnj2zf9bcs1za5am5gs3xpzsxln269kd2c53pzffbnvyg"
+   "commit": "f4982d49d05d3b76db55462ec0f7cfee35f92d20",
+   "sha256": "061xabwvhzkmpvcaqcz47cryj29zcmxvz3sliyvnj0fnqnbpg407"
   },
   "stable": {
    "version": [
     1,
     3,
-    0
+    1
    ],
    "deps": [
     "compat",
     "notmuch"
    ],
-   "commit": "1e52a31d2e9a7ae68e2d512fa82fc89437945809",
-   "sha256": "1b31qqbdnj2zf9bcs1za5am5gs3xpzsxln269kd2c53pzffbnvyg"
+   "commit": "f4982d49d05d3b76db55462ec0f7cfee35f92d20",
+   "sha256": "061xabwvhzkmpvcaqcz47cryj29zcmxvz3sliyvnj0fnqnbpg407"
   }
  },
  {
@@ -86551,30 +86928,30 @@
   "repo": "tarsius/notmuch-transient",
   "unstable": {
    "version": [
-    20250601,
-    1056
+    20251101,
+    2054
    ],
    "deps": [
     "compat",
     "notmuch",
     "transient"
    ],
-   "commit": "c49e1e80246fd6a6f72f353441c9c4b83e2bb680",
-   "sha256": "1wv2a43wr1vk2wn8c51zd4ydldnpnlk2qy5wax3qwwg7f9y36lb1"
+   "commit": "09861654f1a25a46849f5653a4e9651d9a093ecd",
+   "sha256": "0a8324xcfd8nql0w9mbr97mi2hyf0mya9xa53iw1my8zmwdvwf9l"
   },
   "stable": {
    "version": [
     1,
     1,
-    1
+    2
    ],
    "deps": [
     "compat",
     "notmuch",
     "transient"
    ],
-   "commit": "c49e1e80246fd6a6f72f353441c9c4b83e2bb680",
-   "sha256": "1wv2a43wr1vk2wn8c51zd4ydldnpnlk2qy5wax3qwwg7f9y36lb1"
+   "commit": "09861654f1a25a46849f5653a4e9651d9a093ecd",
+   "sha256": "0a8324xcfd8nql0w9mbr97mi2hyf0mya9xa53iw1my8zmwdvwf9l"
   }
  },
  {
@@ -87300,20 +87677,20 @@
   "repo": "will-abb/aws-athena-babel",
   "unstable": {
    "version": [
-    20250713,
-    2235
+    20251102,
+    2212
    ],
-   "commit": "654e20311635c6b371030c0442f5d27105e94f07",
-   "sha256": "1dqfcs6cqkz14cxf3pbrp2nrvnyvg6lmj2bkxydzdg8ycfncxzf8"
+   "commit": "5c73a0ea5b8278c5d288d5fd260b204536fe5413",
+   "sha256": "0zy5z0kjr5zzjxqqx7ha7vvfchm214ii75nkn9rjph6lf6b8wa1c"
   },
   "stable": {
    "version": [
     2,
     1,
-    3
+    4
    ],
-   "commit": "9ae4c947f070f0c6ad3ae28e7c78c306b39154cb",
-   "sha256": "15llx7z1p5w625q8kk4q4ry5p142if4mqv6j9mbljz9zya7y0l43"
+   "commit": "5c73a0ea5b8278c5d288d5fd260b204536fe5413",
+   "sha256": "0zy5z0kjr5zzjxqqx7ha7vvfchm214ii75nkn9rjph6lf6b8wa1c"
   }
  },
  {
@@ -87874,10 +88251,10 @@
  },
  {
   "ename": "ob-git-permalink",
-  "commit": "7851f708191eb1fdfe326460bdb83b5509f544fb",
-  "sha256": "1k545yrcxkygv107f1zjclq62gahvdpac9z5pgijfw72n0hjb4gg",
+  "commit": "e943f5c8927248d9334434dba8bdee20c7a550c7",
+  "sha256": "1g2rp464k4gmskgac077wl2fkqkrpdnibj05x9na79p3r1ksa2i3",
   "fetcher": "github",
-  "repo": "kijimaD/ob-git-permalink",
+  "repo": "kijimad/ob-git-permalink",
   "unstable": {
    "version": [
     20220627,
@@ -88138,11 +88515,11 @@
   "repo": "sunflowerseastar/ob-llm",
   "unstable": {
    "version": [
-    20250611,
-    415
+    20250630,
+    303
    ],
-   "commit": "7058cb271416d56e5bcf73cfadde646141dcabad",
-   "sha256": "1yp85jzzkrxrn5fmir7xb3l5279lh1ki9c7286vljavqmhynv4mf"
+   "commit": "f667dbce7fb30c8acac06a03e60447663616da12",
+   "sha256": "096f92wn66zpvl7mpqk9c9v7vpnq2h367jrmf3870d00ck1myckr"
   },
   "stable": {
    "version": [
@@ -88655,15 +89032,28 @@
   "repo": "xenodium/ob-swiftui",
   "unstable": {
    "version": [
-    20241119,
-    1735
+    20251023,
+    1031
    ],
    "deps": [
     "org",
     "swift-mode"
    ],
-   "commit": "c16b4cddb5387fcebdd1d61a4c6c015f778d2d08",
-   "sha256": "0lqff7cjxc0x4xdza2jm58gbg6rbwfg0w7112jpfvyp98x025abm"
+   "commit": "82154e06ae335ee6669b3c4d344759a0302efab2",
+   "sha256": "010r7acvrgv0370sgqjsj62qmnm7pvhzz99ix83h8k97y42qxnwa"
+  },
+  "stable": {
+   "version": [
+    0,
+    11,
+    1
+   ],
+   "deps": [
+    "org",
+    "swift-mode"
+   ],
+   "commit": "82154e06ae335ee6669b3c4d344759a0302efab2",
+   "sha256": "010r7acvrgv0370sgqjsj62qmnm7pvhzz99ix83h8k97y42qxnwa"
   }
  },
  {
@@ -88979,11 +89369,11 @@
   "repo": "tarides/ocaml-eglot",
   "unstable": {
    "version": [
-    20250716,
-    1427
+    20251114,
+    737
    ],
-   "commit": "2d64c6460571bcfccc5ada74d6d7ac449d20f325",
-   "sha256": "15d03sqf8mhskrfj6x38n8v3za7qnxzqhjdxkza42fx231w2h4nc"
+   "commit": "588e3a51433a9d8acd66dc4ecb3f1b9aee222cf1",
+   "sha256": "0z90hc08yv7ihpqdkslw5ay84q08zc1w5jxsq0gxambs1g25akw8"
   },
   "stable": {
    "version": [
@@ -89018,20 +89408,20 @@
   "repo": "ocaml-ppx/ocamlformat",
   "unstable": {
    "version": [
-    20241202,
-    1532
+    20251024,
+    1250
    ],
-   "commit": "5bac2e7f71d9b0a06bd1908dda9b13da1649eee1",
-   "sha256": "0wdzv54s31lckkkwf776j7npcd7i2sscdy9asiaxy50vgi4y7kbx"
+   "commit": "809492a6044557239ed1e1c2f78eec602f068ea4",
+   "sha256": "0a1mk6gf6bgbnrkikpcgyk3l1vvrv1zaczzhg3l447nbrgy9vl06"
   },
   "stable": {
    "version": [
     0,
-    27,
-    0
+    28,
+    1
    ],
-   "commit": "5bac2e7f71d9b0a06bd1908dda9b13da1649eee1",
-   "sha256": "0wdzv54s31lckkkwf776j7npcd7i2sscdy9asiaxy50vgi4y7kbx"
+   "commit": "809492a6044557239ed1e1c2f78eec602f068ea4",
+   "sha256": "0a1mk6gf6bgbnrkikpcgyk3l1vvrv1zaczzhg3l447nbrgy9vl06"
   }
  },
  {
@@ -89318,30 +89708,30 @@
   "repo": "tarsius/ol-notmuch",
   "unstable": {
    "version": [
-    20250531,
-    2228
+    20251101,
+    2058
    ],
    "deps": [
     "compat",
     "notmuch",
     "org"
    ],
-   "commit": "06288ed5ec088f2702afb8f0d952f7db18bb7d56",
-   "sha256": "15n3hsfqnr4srmr3n2kry4348kbnx71x3cl00knqkr3a3bm66izy"
+   "commit": "7655f5ea25ea40b7d0453ae6531cae59e5ea592f",
+   "sha256": "0cdi73vfikhm8gcj1y05b07fvzvninz811yppb3kyhdis8kzc7qk"
   },
   "stable": {
    "version": [
     2,
     1,
-    1
+    2
    ],
    "deps": [
     "compat",
     "notmuch",
     "org"
    ],
-   "commit": "06288ed5ec088f2702afb8f0d952f7db18bb7d56",
-   "sha256": "15n3hsfqnr4srmr3n2kry4348kbnx71x3cl00knqkr3a3bm66izy"
+   "commit": "7655f5ea25ea40b7d0453ae6531cae59e5ea592f",
+   "sha256": "0cdi73vfikhm8gcj1y05b07fvzvninz811yppb3kyhdis8kzc7qk"
   }
  },
  {
@@ -90183,14 +90573,14 @@
   "repo": "oantolin/orderless",
   "unstable": {
    "version": [
-    20250922,
-    1344
+    20251128,
+    2028
    ],
    "deps": [
     "compat"
    ],
-   "commit": "9cf1c90e2501566ceba59f3220b4630995004efd",
-   "sha256": "04d3121q0k6lcm02f6kxr1r8ix5mi60j1d3qqalbhqb0yzgkvhm6"
+   "commit": "26a384894678a1e51e3bf914af3699a61794fb57",
+   "sha256": "109yywz0z0k91hxv785s6wxw5vxss42falwqk5r1bw1ggwc69sz0"
   },
   "stable": {
    "version": [
@@ -90721,6 +91111,38 @@
   }
  },
  {
+  "ename": "org-aws-iam-role",
+  "commit": "4853b51828556f8d551eecf0f95b627228eb5e06",
+  "sha256": "0bdbp2yfi77pfq8340ykbs9dlx2h2r5lgqwz2sx2p8m20sc1l80i",
+  "fetcher": "github",
+  "repo": "will-abb/org-aws-iam-role",
+  "unstable": {
+   "version": [
+    20251026,
+    2308
+   ],
+   "deps": [
+    "async",
+    "promise"
+   ],
+   "commit": "9c246fe5c716e8515524bd7c1dfd6dcd64114375",
+   "sha256": "00wm2slpwhcwizqj739w7s0x092432mxays0r6cz72dnwzf3lbw5"
+  },
+  "stable": {
+   "version": [
+    1,
+    4,
+    1
+   ],
+   "deps": [
+    "async",
+    "promise"
+   ],
+   "commit": "9c246fe5c716e8515524bd7c1dfd6dcd64114375",
+   "sha256": "00wm2slpwhcwizqj739w7s0x092432mxays0r6cz72dnwzf3lbw5"
+  }
+ },
+ {
   "ename": "org-babel-eval-in-repl",
   "commit": "746947a065c8fd26bfb540c96d869d05a0bd9b53",
   "sha256": "00glg9sscvzkfyp0gf989yqwqz67y607n545x4rchz2bnqw8w2wa",
@@ -90837,14 +91259,15 @@
   "url": "https://repo.or.cz/org-bookmarks.git",
   "unstable": {
    "version": [
-    20250918,
-    2242
+    20251113,
+    351
    ],
    "deps": [
-    "nerd-icons"
+    "nerd-icons",
+    "seq"
    ],
-   "commit": "5850ff12e6483299ff379415c099ea40b1180882",
-   "sha256": "0p9v0jvk914zg8xl9ndkcjxan1llgdnmynb3cjwa3nz5ijmm55ab"
+   "commit": "b3a46dc78175f7398502050420e5ea7d237a736f",
+   "sha256": "14khm57964ykdx2dcd9w7ddy18ksx4f5x8igppmn6gcln7l069rs"
   },
   "stable": {
    "version": [
@@ -90872,14 +91295,14 @@
  },
  {
   "ename": "org-books",
-  "commit": "2362892068bffb99a37e77201924ec12676a5017",
-  "sha256": "1mp0n1x5ka2x2rc6pd4nn54cr8b3qxl7fq8dsyng7bm300gizpf2",
-  "fetcher": "github",
+  "commit": "47153033bd57d0ba895c6135981758421dc26c9e",
+  "sha256": "13887x0q3yhbyvb6v514zqycgalmmg0wk7ssgi146csil562fj9s",
+  "fetcher": "sourcehut",
   "repo": "lepisma/org-books",
   "unstable": {
    "version": [
-    20250630,
-    1215
+    20251022,
+    1020
    ],
    "deps": [
     "dash",
@@ -90889,14 +91312,14 @@
     "org",
     "s"
    ],
-   "commit": "a07acc0895e7d5e5c237b050b0e743c8717e7afd",
-   "sha256": "19ha3jwkp0qazkr59dvzzmz9s7z2w3zvrmfnvjk91fildv29jl70"
+   "commit": "3f769e5a5a85a5eb6a2249ba971a3d77dc6e7d94",
+   "sha256": "0nf5d5nc9x7sjg35hcjk19xspr6k722g60lmfrb855m4vxliril7"
   },
   "stable": {
    "version": [
     0,
     3,
-    0
+    1
    ],
    "deps": [
     "dash",
@@ -90906,8 +91329,8 @@
     "org",
     "s"
    ],
-   "commit": "9f4ec4a981bfc5eebff993c3ad49a4bed26aebd1",
-   "sha256": "1sgckvpjdaig9r2clcvs6ckgf2kx7amikkpq26y30jbnfnbskf0v"
+   "commit": "3f769e5a5a85a5eb6a2249ba971a3d77dc6e7d94",
+   "sha256": "0nf5d5nc9x7sjg35hcjk19xspr6k722g60lmfrb855m4vxliril7"
   }
  },
  {
@@ -91432,15 +91855,15 @@
   "repo": "emacsomancer/org-daily-reflection",
   "unstable": {
    "version": [
-    20250307,
-    1733
+    20251129,
+    33
    ],
    "deps": [
     "compat",
     "org"
    ],
-   "commit": "c38def9361dfef62eeead9fbe42394844df16176",
-   "sha256": "1qkrifhnk2kmjz3qkcfn4innx368zkwk66qddw87mnsahyd2icy2"
+   "commit": "42a8da2a20c4ac31248072ce17803c0a579d11f6",
+   "sha256": "0ybs1mnmq893g23zxj511bs1w0ii39c71wf0np7yqavlyrp0m2h3"
   }
  },
  {
@@ -92462,16 +92885,16 @@
   "repo": "ahungry/org-jira",
   "unstable": {
    "version": [
-    20251004,
-    1853
+    20251120,
+    307
    ],
    "deps": [
     "cl-lib",
     "dash",
     "request"
    ],
-   "commit": "3f4bc7f984301b458c193c47931e8098eca2189d",
-   "sha256": "0wjhfb8bamcn07f5hzq6gv4m8z8l2cgq8x05dajwkb5gyp34rxm2"
+   "commit": "f5ccb0719478a6f7dd2c045b1b191420d04242d7",
+   "sha256": "0sxphr736pcvw7jj6nw67blh4vq6lr64200jf5qn75c20pqqycyl"
   },
   "stable": {
    "version": [
@@ -92669,15 +93092,15 @@
   "url": "https://repo.or.cz/org-link-beautify.git",
   "unstable": {
    "version": [
-    20250919,
-    1411
+    20251108,
+    1403
    ],
    "deps": [
     "nerd-icons",
     "qrencode"
    ],
-   "commit": "a1231808b47fa1bdd99a1e0701f139b772fb1352",
-   "sha256": "106j1bcfxjkcv7rjy5xfx7wzhgzy3mlz6j9n8r84ynbfaaz82mvr"
+   "commit": "a9ac59ca6eaade6a3394f1f27a45ef661735f92a",
+   "sha256": "0nscyh3cy8lb0fk6fshna03iymz2hakqs0bh5c04s1y9cgr2whgp"
   },
   "stable": {
    "version": [
@@ -92752,6 +93175,29 @@
    ],
    "commit": "d0adc5247b205bc73d2f1a83d4a512d2be541eb5",
    "sha256": "1w80kwh17b4svw0md7is8ajc732cbkknychsqcp1ia42qxqq4y8r"
+  }
+ },
+ {
+  "ename": "org-links",
+  "commit": "534fea0ddb7d89da5448530166ad79d3a224984c",
+  "sha256": "1ccfsbxn6f1nbrr9dlp01812xd08ckdgm7w3d4zig6yfk01zmdcn",
+  "fetcher": "github",
+  "repo": "Anoncheg1/emacs-org-links",
+  "unstable": {
+   "version": [
+    20251007,
+    1800
+   ],
+   "commit": "77c13e3dc936c164a46ff4c479b22a2ec12403b6",
+   "sha256": "15656phinm25smk88j519dq5c9bfpvddp13pwphgjibw5n9scs44"
+  },
+  "stable": {
+   "version": [
+    0,
+    2
+   ],
+   "commit": "8b2e05682efb88d35f8342795d6e49c4f2549687",
+   "sha256": "0c78qig3j3riyj326bbp3qh0ma1lf300yn4ymvwkd1wbkgh9hgj2"
   }
  },
  {
@@ -92831,6 +93277,35 @@
   }
  },
  {
+  "ename": "org-mcp",
+  "commit": "45f4e0192241255682c6ee2699e59edc034161c0",
+  "sha256": "0rfydlx0wb006z9njvj7x4mi9gshhvy5mil635c9rrk4cbl5x7w2",
+  "fetcher": "github",
+  "repo": "laurynas-biveinis/org-mcp",
+  "unstable": {
+   "version": [
+    20251111,
+    1319
+   ],
+   "deps": [
+    "mcp-server-lib"
+   ],
+   "commit": "70fef64ee096c13eb33389c4803c5825e146c60e",
+   "sha256": "0r76wcyxmg4glhgj7576jbb0ax7zxbzl7rkg3fx13yfaaxqyw90f"
+  },
+  "stable": {
+   "version": [
+    0,
+    9
+   ],
+   "deps": [
+    "mcp-server-lib"
+   ],
+   "commit": "70fef64ee096c13eb33389c4803c5825e146c60e",
+   "sha256": "0r76wcyxmg4glhgj7576jbb0ax7zxbzl7rkg3fx13yfaaxqyw90f"
+  }
+ },
+ {
   "ename": "org-mem",
   "commit": "e1b5f0b97b74adccc94abb1b36ffea1f6e81a0b6",
   "sha256": "08bzvc0ddk8d8s9csrchdlii2qr8xv5bdk6d3xd0f9mpkh5kbvrf",
@@ -92838,28 +93313,28 @@
   "repo": "meedstrom/org-mem",
   "unstable": {
    "version": [
-    20251008,
-    1625
+    20251107,
+    2038
    ],
    "deps": [
     "el-job",
     "llama"
    ],
-   "commit": "8c057cf3dd463e2d61cc2f95b5c43afa4374dba9",
-   "sha256": "10c94qk4dnjbqw3hw0nfd9fxlrlnvrwwglx0hlgynq4xb9yc63w4"
+   "commit": "531a6b571ba0dcfa77a1997fb2b216a020ca6563",
+   "sha256": "0ga21yxyy2yr9bplgdqfhf8sc67ynjvzacl8l2j1i1rjj9a3h3g4"
   },
   "stable": {
    "version": [
     0,
-    23,
-    2
+    25,
+    0
    ],
    "deps": [
     "el-job",
     "llama"
    ],
-   "commit": "521864ca617a62430553a17b8ed49597ded6ce88",
-   "sha256": "1yrax4qmaqczmpmqd4k19fbqh3lsnf36nc0k0dwya9gr9ibmls3f"
+   "commit": "531a6b571ba0dcfa77a1997fb2b216a020ca6563",
+   "sha256": "0ga21yxyy2yr9bplgdqfhf8sc67ynjvzacl8l2j1i1rjj9a3h3g4"
   }
  },
  {
@@ -92870,11 +93345,11 @@
   "repo": "org-mime/org-mime",
   "unstable": {
    "version": [
-    20250318,
-    2155
+    20251129,
+    111
    ],
-   "commit": "9571c148eed5e86fdd54eb6bf2814947c2c745a6",
-   "sha256": "0k001ppva1zyb9aahisk5dwqglyxdr0snwnkbhk14qv2hvfjz9x6"
+   "commit": "bdca3b962d618728c36444415d64b73e70bdba15",
+   "sha256": "0zqpalax4i67x7mzs9x7hxd81hgq0cva1b7kag4mg1c46z6zm4ki"
   },
   "stable": {
    "version": [
@@ -92965,27 +93440,27 @@
   "repo": "minad/org-modern",
   "unstable": {
    "version": [
-    20250924,
-    1705
+    20251013,
+    934
    ],
    "deps": [
     "compat",
     "org"
    ],
-   "commit": "6c1c38d87fcaa794b64d847851fc54580c3e3b57",
-   "sha256": "0ws6zjwz5kpy1by8ki0sqgvzdpip5mf93nlpkjzfvhvmrarjnrxx"
+   "commit": "8829e48aabd289f970d39875f40915526f3423f2",
+   "sha256": "1vyfv56cgpp5x3sanq6qsxhd6cgjf2n9awcgy1giary1kad455bl"
   },
   "stable": {
    "version": [
     1,
-    9
+    10
    ],
    "deps": [
     "compat",
     "org"
    ],
-   "commit": "16bef888cb8e0198dd26f869b85c10c4491a3444",
-   "sha256": "08ddrzqvlckj10b0anhdis6cfx448dw3n027cswklmzx6bj3rmfz"
+   "commit": "8829e48aabd289f970d39875f40915526f3423f2",
+   "sha256": "1vyfv56cgpp5x3sanq6qsxhd6cgjf2n9awcgy1giary1kad455bl"
   }
  },
  {
@@ -93066,14 +93541,14 @@
   "repo": "jeremy-compostella/org-msg",
   "unstable": {
    "version": [
-    20240902,
-    447
+    20251029,
+    2127
    ],
    "deps": [
     "htmlize"
    ],
-   "commit": "59e2042e5f23e25f31c6aef0db1e70c6f54f117d",
-   "sha256": "0d8y88n1d9agq5w5d4jss2dlygm6w0rkvvnmc0k6i62hzqmxxf0i"
+   "commit": "327768e2c38020f6ea44730e71f2a62f3f0ce3bd",
+   "sha256": "0gvm7865d4c2sv484y03icx1vhdygyrp99divjk7drcrhdqqnvly"
   }
  },
  {
@@ -93201,30 +93676,30 @@
   "repo": "meedstrom/org-node",
   "unstable": {
    "version": [
-    20251007,
-    2201
+    20251128,
+    1323
    ],
    "deps": [
     "llama",
     "magit-section",
     "org-mem"
    ],
-   "commit": "57c57017b42167401d5eed8b62ad3e11f7714c7b",
-   "sha256": "1axqak9ml97jvwlvd6izvricxc9wdm7kf61x7hlfi4wcwd27x46b"
+   "commit": "56c5adb3b421894aec8ccc6d7fa9b4b3385a4ac9",
+   "sha256": "10c71yhbhjm21fq3wqln5ldrag84mri435xxwhcgzz3krhyxmijf"
   },
   "stable": {
    "version": [
     3,
     9,
-    1
+    9
    ],
    "deps": [
     "llama",
     "magit-section",
     "org-mem"
    ],
-   "commit": "a9f4236f61bbc3e3f46eeb85666f47527a2ac9d3",
-   "sha256": "0nvi1gjll8qlin2adv556wgd030rzjzdj6wpflldw16m87cff7x0"
+   "commit": "56c5adb3b421894aec8ccc6d7fa9b4b3385a4ac9",
+   "sha256": "10c71yhbhjm21fq3wqln5ldrag84mri435xxwhcgzz3krhyxmijf"
   }
  },
  {
@@ -94092,25 +94567,22 @@
   "repo": "jkitchin/org-ref",
   "unstable": {
    "version": [
-    20251007,
-    2258
+    20251123,
+    1710
    ],
    "deps": [
     "avy",
     "bibtex-completion",
     "citeproc",
-    "dash",
-    "f",
     "htmlize",
-    "hydra",
     "org",
     "ox-pandoc",
     "parsebib",
     "request",
-    "s"
+    "transient"
    ],
-   "commit": "b7510442d0cd9765b53717fe3a37d7cef33a72d1",
-   "sha256": "1xx2jd1795gaqmi4ryvvc14s7jw6a34a8nrc2k9g5ybk9sx0i2kj"
+   "commit": "5275e58bca7e36c588e519c1b3ebe1e6b28a0654",
+   "sha256": "17npml1j3cyy10aycvb85m9izp48rvg22l6gmaq99r2p9zn5w4py"
   },
   "stable": {
    "version": [
@@ -94162,20 +94634,20 @@
   "repo": "TomoeMami/org-repeat-by-cron.el",
   "unstable": {
    "version": [
-    20250922,
-    610
+    20251028,
+    807
    ],
-   "commit": "1bd31d7aa0b372703db0b32c7e4c9fd99b54dc34",
-   "sha256": "1m543520z3ix76ydryg1cdw10x04g094db4iyq22jkkhrbp54v9i"
+   "commit": "36a5ea61ac6bc97aa83d766440fb87540899864c",
+   "sha256": "1y4ssh2363xshhhdziww2s1bjhw9p329bawwfrs73x3ykndvx65c"
   },
   "stable": {
    "version": [
     1,
     0,
-    1
+    2
    ],
-   "commit": "1bd31d7aa0b372703db0b32c7e4c9fd99b54dc34",
-   "sha256": "1m543520z3ix76ydryg1cdw10x04g094db4iyq22jkkhrbp54v9i"
+   "commit": "36a5ea61ac6bc97aa83d766440fb87540899864c",
+   "sha256": "1y4ssh2363xshhhdziww2s1bjhw9p329bawwfrs73x3ykndvx65c"
   }
  },
  {
@@ -94281,17 +94753,18 @@
   "repo": "org-roam/org-roam",
   "unstable": {
    "version": [
-    20250927,
-    2243
+    20251125,
+    729
    ],
    "deps": [
+    "compat",
     "dash",
     "emacsql",
     "magit-section",
     "org"
    ],
-   "commit": "41f9a10be587b47454ca8ef26f6a8247605cbe34",
-   "sha256": "1caxsm6vg04c0vny0bi7sh3zhnabsr2d93xf7i51v17hxz2dhx0c"
+   "commit": "f4ba41cf3d59084e182a5186d432afc9aa3fc423",
+   "sha256": "0kax0a1i98ffr8fama79sfdk6gx60qpd190g7b2scv2bwbglcbnj"
   },
   "stable": {
    "version": [
@@ -94349,8 +94822,8 @@
   "repo": "ahmed-shariff/org-roam-ql",
   "unstable": {
    "version": [
-    20250923,
-    2102
+    20251116,
+    829
    ],
    "deps": [
     "dash",
@@ -94360,8 +94833,8 @@
     "s",
     "transient"
    ],
-   "commit": "e51853205fa7129484786a6787f8b6b8a130f6e0",
-   "sha256": "07jxk8q86z0a7mvc15p0dm63lnajkcc7j7d7l9di76k4d0x1vfh3"
+   "commit": "b1b91d6e1847807268f1cf24c92bec56863e8877",
+   "sha256": "1zas6vjzrym5996015v1mq4c3yxhdg4jzhqyhzk1xkzpsj825im9"
   },
   "stable": {
    "version": [
@@ -94387,8 +94860,8 @@
   "repo": "ahmed-shariff/org-roam-ql",
   "unstable": {
    "version": [
-    20250902,
-    1916
+    20251030,
+    2042
    ],
    "deps": [
     "org-ql",
@@ -94397,8 +94870,8 @@
     "s",
     "transient"
    ],
-   "commit": "5feceb8f79734a3abcaef9cf2f787d5aa45e750f",
-   "sha256": "0qag1jmv498g6l1axx3d5h2wbvnin9f89qdvzyiillzjrs6rgm1w"
+   "commit": "cdf6b11279783346607542dfac07c74d8651a650",
+   "sha256": "1g91khfa5gmj0n52rr1zw42c6acv4djxvwcmndkf4px549h6mvh0"
   },
   "stable": {
    "version": [
@@ -94462,11 +94935,11 @@
   "repo": "LionyxML/ros",
   "unstable": {
    "version": [
-    20240512,
-    452
+    20251102,
+    1408
    ],
-   "commit": "50e16f5031d281458bd574f07aad16c0d1d18663",
-   "sha256": "0i84ik1rwmp77575vk6kq9cmv0cfh9iy43wcmcv5zgvyw57878kl"
+   "commit": "f212ede14350b339ce5e41b0a0b9ca13482ceb10",
+   "sha256": "12sl22qjnxfdva2sqzgkdkgq0sm6j2vfx49967wqxgqb3mjkblz8"
   }
  },
  {
@@ -94683,6 +95156,42 @@
   }
  },
  {
+  "ename": "org-social",
+  "commit": "7dedcde7b4ee8d2a78389bc329f186bde18b425b",
+  "sha256": "1h7y8qla3vyh5s8dkzhvkz6q9arc98f88yzl39gc6436kizgzl9w",
+  "fetcher": "github",
+  "repo": "tanrax/org-social.el",
+  "unstable": {
+   "version": [
+    20251124,
+    950
+   ],
+   "deps": [
+    "emojify",
+    "org",
+    "request",
+    "seq"
+   ],
+   "commit": "bdc0e7918abd9f9977e522d8a97acde2a1dd33f3",
+   "sha256": "06d8z4jvrxwi3r0wh5wdrlrsxksplwyg1iiiwbfgajx9d84y0md6"
+  },
+  "stable": {
+   "version": [
+    2,
+    7,
+    1
+   ],
+   "deps": [
+    "emojify",
+    "org",
+    "request",
+    "seq"
+   ],
+   "commit": "bdc0e7918abd9f9977e522d8a97acde2a1dd33f3",
+   "sha256": "06d8z4jvrxwi3r0wh5wdrlrsxksplwyg1iiiwbfgajx9d84y0md6"
+  }
+ },
+ {
   "ename": "org-special-block-extras",
   "commit": "c6cb3b3bf575f125f892b10fc3518f3ad1663d03",
   "sha256": "041l129iabm078p9bfdcwx5aax9fa3kbn852h1qbq8jgsks36jv8",
@@ -94763,15 +95272,15 @@
   "repo": "bohonghuang/org-srs",
   "unstable": {
    "version": [
-    20250921,
-    1133
+    20251116,
+    1631
    ],
    "deps": [
     "fsrs",
     "org"
    ],
-   "commit": "d5cfa9964da631273af9c57aba444cb877efd14e",
-   "sha256": "0gjkq9kbx3gxwzshh868v3qv8n3kgvnd8pk8rz84n84m0mdlxd26"
+   "commit": "dcfcddd769be3fb2f4bd08cf78bd56f15b183085",
+   "sha256": "1ninqrwslvpwkbs4a7yzlwilz7hhimwv91xxsa33sxvgdmpmcmrn"
   }
  },
  {
@@ -95101,14 +95610,43 @@
   "url": "https://repo.or.cz/org-tag-beautify.git",
   "unstable": {
    "version": [
-    20250921,
-    154
+    20251107,
+    1152
    ],
    "deps": [
     "nerd-icons"
    ],
-   "commit": "54e2e60cd3738072351e6dd7720bc652f5fbbabe",
-   "sha256": "1c2cshdgmk30y2rqnwd4cxm5jkk24rmc9162m5pqijgqmh6f9k0h"
+   "commit": "9f9f9decde736c41cc1455c0c98a5ec4b7c8b3b6",
+   "sha256": "1jk8da77xcancwsrkrvcwwndfqbwailddf95jag4shh0980xvvfb"
+  }
+ },
+ {
+  "ename": "org-tag-tree",
+  "commit": "b0b4cfd78d786dab342c2661fd477ed028902ba6",
+  "sha256": "15q707izl8h6pxixbrb3xj030qrqwi5l1n7v6pgsiikqwn6wrmr3",
+  "fetcher": "github",
+  "repo": "p-snow/org-tag-tree",
+  "unstable": {
+   "version": [
+    20251109,
+    1131
+   ],
+   "deps": [
+    "org"
+   ],
+   "commit": "af2b574dbddac0f73cc03bfb15acfe675f622f83",
+   "sha256": "0vq29bb6v8i4rbancp46rvg7sr2l6vllp12j9lm0ciaj9akcl279"
+  },
+  "stable": {
+   "version": [
+    0,
+    1
+   ],
+   "deps": [
+    "org"
+   ],
+   "commit": "af2b574dbddac0f73cc03bfb15acfe675f622f83",
+   "sha256": "0vq29bb6v8i4rbancp46rvg7sr2l6vllp12j9lm0ciaj9akcl279"
   }
  },
  {
@@ -95704,11 +96242,11 @@
   "repo": "tesujimath/org-wc",
   "unstable": {
    "version": [
-    20200731,
-    2244
+    20251023,
+    1922
    ],
-   "commit": "dbbf794e4ec6c4080d945f43338185e34a4a582d",
-   "sha256": "0j58591jnj182hps1zc9an692hhnxinlpbw762l7xdc0sa5pjrgb"
+   "commit": "65e2caaeaeea01b4ab3ab3cd964c911297885a0f",
+   "sha256": "04ycnv3z7sn4h53di1kil3lfcnnxw3cc7n8aw6vw2ndcx6hddv26"
   }
  },
  {
@@ -95760,16 +96298,16 @@
   "repo": "p-snow/org-web-track",
   "unstable": {
    "version": [
-    20250112,
-    1533
+    20250610,
+    1142
    ],
    "deps": [
     "enlive",
     "gnuplot",
     "request"
    ],
-   "commit": "2cf9367ef6f8800fa058a8ca30cbb6f2e75fe4de",
-   "sha256": "0ski1bvmxvjr2kf819hjr0lgx1q5y48g4g21mm0wmjcqjngfsh1r"
+   "commit": "c32eebcd1794f618b723cbaadae125cc98781121",
+   "sha256": "1nwmb3hxszyp8klzbqbvqvrgwi3ism6whk4z6yy00ay6jp5dqsi9"
   },
   "stable": {
    "version": [
@@ -96146,30 +96684,31 @@
   "repo": "magit/orgit",
   "unstable": {
    "version": [
-    20250901,
-    1810
+    20251123,
+    1801
    ],
    "deps": [
     "compat",
+    "cond-let",
     "magit",
     "org"
    ],
-   "commit": "8493c248081a9ed71ad6fd61e4d6b48c8a0039ec",
-   "sha256": "1nz9fy4348iha1zbw0v8hzsxv171v5758jilhsn2ksn9nvpkbbyb"
+   "commit": "0444b8659620e5100ab8d09694c6ffe6841b24cd",
+   "sha256": "0yhpihk9hbymncm15xmvnidsb67bmm0swz86nkzs1k0i5drr8mrc"
   },
   "stable": {
    "version": [
     2,
-    0,
-    5
+    1,
+    0
    ],
    "deps": [
     "compat",
     "magit",
     "org"
    ],
-   "commit": "8493c248081a9ed71ad6fd61e4d6b48c8a0039ec",
-   "sha256": "1nz9fy4348iha1zbw0v8hzsxv171v5758jilhsn2ksn9nvpkbbyb"
+   "commit": "9a171dfc7775c9286318b26710fcbf223fbde056",
+   "sha256": "1w5g75mqigfjcwywhdlv6dqpj173wzkagaxsq38kx1j4p7i0sl2p"
   }
  },
  {
@@ -96180,24 +96719,25 @@
   "repo": "magit/orgit-forge",
   "unstable": {
    "version": [
-    20250901,
-    1806
+    20251123,
+    1809
    ],
    "deps": [
     "compat",
+    "cond-let",
     "forge",
     "magit",
     "org",
     "orgit"
    ],
-   "commit": "5a0dbe26012b2e7885895f80283ba8974a1e8b38",
-   "sha256": "0cz2bzpkk3sjsjcycbdfykhchghx1mn76qxx3pbr2a7qjh7zfdd4"
+   "commit": "8b3de493a5b6db36c441202d1ba5b95a5be4dd91",
+   "sha256": "0qscfv6dwbdi7avmvbvrga0sv0qy6n92wmmcdq470fdicqyzgrv4"
   },
   "stable": {
    "version": [
     1,
-    0,
-    3
+    1,
+    0
    ],
    "deps": [
     "compat",
@@ -96206,8 +96746,8 @@
     "org",
     "orgit"
    ],
-   "commit": "5a0dbe26012b2e7885895f80283ba8974a1e8b38",
-   "sha256": "0cz2bzpkk3sjsjcycbdfykhchghx1mn76qxx3pbr2a7qjh7zfdd4"
+   "commit": "964a81d1e4e95a61e6304237172889b222fca845",
+   "sha256": "153z3g3nvggk8a7vpdhr2dm0pvgrypsalk51z7nwspv2cmb6daq3"
   }
  },
  {
@@ -96218,30 +96758,30 @@
   "repo": "tarsius/orglink",
   "unstable": {
    "version": [
-    20250801,
-    948
+    20251101,
+    2047
    ],
    "deps": [
     "compat",
     "org",
     "seq"
    ],
-   "commit": "7dedd3b361b8bd031429e66f45daf83ee35e82d2",
-   "sha256": "0any5ff30v6qaf687hrga8x20wlpkf6ggqmnjdvxal0csnrnijbg"
+   "commit": "1f76298c90ee1c7f4b1c77ab2389f304ea75fc8b",
+   "sha256": "1bwyfpql49jns953skl4ndyzrx8y6i71ngb9y3fr7zaal2rcrwl2"
   },
   "stable": {
    "version": [
     1,
     2,
-    7
+    8
    ],
    "deps": [
     "compat",
     "org",
     "seq"
    ],
-   "commit": "7dedd3b361b8bd031429e66f45daf83ee35e82d2",
-   "sha256": "0any5ff30v6qaf687hrga8x20wlpkf6ggqmnjdvxal0csnrnijbg"
+   "commit": "1f76298c90ee1c7f4b1c77ab2389f304ea75fc8b",
+   "sha256": "1bwyfpql49jns953skl4ndyzrx8y6i71ngb9y3fr7zaal2rcrwl2"
   }
  },
  {
@@ -96271,30 +96811,30 @@
   "repo": "isamert/orgmdb.el",
   "unstable": {
    "version": [
-    20251009,
-    711
+    20251105,
+    2227
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "405df0ac4045c9cb794348f95f24a8b8fb777c42",
-   "sha256": "0mqcjf27madg1hyb1l8vsikxzyrbl2cx3n5k19vr63m22j5655p3"
+   "commit": "416b2d6e9a9db179d69798d0f034307dc9cc762d",
+   "sha256": "0ypga3ywmaiv74r14bxn668zvv77mv6dhw6f3hrmlmvm20k7q0f0"
   },
   "stable": {
    "version": [
     1,
     0,
-    0
+    2
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "4dc658b016f48882730c2cbc2d6de2c39283dbaf",
-   "sha256": "09c3mslhnrqx6xy1js7zckrfc3pk5yvh020bj55845w8knlamjg0"
+   "commit": "416b2d6e9a9db179d69798d0f034307dc9cc762d",
+   "sha256": "0ypga3ywmaiv74r14bxn668zvv77mv6dhw6f3hrmlmvm20k7q0f0"
   }
  },
  {
@@ -96387,11 +96927,11 @@
   "repo": "tbanel/orgaggregate",
   "unstable": {
    "version": [
-    20251009,
-    1306
+    20251123,
+    324
    ],
-   "commit": "cea1e05009aa6608e1ed627efa1746930d857703",
-   "sha256": "1a0300cwcljswjr5n47dpbas3zi6bl90nanbd7ylvanikaa0gxg7"
+   "commit": "ba29730e6687b5c23fde7406c0ed845b08dc8035",
+   "sha256": "09gk6041izzyl4sn1i8rnjzfzrf0pyjh5k9cmjplf2b3i1ds59nq"
   }
  },
  {
@@ -96432,11 +96972,11 @@
   "repo": "tbanel/orgtbljoin",
   "unstable": {
    "version": [
-    20250922,
-    545
+    20251102,
+    1248
    ],
-   "commit": "08c0206bbd01cad8eb436f456c91e285e343935f",
-   "sha256": "0wf2j5cf8axyiqk9q738p8gbps576rasnchsgxr3qwm9hgxq5a7q"
+   "commit": "7eb59d5967fa104b206f8248d79873ce1ec496e9",
+   "sha256": "1r21n3ks5a7ywb2gblyf8zvg09d8prz9wygdx0ndshyz46m49i10"
   }
  },
  {
@@ -96595,25 +97135,25 @@
   "repo": "minad/osm",
   "unstable": {
    "version": [
-    20251008,
-    1041
+    20251116,
+    1456
    ],
    "deps": [
     "compat"
    ],
-   "commit": "b7aa47fbc23711d539705d7a4ad5949f587d173e",
-   "sha256": "0ypx9fvbyhl3i64klg71r979gvd6xz1a4f0dvkannsnldxzg85lp"
+   "commit": "21d3f00d1de77688da604e5fe176710b61c1f062",
+   "sha256": "0avn589jp98nwj4i6wpbkxzxqzgffjdwpj942xsns65aj5sqirnp"
   },
   "stable": {
    "version": [
     1,
-    7
+    9
    ],
    "deps": [
     "compat"
    ],
-   "commit": "72112b358c41d2147122b217d11f272a22f285e4",
-   "sha256": "0fw0hgi2542ivc05dbq07ybr8c2mf8ja0z3f07lnslvn7vn5xp9i"
+   "commit": "7641bf620bf20b71908702e91c0a5e82a103b196",
+   "sha256": "0qsxhjn192gb896qd3gfk28p16gagv6pwrdssh1b6cvl4qv3m202"
   }
  },
  {
@@ -96918,20 +97458,20 @@
   "repo": "jdtsmith/outli",
   "unstable": {
    "version": [
-    20250403,
-    12
+    20251012,
+    1930
    ],
-   "commit": "1c2cf24aca7a6c9bc920974bd5cf70badab018de",
-   "sha256": "01q37gbfc0mal3ha2x5a1axdcd2c0d55imav4w0cfzs3sm48azvs"
+   "commit": "009e74c1757143040a0427f477ae882107b14592",
+   "sha256": "1is10arx057278vyfkpcl3pkxps1i6f7rf79pdx0crs7gj1m80km"
   },
   "stable": {
    "version": [
     0,
-    2,
-    3
+    3,
+    0
    ],
-   "commit": "1c2cf24aca7a6c9bc920974bd5cf70badab018de",
-   "sha256": "01q37gbfc0mal3ha2x5a1axdcd2c0d55imav4w0cfzs3sm48azvs"
+   "commit": "009e74c1757143040a0427f477ae882107b14592",
+   "sha256": "1is10arx057278vyfkpcl3pkxps1i6f7rf79pdx0crs7gj1m80km"
   }
  },
  {
@@ -96942,20 +97482,20 @@
   "repo": "jamescherti/outline-indent.el",
   "unstable": {
    "version": [
-    20250921,
-    2109
+    20251103,
+    1434
    ],
-   "commit": "c99cf257ab5c34cb894bdd6238be9dda9fce9e85",
-   "sha256": "0gzxrq57az4d6vk0m3j2j8klig81qckzr57q2m2r7i7zgp6q5xxr"
+   "commit": "832595bc0f6699171e9ebcafce3952e2a151cb26",
+   "sha256": "1f8s2w54abanb3vykyymsm8fqmwlgjhq0hcbd1z7r56p3pbamm90"
   },
   "stable": {
    "version": [
     1,
     1,
-    2
+    5
    ],
-   "commit": "49c12a5a3f31fe35003a49e0d7ef0d17ba6abaa9",
-   "sha256": "0ppwsipg4birwk9m0i4x2d9rq023iws6nqs1i1lf2iialyhnr313"
+   "commit": "46cb8657bed035042796fc48ccfcb922eb443d81",
+   "sha256": "0vw41bnysacb7hwfacb8m8qyz01skwcpnyzrm1mriwl5j51ni1aj"
   }
  },
  {
@@ -96981,26 +97521,26 @@
   "repo": "tarsius/outline-minor-faces",
   "unstable": {
    "version": [
-    20250901,
-    1338
+    20251101,
+    1934
    ],
    "deps": [
     "compat"
    ],
-   "commit": "2e7a99b07108e6cc34da16e33746c770a2c20f32",
-   "sha256": "1bgx8lp7qc6vsd6fb2qh92vwsfjz63ma2jsrch6h042nsnvyvx7s"
+   "commit": "67a100641d0da0e75bd1f69b760e2b6c39fcb920",
+   "sha256": "0ipwgs6vg4pmabvmhnh4m5477xkqbs25v4qjq2ci0118yxma1fif"
   },
   "stable": {
    "version": [
     1,
     2,
-    0
+    1
    ],
    "deps": [
     "compat"
    ],
-   "commit": "2e7a99b07108e6cc34da16e33746c770a2c20f32",
-   "sha256": "1bgx8lp7qc6vsd6fb2qh92vwsfjz63ma2jsrch6h042nsnvyvx7s"
+   "commit": "67a100641d0da0e75bd1f69b760e2b6c39fcb920",
+   "sha256": "0ipwgs6vg4pmabvmhnh4m5477xkqbs25v4qjq2ci0118yxma1fif"
   }
  },
  {
@@ -97710,16 +98250,16 @@
   "repo": "zzamboni/ox-leanpub",
   "unstable": {
    "version": [
-    20230415,
-    2139
+    20251028,
+    957
    ],
    "deps": [
     "org",
     "ox-gfm",
     "s"
    ],
-   "commit": "e8cd440632fd46812d7311360f565828a12380b7",
-   "sha256": "118km0hgxf1nss765cnykqyymjhg30pim9qjyxl31v07khr1d373"
+   "commit": "c1550a1f828afeee909850f51d7a0219a261e280",
+   "sha256": "1vi91ri2rz3q7z5qlidw357hlvnj7vqpsv85mjlkrwnqlvkkslx1"
   }
  },
  {
@@ -98222,14 +98762,14 @@
   "repo": "jmpunkt/ox-typst",
   "unstable": {
    "version": [
-    20250926,
-    1502
+    20251112,
+    1800
    ],
    "deps": [
     "org"
    ],
-   "commit": "cc7e9665d4eabe0a8e0251408392f9578c7b1dac",
-   "sha256": "05lfwwyfn62599ji2j12c2z0i28dq1qp5g7qgmjiv8bg56lck6z0"
+   "commit": "d75218627ca8441254b1c562c35673cbd96509ff",
+   "sha256": "12ysw60p72jbyj6z2mc5zia8s3n5bf2s5ylxd5d3gkn925p9qz0d"
   }
  },
  {
@@ -98407,11 +98947,11 @@
   "repo": "fbrosda/pacdiff.el",
   "unstable": {
    "version": [
-    20240219,
-    1606
+    20251019,
+    627
    ],
-   "commit": "74996064f7270a3b8fc57bbc8b166f3966c0a4c1",
-   "sha256": "1m58v63gi42j75l2zi2pjvipmbs1k040fmpy3msih7kwqhhvs54a"
+   "commit": "f1c13777e5c8056a6d6e823ecb51b9bbadc8e0c3",
+   "sha256": "0zp3z494a49qr7069q1mlpy92svh00wc4c7yg7cdk8lkcv4vhy3s"
   }
  },
  {
@@ -98514,14 +99054,14 @@
   "repo": "melpa/package-build",
   "unstable": {
    "version": [
-    20250807,
-    1034
+    20251121,
+    1702
    ],
    "deps": [
     "compat"
    ],
-   "commit": "546e7d7f119be9b0aff5c87064a8000f9a6dfc4a",
-   "sha256": "1fakckyidijal8ddc8fq6s37kb09224vr24m518fkx7agqms6rs0"
+   "commit": "f6e92ebc2e2503ba9a2ace6d889ce24223045fc6",
+   "sha256": "08spy6d8jf0q2wjhqp4y97w386bzgmifq427664ixa0y7nz674hq"
   },
   "stable": {
    "version": [
@@ -98941,27 +99481,20 @@
   "repo": "joostkremers/pandoc-mode",
   "unstable": {
    "version": [
-    20251009,
-    956
+    20251029,
+    1925
    ],
-   "deps": [
-    "dash",
-    "hydra"
-   ],
-   "commit": "dfe1013e386f0af067c43d187e23254649060e64",
-   "sha256": "09z20z0bng6jfgwgwrcpr6v3qvg47584i2w2hkk3mb637rfqay3r"
+   "commit": "8d6e976b465cb4fa59d12efe8159b781a57f915e",
+   "sha256": "068gwrgxvbm7p8i6qz3njkigxfxffmyx6bsga74vq7fmr3wcxyjb"
   },
   "stable": {
    "version": [
     2,
-    35
+    90,
+    2
    ],
-   "deps": [
-    "dash",
-    "hydra"
-   ],
-   "commit": "d7f6fa119bb0e883cfd615009d197e4b87916033",
-   "sha256": "0dyf0d5qmshbf5zi2kimplj1byrdhm31yx3fr0mvnq5hp076820d"
+   "commit": "a131a553f48db71b0a051b6bc1d713627b2de3d9",
+   "sha256": "0q76hnpczlqql7mycgaq3cmhd6ls09i331499nxwiq5ih7iqgn6l"
   }
  },
  {
@@ -99104,10 +99637,10 @@
  },
  {
   "ename": "paredit",
-  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
-  "sha256": "0mpay7xqb4910nlp0gmdj8q2zkinq77zh5b9lcg6ah2d9vzxzc9s",
+  "commit": "e41e0782a7b2dbc72a642d8f2469f14eb17b1ffb",
+  "sha256": "16j9qwcx3pvjcbzk1wz7d7dk27szn122dv66p94ydi5yhi4vgzdh",
   "fetcher": "git",
-  "url": "https://mumble.net/~campbell/git/paredit.git",
+  "url": "https://paredit.org/paredit.git",
   "unstable": {
    "version": [
     20241103,
@@ -99194,26 +99727,26 @@
   "repo": "tarsius/paren-face",
   "unstable": {
    "version": [
-    20250901,
-    1803
+    20251101,
+    2048
    ],
    "deps": [
     "compat"
    ],
-   "commit": "ccbf5f5a61f469e40bc7971e6b033d1ee35bf14d",
-   "sha256": "04b4znak3qzy482byyv4z6i8nnvbg6d7y2jwmicgjpn53qspzsr7"
+   "commit": "b121bc08ecb0c11a89705ed9f77c5343e2baec04",
+   "sha256": "0bs5hdn7agyr0r0ywblpihp4x3gn89xdfvzsb8wlyd0gvc2rx6g9"
   },
   "stable": {
    "version": [
     1,
     2,
-    1
+    2
    ],
    "deps": [
     "compat"
    ],
-   "commit": "ccbf5f5a61f469e40bc7971e6b033d1ee35bf14d",
-   "sha256": "04b4znak3qzy482byyv4z6i8nnvbg6d7y2jwmicgjpn53qspzsr7"
+   "commit": "b121bc08ecb0c11a89705ed9f77c5343e2baec04",
+   "sha256": "0bs5hdn7agyr0r0ywblpihp4x3gn89xdfvzsb8wlyd0gvc2rx6g9"
   }
  },
  {
@@ -99248,11 +99781,11 @@
   "repo": "tarsius/paren-face",
   "unstable": {
    "version": [
-    20250822,
-    1936
+    20251101,
+    2048
    ],
-   "commit": "88cbcf779d3c382cf785a540a2134a663b753d7b",
-   "sha256": "0rxrcnpsar1550ihfr6a8qf0cx1p5va14cdx70ykqzfpvcbg5rdw"
+   "commit": "b121bc08ecb0c11a89705ed9f77c5343e2baec04",
+   "sha256": "0bs5hdn7agyr0r0ywblpihp4x3gn89xdfvzsb8wlyd0gvc2rx6g9"
   }
  },
  {
@@ -100197,26 +100730,26 @@
   "repo": "krisbalintona/pdf-meta-edit",
   "unstable": {
    "version": [
-    20250912,
-    1306
+    20251118,
+    2327
    ],
    "deps": [
     "compat"
    ],
-   "commit": "2e12f57480c831f069bcf71fe91c9f52ff06319f",
-   "sha256": "0gim4kzlik13avjgyvwclgkrs4pv4ap7jdn4kn6f19h8fvq4gys8"
+   "commit": "18d8b9156f15f77ed3f79152b221551c703b680c",
+   "sha256": "11s0ka5sjarhpqjwd5nhww3j2q88a985ssn69w299f7hd3zys34d"
   },
   "stable": {
    "version": [
     0,
     2,
-    1
+    2
    ],
    "deps": [
     "compat"
    ],
-   "commit": "74af23554ee929c191c734794f322cbb854f880d",
-   "sha256": "19vk7zvajm99asrm7dai3ip53clfsjs1bfxv6sqqb0d1vlxm056r"
+   "commit": "18d8b9156f15f77ed3f79152b221551c703b680c",
+   "sha256": "11s0ka5sjarhpqjwd5nhww3j2q88a985ssn69w299f7hd3zys34d"
   }
  },
  {
@@ -100747,14 +101280,14 @@
   "repo": "nex3/perspective-el",
   "unstable": {
    "version": [
-    20250523,
-    1316
+    20251104,
+    1408
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "bdd14b96faa54807a4f822d4ddea1680f1bfd6c7",
-   "sha256": "108n8xgyxf0mxv6l0mbqb9s0v20bdnj4xcd2mi0zbl46r48cq6gp"
+   "commit": "7f47c9a7be7b7d03f6d8430c84eec80ae5896699",
+   "sha256": "1zsm848vrp97qfrfwjx7axijg8ji95a8nicxp1zia947g8fbpm33"
   },
   "stable": {
    "version": [
@@ -100936,25 +101469,25 @@
   "repo": "emarsden/pg-el",
   "unstable": {
    "version": [
-    20250928,
-    1446
+    20251126,
+    1322
    ],
    "deps": [
     "peg"
    ],
-   "commit": "5063ec8bb8679ba40b1423b6cc1b086cfb735803",
-   "sha256": "056v8phxw87gzkny6hqbibq659qbb00yxl2s9y100l7y1azsvcqs"
+   "commit": "5545383173cf5db5276be07cf15801fd5a7b93a5",
+   "sha256": "0amwa4jnp7nlkq7ai5h18dqa60xjvalb4pmcwg8xa0prv4gs016w"
   },
   "stable": {
    "version": [
     0,
-    60
+    61
    ],
    "deps": [
     "peg"
    ],
-   "commit": "215cec9499d9069b387a4638a00b16c08d1e0c19",
-   "sha256": "143np0qsfk73zzbkpvyj89x135rf9x957yl1wn5psz1x9hp2m195"
+   "commit": "14a2041ed1076b6b24b96b2e6f0f14ebc4f1ac4d",
+   "sha256": "09fd0rc3fwxxsc9bdvnq0fy6ikp5ml5hadd7d8y8s7p6qz0k44zr"
   }
  },
  {
@@ -101393,16 +101926,16 @@
   "repo": "emacs-php/phpactor.el",
   "unstable": {
    "version": [
-    20250930,
-    1244
+    20251112,
+    706
    ],
    "deps": [
     "async",
     "composer",
     "php-runtime"
    ],
-   "commit": "8526ce3b4f49136d2a48e295ee4c72ceefa98f16",
-   "sha256": "05g5v7yghrywg3sqqwlixi4yjkcbd9cczijbnz1j5lh9vaj6ff4g"
+   "commit": "d0dd8d739812d60f0765276d22add93dc7c61bb9",
+   "sha256": "13xyaymsz37v6gx71f085v7irfm5rvwbsb2547fjs740ps5w2810"
   },
   "stable": {
    "version": [
@@ -102173,10 +102706,10 @@
  },
  {
   "ename": "plain-theme",
-  "commit": "daedc521088b9e4b81ef9ce1e54e8520a5b54a56",
-  "sha256": "0sahhixy74j063hj16ws5d9h226fn6jz2whwj23bb2n28hhgph1y",
+  "commit": "0742da1d0fb37ebf2d66eba4533b914056399036",
+  "sha256": "0igncivhnzzirglmz451czx69cwshjkigqvqddj0a77b1cwszfw8",
   "fetcher": "github",
-  "repo": "yanateras/plain-theme",
+  "repo": "yegortimoshenko/plain-theme",
   "unstable": {
    "version": [
     20171124,
@@ -103064,15 +103597,15 @@
   "repo": "polymode/poly-markdown",
   "unstable": {
    "version": [
-    20250531,
-    1935
+    20251101,
+    1318
    ],
    "deps": [
     "markdown-mode",
     "polymode"
    ],
-   "commit": "f4815f0327e0b3849373870a8867d49bfee37713",
-   "sha256": "1db40pxwlg7crg6wm94ix36y2izmbc4x67d830iyw9bg8mbnmvdv"
+   "commit": "2eb00d1d07a9dd5d94c5c12c27714e095b3b142a",
+   "sha256": "1ng8ld5ydaggvjsgjz7ficcisw1lwlhz87vn7xyqxn5sxc7nfbxl"
   },
   "stable": {
    "version": [
@@ -103363,15 +103896,15 @@
   "repo": "kn66/pomo-cat.el",
   "unstable": {
    "version": [
-    20250914,
-    1145
+    20251127,
+    1631
    ],
    "deps": [
     "popon",
     "posframe"
    ],
-   "commit": "f006de9c1fae681299ba63bbc64176348b62e645",
-   "sha256": "0gd51livwbg30p6syrkr91n5v7km768cvw1xjqjidf0fr6ghddjm"
+   "commit": "441b5f8476e99e740eba72cf52c4edf1bbe51673",
+   "sha256": "0syi1chf570lsjpjh5fi5cbyh018kw5c9347zvgxlmq6ixsvq5zv"
   }
  },
  {
@@ -103811,20 +104344,20 @@
   "repo": "tumashu/posframe",
   "unstable": {
    "version": [
-    20250211,
-    110
+    20251125,
+    846
    ],
-   "commit": "12f540c9ad5da09673b2bca1132b41f94c134e82",
-   "sha256": "1sw5jkm3wqgfbgs044wr32w109kjy94jg8wwcr4z4npxi3dxlk8k"
+   "commit": "d93828bf6c36383c365bd564ad3bab5a4403804c",
+   "sha256": "16hl3whqxw25p3m8fsr2z2bcwrq3dkfcn7x27d9sicj3v64l30pm"
   },
   "stable": {
    "version": [
     1,
-    4,
-    4
+    5,
+    0
    ],
-   "commit": "570273bcf6c21641f02ccfcc9478607728f0a2a2",
-   "sha256": "1p1kfy0x8n1s2njfq70fix2jadfi6zb4m519scjmys51a7ahmy73"
+   "commit": "d93828bf6c36383c365bd564ad3bab5a4403804c",
+   "sha256": "16hl3whqxw25p3m8fsr2z2bcwrq3dkfcn7x27d9sicj3v64l30pm"
   }
  },
  {
@@ -103960,11 +104493,11 @@
   "repo": "jschaf/powershell.el",
   "unstable": {
    "version": [
-    20250614,
-    1529
+    20251122,
+    1430
    ],
-   "commit": "99e0e73082fd48314a9825254dac45f318e5bb59",
-   "sha256": "0m4sric9va2235sl790prbsxxc6gpaqz1lgdy0qkn9ah1p3v27gb"
+   "commit": "ae60e11c96cc1767f05ce0cab6a917240ce2e37a",
+   "sha256": "0l1ilh0qm9wj686ny6cc8cda6wxa3m9gyq5q3d6yq0g5s4hhid0p"
   }
  },
  {
@@ -104078,8 +104611,8 @@
   "repo": "blahgeek/emacs-pr-review",
   "unstable": {
    "version": [
-    20250518,
-    311
+    20251016,
+    1540
    ],
    "deps": [
     "ghub",
@@ -104087,8 +104620,8 @@
     "magit-section",
     "markdown-mode"
    ],
-   "commit": "469e2e1f0f111773899627f81ae433f6ec14e5b5",
-   "sha256": "1z5qmdq7430mc5vnnjjsjbwj9jln03ym8nna6x019f49bs0v21pk"
+   "commit": "d893429168b87003a99bf567932dce57fdac93fa",
+   "sha256": "0i29wh319an1dpyal6wvzs4n0qsx75k08msz6nf2c588lpxcnaxf"
   },
   "stable": {
    "version": [
@@ -104255,6 +104788,21 @@
   }
  },
  {
+  "ename": "pretend-type",
+  "commit": "7274b7b47ef0d2afb152bcba7c759bfe7e9d8c1b",
+  "sha256": "1wb5l207cjwnx45xbswqvazxiqw3m6091pfz3zjwvjal9y4aiw4s",
+  "fetcher": "github",
+  "repo": "haji-ali/pretend-type",
+  "unstable": {
+   "version": [
+    20251019,
+    2122
+   ],
+   "commit": "1396a0c28986af260a462525ff20a1269cb64eb2",
+   "sha256": "0lrhvnrjyprvhqrancwdh69rl9qjq6gdvv94k5rx8dwrqr48rzif"
+  }
+ },
+ {
   "ename": "prettier",
   "commit": "f9103b6c58996e75c0e5c23fc0fb12afd65424c0",
   "sha256": "0k1vlwr1mgpa3mh51i7sr8jdq9ibp24q6vjfzgw7vazm3mzh0vlr",
@@ -104334,10 +104882,10 @@
  },
  {
   "ename": "prettify-greek",
-  "commit": "23c8f10205187babb17e3abc3dc40eb1938e6640",
-  "sha256": "1izl6r6i3zbhd7r7lz2k42yyz6qcng11wfmb7lx4883dj00flsl7",
-  "fetcher": "gitlab",
-  "repo": "fommil/emacs-prettify-greek",
+  "commit": "4c46e2a24740a4d9ac7482961f635c66448e8c7f",
+  "sha256": "037vra54g659d24xlgjcgqxn4dc683317vcwr8ba5p8gdnqidxzv",
+  "fetcher": "github",
+  "repo": "fommil/prettify-greek.el",
   "unstable": {
    "version": [
     20160603,
@@ -104530,11 +105078,11 @@
   "repo": "nverno/prisma-ts-mode",
   "unstable": {
    "version": [
-    20250217,
-    202
+    20251024,
+    1356
    ],
-   "commit": "afbf682f6d302c8c6d0ddbba6fa7cac88c95d15d",
-   "sha256": "0w3i7wjlal4ifh5nqnij35wldygfg34pfqrx4m3zvsv9gjs7r0yx"
+   "commit": "c63117764dc9e177aea7ddbef23c47feba1523d8",
+   "sha256": "19mhcr7v11shhzf1p5b6wbb9b8hx1q0wpzwrxhgypmzvx9837mgz"
   }
  },
  {
@@ -105007,11 +105555,11 @@
   "repo": "buzztaiki/project-rootfile.el",
   "unstable": {
    "version": [
-    20220708,
-    1403
+    20251111,
+    720
    ],
-   "commit": "9259708307c9da6b06f04f5b34ccd28f1fba5eaa",
-   "sha256": "03s30vmpy108ccx9288aiv2i9699pwvnafgdwibrg9cw600mjrxd"
+   "commit": "6c674446350ac3e54536c5520dd3f622463c6f4a",
+   "sha256": "0jp34ahhq8ivqgsan6flyrrkwmb09bpnwd95zzpi3v9sxf82k5ng"
   }
  },
  {
@@ -105620,11 +106168,11 @@
   "repo": "ProofGeneral/PG",
   "unstable": {
    "version": [
-    20250915,
-    1038
+    20251120,
+    1746
    ],
-   "commit": "f33b478d1144d6828dfa0df7f0d7d48da704ea11",
-   "sha256": "0dfd4lpsdjhpp73812i4nb3vkphk4ixmnb9zychv7k2ad6cfhh6p"
+   "commit": "d60382db080370501bfe81d2a4f069035c8372a7",
+   "sha256": "0brab0dqhsla1hw2dzwmg7abnf3pf46csqlpwnm4i0qh7bi6h92z"
   },
   "stable": {
    "version": [
@@ -105732,11 +106280,11 @@
   },
   "stable": {
    "version": [
-    32,
+    33,
     1
    ],
-   "commit": "7fcfd66022455635fa29af92987cdc0967efd4f3",
-   "sha256": "0sl3ahj74gpy4dv8xz9sry7kapnh00kpmghz2iqnlw5j40rvbyy1"
+   "commit": "a8d85ffbc7158660b4247f732371d1b07780510e",
+   "sha256": "1543zr09jvr986y2b5p02mxr5l3vqppb6z4krcch4dzz98pb0vi1"
   }
  },
  {
@@ -106464,11 +107012,11 @@
   "repo": "ideasman42/emacs-py-autopep8",
   "unstable": {
    "version": [
-    20250913,
-    2251
+    20251126,
+    1135
    ],
-   "commit": "a72b83e04dbbeedcc353e19627494de35c74961a",
-   "sha256": "10fw8wc84dld0y651qj96c5v2lg7axcxn2zschfr9m8s95qfn847"
+   "commit": "4582cf1e1f4e0df68572275dd8107fee422dce37",
+   "sha256": "1k2pgpi4b3b4iin19zx14c1chn5hqd7qv0akl9phwzlczgkwfv6m"
   },
   "stable": {
    "version": [
@@ -106595,28 +107143,28 @@
   "repo": "vale981/py-vterm-interaction.el",
   "unstable": {
    "version": [
-    20250619,
-    108
+    20251024,
+    2208
    ],
    "deps": [
     "python",
     "vterm"
    ],
-   "commit": "f6320d0560e28fa1301439ab29b0dfa33988492a",
-   "sha256": "19pa0id26c6xp78ylx4zxirzzyz4dmly1wvgq3wh06qkh531pzbc"
+   "commit": "3e79540a715dc69b7998fe7712a0a8183570387d",
+   "sha256": "1vdfizq5qm9jx1c2q8djzhy8wwflhyrpy34skmr7yv5dhqr89s0f"
   },
   "stable": {
    "version": [
     1,
     0,
-    8
+    9
    ],
    "deps": [
     "python",
     "vterm"
    ],
-   "commit": "6b39ac33fcb622cfc4245f5ec27c708c9fe000b5",
-   "sha256": "144ygc1swx3p9zjc0y8qdlg0sn6fh85s17w6byyzvm0kbrk97hvv"
+   "commit": "3e79540a715dc69b7998fe7712a0a8183570387d",
+   "sha256": "1vdfizq5qm9jx1c2q8djzhy8wwflhyrpy34skmr7yv5dhqr89s0f"
   }
  },
  {
@@ -106826,28 +107374,28 @@
   "repo": "tumashu/pyim",
   "unstable": {
    "version": [
-    20250225,
-    650
+    20251125,
+    839
    ],
    "deps": [
     "async",
     "xr"
    ],
-   "commit": "f5f1be270feb3cade25e9ef910bd58e442e4b016",
-   "sha256": "0lhqirjkv9a6b2km78yiqwp0i682g3ff9di9y7n1wnw1glx04hhl"
+   "commit": "bc85ecc3b2521d05c7585df97939f7c0ec5b1496",
+   "sha256": "0kimpayh9g4snvyn61iydc8ldmaska1xz7mr0x0v6k24r6xmqpvd"
   },
   "stable": {
    "version": [
     5,
     3,
-    4
+    5
    ],
    "deps": [
     "async",
     "xr"
    ],
-   "commit": "f22c20f2e6af55b3a758defabe4c842fb94cde2b",
-   "sha256": "0bnlz5bja6gg619sldlwqzdy1pccmcsxkk4g91njp7d8670xc241"
+   "commit": "bc85ecc3b2521d05c7585df97939f7c0ec5b1496",
+   "sha256": "0kimpayh9g4snvyn61iydc8ldmaska1xz7mr0x0v6k24r6xmqpvd"
   }
  },
  {
@@ -107369,11 +107917,11 @@
   "repo": "python-mode-devs/python-mode",
   "unstable": {
    "version": [
-    20250930,
-    608
+    20251108,
+    1323
    ],
-   "commit": "5aaf8b386aa694429d997c6fd49772b0b359e514",
-   "sha256": "0b6mv1cy5jznpzkxslf1d89k7pk1f3rjpnhb21jx857xqiyid11p"
+   "commit": "048e90ded3a2aa02a0b3535ff28cd88e3f40c1d9",
+   "sha256": "0fcv554qiv0qnnhwdnxy0dka7s2s2c60qvj4q07b0qy924i1vl54"
   },
   "stable": {
    "version": [
@@ -107612,11 +108160,11 @@
   "repo": "psaris/q-mode",
   "unstable": {
    "version": [
-    20250823,
-    1746
+    20251115,
+    2320
    ],
-   "commit": "e6bf9fb684fd857d61757260e023c2fc4a33772b",
-   "sha256": "0d3z1ixfcvand7f799vj50lg97n1sbmlfcnvkdrc540jbjxy4532"
+   "commit": "b42778533328a01d84572ccbdf96a4049ae15935",
+   "sha256": "0i9lpcc2yzhr32gxzlh26dh4ndfaarx7j7wbj7n0nkhx37kix33v"
   }
  },
  {
@@ -107911,11 +108459,11 @@
   "repo": "jamescherti/quick-fasd.el",
   "unstable": {
    "version": [
-    20250915,
-    131
+    20251103,
+    1434
    ],
-   "commit": "fe0d6c611ec995e2f59b23d45af3b8b28244703b",
-   "sha256": "1fsl6l67jf8fm5h6i5qxqvibzssbiyyjzchq3r5sbqry3d8yx3mk"
+   "commit": "98b53d3dbf8446002948d4e81181510ac5b55829",
+   "sha256": "1rca23s8x4jh2v1n41bdsgq7gyjyhqnk11cnzsr9q53041ijlvi3"
   },
   "stable": {
    "version": [
@@ -108118,6 +108666,24 @@
   }
  },
  {
+  "ename": "quotient",
+  "commit": "b905cafd00fea4939d0409a1b2be6c479d446a11",
+  "sha256": "04ws870wgyvh6wy8i16b17yl6sxkjnl7w7rsi135akmkf0a8avqw",
+  "fetcher": "github",
+  "repo": "tvirolai/quotient",
+  "unstable": {
+   "version": [
+    20251029,
+    1348
+   ],
+   "deps": [
+    "compat"
+   ],
+   "commit": "3bece7b17a4ef7745f8c49c0c21570239f2b4ded",
+   "sha256": "1w253hyj10d9pf0qgh84zgj86ln6fkkg0gv8d9003haad7352hik"
+  }
+ },
+ {
   "ename": "qwen-chat-shell",
   "commit": "c20f88160b4caeed30a78ecddd738f18acae39ae",
   "sha256": "17c7bi0yvmpz23qpdhw78dy566b0f5jzr49k65jaxjrb0820g02c",
@@ -108206,14 +108772,14 @@
   "repo": "greghendershott/racket-mode",
   "unstable": {
    "version": [
-    20250830,
-    1625
+    20251101,
+    1518
    ],
    "deps": [
     "compat"
    ],
-   "commit": "f3952cdebb7d92b65bd6755513b51cf01812032a",
-   "sha256": "1n2ngzlhdc0z5rf7hv5k508j8q4sl7sq80ddgyaz8dyzlkmw1p6h"
+   "commit": "c2758f6c0405490aef178e256432be05686a144a",
+   "sha256": "1dlk1s6diygxw5ls92l8pm80mdf4a9c6m7p1zp4if557ym9y8n6q"
   }
  },
  {
@@ -108517,11 +109083,11 @@
   "repo": "punassuming/ranger.el",
   "unstable": {
    "version": [
-    20210125,
-    330
+    20251109,
+    5
    ],
-   "commit": "2498519cb21dcd5791d240607a72a204d1761668",
-   "sha256": "1wzshhg6dchny9drm8lf8sw4s24icgyb4my58xvhm55dp4zl5p3b"
+   "commit": "8774f1bbb2754df7ae79dab8b75a6ce9285cc926",
+   "sha256": "0a4vj854dj28k5z818zqvks4qyqq5asnbpmgv6qq3gi9nrmz9sdz"
   },
   "stable": {
    "version": [
@@ -108696,20 +109262,20 @@
   "repo": "thiagoa/rbtagger",
   "unstable": {
    "version": [
-    20211026,
-    2318
+    20251024,
+    1551
    ],
-   "commit": "351c4006ddacc2f66e6ff8c79d981613e9a8bd22",
-   "sha256": "1ycjw62wlnkbbanqrz6my6xrfffcs9rnf27ihvmwni5k2carv9p0"
+   "commit": "650c428ef145ce697f02ef12cfadd9deb82b856f",
+   "sha256": "1sfggmzm92gr4x0nnnzfk0w8hbg0dbzykq991j2fkziv2qjy85iq"
   },
   "stable": {
    "version": [
     0,
-    4,
-    5
+    5,
+    1
    ],
-   "commit": "bbab9900c7b8cb406da662e4f99064e1a2de729e",
-   "sha256": "0cr32q67ap87b4acbglay0mx9mmpdm7h9byx2q21ad5p5ra1y17w"
+   "commit": "650c428ef145ce697f02ef12cfadd9deb82b856f",
+   "sha256": "1sfggmzm92gr4x0nnnzfk0w8hbg0dbzykq991j2fkziv2qjy85iq"
   }
  },
  {
@@ -108964,20 +109530,20 @@
   "repo": "xenodium/ready-player",
   "unstable": {
    "version": [
-    20250902,
-    2107
+    20251106,
+    732
    ],
-   "commit": "a8e95ca9c07480c188733d7e6315147fd6e4ed24",
-   "sha256": "0vg6pkvkpz02b237f1p3qxsrwyc5ar44l73rr04gk368n7a0lnwv"
+   "commit": "94b181041b4e053fd5aee2c987b754e7a01aff2d",
+   "sha256": "0gn5qqln54v8avwadr6jmifwahygls44c0zvynlslimndnlbk2zv"
   },
   "stable": {
    "version": [
     0,
     32,
-    2
+    3
    ],
-   "commit": "a8e95ca9c07480c188733d7e6315147fd6e4ed24",
-   "sha256": "0vg6pkvkpz02b237f1p3qxsrwyc5ar44l73rr04gk368n7a0lnwv"
+   "commit": "94b181041b4e053fd5aee2c987b754e7a01aff2d",
+   "sha256": "0gn5qqln54v8avwadr6jmifwahygls44c0zvynlslimndnlbk2zv"
   }
  },
  {
@@ -109011,16 +109577,16 @@
   "repo": "realgud/realgud",
   "unstable": {
    "version": [
-    20250605,
-    1143
+    20251024,
+    2145
    ],
    "deps": [
     "load-relative",
     "loc-changes",
     "test-simple"
    ],
-   "commit": "bc479d7e1b14721006ec76b47bc070756baec16b",
-   "sha256": "0mq5chsfm7y6pjqyx70cm946wifdp1rzplgcxq38m2l27h96p2rf"
+   "commit": "56a8d82830ad65c9cbb9c694617f078f007281ac",
+   "sha256": "1n232jphfgqbb44p806bpgg2wisbmr5iz09js71knk7n5gslrz25"
   },
   "stable": {
    "version": [
@@ -109487,11 +110053,11 @@
   "repo": "ideasman42/emacs-recomplete",
   "unstable": {
    "version": [
-    20250913,
-    2251
+    20251126,
+    518
    ],
-   "commit": "6bf7081c448283974b1be519ef2dc946556d8ddb",
-   "sha256": "1qi05dysmqdfdfsi38gncml4rga1xqkwkw76viic4bc14l86rhm0"
+   "commit": "5ee6942e8f900e2709454f8f0c44ea615c92a435",
+   "sha256": "0bipfd2z4qvq3hbg0qjb19jzynmja6paqsjm2b7hvk5jnbmybdlf"
   }
  },
  {
@@ -109984,30 +110550,6 @@
   }
  },
  {
-  "ename": "register-quicknav",
-  "commit": "fed1473b565f42f7849c7676d0c9739a39562c95",
-  "sha256": "1487mkyz2h5929580racxr4nbc343klns9bcm7m5jn4hsx5aiq6m",
-  "fetcher": "git",
-  "url": "https://schlomp.space/tastytea/register-quicknav.git",
-  "unstable": {
-   "version": [
-    20200524,
-    2006
-   ],
-   "commit": "c15ea92b0946c28b3f14986d42b15b0b534aa6a2",
-   "sha256": "03xm5rxhafzngdqnpl884d0zy9qkpx57zbcnh0psalmvswd4d4fh"
-  },
-  "stable": {
-   "version": [
-    0,
-    4,
-    3
-   ],
-   "commit": "e30883a7085ad1f4e1113dc84f5f2222ac4bcd37",
-   "sha256": "18mskl1w5n2cksjds27d1gcrwb065vp9n6hnw9402j3n6z0w8srv"
-  }
- },
- {
   "ename": "rego-mode",
   "commit": "fbc0b93675f6baab6ab023b596e65658c9e2a534",
   "sha256": "0qdmn6kh4bh514qh0ii881c03p3hcdp1qlmdwpp5nlzxlkxbgp07",
@@ -110136,18 +110678,18 @@
   }
  },
  {
-  "ename": "renpy",
-  "commit": "68635e3c52d12c234200680fd393a0b8748d2993",
-  "sha256": "18lnp1920c88j6fvjsrrymqh23amna9qyllh68mf7kssbsh5w2zq",
+  "ename": "renpy-mode",
+  "commit": "ef5541690530285f8b77fab6e650b3b8246349d0",
+  "sha256": "14yfd2jf5hqcfwbpwsbsrm2363zm5jilphn0i9phvnmdcn6ahv0b",
   "fetcher": "github",
   "repo": "Reagankm/renpy-mode",
   "unstable": {
    "version": [
-    20250922,
-    1610
+    20251118,
+    1922
    ],
-   "commit": "76f75a5fdc217756acdca4897d199d1c0074f61e",
-   "sha256": "17di5q9qyr495j89vbhdba2azxsyldim92i2rlbjhh7hwxf8kwmb"
+   "commit": "f4b7512af930efbf6a9be8dd7d43f47031acba40",
+   "sha256": "09qrshrnbay0dd85d98hbm4fvpwr37hjjsdmf5mry9jswxrkppnq"
   }
  },
  {
@@ -110158,11 +110700,11 @@
   "repo": "ideasman42/emacs-repeat-fu",
   "unstable": {
    "version": [
-    20250918,
-    104
+    20251126,
+    529
    ],
-   "commit": "1f43805f227e10462fb97d0794779014d2fb7442",
-   "sha256": "0940azgq92148fs1iqxp67bcv3gz071910jrknxf2kp6bxsw5bc4"
+   "commit": "7efdeecb1eff76f2ae8d5b38d7572b7821b572e1",
+   "sha256": "10aaavnn81i27a3lr2a4y5ni1m9az4nvqrk6fpwi6pd0alkic0sn"
   }
  },
  {
@@ -110661,14 +111203,14 @@
   "repo": "emacsorphanage/restclient",
   "unstable": {
    "version": [
-    20250922,
-    700
+    20251021,
+    1041
    ],
    "deps": [
     "compat"
    ],
-   "commit": "757d82eacb997f82c84c4e6eea08a338b0b6afa8",
-   "sha256": "1xdihcridgglr5bj0xsd4a6ywh47380npgkj8d1axi1b4c9aak98"
+   "commit": "426507f8f7029347fbbc78ce3b963df718abc3ce",
+   "sha256": "0kgww5wczff2pfl60mh8xld3z6gw88knfw40kqsx1qzy82zzdxgp"
   }
  },
  {
@@ -111058,15 +111600,15 @@
   "repo": "dajva/rg.el",
   "unstable": {
    "version": [
-    20251004,
-    2013
+    20251022,
+    457
    ],
    "deps": [
     "transient",
     "wgrep"
    ],
-   "commit": "dcd65fd34b5fcd7c28fd83275129a2ebc7fa8f17",
-   "sha256": "0nk8h7a2alxc0yz5v4mxbhyfb0ys4rpwll18gxwjs5yay26l6rrm"
+   "commit": "9ff6cb24bda58f481886ebaf16b524f4f9b3769c",
+   "sha256": "0yxs6szqhvkmg1ikmpykh5w2kk1jgyfvbymxp19i26pkjfrxfl52"
   },
   "stable": {
    "version": [
@@ -111316,8 +111858,8 @@
   "repo": "DogLooksGood/emacs-rime",
   "unstable": {
    "version": [
-    20241211,
-    808
+    20251105,
+    1505
    ],
    "deps": [
     "cl-lib",
@@ -111325,8 +111867,8 @@
     "popup",
     "posframe"
    ],
-   "commit": "80f09ed36d9f0ca7ce4e1a3ca1020dc4c80ba335",
-   "sha256": "0cgmj0j1kwjxx6077sb3b7hzj1xg6ppynyizs8v0h1x8jbngdrq0"
+   "commit": "f927d26e471e7d63de65ffa92897944242f2fd92",
+   "sha256": "1fy08djlgrq592p6q1va2zm898nr7mv606vphyx913j2k5xyw0py"
   },
   "stable": {
    "version": [
@@ -111749,6 +112291,30 @@
    ],
    "commit": "96c9983ea170503abbd5b3cd79bfe4481c72f43d",
    "sha256": "1g747pkx6a31x1xybs6fq4yaqgz3ngx87rg97i15v3ff2mc5lcr7"
+  }
+ },
+ {
+  "ename": "romkan",
+  "commit": "c2415b2b369e3ff0f3c7f2ee69b325a776b98ab2",
+  "sha256": "0cprhfg90gp7j99bj4gydg3qwhgr4n6sp393v8h1igr86fm7f8r0",
+  "fetcher": "github",
+  "repo": "gicrisf/romkan.el",
+  "unstable": {
+   "version": [
+    20251019,
+    1646
+   ],
+   "commit": "81cf9448450b866913b1f24d899f0a716fa49f0b",
+   "sha256": "0m3ywaaini2snk25y60kx7y7crqnf8v8r8mmxnvbmvcs1swgcjp0"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "commit": "98f41dfd83837b6658a1cf1dc3aeaccba4cf0021",
+   "sha256": "03awa358jmd9yw93fh0c9c2xndx72x4zj6yk8c8vcydv2ylzjxjy"
   }
  },
  {
@@ -112542,11 +113108,11 @@
   "repo": "Anoncheg/emacs-russian-calendar",
   "unstable": {
    "version": [
-    20251005,
-    1815
+    20251026,
+    1548
    ],
-   "commit": "a768d62a60de911dac28832d88b3e1635cb7f5b6",
-   "sha256": "034kwisg36dixqhhklwmqikjzbj53c73mr9kw7rirv9b3viihb48"
+   "commit": "95c7d95476f793f11033923b3e2c1b0c98d10f8b",
+   "sha256": "0h3iz6gzhp46yfrsdcqmfwdwlcfvgwrdsa17lz8bm53bphywha4q"
   },
   "stable": {
    "version": [
@@ -112589,11 +113155,11 @@
   "repo": "dunmaksim/emacs-russian-techwriter-input-method",
   "unstable": {
    "version": [
-    20241222,
-    1903
+    20251010,
+    538
    ],
-   "commit": "0798a620136e7cb6a33e5c2952ed658a65633f9d",
-   "sha256": "1vm8a5w1kppi9zcq4gq1jqafkxq1lcvf9rd89fj0xda86ch79y4q"
+   "commit": "a568c8a3f409f7f9b5cb12143f277af78fef9a26",
+   "sha256": "0h6apa5xxzllq5ly7hfw63w0h6sy1g172i0v0mx5wl0sndqqyjh1"
   },
   "stable": {
    "version": [
@@ -112827,25 +113393,6 @@
    ],
    "commit": "b17d4cf848dec1e20e66458e5c7ff77a2c051a8c",
    "sha256": "1fc132gv48xwrxiw139kc9f5wkhjgsgqdfm6b7v97xj5025zg6hr"
-  }
- },
- {
-  "ename": "s3ed",
-  "commit": "32ba78167bd6908b49f340f6da48643ac38f25f2",
-  "sha256": "08scv3aqnidz28rad5npz7b4pz9dx05rs72qkp3ybkk2vhqf2qwa",
-  "fetcher": "github",
-  "repo": "mattusifer/s3ed",
-  "unstable": {
-   "version": [
-    20200929,
-    1317
-   ],
-   "deps": [
-    "dash",
-    "s"
-   ],
-   "commit": "2234444ead6c4c6fc3fea548958b36d2c29a9938",
-   "sha256": "0amzpw75w3hb186y4m1k3j9c1j3cxbd2cy20gcma218bgg2xg5s0"
   }
  },
  {
@@ -113749,11 +114296,11 @@
   "repo": "ideasman42/emacs-scroll-on-jump",
   "unstable": {
    "version": [
-    20250913,
-    2251
+    20251126,
+    514
    ],
-   "commit": "6b992a611a0998d3543bd91616121202d5843a06",
-   "sha256": "074d8h1a5yv8l8ccmz8lcyi4pg6gdh17rh00z6ffzqfg4s70pmb5"
+   "commit": "ffb6fbfda84a80ce1f42bf2b2259e1e663e1d582",
+   "sha256": "00q1mcc0fdj5vhra2kzs9l6z7nx0ml2rggh4n10mw7ksd74bs75j"
   }
  },
  {
@@ -113910,15 +114457,15 @@
   "repo": "sdm-lang/emacs-sdml-mode",
   "unstable": {
    "version": [
-    20251005,
-    2315
+    20251030,
+    1814
    ],
    "deps": [
     "tree-sitter",
     "tree-sitter-indent"
    ],
-   "commit": "75d627413a13d23c8872a474b4dc16d77d0a7a93",
-   "sha256": "0f5dg5z8yvypgzv1f7dcnpp0hlahv5yprwb6jrni3khk9fs6jqm9"
+   "commit": "3b2430df46a026e70a69da019afa8f40a8ed9225",
+   "sha256": "09v2zyg7pcjk7yiym283gh3qdbdij5qv1hlm0rkn1vqji1zfgg1q"
   },
   "stable": {
    "version": [
@@ -114379,15 +114926,15 @@
   "repo": "emacsmirror/semi",
   "unstable": {
    "version": [
-    20250621,
-    1330
+    20251025,
+    2336
    ],
    "deps": [
     "apel",
     "flim"
    ],
-   "commit": "a9ef04a4693015aa1d8259f804b83eee5e42f9ec",
-   "sha256": "1iqlcj2fcdykhcy7047ykyys0qky0dfv0zrl7dvdwgmz2c5k2220"
+   "commit": "21f790d89f0c60d8bc7ae4eabd3091472a0c2931",
+   "sha256": "0lhmmhami4pmk1znxms1aa545y85js95s88l0qmk8cnl650nymz9"
   }
  },
  {
@@ -115171,20 +115718,20 @@
   "repo": "xenodium/shell-maker",
   "unstable": {
    "version": [
-    20251008,
-    1308
+    20251112,
+    1702
    ],
-   "commit": "ceb6915a0fc2ba3cfc6f1a5fc3bf1a0860bdd36e",
-   "sha256": "04mc23adxv6grkx7cm940hq17an4lj6jnvdhy5w1i0w8jx3884sw"
+   "commit": "a83134afe5404b4c82e871389ab4ab0a01104d53",
+   "sha256": "0jqjqvylkd2hixpi8c9w9z207nff77h6q2p15q8fsfgff9b32ag4"
   },
   "stable": {
    "version": [
     0,
-    82,
-    2
+    84,
+    1
    ],
-   "commit": "61cb4f7ddcdbb8d337812cd78aedccf6392f49b7",
-   "sha256": "1v65gbrw2kczj952j2xx1fvq7sfnxgm6xgdgmz82ydgj3sbrfg44"
+   "commit": "3d2b6d911792d4428da5bc4033cd479ba4e10b46",
+   "sha256": "1g0lwv2g5b0cjqsr61jaw902j93wi61qznwl6yybs4hgjj3vjzgg"
   }
  },
  {
@@ -115462,11 +116009,11 @@
   "repo": "ideasman42/emacs-shift-number",
   "unstable": {
    "version": [
-    20250917,
-    433
+    20251126,
+    348
    ],
-   "commit": "058fa307293287e9232219007893cb56abb2c4b3",
-   "sha256": "0ww933jv7cbsjkc0mx33yzs2cnqpkq0df3zi14yk7znpzh89mix1"
+   "commit": "bb14d9609fed47000b76ecc8393285abff1bb766",
+   "sha256": "09l9c462q8wl4d28fcbk6cs4ya1fvfl1h5gm1257sa187x7r8bh1"
   },
   "stable": {
    "version": [
@@ -115973,11 +116520,11 @@
   "repo": "ideasman42/emacs-sidecar-locals",
   "unstable": {
    "version": [
-    20250918,
-    217
+    20251126,
+    347
    ],
-   "commit": "94fc39a75a53e44de8639204455ccc7bf374d7fc",
-   "sha256": "09j404hjsyadgr0z48n0b82bf2ilvfh0h8n17d3gri7p9znjzhci"
+   "commit": "33c52d010227613d3c730fbbb89806d05688ac23",
+   "sha256": "0b5pbjvy8zdpg4kv8jri2s3zi5j8xa6cb0z4fag31n1c4vrf55gz"
   }
  },
  {
@@ -116655,32 +117202,34 @@
   "repo": "magit/sisyphus",
   "unstable": {
    "version": [
-    20250928,
-    1843
+    20251101,
+    2122
    ],
    "deps": [
     "compat",
+    "cond-let",
     "elx",
     "llama",
     "magit"
    ],
-   "commit": "600dd0b79881908c08fbf72872f0fa392264d548",
-   "sha256": "0f4pk1js74hwyic9imlmw9axh7jby2rxr6m48gf8bamadcdsvlxq"
+   "commit": "8fe6d76d3d31db60149173c1054961c2757c9f74",
+   "sha256": "0aj1q1ggq20n4b77pyi4a44g8ibmb0l918imwmsj83mih51535kc"
   },
   "stable": {
    "version": [
     0,
-    2,
-    5
+    3,
+    1
    ],
    "deps": [
     "compat",
+    "cond-let",
     "elx",
     "llama",
     "magit"
    ],
-   "commit": "9c9fc0624308fba0fe0cc112d1e4de21db81803f",
-   "sha256": "06gsl5cr2x73njhxia2xlxdhkdddzv6w7q3asgj1f6xjx50vvc7b"
+   "commit": "8fe6d76d3d31db60149173c1054961c2757c9f74",
+   "sha256": "0aj1q1ggq20n4b77pyi4a44g8ibmb0l918imwmsj83mih51535kc"
   }
  },
  {
@@ -116706,11 +117255,11 @@
   "repo": "mastro35/sixcolors-theme",
   "unstable": {
    "version": [
-    20250902,
-    1120
+    20251028,
+    1442
    ],
-   "commit": "b0a82b97bf9d7d9ab8f1afcf9481c97da0e23c84",
-   "sha256": "0gwi719wqyp7wd7fca6xfv77l3swqi187azszzjqpcw56sj45hxs"
+   "commit": "be8db0ca5f7868a9f139056cb8067d24aeffe67e",
+   "sha256": "1vkwp8vzzw2j1py4s2cxkx51q1x4ix9wk0d9hv96x3jdhwhxyapc"
   }
  },
  {
@@ -116923,8 +117472,8 @@
   "repo": "emacs-slack/emacs-slack",
   "unstable": {
    "version": [
-    20250924,
-    2025
+    20251120,
+    2352
    ],
    "deps": [
     "alert",
@@ -116936,8 +117485,8 @@
     "ts",
     "websocket"
    ],
-   "commit": "4ad4bb3a2628b2015a591c835566f9348a16b81a",
-   "sha256": "0nmfccpx5cwdhl49q9vccpjzwjbad3c88ijyg6g91h238r19chr4"
+   "commit": "f4bae8aa3ef954c0270a1d1ee534696c146cc3d8",
+   "sha256": "1khwrlms953y219fp62gi4l9bj0yv74bwjcxhdgby06f6hp14gsz"
   }
  },
  {
@@ -116995,14 +117544,14 @@
   "repo": "slime/slime",
   "unstable": {
    "version": [
-    20250918,
-    2258
+    20251122,
+    1352
    ],
    "deps": [
     "macrostep"
    ],
-   "commit": "e57ff4278d519bfda9523a30db8d927b84430516",
-   "sha256": "1fphddhncm42fj5962i0ispiky4zli8cfcp3fj16x4x8rfk0spjs"
+   "commit": "0f0b0835b4229b3ced8af7ad4fa7561500578864",
+   "sha256": "1dys91d5fszpdpghnixdb4zpqfljq3izzswb0zicbc5gcxli1jwb"
   },
   "stable": {
    "version": [
@@ -117297,11 +117846,11 @@
   "repo": "vilij/slurpbarf-elcute",
   "unstable": {
    "version": [
-    20251009,
-    1510
+    20251018,
+    2247
    ],
-   "commit": "cc3237983a9cbd2f1af20c5ae99ecb0a77f42361",
-   "sha256": "15m2580y6dyxa88b17jv22b1iqijibkspajsbk2s4gchid89rhy2"
+   "commit": "20f209035ab01a798645efa29650dfd67d50fad4",
+   "sha256": "0axnb2pnzvc6bg56h5a8fa4zw7kxp4rxf9jfsqjx76154w8idfga"
   }
  },
  {
@@ -117312,11 +117861,11 @@
   "repo": "joaotavora/sly",
   "unstable": {
    "version": [
-    20250930,
-    913
+    20251125,
+    31
    ],
-   "commit": "3041c402169ab1d2f63cbbe1aae2dc35f0928e1e",
-   "sha256": "1j6wck4kvxk0wvl3m1f4f96wyj9x53alxjjm3bchacpv9rl8dv44"
+   "commit": "6a303bae74537f9955fe08e0e28d6da2b2b4ee4e",
+   "sha256": "0nlrjhbv91w7hl5s7zz3lqh6c4w90wnwkgwhnfkhzr5jfiwpl9lr"
   },
   "stable": {
    "version": [
@@ -117508,11 +118057,11 @@
   "repo": "zenitani/elisp",
   "unstable": {
    "version": [
-    20250227,
-    1850
+    20251123,
+    1819
    ],
-   "commit": "f48f508e2669f4ba66d26806bc40da1515dec85f",
-   "sha256": "1zj5s26pflwqk7qz2yw5vci7fnvzrl6pgb723yv79lr3wz1hcspz"
+   "commit": "a306b00bdf64470c9256b7ec5a5920b708b2b17a",
+   "sha256": "07wwfhs0hs0ikj3n0vm3ryd3vahwpzma29i1lmw5splxyd34sfid"
   }
  },
  {
@@ -117783,11 +118332,11 @@
   "repo": "hbin/smart-shift",
   "unstable": {
    "version": [
-    20150203,
-    725
+    20251125,
+    1349
    ],
-   "commit": "a26ab2b240137e62ec4bce1698ed9c5f7b6d13ae",
-   "sha256": "0azhfffm1bkgjx4i3p9f6x2gmw8kc3fafzqj4vxxdibhn0nizqk8"
+   "commit": "b9958f042f974e09a7e9442431a1f9cbd8404f8a",
+   "sha256": "11gn8nyi46r83gf7d1zk8y4nwkhp2s56dkr3078k669gvaqlhdr4"
   }
  },
  {
@@ -118942,20 +119491,20 @@
   "repo": "djgoku/sops",
   "unstable": {
    "version": [
-    20250206,
-    1651
+    20251102,
+    57
    ],
-   "commit": "afeb1232b89335d77a3f4b6639ebe8a2b70fae3f",
-   "sha256": "1n49p86sfvhaig7mp17zm9mrsp14mmvgvprp1n16r6kgfx52wxzq"
+   "commit": "7cce0d6800eff1e9c21ab43fffe1918bcc006e7d",
+   "sha256": "0vi7jw7zqj04ikajnssa68v6npd43bvaiw2afck25wxa9hnaja7f"
   },
   "stable": {
    "version": [
     0,
     1,
-    7
+    8
    ],
-   "commit": "afeb1232b89335d77a3f4b6639ebe8a2b70fae3f",
-   "sha256": "1n49p86sfvhaig7mp17zm9mrsp14mmvgvprp1n16r6kgfx52wxzq"
+   "commit": "4c0eba238837b439ac23493e70255abb22653ac6",
+   "sha256": "0vi7jw7zqj04ikajnssa68v6npd43bvaiw2afck25wxa9hnaja7f"
   }
  },
  {
@@ -119388,11 +119937,11 @@
   "repo": "nashamri/spacemacs-theme",
   "unstable": {
    "version": [
-    20250613,
-    2113
+    20251015,
+    1823
    ],
-   "commit": "2ffca41e6e9aa55d8de5c40c6fb61e0d47763b5d",
-   "sha256": "05p7p4q2p1bx2xqiha1qga5drlj6fn2757zdcdxplb88a9zx606r"
+   "commit": "f4757d701aa64bc3e1a5963c8a4f52cfd135cfed",
+   "sha256": "0mwnl3yl8209b7cghklk7j9cilviqhzk213csl84871z8rr1irc8"
   },
   "stable": {
    "version": [
@@ -119516,11 +120065,11 @@
   "repo": "ideasman42/emacs-spatial-navigate",
   "unstable": {
    "version": [
-    20250915,
-    2339
+    20251126,
+    513
    ],
-   "commit": "0fadd12d73dc40cb6fb3574239d6aa37910d1eb0",
-   "sha256": "085hxnmhpgkff37f0rx1ihm17fv8h2sa97xjhx52j5h3cwn8q8pk"
+   "commit": "51aee2673323bfe8afe3de30f81da860310b8d73",
+   "sha256": "19l78man04g4wgccr3ai7afslb531ll7m2x9kig05hn0q4w2fszn"
   }
  },
  {
@@ -119531,11 +120080,11 @@
   "repo": "condy0919/spdx.el",
   "unstable": {
    "version": [
-    20241220,
-    119
+    20251129,
+    59
    ],
-   "commit": "050971f33487a676bff4b21c82864dba7cf3b6eb",
-   "sha256": "03prllb4z2izv0wcb814cm78wzi36iw6rrg1bi0gpsbr3ya4axqh"
+   "commit": "7fd1c3143cc2393a8fda0c351a5edbd47a599b2e",
+   "sha256": "0f2149gj8gzbr5zlll8nfgsqhhglykr2y2zdvck38p9rvg5hlw26"
   }
  },
  {
@@ -119596,14 +120145,14 @@
   "repo": "dakra/speed-type",
   "unstable": {
    "version": [
-    20250806,
-    2155
+    20251126,
+    1925
    ],
    "deps": [
     "compat"
    ],
-   "commit": "76f74d313420111cb0f8ce578d6c348b1a46817b",
-   "sha256": "089c1997i1y20dkj29h8zpk39kwyyiv5rx6bmna23jzjvcwh21b7"
+   "commit": "1ddeb0b8c63cc0ab267ac6a1e3010c053c1fa5f0",
+   "sha256": "0s36b95wpfkfghdvwda4xhsdc4akc3l99qzif83lx0lmvipahnd7"
   },
   "stable": {
    "version": [
@@ -119671,11 +120220,11 @@
   "repo": "ideasman42/emacs-spell-fu",
   "unstable": {
    "version": [
-    20250913,
-    2251
+    20251126,
+    529
    ],
-   "commit": "b141e2e24e3def0c3c656090cf11705bb34254d1",
-   "sha256": "0zwx03sl1svzwqa4gidipsnlf05rrk05ghc7kqpb6xk8a8s81a3c"
+   "commit": "437f594615c590c87cfb040b669cba7ca66e1f91",
+   "sha256": "1ci23whm2msh97cj4k88ala33i3xfx7y2hc6aqczln93bfjsbd09"
   }
  },
  {
@@ -120202,11 +120751,11 @@
   "repo": "pekingduck/emacs-sqlite3-api",
   "unstable": {
    "version": [
-    20231124,
-    1326
+    20251014,
+    536
    ],
-   "commit": "a601c9965e4d0178705a64b7d4f88709ca9aea66",
-   "sha256": "1d1r65ybcf5idbs8sv0l3dna4l1wy3jba9dvv1kkz7zj6qhr48fs"
+   "commit": "a6376d769cf0749930b9bc00170e962029210406",
+   "sha256": "0ibkdmw15l70j7zc93fzf77xz21pk5yvpx1n502dk966wykqlpy2"
   },
   "stable": {
    "version": [
@@ -120325,11 +120874,11 @@
   "repo": "srfi-explorations/emacs-srfi",
   "unstable": {
    "version": [
-    20250726,
-    420
+    20251031,
+    411
    ],
-   "commit": "3a98b7dbf9618143026c437815f22cacbe81c4b6",
-   "sha256": "1ylqfynkjkdl1w2cwwj618jwwbnw19phgfkfqpi8zq9nfk32wf9z"
+   "commit": "645433927961dcd911320ef01d9f57e2068d63af",
+   "sha256": "12cahv09b0idf9v6jrx6bqzwmbx7j95nc3fci3ykwj7j3asf8z3m"
   },
   "stable": {
    "version": [
@@ -120412,14 +120961,11 @@
   "repo": "magit/ssh-agency",
   "unstable": {
    "version": [
-    20200329,
-    1558
+    20251103,
+    1834
    ],
-   "deps": [
-    "dash"
-   ],
-   "commit": "a5377e4317365a3d5442e06d5c255d4a7c7618db",
-   "sha256": "1i3zmsn0w2k7p2hlzssibckm32kf05l56mkhg96x4sf06g3pwq1d"
+   "commit": "2a6e1784b42b6179da11c6c1077faaa0eb484e0d",
+   "sha256": "1h3nzsiyvd0p4nalg1yll1m4kca1g71aw1w933xazzzs30zr02pb"
   },
   "stable": {
    "version": [
@@ -120609,6 +121155,36 @@
   }
  },
  {
+  "ename": "starling",
+  "commit": "97be589ef077ac109b7d574117a1395e36862b45",
+  "sha256": "1r4f4wj660qg9ww2ax7i3rcvrxfhsm7k318h2f35bqs1qj6ngv5v",
+  "fetcher": "codeberg",
+  "repo": "draxil/starling-el",
+  "unstable": {
+   "version": [
+    20251029,
+    707
+   ],
+   "deps": [
+    "plz"
+   ],
+   "commit": "298186dc003052051cbcac08b270afb2b1f4f2b9",
+   "sha256": "01s7bkn8hr5j4ynk4lclc4269p1dr0l3zl5hlpc047ln32b2gfjb"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    4
+   ],
+   "deps": [
+    "plz"
+   ],
+   "commit": "e6fae24f889d886f3d02cafee0a6067d35576378",
+   "sha256": "1igmjvzjlbvv543laqajd5i08dzabd4dv3p9fvg7r3znk17fl2bq"
+  }
+ },
+ {
   "ename": "starlit-theme",
   "commit": "4b695ee03d16e9253674cedaef785c2545113b67",
   "sha256": "02qb70fgnp7r35hz2g53rpc792rh568ddxgxxsbfw5jg9f429z9x",
@@ -120775,20 +121351,20 @@
   "repo": "stacked-git/stgit",
   "unstable": {
    "version": [
-    20250811,
-    357
+    20251110,
+    503
    ],
-   "commit": "d05f56db8124fc76c37a10c61e8db8a45e8cae15",
-   "sha256": "16r5vx6pnw6ricdv25vx8vqihlkhf092p3n4mrn0qly9m5a7dj2f"
+   "commit": "020140581698f62d846c995ee6e3bebe0c20ff14",
+   "sha256": "0r9canxbj30anga9mbhym87jdrxcd0xp4d7a3lfhrrbmig5z2pff"
   },
   "stable": {
    "version": [
     2,
     5,
-    4
+    5
    ],
-   "commit": "d05f56db8124fc76c37a10c61e8db8a45e8cae15",
-   "sha256": "16r5vx6pnw6ricdv25vx8vqihlkhf092p3n4mrn0qly9m5a7dj2f"
+   "commit": "020140581698f62d846c995ee6e3bebe0c20ff14",
+   "sha256": "0r9canxbj30anga9mbhym87jdrxcd0xp4d7a3lfhrrbmig5z2pff"
   }
  },
  {
@@ -121057,11 +121633,11 @@
   "repo": "akicho8/string-inflection",
   "unstable": {
    "version": [
-    20250831,
-    53
+    20251114,
+    1041
    ],
-   "commit": "67767a8239c23eb91dafc11dd3171ea9e9c6fc7e",
-   "sha256": "0868jms67n9i0m843i2sdgnp5fws1xa7bf38adc40nigjmpdsnid"
+   "commit": "072f7dff43140570788d64ac0ec9d930c3c2a96b",
+   "sha256": "0vvg9ns1rff3zqjsxr3b5lvq142jakgnhz58nc6503mxw5sbx0zl"
   },
   "stable": {
    "version": [
@@ -121156,11 +121732,11 @@
   "repo": "jamescherti/stripspace.el",
   "unstable": {
    "version": [
-    20250915,
-    112
+    20251103,
+    1432
    ],
-   "commit": "99004e3a2539686e7d714ef4f7290726f3ad6fe3",
-   "sha256": "0k80f1xqwcyaqjcwry54d61in6j8h81kysx6h2z956jj170gxpd2"
+   "commit": "c403debb88691cf7839f86f4d6d4a2815c9eeddf",
+   "sha256": "0yxdaqi35mpvyi1ndn5l930a25phr05554hg43n211rhgnd5zmz7"
   },
   "stable": {
    "version": [
@@ -121480,8 +122056,8 @@
   "repo": "Wilfred/suggest.el",
   "unstable": {
    "version": [
-    20231003,
-    404
+    20251128,
+    933
    ],
    "deps": [
     "dash",
@@ -121490,8 +122066,8 @@
     "s",
     "spinner"
    ],
-   "commit": "eca8f6f03b0a77ab649c791f21cb01f4ecae3e73",
-   "sha256": "0wrdig7nwr4fzhcnpnkxmisxbgjzg77qmal06h47b0csgphvfc9l"
+   "commit": "d1395f18519527efc3b43a7b148ebb139017e9ae",
+   "sha256": "1q1niii0lcwgl5ws8v4frwmwhgk4xpj3428g1h232a0fm7194mv0"
   },
   "stable": {
    "version": [
@@ -121535,8 +122111,8 @@
   "repo": "kiyoka/Sumibi",
   "unstable": {
    "version": [
-    20250905,
-    1018
+    20251123,
+    324
    ],
    "deps": [
     "deferred",
@@ -121544,13 +122120,13 @@
     "popup",
     "unicode-escape"
    ],
-   "commit": "1051a201dee73ec6374df459e32671085cd6b026",
-   "sha256": "0s8pyqvimc3fdd4cgiyyr9q0c3lhpjqibyznj5jd5j0rm417v44y"
+   "commit": "b360b7ad9b6cc9b935cdc5a73ddb40e5b3aae7dc",
+   "sha256": "11v2s2jbfzc8q7b7ky9543b732qpccrbvg10k1n9i1j410kq1zlb"
   },
   "stable": {
    "version": [
-    3,
-    7,
+    4,
+    1,
     0
    ],
    "deps": [
@@ -121559,8 +122135,8 @@
     "popup",
     "unicode-escape"
    ],
-   "commit": "1051a201dee73ec6374df459e32671085cd6b026",
-   "sha256": "0s8pyqvimc3fdd4cgiyyr9q0c3lhpjqibyznj5jd5j0rm417v44y"
+   "commit": "b360b7ad9b6cc9b935cdc5a73ddb40e5b3aae7dc",
+   "sha256": "11v2s2jbfzc8q7b7ky9543b732qpccrbvg10k1n9i1j410kq1zlb"
   }
  },
  {
@@ -121830,8 +122406,8 @@
   "repo": "isamert/swagg.el",
   "unstable": {
    "version": [
-    20250913,
-    1822
+    20251110,
+    2034
    ],
    "deps": [
     "compat",
@@ -121840,14 +122416,14 @@
     "s",
     "yaml"
    ],
-   "commit": "1fe1acf42cd7fe7ffbb56b82a030a53e544b8ff6",
-   "sha256": "1128jfyhp591mqv042wwicir1azyg7fv4azh4y3sffx44ij7n1rk"
+   "commit": "87bd1f698bc4c77a1c0d6b252e15f4ee345d2afa",
+   "sha256": "1xlknc7j5vz1sv5gwr8v6vyfginflsksjyzx6qz1svibkdwp223g"
   },
   "stable": {
    "version": [
     0,
-    3,
-    2
+    4,
+    0
    ],
    "deps": [
     "compat",
@@ -121856,8 +122432,8 @@
     "s",
     "yaml"
    ],
-   "commit": "95b4cbac6b0b2f12da982b768be861e20ae13e61",
-   "sha256": "1ccigx15fzb0w321b91gzlc5bs0nvr7g6da0rwksa9iy5nl36hk2"
+   "commit": "87bd1f698bc4c77a1c0d6b252e15f4ee345d2afa",
+   "sha256": "1xlknc7j5vz1sv5gwr8v6vyfginflsksjyzx6qz1svibkdwp223g"
   }
  },
  {
@@ -122068,11 +122644,11 @@
   "repo": "swift-emacs/swift-mode",
   "unstable": {
    "version": [
-    20250922,
-    712
+    20251122,
+    857
    ],
-   "commit": "c2fe47722fcab02a8bd40b443fc11687793591e9",
-   "sha256": "1zxakl1s0c0mddzrvfnik78dfi6lhlxlq28jz9ksn1nh5jl1by46"
+   "commit": "cfae3b85ad09bd293df941261afbc21e41bbb5f8",
+   "sha256": "11jwdk5h3mmsmfzllqfrh11v2p96fpiswf2aahg8hr80zqk4p6nb"
   },
   "stable": {
    "version": [
@@ -123209,14 +123785,14 @@
   "repo": "mclear-tools/tabspaces",
   "unstable": {
    "version": [
-    20250920,
-    2116
+    20251108,
+    1927
    ],
    "deps": [
     "project"
    ],
-   "commit": "d8fceb24064ee8485fdcbcb4cc5de8c9a7d6e0ac",
-   "sha256": "1p5795l2kwh0rm87wqfvssvg7vvplzky3sja906mjz2h2nai0ph3"
+   "commit": "8873c46da96cbabe31056cd5c5e85731f4abf07e",
+   "sha256": "0q080bnyzf0ps74wsbrhkibzsm1r58czq5q9v83571jc66kllwjh"
   }
  },
  {
@@ -123489,6 +124065,21 @@
   }
  },
  {
+  "ename": "tbindent",
+  "commit": "99e36147fb5c50bd1baf18a1bcb40782b650eae6",
+  "sha256": "03yzkfh1cd1ncs70zdawwy7acyw2pgknqqsjir89ivc9kwzhw14n",
+  "fetcher": "github",
+  "repo": "pierre-rouleau/tab-based-indent",
+  "unstable": {
+   "version": [
+    20251125,
+    1304
+   ],
+   "commit": "5e83d2ff760c79363f5bc3045fdfe59038f9eb32",
+   "sha256": "065f40jq9akvlspb3w0lcc65zrz5l9ff4rh26maywid5jd3pfwjn"
+  }
+ },
+ {
   "ename": "tblui",
   "commit": "f4dd6e9dcc73c57f93371ba16b15f2d98d805dae",
   "sha256": "1m0zhk5zyialklnil5az974yz6g1zksw02453cxc0xpn5pf0a3xa",
@@ -123537,11 +124128,11 @@
   "repo": "kanchoku/tc",
   "unstable": {
    "version": [
-    20231123,
-    1424
+    20251019,
+    735
    ],
-   "commit": "6d7d16ae0dd737efb8ba68eebf1cc4cfdc26b05f",
-   "sha256": "1af87804j35gkrjlvf694hvza6p409vcprkikm63cwnjz63rzil4"
+   "commit": "f7d81efa7a2a481e58d8fc0a404473654f7a96a1",
+   "sha256": "1d814m1llwpq5khvvcnqn9b4fn7f5cg9ahqmfs1m3rdfrdk5cm67"
   }
  },
  {
@@ -123615,15 +124206,15 @@
   "repo": "zevlg/telega.el",
   "unstable": {
    "version": [
-    20251009,
-    1004
+    20251128,
+    658
    ],
    "deps": [
     "transient",
     "visual-fill-column"
    ],
-   "commit": "f5b48d2a605c1383ddb8522ed315b625115f16a6",
-   "sha256": "12h4jvqzw2s30c1wxd26qa9m8fhpb2nc1ijh05781fkxd7sqrdkr"
+   "commit": "55f01587e534feede0875aa0d94ffc5a4c6671af",
+   "sha256": "1mrg8g4qibyh4xkncq152ylgcq1qmnx2l32p1fvhp7h6f5lw49fn"
   },
   "stable": {
    "version": [
@@ -123703,14 +124294,14 @@
   "repo": "caramelhooves/teleport.el",
   "unstable": {
    "version": [
-    20251009,
-    739
+    20251118,
+    1056
    ],
    "deps": [
     "dash"
    ],
-   "commit": "0cda2233170109fa87a9ff97a79fb315b039f91e",
-   "sha256": "10dc2asjrj6xk80s3c8xh14yx90pdib4aishziiq31x22a33rnpi"
+   "commit": "0ff615c4b2f19019c9438075c75e0f94b4cec53c",
+   "sha256": "1hxxssp39zyij8jik6lmhri5xfc0n56rk9s4zdv669qg0qikmp4c"
   }
  },
  {
@@ -123754,25 +124345,25 @@
   "repo": "minad/tempel",
   "unstable": {
    "version": [
-    20250920,
-    848
+    20251125,
+    1751
    ],
    "deps": [
     "compat"
    ],
-   "commit": "79e0538f7c273a1ae73ec3f8c77563e38ed31e84",
-   "sha256": "0w9cibpmai4rbfjvjqjqxrizka9z48dx7vh4w2xcic15jywvdrpb"
+   "commit": "f89a57ac413892c03a46f36e62b219434ba6f850",
+   "sha256": "0xc6llzhixh8b5x6n94isqbrq94dzz61a9vrl1wn4lhxqjzbf5ji"
   },
   "stable": {
    "version": [
     1,
-    6
+    8
    ],
    "deps": [
     "compat"
    ],
-   "commit": "aa0f6fab4013d4661c34f9352531ceac1f0973a8",
-   "sha256": "1a5pk000cy4zgh73hdpw08cwf1qr7cgw4hpj5n0dkprwbw5hhm8s"
+   "commit": "56b6e6e3e95054876cfb96b1f3a460824baec8c6",
+   "sha256": "02772vhw5pr60fs879cg82l3g7xn4lxy6frhknk8d5ah80pwzfca"
   }
  },
  {
@@ -124414,15 +125005,15 @@
   "repo": "hcl-emacs/terraform-mode",
   "unstable": {
    "version": [
-    20250528,
-    1335
+    20251115,
+    2210
    ],
    "deps": [
     "dash",
     "hcl-mode"
    ],
-   "commit": "80383ff42bd0047cde6e3a1dfb87bdb9e0340da3",
-   "sha256": "15xgjyl864crx3vpalds68x0vn1qzibkqdcjlbp87xiq88dx2q1x"
+   "commit": "01635df3625c0cec2bb4613a6f920b8569d41009",
+   "sha256": "03b20k26fhglswrqaiqkc86axnb4gvxpqp6ydhy0zir81q40iwrn"
   },
   "stable": {
    "version": [
@@ -124540,14 +125131,14 @@
   "repo": "rocky/emacs-test-simple",
   "unstable": {
    "version": [
-    20230916,
-    1634
+    20251030,
+    2148
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "8b191842318bb05da74052025192d32ebebb033a",
-   "sha256": "1mg4l4y818fcjd3a2hwaaab826z0sgzirpz175m499ixmjdwi21f"
+   "commit": "da8ddb6fecb820c8e0809ac0892374e755e4efec",
+   "sha256": "18a9d1n2xc2fqimvsg0nkvizn7y7sb6ap5i9al526cp40l0yky3n"
   },
   "stable": {
    "version": [
@@ -124689,11 +125280,11 @@
   "repo": "WJCFerguson/textsize",
   "unstable": {
    "version": [
-    20231005,
-    1335
+    20251120,
+    1819
    ],
-   "commit": "d61fd65d823b17ff71a61fba5590a9e9b60e0e92",
-   "sha256": "02n4dsy4xlhxcinag4xhlqajww81pspkfhxvrz75zmqab01qa6ib"
+   "commit": "cfcc4d6a351c43692f408e5f0fd68de2974fcb9f",
+   "sha256": "138b6hqwhmh5fc55rmaizni766ai9zzzvv315hv627kpsr90q4jy"
   },
   "stable": {
    "version": [
@@ -124769,11 +125360,11 @@
   "repo": "tanrax/thankful-eyes-theme.el",
   "unstable": {
    "version": [
-    20250319,
-    921
+    20251010,
+    1114
    ],
-   "commit": "71d5528aa7550be16e92eb5f8d2278775dd1fb1f",
-   "sha256": "0q7wvamgckd2c28wi4q3xfbcarfax1lm68s5jxlpy7saw18aanfh"
+   "commit": "2fdb4271ecb91c75408993b324e1edf8dd13702e",
+   "sha256": "19rjnqiamwhlsxjf1cjacw1fknlnwvpr7yxrzz22f70sdf9618gx"
   }
  },
  {
@@ -124802,11 +125393,11 @@
   "repo": "monkeyjunglejuice/matrix-emacs-theme",
   "unstable": {
    "version": [
-    20240429,
-    920
+    20251103,
+    1021
    ],
-   "commit": "d0c7fd3584c07952de26a5ae44ca6159f1960bb7",
-   "sha256": "0vhmmya0dayjsmvyxiyh1sf3hmdxdgv8qcfx7ffh385saqpqifkd"
+   "commit": "ff0d3ba077d7d48c46a00b724de8eb4ce163fab9",
+   "sha256": "0bnflam6hsayh2kcjd0bydsyj64d33gcjj7w7gj3y8x0h68n89hj"
   }
  },
  {
@@ -125026,21 +125617,21 @@
   "repo": "facebook/fbthrift",
   "unstable": {
    "version": [
-    20251006,
-    1136
+    20251124,
+    952
    ],
-   "commit": "c35086693e07ca7af8ab09cb89710ba9f929c490",
-   "sha256": "13wshgfd8zd07x3mbkrqija425932mgdgb5ivbnkmsx9s55cjvw4"
+   "commit": "d08a6910d620c8560d2a9af574937d11bfb92388",
+   "sha256": "1qcpnxm1g6s5bl9bg1zr1l281s699whak8ii4mxv9rqxmq5yiccw"
   },
   "stable": {
    "version": [
     2025,
-    10,
-    6,
+    11,
+    24,
     0
    ],
-   "commit": "c35086693e07ca7af8ab09cb89710ba9f929c490",
-   "sha256": "13wshgfd8zd07x3mbkrqija425932mgdgb5ivbnkmsx9s55cjvw4"
+   "commit": "d08a6910d620c8560d2a9af574937d11bfb92388",
+   "sha256": "1qcpnxm1g6s5bl9bg1zr1l281s699whak8ii4mxv9rqxmq5yiccw"
   }
  },
  {
@@ -125090,15 +125681,15 @@
   "repo": "polhuang/ticktick.el",
   "unstable": {
    "version": [
-    20250827,
-    2049
+    20251119,
+    45
    ],
    "deps": [
     "request",
     "simple-httpd"
    ],
-   "commit": "edab80659c655af1e1538b3cfbbbe399a428b9c8",
-   "sha256": "038lms98az5m7bpzpmbg2airmkda5wa8wqzrzvfx6x19dna4pfp4"
+   "commit": "860de3af35da55f0e0866b4589dbf1fa877501f0",
+   "sha256": "0kydlf0324a4mlfbhp8i2sc4sh4ji1ankvwqkdmy4dpj6v2zss65"
   }
  },
  {
@@ -125290,6 +125881,21 @@
    ],
    "commit": "e30f50229c617bdd31a1edcd849cba1f3423fea1",
    "sha256": "1ry1v86qw6xf245nkpjrnjinnbhcj57g3xabsv4q566cdi9l3hwy"
+  }
+ },
+ {
+  "ename": "time-zones",
+  "commit": "e95df25a4418580d398da901f40d2ea8951eddd4",
+  "sha256": "0svg9h4kd73lg4klallqijdilpc1ykkb2ajbiz0jflhx6hcm17sg",
+  "fetcher": "github",
+  "repo": "xenodium/time-zones",
+  "unstable": {
+   "version": [
+    20251103,
+    936
+   ],
+   "commit": "23c866db6a3aecac5e860cda6010d9afc847e5c6",
+   "sha256": "0ivdvkvk9jsgb0yzqv54033n473s6r8pqdzdkygzddlhc3g4hk72"
   }
  },
  {
@@ -125503,11 +126109,11 @@
   "repo": "aimebertrand/timu-macos-theme",
   "unstable": {
    "version": [
-    20250409,
-    41
+    20251102,
+    1635
    ],
-   "commit": "48bf3f4f011efaa0392bd93d7e4d0acd0c159bcb",
-   "sha256": "196rcv3zjpsb5vpwd4rv4dlds9xbx02jrl3hjinqqjx6xs43bpkd"
+   "commit": "20f0a64549209457045602b16097e4630f56691d",
+   "sha256": "0p9nlwlra104zki20nf794ainz2gcjfk2v6rjzgnnh9a2q1666d3"
   },
   "stable": {
    "version": [
@@ -125961,11 +126567,11 @@
   "repo": "topikettunen/tok-theme",
   "unstable": {
    "version": [
-    20251007,
-    1430
+    20251010,
+    2231
    ],
-   "commit": "c99b30cfb7bbf98479d1236b199308c31ebede76",
-   "sha256": "0hb6hmhha2vn1kkml0477zsnfpi3agkmf0pxynsxng7bjx3h4pld"
+   "commit": "2fcfa85cbfbe46198e7f126fd4ecd32c0cecee70",
+   "sha256": "1n4gwnpghpivsvgfd4c34wmrasqlksh4qzkhqr3gp6h3n2dp7xdx"
   }
  },
  {
@@ -126102,20 +126708,20 @@
   "repo": "jamescherti/tomorrow-night-deepblue-theme.el",
   "unstable": {
    "version": [
-    20250805,
-    2016
+    20251015,
+    1359
    ],
-   "commit": "0265dc8b8f0da55dfbf83a7e814ebb0ac4fad97b",
-   "sha256": "04ab631fkhwzihlqlka27xfazpn006a1rdm1igij02ybxkvg30fh"
+   "commit": "85084ded2c4f792aaed4a4a1687dadea0347c858",
+   "sha256": "1q3268qy1i3gv3xaqcr29kc7qcxi9z9a258vi218jqizva96gbkr"
   },
   "stable": {
    "version": [
     1,
     2,
-    2
+    3
    ],
-   "commit": "d15dc91f99aa30fbe570f29fe689d49727ee248d",
-   "sha256": "105zxj6w9ipjhfzv19br66iicp21fq62la4rf17qsqy75kfqrj9z"
+   "commit": "85084ded2c4f792aaed4a4a1687dadea0347c858",
+   "sha256": "1q3268qy1i3gv3xaqcr29kc7qcxi9z9a258vi218jqizva96gbkr"
   }
  },
  {
@@ -126561,6 +127167,30 @@
   }
  },
  {
+  "ename": "trailing-newline-indicator",
+  "commit": "15b281d3aa83446fe2e05d2cf3b37b80b086425f",
+  "sha256": "05p5823q2dqdnj1yzk8z5s3kq3frqldf9d1i2419gx6dh0hggdc8",
+  "fetcher": "github",
+  "repo": "saulotoledo/trailing-newline-indicator",
+  "unstable": {
+   "version": [
+    20251115,
+    2242
+   ],
+   "commit": "9d4d8cba8ae20301458b9f9a4399c72951c70471",
+   "sha256": "03a89d2s92j119xh46lx08sbgsczapqm5n37xdhrr8arshwwqsk6"
+  },
+  "stable": {
+   "version": [
+    0,
+    3,
+    4
+   ],
+   "commit": "9d4d8cba8ae20301458b9f9a4399c72951c70471",
+   "sha256": "03a89d2s92j119xh46lx08sbgsczapqm5n37xdhrr8arshwwqsk6"
+  }
+ },
+ {
   "ename": "tramp-auto-auth",
   "commit": "0c8a8841cc7d7634f47610aeecc4a63b20f459f9",
   "sha256": "033110y1kdkqm21pkzp9izp9ic7239km3xc8wifw4vs22js341jj",
@@ -126616,20 +127246,20 @@
   "repo": "fosskers/transducers.el",
   "unstable": {
    "version": [
-    20250215,
-    1046
+    20251118,
+    2154
    ],
-   "commit": "08509ab201973e412dfd5292f721a367514db32a",
-   "sha256": "1hgyq4n96174889jdl8jilh5km6ss9pjg0721qzmp6c7s8p9rvla"
+   "commit": "7d36c9cdbd2179479314e4c277ecaa8020481078",
+   "sha256": "03mrjwf616j82k5fzdmg47whaf84wg5q8qgrkby4qrp6mlw6lmdb"
   },
   "stable": {
    "version": [
     1,
-    4,
+    5,
     0
    ],
-   "commit": "08509ab201973e412dfd5292f721a367514db32a",
-   "sha256": "1hgyq4n96174889jdl8jilh5km6ss9pjg0721qzmp6c7s8p9rvla"
+   "commit": "7d36c9cdbd2179479314e4c277ecaa8020481078",
+   "sha256": "03mrjwf616j82k5fzdmg47whaf84wg5q8qgrkby4qrp6mlw6lmdb"
   }
  },
  {
@@ -126677,28 +127307,30 @@
   "repo": "magit/transient",
   "unstable": {
    "version": [
-    20251006,
-    1815
+    20251120,
+    1950
    ],
    "deps": [
     "compat",
+    "cond-let",
     "seq"
    ],
-   "commit": "053d56e4de2dd78bf32f7af7ed5f289a91cdb6ac",
-   "sha256": "0097px3gqvyjiv05bc1gzandfkncx5khhg34999r2a6ffj65xa68"
+   "commit": "453376f2f1a0beab45da06c84a9e57692afc0607",
+   "sha256": "1d50y6ymz34h913zhq4sx9x6l6a5qr43p5sndlkgw8h35555y3i4"
   },
   "stable": {
    "version": [
     0,
-    10,
-    1
+    11,
+    0
    ],
    "deps": [
     "compat",
+    "cond-let",
     "seq"
    ],
-   "commit": "053d56e4de2dd78bf32f7af7ed5f289a91cdb6ac",
-   "sha256": "0097px3gqvyjiv05bc1gzandfkncx5khhg34999r2a6ffj65xa68"
+   "commit": "0d3f8d4fb6d41b841126820a06ecc98579bd8265",
+   "sha256": "1a5wh5mrh2iqr5d98rcbnhg5cgj946c5lhcgxnsf7wkvnp7hvs34"
   }
  },
  {
@@ -126974,28 +127606,28 @@
   "repo": "tarsius/tray",
   "unstable": {
    "version": [
-    20250601,
-    1101
+    20251111,
+    1731
    ],
    "deps": [
     "compat",
     "transient"
    ],
-   "commit": "aa71423330a6562effa2cc6bae8c96f3d4efaaf5",
-   "sha256": "1bkv2sfh4x37b25829fi5adya6ibzyibm2qwv0m2i2p3y3i63nzc"
+   "commit": "1e35ea126c486ff0b64ac2aa025ed13ac8f2e754",
+   "sha256": "0hav2nwsrka0wgbjsm288h71sjsra3cvhdy07hqb2xb19zcp8vvz"
   },
   "stable": {
    "version": [
     0,
     1,
-    6
+    7
    ],
    "deps": [
     "compat",
     "transient"
    ],
-   "commit": "aa71423330a6562effa2cc6bae8c96f3d4efaaf5",
-   "sha256": "1bkv2sfh4x37b25829fi5adya6ibzyibm2qwv0m2i2p3y3i63nzc"
+   "commit": "ab03fad898e4a9e98ea0a782e7469973e2f5f54a",
+   "sha256": "15a56wsrmjp1if751nhvk0pyqvpbs8hsx3663avzhrrvq058r1c6"
   }
  },
  {
@@ -127153,26 +127785,26 @@
   "repo": "emacs-tree-sitter/tree-sitter-langs",
   "unstable": {
    "version": [
-    20251005,
-    2228
+    20251123,
+    909
    ],
    "deps": [
     "tree-sitter"
    ],
-   "commit": "980deccc43b2a00e9888e04ef6d4935b31b4d92b",
-   "sha256": "1qm02rrxyqib0y008l85nbpf6xi7mmxxshpnjxib029dab29dm3w"
+   "commit": "74a1ab3f99701459fb65db9db4b528834fce8f45",
+   "sha256": "0s5f7grijv7p8z92g7bq8md0qd238g4z6j89xjrk4jd25rb3zv0g"
   },
   "stable": {
    "version": [
     0,
     12,
-    310
+    319
    ],
    "deps": [
     "tree-sitter"
    ],
-   "commit": "980deccc43b2a00e9888e04ef6d4935b31b4d92b",
-   "sha256": "1qm02rrxyqib0y008l85nbpf6xi7mmxxshpnjxib029dab29dm3w"
+   "commit": "74a1ab3f99701459fb65db9db4b528834fce8f45",
+   "sha256": "0s5f7grijv7p8z92g7bq8md0qd238g4z6j89xjrk4jd25rb3zv0g"
   }
  },
  {
@@ -127416,15 +128048,15 @@
   "repo": "rainstormstudio/treemacs-nerd-icons",
   "unstable": {
    "version": [
-    20250116,
-    1651
+    20251024,
+    1914
    ],
    "deps": [
     "nerd-icons",
     "treemacs"
    ],
-   "commit": "eac9fb5d92b8b29e7c4fcf9f3baddb2cb0b04575",
-   "sha256": "15mfxaimbwv87nxsna83wcslmpzyclx8n09kzwmchy97ri2xl67h"
+   "commit": "0c5ddcb978da639f01ddb023febc40fc755171e5",
+   "sha256": "0kmgxzskfkv6rz0s60p6pvwsp68c040060i9nnxx1fx5q2zjgzjd"
   },
   "stable": {
    "version": [
@@ -128003,6 +128635,21 @@
   }
  },
  {
+  "ename": "tts",
+  "commit": "a92345cb3424c48d1577366c0a54d462af899d09",
+  "sha256": "1rsdsl7zc7zcbksr513cbnfhr92d9nwcgb26pcqv852rpq7a99bl",
+  "fetcher": "github",
+  "repo": "DiogoDoreto/emacs-tts",
+  "unstable": {
+   "version": [
+    20251019,
+    1853
+   ],
+   "commit": "e270fec575c35a24a52b762b67ef12651ebbf435",
+   "sha256": "0rslfrzr66acvik0zpjrliipj5x2ixy7y84vv3yll6has1lxmnax"
+  }
+ },
+ {
   "ename": "tuareg",
   "commit": "01fb6435a1dfeebdf4e7fa3f4f5928bc75526809",
   "sha256": "0wx723dmjlpm86xdabl9n8p22zbbxpapyfn6ifz0b0pvhh49ip7q",
@@ -128374,10 +129021,10 @@
  },
  {
   "ename": "typing",
-  "commit": "e6e75695594ce17b618ad8786c8a04e283f68b11",
-  "sha256": "0k2lplqzq3323nn7rybcs377sr87kbww8ci99rrka3yyb5bh1fa1",
-  "fetcher": "github",
-  "repo": "kensanata/typing",
+  "commit": "17d5c4fbf00c8747af839d3c8303665f5a4b2c67",
+  "sha256": "1pqmd439rhq3y6ymf0251wkmlzkvn94xbfmi5d5sg1f7wy1mczmv",
+  "fetcher": "git",
+  "url": "https://src.alexschroeder.ch/typing.git",
   "unstable": {
    "version": [
     20180830,
@@ -128476,6 +129123,38 @@
    ],
    "commit": "938fdad51d1177627ed9a34da6b937481861bda2",
    "sha256": "0q8kgjnbcmqr1my7qgfcwjbk9misgkq4ymvrslhwlfwnnkg18x9a"
+  }
+ },
+ {
+  "ename": "typst-preview",
+  "commit": "55c8b669f7cce2ed8e826076ef6e99c4e0fd888c",
+  "sha256": "17rpw468qh7czf2sq5aaglxzx86nkhpn998661dkx8xv8yxzx791",
+  "fetcher": "github",
+  "repo": "havarddj/typst-preview.el",
+  "unstable": {
+   "version": [
+    20251110,
+    824
+   ],
+   "deps": [
+    "compat",
+    "websocket"
+   ],
+   "commit": "c685857f2d61133fc268509b39796b2718728f29",
+   "sha256": "1c0d87q9jpghwxvxj4a6dch0j9gihxngnncg28931lcss2ibm3gv"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "deps": [
+    "compat",
+    "websocket"
+   ],
+   "commit": "c685857f2d61133fc268509b39796b2718728f29",
+   "sha256": "1c0d87q9jpghwxvxj4a6dch0j9gihxngnncg28931lcss2ibm3gv"
   }
  },
  {
@@ -128745,11 +129424,11 @@
   "repo": "jdtsmith/ultra-scroll",
   "unstable": {
    "version": [
-    20250714,
-    2049
+    20251109,
+    1439
    ],
-   "commit": "077d1e32a604fc4244edbf4ff6ec0f37c738b585",
-   "sha256": "0k1xqkxq89mz8dvzbfpks3jnrcmbd0hcz8a0hib1m3ka55hpczqz"
+   "commit": "19fd73e0ee71558c7770d8daecdbe1793d54c9ae",
+   "sha256": "0gmjn5976ivisi9mrwdvy50387k2c25aw5pzlwb56b7z0rdbn2zi"
   },
   "stable": {
    "version": [
@@ -128905,11 +129584,11 @@
   "repo": "ideasman42/emacs-undo-fu",
   "unstable": {
    "version": [
-    20250611,
-    2331
+    20251126,
+    509
    ],
-   "commit": "545e29459e71a9aca81c96c1385d43a5696e27e9",
-   "sha256": "0kalasgpd0ss2rj17zz8n089jbzjing9znqg4405jp3zdff7m5m2"
+   "commit": "4af1999bf3560a8fc35d1d4c1e5fd216266986a6",
+   "sha256": "18hcka7qsacrymxyvny8m975k196qkkc4a836pxq71j5bidjgyn9"
   }
  },
  {
@@ -128920,11 +129599,11 @@
   "repo": "ideasman42/emacs-undo-fu-session",
   "unstable": {
    "version": [
-    20250918,
-    17
+    20251126,
+    1143
    ],
-   "commit": "366717d88f77182f780829f2041f1a16ca2970c7",
-   "sha256": "101fq3z33f1742gzrzhwv5x8ig8zj1yqlidmvfgdgqkcmm5a61rl"
+   "commit": "d3067c0063d067d79061c10031b7033874d17368",
+   "sha256": "0n7hpxl90zj5r2ms5mfm751536wdpyzvk24z038mjdxkbdrin8xq"
   }
  },
  {
@@ -129154,11 +129833,11 @@
   "repo": "astoff/unicode-math-input.el",
   "unstable": {
    "version": [
-    20220302,
-    1231
+    20251012,
+    953
    ],
-   "commit": "06bf37d649fc3b41fcd5fa29c0b0eda555aaf8bb",
-   "sha256": "0i6qyc5jl1151dyp95wjx7f7fs4m0pb7qnlb6skr33rrfl1icmpn"
+   "commit": "d7ee1a963f140acd5650b86e808129077c6a7828",
+   "sha256": "0xsf0v2pnq1zaln8hcrd4np9d5clxykh9bhfvhrkp2zwi9xirr5s"
   }
  },
  {
@@ -129317,14 +129996,14 @@
   "repo": "tbanel/uniline",
   "unstable": {
    "version": [
-    20251005,
-    1159
+    20251123,
+    1415
    ],
    "deps": [
     "hydra"
    ],
-   "commit": "c55d942b145df12658116ce174e11ed593b554dc",
-   "sha256": "03xnzngk8jc71qimp4a6zd7mgss1hi6krpdbmcyddpbgx9qs173w"
+   "commit": "111930d8c4965e3447deb1d0b5e027d064d81798",
+   "sha256": "0c7mn6np0szv9xlm1ki7akimpxdd2hjy1axl5gf2s7l68wnzrhvs"
   }
  },
  {
@@ -129443,26 +130122,26 @@
   "repo": "swflint/emacs-universal-sidecar",
   "unstable": {
    "version": [
-    20250731,
-    200
+    20251029,
+    1934
    ],
    "deps": [
     "magit-section"
    ],
-   "commit": "c7dcbfe357b7b32f15f3a34db29adb49044d4942",
-   "sha256": "102lmxqrz788s6izwlwyiw2z5v4mrk4vn5rpnnrn5kbhrnx8g3ag"
+   "commit": "01b12aecca0ce66f5427e7fe65012d37e7e128b2",
+   "sha256": "1gm5337d87mm3y41f787wadk7kmkdrw4rq9anb3wqhx8sn6j63gh"
   },
   "stable": {
    "version": [
     1,
-    7,
+    9,
     0
    ],
    "deps": [
     "magit-section"
    ],
-   "commit": "c7f17d5377c8d97a72f6548a82d6b259dfc8fc07",
-   "sha256": "0pjvqrjmb616x9jc1zzwvrnlnsyws6acm1c4z6hs2c6nlh18ypnk"
+   "commit": "01b12aecca0ce66f5427e7fe65012d37e7e128b2",
+   "sha256": "1gm5337d87mm3y41f787wadk7kmkdrw4rq9anb3wqhx8sn6j63gh"
   }
  },
  {
@@ -129473,26 +130152,26 @@
   "repo": "swflint/emacs-universal-sidecar",
   "unstable": {
    "version": [
-    20250704,
-    342
+    20251029,
+    1934
    ],
    "deps": [
     "citeproc"
    ],
-   "commit": "c7f17d5377c8d97a72f6548a82d6b259dfc8fc07",
-   "sha256": "0pjvqrjmb616x9jc1zzwvrnlnsyws6acm1c4z6hs2c6nlh18ypnk"
+   "commit": "01b12aecca0ce66f5427e7fe65012d37e7e128b2",
+   "sha256": "1gm5337d87mm3y41f787wadk7kmkdrw4rq9anb3wqhx8sn6j63gh"
   },
   "stable": {
    "version": [
     1,
-    7,
+    9,
     0
    ],
    "deps": [
     "citeproc"
    ],
-   "commit": "c7f17d5377c8d97a72f6548a82d6b259dfc8fc07",
-   "sha256": "0pjvqrjmb616x9jc1zzwvrnlnsyws6acm1c4z6hs2c6nlh18ypnk"
+   "commit": "01b12aecca0ce66f5427e7fe65012d37e7e128b2",
+   "sha256": "1gm5337d87mm3y41f787wadk7kmkdrw4rq9anb3wqhx8sn6j63gh"
   }
  },
  {
@@ -129503,21 +130182,21 @@
   "repo": "swflint/emacs-universal-sidecar",
   "unstable": {
    "version": [
-    20250704,
-    342
+    20251029,
+    1934
    ],
    "deps": [
     "bibtex-completion",
     "elfeed",
     "universal-sidecar"
    ],
-   "commit": "c7f17d5377c8d97a72f6548a82d6b259dfc8fc07",
-   "sha256": "0pjvqrjmb616x9jc1zzwvrnlnsyws6acm1c4z6hs2c6nlh18ypnk"
+   "commit": "01b12aecca0ce66f5427e7fe65012d37e7e128b2",
+   "sha256": "1gm5337d87mm3y41f787wadk7kmkdrw4rq9anb3wqhx8sn6j63gh"
   },
   "stable": {
    "version": [
     1,
-    7,
+    9,
     0
    ],
    "deps": [
@@ -129525,8 +130204,8 @@
     "elfeed",
     "universal-sidecar"
    ],
-   "commit": "c7f17d5377c8d97a72f6548a82d6b259dfc8fc07",
-   "sha256": "0pjvqrjmb616x9jc1zzwvrnlnsyws6acm1c4z6hs2c6nlh18ypnk"
+   "commit": "01b12aecca0ce66f5427e7fe65012d37e7e128b2",
+   "sha256": "1gm5337d87mm3y41f787wadk7kmkdrw4rq9anb3wqhx8sn6j63gh"
   }
  },
  {
@@ -129537,21 +130216,21 @@
   "repo": "swflint/emacs-universal-sidecar",
   "unstable": {
    "version": [
-    20250704,
-    342
+    20251029,
+    1934
    ],
    "deps": [
     "elfeed",
     "elfeed-score",
     "universal-sidecar"
    ],
-   "commit": "c7f17d5377c8d97a72f6548a82d6b259dfc8fc07",
-   "sha256": "0pjvqrjmb616x9jc1zzwvrnlnsyws6acm1c4z6hs2c6nlh18ypnk"
+   "commit": "01b12aecca0ce66f5427e7fe65012d37e7e128b2",
+   "sha256": "1gm5337d87mm3y41f787wadk7kmkdrw4rq9anb3wqhx8sn6j63gh"
   },
   "stable": {
    "version": [
     1,
-    7,
+    9,
     0
    ],
    "deps": [
@@ -129559,8 +130238,8 @@
     "elfeed-score",
     "universal-sidecar"
    ],
-   "commit": "c7f17d5377c8d97a72f6548a82d6b259dfc8fc07",
-   "sha256": "0pjvqrjmb616x9jc1zzwvrnlnsyws6acm1c4z6hs2c6nlh18ypnk"
+   "commit": "01b12aecca0ce66f5427e7fe65012d37e7e128b2",
+   "sha256": "1gm5337d87mm3y41f787wadk7kmkdrw4rq9anb3wqhx8sn6j63gh"
   }
  },
  {
@@ -129571,28 +130250,28 @@
   "repo": "swflint/emacs-universal-sidecar",
   "unstable": {
    "version": [
-    20250704,
-    342
+    20251029,
+    1934
    ],
    "deps": [
     "org-roam",
     "universal-sidecar"
    ],
-   "commit": "c7f17d5377c8d97a72f6548a82d6b259dfc8fc07",
-   "sha256": "0pjvqrjmb616x9jc1zzwvrnlnsyws6acm1c4z6hs2c6nlh18ypnk"
+   "commit": "01b12aecca0ce66f5427e7fe65012d37e7e128b2",
+   "sha256": "1gm5337d87mm3y41f787wadk7kmkdrw4rq9anb3wqhx8sn6j63gh"
   },
   "stable": {
    "version": [
     1,
-    7,
+    9,
     0
    ],
    "deps": [
     "org-roam",
     "universal-sidecar"
    ],
-   "commit": "c7f17d5377c8d97a72f6548a82d6b259dfc8fc07",
-   "sha256": "0pjvqrjmb616x9jc1zzwvrnlnsyws6acm1c4z6hs2c6nlh18ypnk"
+   "commit": "01b12aecca0ce66f5427e7fe65012d37e7e128b2",
+   "sha256": "1gm5337d87mm3y41f787wadk7kmkdrw4rq9anb3wqhx8sn6j63gh"
   }
  },
  {
@@ -130033,11 +130712,11 @@
   "repo": "ideasman42/emacs-utimeclock",
   "unstable": {
    "version": [
-    20250913,
-    2251
+    20251126,
+    346
    ],
-   "commit": "a3022c1d4c69de1b51e061288e8f08cab02ef991",
-   "sha256": "1jf232h9cla1nnm2rh673npw73fjgz0sp2dcmjrij50vqsy3kqz2"
+   "commit": "ae0659efff1ef369deba01019240b19b238d36a7",
+   "sha256": "1lh9bjcg3hmhg4s8xbnwwj5pdvxmdv31qxsiqyl7z7ydm0zlzjj7"
   }
  },
  {
@@ -130102,10 +130781,10 @@
   "stable": {
    "version": [
     1,
-    0
+    2
    ],
-   "commit": "f096f35a6e1f27d2bc9e9093cd61dd97bc33f502",
-   "sha256": "1nzf7cllyvx7kwdzpf0nl3g5a8mn6qgifa60aw68h0sx9a80xp01"
+   "commit": "7b728c1d92e196c3acf87a004949335cfc18eab3",
+   "sha256": "1z7x4p1qgyginn74xapd1iq0k53m9qbfk57dzc8srg7fcn5ip1js"
   }
  },
  {
@@ -130847,11 +131526,11 @@
   "repo": "federicotdn/verb",
   "unstable": {
    "version": [
-    20250916,
-    350
+    20251026,
+    1520
    ],
-   "commit": "3179e53373b9c39845a460474e5483a28c0d22c5",
-   "sha256": "0xwnzskbaladg7646y99rpcq4615l2qjqlrn241gqrk8xjkh78qc"
+   "commit": "600a9bdf82aad7d88c93ba929a7eb94c6a7c0034",
+   "sha256": "0pkjbqpl90viprlncpg9828dwk3gj2qpqz3ag7rkm6qi1yxmb712"
   },
   "stable": {
    "version": [
@@ -130908,8 +131587,8 @@
   "repo": "gmlarumbe/verilog-ext",
   "unstable": {
    "version": [
-    20251008,
-    2322
+    20251121,
+    1445
    ],
    "deps": [
     "ag",
@@ -130923,8 +131602,8 @@
     "verilog-ts-mode",
     "yasnippet"
    ],
-   "commit": "fb7d629688f862e0bdb91986d72bcff2ae7c3e23",
-   "sha256": "1hgplmd9zzikp6wklx4y8svzd7n2i0rmfhphpms0f2zl74ana6c6"
+   "commit": "541e031ca391960aaaa41f774d83ed55a90f6767",
+   "sha256": "16l75pscb7qii8rldck7c5iy3xplfwdjm60259nbr4zwpkh01zqh"
   },
   "stable": {
    "version": [
@@ -131079,25 +131758,25 @@
   "repo": "minad/vertico",
   "unstable": {
    "version": [
-    20250908,
-    1638
+    20251115,
+    1826
    ],
    "deps": [
     "compat"
    ],
-   "commit": "488685badfdf49bb750a213f228bdba8e113c7c8",
-   "sha256": "1cc7myy92sc6rks0fp0916cbgfdh5ars0z918cpyfrm0pkingq7x"
+   "commit": "8cff876a15203d24c42e19585fe6dcce8f735bbe",
+   "sha256": "167kxzp9j6xffblzqqdrbr1bpgkxnlkvkb3szsksrjy25qzkl5sy"
   },
   "stable": {
    "version": [
     2,
-    5
+    6
    ],
    "deps": [
     "compat"
    ],
-   "commit": "488685badfdf49bb750a213f228bdba8e113c7c8",
-   "sha256": "1cc7myy92sc6rks0fp0916cbgfdh5ars0z918cpyfrm0pkingq7x"
+   "commit": "8cff876a15203d24c42e19585fe6dcce8f735bbe",
+   "sha256": "167kxzp9j6xffblzqqdrbr1bpgkxnlkvkb3szsksrjy25qzkl5sy"
   }
  },
  {
@@ -131186,8 +131865,8 @@
   "repo": "gmlarumbe/vhdl-ext",
   "unstable": {
    "version": [
-    20251009,
-    1205
+    20251118,
+    1340
    ],
    "deps": [
     "ag",
@@ -131198,8 +131877,8 @@
     "ripgrep",
     "vhdl-ts-mode"
    ],
-   "commit": "abaeede75309794b6d104af2d387452f148e5ca4",
-   "sha256": "1nh3qi25rlgq701gzxjibx8mplzwps1j4rz6cq65vkbrbzxj16l1"
+   "commit": "19b5be6e3b794e848b2554ffc6f03dfb35c75c8e",
+   "sha256": "0pqfci24mbp8cjwrikvs4gvfvgf0wjqv68nzzcs7lqx41682ixpd"
   },
   "stable": {
    "version": [
@@ -131342,11 +132021,11 @@
   "repo": "jamescherti/vim-tab-bar.el",
   "unstable": {
    "version": [
-    20250914,
-    124
+    20251103,
+    1435
    ],
-   "commit": "ec339632e0fa52045fc4bdc7fcfaee60d6e8eff1",
-   "sha256": "0cvjx9fw5aznbkw6di450x3hpbk491rl2a4hshxhbm6j5bp5bfjx"
+   "commit": "443d30204c63111190759721d87812cd13bb8a7b",
+   "sha256": "0f5354rr1h33w0hnqla4pjbrbbvwnfv1g07yq2az9mffss17xacm"
   },
   "stable": {
    "version": [
@@ -131390,15 +132069,15 @@
   "repo": "matsievskiysv/vimish-fold",
   "unstable": {
    "version": [
-    20201205,
-    1156
+    20251023,
+    1551
    ],
    "deps": [
     "cl-lib",
     "f"
    ],
-   "commit": "a6501cbfe3db791f9ca17fd986c7202a87f3adb8",
-   "sha256": "0w0r951c6vn890h1cz5l8rl6hicna6rbdzfgbg4lpm280yds9lpb"
+   "commit": "f71f374d28a83e5f15612fa64aac1b2e78be2dcd",
+   "sha256": "0jsfp9kz1ydxck8ds5rghw1aqpmlz0k3l39glzcs8gq0jvb0q8fl"
   },
   "stable": {
    "version": [
@@ -131550,17 +132229,17 @@
  },
  {
   "ename": "visible-mark",
-  "commit": "a3645b08cb46e3d91081da7baa982b5283918447",
-  "sha256": "1imb44nf7nr61fypar60cmvggqg3nsfnhykqjdbm2nv3z4yfsrjw",
-  "fetcher": "sourcehut",
-  "repo": "iank/visible-mark",
+  "commit": "84811dc2212c5e2d1bb7e2b51e9dbef2067b7cc1",
+  "sha256": "1r83gf7zw6iw73rr2917ifv4a6n2s3h8ig46a1864kmk3715505b",
+  "fetcher": "codeberg",
+  "repo": "ideasman42/emacs-visible-mark",
   "unstable": {
    "version": [
-    20150624,
-    450
+    20251126,
+    345
    ],
-   "commit": "c1852e13b6b61982738b56977a452ec9026faf1b",
-   "sha256": "15zdbvv6c114mv6hdq375l7ax70sss06p9d7m86hgssc3kiv9vsv"
+   "commit": "af4e38bb919e1d5aaaa9bb10877530a96038342f",
+   "sha256": "1q88kzm8682m2bf9zg6138412hzwlr0riqnnfwi40y6ql8igki1k"
   }
  },
  {
@@ -131586,19 +132265,20 @@
   "repo": "joostkremers/visual-fill-column",
   "unstable": {
    "version": [
-    20250925,
-    1054
+    20251110,
+    1039
    ],
-   "commit": "a38e3a28e580084749f5adb31a382aba118fa2bd",
-   "sha256": "0dlwbp59dcyikr2p0jyjz9k81la2scskj7wc9w085y1fcf36fpnr"
+   "commit": "9c0ecc2af21d3024a2a838c30d574e86265a52be",
+   "sha256": "1xsc49w5bkznaij2g9qdspv6gh83bxdhxb44s3wxvjrb8cyvy9sq"
   },
   "stable": {
    "version": [
     2,
-    7
+    7,
+    1
    ],
-   "commit": "30fc3e4ea9aa415eccc873e5d7c4f1bbc0491495",
-   "sha256": "0sy01jx8z229ival3y4bj0jrb3w2ys8kiw3bmy6ssjwbl7xlyxxj"
+   "commit": "9c0ecc2af21d3024a2a838c30d574e86265a52be",
+   "sha256": "1xsc49w5bkznaij2g9qdspv6gh83bxdhxb44s3wxvjrb8cyvy9sq"
   }
  },
  {
@@ -131813,11 +132493,11 @@
   "repo": "emacs-vs/vs-dark-theme",
   "unstable": {
    "version": [
-    20250725,
-    1905
+    20251111,
+    322
    ],
-   "commit": "c3a6d1545600ff4813d8ce2cf5a77beb9e3f8a1e",
-   "sha256": "0imikmw2dkh8ajyr47bcz49w00y96xszlj9fry8sjgfla2d8srad"
+   "commit": "3618c438b8eba8f89cba760b546c3d0f69c9d167",
+   "sha256": "04550skwv41n57wgb88pjdj3vvz6k7iwc8my4ci4pln1x4vdxj21"
   },
   "stable": {
    "version": [
@@ -131836,11 +132516,11 @@
   "repo": "emacs-vs/vs-light-theme",
   "unstable": {
    "version": [
-    20250725,
-    1905
+    20251111,
+    322
    ],
-   "commit": "a3edd50b794816e59ef5ab744dffe5dc3e192210",
-   "sha256": "10zfhran587zaxp0wdl0xbhq2qr0ciki1wmzb7ms85qfw1pgc2jz"
+   "commit": "5df4eb5df7ed6a93c4e55bc622a7ad39424bc996",
+   "sha256": "0bjgzfb7k1wbhsxx8b9nbl8rcxvsbsb3d25nv4ssi316w6d5bjma"
   },
   "stable": {
    "version": [
@@ -131928,11 +132608,11 @@
   "repo": "akermu/emacs-libvterm",
   "unstable": {
    "version": [
-    20250929,
-    1514
+    20251119,
+    1653
    ],
-   "commit": "adf8d10212d15f9bd5ca62b96c7b423be02ce3c4",
-   "sha256": "1275g9wjqp56ghjgki9pqzb569pp58hcxiy3hy0752pgx0qyaa17"
+   "commit": "a01a2894a1c1e81a39527835a9169e35b7ec5dec",
+   "sha256": "0j8ngl6k0i5nfhkrqvw0bdrk2m3yzjd7vsf3r9hz2gg2pln4za8p"
   }
  },
  {
@@ -132519,16 +133199,16 @@
   "repo": "emacsmirror/wanderlust",
   "unstable": {
    "version": [
-    20250907,
-    2201
+    20251102,
+    2110
    ],
    "deps": [
     "apel",
     "flim",
     "semi"
    ],
-   "commit": "a642423f7fee4a55406501ea896e17c7cf9e3133",
-   "sha256": "0fhpcvgb9g0yk342iqfx4mgygc14xcqmc86yybb8m17amkhs50dd"
+   "commit": "9414fc386945870913e5183817593596315eddd8",
+   "sha256": "18cs87m7h7djpb8pfignjcfhjgx2sh0p1fad0nhbyrykh94ym73i"
   }
  },
  {
@@ -133087,17 +133767,17 @@
  },
  {
   "ename": "websearch",
-  "commit": "21936b2b821a564c02415d31982cbf0af8b05049",
-  "sha256": "1y7nh200ckjd2h2zfki4sc3464jv0g4x3g2g9vc90hyg1yvq1vcy",
+  "commit": "dcf3a770af51d6cb3a45b85d81d4a517f7d91959",
+  "sha256": "0im8mf8mdqcn4zrzzfl53g1vsaa928l0ia4vhwhjfzp4b8jcz6jn",
   "fetcher": "gitlab",
-  "repo": "xgqt/emacs-websearch",
+  "repo": "xgqt/xgqt-elisp-lib-websearch",
   "unstable": {
    "version": [
-    20230705,
-    1639
+    20251026,
+    2108
    ],
-   "commit": "5120cec3c36ddcdaceb5235c0b52eecbc3b37fcb",
-   "sha256": "0q6y2347w4mfshnxjvkk4vm0bmi24zpz7kc0irk0cl7hxa20025d"
+   "commit": "7d5700b1f0b9e276ab423e06f3f98d661c67b022",
+   "sha256": "1zd59bamd58296r1iig7c5dib3gnkkm4irhjhx6k125jzyfgbjar"
   },
   "stable": {
    "version": [
@@ -134163,19 +134843,19 @@
   "repo": "warsaw/winring",
   "unstable": {
    "version": [
-    20240905,
-    1634
+    20251122,
+    112
    ],
-   "commit": "83f0d5662ad48c0813b824501a36a599bdd7acf6",
-   "sha256": "0mlsad3mwdxzrnnglhwsifzgbcl1wvi6z1rpq115j2jfv01pn284"
+   "commit": "286bd61536396e262295a442b7a5ed49cbcc81d9",
+   "sha256": "1h14wv8wqxkd3msdrwgdikhy3xmpd1iz7059c2jz695css666pm0"
   },
   "stable": {
    "version": [
-    5,
-    2
+    6,
+    0
    ],
-   "commit": "5a5e496364ecdb3245e396fab6c9e2fe25dd943c",
-   "sha256": "1hw7z80hw3xg7a7ngw98iv16sw86cdm2d98bi98f6b1dvng1jbnz"
+   "commit": "286bd61536396e262295a442b7a5ed49cbcc81d9",
+   "sha256": "1h14wv8wqxkd3msdrwgdikhy3xmpd1iz7059c2jz695css666pm0"
   }
  },
  {
@@ -134218,11 +134898,11 @@
   "url": "https://hg.sr.ht/~arnebab/wisp",
   "unstable": {
    "version": [
-    20240921,
-    1758
+    20251108,
+    2318
    ],
-   "commit": "61d068638c88d149a6f75619e284f8c1e9657e90",
-   "sha256": "13z6xy84cswimjl8r07pxn5g3b1kcimgl1jfw8ay2ckq25z8r3ab"
+   "commit": "cfebcd5f097f2f7bbb0f5b0c3730584313c93bac",
+   "sha256": "1pq5qiswihisym9c7161m3flh4idhmk1dagzlvak8riz0h47glm4"
   },
   "stable": {
    "version": [
@@ -134272,26 +134952,26 @@
   "repo": "magit/with-editor",
   "unstable": {
    "version": [
-    20250901,
-    1618
+    20251101,
+    2100
    ],
    "deps": [
     "compat"
    ],
-   "commit": "87a384a0e59260cca41ca8831d98e195b1ec8ada",
-   "sha256": "1d0y32y934ld60vdyx9hwbvpifmhdmm08066x0ivxqcyw0qyggxg"
+   "commit": "dbc694406c2fd8e9d3e6ffbc4f8aff4e8c28029f",
+   "sha256": "0x4qw9yd0kzg2kkm8wjm9l0ikzb9aj9v5s753bjp3bajal94jw3q"
   },
   "stable": {
    "version": [
     3,
     4,
-    6
+    7
    ],
    "deps": [
     "compat"
    ],
-   "commit": "87a384a0e59260cca41ca8831d98e195b1ec8ada",
-   "sha256": "1d0y32y934ld60vdyx9hwbvpifmhdmm08066x0ivxqcyw0qyggxg"
+   "commit": "dbc694406c2fd8e9d3e6ffbc4f8aff4e8c28029f",
+   "sha256": "0x4qw9yd0kzg2kkm8wjm9l0ikzb9aj9v5s753bjp3bajal94jw3q"
   }
  },
  {
@@ -134574,28 +135254,28 @@
   "repo": "swflint/emacs-universal-sidecar",
   "unstable": {
    "version": [
-    20250704,
-    342
+    20251029,
+    1934
    ],
    "deps": [
     "compat",
     "universal-sidecar"
    ],
-   "commit": "c7f17d5377c8d97a72f6548a82d6b259dfc8fc07",
-   "sha256": "0pjvqrjmb616x9jc1zzwvrnlnsyws6acm1c4z6hs2c6nlh18ypnk"
+   "commit": "01b12aecca0ce66f5427e7fe65012d37e7e128b2",
+   "sha256": "1gm5337d87mm3y41f787wadk7kmkdrw4rq9anb3wqhx8sn6j63gh"
   },
   "stable": {
    "version": [
     1,
-    7,
+    9,
     0
    ],
    "deps": [
     "compat",
     "universal-sidecar"
    ],
-   "commit": "c7f17d5377c8d97a72f6548a82d6b259dfc8fc07",
-   "sha256": "0pjvqrjmb616x9jc1zzwvrnlnsyws6acm1c4z6hs2c6nlh18ypnk"
+   "commit": "01b12aecca0ce66f5427e7fe65012d37e7e128b2",
+   "sha256": "1gm5337d87mm3y41f787wadk7kmkdrw4rq9anb3wqhx8sn6j63gh"
   }
  },
  {
@@ -134999,14 +135679,14 @@
   "repo": "cjennings/emacs-wttrin",
   "unstable": {
    "version": [
-    20250925,
-    1236
+    20251113,
+    2014
    ],
    "deps": [
     "xterm-color"
    ],
-   "commit": "4d8973dcc5c3c3d043011e67c8d4e9d581df6a43",
-   "sha256": "18mrw1g3vix6a1jh0wldlrqjjbd34q3hg2qwwm0jflzdsjlzjkqg"
+   "commit": "bf989bb594680eb2e3b69f55752353aa33cb47bb",
+   "sha256": "0vphfq7whv53k631pn91hq6m28dmzn6hblgzwkcda6sval4x6qs8"
   },
   "stable": {
    "version": [
@@ -135120,14 +135800,14 @@
   "repo": "jobbflykt/x509-mode",
   "unstable": {
    "version": [
-    20250317,
-    1016
+    20251105,
+    1853
    ],
    "deps": [
     "compat"
    ],
-   "commit": "a59a548f087bfad4f81d9410b6facdcf0fdd98f9",
-   "sha256": "15mypcysz2f4f027j7k9yh6inrj24dllpiqxjc89srw8j6k770qb"
+   "commit": "02e62ebd857946de629e45bff6a7de533f9022bc",
+   "sha256": "16dyzhm7h19w64y40ma8x2bnmmg9ww5hhwp80sdqfcckyrzw08sm"
   }
  },
  {
@@ -135651,11 +136331,11 @@
   "repo": "ideasman42/emacs-xref-rst",
   "unstable": {
    "version": [
-    20240421,
-    814
+    20251126,
+    344
    ],
-   "commit": "c6dd6cc6df1d9dd311cb0f421b86beadfa3156ce",
-   "sha256": "0cb7ijk4x65r9wxwgrvwjqh1s8mg9vj3d41208rgn9q3849krg48"
+   "commit": "b21455d2b9949c6ae2787d31d2c3f2703ec8688f",
+   "sha256": "0gk4321zqsbrqrmb7sg8isls09sgsrgcpqj3sln414zxgwl7zjdw"
   }
  },
  {
@@ -135690,11 +136370,11 @@
   "repo": "atomontage/xterm-color",
   "unstable": {
    "version": [
-    20230321,
-    3
+    20251128,
+    1842
    ],
-   "commit": "2ad407c651e90fff2ea85d17bf074cee2c022912",
-   "sha256": "1zy6sap394f4gb0q41mdipd7gii9qyy2840pgkf4mfpsxim3agls"
+   "commit": "ce82e87ea3d277c7e4fc48ce390d540fbd78f6d1",
+   "sha256": "0zkjfvma70lw0iv31g1n1naz40d2wpngiasnjy9gslm1nybxj76a"
   },
   "stable": {
    "version": [
@@ -135989,20 +136669,20 @@
   "repo": "zkry/yaml.el",
   "unstable": {
    "version": [
-    20250316,
-    1721
+    20251029,
+    2056
    ],
-   "commit": "f99ef76c80e6fc3fcf650c4fe34e10726594a4c4",
-   "sha256": "1fpfyrbi8dzbcck0k1whszqr9qmyw4x6rk68sxzz7zr5sqw69172"
+   "commit": "3fbeaee97dce3c76a18b02a28c58777cbcdadf2f",
+   "sha256": "15rkbyxz7zzkizj77ml4j6h2i2fmxf8hr4xa8zwpi8al8s3ja2vk"
   },
   "stable": {
    "version": [
     1,
     2,
-    0
+    1
    ],
-   "commit": "09e46d563f1f3ff948852e08360c7d3c76e2acba",
-   "sha256": "131g2nv18fjcqgc9v17b0a7zyw2m6ydbhj6riahihd340bci2s6w"
+   "commit": "d3762199e6d525e26b49c8263648229bdb512247",
+   "sha256": "1gp3076cf32vq8925c38xpd9cxnndlx5xazagh34irrq6dvb2y10"
   }
  },
  {
@@ -136334,14 +137014,14 @@
   "repo": "AndreaCrotti/yasnippet-snippets",
   "unstable": {
    "version": [
-    20250808,
-    819
+    20251010,
+    1018
    ],
    "deps": [
     "yasnippet"
    ],
-   "commit": "4f9f9e7b29822d66a34b7d5f1c19ed65cce1d8e1",
-   "sha256": "16br8pmhv3i4jcxwrk39f9ki5pixzwfz9x1bw5cvywdpqs0d4367"
+   "commit": "182a43cb937d98847448c17466eed224d8893930",
+   "sha256": "15c4c90ckymybsj09ngnjccpvvw8kqz8h0bcp3fcxwqqhfghzqyf"
   },
   "stable": {
    "version": [
@@ -136542,14 +137222,14 @@
   "url": "https://git.thanosapollo.org/yeetube",
   "unstable": {
    "version": [
-    20250927,
-    411
+    20251028,
+    1659
    ],
    "deps": [
     "compat"
    ],
-   "commit": "e897ff82307b1003b9bdb88e7594a9df90398d7f",
-   "sha256": "1qi7l606rdiz9i0vd27k9bhnqbwdixw7vjc0frcycxih26dvkvzz"
+   "commit": "02bc06de12e1ff4786a15ec9aa17d6c568c8e42a",
+   "sha256": "1hnh5hwbm3g3q3mrlfa6zm7dn26l88hv5bqk244rwh8v61y8lha5"
   },
   "stable": {
    "version": [
@@ -136940,11 +137620,11 @@
   "repo": "bbatsov/zenburn-emacs",
   "unstable": {
    "version": [
-    20240926,
-    619
+    20251028,
+    1226
    ],
-   "commit": "82112c64c5b0d3b866e82417dd730e0d0d7e1424",
-   "sha256": "0bvdcdk7jhwv6jqv9wlprpwn6w0j9k2yy9xm2nx8m5wn2rgf6caq"
+   "commit": "d9557cf5ab9c03dc70693e3892f5ffdc5d345d22",
+   "sha256": "12h0xq6nicp6yz7mclr8kr4hqca4b85n9dxxm2s07w9jvzi487fp"
   },
   "stable": {
    "version": [
@@ -137439,14 +138119,14 @@
   "repo": "dcolazin/ziggy-mode",
   "unstable": {
    "version": [
-    20250930,
-    4
+    20251017,
+    527
    ],
    "deps": [
     "reformatter"
    ],
-   "commit": "07db893782d095b95f304669b7c652f5a7888ddd",
-   "sha256": "1b4mmhzy8a7vgrhnmxwcyn59xw4vwfq7lk9c38pc5pmvbqn3aay5"
+   "commit": "5b42008a022ae1d9221add6f57ce65715d7f9947",
+   "sha256": "0j9wpqdm6hlalbpqjlh405xza99hh68yj7qywkyqkrrqrh4d16yg"
   }
  },
  {
@@ -137486,6 +138166,26 @@
    ],
    "commit": "76cf76bdc871cb0454a6fc555aeb1aa94f1b6e57",
    "sha256": "1vx4j9n5q4gmc63lk1l4gbz5j5qn2423cyfibqcbynkkbwgas11z"
+  }
+ },
+ {
+  "ename": "zine-mode",
+  "commit": "075aa84a263c28c7ccf9196644023dc12c2f10ac",
+  "sha256": "0xfa6zv82asnxzi54q0wr38id96krza1sb42qvzafi8h0a2r9dn7",
+  "fetcher": "github",
+  "repo": "dcolazin/zine-mode",
+  "unstable": {
+   "version": [
+    20251022,
+    2145
+   ],
+   "deps": [
+    "markdown-mode",
+    "reformatter",
+    "ziggy-mode"
+   ],
+   "commit": "e54a3bde1f8ea5ed00b91c7bf038329a9b0da174",
+   "sha256": "12abrx4rz58baaagim55gdgdvkvq44fggl4pwdgg692isyny0xcv"
   }
  },
  {

--- a/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
@@ -86660,11 +86660,11 @@
   "repo": "ashton314/nordic-night",
   "unstable": {
    "version": [
-    20251129,
-    409
+    20250624,
+    1732
    ],
-   "commit": "5d35f9c9da0ab7138b0a4897daaf52d78f4a1a37",
-   "sha256": "1l2k4xd2bcnbsyj733ry2p8vqr39rrdypzapsrg8hcp86zcnvk1p"
+   "commit": "a500ccc22fab22b291dfbddc8c534e665ae144f9",
+   "sha256": "03h3q9kwq3ss89hbs8ahl8xxafnx1fx3cdfidz3hbh5nm7ycz08l"
   },
   "stable": {
    "version": [


### PR DESCRIPTION
Runs `pkgs/applications/editors/emacs/elisp-packages/update` to update Emacs package data. 

related: #466358 and #465282.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
