### PR TITLE
xfce.xfce4-terminal: add sixel support

### DIFF
--- a/pkgs/by-name/vt/vte-sixel/package.nix
+++ b/pkgs/by-name/vt/vte-sixel/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  vte,
+  fetchFromGitHub,
+}:
+
+vte.overrideAttrs (old: {
+  src = fetchFromGitHub {
+    owner = "GNOME";
+    repo = "vte";
+    rev = "f83883d4d3f2cbf73516e073a61d715a5d2aadd2";
+    hash = "sha256-kc9tlqfQDYQTOgtIEJsUsjP9ZTRypDLhck5N6guL4us=";
+  };
+
+  patches = [ ];
+
+  mesonFlags =
+    (lib.filter (
+      flag:
+      # app option needs to be removed:
+      # meson.build:17:0: ERROR: Unknown option: "app".
+      !(lib.hasPrefix "-Dapp=" flag)
+    ) old.mesonFlags)
+    ++ [
+      (lib.mesonBool "sixel" true)
+    ];
+})

--- a/pkgs/desktops/xfce/applications/xfce4-terminal/default.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-terminal/default.nix
@@ -17,11 +17,16 @@
   libxfce4ui,
   pcre2,
   vte,
+  vte-sixel,
   xfconf,
   nixosTests,
   gitUpdater,
+  withSixel ? false,
 }:
 
+let
+  vte' = if withSixel then vte-sixel else vte;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "xfce4-terminal";
   version = "1.1.5";
@@ -55,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
     libX11
     libxfce4ui
     pcre2
-    vte
+    vte'
     xfconf
   ];
 

--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -88,6 +88,9 @@ makeScopeWithSplicing' {
       xfce4-dict = callPackage ./applications/xfce4-dict { };
 
       xfce4-terminal = callPackage ./applications/xfce4-terminal { };
+      xfce4-terminal-sixel = callPackage ./applications/xfce4-terminal {
+        withSixel = true;
+      };
 
       xfce4-screensaver = callPackage ./applications/xfce4-screensaver { };
 


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/252845

I'm not really expecting to get this merged, ~~especially that it doesn't work~~ only works with old `vte`.
This serves as a proof of concept if anyone else wants to try it.

Related:
- push back against adding sixel to vte: https://github.com/NixOS/nixpkgs/pull/224104
- blackbox got sixel support: https://github.com/NixOS/nixpkgs/pull/248682
  - reverted in https://github.com/NixOS/nixpkgs/pull/464357 due to maintainance burden

To try this makes sure xfce4-terminal is not open (eg. do this from alacritty) and run:
`nix run github:gepbird/nixpkgs/feat/xfce4-terminal/sixel#xfce.xfce4-terminal-sixel`

For me it shows that sixel support is enabled, `lsix` doesn't complain, but the image itself is not displayed:

<img width="946" height="951" alt="image" src="https://github.com/user-attachments/assets/995132f7-1d13-431b-948f-281d2dd7e695" />


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
