### PR TITLE
go-hass-agent: init at 11.1.2

### DIFF
--- a/pkgs/by-name/go/go-hass-agent/package.nix
+++ b/pkgs/by-name/go/go-hass-agent/package.nix
@@ -1,0 +1,115 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+  writeShellScriptBin,
+  installShellFiles,
+  mage,
+  pkg-config,
+  writableTmpDirAsHomeHook,
+  libglvnd,
+  xorg,
+  go,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "go-hass-agent";
+  version = "11.1.2";
+
+  src = fetchFromGitHub {
+    owner = "joshuar";
+    repo = "go-hass-agent";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ahEeZdVTL9psd+TurRxDCz7EG4AK/xW94pYImYIMsrw=";
+  };
+
+  vendorHash = "sha256-02sWRWWadZFMaLjJV181bAioNyuN7mG0ZzrkrTdUTqU=";
+
+  nativeBuildInputs =
+    let
+      # dont need to pull in actual git just need the build script
+      # to have this info
+      fakeGit = writeShellScriptBin "git" ''
+        if [[ $@ = "describe --tags --always --dirty" ]]; then
+            echo "v${finalAttrs.version}"
+        elif [[ $@ = "rev-parse --short HEAD" ]]; then
+            echo ""
+        elif [[ $@ = "log --date=iso8601-strict -1 --pretty=%ct" ]]; then
+            echo "0"
+        else
+            >&2 echo "Unknown command: $@"
+            exit 1
+        fi
+      '';
+    in
+    [
+      fakeGit
+      installShellFiles
+      mage
+      pkg-config
+      writableTmpDirAsHomeHook
+    ];
+
+  buildInputs = [
+    libglvnd
+    xorg.libXcursor
+    xorg.libXi
+    xorg.libXinerama
+    xorg.libXrandr
+    xorg.libXxf86vm
+  ];
+
+  desktopItems = [ "assets/go-hass-agent.desktop" ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    mage -d build/magefiles -w . build:full
+
+    runHook postBuild
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+
+    mage -d build/magefiles -w . tests:test
+
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    installBin dist/go-hass-agent-${go.GOARCH}
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Home Assistant native app for desktop/laptop devices";
+    mainProgram = "go-hass-agent";
+    longDescription = ''
+      Go Hass Agent is an application to expose sensors, controls, and events
+      from a device to Home Assistant. You can think of it as something similar
+      to the Home Assistant companion app for mobile devices, but for your
+      desktop, server, Raspberry Pi, Arduino, toaster, whatever. If it can run
+      Go and Linux, it can run Go Hass Agent!
+
+      Out of the box, Go Hass Agent will report lots of details about the system
+      it is running on. You can extend it with additional sensors and controls
+      by hooking it up to MQTT. You can extend it even further with your own
+      custom sensors and controls with scripts/programs.
+
+      You can then use these sensors, controls, or events in any automations and
+      dashboards, just like the companion app or any other “thing” you've added
+      into Home Assistant.
+    '';
+    license = lib.licenses.mit;
+    homepage = "https://github.com/joshuar/go-hass-agent";
+    changelog = "https://github.com/joshuar/go-hass-agent/blob/v${finalAttrs.version}/CHANGELOG.md";
+    maintainers = [ lib.maintainers.ethancedwards8 ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Closes: https://github.com/NixOS/nixpkgs/pull/374215

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
