### PR TITLE
python3Packages.peft: 0.17.1 -> 0.18.0

### DIFF
--- a/pkgs/development/python-modules/peft/default.nix
+++ b/pkgs/development/python-modules/peft/default.nix
@@ -31,14 +31,14 @@
 
 buildPythonPackage rec {
   pname = "peft";
-  version = "0.17.1";
+  version = "0.18.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "huggingface";
     repo = "peft";
     tag = "v${version}";
-    hash = "sha256-xtpxwbKf7ZaUYblGdwtPZE09qrlBQTMm5oryUJwa6AA=";
+    hash = "sha256-LLV6fMFPh45IvNJv9totMYDoKAkZW/1Bx3qOlDTWMLA=";
   };
 
   build-system = [ setuptools ];
@@ -73,6 +73,8 @@ buildPythonPackage rec {
   # These tests fail when MPS devices are detected
   disabledTests = lib.optional stdenv.hostPlatform.isDarwin [
     "gpu"
+    "test_save_load"
+    "test_resume_training_model_with_topk_weights"
   ];
 
   disabledTestPaths = [
@@ -81,6 +83,7 @@ buildPythonPackage rec {
 
     # Require internet access to download a dataset
     "tests/test_adaption_prompt.py"
+    "tests/test_arrow.py"
     "tests/test_auto.py"
     "tests/test_boft.py"
     "tests/test_cpt.py"
@@ -92,9 +95,9 @@ buildPythonPackage rec {
     "tests/test_hub_features.py"
     "tests/test_incremental_pca.py"
     "tests/test_initialization.py"
+    "tests/test_lora_variants.py"
     "tests/test_mixed.py"
     "tests/test_multitask_prompt_tuning.py"
-    "tests/test_other.py"
     "tests/test_other.py"
     "tests/test_poly.py"
     "tests/test_stablediffusion.py"


### PR DESCRIPTION
CHANGELOG: https://github.com/huggingface/peft/releases/tag/v0.18.0
DIFF: https://github.com/huggingface/peft/compare/v0.17.1...v0.18.0
 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
