### PR TITLE
masklint: 0.3.0 -> 0.4.1

### DIFF
--- a/pkgs/by-name/ma/masklint/package.nix
+++ b/pkgs/by-name/ma/masklint/package.nix
@@ -2,11 +2,14 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  shellcheck,
+  ruff,
+  rubocop,
   nix-update-script,
 }:
 
 let
-  version = "0.3.0";
+  version = "0.4.1";
 in
 rustPlatform.buildRustPackage {
   pname = "masklint";
@@ -16,10 +19,16 @@ rustPlatform.buildRustPackage {
     owner = "brumhard";
     repo = "masklint";
     rev = "v${version}";
-    hash = "sha256-Dku2pDUCblopHtoj6viUqHVpVH5GDApp+QLjor38j7g=";
+    hash = "sha256-PhhSJwzLTMFmisrdmsRjxWDBkBr+NjIkENHjdkTeviM=";
   };
 
-  cargoHash = "sha256-TDk7hEZ628iUnKI0LMBtsSAVNF6BGukHwB8kh70eo4U=";
+  cargoHash = "sha256-WZwl7fdy1HNKQU1zCwifoOvmFRr/fnsvmIG2wf6ILPY=";
+
+  nativeCheckInputs = [
+    shellcheck # shells
+    ruff # python
+    rubocop # ruby
+  ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/ma/masklint/package.nix
+++ b/pkgs/by-name/ma/masklint/package.nix
@@ -2,8 +2,12 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  makeWrapper,
+  withShell ? true,
   shellcheck,
+  withPython ? true,
   ruff,
+  withRuby ? true,
   rubocop,
   nix-update-script,
 }:
@@ -29,6 +33,24 @@ rustPlatform.buildRustPackage {
     ruff # python
     rubocop # ruby
   ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = (
+    if (withShell || withPython || withRuby) then
+      ''
+        wrapProgram $out/bin/masklint \
+          --prefix PATH : ${
+            lib.makeBinPath (
+              (lib.optional withShell shellcheck)
+              ++ (lib.optional withPython ruff)
+              ++ (lib.optional withRuby rubocop)
+            )
+          }
+      ''
+    else
+      ""
+  );
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
The upgrade introduced some tests, the test check :

* a shell script with `shellcheck`
* a python script with `ruff`
* a ruby script with `rubocop`

[brumhard/masklint@`v0.3.0...v0.4.1?w=1`#diff-42cb6807ad](https://github.com/brumhard/masklint/compare/v0.3.0...v0.4.1?w=1#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR161)

https://github.com/brumhard/masklint/blob/v0.4.1/test/maskfile.md

Closes brumhard/masklint#6

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
