### PR TITLE
nixos/waydroid: use waydroid-nftables by default also if kernel.version >= 6.17

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -346,7 +346,7 @@
 
 - `vmalert` now supports multiple instances with the option `services.vmalert.instances."".enable`
 
-- [`virtualisation.waydroid.package`](#opt-virtualisation.waydroid.package) now defaults to `waydroid-nftables` on systems with nftables enabled.
+- [`virtualisation.waydroid.package`](#opt-virtualisation.waydroid.package) now defaults to `waydroid-nftables` on systems with either nftables enabled or a kernel version of at least 6.17.
 
 - [`services.victorialogs.package`](#opt-services.victorialogs.package) now defaults to `victorialogs`, as `victoriametrics` no longer contains the VictoriaLogs binaries.
 

--- a/nixos/modules/virtualisation/waydroid.nix
+++ b/nixos/modules/virtualisation/waydroid.nix
@@ -26,8 +26,15 @@ in
   options.virtualisation.waydroid = {
     enable = lib.mkEnableOption "Waydroid";
     package = lib.mkPackageOption pkgs "waydroid" { } // {
-      default = if config.networking.nftables.enable then pkgs.waydroid-nftables else pkgs.waydroid;
-      defaultText = lib.literalExpression ''if config.networking.nftables.enable then pkgs.waydroid-nftables else pkgs.waydroid'';
+      default =
+        if
+          config.networking.nftables.enable
+          || lib.versionAtLeast (lib.getVersion config.boot.kernelPackages.kernel) "6.17"
+        then
+          pkgs.waydroid-nftables
+        else
+          pkgs.waydroid;
+      defaultText = lib.literalExpression ''if config.networking.nftables.enable || lib.versionAtLeast (lib.getVersion config.boot.kernelPackages.kernel) "6.17" then pkgs.waydroid-nftables else pkgs.waydroid'';
     };
   };
 

--- a/nixos/modules/virtualisation/waydroid.nix
+++ b/nixos/modules/virtualisation/waydroid.nix
@@ -26,8 +26,15 @@ in
   options.virtualisation.waydroid = {
     enable = lib.mkEnableOption "Waydroid";
     package = lib.mkPackageOption pkgs "waydroid" { } // {
-      default = if config.networking.nftables.enable then pkgs.waydroid-nftables else pkgs.waydroid;
-      defaultText = lib.literalExpression "if config.networking.nftables.enable then pkgs.waydroid-nftables else pkgs.waydroid";
+      default =
+        if
+          config.networking.nftables.enable
+          || lib.versionAtLeast (lib.getVersion config.boot.kernelPackages.kernel) "6.17"
+        then
+          pkgs.waydroid-nftables
+        else
+          pkgs.waydroid;
+      defaultText = lib.literalExpression ''if config.networking.nftables.enable || lib.versionAtLeast (lib.getVersion config.boot.kernelPackages.kernel) "6.17" then pkgs.waydroid-nftables else pkgs.waydroid'';
     };
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

also set the default waydroid package to waydroid-nftables if the kernel version is beyond the point at which ip_tables is unavaliable by default. (6.16.9)

fixes [nixos/waydroid: waydroid fails to start on latest nixpkgs unstable #459520](https://github.com/NixOS/nixpkgs/issues/459520)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
