### PR TITLE
babeldoc: init at 0.5.22

### DIFF
--- a/pkgs/by-name/ba/babeldoc/package.nix
+++ b/pkgs/by-name/ba/babeldoc/package.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  fetchpatch2,
+  writableTmpDirAsHomeHook,
+  versionCheckHook,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "babeldoc";
+  version = "0.5.22";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "funstory-ai";
+    repo = "BabelDOC";
+    tag = "v${version}";
+    hash = "sha256-ArLTv5AjpUdbsN8bQs03ATwg5ugXetld2FmHhicU8OE=";
+  };
+
+  patches = [
+    (fetchpatch2 {
+      name = "rename-python-levenshtein-to-levenshtein";
+      url = "https://github.com/funstory-ai/BabelDOC/pull/542.patch?full_index=1";
+      hash = "sha256-rjXhKVFivkJo54WdYiihqB3lrlu4YEwVZZkE4WBatWs=";
+    })
+  ];
+
+  build-system = with python3Packages; [ hatchling ];
+
+  dependencies =
+    with python3Packages;
+    [
+      bitstring
+      configargparse
+      httpx
+      huggingface-hub
+      numpy
+      onnx
+      onnxruntime
+      openai
+      orjson
+      charset-normalizer
+      cryptography
+      peewee
+      psutil
+      pymupdf
+      rich
+      toml
+      tqdm
+      xsdata
+      msgpack
+      pydantic
+      tenacity
+      scikit-image
+      freetype-py
+      tiktoken
+      levenshtein
+      opencv-python-headless
+      rapidocr-onnxruntime
+      pyzstd
+      hyperscan
+      rtree
+      chardet
+      scipy
+      uharfbuzz
+      scikit-learn
+    ]
+    ++ httpx.optional-dependencies.socks
+    ++ (with xsdata.optional-dependencies; cli ++ lxml ++ soap);
+
+  pythonImportsCheck = [ "babeldoc" ];
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+    python3Packages.pytestCheckHook
+    versionCheckHook
+  ];
+  versionCheckKeepEnvironment = "HOME";
+
+  meta = {
+    description = "PDF scientific paper translation and bilingual comparison library";
+    homepage = "https://github.com/funstory-ai/BabelDOC";
+    changelog = "https://github.com/funstory-ai/BabelDOC/releases/tag/${src.tag}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ ryota2357 ];
+    mainProgram = "babeldoc";
+  };
+}


### PR DESCRIPTION
BabelDOC is a PDF scientific paper translation and bilingual comparison library.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin (build with `--system x86_64-darwin`)
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
