### PR TITLE
qutebrowser: fix MacOS app bundle to register qutebrowser as browser

### DIFF
--- a/pkgs/by-name/qu/qutebrowser/patch-bundle-info.py
+++ b/pkgs/by-name/qu/qutebrowser/patch-bundle-info.py
@@ -1,0 +1,34 @@
+import plistlib
+import sys
+
+plist_path = sys.argv[1]
+
+# Load existing Info.plist
+with open(plist_path, 'rb') as f:
+    pl = plistlib.load(f)
+
+# These document types are required to be considered a browser by System Preferences
+document_types = [
+    {
+        'CFBundleTypeName': 'HTML Document',
+        'CFBundleTypeRole': 'Viewer',
+        'LSItemContentTypes': ['public.html', 'public.xhtml']
+    }
+]
+# These URL schemes are required to be considered a browser by System Preferences
+url_types = [
+    {
+        'CFBundleURLName': 'http(s) URLs',
+        'CFBundleURLSchemes': ['http', 'https']
+    },
+    {
+        'CFBundleURLName': 'local file URLs',
+        'CFBundleURLSchemes': ['file']
+    }
+]
+
+pl['CFBundleDocumentTypes'] = document_types
+pl['CFBundleURLTypes'] = url_types
+
+with open(plist_path, 'wb') as f:
+    plistlib.dump(pl, f)


### PR DESCRIPTION

This package currently uses `desktopToDarwinBundle` to generate an app bundle (`qutebrowser.app`) from the qutebrowser XDG Desktop specification file (`./misc/org.qutebrowser.qutebrowser.desktop`).

Since `desktopToDarwinBundle` doesn't use the MIME metadata from the .desktop file, it does not generate necessary keys in Info.plist for qutebrowser to be recognized by MacOS  as a valid browser.

This change updates the bundle's Info.plist to correctly register qutebrowser as a browser on MacOS


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
