### PR TITLE
python3Packages.typer: use mkPythonMetaPackage

### DIFF
--- a/pkgs/development/python-modules/typer-slim/default.nix
+++ b/pkgs/development/python-modules/typer-slim/default.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  pdm-backend,
+
+  # dependencies
+  click,
+  typing-extensions,
+
+  # optional-dependencies
+  rich,
+  shellingham,
+
+  # tests
+  pytest-xdist,
+  pytestCheckHook,
+  writableTmpDirAsHomeHook,
+  procps,
+}:
+
+buildPythonPackage rec {
+  pname = "typer-slim";
+  version = "0.19.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "fastapi";
+    repo = "typer";
+    tag = version;
+    hash = "sha256-mMsOEI4FpLkLkpjxjnUdmKdWD65Zx3Z1+L+XsS79k44=";
+  };
+
+  postPatch = ''
+    for f in $(find tests -type f -print); do
+      # replace `sys.executable -m coverage run` with `sys.executable`
+      sed -z -i 's/"-m",\n\?\s*"coverage",\n\?\s*"run",//g' "$f"
+    done
+  '';
+
+  env.TIANGOLO_BUILD_PACKAGE = "typer-slim";
+
+  build-system = [ pdm-backend ];
+
+  dependencies = [
+    click
+    typing-extensions
+  ];
+
+  optional-dependencies = {
+    standard = [
+      rich
+      shellingham
+    ];
+  };
+
+  nativeCheckInputs = [
+    pytest-xdist
+    pytestCheckHook
+    writableTmpDirAsHomeHook
+  ]
+  ++ lib.concatAttrValues optional-dependencies
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    procps
+  ];
+
+  disabledTests = [
+    "test_scripts"
+    # Likely related to https://github.com/sarugaku/shellingham/issues/35
+    # fails also on Linux
+    "test_show_completion"
+    "test_install_completion"
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+    "test_install_completion"
+  ];
+
+  pythonImportsCheck = [ "typer" ];
+
+  meta = {
+    description = "Library for building CLI applications";
+    homepage = "https://typer.tiangolo.com/";
+    changelog = "https://github.com/tiangolo/typer/releases/tag/${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ winpat ];
+  };
+}

--- a/pkgs/development/python-modules/typer/default.nix
+++ b/pkgs/development/python-modules/typer/default.nix
@@ -1,97 +1,20 @@
 {
   lib,
-  stdenv,
-  buildPythonPackage,
-  fetchFromGitHub,
-
-  # build-system
-  pdm-backend,
-
-  # dependencies
-  click,
-  typing-extensions,
-
-  # optional-dependencies
-  rich,
-  shellingham,
-
-  # tests
-  pytest-xdist,
-  pytestCheckHook,
-  writableTmpDirAsHomeHook,
-  procps,
-
-  # typer or typer-slim
-  package ? "typer",
+  mkPythonMetaPackage,
+  typer-slim,
 }:
 
-buildPythonPackage rec {
-  pname = package;
-  version = "0.19.2";
-  pyproject = true;
-
-  src = fetchFromGitHub {
-    owner = "fastapi";
-    repo = "typer";
-    tag = version;
-    hash = "sha256-mMsOEI4FpLkLkpjxjnUdmKdWD65Zx3Z1+L+XsS79k44=";
-  };
-
-  postPatch = ''
-    for f in $(find tests -type f -print); do
-      # replace `sys.executable -m coverage run` with `sys.executable`
-      sed -z -i 's/"-m",\n\?\s*"coverage",\n\?\s*"run",//g' "$f"
-    done
-  '';
-
-  env.TIANGOLO_BUILD_PACKAGE = package;
-
-  build-system = [ pdm-backend ];
-
-  dependencies = [
-    click
-    typing-extensions
-  ]
-  # typer includes the standard optional by default
-  # https://github.com/tiangolo/typer/blob/0.12.3/pyproject.toml#L71-L72
-  ++ lib.optionals (package == "typer") optional-dependencies.standard;
-
-  optional-dependencies = {
-    standard = [
-      rich
-      shellingham
-    ];
-  };
-
-  doCheck = package == "typer"; # tests expect standard dependencies
-
-  nativeCheckInputs = [
-    pytest-xdist
-    pytestCheckHook
-    writableTmpDirAsHomeHook
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    procps
-  ];
-
-  disabledTests = [
-    "test_scripts"
-    # Likely related to https://github.com/sarugaku/shellingham/issues/35
-    # fails also on Linux
-    "test_show_completion"
-    "test_install_completion"
-  ]
-  ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
-    "test_install_completion"
-  ];
-
-  pythonImportsCheck = [ "typer" ];
-
+mkPythonMetaPackage {
+  pname = "typer";
+  inherit (typer-slim) version optional-dependencies;
+  dependencies = [ typer-slim ] ++ typer-slim.optional-dependencies.standard;
   meta = {
-    description = "Library for building CLI applications";
-    homepage = "https://typer.tiangolo.com/";
-    changelog = "https://github.com/tiangolo/typer/releases/tag/${version}";
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ winpat ];
+    inherit (typer-slim.meta)
+      changelog
+      description
+      homepage
+      license
+      maintainers
+      ;
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19255,7 +19255,7 @@ self: super: with self; {
 
   typer-shell = callPackage ../development/python-modules/typer-shell { };
 
-  typer-slim = self.typer.override { package = "typer-slim"; };
+  typer-slim = callPackage ../development/python-modules/typer-slim { };
 
   types-aiobotocore = callPackage ../development/python-modules/types-aiobotocore { };
 


### PR DESCRIPTION
This fixes a collision between typer and typer-slim when building

    python3.withPackages (ps: [ ps.spacy ])

fixes https://github.com/NixOS/nixpkgs/issues/464762
closes https://github.com/NixOS/nixpkgs/pull/466257
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
