### PR TITLE
haskellPackages.3d-graphics-example: fix the eval

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -2147,7 +2147,7 @@ builtins.intersectAttrs super {
   lib.genAttrs
     [
       "2captcha"
-      "3d-graphics-example"
+      "3d-graphics-examples"
       "3dmodels"
       "4Blocks"
       "assert"


### PR DESCRIPTION
Without the change the eval fails as:

    $ nix build --no-link -f. haskellPackages.3d-graphics-example
    error:
       … while evaluating the attribute 'value'
         at pkgs/development/haskell-modul
         2162|         name = old;
         2163|         value =
             |         ^
         2164|           lib.warnOnInstantiate "haskell.packages.*.${old} has b

       … in the right operand of the update (//) operator
         at lib/derivations.nix:253:12:
          252|     in
          253|     drv // mapAttrs (_: lib.warn msg) drvToWrap;
             |            ^
          254| }

       (stack trace truncated; use '--show-trace' to show the full, detailed tr

       error: attribute '_3d-graphics-example' missing
       at pkgs/development/haskell-modules/configuration-nix.nix:2165:13:
         2164|           lib.warnOnInstantiate "haskell.packages.*.${old} has been renamed to haskell.packages.*.${new}"
         2165|             self.${new};
             |             ^
         2166|       }
       Did you mean one of 3d-graphics-example or _3d-graphics-examples?


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
