### PR TITLE
bandcamp-dl: init at 0.0.17

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21219,6 +21219,12 @@
     githubId = 20472367;
     name = "Peter Hebden";
   };
+  pivok = {
+    email = "pivoc@protonmail.com";
+    github = "Pivok7";
+    githubId = 153895536;
+    name = "Bartłomiej Witaszczyk";
+  };
   pixel-87 = {
     email = "edwardoliverthomas@gmail.com";
     github = "pixel-87";

--- a/pkgs/by-name/ba/bandcamp-dl/package.nix
+++ b/pkgs/by-name/ba/bandcamp-dl/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+}:
+
+let
+  # Upstream is unmaintained so we fetch it directly from github
+  # instead of moving it to a seperate package
+  unicode-slugify =
+    let
+      pname = "unicode-slugify";
+      version = "0.1.5";
+    in
+    python3Packages.buildPythonPackage {
+      format = "setuptools";
+      inherit pname version;
+
+      src = fetchFromGitHub {
+        owner = "mozilla";
+        repo = "unicode-slugify";
+        rev = "74d175dd4c9d21b1586842a3909118c7ec58f4ce";
+        hash = "sha256-m67ZvXr/iDOWL8UcRbKGWIw+zvV1WCUjMc3Y2hvzY0E=";
+      };
+
+      propagatedBuildInputs = with python3Packages; [
+        six
+        unidecode
+      ];
+
+      doCheck = false;
+    };
+in
+python3Packages.buildPythonPackage rec {
+  pname = "bandcamp-dl";
+  version = "0.0.17";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Evolution0";
+    repo = "bandcamp-dl";
+    tag = "v${version}";
+    hash = "sha256-PNyVEzwRMXE0AtTTg+JyWw6+FSuxobi3orXuxkG0kxw=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    beautifulsoup4
+    demjson3
+    mutagen
+    requests
+    unicode-slugify
+  ];
+
+  meta = {
+    description = "Simple python script to download Bandcamp albums";
+    homepage = "https://github.com/Evolution0/bandcamp-dl";
+    maintainers = [ lib.maintainers.pivok ];
+    license = lib.licenses.unlicense;
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
Simple python script to download Bandcamp albums

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
