### PR TITLE
pinsel: unstable-2021-09-13 -> 0-unstable-2022-03-27, license is MIT now

### DIFF
--- a/pkgs/by-name/pi/pinsel/package.nix
+++ b/pkgs/by-name/pi/pinsel/package.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation {
   pname = "pinsel";
-  version = "unstable-2021-09-13";
+  version = "0-unstable-2022-03-27";
 
   src = fetchFromGitHub {
     owner = "Nooo37";
     repo = "pinsel";
-    rev = "24b0205ca041511b3efb2a75ef296539442f9f54";
-    sha256 = "sha256-w+jiKypZODsmZq3uWGNd8PZhe1SowHj0thcQTX8WHfQ=";
+    rev = "4955b93365a1816bffbddc3d2ddfe3f4b3d60107";
+    hash = "sha256-H5DCAb8lJx2W4LNeGV+WOIiLUHsRVv1gSU2YMegkDFM=";
   };
 
   strictDeps = true;
@@ -40,8 +40,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "Minimal screenshot annotation tool with lua config";
     homepage = "https://github.com/Nooo37/pinsel";
-    # no license
-    license = licenses.unfree;
+    license = licenses.mit;
     maintainers = with maintainers; [ lom ];
     mainProgram = "pinsel";
   };

--- a/pkgs/by-name/pi/pinsel/package.nix
+++ b/pkgs/by-name/pi/pinsel/package.nix
@@ -42,6 +42,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/Nooo37/pinsel";
     license = licenses.mit;
     maintainers = with maintainers; [ lom ];
+    platforms = platforms.linux;
     mainProgram = "pinsel";
   };
 }


### PR DESCRIPTION
Diff: https://github.com/Nooo37/pinsel/compare/24b0205ca041511b3efb2a75ef296539442f9f54...4955b93365a1816bffbddc3d2ddfe3f4b3d60107


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
