### PR TITLE
treewide: fix missing dollar symbol when referencing version

### DIFF
--- a/pkgs/applications/blockchains/groestlcoin/default.nix
+++ b/pkgs/applications/blockchains/groestlcoin/default.nix
@@ -121,7 +121,7 @@ stdenv.mkDerivation rec {
       with each other, with the help of a P2P network to check for double-spending.
     '';
     homepage = "https://groestlcoin.org/";
-    downloadPage = "https://github.com/Groestlcoin/groestlcoin/releases/tag/v{version}/";
+    downloadPage = "https://github.com/Groestlcoin/groestlcoin/releases/tag/v${version}/";
     maintainers = with maintainers; [ gruve-p ];
     license = licenses.mit;
     platforms = platforms.unix;

--- a/pkgs/applications/misc/electrum/grs.nix
+++ b/pkgs/applications/misc/electrum/grs.nix
@@ -137,7 +137,7 @@ python3.pkgs.buildPythonApplication {
       of the blockchain.
     '';
     homepage = "https://groestlcoin.org/";
-    downloadPage = "https://github.com/Groestlcoin/electrum-grs/releases/tag/v{version}";
+    downloadPage = "https://github.com/Groestlcoin/electrum-grs/releases/tag/v${version}";
     license = licenses.mit;
     platforms = platforms.all;
     maintainers = with maintainers; [ gruve-p ];

--- a/pkgs/by-name/la/landrun/package.nix
+++ b/pkgs/by-name/la/landrun/package.nix
@@ -102,7 +102,7 @@ buildGoModule (finalAttrs: {
       Linux 5.13+ is required for file access restrictions, Linux 6.7+ for TCP restrictions.
     '';
     homepage = "https://github.com/Zouuup/landrun";
-    changelog = "https://github.com/Zouuup/landrun/releases/tag/{finalAttrs.src.tag}";
+    changelog = "https://github.com/Zouuup/landrun/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl2Only;
     maintainers = [ lib.maintainers.fliegendewurst ];
     platforms = lib.platforms.linux;

--- a/pkgs/development/python-modules/django-celery-results/default.nix
+++ b/pkgs/development/python-modules/django-celery-results/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Celery result back end with django";
     homepage = "https://github.com/celery/django-celery-results";
-    changelog = "https://github.com/celery/django-celery-results/blob/v{version}/Changelog";
+    changelog = "https://github.com/celery/django-celery-results/blob/v${version}/Changelog";
     license = licenses.bsd3;
     maintainers = [ ];
   };

--- a/pkgs/development/python-modules/mdformat-frontmatter/default.nix
+++ b/pkgs/development/python-modules/mdformat-frontmatter/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Mdformat plugin to ensure frontmatter is respected";
     homepage = "https://github.com/butler54/mdformat-frontmatter";
-    changelog = "https://github.com/butler54/mdformat-frontmatter/blob/v{version}/CHANGELOG.md";
+    changelog = "https://github.com/butler54/mdformat-frontmatter/blob/v${version}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [
       aldoborrero

--- a/pkgs/development/python-modules/pcre2-py/default.nix
+++ b/pkgs/development/python-modules/pcre2-py/default.nix
@@ -82,7 +82,7 @@ buildPythonPackage rec {
   meta = {
     description = "Python bindings for the PCRE2 library created by Philip Hazel";
     homepage = "https://github.com/grtetrault/pcre2.py";
-    changelog = "https://github.com/grtetrault/pcre2.py/releases/tag/v{version}";
+    changelog = "https://github.com/grtetrault/pcre2.py/releases/tag/v${version}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ tochiaha ];
   };


### PR DESCRIPTION
`grep -RPl '(?<!\$)\{version' .`
`grep -RPl '(?<!\$)\{finalAttrs' .`

Bunster is being fixed in https://github.com/NixOS/nixpkgs/pull/445285

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
