### PR TITLE
librepods: init at 0.1.0

### DIFF
--- a/pkgs/by-name/li/librepods/package.nix
+++ b/pkgs/by-name/li/librepods/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  qt6,
+  openssl,
+  libpulseaudio,
+  pkg-config,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "librepods";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "kavishdevar";
+    repo = "librepods";
+    rev = "linux-v${finalAttrs.version}";
+    hash = "sha256-HHF14I6mpCHsRcSzQmrZhGeCGr+1oNCK4esOjVu4M+E=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/linux";
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtconnectivity
+    qt6.qtmultimedia
+    qt6.qtdeclarative
+    openssl
+    libpulseaudio
+  ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version-regex=linux-v([\\d\\.]+)" ];
+  };
+
+  meta = {
+    description = "Open-source AirPods integration for Linux";
+    homepage = "https://github.com/kavishdevar/librepods";
+    changelog = "https://github.com/kavishdevar/librepods/releases/tag/${finalAttrs.src.rev}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ shgew ];
+    platforms = lib.platforms.linux;
+    mainProgram = "librepods";
+  };
+})


### PR DESCRIPTION
## What is LibrePods?
LibrePods unlocks Apple's exclusive AirPods features on non-Apple devices. Get access to noise control modes, adaptive transparency, ear detection, hearing aid, customized transparency mode, battery status, and more - all the premium features you paid for but Apple locked to their ecosystem.

https://github.com/kavishdevar/librepods

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
