### PR TITLE
adwaita-qt: migrate to by-name, refactor

### DIFF
--- a/pkgs/by-name/ad/adwaita-qt/package.nix
+++ b/pkgs/by-name/ad/adwaita-qt/package.nix
@@ -11,7 +11,7 @@
   useQt6 ? false,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "adwaita-qt";
   version = "1.4.2";
 
@@ -23,8 +23,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "FedoraQt";
     repo = "adwaita-qt";
-    rev = version;
-    sha256 = "sha256-K/+SL52C+M2OC4NL+mhBnm/9BwH0KNNTGIDmPwuUwkM=";
+    tag = finalAttrs.version;
+    hash = "sha256-K/+SL52C+M2OC4NL+mhBnm/9BwH0KNNTGIDmPwuUwkM=";
   };
 
   nativeBuildInputs = [
@@ -32,18 +32,18 @@ stdenv.mkDerivation rec {
     ninja
   ];
 
-  buildInputs = [
-    qt5.qtbase
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
-    libxcb
-  ]
-  ++ lib.optionals (!useQt6) [
-    qt5.qtx11extras
-  ]
-  ++ lib.optionals useQt6 [
-    qt6.qtwayland
-  ];
+  buildInputs =
+    lib.optionals (!useQt6) [
+      qt5.qtbase
+      qt5.qtx11extras
+    ]
+    ++ lib.optionals useQt6 [
+      qt6.qtbase
+      qt6.qtwayland
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      libxcb
+    ];
 
   # Qt setup hook complains about missing `wrapQtAppsHook` otherwise.
   dontWrapQtApps = true;
@@ -69,4 +69,4 @@ stdenv.mkDerivation rec {
     maintainers = [ ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/ad/adwaita-qt/package.nix
+++ b/pkgs/by-name/ad/adwaita-qt/package.nix
@@ -5,9 +5,8 @@
   nix-update-script,
   cmake,
   ninja,
-  qtbase,
-  qtwayland,
   qt5,
+  qt6,
   libxcb,
   useQt6 ? false,
 }:
@@ -34,7 +33,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    qtbase
+    qt5.qtbase
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     libxcb
@@ -43,7 +42,7 @@ stdenv.mkDerivation rec {
     qt5.qtx11extras
   ]
   ++ lib.optionals useQt6 [
-    qtwayland
+    qt6.qtwayland
   ];
 
   # Qt setup hook complains about missing `wrapQtAppsHook` otherwise.

--- a/pkgs/by-name/ad/adwaita-qt6/package.nix
+++ b/pkgs/by-name/ad/adwaita-qt6/package.nix
@@ -1,0 +1,7 @@
+{
+  adwaita-qt,
+}:
+
+adwaita-qt.override {
+  useQt6 = true;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9331,12 +9331,6 @@ with pkgs;
 
   ### DATA
 
-  adwaita-qt = libsForQt5.callPackage ../data/themes/adwaita-qt { };
-
-  adwaita-qt6 = qt6Packages.callPackage ../data/themes/adwaita-qt {
-    useQt6 = true;
-  };
-
   dejavu_fonts = lowPrio (callPackage ../data/fonts/dejavu-fonts { });
 
   docbook_sgml_dtd_31 = callPackage ../data/sgml+xml/schemas/sgml-dtd/docbook/3.1.nix { };


### PR DESCRIPTION
This pull request refactors the packaging of the `adwaita-qt` theme for Qt5 and Qt6 in Nixpkgs. The main changes include moving and updating the package definition, improving Qt5/Qt6 support, and simplifying the way the Qt6 variant is built.

**Refactoring and package improvements:**

* Moved and renamed the `adwaita-qt` package file from `pkgs/data/themes/adwaita-qt/default.nix` to `pkgs/by-name/ad/adwaita-qt/package.nix`, modernizing the file structure and updating the code to use the latest conventions.
* Updated the package definition to use attribute sets (`finalAttrs`) and improved the use of the `lib` namespace for licenses and platforms.

**Qt5/Qt6 support improvements:**

* Refactored build inputs to explicitly use `qt5.qtbase` for Qt5 and `qt6.qtwayland` for Qt6, and added a `useQt6` flag to toggle between Qt versions [[1]](diffhunk://#diff-6160d1d3777c88511ac39c4c7f11da525d335f8bf217e79091f87b7495a9cb24L37-R36) [[2]](diffhunk://#diff-6160d1d3777c88511ac39c4c7f11da525d335f8bf217e79091f87b7495a9cb24L46-R45).
* Updated the `src` attribute to use `tag` and `hash` instead of `rev` and `sha256` for fetching from GitHub, aligning with modern Nix best practices.

**Simplification of Qt6 variant:**

* Added a new `adwaita-qt6` package definition that simply overrides the main `adwaita-qt` package with `useQt6 = true`, reducing duplication and simplifying maintenance.
* Removed the old `adwaita-qt` and `adwaita-qt6` package definitions from `pkgs/top-level/all-packages.nix`, as the new approach supersedes them.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
