### PR TITLE
texinfoInteractive: add patch for perl 5.42

### DIFF
--- a/pkgs/development/tools/misc/texinfo/common.nix
+++ b/pkgs/development/tools/misc/texinfo/common.nix
@@ -38,6 +38,7 @@ let
     optional
     optionals
     optionalString
+    versionAtLeast
     versionOlder
     ;
   crossBuildTools = stdenv.hostPlatform != stdenv.buildPlatform;
@@ -52,7 +53,12 @@ stdenv.mkDerivation {
     inherit hash;
   };
 
-  patches = patches ++ optional crossBuildTools ./cross-tools-flags.patch;
+  patches =
+    patches
+    ++ optional (
+      interactive && versionAtLeast version "7.2"
+    ) ./fix-test-suite-failures-with-perl-5.42.patch
+    ++ optional crossBuildTools ./cross-tools-flags.patch;
 
   postPatch = ''
     patchShebangs tp/maintain/regenerate_commands_perl_info.pl

--- a/pkgs/development/tools/misc/texinfo/fix-test-suite-failures-with-perl-5.42.patch
+++ b/pkgs/development/tools/misc/texinfo/fix-test-suite-failures-with-perl-5.42.patch
@@ -1,0 +1,41 @@
+>From 1af3c9b91625e4d115ea979c45a75752b872c10f Mon Sep 17 00:00:00 2001
+From: Niko Tyni <ntyni@debian.org>
+Date: Sat, 13 Sep 2025 08:57:55 +0100
+Subject: [PATCH] Fix test suite failures with Perl 5.42
+
+The precedence issues here were flagged by new diagnostics in Perl 5.42,
+and the resulting warnings caused test failures.
+---
+ tp/Texinfo/Convert/Converter.pm | 2 +-
+ tp/Texinfo/Convert/LaTeX.pm     | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tp/Texinfo/Convert/Converter.pm b/tp/Texinfo/Convert/Converter.pm
+index 5e14a9e..89e623b 100644
+--- a/tp/Texinfo/Convert/Converter.pm
++++ b/tp/Texinfo/Convert/Converter.pm
+@@ -386,7 +386,7 @@ sub output_tree($$)
+ 
+   my $fh;
+   my $encoded_output_file;
+-  if (! $output_file eq '') {
++  if ($output_file ne '') {
+     my $path_encoding;
+     ($encoded_output_file, $path_encoding)
+       = $self->encoded_output_file_name($output_file);
+diff --git a/tp/Texinfo/Convert/LaTeX.pm b/tp/Texinfo/Convert/LaTeX.pm
+index ae947d1..f4ba076 100644
+--- a/tp/Texinfo/Convert/LaTeX.pm
++++ b/tp/Texinfo/Convert/LaTeX.pm
+@@ -1085,7 +1085,7 @@ sub output($$)
+ 
+   my $fh;
+   my $encoded_output_file;
+-  if (! $output_file eq '') {
++  if ($output_file ne '') {
+     my $path_encoding;
+     ($encoded_output_file, $path_encoding)
+       = $self->encoded_output_file_name($output_file);
+-- 
+2.51.0
+


### PR DESCRIPTION
Add patch for perl 5.42 from Debian that fixes syntax warnings causing test failures via Texinfo::Convert::Coverter and Texinfo::Convert::LaTeX
    
The patch is only applied if:
   
- Versions =< 7.2, since this is fixed in later git releases of texinfo
    
- interactive = true, since tests are disabled for other cases, and applying it for all cases causes a mass rebuild.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
