### PR TITLE
exabgp: 4.2.25 -> 5.0.1

### DIFF
--- a/pkgs/by-name/ex/exabgp/package.nix
+++ b/pkgs/by-name/ex/exabgp/package.nix
@@ -1,24 +1,31 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchFromGitHub,
   exabgp,
   testers,
 }:
 
-python3.pkgs.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "exabgp";
-  version = "4.2.25";
-  format = "pyproject";
+  version = "5.0.1";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Exa-Networks";
     repo = "exabgp";
     tag = version;
-    hash = "sha256-YBxRDcm4Qt44W3lBHDwdvZq2pXEujbqJDh24JbXthMg=";
+    hash = "sha256-UFo92jS/QmwTUEAhxQnbtY9K905jiBrJujfqGIUCUOg=";
   };
 
-  nativeBuildInputs = with python3.pkgs; [
+  postPatch = ''
+    # https://github.com/Exa-Networks/exabgp/pull/1344
+    substituteInPlace src/exabgp/application/healthcheck.py --replace-fail \
+      "f'/sbin/ip -o address show dev {ifname}'.split()" \
+      '["ip", "-o", "address", "show", "dev", ifname]'
+  '';
+
+  build-system = with python3Packages; [
     setuptools
   ];
 
@@ -26,13 +33,31 @@ python3.pkgs.buildPythonApplication rec {
     "exabgp"
   ];
 
-  nativeCheckInputs = with python3.pkgs; [
+  nativeCheckInputs = with python3Packages; [
+    hypothesis
+    psutil
+    pytest-asyncio
+    pytest-benchmark
+    pytest-timeout
+    pytest-xdist
     pytestCheckHook
+  ];
+
+  __darwinAllowLocalNetworking = true;
+
+  pytestFlags = [ "--benchmark-disable" ];
+
+  enabledTests = [ "tests" ];
+
+  disabledTests = [
+    # AssertionError: Server should receive connection
+    "test_outgoing_connection_establishment"
   ];
 
   passthru.tests = {
     version = testers.testVersion {
       package = exabgp;
+      command = "exabgp version";
     };
   };
 


### PR DESCRIPTION
https://github.com/Exa-Networks/exabgp/releases/tag/5.0.0
https://github.com/Exa-Networks/exabgp/releases/tag/5.0.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
