### PR TITLE
nixos/roundcube: add mysql support

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1349,7 +1349,7 @@ in
   rmfakecloud = runTest ./rmfakecloud.nix;
   robustirc-bridge = runTest ./robustirc-bridge.nix;
   rosenpass = runTest ./rosenpass.nix;
-  roundcube = runTest ./roundcube.nix;
+  roundcube = import ./roundcube.nix { inherit pkgs; };
   routinator = handleTest ./routinator.nix { };
   rshim = handleTest ./rshim.nix { };
   rspamd = handleTest ./rspamd.nix { };

--- a/nixos/tests/roundcube.nix
+++ b/nixos/tests/roundcube.nix
@@ -1,38 +1,53 @@
 { pkgs, ... }:
-{
-  name = "roundcube";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ globin ];
-  };
-
-  nodes = {
-    roundcube =
-      { config, pkgs, ... }:
-      {
-        services.roundcube = {
-          enable = true;
-          hostName = "roundcube";
-          database.password = "not production";
-          package = pkgs.roundcube.withPlugins (plugins: [ plugins.persistent_login ]);
-          plugins = [ "persistent_login" ];
-          dicts = with pkgs.aspellDicts; [
-            en
-            fr
-            de
-          ];
-        };
-        services.nginx.virtualHosts.roundcube = {
-          forceSSL = false;
-          enableACME = false;
-        };
+let
+  supportedDbTypes = [
+    "mysql"
+    "pgsql"
+  ];
+  makeLocalDbTest =
+    dbType:
+    pkgs.testers.nixosTest {
+      name = "roundcube-localDb-${dbType}";
+      meta = with pkgs.lib.maintainers; {
+        maintainers = [ globin ];
       };
-  };
 
-  testScript = ''
-    roundcube.start
-    roundcube.wait_for_unit("postgresql.target")
-    roundcube.wait_for_unit("phpfpm-roundcube.service")
-    roundcube.wait_for_unit("nginx.service")
-    roundcube.succeed("curl -sSfL http://roundcube/ | grep 'Keep me logged in'")
-  '';
-}
+      nodes = {
+        roundcube =
+          { config, pkgs, ... }:
+          {
+            services.roundcube = {
+              enable = true;
+              hostName = "roundcube";
+              database.type = dbType;
+              package = pkgs.roundcube.withPlugins (plugins: [ plugins.persistent_login ]);
+              plugins = [ "persistent_login" ];
+              dicts = with pkgs.aspellDicts; [
+                en
+                fr
+                de
+              ];
+            };
+            services.nginx.virtualHosts.roundcube = {
+              forceSSL = false;
+              enableACME = false;
+            };
+          };
+      };
+
+      testScript =
+        let
+          dbUnit = if dbType == "mysql" then "mysql.service" else "postgresql.target";
+        in
+        ''
+          roundcube.start
+          roundcube.wait_for_unit("${dbUnit}")
+          roundcube.wait_for_unit("phpfpm-roundcube.service")
+          roundcube.wait_for_unit("nginx.service")
+          roundcube.succeed("curl -sSfL http://roundcube/ | grep 'Keep me logged in'")
+        '';
+    };
+in
+pkgs.lib.listToAttrs (
+  map (test: pkgs.lib.nameValuePair test.name test) (map makeLocalDbTest supportedDbTypes)
+)


### PR DESCRIPTION
This PR adds mysql support to the Roundcube module. The updates this PR performs to achieve this are as follows:

- A new option `database.type` which can be either set to `pgsql` or `mysql`. To stay backwards compatible to existing installs, this defaults to `pgsql`,
- Introduce the local variables `pgsqlLocal` and `mysqlLocal`. These are the same as `dbLocal` but are only `true` if the set appropriately, allowing simpler service selection later on.
- Create a local mysql service, if `localDb` is true and mysql is selected.
- The most intrusive changes are in the systemd unit, as I did some refactoring there to arrive at simpler code:
  - `requires` and `after` now select their target based on `database.type`. To reduce the amount of conditionals, I migrated this part of the code from `lib.mkMerge` to the `++ lib.optional` syntax.
  - `scirpt` now has a fairly large `let .. in` block, which is responsible for building an engine-specific command for setting up and querying the database that can later be used by the script in place of `psql`. That engine-specific command includes all the parameters needed by the engine (username, password, host, database name, flags) so the script can just use it as a black box to gain db access.

`database.password` will not be supported by mysql since the option is deprecated anyway. This is reflected in the documentation of the option and an assertion checking this is in place.

Additionally, I extended the test case to test local setup with both databse engines. The changes here are pretty minor. Using a diff that ignores whitespace changes will go a long way.

This PR resolves #406823

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
