### PR TITLE
buildstream: Remove unneeded dependencies

### DIFF
--- a/pkgs/by-name/bu/buildstream/package.nix
+++ b/pkgs/by-name/bu/buildstream/package.nix
@@ -46,7 +46,6 @@ python3Packages.buildPythonApplication rec {
   ]
   ++ (with python3Packages; [
     click
-    dulwich
     grpcio
     jinja2
     markupsafe
@@ -55,10 +54,8 @@ python3Packages.buildPythonApplication rec {
     protobuf
     psutil
     pyroaring
-    requests
     ruamel-yaml
     ruamel-yaml-clib
-    tomlkit
     ujson
   ])
   ++ lib.optionals enableBuildstreamPlugins [


### PR DESCRIPTION
A small bugfix to the BuildStream package, as `dulwich` is currently broken when using `bst source track` on `git_repo` sources.

At the same time, I've trimmed a few of the dependencies that aren't a strict dependency of BuildStream from the derivation.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
