### PR TITLE
flint: 3.3.1 -> 3.4.0

### DIFF
--- a/pkgs/by-name/fl/flint/package.nix
+++ b/pkgs/by-name/fl/flint/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchurl,
-  fetchpatch,
   windows,
   autoconf,
   automake,
@@ -26,11 +25,11 @@ assert
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "flint";
-  version = "3.3.1";
+  version = "3.4.0";
 
   src = fetchurl {
     url = "https://flintlib.org/download/flint-${finalAttrs.version}.tar.gz";
-    hash = "sha256-ZNcOUTB2z6lx4EELWMHaXTURKRPppWtE4saBtFnT6vs=";
+    hash = "sha256-lJdnmATerZJuOv/rjUxYc50cdoTWDCwSgnVQ0o5FSjM=";
   };
 
   patches = [

--- a/pkgs/by-name/sa/sage/sage-src.nix
+++ b/pkgs/by-name/sa/sage/sage-src.nix
@@ -89,6 +89,13 @@ stdenv.mkDerivation rec {
       url = "https://github.com/sagemath/sage/commit/fa00696112fde95e0c4241ad6063936200ce6f68.patch?full_index=1";
       hash = "sha256-eFDpNu/2gcQATELmQ7/VzXI35xIzaVrD8bhhJ57e2gc=";
     })
+
+    # https://github.com/sagemath/sage/pull/41233, landed in 10.8.rc0
+    (fetchpatch2 {
+      name = "flint-3.4-update.patch";
+      url = "https://github.com/sagemath/sage/commit/9bd5304f1a222e215d7006a04854ff66616748bf.patch?full_index=1";
+      hash = "sha256-7bgouXV3pM20IX5PM24ZpJWOBlZjQksGtjopgouEbyg=";
+    })
   ];
 
   patches = nixPatches ++ bugfixPatches ++ packageUpgradePatches;


### PR DESCRIPTION
https://flintlib.org/doc/history.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
