### PR TITLE
fdt-viewer: init at 0-unstable-2024-12-06

### DIFF
--- a/pkgs/by-name/fd/fdt-viewer/package.nix
+++ b/pkgs/by-name/fd/fdt-viewer/package.nix
@@ -1,0 +1,41 @@
+{
+  cmake,
+  fetchFromGitHub,
+  git,
+  lib,
+  qt6,
+  stdenv,
+  unstableGitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fdt-viewer";
+  version = "0-unstable-2024-12-06";
+
+  src = fetchFromGitHub {
+    owner = "dev-0x7C6";
+    repo = "fdt-viewer";
+    rev = "3488a599bfe0a92a0aec3cf421ef0c6f385f0737";
+    hash = "sha256-THu6HZpVSqsU2M/5AVflTaW8l8FNSYVI/f1kbZ+zCsA=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    qt6.wrapQtAppsHook
+    cmake
+    git
+  ];
+
+  buildInputs = [ qt6.qtbase ];
+
+  passthru.updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
+
+  meta = {
+    description = "Flattened Device Tree Viewer written in Qt";
+    homepage = "https://github.com/dev-0x7C6/fdt-viewer";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.jmbaur ];
+    mainProgram = "fdt-viewer";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
