### PR TITLE
python3Packages.ziafont: 0.10 -> 0.11

### DIFF
--- a/pkgs/development/python-modules/ziafont/checkfonts.nix
+++ b/pkgs/development/python-modules/ziafont/checkfonts.nix
@@ -85,4 +85,8 @@
     url = "https://github.com/google/fonts/raw/main/ofl/arizonia/Arizonia-Regular.ttf";
     hash = "sha256-jfHBC8FdCroUXUWZwlyvrYPbaG0s76QmGfBptvG7zmI=";
   }
+  {
+    url = "https://mirrors.ctan.org/fonts/cinzel/truetype/CinzelDecorative-Regular.ttf";
+    hash = "sha256-OKi38GSSsvwkC5pFs/uDyZWpydVIKZ7AIjma8nfJDEY=";
+  }
 ]

--- a/pkgs/development/python-modules/ziafont/default.nix
+++ b/pkgs/development/python-modules/ziafont/default.nix
@@ -11,7 +11,7 @@
 }:
 buildPythonPackage rec {
   pname = "ziafont";
-  version = "0.10";
+  version = "0.11";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "cdelker";
     repo = "ziafont";
     tag = version;
-    hash = "sha256-tDwl+2EChzBDCFcZW71r4eSKyazlJSv7tRX6soPNSuY=";
+    hash = "sha256-KjJ+/Yo5mLV6m7Y0eIGHECH0RvdI+eaFTccDmytNTKI=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
https://github.com/cdelker/ziafont/compare/0.10...0.11

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
