### PR TITLE
faiss: optional builds for C API and shared libraries

### DIFF
--- a/pkgs/by-name/fa/faiss/package.nix
+++ b/pkgs/by-name/fa/faiss/package.nix
@@ -3,11 +3,13 @@
   config,
   fetchFromGitHub,
   stdenv,
+  capiSupport ? false,
   cmake,
   cudaPackages ? { },
   cudaSupport ? config.cudaSupport,
   pythonSupport ? true,
   python3Packages,
+  sharedLibrarySupport ? false,
   llvmPackages,
   blas,
   swig,
@@ -73,6 +75,8 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals cudaSupport cudaComponents;
 
   cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" sharedLibrarySupport)
+    (lib.cmakeBool "FAISS_ENABLE_C_API" capiSupport)
     (lib.cmakeBool "FAISS_ENABLE_GPU" cudaSupport)
     (lib.cmakeBool "FAISS_ENABLE_PYTHON" pythonSupport)
     (lib.cmakeFeature "FAISS_OPT_LEVEL" optLevel)

--- a/pkgs/by-name/fa/faiss/package.nix
+++ b/pkgs/by-name/fa/faiss/package.nix
@@ -3,7 +3,7 @@
   config,
   fetchFromGitHub,
   stdenv,
-  capiSupport ? false,
+  capiSupport ? true,
   cmake,
   cudaPackages ? { },
   cudaSupport ? config.cudaSupport,


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
FAISS exposes cmake options to generate a [C API](https://github.com/facebookresearch/faiss/blob/f5405d552191afbf4efcec351925de5e86cababa/c_api/INSTALL.md#compilation-instructions) and [shared libraries](https://github.com/facebookresearch/faiss/blob/f5405d552191afbf4efcec351925de5e86cababa/INSTALL.md?plain=1#L136). This PR adds optional support for both of these features but defaults to the current behavior

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
