### PR TITLE
pkgs/gvfs: Add missing binaries to installable.

### DIFF
--- a/pkgs/by-name/gv/gvfs/package.nix
+++ b/pkgs/by-name/gv/gvfs/package.nix
@@ -117,6 +117,7 @@ stdenv.mkDerivation (finalAttrs: {
   mesonFlags = [
     "-Dsystemduserunitdir=${placeholder "out"}/lib/systemd/user"
     "-Dtmpfilesdir=no"
+    "--libexecdir=${placeholder "out"}/bin"
   ]
   ++ lib.optionals (!udevSupport) [
     "-Dgudev=false"
@@ -158,6 +159,11 @@ stdenv.mkDerivation (finalAttrs: {
       versionPolicy = "odd-unstable";
     };
   };
+
+  # Retain backwards-compat with those relying on libexec
+  postInstall = ''
+    ln -s $out/bin $out/libexec
+  '';
 
   meta = with lib; {
     description =


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

# Problem

The `gvfs` package and in general the functionality needs both a daemon *and* some binaries in $PATH for client applications to invoke (in my case, emacs). However, the current package does NOT expose any of thee when installed in the `environment` as the binaries are solely in the `libexec` folder. Or I start wrapping programs I want to use these with and stuffing this in their path.

Note that this cannot be made a multi-output package due to cyclic dependencies between lib and libexec. I also unfortunately did not find a way to expose the libexec binaries to NIxlang in a better way, atleast not without editing the builder script. Only other way I can think of is making a separate package that essentially just does this fix.

# Solution
Tell meson to treat `$out/bin` as the libexec dir, and drop a symlink to `$out/bin` at `$out/libexec` to retain backwards compat. 

I added a post install hook to create `$out/bin` and symlinked it to `$out/libexec`. This is quite an odd package in that it wants to have binaries that clients may want to use in libexec.

## Things done

Edited gvfs.nix

CC Maintainers: @NixOS/gnome 
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
