### PR TITLE
xv: 6.0.4 -> 6.1.0

### DIFF
--- a/pkgs/by-name/xv/xv/package.nix
+++ b/pkgs/by-name/xv/xv/package.nix
@@ -10,17 +10,18 @@
   libjpeg,
   jasper,
   libxrandr,
+  libexif,
 }:
 
 stdenv.mkDerivation rec {
   pname = "xv";
-  version = "6.0.4";
+  version = "6.1.0";
 
   src = fetchFromGitHub {
     owner = "jasper-software";
     repo = "xv";
     rev = "v${version}";
-    sha256 = "sha256-5bhLMGdj7HJOsSOFjNO5s3wDA9XbPTwG+g7OSrKMMXk=";
+    sha256 = "sha256-bq9xEGQRzWZ3/Unu49q6EW9/XSCgpalyXn4l4Mg255g=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -33,6 +34,7 @@ stdenv.mkDerivation rec {
     libjpeg
     jasper
     libxrandr
+    libexif
   ];
 
   meta = {


### PR DESCRIPTION
* [Release on GitHub](https://github.com/jasper-software/xv/releases/tag/v6.1.0)

* [Compare changes on GitHub](https://github.com/jasper-software/xv/compare/v6.0.4...v6.1.0) 

This also adds a new dependency `libexif` since this version now supports EXIF orientation tags when the library is available.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
