### PR TITLE
fetchgit: fetch tags reproducibly and allow unstable version package to use `git describe`

### DIFF
--- a/doc/build-helpers/fetchers.chapter.md
+++ b/doc/build-helpers/fetchers.chapter.md
@@ -802,9 +802,81 @@ Additionally, the following optional arguments can be given:
 : Clone the entire repository as opposed to just creating a shallow clone.
   This implies `leaveDotGit`.
 
-*`fetchTags`* (Boolean)
+*`fetchTags`* ("Attribute set of lists" or boolean)
 
-: Whether to fetch all tags from the remote repository. This is useful when the build process needs to run `git describe` or other commands that require tag information to be available. This parameter implies `leaveDotGit`, as tags are stored in the `.git` directory.
+: Tags to fetch for the main project and each submodule.
+
+  ::: {.note}
+  The `tag` arguments cover the most common tag fetching cases -- fetching a tag into the main project.
+  `fetchTags` are reserved for advanced tag fetching configuration, such as ones involving submodules or more than one tags.
+
+  See below for details about how the `tag` argument interacts with `fetchTags`.
+  :::
+
+  Each attribute name corresponds to the relative path to each submodule, with a list of tag names as its attribute value.
+  The attribute name correspond to the main project is an empty string (`""`).
+
+  ::: {.example #ex-fetchgit-fetchTags-attrs}
+  # Use of `fetchTags` to fetch Git tags deterministically
+
+  ```nix
+  { stdenv, fetchgit }:
+
+  stdenv.mkDerivation {
+    name = "hello";
+    src = fetchgit {
+      url = "https://...";
+      fetchTags = {
+        # Fetch tag1 and tag2 for the main project.
+        "" = [
+          "tag1"
+          "tag2"
+        ];
+        # Fetch tag3 for the submodule at contrib/submodule1 relative to the main project.
+        "contrib/submodule1" = [ "tag3" ];
+        # Fetch tag4 for the submodule tests/data/submodule2
+        "tests/data/submodule2" = [ "tag4" ];
+      };
+      hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    };
+  }
+  ```
+  :::
+
+  When the `tag` argument is specified and `leaveDotGit` is false, `fetchgit` defaults to fetch the tag for the main project.
+  As this behaviour covers most of the tag-fetching cases, one usually don't have to set `fetchTags` manually.
+  - If `rev` is also specified, `fetchTags` will default to `{ "" = [ tag ]; }`, fetching `tag` into the main project.
+    This is useful for packages pinned to an unstable revision while requiring the presence of the previous stable tag to build.
+    ::: {.example #ex-fetchgit-both-tag-and-rev}
+
+    # Specify `rev` and `tag` simultaneously to fetch the tag `tag` while cloning from `rev`
+
+    ```nix
+    { fetchgit }:
+    fetchgit {
+      name = "describe-tag-nix-source";
+      url = "https://github.com/NixOS/nix";
+      rev = "9d9dbe6ed05854e03811c361a3380e09183f4f4a";
+      # for `git describe`
+      tag = "2.3.15";
+      hash = "sha256-7DszvbCNTjpzGRmpIVAWXk20P0/XTrWZ79KSOGLrUWY=";
+      postCheckout = ''
+        { git -C "$out" describe || echo "git describe failed"; } | tee describe-output.txt
+      '';
+    }
+    ```
+    :::
+  - If `tag` is specified alone, `fetchTags` will default to `{ }`, while `fetchgit` still fetches the specified tag will still be fetched.
+
+  When specified as a boolean, it specifies whether to fetch all tags from the remote repository.
+  Setting `fetchTags = true` implies `leaveDotGit = true`, as tags are stored in the `.git` directory.
+
+  ::: {.warning}
+  Specifying `fetchTags` as boolean is deprecated.
+  The behaviour is kept for compatibility purposes.
+
+  Setting `fetchTags = true` makes the `.git` non-reproducible as the upstream pushes new tags into their repository.
+  :::
 
 *`sparseCheckout`* (List of String)
 

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -105,6 +105,12 @@
   "ex-build-helpers-extendMkDerivation": [
     "index.html#ex-build-helpers-extendMkDerivation"
   ],
+  "ex-fetchgit-both-tag-and-rev": [
+    "index.html#ex-fetchgit-both-tag-and-rev"
+  ],
+  "ex-fetchgit-fetchTags-attrs": [
+    "index.html#ex-fetchgit-fetchTags-attrs"
+  ],
   "ex-pkgs-replace-vars": [
     "index.html#ex-pkgs-replace-vars",
     "index.html#ex-pkgs-substituteAll",

--- a/pkgs/build-support/fetchgit/builder.sh
+++ b/pkgs/build-support/fetchgit/builder.sh
@@ -20,7 +20,7 @@ $SHELL $fetcher --builder --url "$url" --out "$out" --rev "$rev" --name "$name" 
   ${fetchLFS:+--fetch-lfs} \
   ${deepClone:+--deepClone} \
   ${fetchSubmodules:+--fetch-submodules} \
-  ${fetchTags:+--fetch-tags} \
+  "${fetchTagFlags[@]}" \
   ${sparseCheckoutText:+--sparse-checkout "$sparseCheckoutText"} \
   ${nonConeMode:+--non-cone-mode} \
   ${branchName:+--branch-name "$branchName"} \

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -65,7 +65,7 @@ lib.makeOverridable (
             # when rootDir is specified, avoid invalidating the result when rev changes
             append = if rootDir != "" then "-${lib.strings.sanitizeDerivationName rootDir}" else "";
           },
-          # When null, will default to: `deepClone || fetchTags`
+          # When null, will default to: `deepClone || fetchTags == true` for backward compatibility.
           leaveDotGit ? null,
           outputHash ? lib.fakeHash,
           outputHashAlgo ? null,
@@ -97,8 +97,12 @@ lib.makeOverridable (
           passthru ? { },
           meta ? { },
           allowedRequisites ? null,
-          # fetch all tags after tree (useful for git describe)
-          fetchTags ? false,
+          # Additional tags to fetch after tree (useful for git describe)
+          # Specify as `{ ${"<subPath>"} = [ "<tag1>" "<tag2>" ]; }`,
+          # where subpath is relative to the fetching project root.
+          # The `subPath` of the main project is `""`.
+          # If `fetchTags` is specified as `true`, fetch all tags (with potential non-reproducibility).
+          fetchTags ? { },
           # make this subdirectory the root of the result
           rootDir ? "",
           # GIT_CONFIG_GLOBAL (as a file)
@@ -194,17 +198,36 @@ lib.makeOverridable (
             preFetch
             postCheckout
             postFetch
-            fetchTags
             rootDir
             gitConfigFile
             ;
+          fetchTags = if fetchTags == false then { } else fetchTags;
+          fetchTagFlags =
+            if lib.isAttrs finalAttrs.fetchTags then
+              lib.concatLists (
+                lib.attrValues (
+                  lib.mapAttrs (
+                    subPath:
+                    lib.concatMap (tag: [
+                      "--fetch-submodule-tag"
+                      subPath
+                      tag
+                    ])
+                  ) finalAttrs.fetchTags
+                )
+              )
+            else if finalAttrs.fetchTags == true then
+              [ "--fetch-tags" ]
+            else if finalAttrs.fetchTags == false then
+              [ ]
+            else
+              throw "fetchgit: unsupported fetchTags value, expecting either attribute sets of subpaths and tags, or boolean `true'";
           leaveDotGit =
             if leaveDotGit != null then
-              assert fetchTags -> leaveDotGit;
               assert rootDir != "" -> !leaveDotGit;
               leaveDotGit
             else
-              deepClone || fetchTags;
+              deepClone || fetchTags == true;
           nonConeMode = lib.defaultTo (finalAttrs.rootDir != "") nonConeMode;
           inherit tag;
           revCustom = rev;

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -25,12 +25,10 @@ let
       rev ? null,
       tag ? null,
     }:
-    if tag != null && rev != null then
-      throw "fetchgit requires one of either `rev` or `tag` to be provided (not both)."
+    if rev != null then
+      rev
     else if tag != null then
       "refs/tags/${tag}"
-    else if rev != null then
-      rev
     else
       # FIXME fetching HEAD if no rev or tag is provided is problematic at best
       "HEAD";
@@ -201,7 +199,20 @@ lib.makeOverridable (
             rootDir
             gitConfigFile
             ;
-          fetchTags = if fetchTags == false then { } else fetchTags;
+          fetchTags =
+            let
+              addAdditionalTag = finalAttrs.revCustom != null && finalAttrs.tag != null;
+              additionalTags = [ finalAttrs.tag ];
+            in
+            if lib.isAttrs fetchTags then
+              fetchTags
+              // {
+                ${if addAdditionalTag then "" else null} = fetchTags."" or [ ] ++ additionalTags;
+              }
+            else if fetchTags == false then
+              { ${if addAdditionalTag then "" else null} = additionalTags; }
+            else
+              fetchTags;
           fetchTagFlags =
             if lib.isAttrs finalAttrs.fetchTags then
               lib.concatLists (

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -65,7 +65,7 @@ lib.makeOverridable (
             # when rootDir is specified, avoid invalidating the result when rev changes
             append = if rootDir != "" then "-${lib.strings.sanitizeDerivationName rootDir}" else "";
           },
-          # When null, will default to: `deepClone || fetchTags`
+          # When null, will default to: `deepClone || fetchTags == true` for backward compatibility.
           leaveDotGit ? null,
           outputHash ? lib.fakeHash,
           outputHashAlgo ? null,
@@ -97,8 +97,12 @@ lib.makeOverridable (
           passthru ? { },
           meta ? { },
           allowedRequisites ? null,
-          # fetch all tags after tree (useful for git describe)
-          fetchTags ? false,
+          # Additional tags to fetch after tree (useful for git describe)
+          # Specify as `{ ${"<subPath>"} = [ "<tag1>" "<tag2>" ]; }`,
+          # where subpath is relative to the fetching project root.
+          # The `subPath` of the main project is `""`.
+          # If `fetchTags` is specified as `true`, fetch all tags (with potential non-reproducibility).
+          fetchTags ? { },
           # make this subdirectory the root of the result
           rootDir ? "",
           # GIT_CONFIG_GLOBAL (as a file)
@@ -195,17 +199,36 @@ lib.makeOverridable (
             preFetch
             postCheckout
             postFetch
-            fetchTags
             rootDir
             gitConfigFile
             ;
+          fetchTags = if fetchTags == false then { } else fetchTags;
+          fetchTagFlags =
+            if lib.isAttrs finalAttrs.fetchTags then
+              lib.concatLists (
+                lib.attrValues (
+                  lib.mapAttrs (
+                    subPath:
+                    lib.concatMap (tag: [
+                      "--fetch-submodule-tag"
+                      subPath
+                      tag
+                    ])
+                  ) finalAttrs.fetchTags
+                )
+              )
+            else if finalAttrs.fetchTags == true then
+              [ "--fetch-tags" ]
+            else if finalAttrs.fetchTags == false then
+              [ ]
+            else
+              throw "fetchgit: unsupported fetchTags value, expecting either attribute sets of subpaths and tags, or boolean `true'";
           leaveDotGit =
             if leaveDotGit != null then
-              assert fetchTags -> leaveDotGit;
               assert rootDir != "" -> !leaveDotGit;
               leaveDotGit
             else
-              deepClone || fetchTags;
+              deepClone || fetchTags == true;
           nonConeMode = lib.defaultTo (finalAttrs.rootDir != "") nonConeMode;
           inherit tag;
           revCustom = rev;

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -25,12 +25,10 @@ let
       rev ? null,
       tag ? null,
     }:
-    if tag != null && rev != null then
-      throw "fetchgit requires one of either `rev` or `tag` to be provided (not both)."
+    if rev != null then
+      rev
     else if tag != null then
       "refs/tags/${tag}"
-    else if rev != null then
-      rev
     else
       # FIXME fetching HEAD if no rev or tag is provided is problematic at best
       "HEAD";
@@ -202,7 +200,20 @@ lib.makeOverridable (
             rootDir
             gitConfigFile
             ;
-          fetchTags = if fetchTags == false then { } else fetchTags;
+          fetchTags =
+            let
+              addAdditionalTag = finalAttrs.revCustom != null && finalAttrs.tag != null;
+              additionalTags = [ finalAttrs.tag ];
+            in
+            if lib.isAttrs fetchTags then
+              fetchTags
+              // {
+                ${if addAdditionalTag then "" else null} = fetchTags."" or [ ] ++ additionalTags;
+              }
+            else if fetchTags == false then
+              { ${if addAdditionalTag then "" else null} = additionalTags; }
+            else
+              fetchTags;
           fetchTagFlags =
             if lib.isAttrs finalAttrs.fetchTags then
               lib.concatLists (

--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -12,6 +12,7 @@ fetchSubmodules=
 fetchLFS=
 builder=
 fetchTags=
+declare -A tagsToFetch=()
 branchName=$NIX_PREFETCH_GIT_BRANCH_NAME
 
 # ENV params
@@ -57,7 +58,10 @@ Options:
       --leave-dotGit  Keep the .git directories.
       --fetch-lfs     Fetch git Large File Storage (LFS) files.
       --fetch-submodules Fetch submodules.
-      --fetch-tags    Fetch all tags (useful for git describe).
+      --fetch-submodule-tag subpath tag
+          Fetch a tag for a submodule or the main repo, useful for reproducible \`git describe'.
+      --fetch-tag     Fetch the specified tag for the main repo, equivalent to \`--fetch-submodule-tag "" tag'.
+      --fetch-tags    Fetch all tags. This option is less reproducible than \`--fetch-submodule-tag'.
       --builder       Clone as fetchgit does, but url, rev, and out option are mandatory.
       --no-add-path   Do not actually add the contents of the git repo to the store.
       --root-dir dir  Directory in the repository that will be copied to the output instead of the full repository.
@@ -73,6 +77,7 @@ clean_git(){
 
 argi=0
 argfun=""
+preserve_argfun=""
 for arg; do
     if test -z "$argfun"; then
         case $arg in
@@ -90,6 +95,8 @@ for arg; do
             --leave-dotGit) leaveDotGit=true;;
             --fetch-lfs) fetchLFS=true;;
             --fetch-submodules) fetchSubmodules=true;;
+            --fetch-submodule-tag) argfun=add_submodule_tag_key;;
+            --fetch-tag) argfun=add_main_tag;;
             --fetch-tags) fetchTags=true;;
             --builder) builder=true;;
             --no-add-path) noAddPath=true;;
@@ -111,8 +118,24 @@ for arg; do
                 var=${argfun#set_}
                 eval "$var=$(printf %q "$arg")"
                 ;;
+            add_submodule_tag_key)
+                argfun=add_submodule_tag_value_$arg
+                preserve_argfun=1
+                ;;
+            add_submodule_tag_value_*)
+                key=${argfun#add_submodule_tag_value_}
+                key="/${key#/}"
+                tagsToFetch[$key]="${tagsToFetch[$key]-}${tagsToFetch[$key]:+ } $arg"
+                ;;
+            add_main_tag)
+                key="/"
+                tagsToFetch[$key]="${tagsToFetch[$key]-}${tagsToFetch[$key]:+ } $arg"
+                ;;
         esac
-        argfun=""
+        if [[ -z "$preserve_argfun" ]]; then
+            argfun=""
+        fi
+        preserve_argfun=""
     fi
 done
 
@@ -295,6 +318,14 @@ clone(){
         init_submodules
     fi
 
+    for key in "${!tagsToFetch[@]}"; do
+        subpath="${key#/}"
+        echo "fetching specified tags${subpath:+ at submodule $subpath}..." >&2
+        for tagToFetch in ${tagsToFetch[$key]}; do
+            clean_git -C "$subpath" fetch origin "refs/tags/$tagToFetch:refs/tags/$tagToFetch" || echo "warning: failed to fetch tag $tagToFetch" >&2
+        done
+    done
+
     if [ -z "$builder" ] && [ -f .topdeps ]; then
         if tg help &>/dev/null; then
             echo "populating TopGit branches..."
@@ -450,6 +481,21 @@ json_escape() {
     echo "$s"
 }
 
+json_list() {
+    local result=
+    local arg
+    for arg; do
+        if [[ -n "$isFirst" ]]; then
+            result="$result, "
+        else
+            result="["
+        fi
+        result="$result\"$(json_escape "$arg")\""
+    done
+    result="$result]"
+    echo "$result"
+}
+
 print_results() {
     hash="$1"
     if ! test -n "$QUIET"; then
@@ -476,7 +522,23 @@ print_results() {
   "fetchLFS": $([[ -n "$fetchLFS" ]] && echo true || echo false),
   "fetchSubmodules": $([[ -n "$fetchSubmodules" ]] && echo true || echo false),
   "deepClone": $([[ -n "$deepClone" ]] && echo true || echo false),
-  "fetchTags": $([[ -n "$fetchTags" ]] && echo true || echo false),
+  "fetchTags": $(
+    if [[ -n "$fetchTags" ]]; then
+        echo true
+    elif ((${#tagsToFetch[@]})); then
+        keys=("${!tagsToFetch[@]}")
+        keysWithComma=("${keys[@]:0:${#keys[@]-1}}")
+        keyLast="${keys[@]:${#keys[@]-1}:1}"
+        echo "{"
+        for key in "${keysWithComma[@]}"; do
+            echo "    \"$(json_escape "${key#/}")\": $(json_list ${tagsToFetch[$key]}),"
+        done
+        echo "    \"$(json_escape "${key#/}")\": $(json_list ${tagsToFetch[$keyLast]})"
+        echo "  }"
+    else
+        echo "{}"
+    fi
+  ),
   "leaveDotGit": $([[ -n "$leaveDotGit" ]] && echo true || echo false),
   "rootDir": "$(json_escape "$rootDir")"
 }

--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -12,6 +12,7 @@ fetchSubmodules=
 fetchLFS=
 builder=
 fetchTags=
+declare -A tagsToFetch=()
 branchName=$NIX_PREFETCH_GIT_BRANCH_NAME
 
 # ENV params
@@ -57,7 +58,10 @@ Options:
       --leave-dotGit  Keep the .git directories.
       --fetch-lfs     Fetch git Large File Storage (LFS) files.
       --fetch-submodules Fetch submodules.
-      --fetch-tags    Fetch all tags (useful for git describe).
+      --fetch-submodule-tag subpath tag
+          Fetch a tag for a submodule or the main repo, useful for reproducible \`git describe'.
+      --fetch-tag     Fetch the specified tag for the main repo, equivalent to \`--fetch-submodule-tag "" tag'.
+      --fetch-tags    Fetch all tags. This option is less reproducible than \`--fetch-submodule-tag'.
       --builder       Clone as fetchgit does, but url, rev, and out option are mandatory.
       --no-add-path   Do not actually add the contents of the git repo to the store.
       --root-dir dir  Directory in the repository that will be copied to the output instead of the full repository.
@@ -73,6 +77,7 @@ clean_git(){
 
 argi=0
 argfun=""
+preserve_argfun=""
 for arg; do
     if test -z "$argfun"; then
         case $arg in
@@ -90,6 +95,8 @@ for arg; do
             --leave-dotGit) leaveDotGit=true;;
             --fetch-lfs) fetchLFS=true;;
             --fetch-submodules) fetchSubmodules=true;;
+            --fetch-submodule-tag) argfun=add_submodule_tag_key;;
+            --fetch-tag) argfun=add_main_tag;;
             --fetch-tags) fetchTags=true;;
             --builder) builder=true;;
             --no-add-path) noAddPath=true;;
@@ -111,8 +118,24 @@ for arg; do
                 var=${argfun#set_}
                 eval "$var=$(printf %q "$arg")"
                 ;;
+            add_submodule_tag_key)
+                argfun=add_submodule_tag_value_$arg
+                preserve_argfun=1
+                ;;
+            add_submodule_tag_value_*)
+                key=${argfun#add_submodule_tag_value_}
+                key="/${key#/}"
+                tagsToFetch[$key]="${tagsToFetch[$key]-}${tagsToFetch[$key]:+ } $arg"
+                ;;
+            add_main_tag)
+                key="/"
+                tagsToFetch[$key]="${tagsToFetch[$key]-}${tagsToFetch[$key]:+ } $arg"
+                ;;
         esac
-        argfun=""
+        if [[ -z "$preserve_argfun" ]]; then
+            argfun=""
+        fi
+        preserve_argfun=""
     fi
 done
 
@@ -299,6 +322,14 @@ clone(){
         init_submodules
     fi
 
+    for key in "${!tagsToFetch[@]}"; do
+        subpath="${key#/}"
+        echo "fetching specified tags${subpath:+ at submodule $subpath}..." >&2
+        for tagToFetch in ${tagsToFetch[$key]}; do
+            clean_git -C "$subpath" fetch origin "refs/tags/$tagToFetch:refs/tags/$tagToFetch" || echo "warning: failed to fetch tag $tagToFetch" >&2
+        done
+    done
+
     if [ -z "$builder" ] && [ -f .topdeps ]; then
         if tg help &>/dev/null; then
             echo "populating TopGit branches..."
@@ -454,6 +485,21 @@ json_escape() {
     echo "$s"
 }
 
+json_list() {
+    local result=
+    local arg
+    for arg; do
+        if [[ -n "$isFirst" ]]; then
+            result="$result, "
+        else
+            result="["
+        fi
+        result="$result\"$(json_escape "$arg")\""
+    done
+    result="$result]"
+    echo "$result"
+}
+
 print_results() {
     hash="$1"
     if ! test -n "$QUIET"; then
@@ -480,7 +526,23 @@ print_results() {
   "fetchLFS": $([[ -n "$fetchLFS" ]] && echo true || echo false),
   "fetchSubmodules": $([[ -n "$fetchSubmodules" ]] && echo true || echo false),
   "deepClone": $([[ -n "$deepClone" ]] && echo true || echo false),
-  "fetchTags": $([[ -n "$fetchTags" ]] && echo true || echo false),
+  "fetchTags": $(
+    if [[ -n "$fetchTags" ]]; then
+        echo true
+    elif ((${#tagsToFetch[@]})); then
+        keys=("${!tagsToFetch[@]}")
+        keysWithComma=("${keys[@]:0:${#keys[@]-1}}")
+        keyLast="${keys[@]:${#keys[@]-1}:1}"
+        echo "{"
+        for key in "${keysWithComma[@]}"; do
+            echo "    \"$(json_escape "${key#/}")\": $(json_list ${tagsToFetch[$key]}),"
+        done
+        echo "    \"$(json_escape "${key#/}")\": $(json_list ${tagsToFetch[$keyLast]})"
+        echo "  }"
+    else
+        echo "{}"
+    fi
+  ),
   "leaveDotGit": $([[ -n "$leaveDotGit" ]] && echo true || echo false),
   "rootDir": "$(json_escape "$rootDir")"
 }

--- a/pkgs/build-support/fetchgit/tests.nix
+++ b/pkgs/build-support/fetchgit/tests.nix
@@ -45,6 +45,18 @@
     '';
   };
 
+  describe-tag-unstable-version = testers.invalidateFetcherByDrvHash fetchgit {
+    name = "describe-tag-nix-source";
+    url = "https://github.com/NixOS/nix";
+    rev = "9d9dbe6ed05854e03811c361a3380e09183f4f4a";
+    # for `git describe`
+    tag = "2.3.15";
+    hash = "sha256-7DszvbCNTjpzGRmpIVAWXk20P0/XTrWZ79KSOGLrUWY=";
+    postCheckout = ''
+      { git -C "$out" describe || echo "git describe failed"; } | tee describe-output.txt
+    '';
+  };
+
   sparseCheckout = testers.invalidateFetcherByDrvHash fetchgit {
     name = "sparse-checkout-nix-source";
     url = "https://github.com/NixOS/nix";

--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -55,9 +55,9 @@ decorate (
   }@args:
 
   assert (
-    lib.assertMsg (lib.xor (tag == null) (
-      rev == null
-    )) "fetchFromGitHub requires one of either `rev` or `tag` to be provided (not both)."
+    lib.assertMsg (
+      tag != null || rev != null
+    ) "fetchFromGitHub requires at least one of `rev` or `tag` to be provided."
   );
 
   let

--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -59,8 +59,9 @@ decorate (
   }@args:
 
   assert (
-    lib.xor (tag == null) (rev == null)
-    || throw "fetchFromGitHub requires one of either `rev` or `tag` to be provided (not both)."
+    lib.assertMsg (
+      tag != null || rev != null
+    ) "fetchFromGitHub requires at least one of `rev` or `tag` to be provided."
   );
 
   let

--- a/pkgs/build-support/fetchgitlab/default.nix
+++ b/pkgs/build-support/fetchgitlab/default.nix
@@ -17,6 +17,7 @@ lib.makeOverridable (
     domain ? "gitlab.com",
     group ? null,
     fetchSubmodules ? false,
+    postCheckout ? "",
     leaveDotGit ? false,
     deepClone ? false,
     forceFetchGit ? false,
@@ -27,9 +28,9 @@ lib.makeOverridable (
   }@args:
 
   assert (
-    lib.assertMsg (lib.xor (tag == null) (
-      rev == null
-    )) "fetchFromGitLab requires one of either `rev` or `tag` to be provided (not both)."
+    lib.assertMsg (
+      tag != null || rev != null
+    ) "fetchFromGitLab requires at least one of `rev` or `tag` to be provided."
   );
 
   let
@@ -40,7 +41,7 @@ lib.makeOverridable (
         repo
       ]
     );
-    revWithTag = if tag != null then "refs/tags/" + tag else rev;
+    revWithTag = fetchgit.getRevWithTag { inherit rev tag; };
     escapedSlug = lib.replaceStrings [ "." "/" ] [ "%2E" "%2F" ] slug;
     escapedRevWithTag = lib.replaceStrings [ "+" "%" "/" ] [ "%2B" "%25" "%2F" ] revWithTag;
     passthruAttrs = removeAttrs args [
@@ -61,7 +62,7 @@ lib.makeOverridable (
 
     varBase = "NIX${lib.optionalString (varPrefix != null) "_${varPrefix}"}_GITLAB_PRIVATE_";
     useFetchGit =
-      fetchSubmodules || leaveDotGit || deepClone || forceFetchGit || (sparseCheckout != [ ]);
+      fetchSubmodules || postCheckout != "" || deepClone || forceFetchGit || (sparseCheckout != [ ]);
     fetcher = if useFetchGit then fetchgit else fetchzip;
 
     privateAttrs = lib.optionalAttrs private (

--- a/pkgs/build-support/fetchgitlab/default.nix
+++ b/pkgs/build-support/fetchgitlab/default.nix
@@ -17,6 +17,7 @@ lib.makeOverridable (
     domain ? "gitlab.com",
     group ? null,
     fetchSubmodules ? false,
+    postCheckout ? "",
     leaveDotGit ? false,
     deepClone ? false,
     forceFetchGit ? false,
@@ -27,8 +28,9 @@ lib.makeOverridable (
   }@args:
 
   assert (
-    lib.xor (tag == null) (rev == null)
-    || throw "fetchFromGitLab requires one of either `rev` or `tag` to be provided (not both)."
+    lib.assertMsg (
+      tag != null || rev != null
+    ) "fetchFromGitLab requires at least one of `rev` or `tag` to be provided."
   );
 
   let
@@ -39,7 +41,7 @@ lib.makeOverridable (
         repo
       ]
     );
-    revWithTag = if tag != null then "refs/tags/" + tag else rev;
+    revWithTag = fetchgit.getRevWithTag { inherit rev tag; };
     escapedSlug = lib.replaceStrings [ "." "/" ] [ "%2E" "%2F" ] slug;
     escapedRevWithTag = lib.replaceStrings [ "+" "%" "/" ] [ "%2B" "%25" "%2F" ] revWithTag;
     passthruAttrs = removeAttrs args [
@@ -60,7 +62,7 @@ lib.makeOverridable (
 
     varBase = "NIX${lib.optionalString (varPrefix != null) "_${varPrefix}"}_GITLAB_PRIVATE_";
     useFetchGit =
-      fetchSubmodules || leaveDotGit || deepClone || forceFetchGit || (sparseCheckout != [ ]);
+      fetchSubmodules || postCheckout != "" || deepClone || forceFetchGit || (sparseCheckout != [ ]);
     fetcher = if useFetchGit then fetchgit else fetchzip;
 
     privateAttrs = lib.optionalAttrs private (


### PR DESCRIPTION
## Description

This PR addresses the unsolved question of #465497 about the reproducible `git describe` for packages with unstable versions.

- This PR allows specifying `fetchTags` as an attribute set, and changes its default to `{ }`, allowing reproducible fetching of additional tags from the main module and submodules.
  - Unlike `fetchTags = true`, specifying `fetchTags` as an attribute set does not imply `leaveDotGit = true`. This encourages the use of `postCheckout` for better hash stability.
  - The corresponding command-line arguments for `nix-prefetch-git` is `--fetch-tag TAG`, which can be specified multiple times.
- This PR allows `fetchgit` to take both `rev` and `tag` simultaneously. In such scenario, the `rev` will be observed as the revision to fetch, and the `tag` will be added to the `fetchTags` list.

Example use case:

```nix
{
  lib,
  stdenv,
  fetchgit,
}:
let
  getPreviousStableVersion =
    v:
    let
      matched = lib.match "(.*)-unstable-[0-9]{4}-[0-9]{2}-[0-9]{2}" v;
    in
    if matched == null then v else lib.head matched;
in
stdenv.mkDerivation {
  pname = "my-package";
  version = "0.1.0-unstable-2024-12-31";
  src = fetchgit {
    url = "https://example.com/source.git";
    rev = "9d9dbe6ed05854e03811c361a3380e09183f4f4a"
    tag = "v${getPreviousStableVersion finalAttrs.version}";
    hash = "sha256-7DszvbCNTjpzGRmpIVAWXk20P0/XTrWZ79KSOGLrUWY=";
    postCheckout = ''
      git describe | tee git_describe_output.txt
    '';
  };
}
```

This PR depends on the following PRs:
- #462032
- #456226
- #464475
- #465497

The diff will be shorter once the depending PR is merged.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
