### PR TITLE
llef: Fix version parsing on Darwin

### DIFF
--- a/pkgs/development/compilers/llvm/common/default.nix
+++ b/pkgs/development/compilers/llvm/common/default.nix
@@ -253,7 +253,7 @@ makeScopeWithSplicing' {
           {
             otherSplices = lib.mapAttrs (_: selfSplice: selfSplice.lldbPlugins or { }) otherSplices;
             f = selfLldbPlugins: {
-              llef = selfLldbPlugins.callPackage ./lldb-plugins/llef.nix { };
+              llef = selfLldbPlugins.callPackage ./lldb-plugins/llef { };
             };
           }
       );

--- a/pkgs/development/compilers/llvm/common/lldb-plugins/llef/darwin-version.patch
+++ b/pkgs/development/compilers/llvm/common/lldb-plugins/llef/darwin-version.patch
@@ -1,0 +1,13 @@
+diff --git a/llef.py b/llef.py
+index 7f3adf4..8ca36c5 100644
+--- a/llef.py
++++ b/llef.py
+@@ -54,7 +54,7 @@ def __lldb_init_module(debugger: SBDebugger, _: Dict[Any, Any]) -> None:
+         handler.lldb_self_register(debugger, "llef")
+ 
+     LLEFState.platform = platform.system()
+-    if LLEFState.platform == "Darwin":
++    if False and LLEFState.platform == "Darwin": # Nix lldb on Darwin also follows the "regular" version scheme
+         # Getting Clang version (e.g.  lldb-1600.0.36.3)
+         LLEFState.version = [int(x) for x in debugger.GetVersionString().split()[0].split("-")[1].split(".")]
+     else:

--- a/pkgs/development/compilers/llvm/common/lldb-plugins/llef/default.nix
+++ b/pkgs/development/compilers/llvm/common/lldb-plugins/llef/default.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ makeWrapper ];
 
+  patches = [ ./darwin-version.patch ];
+
   installPhase = ''
     runHook preInstall
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

llef differentiates between darwin lldb and "regular" lldb because the format with which they print their version string differs. When you use nix-lldb however, the version format is exactly the same as regular lldb, even on darwin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
