### PR TITLE
mvoice: init at 0-unstable-2025-09-19

### DIFF
--- a/pkgs/by-name/mv/mvoice/package.nix
+++ b/pkgs/by-name/mv/mvoice/package.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  stdenv,
+  gettext,
+  fltk-minimal,
+  alsa-lib,
+  opendht,
+  msgpack-cxx,
+  fmt,
+  gnutls,
+  nlohmann_json,
+  curl,
+  copyDesktopItems,
+  makeDesktopItem,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation {
+  pname = "mvoice";
+  version = "0-unstable-2025-09-19";
+
+  src = fetchFromGitHub {
+    owner = "n7tae";
+    repo = "mvoice";
+    rev = "aef3662ee6ef86ecb10a71dd686ca41a067162c0";
+    hash = "sha256-FosfD1949shlPXq594gdqodlXM3cGKpFi68tc+/YQ4g=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    fltk-minimal
+    gettext
+  ];
+
+  buildInputs = [
+    alsa-lib
+    curl
+    fltk-minimal
+    fmt
+    gnutls
+    msgpack-cxx
+    nlohmann_json
+    opendht
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "mvoice";
+      desktopName = "MVoice";
+      comment = "MVoice by N7TAE - M17 figital voice gateway";
+      exec = "mvoice";
+      categories = [
+        "Network"
+        "X-Ham Radio"
+      ];
+    })
+  ];
+
+  postPatch = ''
+    # fix hardcoded paths in Makefile
+    substituteInPlace Makefile \
+      --replace-fail "g++" "\$(CXX)" \
+      --replace-fail "/bin/cp" "cp"
+  '';
+
+  makeFlags = [
+    "BASEDIR=$(out)"
+    "CFGDIR=.config/mvoice"
+    "DEBUG=false"
+    "USE44100=false"
+    "USE_DHT=true"
+  ];
+
+  meta = {
+    description = "M17 digital voice gateway and module for voice and data modes";
+    homepage = "https://github.com/n7tae/mvoice";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.juliabru ];
+  };
+}


### PR DESCRIPTION
MVoice is a M17 ham radio digital mode gateway application created and maintained by N7TAE on GitHub ([repo](https://github.com/n7tae/mvoice)).

M17 is a patent free open source digital voice and data mode as opposed to DMR which is an open ETSI standard but uses proprietary voice coding.

Though intended for use on the raspberry Pi, it runs on any linux machine that has ALSA and fltk.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
