### PR TITLE
nixos/gollum: remove services.gollum.local-time option

### DIFF
--- a/nixos/modules/services/misc/gollum.nix
+++ b/nixos/modules/services/misc/gollum.nix
@@ -18,6 +18,11 @@ in
       ]
       "MathJax rendering might be discontinued in the future, use services.gollum.math instead to enable KaTeX rendering or file a PR if you really need Mathjax"
     )
+    (lib.mkRemovedOptionModule [
+      "services"
+      "gollum"
+      "local-time"
+    ] "Set the value in services.gollum.extraConfig")
   ];
 
   options.services.gollum = {
@@ -38,6 +43,13 @@ in
     extraConfig = lib.mkOption {
       type = lib.types.lines;
       default = "";
+      example = ''
+        wiki_options = {
+          show_local_time: true
+        }
+
+        Precious::App.set(:wiki_options, wiki_options)
+      '';
       description = "Content of the configuration file";
     };
 
@@ -85,12 +97,6 @@ in
       type = lib.types.bool;
       default = false;
       description = "Disable editing pages";
-    };
-
-    local-time = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = "Use the browser's local timezone instead of the server's for displaying dates.";
     };
 
     branch = lib.mkOption {
@@ -159,7 +165,6 @@ in
             ${lib.optionalString cfg.emoji "--emoji"} \
             ${lib.optionalString cfg.h1-title "--h1-title"} \
             ${lib.optionalString cfg.no-edit "--no-edit"} \
-            ${lib.optionalString cfg.local-time "--local-time"} \
             ${lib.optionalString (cfg.allowUploads != null) "--allow-uploads ${cfg.allowUploads}"} \
             ${lib.optionalString (cfg.user-icons != null) "--user-icons ${cfg.user-icons}"} \
             ${cfg.stateDir}

--- a/nixos/tests/gollum.nix
+++ b/nixos/tests/gollum.nix
@@ -7,6 +7,13 @@
       { pkgs, lib, ... }:
       {
         services.gollum.enable = true;
+        services.gollum.extraConfig = ''
+          wiki_options = {
+            show_local_time: true
+          }
+
+          Precious::App.set(:wiki_options, wiki_options)
+        '';
       };
   };
 


### PR DESCRIPTION
Closes #466724 

The option was long removed, so we backport it to 25.05

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
