### PR TITLE
slipshow: 0.6.0 -> 0.7.0

### DIFF
--- a/nixos/tests/slipshow.nix
+++ b/nixos/tests/slipshow.nix
@@ -25,11 +25,9 @@
       start_all()
 
       # it may take around a minute to compile the file and serve it
-      machine.succeed("slipshow serve /etc/slipshow/bbslides.md &>/dev/null &")
+      machine.succeed("slipshow serve -p 6000 /etc/slipshow/bbslides.md &>/dev/null &")
 
-      # slipshow serves defaultly on :8080 and unfortunately cannot
-      # be changed currently
-      machine.wait_for_open_port(8080)
-      machine.succeed("curl -i 0.0.0.0:8080")
+      machine.wait_for_open_port(6000)
+      machine.succeed("curl -i 0.0.0.0:6000")
     '';
 }

--- a/pkgs/by-name/sl/slipshow/package.nix
+++ b/pkgs/by-name/sl/slipshow/package.nix
@@ -9,13 +9,13 @@
 
 ocamlPackages.buildDunePackage rec {
   pname = "slipshow";
-  version = "0.6.0";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "panglesd";
     repo = "slipshow";
     tag = "v${version}";
-    hash = "sha256-cmBq9RYjvl355+tV+Nf7XmDzgbOqusCjVrqoC34R5CI=";
+    hash = "sha256-HV4qUp/da0GjZ/KSaE4L/qxdosnOTRcC83zIRigxFSY=";
   };
 
   postPatch = ''
@@ -40,6 +40,7 @@ ocamlPackages.buildDunePackage rec {
     lwt
     magic-mime
     ppx_blob
+    ppx_deriving_yojson
     ppx_sexp_value
     sexplib
   ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Changelog: https://github.com/panglesd/slipshow/releases/tag/v0.7.0

Highlight includes adding the the port command line option.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
