### PR TITLE
python313Packages.gnocchiclient: init at 7.2.0

### DIFF
--- a/pkgs/development/python-modules/futurist/default.nix
+++ b/pkgs/development/python-modules/futurist/default.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  debtcollector,
+  pbr,
+  eventlet,
+  coverage,
+  oslotest,
+  stestr,
+  testscenarios,
+  testtools,
+  prettytable,
+}:
+
+buildPythonPackage rec {
+  pname = "futurist";
+  version = "3.2.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "openstack";
+    repo = "futurist";
+    tag = "${version}";
+    hash = "sha256-IrISdaVykQsRnfPk9bu1FpYtbyvMxzWm39FLpQmrFAM=";
+  };
+
+  env.PBR_VERSION = version;
+
+  build-system = [
+    pbr
+  ];
+
+  dependencies = [ debtcollector ];
+
+  pythonImportsCheck = [ "futurist" ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    stestr run
+
+    runHook postCheck
+  '';
+
+  nativeCheckInputs = [
+    eventlet
+    coverage
+    oslotest
+    stestr
+    testscenarios
+    testtools
+    prettytable
+  ];
+
+  meta = {
+    homepage = "https://opendev.org/openstack/futurist";
+    description = "Collection of async functionality and additions from the future";
+    license = lib.licenses.asl20;
+    maintainers = lib.teams.openstack.members;
+  };
+}

--- a/pkgs/development/python-modules/python-gnocchiclient/default.nix
+++ b/pkgs/development/python-modules/python-gnocchiclient/default.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+  setuptools-scm,
+
+  # dependencies
+  cliff,
+  debtcollector,
+  futurist,
+  iso8601,
+  keystoneauth1,
+  python-dateutil,
+  ujson,
+
+  # tests and doc
+  flake8,
+  python-openstackclient,
+  pytestCheckHook,
+  pytest-xdist,
+  openstackdocstheme,
+  sphinx,
+  sphinxcontrib-apidoc,
+}:
+
+buildPythonPackage rec {
+  pname = "python-gnocchiclient";
+  version = "7.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "gnocchixyz";
+    repo = "python-gnocchiclient";
+    tag = version;
+    hash = "sha256-6j33+r4ZWg04on/mIorx8sZ09wgszfQVUjgxzR6LlI8=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  nativeBuildInputs = [
+    openstackdocstheme
+    sphinx
+    sphinxcontrib-apidoc
+  ];
+
+  dependencies = [
+    cliff
+    debtcollector
+    futurist
+    iso8601
+    keystoneauth1
+    python-dateutil
+    ujson
+  ];
+
+  nativeCheckInputs = [
+    flake8
+    python-openstackclient
+    pytestCheckHook
+    pytest-xdist
+  ];
+
+  pythonImportsCheck = [ "gnocchiclient" ];
+
+  meta = with lib; {
+    description = "Python client library for Gnocchi";
+    homepage = "https://github.com/gnocchixyz/python-gnocchiclient";
+    mainProgram = "gnocchi";
+    license = licenses.asl20;
+    teams = [ teams.openstack ];
+  };
+}

--- a/pkgs/development/python-modules/python-openstackclient/default.nix
+++ b/pkgs/development/python-modules/python-openstackclient/default.nix
@@ -11,6 +11,7 @@
   python-barbicanclient,
   python-cinderclient,
   python-designateclient,
+  python-gnocchiclient,
   python-heatclient,
   python-ironicclient,
   python-keystoneclient,
@@ -84,6 +85,7 @@ buildPythonPackage rec {
       python-aodhclient
       python-barbicanclient
       python-designateclient
+      python-gnocchiclient
       python-heatclient
       python-ironicclient
       python-magnumclient

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8133,6 +8133,7 @@ with pkgs;
   });
   barbicanclient = with python313Packages; toPythonApplication python-barbicanclient;
   glanceclient = with python313Packages; toPythonApplication python-glanceclient;
+  gnocchiclient = with python313Packages; toPythonApplication python-gnocchiclient;
   heatclient = with python313Packages; toPythonApplication python-heatclient;
   ironicclient = with python313Packages; toPythonApplication python-ironicclient;
   magnumclient = with python313Packages; toPythonApplication python-magnumclient;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5791,6 +5791,8 @@ self: super: with self; {
 
   future-typing = callPackage ../development/python-modules/future-typing { };
 
+  futurist = callPackage ../development/python-modules/futurist { };
+
   fuzzyfinder = callPackage ../development/python-modules/fuzzyfinder { };
 
   fuzzytm = callPackage ../development/python-modules/fuzzytm { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15131,6 +15131,8 @@ self: super: with self; {
 
   python-glanceclient = callPackage ../development/python-modules/python-glanceclient { };
 
+  python-gnocchiclient = callPackage ../development/python-modules/python-gnocchiclient { };
+
   python-gnupg = callPackage ../development/python-modules/python-gnupg { };
 
   python-google-drive-api = callPackage ../development/python-modules/python-google-drive-api { };


### PR DESCRIPTION
This MR adds `python-gnocchiclient` for OpenStack.  
It can be used with the standalone CLI or with the Openstack client.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
