### PR TITLE
zfs: clevis support for all filesystems, not just those needed for boot

### DIFF
--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -24,10 +24,7 @@ let
     lib.filterAttrs (
       device: _:
       lib.any (
-        e:
-        e.fsType == "zfs"
-        && (utils.fsNeededForBoot e)
-        && (e.device == device || lib.hasPrefix "${device}/" e.device)
+        e: e.fsType == "zfs" && (e.device == device || lib.hasPrefix "${device}/" e.device)
       ) config.system.build.fileSystems
     ) config.boot.initrd.clevis.devices
   );
@@ -217,7 +214,7 @@ let
           if poolImported "${pool}"; then
           ${lib.optionalString config.boot.initrd.clevis.enable (
             lib.concatMapStringsSep "\n" (
-              elem: "clevis decrypt < /etc/clevis/${elem}.jwe | zfs load-key ${elem} || true "
+              elem: "clevis decrypt < /etc/clevis/${elem}.jwe | zfs load-key -L prompt ${elem} || true "
             ) (lib.filter (p: (lib.elemAt (lib.splitString "/" p) 0) == pool) clevisDatasets)
           )}
 


### PR DESCRIPTION
Load zfs key from clevis for any dataset that has a matching clevis device configured, not just those needed for boot

Also works for dual keys, e.g. those with a clevis key, and a zfs keylocation of `file:///` (previously it would error if the zfs keylocation was not `prompt`)

Similar to #357755 

Motivation is i want to switch from using sops-nix to clevis for zfs keys. I also wanted the option to fall back to a file based keylocation, hence the `-L prompt` change to `zfs load-keys`. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
removed `utils.fsNeededForBoot` check
added `-L prompt` to `zfs load-key` to stop errors if `keylocation` is not prompt

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
