### PR TITLE
hayabusa-sec: 3.3.0-unstable-2025-07-17 -> 3.7.0-unstable-2025-12-02

### DIFF
--- a/pkgs/by-name/ha/hayabusa-sec/package.nix
+++ b/pkgs/by-name/ha/hayabusa-sec/package.nix
@@ -2,6 +2,8 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  makeWrapper,
+  unstableGitUpdater,
   pkg-config,
   openssl,
   rust-jemalloc-sys,
@@ -9,20 +11,21 @@
 
 rustPlatform.buildRustPackage {
   pname = "hayabusa-sec";
-  version = "3.3.0-unstable-2025-07-17";
+  version = "3.7.0-unstable-2025-12-02";
 
   src = fetchFromGitHub {
     owner = "Yamato-Security";
     repo = "hayabusa";
-    rev = "feaa165b4c0af34919ad26f634cb684e23172359";
-    hash = "sha256-h08InhNVW33IjPA228gv6Enlg6EKmj0yHb/UvJ/f7uw=";
+    rev = "1c4f332b446f20af154257b2e9b581f7bcb4b1a2";
+    hash = "sha256-JWb54yudfB6pOMZca8sFeoRqNA7M//xJ3IBKfIcGBnM=";
     # Include the hayabusa-rules
     fetchSubmodules = true;
   };
 
-  cargoHash = "sha256-wcH1Ron5Zx2ypWyaW0z7L9rCanAcosvpPQnP60qbvWQ=";
+  cargoHash = "sha256-JIHkFokaZ+nt1hW+gRxFrb1DVZcm4jsZKT12gx/BRCA=";
 
   nativeBuildInputs = [
+    makeWrapper
     pkg-config
   ];
 
@@ -38,6 +41,15 @@ rustPlatform.buildRustPackage {
   # end up passed to executing `hayabusa`
   # > error: unexpected argument '--skip' found
   doCheck = false;
+
+  postInstall = ''
+    mkdir -p $out/share/hayabusa-sec
+    cp -r rules $out/share/hayabusa-sec/
+    mv $out/bin/hayabusa $out/share/hayabusa-sec/
+    makeWrapper $out/share/hayabusa-sec/hayabusa $out/bin/hayabusa
+  '';
+
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = {
     description = "Sigma-based threat hunting and fast forensics timeline generator for Windows event logs";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
