### PR TITLE
govee2mqtt: 2024.01.24-ea3cd430 -> 2025.11.25-60a39bcc

### DIFF
--- a/pkgs/by-name/go/govee2mqtt/dont-vendor-openssl.diff
+++ b/pkgs/by-name/go/govee2mqtt/dont-vendor-openssl.diff
@@ -1,24 +1,24 @@
 diff --git a/Cargo.lock b/Cargo.lock
-index 303f6f8..952a7ff 100644
+index 76cb503..19245e0 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -1373,15 +1373,6 @@ version = "0.1.5"
+@@ -1496,15 +1496,6 @@ version = "0.1.6"
  source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
  
 -[[package]]
 -name = "openssl-src"
--version = "300.2.1+3.2.0"
+-version = "300.5.4+3.5.4"
 -source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "3fe476c29791a5ca0d1273c697e96085bbabbbea2ef7afd5617e78a4b40332d3"
+-checksum = "a507b3792995dae9b0df8a1c1e3771e8418b7c2d9f0baeba32e6fe8b06c7cb72"
 -dependencies = [
 - "cc",
 -]
 -
  [[package]]
  name = "openssl-sys"
- version = "0.9.98"
-@@ -1390,7 +1381,6 @@ checksum = "c1665caf8ab2dc9aef43d1c0023bd904633a6a05cb30b0ad59bec2ae986e57a7"
+ version = "0.9.111"
+@@ -1513,7 +1504,6 @@ checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
  dependencies = [
   "cc",
   "libc",
@@ -27,15 +27,14 @@ index 303f6f8..952a7ff 100644
   "vcpkg",
  ]
 diff --git a/Cargo.toml b/Cargo.toml
-index a4cf25c..42fde6d 100644
+index 290b9fb..3b04346 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -44,7 +44,7 @@ parking_lot = "0.12.1"
+@@ -44,7 +44,6 @@ parking_lot = "0.12.1"
  
  [dependencies.mosquitto-rs]
  version="0.11.1"
 -features = ["vendored-openssl"]
-+features = ["router"]
  #path = "../mosquitto-rs/mosquitto-rs"
  
  [dev-dependencies]

--- a/pkgs/by-name/go/govee2mqtt/package.nix
+++ b/pkgs/by-name/go/govee2mqtt/package.nix
@@ -2,32 +2,23 @@
   rustPlatform,
   lib,
   fetchFromGitHub,
-  fetchpatch,
   openssl,
   pkg-config,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "govee2mqtt";
-  version = "2024.01.24-ea3cd430";
+  version = "2025.11.25-60a39bcc";
 
   src = fetchFromGitHub {
     owner = "wez";
     repo = "govee2mqtt";
-    rev = version;
-    hash = "sha256-iGOj0a4+wLd8QlM1tr+NYfd2tuwgHV+u5dt0zf+WscY=";
+    tag = finalAttrs.version;
+    hash = "sha256-8N/qQHJvVKWdlPQDbLskGw9le0L7yzTwxwz1w4cFu5g=";
   };
 
   cargoPatches = [
     ./dont-vendor-openssl.diff
-  ];
-
-  patches = [
-    # update test fixtures https://github.com/wez/govee2mqtt/pull/120
-    (fetchpatch {
-      url = "https://github.com/wez/govee2mqtt/commit/0c2dc3e1cc1ccd44ddf98ead34e081ac4b4335f1.patch";
-      hash = "sha256-0TNYyvRRcMkE9FYPcVoKburejhAn/cVYM3eaobS4nx8=";
-    })
   ];
 
   postPatch = ''
@@ -35,7 +26,7 @@ rustPlatform.buildRustPackage rec {
       --replace '"assets"' '"${placeholder "out"}/share/govee2mqtt/assets"'
   '';
 
-  cargoHash = "sha256-RJqAhAhrMHLunJwTtvUIBNO45xUWY251KXyX0RLruwk=";
+  cargoHash = "sha256-rs3wfvotR2p7jC6dn+JkTLJxVBtQR/IWgM9KmoYSelA=";
 
   nativeBuildInputs = [ pkg-config ];
 
@@ -46,12 +37,12 @@ rustPlatform.buildRustPackage rec {
     cp -r assets $out/share/govee2mqtt/
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Connect Govee lights and devices to Home Assistant";
     homepage = "https://github.com/wez/govee2mqtt";
-    changelog = "https://github.com/wez/govee2mqtt/blob/${src.rev}/addon/CHANGELOG.md";
-    license = licenses.mit;
-    maintainers = with maintainers; [ SuperSandro2000 ];
+    changelog = "https://github.com/wez/govee2mqtt/blob/${finalAttrs.version}/addon/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
     mainProgram = "govee";
   };
-}
+})


### PR DESCRIPTION
https://github.com/wez/govee2mqtt/blob/2025.11.25-60a39bcc/addon/CHANGELOG.md

First ever update to this package since its initialization almost two years ago. No automated updates thus far because both patches conflicted.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
