### PR TITLE
python3Packages.fickling: 0.1.4 -> 0.1.5, adopt

### DIFF
--- a/pkgs/development/python-modules/fickling/default.nix
+++ b/pkgs/development/python-modules/fickling/default.nix
@@ -55,6 +55,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/trailofbits/fickling";
     changelog = "https://github.com/trailofbits/fickling/releases/tag/${src.tag}";
     license = lib.licenses.lgpl3Plus;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ sarahec ];
   };
 }

--- a/pkgs/development/python-modules/fickling/default.nix
+++ b/pkgs/development/python-modules/fickling/default.nix
@@ -1,40 +1,36 @@
 {
   lib,
-  astunparse,
   buildPythonPackage,
-  distutils,
   fetchFromGitHub,
-  flit-core,
+  hatchling,
   numpy,
   pytestCheckHook,
+  stdlib-list,
   torch,
   torchvision,
-  stdlib-list,
 }:
 
 buildPythonPackage rec {
   pname = "fickling";
-  version = "0.1.4";
+  version = "0.1.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "trailofbits";
     repo = "fickling";
     tag = "v${version}";
-    hash = "sha256-EgVtMYPwSVBlw1bmX3qEeUKvEY7Awv6DOB5tgSLG+xQ=";
+    hash = "sha256-ExyjOTpIkDM2PmHxYUbe8xNhhQChqfUqTtsNR8Z7ZEk=";
   };
 
   build-system = [
-    distutils
-    flit-core
+    hatchling
   ];
 
   dependencies = [
-    astunparse
     stdlib-list
   ];
 
-  pythonRelaxDeps = [ "stdlib_list" ];
+  pythonRelaxDeps = [ "stdlib-list" ];
 
   optional-dependencies = {
     torch = [


### PR DESCRIPTION
Version bump, adopt as maintainer.

CHANGELOG: https://github.com/trailofbits/fickling/releases/tag/v0.1.5
DIFF: https://github.com/trailofbits/fickling/compare/v0.1.4...v0.1.5

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
