### PR TITLE
udev-hid-bpf: init at 2.2.0-20251121

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10456,6 +10456,12 @@
     githubId = 18178614;
     name = "Spencer Heywood";
   };
+  heyzec = {
+    email = "hz.tiang+nixpkgs@gmail.com";
+    github = "heyzec";
+    githubId = 61238538;
+    name = "heyzec";
+  };
   hh = {
     email = "hh@m-labs.hk";
     github = "HarryMakes";

--- a/pkgs/by-name/ud/udev-hid-bpf/package.nix
+++ b/pkgs/by-name/ud/udev-hid-bpf/package.nix
@@ -1,0 +1,91 @@
+{
+  bpftools,
+  clang,
+  elfutils,
+  fetchFromGitLab,
+  lib,
+  libbpf,
+  meson,
+  ninja,
+  pkg-config,
+  python3,
+  python3Packages,
+  rustPlatform,
+  systemd,
+  zlib,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "udev-hid-bpf";
+  version = "2.2.0-20251121";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "libevdev";
+    repo = pname;
+    rev = "${version}";
+    hash = "sha256-zZy0qjwirKYbNKFPt3SoM9993h6jOzfmg9jet/7vJ6U=";
+  };
+
+  cargoHash = "sha256-cf5FLPT581Dy4msM1hdvflN1OHij+sVdZwLHyRRYWw8=";
+
+  nativeBuildInputs = [
+    bpftools
+    clang
+    meson
+    ninja
+    pkg-config
+    python3
+  ];
+
+  buildInputs = [
+    elfutils
+    libbpf
+    systemd.dev
+    zlib
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    click
+    gitpython
+    pytest
+  ];
+
+  dontUseNinjaBuild = true;
+  dontUseNinjaCheck = true;
+  dontUseNinjaInstall = true;
+
+  # mesonFlags = [
+  #   "-Dprefix=$out"
+  #   "-Dudev-dir=$out/etc"
+  # ];
+
+  patchPhase = ''
+    sed -i '1s|.*|#!${python3}/bin/python3|' tools/generate-hwdb.py
+    sed -i '266s|libbpf\.so|${libbpf}/lib/libbpf.so|' test/btf.py
+  '';
+
+  configurePhase = ''
+    meson setup -Dprefix=$out -Dudevdir=$out/etc build
+  '';
+
+  buildPhase = ''
+    meson compile -C build
+  '';
+
+  installPhase = ''
+    meson install -C build
+  '';
+
+  # Otherwise, clang fails with error: unsupported option '-fzero-call-used-regs=used-gpr' for target 'bpf'
+  hardeningDisable = [
+    "zerocallusedregs"
+  ];
+
+  meta = with lib; {
+    description = "An automatic HID-BPF loader based on udev events written in rust";
+    homepage = "https://gitlab.freedesktop.org/libevdev/udev-hid-bpf";
+    license = licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ heyzec ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## What is udev-hid-bpf
[udev-hid-bpf](https://gitlab.freedesktop.org/libevdev/udev-hid-bpf) is a tool for loading HID-BPF programs either manually or automatically based on udev triggers. HID-BPF programs allow one to fix or modify behaviour of HID devices (e.g. mouse, touchpad) without patching the kernel driver. This is possible because the kernel loads the eBPF program and lets it intercept raw packets.


Homepage: https://gitlab.freedesktop.org/libevdev/udev-hid-bpf
Docs: https://gitlab.freedesktop.org/libevdev/udev-hid-bpf

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
