### PR TITLE
pyjwkest: remove 'future' dependency to fix build

### DIFF
--- a/pkgs/development/python-modules/pyjwkest/default.nix
+++ b/pkgs/development/python-modules/pyjwkest/default.nix
@@ -1,35 +1,48 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
-  future,
+  fetchFromGitHub,
   pycryptodomex,
-  pytest,
+  pytestCheckHook,
   requests,
+  setuptools,
   six,
 }:
 
 buildPythonPackage rec {
   pname = "pyjwkest";
-  version = "1.4.2";
-  format = "setuptools";
+  version = "1.4.4";
+  pyproject = true;
 
-  meta = {
-    description = "Implementation of JWT, JWS, JWE and JWK";
-    homepage = "https://github.com/rohe/pyjwkest";
-    license = lib.licenses.asl20;
+  src = fetchFromGitHub {
+    owner = "IdentityPython";
+    repo = "pyjwkest";
+    tag = "v${version}";
+    hash = "sha256-G4/qLOOQHsNSMVndUdYBhrrk8uEufbI8Od3ziQiY0XI=";
   };
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "5560fd5ba08655f29ff6ad1df1e15dc05abc9d976fcbcec8d2b5167f49b70222";
-  };
+  build-system = [ setuptools ];
 
-  buildInputs = [ pytest ];
-  propagatedBuildInputs = [
-    future
+  # Remove unused future import, see pending PR:
+  # https://github.com/IdentityPython/pyjwkest/pull/107
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail '"future"' ""
+  '';
+
+  dependencies = [
     pycryptodomex
     requests
     six
   ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "jwkest" ];
+
+  meta = {
+    description = "Implementation of JWT, JWS, JWE and JWK";
+    homepage = "https://github.com/IdentityPython/pyjwkest";
+    license = lib.licenses.asl20;
+  };
 }


### PR DESCRIPTION
This dependency is unused in pyjwkest, but disabled in nixpkgs. There is an upstream pull request pending to remove the dependency: https://github.com/IdentityPython/pyjwkest/pull/107

Before this change, these 2 Python packages failed to build:

```
nix build .#python313Packages.pyjwkest
nix build .#python313Packages.oic
```

With the following message:

```
error:
       … while evaluating the attribute 'drvPath'
         at /nix/store/65sypvf1f26fyi1vq6h25wg9z5gipgy8-source/lib/customisation.nix:429:7:
          428|     // {
          429|       drvPath =
             |       ^
          430|         assert condition;

       … while evaluating the attribute 'drvPath'
         at /nix/store/65sypvf1f26fyi1vq6h25wg9z5gipgy8-source/lib/customisation.nix:429:7:
          428|     // {
          429|       drvPath =
             |       ^
          430|         assert condition;

       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: future-1.0.0 not supported for interpreter python3.13
```

(I am using the oic package via the pretix-oidc plugin.)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
