### PR TITLE
cargo-*: start maintaining and migrate to `finalAttrs`

### DIFF
--- a/pkgs/by-name/ca/cargo-benchcmp/package.nix
+++ b/pkgs/by-name/ca/cargo-benchcmp/package.nix
@@ -39,6 +39,6 @@ rustPlatform.buildRustPackage rec {
       mit
       unlicense
     ];
-    maintainers = [ ];
+    maintainers = [ maintainers.progrm_jarvis ];
   };
 }

--- a/pkgs/by-name/ca/cargo-benchcmp/package.nix
+++ b/pkgs/by-name/ca/cargo-benchcmp/package.nix
@@ -6,14 +6,14 @@
   stdenv,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-benchcmp";
   version = "0.4.5";
 
   src = fetchFromGitHub {
     owner = "BurntSushi";
     repo = "cargo-benchcmp";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-J8KFI0V/mOhUlYtVnFAQgPIpXL9/dLhOFxSly4bR00I=";
   };
 
@@ -31,14 +31,14 @@ rustPlatform.buildRustPackage rec {
     "--skip=different_input_colored"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Small utility to compare Rust micro-benchmarks";
     mainProgram = "cargo-benchcmp";
     homepage = "https://github.com/BurntSushi/cargo-benchcmp";
-    license = with licenses; [
+    license = with lib.licenses; [
       mit
       unlicense
     ];
-    maintainers = [ maintainers.progrm_jarvis ];
+    maintainers = [ lib.maintainers.progrm_jarvis ];
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-benchcmp/package.nix
+++ b/pkgs/by-name/ca/cargo-benchcmp/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   replaceVars,
   stdenv,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -30,6 +31,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     # thread 'different_input_colored' panicked at 'assertion failed: `(left == right)`
     "--skip=different_input_colored"
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Small utility to compare Rust micro-benchmarks";

--- a/pkgs/by-name/ca/cargo-component/package.nix
+++ b/pkgs/by-name/ca/cargo-component/package.nix
@@ -4,16 +4,17 @@
   fetchFromGitHub,
   pkg-config,
   openssl,
+  versionCheckHook,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-component";
   version = "0.21.1";
 
   src = fetchFromGitHub {
     owner = "bytecodealliance";
     repo = "cargo-component";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Tlx14q/2k/0jZZ1nECX7zF/xNTeMCZg/fN+fhRM4uhc=";
   };
 
@@ -30,12 +31,16 @@ rustPlatform.buildRustPackage rec {
   # requires the wasm32-wasi target
   doCheck = false;
 
-  meta = with lib; {
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  meta = {
     description = "Cargo subcommand for creating WebAssembly components based on the component model proposal";
     homepage = "https://github.com/bytecodealliance/cargo-component";
-    changelog = "https://github.com/bytecodealliance/cargo-component/releases/tag/${src.rev}";
-    license = licenses.asl20;
-    maintainers = [ maintainers.progrm_jarvis ];
+    changelog = "https://github.com/bytecodealliance/cargo-component/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.progrm_jarvis ];
     mainProgram = "cargo-component";
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-component/package.nix
+++ b/pkgs/by-name/ca/cargo-component/package.nix
@@ -5,6 +5,7 @@
   pkg-config,
   openssl,
   versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -34,6 +35,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Cargo subcommand for creating WebAssembly components based on the component model proposal";

--- a/pkgs/by-name/ca/cargo-component/package.nix
+++ b/pkgs/by-name/ca/cargo-component/package.nix
@@ -35,7 +35,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/bytecodealliance/cargo-component";
     changelog = "https://github.com/bytecodealliance/cargo-component/releases/tag/${src.rev}";
     license = licenses.asl20;
-    maintainers = [ ];
+    maintainers = [ maintainers.progrm_jarvis ];
     mainProgram = "cargo-component";
   };
 }

--- a/pkgs/by-name/ca/cargo-cranky/package.nix
+++ b/pkgs/by-name/ca/cargo-cranky/package.nix
@@ -2,6 +2,7 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -16,6 +17,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   cargoHash = "sha256-m9n2YyrMpuz/X/kvHgn+g4w9/Pg+n6VnnfwjaOnyPvY=";
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Easy to configure wrapper for Rust's clippy";

--- a/pkgs/by-name/ca/cargo-cranky/package.nix
+++ b/pkgs/by-name/ca/cargo-cranky/package.nix
@@ -4,28 +4,28 @@
   fetchFromGitHub,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-cranky";
   version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "ericseppanen";
     repo = "cargo-cranky";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-3ARl3z+2nz05UaKf8ChN6mvPY2qMjUNxGnGJ1P0xkas=";
   };
 
   cargoHash = "sha256-m9n2YyrMpuz/X/kvHgn+g4w9/Pg+n6VnnfwjaOnyPvY=";
 
-  meta = with lib; {
+  meta = {
     description = "Easy to configure wrapper for Rust's clippy";
     mainProgram = "cargo-cranky";
     homepage = "https://github.com/ericseppanen/cargo-cranky";
-    changelog = "https://github.com/ericseppanen/cargo-cranky/releases/tag/${src.rev}";
-    license = with licenses; [
+    changelog = "https://github.com/ericseppanen/cargo-cranky/releases/tag/v${finalAttrs.version}";
+    license = with lib.licenses; [
       asl20
       mit
     ];
-    maintainers = [ maintainers.progrm_jarvis ];
+    maintainers = [ lib.maintainers.progrm_jarvis ];
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-cranky/package.nix
+++ b/pkgs/by-name/ca/cargo-cranky/package.nix
@@ -26,6 +26,6 @@ rustPlatform.buildRustPackage rec {
       asl20
       mit
     ];
-    maintainers = [ ];
+    maintainers = [ maintainers.progrm_jarvis ];
   };
 }

--- a/pkgs/by-name/ca/cargo-local-registry/package.nix
+++ b/pkgs/by-name/ca/cargo-local-registry/package.nix
@@ -46,6 +46,6 @@ rustPlatform.buildRustPackage rec {
       asl20
       mit
     ];
-    maintainers = [ ];
+    maintainers = [ maintainers.progrm_jarvis ];
   };
 }

--- a/pkgs/by-name/ca/cargo-local-registry/package.nix
+++ b/pkgs/by-name/ca/cargo-local-registry/package.nix
@@ -8,6 +8,7 @@
   openssl,
   zlib,
   versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -41,6 +42,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Cargo subcommand to manage local registries";

--- a/pkgs/by-name/ca/cargo-local-registry/package.nix
+++ b/pkgs/by-name/ca/cargo-local-registry/package.nix
@@ -7,16 +7,17 @@
   libgit2,
   openssl,
   zlib,
+  versionCheckHook,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-local-registry";
   version = "0.2.9";
 
   src = fetchFromGitHub {
     owner = "dhovart";
     repo = "cargo-local-registry";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-DzBD7N7GQZ9nhF22DnxRse0P8MUGReOcXHQ56KOqW6I=";
   };
 
@@ -37,15 +38,19 @@ rustPlatform.buildRustPackage rec {
   # tests require internet access
   doCheck = false;
 
-  meta = with lib; {
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  meta = {
     description = "Cargo subcommand to manage local registries";
     mainProgram = "cargo-local-registry";
     homepage = "https://github.com/dhovart/cargo-local-registry";
-    changelog = "https://github.com/dhovart/cargo-local-registry/releases/tag/${src.rev}";
-    license = with licenses; [
+    changelog = "https://github.com/dhovart/cargo-local-registry/releases/tag/v${finalAttrs.version}";
+    license = with lib.licenses; [
       asl20
       mit
     ];
-    maintainers = [ maintainers.progrm_jarvis ];
+    maintainers = [ lib.maintainers.progrm_jarvis ];
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-mutants/package.nix
+++ b/pkgs/by-name/ca/cargo-mutants/package.nix
@@ -2,6 +2,7 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -19,6 +20,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   # too many tests require internet access
   doCheck = false;
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Mutation testing tool for Rust";

--- a/pkgs/by-name/ca/cargo-mutants/package.nix
+++ b/pkgs/by-name/ca/cargo-mutants/package.nix
@@ -26,6 +26,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/sourcefrog/cargo-mutants";
     changelog = "https://github.com/sourcefrog/cargo-mutants/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = [ ];
+    maintainers = [ maintainers.progrm_jarvis ];
   };
 }

--- a/pkgs/by-name/ca/cargo-mutants/package.nix
+++ b/pkgs/by-name/ca/cargo-mutants/package.nix
@@ -4,14 +4,14 @@
   fetchFromGitHub,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-mutants";
   version = "25.3.1";
 
   src = fetchFromGitHub {
     owner = "sourcefrog";
     repo = "cargo-mutants";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-T+BMLjp74IO71u/ftNfz67FPSt1LYCgsRP65gL0wScg=";
   };
 
@@ -20,12 +20,12 @@ rustPlatform.buildRustPackage rec {
   # too many tests require internet access
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "Mutation testing tool for Rust";
     mainProgram = "cargo-mutants";
     homepage = "https://github.com/sourcefrog/cargo-mutants";
-    changelog = "https://github.com/sourcefrog/cargo-mutants/releases/tag/${src.rev}";
-    license = licenses.mit;
-    maintainers = [ maintainers.progrm_jarvis ];
+    changelog = "https://github.com/sourcefrog/cargo-mutants/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.progrm_jarvis ];
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-play/package.nix
+++ b/pkgs/by-name/ca/cargo-play/package.nix
@@ -28,6 +28,6 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "cargo-play";
     homepage = "https://github.com/fanzeyi/cargo-play";
     license = licenses.mit;
-    maintainers = [ ];
+    maintainers = [ maintainers.progrm_jarvis ];
   };
 }

--- a/pkgs/by-name/ca/cargo-play/package.nix
+++ b/pkgs/by-name/ca/cargo-play/package.nix
@@ -3,6 +3,7 @@
   rustPlatform,
   fetchFromGitHub,
   versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -27,6 +28,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Run your rust code without setting up cargo";

--- a/pkgs/by-name/ca/cargo-play/package.nix
+++ b/pkgs/by-name/ca/cargo-play/package.nix
@@ -2,16 +2,17 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  versionCheckHook,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-play";
   version = "0.5.1";
 
   src = fetchFromGitHub {
     owner = "fanzeyi";
     repo = "cargo-play";
-    tag = version;
+    tag = finalAttrs.version;
     sha256 = "sha256-Z5zcLQYfQeGybsnt2U+4Z+peRHxNPbDriPMKWhJ+PeA=";
   };
 
@@ -23,11 +24,16 @@ rustPlatform.buildRustPackage rec {
     "--skip=infer_override"
   ];
 
-  meta = with lib; {
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  meta = {
     description = "Run your rust code without setting up cargo";
     mainProgram = "cargo-play";
     homepage = "https://github.com/fanzeyi/cargo-play";
-    license = licenses.mit;
-    maintainers = [ maintainers.progrm_jarvis ];
+    changelog = "https://github.com/fanzeyi/cargo-play/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.progrm_jarvis ];
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-release/package.nix
+++ b/pkgs/by-name/ca/cargo-release/package.nix
@@ -8,6 +8,7 @@
   stdenv,
   curl,
   git,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -41,6 +42,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   # disable vendored-libgit2 and vendored-openssl
   buildNoDefaultFeatures = true;
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = ''Cargo subcommand "release": everything about releasing a rust crate'';

--- a/pkgs/by-name/ca/cargo-release/package.nix
+++ b/pkgs/by-name/ca/cargo-release/package.nix
@@ -10,14 +10,14 @@
   git,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-release";
   version = "0.25.22";
 
   src = fetchFromGitHub {
     owner = "crate-ci";
     repo = "cargo-release";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-NFI7UIHbo1xcH+pXim3ar8hvkn2EdIFpI2rpsivhVHg=";
   };
 
@@ -46,7 +46,7 @@ rustPlatform.buildRustPackage rec {
     description = ''Cargo subcommand "release": everything about releasing a rust crate'';
     mainProgram = "cargo-release";
     homepage = "https://github.com/crate-ci/cargo-release";
-    changelog = "https://github.com/crate-ci/cargo-release/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/crate-ci/cargo-release/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = with lib.licenses; [
       asl20 # or
       mit
@@ -56,4 +56,4 @@ rustPlatform.buildRustPackage rec {
       progrm_jarvis
     ];
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-release/package.nix
+++ b/pkgs/by-name/ca/cargo-release/package.nix
@@ -53,6 +53,7 @@ rustPlatform.buildRustPackage rec {
     ];
     maintainers = with lib.maintainers; [
       gerschtli
+      progrm_jarvis
     ];
   };
 }

--- a/pkgs/by-name/ca/cargo-shuttle/package.nix
+++ b/pkgs/by-name/ca/cargo-shuttle/package.nix
@@ -5,16 +5,17 @@
   pkg-config,
   openssl,
   zlib,
+  versionCheckHook,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-shuttle";
   version = "0.57.3";
 
   src = fetchFromGitHub {
     owner = "shuttle-hq";
     repo = "shuttle";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-qPevl75wmOYVhTgMiJOi+6j8LBWKzM7HPhd5mdf2B+8=";
   };
 
@@ -32,17 +33,21 @@ rustPlatform.buildRustPackage rec {
     "cargo-shuttle"
   ];
 
-  cargoTestFlags = cargoBuildFlags ++ [
+  cargoTestFlags = finalAttrs.cargoBuildFlags ++ [
     # other tests are failing for different reasons
     "init::shuttle_init_tests::"
   ];
 
-  meta = with lib; {
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  meta = {
     description = "Cargo command for the shuttle platform";
     mainProgram = "cargo-shuttle";
     homepage = "https://shuttle.rs";
-    changelog = "https://github.com/shuttle-hq/shuttle/releases/tag/${src.rev}";
-    license = licenses.asl20;
-    maintainers = [ maintainers.progrm_jarvis ];
+    changelog = "https://github.com/shuttle-hq/shuttle/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.progrm_jarvis ];
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-shuttle/package.nix
+++ b/pkgs/by-name/ca/cargo-shuttle/package.nix
@@ -43,6 +43,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://shuttle.rs";
     changelog = "https://github.com/shuttle-hq/shuttle/releases/tag/${src.rev}";
     license = licenses.asl20;
-    maintainers = [ ];
+    maintainers = [ maintainers.progrm_jarvis ];
   };
 }

--- a/pkgs/by-name/ca/cargo-shuttle/package.nix
+++ b/pkgs/by-name/ca/cargo-shuttle/package.nix
@@ -6,6 +6,7 @@
   openssl,
   zlib,
   versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -41,6 +42,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Cargo command for the shuttle platform";

--- a/pkgs/by-name/ca/cargo-tarpaulin/package.nix
+++ b/pkgs/by-name/ca/cargo-tarpaulin/package.nix
@@ -7,6 +7,7 @@
   stdenv,
   curl,
   versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -37,6 +38,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Code coverage tool for Rust projects";

--- a/pkgs/by-name/ca/cargo-tarpaulin/package.nix
+++ b/pkgs/by-name/ca/cargo-tarpaulin/package.nix
@@ -44,6 +44,7 @@ rustPlatform.buildRustPackage rec {
     ];
     maintainers = with maintainers; [
       hugoreeves
+      progrm_jarvis
     ];
   };
 }

--- a/pkgs/by-name/ca/cargo-tarpaulin/package.nix
+++ b/pkgs/by-name/ca/cargo-tarpaulin/package.nix
@@ -6,16 +6,17 @@
   openssl,
   stdenv,
   curl,
+  versionCheckHook,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-tarpaulin";
   version = "0.34.1";
 
   src = fetchFromGitHub {
     owner = "xd009642";
     repo = "tarpaulin";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-HJgcFQrHINm4BPfZ4c5ZHQYBTSBVYdSl/n0qBlSsNOI=";
   };
 
@@ -33,18 +34,22 @@ rustPlatform.buildRustPackage rec {
 
   doCheck = false;
 
-  meta = with lib; {
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  meta = {
     description = "Code coverage tool for Rust projects";
     mainProgram = "cargo-tarpaulin";
     homepage = "https://github.com/xd009642/tarpaulin";
-    changelog = "https://github.com/xd009642/tarpaulin/blob/${src.rev}/CHANGELOG.md";
-    license = with licenses; [
+    changelog = "https://github.com/xd009642/tarpaulin/blob/${finalAttrs.version}/CHANGELOG.md";
+    license = with lib.licenses; [
       mit # or
       asl20
     ];
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       hugoreeves
       progrm_jarvis
     ];
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-zigbuild/package.nix
+++ b/pkgs/by-name/ca/cargo-zigbuild/package.nix
@@ -5,6 +5,7 @@
   makeWrapper,
   zig,
   versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -30,6 +31,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Tool to compile Cargo projects with zig as the linker";

--- a/pkgs/by-name/ca/cargo-zigbuild/package.nix
+++ b/pkgs/by-name/ca/cargo-zigbuild/package.nix
@@ -32,6 +32,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/messense/cargo-zigbuild";
     changelog = "https://github.com/messense/cargo-zigbuild/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.progrm_jarvis ];
   };
 }

--- a/pkgs/by-name/ca/cargo-zigbuild/package.nix
+++ b/pkgs/by-name/ca/cargo-zigbuild/package.nix
@@ -4,16 +4,17 @@
   fetchFromGitHub,
   makeWrapper,
   zig,
+  versionCheckHook,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-zigbuild";
   version = "0.20.1";
 
   src = fetchFromGitHub {
     owner = "messense";
     repo = "cargo-zigbuild";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-xJiYtVrvWEBsyTbcHKsbnTpbcTryX+ZP/OjD7GP6gQU=";
   };
 
@@ -26,12 +27,16 @@ rustPlatform.buildRustPackage rec {
       --prefix PATH : ${zig}/bin
   '';
 
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
   meta = {
     description = "Tool to compile Cargo projects with zig as the linker";
     mainProgram = "cargo-zigbuild";
     homepage = "https://github.com/messense/cargo-zigbuild";
-    changelog = "https://github.com/messense/cargo-zigbuild/releases/tag/v${version}";
+    changelog = "https://github.com/messense/cargo-zigbuild/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.progrm_jarvis ];
   };
-}
+})


### PR DESCRIPTION
Took maintenance of the following packages:
* `cargo-benchcmp`;
* `cargo-component`;
* `cargo-cranky`;
* `cargo-local-registry`;
* `cargo-mutants`;
* `cargo-play`;
* `cargo-release`;
* `cargo-shuttle`;
* `cargo-tarpaulin`;
* `cargo-zigbuild`.

These are `cargo-*` packages which are up-to-date in terms of their version.

This should partially cover packages in #458096.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
