### PR TITLE
db{48,53,60,62}: get gentoo patch for gcc15 and Wno-error=incompatible-pointer-types

### DIFF
--- a/pkgs/development/libraries/db/db-4.8.nix
+++ b/pkgs/development/libraries/db/db-4.8.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  fetchpatch,
   fetchurl,
   autoreconfHook,
   ...

--- a/pkgs/development/libraries/db/db-5.3.nix
+++ b/pkgs/development/libraries/db/db-5.3.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  fetchpatch,
   fetchurl,
   autoreconfHook,
   ...

--- a/pkgs/development/libraries/db/db-6.0.nix
+++ b/pkgs/development/libraries/db/db-6.0.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  fetchpatch,
   fetchurl,
   autoreconfHook,
   ...

--- a/pkgs/development/libraries/db/db-6.2.nix
+++ b/pkgs/development/libraries/db/db-6.2.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  fetchpatch,
   fetchurl,
   autoreconfHook,
   ...

--- a/pkgs/development/libraries/db/generic.nix
+++ b/pkgs/development/libraries/db/generic.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  fetchpatch,
   fetchurl,
   autoreconfHook,
   cxxSupport ? true,
@@ -29,7 +30,14 @@ stdenv.mkDerivation (
     # configure checks to work incorrectly with clang 16.
     nativeBuildInputs = [ autoreconfHook ];
 
-    patches = extraPatches;
+    patches = [
+      (fetchpatch {
+        name = "gcc15.patch";
+        url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sys-libs/db/files/db-4.8.30-tls-configure.patch?id=1ae36006c79ef705252f5f7009e79f6add7dc353";
+        hash = "sha256-OzQL+kgXtcvhvyleDLuH1abhY4Shb/9IXx4ZkeFbHOA=";
+      })
+    ]
+    ++ extraPatches;
 
     outputs = [
       "bin"
@@ -74,6 +82,10 @@ stdenv.mkDerivation (
       )
       popd
     '';
+
+    NIX_CFLAGS_COMPILE = [
+      "-Wno-error=incompatible-pointer-types"
+    ];
 
     configureFlags = [
       (if cxxSupport then "--enable-cxx" else "--disable-cxx")


### PR DESCRIPTION
Fixes for https://github.com/NixOS/nixpkgs/pull/440456

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
