### PR TITLE
starship-jj: init at 0.7.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18906,6 +18906,12 @@
     github = "Nemin32";
     githubId = 2953293;
   };
+  nemith = {
+    email = "nix@brbe.me";
+    github = "nemith";
+    githubId = 349360;
+    name = "Brandon Bennett";
+  };
   neosimsim = {
     email = "me@abn.sh";
     github = "neosimsim";

--- a/pkgs/by-name/st/starship-jj/package.nix
+++ b/pkgs/by-name/st/starship-jj/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  fetchCrate,
+  rustPlatform,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "starship-jj";
+  version = "0.7.0";
+
+  src = fetchCrate {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-oisz3V3UDHvmvbA7+t5j7waN9NykMUWGOpEB5EkmYew=";
+  };
+
+  cargoHash = "sha256-NNeovW27YSK/fO2DjAsJqBvebd43usCw7ni47cgTth8=";
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Starship plugin for jj";
+    homepage = "https://gitlab.com/lanastara_foss/starship-jj";
+    changelog = "https://gitlab.com/lanastara_foss/starship-jj/-/blob/${finalAttrs.version}/CHANGELOG.md";
+    maintainers = with lib.maintainers; [
+      nemith
+    ];
+    license = lib.licenses.mit;
+    mainProgram = "starship-jj";
+  };
+})


### PR DESCRIPTION
starship-jj is a plugin to the starship prompt utility to add some advanced support for the jujutsu VCS tool. 

https://gitlab.com/lanastara_foss/starship-jj

 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
