### PR TITLE
python3Packages.markdown-it-py: 3.0.0 -> 4.0.0

### DIFF
--- a/pkgs/development/python-modules/markdown-it-py/default.nix
+++ b/pkgs/development/python-modules/markdown-it-py/default.nix
@@ -1,10 +1,11 @@
 {
   lib,
-  attrs,
   buildPythonPackage,
   commonmark,
   fetchFromGitHub,
   flit-core,
+  ipykernel,
+  jupyter-sphinx,
   linkify-it-py,
   markdown,
   mdit-py-plugins,
@@ -21,31 +22,28 @@
   stdenv,
   pytest-regressions,
   pytestCheckHook,
-  pythonOlder,
 }:
 
 buildPythonPackage rec {
   pname = "markdown-it-py";
-  version = "3.0.0";
-  format = "pyproject";
-
-  disabled = pythonOlder "3.6";
+  version = "4.0.0";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "executablebooks";
     repo = "markdown-it-py";
     tag = "v${version}";
-    hash = "sha256-cmjLElJA61EysTUFMVY++Kw0pI4wOIXOyCY3To9fpQc=";
+    hash = "sha256-92J9cMit2zwyjoE8G1YpwDxj+wiApQW2eUHxUOUt3as=";
   };
 
   # fix downstrem usage of markdown-it-py[linkify]
   pythonRelaxDeps = [ "linkify-it-py" ];
 
-  nativeBuildInputs = [
+  build-system = [
     flit-core
   ];
 
-  propagatedBuildInputs = [ mdurl ];
+  dependencies = [ mdurl ];
 
   nativeCheckInputs = [
     pytest-regressions
@@ -68,24 +66,27 @@ buildPythonPackage rec {
       mistletoe
       mistune
       panflute
+      # FIXME package markdown-it-pyrs
     ];
     linkify = [ linkify-it-py ];
     plugins = [ mdit-py-plugins ];
     rtd = [
-      attrs
+      mdit-py-plugins
       myst-parser
       pyyaml
       sphinx
       sphinx-copybutton
       sphinx-design
       sphinx-book-theme
+      jupyter-sphinx
+      ipykernel
     ];
   };
 
   meta = {
     description = "Markdown parser in Python";
     homepage = "https://markdown-it-py.readthedocs.io/";
-    changelog = "https://github.com/executablebooks/markdown-it-py/blob/${src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/executablebooks/markdown-it-py/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     mainProgram = "markdown-it";
   };

--- a/pkgs/development/python-modules/mdit-py-plugins/default.nix
+++ b/pkgs/development/python-modules/mdit-py-plugins/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonOlder,
   flit-core,
   markdown-it-py,
   pytest-regressions,
@@ -11,21 +10,19 @@
 
 buildPythonPackage rec {
   pname = "mdit-py-plugins";
-  version = "0.4.2";
-  format = "pyproject";
-
-  disabled = pythonOlder "3.6";
+  version = "0.5.0";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "executablebooks";
     repo = "mdit-py-plugins";
     tag = "v${version}";
-    hash = "sha256-aY2DMLh1OkWVcN6A29FLba1ETerf/EOqSjHVpsdE21M=";
+    hash = "sha256-MQU6u49KsWGaKeWU5v066kZidcfCoubqClxAapAZb9A=";
   };
 
-  nativeBuildInputs = [ flit-core ];
+  build-system = [ flit-core ];
 
-  propagatedBuildInputs = [ markdown-it-py ];
+  dependencies = [ markdown-it-py ];
 
   nativeCheckInputs = [
     pytestCheckHook
@@ -37,7 +34,7 @@ buildPythonPackage rec {
   meta = {
     description = "Collection of core plugins for markdown-it-py";
     homepage = "https://github.com/executablebooks/mdit-py-plugins";
-    changelog = "https://github.com/executablebooks/mdit-py-plugins/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/executablebooks/mdit-py-plugins/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = [ ];
   };


### PR DESCRIPTION
Diff: https://github.com/executablebooks/markdown-it-py/compare/v3.0.0...v4.0.0

Changelog: https://github.com/executablebooks/markdown-it-py/blob/v4.0.0/CHANGELOG.md

closes https://github.com/NixOS/nixpkgs/pull/433943
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
