### PR TITLE
stevia: init at 0.51.0

### DIFF
--- a/pkgs/by-name/st/stevia/package.nix
+++ b/pkgs/by-name/st/stevia/package.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  meson,
+  ninja,
+  pkg-config,
+  python3,
+  wayland-scanner,
+  wrapGAppsHook3,
+  appstream,
+  cmake,
+  feedbackd,
+  fzf,
+  glib,
+  gmobile,
+  gnome-desktop,
+  gtk3,
+  hunspell,
+  json-glib,
+  libhandy,
+  libxkbcommon,
+  systemd,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "stevia";
+  version = "0.51.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "World/Phosh";
+    repo = "stevia";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-dRygDUHXpXjEuwNNfgVy742jfIhT9erN7IcmaMImuYw=";
+  };
+
+  mesonFlags = [
+    "-Dc_args=-I${glib.dev}/include/gio-unix-2.0"
+    "-Dsystemd_user_unit_dir=${placeholder "out"}/lib/systemd/user"
+  ];
+
+  postPatch = ''
+    patchShebangs tools/write-layout-info.py
+  '';
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    python3
+    wayland-scanner
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    appstream
+    cmake
+    feedbackd
+    fzf
+    glib.dev
+    gmobile
+    gnome-desktop
+    gtk3
+    hunspell
+    json-glib
+    libhandy
+    libxkbcommon
+    systemd
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A user friendly on screen keyboard for Phosh";
+    homepage = "https://gitlab.gnome.org/World/Phosh/stevia";
+    changelog = "https://gitlab.gnome.org/World/Phosh/stevia/-/releases/v${finalAttrs.version}";
+    license = with lib.licenses; [ gpl3Plus ];
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+    mainProgram = "stevia";
+  };
+})


### PR DESCRIPTION
## Things done
- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
