### PR TITLE
smokeping: add LWPProtocolHttps dependency

### DIFF
--- a/pkgs/by-name/sm/smokeping/package.nix
+++ b/pkgs/by-name/sm/smokeping/package.nix
@@ -40,6 +40,7 @@ stdenv.mkDerivation rec {
     NetOpenSSH
     NetSNMP
     LWP
+    LWPProtocolHttps
     IOTty
     fping
     NetDNS


### PR DESCRIPTION
Add a missing dependency `LWPProtocolHttps`.

I met the error
```
Nov 29 01:20:11 raspberry smokeping[2192622]: WARNING Master said 501 Protocol scheme 'https' is not supported (LWP::Protocol::https not installed)
Nov 29 01:20:11 raspberry smokeping[2192622]: ERROR: we did not get config from the master. Maybe we are not configured as a slave for any of the targets on the master ?
```
when I was running slave-mode SmokePing with an https `--master-url`, and I fixed it by adding `LWPProtocolHttps` dependency.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
