### PR TITLE
pkgs: Add config.derivationMeta

### DIFF
--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -53,6 +53,15 @@ let
 
     # Config options
 
+    derivationMeta = mkOption {
+      description = ''
+        Whether to store `meta` information in the derivations.
+
+        This requires a Nix evaluator and builder(s) with [`derivation-meta`](https://nix.dev/manual/nix/latest/development/experimental-features.html#xp-feature-derivation-meta) enabled.
+      '';
+      default = false;
+    };
+
     warnUndeclaredOptions = mkOption {
       description = "Whether to warn when `config` contains an unrecognized attribute.";
       type = types.bool;


### PR DESCRIPTION
Enables support for the proposed `derivation-meta` feature in Nix, allowing derivations to convey metadata without affecting output hashing and causing mass rebuilds.
Dropping `meta` has been Nixpkgs' responsibility, so to expose it to Nix we need this opt-in.

This functionality helps with
- Implementing `meta.timeout` correctly
- SBOMs
- Analyzing licenses directly, etc


## Context

- Can be used with https://github.com/NixOS/nix/pull/14686
- Can also be used without it (but would cause a mass-rebuild if you blindly added the required feature)
- Rebuild-free alternative to https://github.com/NixOS/nixpkgs/pull/420575

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
