### PR TITLE
python3Packages.gst-python: fix installCheckPhase

### DIFF
--- a/pkgs/development/python-modules/gst-python/default.nix
+++ b/pkgs/development/python-modules/gst-python/default.nix
@@ -89,14 +89,14 @@ buildPythonPackage rec {
     (lib.mesonEnable "tests" gst-python.doInstallCheck)
   ];
 
-  # Tests are very flaky on Darwin.
-  # See: https://github.com/NixOS/nixpkgs/issues/454955
-  doCheck = !stdenv.hostPlatform.isDarwin;
-
   # `buildPythonPackage` uses `installCheckPhase` and leaves `checkPhase`
   # empty. It renames `doCheck` from its arguments, but not `checkPhase`.
   # See: https://github.com/NixOS/nixpkgs/issues/47390
-  installCheckPhase = "mesonCheckPhase";
+  installCheckPhase = ''
+    runHook preCheck
+    mesonCheckPhase
+    runHook postCheck
+  '';
 
   preCheck = lib.optionalString stdenv.hostPlatform.isDarwin ''
     export DYLD_LIBRARY_PATH="${gst_all_1.gst-plugins-base}/lib"


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/311170764

Tests timed out in Hydra for Darwin. But notice that the plugins to be tested weren't getting loaded:
```sh
Test gst time out (After 30 seconds)          30/30s
1/4 Test gst                 TIMEOUT        30.14s   killed by signal 15 SIGTERM
>>> MSAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1 GST_OVERRIDE_SRC_PATH=/private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/testsuite/../gi/overrides GST_PLUGIN_LOADING_WHITELIST=gstreamer:gst-plugins-base:gst-python@/private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/build MESON_TEST_ITERATION=1 MALLOC_PERTURB_=108 GST_OVERRIDE_BUILD_PATH=/private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/build/testsuite/../gi/overrides GST_PLUGIN_PATH_1_0=/private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/build:/nix/store/glyhql2ry9fqlkn28ssgkyjafl33z5cz-gstreamer-1.26.3/lib/gstreamer-1.0:/nix/store/l1xnakm322fryvq28cfbq6qx8pnkslg7-gst-plugins-base-1.26.3/lib/gstreamer-1.0:/private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/build/plugin:/private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/testsuite ASAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1 GST_REGISTRY='/private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/build/testsuite/Test gst.registry' UBSAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1 /nix/store/7jg8qwj1ipjiyrd3c2v99xpxi09h6g73-python3-3.12.12/bin/python3.12 /private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/build/../testsuite/runtests.py test_gst.py
 ✀  
stderr:

(gst-plugin-scanner:65640): GStreamer-WARNING **: 06:31:39.713: Failed to load plugin '/private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/build/gi/overrides/_gi_gst.cpython-312-darwin.so': dlopen(/private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/build/gi/overrides/_gi_gst.cpython-312-darwin.so, 0x0006): symbol not found in flat namespace '_PyBool_Type'

(gst-plugin-scanner:65640): GStreamer-WARNING **: 06:31:40.345: Failed to load plugin '/private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/build/gi/overrides/_gi_gst_analytics.cpython-312-darwin.so': dlopen(/private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/build/gi/overrides/_gi_gst_analytics.cpython-312-darwin.so, 0x0006): symbol not found in flat namespace '_PyCapsule_Type'


Test plugins time out (After 30 seconds)   30/30s
2/4 Test plugins             TIMEOUT        30.22s   killed by signal 15 SIGTERM
>>> MSAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1 GST_OVERRIDE_SRC_PATH=/private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/testsuite/../gi/overrides GST_PLUGIN_LOADING_WHITELIST=gstreamer:gst-plugins-base:gst-python@/private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/build MESON_TEST_ITERATION=1 GST_OVERRIDE_BUILD_PATH=/private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/build/testsuite/../gi/overrides GST_PLUGIN_PATH_1_0=/private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/build:/nix/store/glyhql2ry9fqlkn28ssgkyjafl33z5cz-gstreamer-1.26.3/lib/gstreamer-1.0:/nix/store/l1xnakm322fryvq28cfbq6qx8pnkslg7-gst-plugins-base-1.26.3/lib/gstreamer-1.0:/private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/build/plugin:/private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/testsuite MALLOC_PERTURB_=178 ASAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1 UBSAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1 GST_REGISTRY='/private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/build/testsuite/Test plugins.registry' /nix/store/7jg8qwj1ipjiyrd3c2v99xpxi09h6g73-python3-3.12.12/bin/python3.12 /private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/build/../testsuite/runtests.py test_plugin.py
 ✀  
stderr:

(gst-plugin-scanner:65639): GStreamer-WARNING **: 06:31:39.712: Failed to load plugin '/private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/build/gi/overrides/_gi_gst.cpython-312-darwin.so': dlopen(/private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/build/gi/overrides/_gi_gst.cpython-312-darwin.so, 0x0006): symbol not found in flat namespace '_PyBool_Type'

(gst-plugin-scanner:65639): GStreamer-WARNING **: 06:31:40.345: Failed to load plugin '/private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/build/gi/overrides/_gi_gst_analytics.cpython-312-darwin.so': dlopen(/private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/build/gi/overrides/_gi_gst_analytics.cpython-312-darwin.so, 0x0006): symbol not found in flat namespace '_PyCapsule_Type'


Test fundamentals time out (After 30 seconds)
3/4 Test fundamentals        TIMEOUT        30.23s   killed by signal 15 SIGTERM
>>> MSAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1 GST_REGISTRY='/private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/build/testsuite/Test fundamentals.registry' GST_OVERRIDE_SRC_PATH=/private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/testsuite/../gi/overrides GST_PLUGIN_LOADING_WHITELIST=gstreamer:gst-plugins-base:gst-python@/private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/build MESON_TEST_ITERATION=1 MALLOC_PERTURB_=198 GST_OVERRIDE_BUILD_PATH=/private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/build/testsuite/../gi/overrides GST_PLUGIN_PATH_1_0=/private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/build:/nix/store/glyhql2ry9fqlkn28ssgkyjafl33z5cz-gstreamer-1.26.3/lib/gstreamer-1.0:/nix/store/l1xnakm322fryvq28cfbq6qx8pnkslg7-gst-plugins-base-1.26.3/lib/gstreamer-1.0:/private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/build/plugin:/private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/testsuite ASAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1 UBSAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1 /nix/store/7jg8qwj1ipjiyrd3c2v99xpxi09h6g73-python3-3.12.12/bin/python3.12 /private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/build/../testsuite/runtests.py test_types.py
 ✀  
stderr:

(gst-plugin-scanner:65638): GStreamer-WARNING **: 06:31:39.712: Failed to load plugin '/private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/build/gi/overrides/_gi_gst.cpython-312-darwin.so': dlopen(/private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/build/gi/overrides/_gi_gst.cpython-312-darwin.so, 0x0006): symbol not found in flat namespace '_PyBool_Type'

(gst-plugin-scanner:65638): GStreamer-WARNING **: 06:31:40.345: Failed to load plugin '/private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/build/gi/overrides/_gi_gst_analytics.cpython-312-darwin.so': dlopen(/private/tmp/nix-build-python3.12-gst-python-1.26.0.drv-0/gst-python-1.26.0/build/gi/overrides/_gi_gst_analytics.cpython-312-darwin.so, 0x0006): symbol not found in flat namespace '_PyCapsule_Type'
```

The overridden `installCheckPhase` properly called `mesonCheckPhase` but failed to call pre/postCheck. `preCheck` is needed to put the plugins being tested on the load path.

Fixes:
1. Updated `installCheckPhase` to call pre/post hooks

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
