### PR TITLE
Minor `check-meta.nix` optimisations and cleanups

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -302,8 +302,9 @@ let
     '';
 
   handleEvalIssue =
-    { meta, attrs }:
     {
+      meta,
+      attrs,
       reason,
       errormsg ? "",
       remediation,
@@ -324,8 +325,9 @@ let
     handler msg;
 
   handleEvalWarning =
-    { meta, attrs }:
     {
+      meta,
+      attrs,
       reason,
       errormsg ? "",
       remediation,
@@ -751,9 +753,15 @@ let
           if valid == "yes" then
             true
           else if valid == "no" then
-            (handleEvalIssue { inherit meta attrs; } { inherit (validity) reason errormsg remediation; })
+            (handleEvalIssue {
+              inherit meta attrs;
+              inherit (validity) reason errormsg remediation;
+            })
           else if valid == "warn" then
-            (handleEvalWarning { inherit meta attrs; } { inherit (validity) reason errormsg remediation; })
+            (handleEvalWarning {
+              inherit meta attrs;
+              inherit (validity) reason errormsg remediation;
+            })
           else
             throw "Unknown validity: '${valid}'"
         );

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -100,7 +100,7 @@ let
   isUnfree =
     licenses:
     if isAttrs licenses then
-      !licenses.free or true
+      !(licenses.free or true)
     # TODO: Returning false in the case of a string is a bug that should be fixed.
     # In a previous implementation of this function the function body
     # was `licenses: lib.lists.any (l: !l.free or true) licenses;`
@@ -108,7 +108,7 @@ let
     else if isString licenses then
       false
     else
-      any (l: !l.free or true) licenses;
+      any (l: !(l.free or true)) licenses;
 
   hasUnfreeLicense = attrs: hasLicense attrs && isUnfree attrs.meta.license;
 
@@ -173,7 +173,7 @@ let
   isNonSource = sourceTypes: any (t: !t.isSource) sourceTypes;
 
   hasNonSourceProvenance =
-    attrs: (attrs ? meta.sourceProvenance) && isNonSource attrs.meta.sourceProvenance;
+    attrs: attrs ? meta.sourceProvenance && isNonSource attrs.meta.sourceProvenance;
 
   # Allow granular checks to allow only some non-source-built packages
   # Example:
@@ -753,15 +753,15 @@ let
           if valid == "yes" then
             true
           else if valid == "no" then
-            (handleEvalIssue {
+            handleEvalIssue {
               inherit meta attrs;
               inherit (validity) reason errormsg remediation;
-            })
+            }
           else if valid == "warn" then
-            (handleEvalWarning {
+            handleEvalWarning {
               inherit meta attrs;
               inherit (validity) reason errormsg remediation;
-            })
+            }
           else
             throw "Unknown validity: '${valid}'"
         );


### PR DESCRIPTION
Various minor performance optimisations and some refactorings. Motivated as preparation for https://github.com/NixOS/nixpkgs/pull/338267

## Things done

- [x] Checked performance (about 1% faster all around): https://github.com/NixOS/nixpkgs/actions/runs/19837639476?pr=466947#summary-56839009923

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
