### PR TITLE
python3Packages.wagtail: 7.2 -> 7.2.1

### DIFF
--- a/pkgs/development/python-modules/wagtail/default.nix
+++ b/pkgs/development/python-modules/wagtail/default.nix
@@ -32,7 +32,7 @@
 
 buildPythonPackage rec {
   pname = "wagtail";
-  version = "7.2";
+  version = "7.2.1";
   pyproject = true;
 
   # The GitHub source requires some assets to be compiled, which in turn
@@ -40,7 +40,7 @@ buildPythonPackage rec {
   # until https://github.com/wagtail/wagtail/pull/13136 gets merged.
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-ijnfkIvWSrAp4IvxkfR19UzJFPhKpB6a55tBv0HVXsM=";
+    hash = "sha256-OIu0LEgYwIGk3fNub0Upv7xU7SYqkbZbDl+VFHbyz3Q=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/wagtail/tests.nix
+++ b/pkgs/development/python-modules/wagtail/tests.nix
@@ -11,6 +11,7 @@
   python-dateutil,
   python,
   pytz,
+  responses,
   wagtail,
   wagtail-factories,
 }:
@@ -34,6 +35,7 @@ buildPythonPackage {
     msrest
     python-dateutil
     pytz
+    responses
     wagtail
     wagtail-factories
   ];


### PR DESCRIPTION
[Wagtail 7.2.1](https://github.com/wagtail/wagtail/blob/3544a15d8ea257893b380712ecded1e914b62388/CHANGELOG.txt#L39)

This PR is a continuation of https://github.com/NixOS/nixpkgs/pull/457559 with the missing input added.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
