### PR TITLE
superlu_dist: fix build with mpich

### DIFF
--- a/pkgs/by-name/su/superlu_dist/package.nix
+++ b/pkgs/by-name/su/superlu_dist/package.nix
@@ -18,6 +18,7 @@
   isILP64 ? false,
 
   # passthru.tests
+  mpich,
   superlu_dist,
 }:
 
@@ -35,6 +36,13 @@ stdenv.mkDerivation (finalAttrs: {
     postFetch = "rm $out/SRC/prec-independent/mc64ad_dist.c";
     hash = "sha256-i/Gg+9oMNNRlviwXUSRkWNaLRZLPWZRtA1fGYqh2X0k=";
   };
+
+  # --oversubscribe unrecognized by mpich
+  # see https://github.com/xiaoyeli/superlu_dist/issues/208
+  postPatch = ''
+    substituteInPlace TEST/CMakeLists.txt \
+      --replace-fail "-oversubscribe" ""
+  '';
 
   patches = [
     ./mc64ad_dist-stub.patch
@@ -89,6 +97,11 @@ stdenv.mkDerivation (finalAttrs: {
     inherit isILP64;
     tests = {
       ilp64 = superlu_dist.override { isILP64 = true; };
+    }
+    // lib.optionalAttrs stdenv.hostPlatform.isLinux {
+      mpich = superlu_dist.override {
+        mpi = mpich;
+      };
     };
   };
 


### PR DESCRIPTION
see also https://github.com/xiaoyeli/superlu_dist/issues/208

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
