### PR TITLE
podman-desktop: set system defaults dir to /etc/podman-desktop

### DIFF
--- a/pkgs/by-name/po/podman-desktop/package.nix
+++ b/pkgs/by-name/po/podman-desktop/package.nix
@@ -69,6 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     # podman should be installed with nix; disable auto-installation
     ./extension-no-download-podman.patch
+    ./system-defaults-dir.patch
   ];
 
   ELECTRON_SKIP_BINARY_DOWNLOAD = "1";

--- a/pkgs/by-name/po/podman-desktop/system-defaults-dir.patch
+++ b/pkgs/by-name/po/podman-desktop/system-defaults-dir.patch
@@ -1,0 +1,10 @@
+diff --git a/packages/main/src/plugin/managed-by-constants.ts b/packages/main/src/plugin/managed-by-constants.ts
+index 5a20d2de29e..9fea8a17165 100644
+--- a/packages/main/src/plugin/managed-by-constants.ts
++++ b/packages/main/src/plugin/managed-by-constants.ts
+@@ -29,4 +29,4 @@ export const SYSTEM_LOCKED_FILENAME = 'locked.json';
+ // Folders for managed defaults on different platforms
+ export const SYSTEM_DEFAULTS_FOLDER_MACOS = '/Library/Application Support/io.podman_desktop.PodmanDesktop';
+ export const SYSTEM_DEFAULTS_FOLDER_WINDOWS = 'Podman Desktop';
+-export const SYSTEM_DEFAULTS_FOLDER_LINUX = '/usr/share/podman-desktop';
++export const SYSTEM_DEFAULTS_FOLDER_LINUX = '/etc/podman-desktop';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR patches Podman Desktop code to set the system defaults directory to `/etc/podman-desktop` instead of `/usr/share/podman-desktop`.

This, at first, would allow any user willing to configure [managed settings](https://podman-desktop.io/docs/configuration/managed-configuration) by creating the `defaults-settings.json` and/or `locked.json` files under `/etc/podman-desktop`.

This would also allow us to provide a new module for podman-desktop with configurable settings since we could just write them with `environment.etc`.

Note that I only patched the path for Linux platforms as I’m not sure there is a `/etc` on Mac. I do have some Macs around but I didn't took the time to look at this yet. Hence this should not be merged as-is, imo.

Also note that the file targeted by the patch was introduced in v1.23.0, so backports for older revisions (as the one actually available in nixpkgs 25.05 - v1.22.1) will not be possible if this is merged. Anyway, 25.05 being deprecated now, this shouldn't matter much, but I still wanted to point it out.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
