### PR TITLE
nixos/glance: refactor to use `genJqSecretsReplacementSnippet`

### DIFF
--- a/nixos/modules/services/web-apps/glance.nix
+++ b/nixos/modules/services/web-apps/glance.nix
@@ -210,5 +210,7 @@ in
   };
 
   meta.doc = ./glance.md;
-  meta.maintainers = [ ];
+  meta.maintainers = with lib.maintainers; [
+    gepbird
+  ];
 }

--- a/nixos/modules/services/web-apps/glance.nix
+++ b/nixos/modules/services/web-apps/glance.nix
@@ -2,14 +2,13 @@
   config,
   lib,
   pkgs,
+  utils,
   ...
 }:
 let
   cfg = config.services.glance;
 
   inherit (lib)
-    catAttrs
-    concatMapStrings
     getExe
     mkEnableOption
     mkIf
@@ -18,17 +17,8 @@ let
     types
     ;
 
-  inherit (builtins)
-    concatLists
-    isAttrs
-    isList
-    attrNames
-    getAttr
-    ;
-
   settingsFormat = pkgs.formats.yaml { };
-  settingsFile = settingsFormat.generate "glance.yaml" cfg.settings;
-  mergedSettingsFile = "/run/glance/glance.yaml";
+  settingsFile = "/run/glance/glance.yaml";
 in
 {
   options.services.glance = {
@@ -180,41 +170,16 @@ in
       requires = [
         "nss-user-lookup.target"
       ];
-      path = [ pkgs.replace-secret ];
 
       serviceConfig = {
         ExecStartPre =
-          let
-            findSecrets =
-              data:
-              if isAttrs data then
-                if data ? _secret then
-                  [ data ]
-                else
-                  concatLists (map (attr: findSecrets (getAttr attr data)) (attrNames data))
-              else if isList data then
-                concatLists (map findSecrets data)
-              else
-                [ ];
-            secretPaths = catAttrs "_secret" (findSecrets cfg.settings);
-            mkSecretReplacement = secretPath: ''
-              replace-secret ${
-                lib.escapeShellArgs [
-                  "_secret: ${secretPath}"
-                  secretPath
-                  mergedSettingsFile
-                ]
-              }
-            '';
-            secretReplacements = concatMapStrings mkSecretReplacement secretPaths;
-          in
           # Use "+" to run as root because the secrets may not be accessible to glance
           "+"
           + pkgs.writeShellScript "glance-start-pre" ''
-            install -m 600 -o $USER ${settingsFile} ${mergedSettingsFile}
-            ${secretReplacements}
+            ${utils.genJqSecretsReplacementSnippet cfg.settings settingsFile}
+            chown $USER ${settingsFile}
           '';
-        ExecStart = "${getExe cfg.package} --config ${mergedSettingsFile}";
+        ExecStart = "${getExe cfg.package} --config ${settingsFile}";
         Restart = "on-failure";
         WorkingDirectory = "/var/lib/glance";
         EnvironmentFile = cfg.environmentFile;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This simplifies how secrets are injected at runtime, and makes it slightly more correct by not adding extra new lines.
Another difference is the config file is technically JSON and not YAML, but it is a superset of YAML (at least what is generated from Nix options, in fact [this](https://github.com/NixOS/nixpkgs/blob/831510c20940d7425bb3bde73ccba9457af0d928/lib/generators.nix#L907-L923) YAML implementation is just JSON)

This module got recently orphaned and I previously made some changes to it, so might as well adopt it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
