### PR TITLE
[Backport release-25.11] break-time: mark vulnerable

### DIFF
--- a/pkgs/by-name/br/break-time/package.nix
+++ b/pkgs/by-name/br/break-time/package.nix
@@ -44,6 +44,16 @@ rustPlatform.buildRustPackage rec {
     description = "Break timer that forces you to take a break";
     mainProgram = "break-time";
     homepage = "https://github.com/cdepillabout/break-time";
+    knownVulnerabilities = [
+      "Unmaintained upstream, and has the following issues in dependencies:"
+      "GHSA-8qv2-5vq6-g2g7"
+      "GHSA-2xpg-3hx4-fm9r"
+      "GHSA-3288-cwgw-ch86"
+      "GHSA-3cj3-jrrp-9rxf"
+      "GHSA-mp6r-fgw2-rxfx"
+      "GHSA-5h46-h7hh-c6x9"
+      "and others"
+    ];
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ cdepillabout ];
     platforms = platforms.linux;


### PR DESCRIPTION
Manual backport of #466970.

Unmaintained upstream, and has the following issues in dependencies:
  * GHSA-8qv2-5vq6-g2g7
  * GHSA-2xpg-3hx4-fm9r
  * GHSA-3288-cwgw-ch86
  * GHSA-3cj3-jrrp-9rxf
  * GHSA-mp6r-fgw2-rxfx
  * GHSA-5h46-h7hh-c6x9
  * and others

(cherry picked from commit 28a435f862bd7f6fbab85ee69622d484bf070c99)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
