### PR TITLE
ocamlPackages.mirage-flow: 4.0.2 → 5.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/mirage-flow/combinators.nix
+++ b/pkgs/development/ocaml-modules/mirage-flow/combinators.nix
@@ -4,7 +4,7 @@
   lwt,
   logs,
   cstruct,
-  mirage-clock,
+  mirage-mtime,
 }:
 
 buildDunePackage {
@@ -12,13 +12,11 @@ buildDunePackage {
 
   inherit (mirage-flow) version src;
 
-  duneVersion = "3";
-
   propagatedBuildInputs = [
     lwt
     logs
     cstruct
-    mirage-clock
+    mirage-mtime
     mirage-flow
   ];
 

--- a/pkgs/development/ocaml-modules/mirage-flow/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-flow/default.nix
@@ -7,15 +7,13 @@
   lwt,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "mirage-flow";
-  version = "4.0.2";
-
-  minimalOCamlVersion = "4.05";
+  version = "5.0.0";
 
   src = fetchurl {
-    url = "https://github.com/mirage/mirage-flow/releases/download/v${version}/mirage-flow-${version}.tbz";
-    hash = "sha256-SGXj3S4b53O9JENUFuMl3I+QoiZ0QSrYu7zTet7q+1o=";
+    url = "https://github.com/mirage/mirage-flow/releases/download/v${finalAttrs.version}/mirage-flow-${finalAttrs.version}.tbz";
+    hash = "sha256-N8p5yuDtmycLh3Eu3LOXpd7Eqzk1eygQfgDapshVMyM=";
   };
 
   propagatedBuildInputs = [
@@ -30,4 +28,4 @@ buildDunePackage rec {
     license = lib.licenses.isc;
     maintainers = [ lib.maintainers.vbgl ];
   };
-}
+})

--- a/pkgs/development/ocaml-modules/mirage-flow/unix.nix
+++ b/pkgs/development/ocaml-modules/mirage-flow/unix.nix
@@ -3,7 +3,7 @@
   fmt,
   logs,
   mirage-flow,
-  ocaml_lwt,
+  lwt,
   cstruct,
   alcotest,
   mirage-flow-combinators,
@@ -14,18 +14,11 @@ buildDunePackage {
 
   inherit (mirage-flow) version src;
 
-  duneVersion = "3";
-
-  # Make tests compatible with alcotest 1.4.0
-  postPatch = ''
-    substituteInPlace test/test.ml --replace 'Fmt.kstrf Alcotest.fail' 'Fmt.kstrf (fun s -> Alcotest.fail s)'
-  '';
-
   propagatedBuildInputs = [
     fmt
     logs
     mirage-flow
-    ocaml_lwt
+    lwt
     cstruct
   ];
 


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
