### PR TITLE
vde2: fix build with gcc15

### DIFF
--- a/pkgs/by-name/vd/vde2/package.nix
+++ b/pkgs/by-name/vd/vde2/package.nix
@@ -26,6 +26,10 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  # Fix build with gcc15
+  # https://github.com/virtualsquare/vde-2/commit/fedcb99c5f44c397f459ed0951a8fba4f4effb73
+  env.NIX_CFLAGS_COMPILE = "-std=gnu17";
+
   preConfigure = lib.optionalString (lib.versionAtLeast stdenv.hostPlatform.darwinMinVersion "11") ''
     MACOSX_DEPLOYMENT_TARGET=10.16
   '';


### PR DESCRIPTION
- add "-std=gnu17" to `env.NIX_CFLAGS_COMPILE` similar to merged upstream commit (patch from commit does not apply):
https://github.com/virtualsquare/vde-2/commit/fedcb99c5f44c397f459ed0951a8fba4f4effb73

Fixes build failure with gcc15:
```
libvdehist.c:39:27: error: initialization of 'ssize_fun' {aka 'long
int (*)(void)'} from incompatible pointer type
'ssize_t (*)(int,  void *, size_t)' {aka 'long int (>
   39 | ssize_fun vdehist_vderead=read;
      |                           ^~~~
In file included from /nix/store/gi4cz4ir3zlwhf1azqfgxqdnczfrwsr7-glibc-2.40-66-dev/include/unistd.h:1217,
                 from libvdehist.c:21:
/nix/store/gi4cz4ir3zlwhf1azqfgxqdnczfrwsr7-glibc-2.40-66-dev/include/bits/unistd.h:26:1:
note: 'read' declared here
   26 | read (int __fd, __fortify_clang_overload_arg0 (void *, ,__buf), size_t __nbytes)
      | ^~~~
libvdehist.c:38:20: note: 'ssize_fun' declared here
   38 | typedef ssize_t (* ssize_fun)();
      |                    ^~~~~~~~~
libvdehist.c: In function 'showexpand':
libvdehist.c:99:25: error: too many arguments to function 'vdehist_termwrite';
expected 0, have 3
   99 |                         vdehist_termwrite(termfd,buf,strlen(buf));
      |                         ^~~~~~~~~~~~~~~~~ ~~~~~~
libvdehist.c: In function 'vdehist_create_commandlist':
libvdehist.c:192:17: error: too many arguments to function 'vdehist_vdewrite';
expected 0, have 3
  192 |                 vdehist_vdewrite(vdefd,"help\n",5);
      |                 ^~~~~~~~~~~~~~~~ ~~~~~
libvdehist.c:323:27: error: too many arguments to function 'vdehist_vderead';
expected 0, have 3
  323 |                         n=vdehist_vderead(st->mgmtfd,buf,BUFSIZE);
      |                           ^~~~~~~~~~~~~~~ ~~~~~~~~~~
```

---

Tested build with:

```bash
nix-build --expr 'with import ./. {}; vde2.override { stdenv = gcc15Stdenv; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
