### PR TITLE
gfxstream: fix build with gcc15

### DIFF
--- a/pkgs/by-name/gf/gfxstream/gfxstream-add-include-cstdint.patch
+++ b/pkgs/by-name/gf/gfxstream/gfxstream-add-include-cstdint.patch
@@ -1,0 +1,49 @@
+diff --git a/host/BorrowedImage.h b/host/BorrowedImage.h
+index ed2890568..51ea2b6b1 100644
+--- a/host/BorrowedImage.h
++++ b/host/BorrowedImage.h
+@@ -12,6 +12,7 @@
+ // See the License for the specific language governing permissions and
+ // limitations under the License.
+ 
++#include <cstdint>
+ #pragma once
+ 
+ namespace gfxstream {
+diff --git a/host/compressedTextureFormats/AstcCpuDecompressor.h b/host/compressedTextureFormats/AstcCpuDecompressor.h
+index 4823ee255..3af0bdc64 100644
+--- a/host/compressedTextureFormats/AstcCpuDecompressor.h
++++ b/host/compressedTextureFormats/AstcCpuDecompressor.h
+@@ -15,6 +15,7 @@
+ 
+ #include <memory>
+ #include <string>
++#include <cstdint>
+ 
+ namespace gfxstream {
+ namespace vk {
+diff --git a/host/magma/DrmContext.h b/host/magma/DrmContext.h
+index db3ef45e4..5030c7dd6 100644
+--- a/host/magma/DrmContext.h
++++ b/host/magma/DrmContext.h
+@@ -16,6 +16,7 @@
+ 
+ #include <memory>
+ #include <optional>
++#include <cstdint>
+ 
+ #include "aemu/base/Compiler.h"
+ 
+diff --git a/host/vulkan/BufferVk.h b/host/vulkan/BufferVk.h
+index 9016fd745..a8a3fe3eb 100644
+--- a/host/vulkan/BufferVk.h
++++ b/host/vulkan/BufferVk.h
+@@ -14,6 +14,7 @@
+ 
+ #include <memory>
+ #include <vector>
++#include <cstdint>
+ 
+ namespace gfxstream {
+ namespace vk {
+

--- a/pkgs/by-name/gf/gfxstream/package.nix
+++ b/pkgs/by-name/gf/gfxstream/package.nix
@@ -25,6 +25,11 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-AN6OpZQ2te4iVuh/kFHXzmLAWIMyuoj9FHTVicnbiPw=";
   };
 
+  patches = [
+    # Fix build with gcc15
+    ./gfxstream-add-include-cstdint.patch
+  ];
+
   # Ensure that meson can find an Objective-C compiler on Darwin.
   postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
     substituteInPlace meson.build \


### PR DESCRIPTION
- add patch that adds missing `#include <cstdint>`, similar to what fedora does:
https://src.fedoraproject.org/rpms/gfxstream/raw/2c7cbc24596973e2efc8180af81e57ddfa24654b/f/fix_missing_cstdint.patch
(it applies, but somehow we hit more places with missing headers even with that patch)

Fixes build failure with gcc15:
```
In file included from ../host/compressedTextureFormats/AstcCpuDecompressorNoOp.cpp:15:
../host/compressedTextureFormats/AstcCpuDecompressor.h:48:32:
error: 'uint32_t' has not been declared
   48 |     virtual int32_t decompress(uint32_t imgWidth, uint32_t imgHeight, uint32_t blockWidth,
      |                                ^~~~~~~~
../host/compressedTextureFormats/AstcCpuDecompressor.h:18:1:
note: 'uint32_t' is defined in header '<cstdint>'; this is probably
fixable by adding '#include <cstdint>'
   17 | #include <string>
  +++ |+#include <cstdint>
   18 |
../host/compressedTextureFormats/AstcCpuDecompressorNoOp.cpp:25:43:
error: 'uint32_t' has not been declared
   25 |     int32_t decompress(uint32_t imgWidth, uint32_t imgHeight, uint32_t blockWidth,
      |                                           ^~~~~~~~
../host/compressedTextureFormats/AstcCpuDecompressorNoOp.cpp:25:43:
note: 'uint32_t' is defined in header '<cstdint>'; this is probably
fixable by adding '#include <cstdint>'
```
---
Tested build with:

```bash
nix-build --expr 'with import ./. {}; gfxstream.override { stdenv = gcc15Stdenv; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
