### PR TITLE
unixODBCDrivers.mariadb: fix build with gcc15

### DIFF
--- a/pkgs/development/libraries/unixODBCDrivers/default.nix
+++ b/pkgs/development/libraries/unixODBCDrivers/default.nix
@@ -61,6 +61,14 @@
       ./mariadb-connector-odbc-unistd.patch
 
       ./mariadb-connector-odbc-musl.patch
+
+      # Fix build with gcc15
+      # https://github.com/mariadb-corporation/mariadb-connector-odbc/pull/63
+      (fetchpatch {
+        name = "mariadb-connector-odbc-add-include-cstdint-gcc15.patch";
+        url = "https://github.com/mariadb-corporation/mariadb-connector-odbc/commit/a3ced654db2ef93de0a818f2d66171f6084e5f2d.patch";
+        hash = "sha256-GZITSryfRdAgNxZehasoBModGNZo575Dd5aokwNWzpY=";
+      })
     ];
 
     nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
- add patch from merged upstream PR that adds missing `#include <cstdint>` https://www.github.com/mariadb-corporation/mariadb-connector-odbc/pull/63
https://github.com/mariadb-corporation/mariadb-connector-odbc/commit/a3ced654db2ef93de0a818f2d66171f6084e5f2d

Fixes build failure with gcc15:
```
/build/source/driver/class/ColumnDefinition.h:55:10: error: 'uint8_t'
does not name a type
   55 |   static uint8_t maxCharlen[];
      |          ^~~~~~~
/build/source/driver/class/ColumnDefinition.h:30:1: note: 'uint8_t' is
defined in header '<cstdint>'; this is probably fixable by adding
'#include <cstdint>'
   29 | #include "SQLString.h"
  +++ |+#include <cstdint>
   30 |
/build/source/driver/interface/CmdInformation.h:35:15: error: 'int64_t'
was not declared in this scope
   35 |   std::vector<int64_t> batchRes;
      |               ^~~~~~~
/build/source/driver/interface/CmdInformation.h:26:1: note: 'int64_t' is
defined in header '<cstdint>'; this is probably fixable by adding
'#include <cstdint>'
   25 | #include <memory>
  +++ |+#include <cstdint>
   26 |
```

---

Tested build with:

```bash
nix-build --expr 'with import ./. {}; unixODBCDrivers.mariadb.override { stdenv = gcc15Stdenv; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
