### PR TITLE
texlive.bin.core{,-big}: fix build with gcc15

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -176,6 +176,7 @@ let
       "--disable-texlive" # do not build the texlive (TeX Live scripts) package
       "--disable-linked-scripts" # do not install the linked scripts
       "-C" # use configure cache to speed up
+      "CFLAGS=-std=gnu17" # fix build with gcc15
     ]
     ++ withSystemLibs [
       # see "from TL tree" vs. "Using installed"  in configure output


### PR DESCRIPTION
- add `"CFLAGS=-std=gnu17"` to `configureFlags`

Fixes build failure with gcc15:
```
euptex0.c:13216:11: error: two or more data types in declaration specifiers
13216 |   boolean bool  ;
      |           ^~~~
euptex0.c:13216:3: warning: useless type name in empty declaration
13216 |   boolean bool  ;
      |   ^~~~~~~
euptex0.c:13370:12: error: expected identifier or '(' before '=' token
13370 |       bool = scankeyword ( 876 ) ;
      |            ^
euptex0.c:13372:17: error: expected identifier or '(' before ')' token
13372 |       if ( bool )
      |                 ^
euptex0.c:13372:12: error: declaration in the controlling expression
must have an initializer
13372 |       if ( bool )
      |            ^~~~
euptex0.c:13385:23: error: expected expression before 'bool'
13385 |       getmd5sum ( s , bool ) ;
      |                       ^~~~
```

---

Tested on top of gcc15 default from https://github.com/NixOS/nixpkgs/pull/440456
(have not figured out how to change `stdenv` to `gcc15Stdenv` otherwise)

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

---

Upstream has commits with fixes, but first one does not apply and I assume more errors will come up after that:
https://github.com/TeX-Live/texlive-source/commit/1f193bcb73ae24a580bcbf5fad0ff097e477e242
https://github.com/TeX-Live/texlive-source/commit/c2ac1c5758a4c56e4386036d711fc7effa35a983
https://github.com/TeX-Live/texlive-source/commit/cc687b6c0ae8c6a4b566646282a7bc702d822e6d

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
