### PR TITLE
television: remove the unexpected key bindings

### DIFF
--- a/pkgs/by-name/te/television/package.nix
+++ b/pkgs/by-name/te/television/package.nix
@@ -39,6 +39,27 @@ let
     # https://github.com/NixOS/nixpkgs/pull/423662#issuecomment-3156362941
     doCheck = false;
 
+    postPatch = ''
+      # Remove keybinding overrides from shell completion scripts
+      # Users should configure their own keybindings
+
+      # Bash: Remove bind commands
+      sed -i '/^# Bind the functions to key combinations/,$d' \
+        television/utils/shell/completion.bash
+
+      # Fish: Remove bind commands for both modes
+      sed -i '/^for mode in default insert/,$d' \
+        television/utils/shell/completion.fish
+
+      # Nushell: Remove keybinding configuration
+      sed -i '/^# Bind custom keybindings/,$d' \
+        television/utils/shell/completion.nu
+
+      # Zsh: Remove zle and bindkey commands
+      sed -i '/^zle -N tv-smart-autocomplete/,$d' \
+        television/utils/shell/completion.zsh
+    '';
+
     postInstall = ''
       installManPage target/${stdenv.hostPlatform.rust.cargoShortTarget}/assets/tv.1
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The `television` package currently installs files from `utils/shell/completion.*` using `installShellCompletion`. However, these upstream files are not pure completion scripts; they are full shell integration scripts that include aggressive keybindings (e.g., overriding `Ctrl+r` or similar https://github.com/alexpasmantier/television/blob/3b9ddf6e39aca9068d3719552df2c96bd74d4c2a/television/utils/shell/completion.nu#L31-L59). I believe this violates the purity of nixpkgs. 



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
