### PR TITLE
timr-tui: init at 1.6.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8715,6 +8715,12 @@
     githubId = 12560461;
     name = "Arne Keller";
   };
+  flokkq = {
+    email = "weberclemens07@gmail.com";
+    github = "flokkq";
+    githubId = 98653095;
+    name = "Clemens Weber";
+  };
   flokli = {
     email = "flokli@flokli.de";
     github = "flokli";

--- a/pkgs/by-name/ti/timr-tui/package.nix
+++ b/pkgs/by-name/ti/timr-tui/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  alsa-lib-with-plugins,
+  alsa-plugins,
+  pipewire,
+  writableTmpDirAsHomeHook,
+  versionCheckHook,
+  nix-update-script,
+  enableSound ? false,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "timr-tui";
+  version = "1.6.1";
+
+  src = fetchFromGitHub {
+    owner = "sectore";
+    repo = "timr-tui";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-s2FnMwDq4tYBaWaT9y1GLbVGFs7zSnOmjcF5leO12JE=";
+  };
+
+  cargoHash = "sha256-9yd348QGjFxt+QmEBuYzd612mFm/PyETrZy4z5wW+nI=";
+
+  # Enable upstream "sound" feature when requested
+  buildFeatures = lib.optionals enableSound [ "sound" ];
+
+  nativeBuildInputs = lib.optionals (enableSound && stdenv.isLinux) [ pkg-config ];
+
+  # Runtime/FFI deps for the sound feature (Linux)
+  buildInputs = lib.optionals (enableSound && stdenv.isLinux) [
+    (alsa-lib-with-plugins.override {
+      plugins = [
+        alsa-plugins
+        pipewire
+      ];
+    })
+  ];
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+  ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--version";
+  # Error: Operation not permitted (os error 1)
+  versionCheckKeepEnvironment = lib.optionals stdenv.hostPlatform.isDarwin [ "HOME" ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "TUI to organize your time: Pomodoro, Countdown, Timer";
+    homepage = "https://github.com/sectore/timr-tui";
+    changelog = "https://github.com/sectore/timr-tui/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "timr-tui";
+    maintainers = [ lib.maintainers.flokkq ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
<!--
TUI to organize your time: Pomodoro, Countdown, Timer.
https://github.com/sectore/timr-tui
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - ~~[ ] [NixOS tests] in [nixos/tests].~~
  - ~~[ ] [Package tests] at `passthru.tests`.~~
  - ~~[ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.~~
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - ~~[ ] Package update: when the change is major or breaking.~~
- NixOS Release Notes
  - ~~[ ] Module addition: when adding a new NixOS module.~~
  - ~~[ ] Module update: when the change is significant.~~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
