### PR TITLE
nixos-rebuild-ng: check if .git exists in nixpkgs directory before parsing rev

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/README.md
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/README.md
@@ -1,39 +1,8 @@
 # nixos-rebuild-ng
 
-Work-in-Progress rewrite of
-[`nixos-rebuild`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh).
-
-## Why the rewrite?
-
-The current state of `nixos-rebuild` is dire: it is one of the most critical
-pieces of code we have in NixOS, but it has tons of issues:
-- The code is written in Bash, and while this by itself is not necessarily bad,
-  it means that it is difficult to do refactorings due to the lack of tooling
-  for the language
-- The code itself is a hacky mess. Changing even one line of code can cause
-  issues that affect dozens of people
-- Lack of proper testing (we do have some integration tests, but no unit tests
-  and coverage is probably pitiful)
-- The code predates some of the improvements `nix` had over the years, e.g., it
-  builds Flakes inside a temporary directory and reads the resulting symlink
-  since the code seems to predate `--print-out-paths` flag
-
-Given all of the above, improvements in the `nixos-rebuild` are difficult to
-do. A full rewrite is probably the easier way to improve the situation since
-this can be done in a separate package that will not break anyone. So this is
-an attempt of the rewrite.
-
-## Why Python?
-
-- It is the language of choice for many critical things inside `nixpkgs`, like
-  the `NixOSTest` and `systemd-boot-builder.py` activation scripts
-- It is a language with great tooling, e.g.: `mypy` for type checking, `ruff`
-  for linting, `pytest` for unit testing
-- It is a scripting language that fits well with the scope of this project
-- Python's standard library is great and it means we will need a low number of
-  external dependencies for this project. For example, `nixos-rebuild`
-  currently depends on `jq` for JSON parsing, while Python has `json` in
-  standard library
+`nixos-rebuild-ng` is a command-line tool that builds and switches your NixOS
+system to a new configuration based on your `configuration.nix` and related Nix
+files.
 
 ## Development
 
@@ -66,60 +35,3 @@ ruff check --fix .
 # format code
 ruff format .
 ```
-
-## Breaking changes
-
-While `nixos-rebuild-ng` tries to be as much of a clone of the original as
-possible, there are still some breaking changes that were done in order to
-improve the user experience. If they break your workflow in some way that is
-not possible to fix, please open an issue and we can discuss a solution.
-
-- For `--build-host` and `--target-host`, `nixos-rebuild-ng` does not allocate
-  a pseudo-TTY via SSH (e.g., `ssh -t`) anymore. The reason for this is that
-  pseudo-TTY breaks some expectations from SSH, like it mangles stdout and
-  stderr, and can
-  [break terminal output](https://github.com/NixOS/nixpkgs/issues/336967) in
-  some situations.
-  The issue is that `sudo` needs a TTY to ask for password, otherwise it will
-  fail. The solution for this is a new flag, `--ask-sudo-password`, that when
-  used with `--target-host` (`--build-host` doesn't need `sudo`), will ask for
-  the `sudo` password for the target host using Python's
-  [getpass](https://docs.python.org/3/library/getpass.html) and forward it to
-  every `sudo` request. Keep in mind that there is no check, so if you type
-  your password wrong, it will fail during activation (this can be improved
-  though)
-- When `--build-host` and `--target-host` are used together, we will use `nix
-  copy` instead of SSH'ing to build host and using
-  `nix-copy-closure --to target-host`. The reason for this is documented in PR
-  [#364698](https://github.com/NixOS/nixpkgs/pull/364698). If you do need the
-  previous behavior, you can simulate it using `ssh build-host --
-  nixos-rebuild-ng switch --target-host target-host`. If that is not the case,
-  please open an issue
-- We do some additional validation of flags, like exiting with an error when
-  `--build-host` or `--target-host` is used with `repl`, since the user could
-  assume that the `repl` would be run remotely while it always runs the local
-  machine. `nixos-rebuild` silently ignored those flags, so this
-  [may cause some issues](https://github.com/NixOS/nixpkgs/pull/363922) for
-  wrappers
-
-## Caveats
-
-- Bugs in the profile manipulation can cause corruption of your profile that
-  may be difficult to fix, so right now I only recommend using
-  `nixos-rebuild-ng` if you are testing in a VM or in a filesystem with
-  snapshots like BTRFS or ZFS. Those bugs are unlikely to be unfixable but the
-  errors can be difficult to understand. If you want to go on,
-  `nix-collect-garbage -d` and `nix store repair` are your friends
-
-## TODON'T
-
-- Nix bootstrap: it is only used for non-Flake paths and it is basically
-  useless nowadays. It was created at a time when Nix was changing frequently
-  and there was a need to bootstrap a new version of Nix before evaluating the
-  configuration (otherwise the new Nixpkgs version may have code that is only
-  compatible with a newer version of Nix). Nixpkgs now has a policy to be
-  compatible with Nix 2.18, and even if this is bumped as long we don't do
-  drastic minimum version changes this should not be an issue. Also, the daemon
-  itself always run with the previous version since even we can replace Nix in
-  `PATH` (so Nix client), but we can't replace the daemon without switching to
-  a new version.

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -382,6 +382,9 @@ def get_nixpkgs_rev(nixpkgs_path: Path | None) -> str | None:
     if not nixpkgs_path:
         return None
 
+    if not (nixpkgs_path / ".git").exists():
+        return None
+
     try:
         # Get current revision
         r = run_wrapper(

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -141,7 +141,7 @@ def test_parse_args() -> None:
 @patch("subprocess.run", autospec=True)
 def test_execute_nix_boot(mock_run: Mock, tmp_path: Path) -> None:
     nixpkgs_path = tmp_path / "nixpkgs"
-    nixpkgs_path.mkdir()
+    (nixpkgs_path / ".git").mkdir(parents=True)
     config_path = tmp_path / "test"
     config_path.touch()
 
@@ -932,7 +932,7 @@ def test_execute_nix_switch_flake_build_host(
 @patch("subprocess.run", autospec=True)
 def test_execute_switch_rollback(mock_run: Mock, tmp_path: Path) -> None:
     nixpkgs_path = tmp_path / "nixpkgs"
-    nixpkgs_path.touch()
+    (nixpkgs_path / ".git").mkdir(parents=True)
 
     def run_side_effect(args: list[str], **kwargs: Any) -> CompletedProcess[str]:
         if args[0] == "nix-instantiate":

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -345,7 +345,7 @@ def test_get_build_image_variants(mock_run: Mock, tmp_path: Path) -> None:
         stdout=PIPE,
     )
 
-    build_attr = m.BuildAttr(Path(tmp_path), "preAttr")
+    build_attr = m.BuildAttr(tmp_path, "preAttr")
     assert n.get_build_image_variants(build_attr, {"inst_flag": True}) == {
         "azure": "nixos-image-azure-25.05.20250102.6df2492-x86_64-linux.vhd",
         "vmware": "nixos-image-vmware-25.05.20250102.6df2492-x86_64-linux.vmdk",
@@ -404,31 +404,20 @@ def test_get_build_image_variants_flake(mock_run: Mock) -> None:
     )
 
 
-def test_get_nixpkgs_rev() -> None:
+def test_get_nixpkgs_rev(tmpdir: Path) -> None:
     assert n.get_nixpkgs_rev(None) is None
+    assert n.get_nixpkgs_rev(tmpdir) is None
 
-    path = Path("/path/to/nix")
-
-    with patch(
-        get_qualified_name(n.run_wrapper, n),
-        autospec=True,
-        side_effect=[CompletedProcess([], 0, "")],
-    ) as mock_run:
-        assert n.get_nixpkgs_rev(path) is None
-        mock_run.assert_called_with(
-            ["git", "-C", path, "rev-parse", "--short", "HEAD"],
-            check=False,
-            capture_output=True,
-        )
+    (tmpdir / ".git").mkdir()
 
     expected_calls = [
         call(
-            ["git", "-C", path, "rev-parse", "--short", "HEAD"],
+            ["git", "-C", tmpdir, "rev-parse", "--short", "HEAD"],
             check=False,
             capture_output=True,
         ),
         call(
-            ["git", "-C", path, "diff", "--quiet"],
+            ["git", "-C", tmpdir, "diff", "--quiet"],
             check=False,
         ),
     ]
@@ -441,7 +430,7 @@ def test_get_nixpkgs_rev() -> None:
             CompletedProcess([], returncode=0),
         ],
     ) as mock_run:
-        assert n.get_nixpkgs_rev(path) == ".git.0f7c82403fd6"
+        assert n.get_nixpkgs_rev(tmpdir) == ".git.0f7c82403fd6"
         mock_run.assert_has_calls(expected_calls)
 
     with patch(
@@ -452,7 +441,7 @@ def test_get_nixpkgs_rev() -> None:
             CompletedProcess([], returncode=1),
         ],
     ) as mock_run:
-        assert n.get_nixpkgs_rev(path) == ".git.0f7c82403fd6M"
+        assert n.get_nixpkgs_rev(tmpdir) == ".git.0f7c82403fd6M"
         mock_run.assert_has_calls(expected_calls)
 
 


### PR DESCRIPTION
This should matches more closely the behavior of legacy `nixos-rebuild`.

https://github.com/NixOS/nixpkgs/blob/476148c6342020022817362bb9d65db2b1e0bab8/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh#L588-L593

Should fix this issue reported in Discourse:
https://discourse.nixos.org/t/nixos-25-11-released/72711/7.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
