### PR TITLE
rclone-ui: 2.2.0 -> 2.8.1

### DIFF
--- a/pkgs/by-name/rc/rclone-ui/package.nix
+++ b/pkgs/by-name/rc/rclone-ui/package.nix
@@ -20,26 +20,26 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rclone-ui";
-  version = "2.2.0";
+  version = "2.8.1";
 
   src = fetchFromGitHub {
     owner = "rclone-ui";
     repo = "rclone-ui";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-gwZXI501lE3Tm9M8k6a2NJCsvbiPB3Y4yhhr4gkpkY4=";
+    hash = "sha256-z8SAXYK3HgtJSiFTJopo+zVZw2kd8ByUXufyauoUNFM=";
   };
 
   npmDeps = fetchNpmDeps {
     name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
     inherit (finalAttrs) src;
     forceGitDeps = true;
-    hash = "sha256-OkPVPT4JBbkVcfGtSs6oi+VFA3sxp1b6fVr68ILtnPU=";
+    hash = "sha256-8Os5mFILRpe8tROQdDAW6y/RTp/X0X/5z+Psf/lQpi4=";
   };
 
   cargoRoot = "src-tauri";
   buildAndTestSubdir = finalAttrs.cargoRoot;
 
-  cargoHash = "sha256-8RK1rrGyxRNCTARlYUJNXWaH9F/3hV31uyNXjvWJaFU=";
+  cargoHash = "sha256-c/BHtHWj8F6mCmIpxDPIVy/5bRBCUFACWZEpsDO6CTU=";
 
   # Disable tauri bundle updater, can be removed when #389107 is merged
   patches = [ ./remove_updater.patch ];

--- a/pkgs/by-name/rc/rclone-ui/remove_updater.patch
+++ b/pkgs/by-name/rc/rclone-ui/remove_updater.patch
@@ -1,23 +1,37 @@
 diff --git a/src-tauri/src/lib.rs b/src-tauri/src/lib.rs
-index 04ea191..72d178d 100644
+index 5200821..8994d35 100644
 --- a/src-tauri/src/lib.rs
 +++ b/src-tauri/src/lib.rs
-@@ -83,7 +83,6 @@ pub fn run() {
- 	
+@@ -673,7 +673,7 @@ async fn update_system_rclone() -> Result<i32, String> {
+                 // Fallback to sudo with custom prompt (works if the user has NOPASSWD or cached credentials)
+                 let mut sudo_env = std::collections::HashMap::new();
+                 sudo_env.insert("SUDO_PROMPT", "Rclone UI needs permission to run rclone selfupdate. Please enter your password: ");
+-                
++
+                 let mut sudo_args: Vec<String> = Vec::new();
+                 sudo_args.push("-n".to_string());
+                 sudo_args.push("env".to_string());
+@@ -735,11 +735,10 @@ pub fn run() {
+     ));
+ 
+     let _guard = tauri_plugin_sentry::minidump::init(&client);
+-	
++
      let mut app = tauri::Builder::default()
+ 		.plugin(tauri_plugin_sentry::init_with_no_injection(&client))
          .plugin(tauri_plugin_clipboard_manager::init())
 -        .plugin(tauri_plugin_updater::Builder::new().build())
          .plugin(tauri_plugin_os::init())
          .plugin(tauri_plugin_notification::init())
          .plugin(tauri_plugin_process::init())
 diff --git a/src-tauri/tauri.conf.json b/src-tauri/tauri.conf.json
-index 8b1c89f..1705861 100644
+index 933f067..bbb69fc 100644
 --- a/src-tauri/tauri.conf.json
 +++ b/src-tauri/tauri.conf.json
-@@ -86,16 +86,9 @@
-                 "installMode": "both"
-             },
-             "signCommand": "trusted-signing-cli -e https://eus.codesigning.azure.net -a sign-1 -c Sign1 -d Rclone %1"
+@@ -87,16 +87,9 @@
+             "rpm": {
+                 "depends": ["(libappindicator-gtk3 or libayatana-appindicator-gtk3)"]
+             }
 -        },
 -        "createUpdaterArtifacts": true
 +        }


### PR DESCRIPTION
rclone-ui: 2.2.0 -> 2.8.1

This updates rclone-ui to the latest version.

Changelog highlights since 2.2.0:
- **v2.8.0:** Adds additional mount types like `UNION`, `CRYPT`, and many other remotes.

The full list of changes can be found on the [rclone-ui releases page](https://github.com/rclone-ui/rclone-ui/releases).

The new patch was made using cloning the repo with the corresponding hash and making the diff manually there adding it here.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
