### PR TITLE
python3.pkgs.beets: allow to override passthru

### DIFF
--- a/pkgs/development/python-modules/beets/default.nix
+++ b/pkgs/development/python-modules/beets/default.nix
@@ -106,7 +106,16 @@
   runCommand,
 }:
 
-buildPythonPackage rec {
+let
+  # Avoid using `rec`, so that using e.g `passthru` or any other attributes
+  # defined inside, will have to be done via the beets argument, which can be
+  # overriden. Until `finalAttrs` support reaches `buildPythonPackage`, there
+  # is no way to avoid this. See:
+  #
+  # https://github.com/NixOS/nixpkgs/issues/258246
+  version = "2.5.1";
+in
+buildPythonPackage {
   pname = "beets";
   version = "2.5.1";
   src = fetchFromGitHub {

--- a/pkgs/development/python-modules/beets/default.nix
+++ b/pkgs/development/python-modules/beets/default.nix
@@ -145,7 +145,7 @@ buildPythonPackage rec {
     typing-extensions
     lap
   ]
-  ++ (lib.concatMap (p: p.propagatedBuildInputs) (lib.attrValues passthru.plugins.enabled));
+  ++ (lib.concatMap (p: p.propagatedBuildInputs) (lib.attrValues beets.passthru.plugins.enabled));
 
   nativeBuildInputs = [
     gobject-introspection
@@ -186,7 +186,7 @@ buildPythonPackage rec {
   makeWrapperArgs = [
     "--set GI_TYPELIB_PATH \"$GI_TYPELIB_PATH\""
     "--set GST_PLUGIN_SYSTEM_PATH_1_0 \"$GST_PLUGIN_SYSTEM_PATH_1_0\""
-    "--prefix PATH : ${lib.makeBinPath passthru.plugins.wrapperBins}"
+    "--prefix PATH : ${lib.makeBinPath beets.passthru.plugins.wrapperBins}"
   ];
 
   nativeCheckInputs = [
@@ -199,12 +199,12 @@ buildPythonPackage rec {
     pillow
     writableTmpDirAsHomeHook
   ]
-  ++ passthru.plugins.wrapperBins;
+  ++ beets.passthru.plugins.wrapperBins;
 
   __darwinAllowLocalNetworking = true;
 
   disabledTestPaths =
-    passthru.plugins.disabledTestPaths
+    beets.passthru.plugins.disabledTestPaths
     ++ [
       # touches network
       "test/plugins/test_aura.py"
@@ -246,14 +246,14 @@ buildPythonPackage rec {
       \( -name '*.py' -o -path 'beetsplug/*/__init__.py' \) -print \
       | sed -n -re 's|^beetsplug/([^/.]+).*|\1|p' \
       | sort -u > plugins_available
-    ${diffPlugins (lib.attrNames passthru.plugins.builtins) "plugins_available"}
+    ${diffPlugins (lib.attrNames beets.passthru.plugins.builtins) "plugins_available"}
 
     export BEETS_TEST_SHELL="${lib.getExe bashInteractive} --norc"
 
     env EDITOR="${writeScript "beetconfig.sh" ''
       #!${runtimeShell}
       cat > "$1" <<CFG
-      plugins: ${lib.concatStringsSep " " (lib.attrNames passthru.plugins.enabled)}
+      plugins: ${lib.concatStringsSep " " (lib.attrNames beets.passthru.plugins.enabled)}
       CFG
     ''}" "$out/bin/beet" config -e
     env EDITOR=true "$out/bin/beet" config -e
@@ -433,10 +433,10 @@ buildPythonPackage rec {
           testPaths = [ ];
         };
       };
-      base = lib.mapAttrs (_: a: { builtin = true; } // a) passthru.plugins.builtins;
+      base = lib.mapAttrs (_: a: { builtin = true; } // a) beets.passthru.plugins.builtins;
       overrides = lib.mapAttrs (
         plugName:
-        lib.throwIf (passthru.plugins.builtins.${plugName}.deprecated or false)
+        lib.throwIf (beets.passthru.plugins.builtins.${plugName}.deprecated or false)
           "beets evaluation error: Plugin ${plugName} was enabled in pluginOverrides, but it has been removed. Remove the override to fix evaluation."
       ) pluginOverrides;
       all = lib.mapAttrs (
@@ -450,13 +450,13 @@ buildPythonPackage rec {
           wrapperBins = [ ];
         }
         // a
-      ) (lib.recursiveUpdate passthru.plugins.base passthru.plugins.overrides);
-      enabled = lib.filterAttrs (_: p: p.enable) passthru.plugins.all;
-      disabled = lib.filterAttrs (_: p: !p.enable) passthru.plugins.all;
+      ) (lib.recursiveUpdate beets.passthru.plugins.base beets.passthru.plugins.overrides);
+      enabled = lib.filterAttrs (_: p: p.enable) beets.passthru.plugins.all;
+      disabled = lib.filterAttrs (_: p: !p.enable) beets.passthru.plugins.all;
       disabledTestPaths = lib.flatten (
-        lib.attrValues (lib.mapAttrs (_: v: v.testPaths) passthru.plugins.disabled)
+        lib.attrValues (lib.mapAttrs (_: v: v.testPaths) beets.passthru.plugins.disabled)
       );
-      wrapperBins = lib.concatMap (p: p.wrapperBins) (lib.attrValues passthru.plugins.enabled);
+      wrapperBins = lib.concatMap (p: p.wrapperBins) (lib.attrValues beets.passthru.plugins.enabled);
     };
     tests = {
       gstreamer =


### PR DESCRIPTION
Tested with:

```diff
diff --git i/pkgs/top-level/python-packages.nix w/pkgs/top-level/python-packages.nix
index 6051daa09f6a..2dde3c3c327b 100644
--- i/pkgs/top-level/python-packages.nix
+++ w/pkgs/top-level/python-packages.nix
@@ -1871,6 +1871,25 @@ self: super: with self; {
   beets = callPackage ../development/python-modules/beets {
     inherit (pkgs) chromaprint;
   };
+  beets-test = let
+    # Not using `overridePythonAttrs` because it doesn't produce a derivation
+    # with a `.override` method, as required later.
+    patched = beets.overrideAttrs(oldAttrs: {
+      patches = oldAttrs.patches ++ [
+        (pkgs.fetchpatch {
+          name = "beets-importsource-plugin.patch";
+          url = "https://github.com/beetbox/beets/commit/9608ec0925979356fb7bf3a870fbde760362a973.patch";
+          hash = "sha256-wseJe+2jS7hsKKJ5jWrkBlPmOkVwLhPS23PRMqAR7is=";
+        })
+      ];
+      passthru = lib.recursiveUpdate oldAttrs.passthru {
+        plugins.builtins.importsource = {};
+      };
+    });
+  in
+    patched.override {
+      beets = patched;
+    };
 
   beets-alternatives = callPackage ../development/python-modules/beets-alternatives { };
 
```
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc