### PR TITLE
neovim-qt: build with qt6

### DIFF
--- a/pkgs/by-name/ne/neovim-qt-unwrapped/package.nix
+++ b/pkgs/by-name/ne/neovim-qt-unwrapped/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  libsForQt5,
+  qt6,
   fetchFromGitHub,
   cmake,
   doxygen,
@@ -24,12 +24,13 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     "-DUSE_SYSTEM_MSGPACK=1"
     "-DENABLE_TESTS=0" # tests fail because xcb platform plugin is not found
+    "-DWITH_QT=Qt6"
   ];
 
   nativeBuildInputs = [
     cmake
     doxygen
-    libsForQt5.wrapQtAppsHook
+    qt6.wrapQtAppsHook
     (python3.withPackages (ps: [
       ps.jinja2
       ps.msgpack
@@ -38,8 +39,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     neovim.unwrapped # only used to generate help tags at build time
-    libsForQt5.qtbase
-    libsForQt5.qtsvg
+    qt6.qtbase
+    qt6.qtsvg
     msgpack-c
   ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
