### PR TITLE
nixos/console: fix optimizedKeymap derivation isUnicode condition

### DIFF
--- a/nixos/modules/config/console.nix
+++ b/nixos/modules/config/console.nix
@@ -9,7 +9,7 @@ let
 
   makeColor = i: lib.concatMapStringsSep "," (x: "0x" + lib.substring (2 * i) 2 x);
 
-  isUnicode = lib.hasSuffix "UTF-8" (lib.toUpper config.i18n.defaultLocale);
+  isUnicode = config.i18n.defaultCharset == "UTF-8" || cfg.useXkbConfig;
 
   optimizedKeymap =
     pkgs.runCommand "keymap"

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -385,6 +385,7 @@ in
   collectd = runTest ./collectd.nix;
   commafeed = runTest ./commafeed.nix;
   connman = runTest ./connman.nix;
+  console-xkb-and-i18n = runTest ./console-xkb-and-i18n.nix;
   consul = runTest ./consul.nix;
   consul-template = runTest ./consul-template.nix;
   containers-bridge = runTest ./containers-bridge.nix;

--- a/nixos/tests/console-xkb-and-i18n.nix
+++ b/nixos/tests/console-xkb-and-i18n.nix
@@ -1,0 +1,23 @@
+{ lib, ... }:
+{
+  name = "console-xkb-and-i18n";
+  meta.maintainers = with lib.maintainers; [ doronbehar ];
+
+  nodes = {
+    # Nothing to run on this node, a bug (TODO: where?) is causing a builder of
+    # the configuration to fail. See:
+    #
+    # - https://github.com/NixOS/nixpkgs/issues/445666
+    # - https://github.com/NixOS/nixpkgs/issues/411374
+    #
+    x = {
+      i18n.defaultLocale = "eo";
+      console.useXkbConfig = true;
+      services.xserver.xkb = {
+        layout = "us";
+        variant = "colemak";
+      };
+    };
+  };
+  testScript = { nodes, ... }: "";
+}

--- a/nixos/tests/console-xkb-and-i18n.nix
+++ b/nixos/tests/console-xkb-and-i18n.nix
@@ -4,8 +4,8 @@
   meta.maintainers = with lib.maintainers; [ doronbehar ];
 
   nodes = {
-    # Nothing to run on this node, a bug (TODO: where?) is causing a builder of
-    # the configuration to fail. See:
+    # Nothing to run on this node. Only verify that this configuration doesn't
+    # produce the bugs described here:
     #
     # - https://github.com/NixOS/nixpkgs/issues/445666
     # - https://github.com/NixOS/nixpkgs/issues/411374


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc