### PR TITLE
ecl: fix build with gcc15

### DIFF
--- a/pkgs/development/compilers/ecl/default.nix
+++ b/pkgs/development/compilers/ecl/default.nix
@@ -59,6 +59,8 @@ stdenv.mkDerivation rec {
   ];
 
   configureFlags = [
+    # Fix build with gcc15
+    "CFLAGS=-std=gnu17"
     (if threadSupport then "--enable-threads" else "--disable-threads")
     "--with-gmp-incdir=${lib.getDev gmp}/include"
     "--with-gmp-libdir=${lib.getLib gmp}/lib"


### PR DESCRIPTION
- add "CFLAGS=-std=gnu17" to `configureFlags`.

There are patches upstream to make it build with `-std=gnu23`
(default in gcc15):
https://gitlab.com/embeddable-common-lisp/ecl/-/merge_requests/325
https://gitlab.com/embeddable-common-lisp/ecl/-/merge_requests/345
but applying them makes it not build with `-std=gnu17` (default in gcc14)
instead.

Fixes build failure with gcc15:
```
/build/ecl-24.5.10/src/c/dpp.c:112:13: error: 'bool' cannot be defined
via 'typedef'
  112 | typedef int bool;
      |             ^~~~
/build/ecl-24.5.10/src/c/dpp.c:112:13: note: 'bool' is a keyword
with '-std=c23' onwards
/build/ecl-24.5.10/src/c/dpp.c:112:1: warning: useless type name in
empty declaration
  112 | typedef int bool;
      | ^~~~~~~
```

---

Tested build with:

```bash
nix-build --expr 'with import ./. {}; ecl.override { stdenv = gcc15Stdenv; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

---

Regarding new version with fixes, upstream does not seem ready at the moment:
https://gitlab.com/embeddable-common-lisp/ecl/-/work_items/798

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
