### PR TITLE
mcomix: 3.1.0 -> 3.1.1

### DIFF
--- a/pkgs/by-name/mc/mcomix/package.nix
+++ b/pkgs/by-name/mc/mcomix/package.nix
@@ -5,7 +5,7 @@
   gobject-introspection,
   gtk3,
   mcomix,
-  python312, # TODO: Revert to python3 when upgrading past 3.1.0
+  python3,
   testers,
   wrapGAppsHook3,
 
@@ -17,14 +17,14 @@
   unrarSupport ? false, # unfree software
 }:
 
-python312.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "mcomix";
-  version = "3.1.0";
+  version = "3.1.1";
   pyproject = true;
 
   src = fetchurl {
     url = "mirror://sourceforge/mcomix/mcomix-${version}.tar.gz";
-    hash = "sha256-+Shuun/7w86VKBNamTmCPEJfO76fdKY5+HBvzCi0xCc=";
+    hash = "sha256-oQqq7XvAfet0796Tv5qKJ+G8vxgkoFGbJkz+5YK+zvg=";
   };
 
   buildInputs = [
@@ -34,12 +34,12 @@ python312.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = [
     gobject-introspection
-    python312.pkgs.setuptools
+    python3.pkgs.setuptools
     wrapGAppsHook3
   ];
 
   propagatedBuildInputs =
-    with python312.pkgs;
+    with python3.pkgs;
     [
       pillow
       pycairo
@@ -79,6 +79,9 @@ python312.pkgs.buildPythonApplication rec {
     '';
     homepage = "https://sourceforge.net/projects/mcomix/";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ thiagokokada ];
+    maintainers = with maintainers; [
+      confus
+      thiagokokada
+    ];
   };
 }


### PR DESCRIPTION
Updates mcomix from 3.1.0 to 3.1.1 see: https://sourceforge.net/p/mcomix/news/2025/09/changelog---mcomix-311/

Should make it compatible with Python > 3.12 (https://github.com/NixOS/nixpkgs/issues/428631)

Sorted the maintainers alphabetically, I hope that's okay with @thiagokokada, I didn't mean to imply anything there.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
