### PR TITLE
{rmtfs,tqftpserv}: small fixes

### DIFF
--- a/pkgs/by-name/rm/rmtfs/package.nix
+++ b/pkgs/by-name/rm/rmtfs/package.nix
@@ -12,10 +12,10 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.1.1";
 
   src = fetchFromGitHub {
-    owner = "andersson";
+    owner = "linux-msm";
     repo = "rmtfs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-00KOjdkwcAER261lleSl7OVDEAEbDyW9MWxDd0GI8KA=";
+    hash = "sha256-ehd8SbKNOpyVoF9oc7e5uYmJOHI+Q6woLyvwO8hhKEc=";
   };
 
   buildInputs = [
@@ -32,5 +32,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/linux-msm/rmtfs";
     license = licenses.bsd3;
     platforms = platforms.aarch64;
+    mainProgram = "rmtfs";
   };
 })

--- a/pkgs/by-name/tq/tqftpserv/package.nix
+++ b/pkgs/by-name/tq/tqftpserv/package.nix
@@ -12,13 +12,15 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tqftpserv";
-  version = "1.1";
+  # Use unstable for fixed systemd service
+  # with removed qrtr-ns dependency.
+  version = "1.1-unstable-2025-08-01";
 
   src = fetchFromGitHub {
     owner = "linux-msm";
     repo = "tqftpserv";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-Djw2rx1FXYYPXs6Htq7jWcgeXFvfCUoeidKtYUvTqZU=";
+    rev = "408ca1ed5e4e0a9ac3650b13d3f3c60079b3e2a3";
+    hash = "sha256-IlM/HVdo/7cA9NnJrCW/B0yKks5jWYqxRyy3ay4wDr8=";
   };
 
   buildInputs = [
@@ -45,5 +47,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/andersson/tqftpserv";
     license = licenses.bsd3;
     platforms = platforms.aarch64;
+    mainProgram = "tqftpserv";
   };
 })


### PR DESCRIPTION
Update upstream repository for rmtfs and use latest unstable commit for tqftpserv to fix systemd service.

This fixes Wi-Fi on my POCO X3 NFC.

@MatthewCroughan By the way, #457181 and #457180 were ready for merging before #462279 was opened. It would be nice if you could check existing PRs next time before creating a new PR to reduce duplicate work.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
