### PR TITLE
spotifycli: init at 2.1.0

### DIFF
--- a/pkgs/by-name/sp/spotifycli/package.nix
+++ b/pkgs/by-name/sp/spotifycli/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "spotifycli";
+  version = "2.1.0";
+
+  src = fetchFromGitHub {
+    owner = "doronbehar";
+    repo = "spotifycli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-AJysKgk58R0LwcXO0UzpgYmflJlAIqvaiyMRP8R9xGE=";
+  };
+
+  vendorHash = "sha256-MJtOJ4ZYSspumvPnK0ANL1wvWng9Na4+IlmBCoA80Hw=";
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd spotifycli \
+      --bash <($out/bin/spotifycli completion bash) \
+      --zsh  <($out/bin/spotifycli completion zsh ) \
+      --fish <($out/bin/spotifycli completion fish)
+  '';
+
+  meta = {
+    description = "CLI to manage Spotify playlists";
+    homepage = "https://github.com/doronbehar/spotifycli";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ doronbehar ];
+    mainProgram = "spotifycli";
+  };
+})


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc