### PR TITLE
moc: fix build (undefined AM_ICONV from gettext)

### DIFF
--- a/pkgs/by-name/mo/moc/fix_gettext_0_25.patch
+++ b/pkgs/by-name/mo/moc/fix_gettext_0_25.patch
@@ -1,0 +1,17 @@
+diff --git a/configure.in b/configure.in
+index eb71bdf..ba056df 100644
+--- a/configure.in
++++ b/configure.in
+@@ -1,9 +1,12 @@
+ AC_INIT([Music On Console],[2.6-alpha3],[mocmaint@daper.net],[moc],
+                            [http://moc.daper.net/])
++AC_CONFIG_MACRO_DIRS([m4])
+ AC_CONFIG_SRCDIR([main.c])
+ AC_CONFIG_HEADERS([config.h])
+ 
+ AM_INIT_AUTOMAKE([dist-xz no-dist-gzip])
++AM_GNU_GETTEXT_VERSION([0.20])
++AM_GNU_GETTEXT([external])
+ 
+ AC_PREREQ([2.64])
+ 

--- a/pkgs/by-name/mo/moc/package.nix
+++ b/pkgs/by-name/mo/moc/package.nix
@@ -6,6 +6,7 @@
   pkg-config,
   autoreconfHook,
   autoconf-archive,
+  gettext,
   ncurses,
   db,
   popt,
@@ -79,6 +80,7 @@ stdenv.mkDerivation {
     })
 
     ./use-ax-check-compile-flag.patch
+    ./fix_gettext_0_25.patch
   ]
   ++ lib.optional pulseSupport ./pulseaudio.patch;
 
@@ -90,6 +92,7 @@ stdenv.mkDerivation {
     pkg-config
     autoreconfHook
     autoconf-archive
+    gettext
   ];
 
   buildInputs = [


### PR DESCRIPTION
This fixes the following build error:

    configure.in:399: error: possibly undefined macro: AM_ICONV
          If this token and others are legitimate, please use m4_pattern_allow.
          See the Autoconf documentation.
    autoreconf: error: /nix/store/0a184ki65w8ra3qmn2qc8clamfjmxdfz-autoconf-2.72/bin/autoconf failed with exit status: 1


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
