### PR TITLE
fetchdarcs: add mirror support

### DIFF
--- a/pkgs/build-support/fetchdarcs/builder.sh
+++ b/pkgs/build-support/fetchdarcs/builder.sh
@@ -14,8 +14,19 @@ elif test -n "$context"; then
     tagflags="--context=$context"
 fi
 
-echo "Cloning $url ${tagtext} into $out"
+# Repository list may contain ?. No glob expansion for that.
+set -o noglob
 
-darcs clone --lazy $tagflags "$url" "$out"
-# remove metadata, because it can change
-rm -rf "$out/_darcs"
+for repository in $repositories; do
+    echo "Trying to clone $repository $tagtext into $out …"
+    if darcs clone --lazy $tagflags "$repository" "$out"; then
+        # remove metadata, because it can change
+        rm -rf "$out/_darcs"
+        exit 0
+    fi
+done
+
+set +o noglob
+
+echo "Error: couldn’t clone repository from any mirror" 1>&2
+exit 1

--- a/pkgs/build-support/fetchdarcs/builder.sh
+++ b/pkgs/build-support/fetchdarcs/builder.sh
@@ -1,3 +1,5 @@
+set -u
+
 tagtext=""
 tagflags=""
 # Darcs hashes are sha1 (120 bits, 40-character hex)
@@ -12,7 +14,7 @@ elif test -n "$context"; then
     tagflags="--context=$context"
 fi
 
-echo "Cloning $url $partial ${tagtext} into $out"
+echo "Cloning $url ${tagtext} into $out"
 
 darcs clone --lazy $tagflags "$url" "$out"
 # remove metadata, because it can change

--- a/pkgs/build-support/fetchdarcs/default.nix
+++ b/pkgs/build-support/fetchdarcs/default.nix
@@ -8,7 +8,11 @@
 lib.makeOverridable (
   lib.fetchers.withNormalizedHash { } (
     {
+      # Repository to fetch
       url,
+      # Additional list of repositories specifying alternative download
+      # location to be tried in order, if the prior repository failed to fetch.
+      mirrors ? [ ],
       rev ? null,
       context ? null,
       outputHash ? lib.fakeHash,
@@ -27,11 +31,12 @@ lib.makeOverridable (
       outputHashMode = "recursive";
 
       inherit
-        url
         rev
         context
         name
         ;
+
+      repositories = [ url ] ++ mirrors;
     }
   )
 )


### PR DESCRIPTION
This worked for me. This allows users to provide fallback mirrors for Darcs repositories in case a mirror is down—similar to `fetchZip`’s `urls` but not an either/or for `url`.

---

As an aside, I dislike the API layer of `fetchdarcs`. I don’t think this test for `hash` vs. `tag` is good rather than being explicit & with an `assert`. IMO these should just be `hash`, `tag`, `context` + an `assert` that 1 is set (except that `hash` in a name collision). Additionally, the Darcs CLI calls it `<REPOSITORY>` or `--repo*` so I would expect one of these… not `url` which is not mentioned (as it can be a file too). Is there an appetite to fix the Nix API to match the tool?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
