### PR TITLE
checkBinaryArchHook: init

### DIFF
--- a/doc/hooks/checkBinaryArchHook.section.md
+++ b/doc/hooks/checkBinaryArchHook.section.md
@@ -1,0 +1,100 @@
+# checkBinaryArchHook {#checkbinaryarchhook}
+
+This hook verifies that ELF binaries in a package match the expected host platform architecture.
+It helps catch cases where prebuilt binaries for the wrong architecture are accidentally included,
+which is particularly useful for cross-compilation scenarios or packages that fetch prebuilt binaries.
+
+The hook runs during `fixupPhase` and fails the build if any ELF binary has a different `e_machine`
+value than expected for the host platform.
+
+## Usage {#checkbinaryarchhook-usage}
+
+```nix
+{
+  lib,
+  stdenv,
+  checkBinaryArchHook,
+}:
+
+stdenv.mkDerivation {
+  # ...
+
+  nativeBuildInputs = [ checkBinaryArchHook ];
+
+  # ...
+}
+```
+
+## How it works {#checkbinaryarchhook-how-it-works}
+
+The hook:
+
+1. Compiles an empty C file using the host compiler (`$CC`) to get a reference object file
+2. Extracts the `e_machine` value from the ELF header of this reference object
+3. Scans all ELF files in `bin/` and `lib/` directories (recursively) across all outputs
+4. Compares each ELF file's `e_machine` value against the expected value
+5. Fails the build if any mismatch is found, reporting the mismatched files
+
+## Configuration variables {#checkbinaryarchhook-configuration}
+
+### `dontCheckBinaryArch` {#checkbinaryarchhook-dontCheckBinaryArch}
+
+Set to `true` to disable the check entirely.
+
+```nix
+{
+  dontCheckBinaryArch = true;
+}
+```
+
+### `checkBinaryArchExtraPaths` {#checkbinaryarchhook-checkBinaryArchExtraPaths}
+
+Additional paths to check beyond the default `bin/` and `lib/` directories.
+Paths are checked recursively.
+
+```nix
+{
+  checkBinaryArchExtraPaths = [
+    "$out/libexec"
+    "$out/share/foo/bin"
+  ];
+}
+```
+
+### `checkBinaryArchDebug` {#checkbinaryarchhook-checkBinaryArchDebug}
+
+Set to `true` to enable verbose debug output, which shows each file being checked
+and the architecture detection process.
+
+```nix
+{
+  checkBinaryArchDebug = true;
+}
+```
+
+## Common causes of failures {#checkbinaryarchhook-common-causes}
+
+When the hook fails, it typically indicates one of:
+
+- **Prebuilt binary fetched for wrong architecture**: The package downloads binaries that don't match the target platform
+- **Cross-compilation misconfiguration**: Build system is using the wrong compiler or targeting the wrong architecture
+
+## Example error output {#checkbinaryarchhook-example-error}
+
+```
+check-binary-arch: ERROR: Binary architecture mismatch detected!
+
+Expected architecture: aarch64 (e_machine=183)
+
+Mismatched binaries:
+  /nix/store/.../bin/wrongarch
+    Found:    x86_64 (e_machine=62)
+    Expected: aarch64 (e_machine=183)
+
+This usually means the binary was built for a different platform.
+Common causes:
+  - Prebuilt binary fetched for wrong architecture
+  - Cross-compilation misconfiguration
+
+To disable this check, set: dontCheckBinaryArch = true;
+```

--- a/doc/hooks/index.md
+++ b/doc/hooks/index.md
@@ -13,6 +13,7 @@ aws-c-common.section.md
 bmake.section.md
 breakpoint.section.md
 cernlib.section.md
+checkBinaryArchHook.section.md
 cmake.section.md
 desktop-file-utils.section.md
 gdk-pixbuf.section.md

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -2434,6 +2434,33 @@
   "cernlib-hook": [
     "index.html#cernlib-hook"
   ],
+  "checkbinaryarchhook": [
+    "index.html#checkbinaryarchhook"
+  ],
+  "checkbinaryarchhook-usage": [
+    "index.html#checkbinaryarchhook-usage"
+  ],
+  "checkbinaryarchhook-how-it-works": [
+    "index.html#checkbinaryarchhook-how-it-works"
+  ],
+  "checkbinaryarchhook-configuration": [
+    "index.html#checkbinaryarchhook-configuration"
+  ],
+  "checkbinaryarchhook-dontCheckBinaryArch": [
+    "index.html#checkbinaryarchhook-dontCheckBinaryArch"
+  ],
+  "checkbinaryarchhook-checkBinaryArchExtraPaths": [
+    "index.html#checkbinaryarchhook-checkBinaryArchExtraPaths"
+  ],
+  "checkbinaryarchhook-checkBinaryArchDebug": [
+    "index.html#checkbinaryarchhook-checkBinaryArchDebug"
+  ],
+  "checkbinaryarchhook-common-causes": [
+    "index.html#checkbinaryarchhook-common-causes"
+  ],
+  "checkbinaryarchhook-example-error": [
+    "index.html#checkbinaryarchhook-example-error"
+  ],
   "cmake": [
     "index.html#cmake"
   ],

--- a/pkgs/build-support/setup-hooks/check-binary-arch.py
+++ b/pkgs/build-support/setup-hooks/check-binary-arch.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""
+Verify that ELF binaries match the expected host platform architecture.
+
+This tool compiles an empty object file to determine the expected e_machine
+value, then checks all ELF files in the specified paths to ensure they match.
+"""
+
+import argparse
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+# Global debug flag
+DEBUG = False
+
+
+def debug(msg: str) -> None:
+    """Print debug message if debug mode is enabled."""
+    if DEBUG:
+        print(f"[DEBUG] {msg}", file=sys.stderr)
+
+# ELF magic bytes
+ELF_MAGIC = b"\x7fELF"
+
+# e_machine field offset and size in ELF header
+E_MACHINE_OFFSET = 18
+E_MACHINE_SIZE = 2
+
+# Mapping from e_machine values to human-readable architecture names
+# See: https://refspecs.linuxfoundation.org/elf/gabi4+/ch4.eheader.html
+E_MACHINE_NAMES: dict[int, str] = {
+    3: "i386",
+    8: "mips",
+    20: "powerpc",
+    21: "powerpc64",
+    40: "arm",
+    43: "sparc",
+    62: "x86_64",
+    183: "aarch64",
+    243: "riscv",
+}
+
+
+def get_arch_name(e_machine: int) -> str:
+    """Get human-readable architecture name for e_machine value."""
+    return E_MACHINE_NAMES.get(e_machine, f"unknown({e_machine})")
+
+
+def is_elf(path: Path) -> bool:
+    """Check if file starts with ELF magic bytes."""
+    try:
+        with open(path, "rb") as f:
+            magic = f.read(4)
+            result = magic == ELF_MAGIC
+            debug(f"is_elf({path}): magic={magic.hex()}, is_elf={result}")
+            return result
+    except (OSError, IOError) as e:
+        debug(f"is_elf({path}): error reading file: {e}")
+        return False
+
+
+def get_e_machine(path: Path) -> int | None:
+    """Read e_machine field (2 bytes at offset 18) from ELF header."""
+    try:
+        with open(path, "rb") as f:
+            f.seek(E_MACHINE_OFFSET)
+            data = f.read(E_MACHINE_SIZE)
+            if len(data) != E_MACHINE_SIZE:
+                debug(f"get_e_machine({path}): insufficient data read")
+                return None
+            # e_machine is a 16-bit little-endian value
+            e_machine = struct.unpack("<H", data)[0]
+            debug(f"get_e_machine({path}): e_machine={e_machine} ({get_arch_name(e_machine)})")
+            return e_machine
+    except (OSError, IOError) as e:
+        debug(f"get_e_machine({path}): error reading file: {e}")
+        return None
+
+
+def get_expected_e_machine(cc: str) -> int:
+    """Compile an empty object file and extract its e_machine value."""
+    debug(f"get_expected_e_machine: using compiler {cc}")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        obj_path = Path(tmpdir) / "ref.o"
+        debug(f"get_expected_e_machine: compiling reference object to {obj_path}")
+        try:
+            # Compile empty C file to object
+            subprocess.run(
+                [cc, "-c", "-x", "c", "-", "-o", str(obj_path)],
+                input=b"",
+                capture_output=True,
+                check=True,
+            )
+        except subprocess.CalledProcessError as e:
+            print(
+                "check-binary-arch: ERROR: Failed to compile reference object",
+                file=sys.stderr,
+            )
+            print(f"  Command: {cc} -c -x c - -o {obj_path}", file=sys.stderr)
+            print(f"  stderr: {e.stderr.decode()}", file=sys.stderr)
+            sys.exit(1)
+        except FileNotFoundError:
+            print(f"check-binary-arch: ERROR: Compiler not found: {cc}", file=sys.stderr)
+            sys.exit(1)
+
+        e_machine = get_e_machine(obj_path)
+        if e_machine is None:
+            print(
+                "check-binary-arch: ERROR: Failed to read e_machine from reference object",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        debug(f"get_expected_e_machine: expected e_machine={e_machine} ({get_arch_name(e_machine)})")
+        return e_machine
+
+
+def check_binary(path: Path, expected: int) -> tuple[Path, int | None] | None:
+    """
+    Check if a binary has the expected architecture.
+
+    Returns (path, actual_e_machine) if mismatch, None if OK or not an ELF.
+    Returns (path, None) if e_machine could not be read.
+    """
+    debug(f"check_binary: checking {path}")
+    if not path.is_file() or path.is_symlink():
+        debug(f"check_binary: {path} is not a regular file or is a symlink, skipping")
+        return None
+
+    if not is_elf(path):
+        debug(f"check_binary: {path} is not an ELF file, skipping")
+        return None
+
+    actual = get_e_machine(path)
+    if actual is None:
+        debug(f"check_binary: {path} could not read e_machine")
+        return (path, None)
+
+    if actual != expected:
+        debug(f"check_binary: {path} MISMATCH: got {actual}, expected {expected}")
+        return (path, actual)
+
+    debug(f"check_binary: {path} OK")
+    return None
+
+
+def find_binaries(paths: list[Path]) -> list[Path]:
+    """Find all files in the given paths recursively."""
+    debug(f"find_binaries: searching in {paths}")
+    binaries = []
+    for path in paths:
+        if path.is_dir():
+            debug(f"find_binaries: scanning directory {path} recursively")
+            for entry in path.rglob("*"):
+                if entry.is_file() and not entry.is_symlink():
+                    debug(f"find_binaries: found file {entry}")
+                    binaries.append(entry)
+        elif path.is_file():
+            debug(f"find_binaries: adding file {path}")
+            binaries.append(path)
+    debug(f"find_binaries: found {len(binaries)} files to check")
+    return binaries
+
+
+def main() -> None:
+    global DEBUG
+
+    parser = argparse.ArgumentParser(
+        description="Verify ELF binaries match expected architecture"
+    )
+    parser.add_argument(
+        "--cc",
+        required=True,
+        help="Path to the C compiler",
+    )
+    parser.add_argument(
+        "--paths",
+        nargs="+",
+        required=True,
+        type=Path,
+        help="Directories or files to check",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable verbose debug logging",
+    )
+
+    args = parser.parse_args()
+
+    # Enable debug mode via --debug flag or checkBinaryArchDebug env var
+    DEBUG = args.debug or os.environ.get("checkBinaryArchDebug", "") != ""
+
+    # Get number of parallel jobs from NIX_BUILD_CORES, defaulting to 1
+    jobs = int(os.environ.get("NIX_BUILD_CORES", "1")) or 1
+
+    if DEBUG:
+        debug("Debug mode enabled")
+        debug(f"Arguments: cc={args.cc}, paths={args.paths}, jobs={jobs}")
+
+    # Get expected e_machine from compiler
+    expected = get_expected_e_machine(args.cc)
+
+    # Find all binaries to check
+    binaries = find_binaries(args.paths)
+
+    if not binaries:
+        return
+
+    # Check all binaries in parallel
+    errors: list[tuple[Path, int | None]] = []
+    with ThreadPoolExecutor(max_workers=jobs) as executor:
+        futures = {
+            executor.submit(check_binary, binary, expected): binary
+            for binary in binaries
+        }
+        for future in as_completed(futures):
+            result = future.result()
+            if result:
+                errors.append(result)
+
+    if errors:
+        expected_name = get_arch_name(expected)
+        print(
+            "check-binary-arch: ERROR: Binary architecture mismatch detected!",
+            file=sys.stderr,
+        )
+        print(file=sys.stderr)
+        print(
+            f"Expected architecture: {expected_name} (e_machine={expected})",
+            file=sys.stderr,
+        )
+        print(file=sys.stderr)
+        print("Mismatched binaries:", file=sys.stderr)
+        for path, actual in sorted(errors, key=lambda x: str(x[0])):
+            print(f"  {path}", file=sys.stderr)
+            if actual is None:
+                print("    Error: could not read e_machine", file=sys.stderr)
+            else:
+                actual_name = get_arch_name(actual)
+                print(
+                    f"    Found:    {actual_name} (e_machine={actual})",
+                    file=sys.stderr,
+                )
+                print(
+                    f"    Expected: {expected_name} (e_machine={expected})",
+                    file=sys.stderr,
+                )
+        print(file=sys.stderr)
+        print(
+            "This usually means the binary was built for a different platform.",
+            file=sys.stderr,
+        )
+        print("Common causes:", file=sys.stderr)
+        print("  - Prebuilt binary fetched for wrong architecture", file=sys.stderr)
+        print("  - Cross-compilation misconfiguration", file=sys.stderr)
+        print(file=sys.stderr)
+        print("To disable this check, set: dontCheckBinaryArch = true;", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/build-support/setup-hooks/check-binary-arch.sh
+++ b/pkgs/build-support/setup-hooks/check-binary-arch.sh
@@ -1,0 +1,75 @@
+# shellcheck shell=bash
+
+# checkBinaryArchHook - Verify ELF binaries match the expected architecture
+#
+# This hook runs during fixupPhase and fails the build if any ELF binary has
+# a different e_machine value than expected for the host platform. This helps
+# catch cases where prebuilt binaries for the wrong architecture are accidentally
+# included in a package.
+#
+# By default, the hook checks all files in bin/ and lib/ directories (recursively)
+# across all outputs.
+#
+# Configuration variables:
+#
+#   dontCheckBinaryArch (bool)
+#     Set to true to disable the check entirely.
+#     Example: dontCheckBinaryArch = true;
+#
+#   checkBinaryArchExtraPaths (list of strings)
+#     Additional paths to check beyond the default bin/ and lib/ directories.
+#     Paths are checked recursively.
+#     Example: checkBinaryArchExtraPaths = [ "$out/libexec" "$out/share/foo/bin" ];
+#
+#   checkBinaryArchDebug (bool)
+#     Set to true to enable verbose debug output.
+#     Example: checkBinaryArchDebug = true;
+
+echo "Sourcing check-binary-arch-hook"
+
+checkBinaryArch() {
+    if [[ -n "${dontCheckBinaryArch-}" ]]; then
+        return
+    fi
+
+    echo "Executing checkBinaryArch"
+
+    local dir
+    local pathsToCheck=()
+
+    # Add default paths (bin/ and lib/ in all outputs)
+    for output in $(getAllOutputNames); do
+        for dir in "${!output}/bin" "${!output}/lib"; do
+            if [[ -d "$dir" ]]; then
+                pathsToCheck+=("$dir")
+            fi
+        done
+    done
+
+    # Add extra paths from checkBinaryArchExtraPaths
+    for dir in ${checkBinaryArchExtraPaths-}; do
+        if [[ -d "$dir" ]]; then
+            pathsToCheck+=("$dir")
+        fi
+    done
+
+    if [[ ${#pathsToCheck[@]} -eq 0 ]]; then
+        echo "checkBinaryArch: no directories to check, skipping"
+        return
+    fi
+
+    echo "checkBinaryArch: checking ${pathsToCheck[*]}"
+
+    local debugFlag=""
+    if [[ -n "${checkBinaryArchDebug-}" ]]; then
+        debugFlag="--debug"
+    fi
+
+    python3 @pythonScript@ --cc "$CC" --paths "${pathsToCheck[@]}" $debugFlag
+    local ret=$?
+
+    echo "Finished executing checkBinaryArch"
+    return $ret
+}
+
+postFixupHooks+=(checkBinaryArch)

--- a/pkgs/development/python-modules/bcrypt/default.nix
+++ b/pkgs/development/python-modules/bcrypt/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   cargo,
   rustPlatform,
@@ -8,6 +9,7 @@
   setuptools-rust,
   fetchFromGitHub,
   pytestCheckHook,
+  checkBinaryArchHook,
   # for passthru.tests
   asyncssh,
   django_4,
@@ -48,6 +50,9 @@ buildPythonPackage rec {
     rustPlatform.cargoSetupHook
     cargo
     rustc
+  ]
+  ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    checkBinaryArchHook
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];

--- a/pkgs/test/check-binary-arch-hook/cross-compilation.nix
+++ b/pkgs/test/check-binary-arch-hook/cross-compilation.nix
@@ -1,0 +1,57 @@
+# Test that cross-compiled binaries pass the check when built for the correct
+# target architecture. This verifies the hook works correctly in cross-compilation
+# scenarios where the build platform differs from the host platform.
+# Tests both /bin executables and /lib shared objects.
+{
+  pkgsCross,
+}:
+
+let
+  # Use aarch64 cross-compilation toolchain
+  pkgs = pkgsCross.aarch64-multiplatform;
+in
+
+pkgs.stdenv.mkDerivation {
+  name = "check-binary-arch-test-cross";
+
+  nativeBuildInputs = [ pkgs.checkBinaryArchHook ];
+
+  # Enable debug mode for verbose output
+  checkBinaryArchDebug = "1";
+
+  dontUnpack = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    # Create a test executable
+    echo 'int main() { return 0; }' > test.c
+    $CC -o test test.c
+
+    # Create a test shared library
+    echo 'int foo() { return 42; }' > libtest.c
+    $CC -shared -fPIC -o libtest.so libtest.c
+
+    # Create another shared library for subdirectory test
+    echo 'int bar() { return 99; }' > libsub.c
+    $CC -shared -fPIC -o libsub.so libsub.c
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin $out/lib $out/lib/subdir
+    cp test $out/bin/
+    cp libtest.so $out/lib/
+    # Place a library in a subdirectory to test recursive search
+    cp libsub.so $out/lib/subdir/
+    runHook postInstall
+  '';
+
+  # The hook runs in fixupPhase - if we get here, the cross-compiled binary
+  # and library were correctly identified as matching the target architecture
+  postFixup = ''
+    touch $out/success
+  '';
+}

--- a/pkgs/test/check-binary-arch-hook/cross-wrong-arch.nix
+++ b/pkgs/test/check-binary-arch-hook/cross-wrong-arch.nix
@@ -1,0 +1,59 @@
+# Test that the hook correctly detects wrong architecture binaries in a
+# cross-compilation context. We cross-compile for aarch64 but include
+# x86_64 binaries in both /bin and /lib, which should be detected as mismatches.
+{
+  pkgsCross,
+  pkgs,
+}:
+
+let
+  # Use aarch64 cross-compilation toolchain
+  crossPkgs = pkgsCross.aarch64-multiplatform;
+  # Get native x86_64 binaries to use as "wrong" binaries
+  wrongArchBinary = pkgs.pkgsStatic.busybox;
+  # Get a native x86_64 shared library
+  wrongArchLib = pkgs.zlib;
+in
+
+crossPkgs.stdenv.mkDerivation {
+  name = "check-binary-arch-test-cross-wrong";
+
+  nativeBuildInputs = [ crossPkgs.checkBinaryArchHook ];
+
+  # Enable debug mode for verbose output
+  checkBinaryArchDebug = "1";
+
+  dontUnpack = true;
+
+  buildPhase = ''
+    runHook preBuild
+    # Copy x86_64 binary and library into our aarch64 build
+    cp ${wrongArchBinary}/bin/busybox wrongarch
+    chmod +x wrongarch
+    cp ${wrongArchLib}/lib/libz.so wronglib.so
+    cp ${wrongArchLib}/lib/libz.so wronglib-sub.so
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin $out/lib $out/lib/subdir
+    cp wrongarch $out/bin/
+    cp wronglib.so $out/lib/
+    # Place a library in a subdirectory to test recursive search
+    cp wronglib-sub.so $out/lib/subdir/
+    runHook postInstall
+  '';
+
+  # Override fixupPhase to catch the expected failure
+  fixupPhase = ''
+    # The checkBinaryArch hook should fail here because we have x86_64
+    # binaries in an aarch64 build
+    if checkBinaryArch 2>&1; then
+      echo "ERROR: check-binary-arch hook should have failed but didn't"
+      exit 1
+    fi
+    echo "check-binary-arch correctly detected wrong architecture in cross-compilation"
+    touch $out/success
+  '';
+}

--- a/pkgs/test/check-binary-arch-hook/default.nix
+++ b/pkgs/test/check-binary-arch-hook/default.nix
@@ -1,0 +1,13 @@
+{
+  lib,
+  callPackage,
+  pkgs,
+  pkgsCross,
+}:
+
+lib.recurseIntoAttrs {
+  # Test that cross-compilation works correctly (checks both /bin and /lib)
+  crossCompilation = callPackage ./cross-compilation.nix { inherit pkgsCross; };
+  # Test that wrong architecture is detected in cross-compilation (checks both /bin and /lib)
+  crossWrongArch = callPackage ./cross-wrong-arch.nix { inherit pkgs pkgsCross; };
+}

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -225,6 +225,8 @@ in
 
   auto-patchelf-hook = callPackage ./auto-patchelf-hook { };
 
+  check-binary-arch-hook = callPackage ./check-binary-arch-hook { };
+
   # Accumulate all passthru.tests from arrayUtilities into a single attribute set.
   arrayUtilities = recurseIntoAttrs (
     concatMapAttrs (

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -240,6 +240,14 @@ with pkgs;
     };
   } ../build-support/setup-hooks/auto-patchelf.sh;
 
+  checkBinaryArchHook = makeSetupHook {
+    name = "check-binary-arch-hook";
+    propagatedBuildInputs = [ python3Minimal ];
+    substitutions = {
+      pythonScript = ../build-support/setup-hooks/check-binary-arch.py;
+    };
+  } ../build-support/setup-hooks/check-binary-arch.sh;
+
   appimageTools = callPackage ../build-support/appimage { };
 
   appimageupdate-qt = appimageupdate.override { withQtUI = true; };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Add a new setup hook that verifies ELF binaries match the expected host
platform architecture during fixupPhase. This helps catch cases where:

- Prebuilt binaries for the wrong architecture are included
- Cross-compilation is misconfigured

The hook compiles an empty object file to determine the expected
e_machine value, then checks all ELF files in bin/ and lib/ directories.

Configuration:
- dontCheckBinaryArch: disable the check
- checkBinaryArchExtraPaths: additional paths to scan
- checkBinaryArchDebug: verbose output
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

