### PR TITLE
poetryPlugins.poetry-audit-plugin: 0.4.0 -> 1.0.0

### DIFF
--- a/pkgs/by-name/po/poetry/plugins/poetry-audit-plugin.nix
+++ b/pkgs/by-name/po/poetry/plugins/poetry-audit-plugin.nix
@@ -1,7 +1,6 @@
 {
   lib,
   buildPythonPackage,
-  pythonOlder,
   fetchFromGitHub,
   poetry-core,
   poetry,
@@ -11,24 +10,18 @@
 
 buildPythonPackage rec {
   pname = "poetry-audit-plugin";
-  version = "0.4.0";
+  version = "1.0.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "opeco17";
     repo = "poetry-audit-plugin";
-    rev = "refs/tags/${version}";
-    hash = "sha256-kiNtzEup2ygCTk0zk8YV2jxAj6ZzOhP8v0U4FbV15hI=";
+    tag = version;
+    hash = "sha256-aAQzgxzBJa/pK+hQj0tN4Zg1MG/sT0rbaMNMIxnhxdU=";
   };
 
   build-system = [
     poetry-core
-  ];
-
-  pythonRelaxDeps = [
-    "poetry"
   ];
 
   buildInputs = [
@@ -50,6 +43,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = {
+    changelog = "https://github.com/opeco17/poetry-audit-plugin/releases/tag/${src.tag}";
     description = "Poetry plugin for checking security vulnerabilities in dependencies";
     homepage = "https://github.com/opeco17/poetry-audit-plugin";
     license = lib.licenses.mit;


### PR DESCRIPTION
Diff: https://github.com/opeco17/poetry-audit-plugin/compare/0.4.0...1.0.0

Changelog: https://github.com/opeco17/poetry-audit-plugin/releases/tag/1.0.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
