### PR TITLE
libkcapi: make bashless

### DIFF
--- a/pkgs/by-name/li/libkcapi/package.nix
+++ b/pkgs/by-name/li/libkcapi/package.nix
@@ -13,16 +13,23 @@
   kcapi-dgstapp ? true,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libkcapi";
   version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "smuellerDD";
     repo = "libkcapi";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-xOI29cjhUGUeHLaYIrPA5ZwwCE9lBdZG6kaW0lo1uL8=";
   };
+
+  outputs = [
+    "out"
+  ]
+  ++ lib.optionals kcapi-test [
+    "selftests"
+  ];
 
   nativeBuildInputs = [ autoreconfHook ];
 
@@ -33,6 +40,7 @@ stdenv.mkDerivation rec {
     buildPackages.stdenv.cc
   ];
 
+  strictDeps = true;
   enableParallelBuilding = true;
 
   configureFlags =
@@ -42,6 +50,11 @@ stdenv.mkDerivation rec {
     ++ lib.optional kcapi-rngapp "--enable-kcapi-rngapp"
     ++ lib.optional kcapi-encapp "--enable-kcapi-encapp"
     ++ lib.optional kcapi-dgstapp "--enable-kcapi-dgstapp";
+
+  postInstall = lib.optionalString kcapi-test ''
+    mkdir -p $selftests/bin
+    find $out -iname '*.sh' -exec mv {} $selftests/bin/ \;
+  '';
 
   meta = {
     homepage = "http://www.chronox.de/libkcapi.html";
@@ -56,4 +69,4 @@ stdenv.mkDerivation rec {
       thillux
     ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
