### PR TITLE
Revert "nixos/niri: add nautilus to systemPackages"

### DIFF
--- a/nixos/modules/programs/wayland/niri.nix
+++ b/nixos/modules/programs/wayland/niri.nix
@@ -12,22 +12,12 @@ in
     enable = lib.mkEnableOption "Niri, a scrollable-tiling Wayland compositor";
 
     package = lib.mkPackageOption pkgs "niri" { };
-
-    useNautilus = lib.mkEnableOption "Nautilus as file-chooser for xdg-desktop-portal-gnome" // {
-      default = true;
-    };
   };
 
   config = lib.mkIf cfg.enable (
     lib.mkMerge [
       {
-        environment.systemPackages = [
-          cfg.package
-        ]
-        # Required for xdg-desktop-portal-gnome's FileChooser to work properly
-        ++ lib.optionals cfg.useNautilus [
-          pkgs.nautilus
-        ];
+        environment.systemPackages = [ cfg.package ];
 
         services = {
           displayManager.sessionPackages = [ cfg.package ];
@@ -43,10 +33,6 @@ in
           enable = lib.mkDefault true;
 
           configPackages = [ cfg.package ];
-
-          config.niri = lib.mkIf (!cfg.useNautilus) {
-            "org.freedesktop.impl.portal.FileChooser" = lib.mkDefault "gtk";
-          };
 
           # Recommended by upstream, required for screencast support
           # https://github.com/YaLTeR/niri/wiki/Important-Software#portals


### PR DESCRIPTION
This reverts commit [ac518ed16b15a950c61d6d12bfa8036b80901401](https://github.com/NixOS/nixpkgs/commit/ac518ed16b15a950c61d6d12bfa8036b80901401).

### Why revert?

The original commit introduces an unexpected and intrusive side effect: enabling a non-GNOME desktop (such as Niri) causes the GNOME file manager (Nautilus) to be added globally to `environment.systemPackages`.

This occurs even when:

- the user does not use GNOME
- the user has no mention of Nautilus in their config
- the user has no gvfs, GTK stack, or GNOME components enabled

This behavior violates the NixOS module design principle; modules should not inject arbitrary applications into `environment.systemPackages` by default. Niri is a window manager, not a desktop environment. Enabling a window manager should *not* install unrelated GUI applications.  It also breaks the expectation of minimalism and explicitness.


- Built on platform:
  - [X] ~~x86_64-linux~~ N/A
  - [X] ~~aarch64-linux~~ N/A
  - [X] ~~x86_64-darwin~~ N/A
  - [X] ~~aarch64-darwin~~ N/A
- Tested, as applicable:
  - [X] ~~[NixOS tests] in [nixos/tests].~~ N/A
  - [X] ~~[Package tests] at `passthru.tests`.~~ N/A
  - [X] ~~Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.~~ N/A
- [X] ~~Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].~~ N/A
- [X] ~~Tested basic functionality of all binary files, usually in `./result/bin/`.~~ N/A
- Nixpkgs Release Notes
  - [X] ~~Package update: when the change is major or breaking.~~ N/A
- NixOS Release Notes
  - [X] ~~Module addition: when adding a new NixOS module.~~ N/A
  - [X] ~~Module update: when the change is significant.~~ N/A
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
