### PR TITLE
python3Packages.{pyppeteer-ng,price-parser,panzi-json-logic}: modernize

### DIFF
--- a/pkgs/development/python-modules/panzi-json-logic/default.nix
+++ b/pkgs/development/python-modules/panzi-json-logic/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  gitUpdater,
   unittestCheckHook,
   setuptools,
 }:
@@ -23,6 +24,8 @@ buildPythonPackage rec {
   nativeCheckInputs = [ unittestCheckHook ];
 
   pythonImportsCheck = [ "json_logic" ];
+
+  passthru.updateScript = gitUpdater { };
 
   meta = {
     description = "Pure Python 3 JsonLogic and CertLogic implementation.";

--- a/pkgs/development/python-modules/price-parser/default.nix
+++ b/pkgs/development/python-modules/price-parser/default.nix
@@ -4,14 +4,14 @@
   fetchFromGitHub,
   pytestCheckHook,
   setuptools,
-  pytest-cov,
+  pytest-cov-stub,
   attrs,
 }:
 
 buildPythonPackage rec {
   pname = "price-parser";
   version = "0.4.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "scrapinghub";
@@ -20,11 +20,13 @@ buildPythonPackage rec {
     hash = "sha256-9f/+Yw94SVvg9fl9zYR9YEMwAgKHwySG5cysPMomnA0=";
   };
 
+  build-system = [ setuptools ];
+
   dependencies = [ attrs ];
 
   nativeCheckInputs = [
     pytestCheckHook
-    pytest-cov
+    pytest-cov-stub
   ];
 
   pythonImportsCheck = [ "price_parser" ];

--- a/pkgs/development/python-modules/price-parser/default.nix
+++ b/pkgs/development/python-modules/price-parser/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  gitUpdater,
   pytestCheckHook,
   setuptools,
   pytest-cov-stub,
@@ -30,6 +31,8 @@ buildPythonPackage rec {
   ];
 
   pythonImportsCheck = [ "price_parser" ];
+
+  passthru.updateScript = gitUpdater { };
 
   meta = {
     description = "Extract price amount and currency symbol from a raw text string";

--- a/pkgs/development/python-modules/pyppeteer-ng/default.nix
+++ b/pkgs/development/python-modules/pyppeteer-ng/default.nix
@@ -21,7 +21,7 @@
   pyee,
   pylint,
   pytest,
-  pytest-cov,
+  pytest-cov-stub,
   pytest-timeout,
   pytest-xdist,
   pytestCheckHook,
@@ -42,8 +42,6 @@ buildPythonPackage rec {
   pname = "pyppeteer-ng";
   version = "2.0.0rc10";
   pyproject = true;
-
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "dgtlmoon";
@@ -96,7 +94,7 @@ buildPythonPackage rec {
     pydocstyle
     pylint
     pytest
-    pytest-cov
+    pytest-cov-stub
     pytest-timeout
     pytest-xdist
     readme-renderer

--- a/pkgs/development/python-modules/pyppeteer-ng/default.nix
+++ b/pkgs/development/python-modules/pyppeteer-ng/default.nix
@@ -4,6 +4,7 @@
   aiohttp,
   appdirs,
   buildPythonPackage,
+  gitUpdater,
   certifi,
   diff-match-patch,
   fetchFromGitHub,
@@ -146,6 +147,8 @@ buildPythonPackage rec {
   ];
 
   pythonImportsCheck = [ "pyppeteer" ];
+
+  passthru.updateScript = gitUpdater { };
 
   meta = {
     description = "Headless chrome/chromium automation library (unofficial port of puppeteer)";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Adds suggestions by @SuperSandro2000 from #445661 after it was merged.
- Adds passthru.updateScript for python3Packages.{pyppeteer-ng,price-parser,panzi-json-logic} added in #445661.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
