### PR TITLE
maintainers: drop inactive committers

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -206,9 +206,9 @@ nixos/modules/installer/tools/nix-fallback-paths.nix  @NixOS/nix-team @raitobeza
 /pkgs/top-level/haskell-packages.nix          @sternenseemann @maralorn @wolfgangwalther
 
 # Perl
-/pkgs/development/interpreters/perl @stigtsp @zakame @marcusramberg
-/pkgs/top-level/perl-packages.nix   @stigtsp @zakame @marcusramberg
-/pkgs/development/perl-modules      @stigtsp @zakame @marcusramberg
+/pkgs/development/interpreters/perl @stigtsp @marcusramberg
+/pkgs/top-level/perl-packages.nix   @stigtsp @marcusramberg
+/pkgs/development/perl-modules      @stigtsp @marcusramberg
 
 # R
 /pkgs/applications/science/math/R   @jbedo

--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -262,7 +262,7 @@ pkgs/development/python-modules/buildcatrust/ @ajs124 @lukegb @mweinelt
 /pkgs/top-level/java-packages.nix @NixOS/java
 
 # Jetbrains
-/pkgs/applications/editors/jetbrains @edwtjo @leona-ya @theCapypara
+/pkgs/applications/editors/jetbrains @leona-ya @theCapypara
 
 # Licenses
 /lib/licenses.nix @alyssais @emilazy @jopejoe1

--- a/maintainers/github-teams.json
+++ b/maintainers/github-teams.json
@@ -499,7 +499,6 @@
     },
     "members": {
       "cpages": 411324,
-      "edwtjo": 54799,
       "minijackson": 1200507,
       "peterhoeg": 722550,
       "sephalon": 893474

--- a/maintainers/github-teams.json
+++ b/maintainers/github-teams.json
@@ -894,9 +894,7 @@
       "winterqt": 78392041,
       "zowoq": 59103226
     },
-    "members": {
-      "tjni": 3806110
-    },
+    "members": {},
     "name": "rust"
   },
   "scala": {

--- a/maintainers/github-teams.json
+++ b/maintainers/github-teams.json
@@ -49,8 +49,7 @@
       "ethercrow": 222467,
       "groodt": 343415,
       "kalbasit": 87115,
-      "mboes": 51356,
-      "uri-canva": 33242106
+      "mboes": 51356
     },
     "name": "Bazel"
   },
@@ -259,7 +258,6 @@
       "thefloweringash": 42933,
       "tricktron": 16036882,
       "uncenter": 47499684,
-      "uri-canva": 33242106,
       "usertam": 22500027,
       "veprbl": 245573,
       "viraptor": 188063,

--- a/maintainers/github-teams.json
+++ b/maintainers/github-teams.json
@@ -526,7 +526,6 @@
     "members": {
       "K900": 386765,
       "Ma27": 6025220,
-      "NeQuissimus": 628342,
       "TredwellGit": 61860346
     },
     "name": "Linux kernel"

--- a/maintainers/github-teams.json
+++ b/maintainers/github-teams.json
@@ -61,7 +61,6 @@
       "happysalada": 5317234
     },
     "members": {
-      "Br1ght0ne": 12615679,
       "DianaOlympos": 15774340,
       "adamcstephens": 2071575,
       "ankhers": 750786,
@@ -146,7 +145,6 @@
       "peterhoeg": 722550
     },
     "members": {
-      "Br1ght0ne": 12615679,
       "manveru": 3507
     },
     "name": "crystal-lang"

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26411,14 +26411,6 @@
     githubId = 36288711;
     name = "Tim Keller";
   };
-  tjni = {
-    email = "43ngvg@masqt.com";
-    matrix = "@tni:matrix.org";
-    name = "Theodore Ni";
-    github = "tjni";
-    githubId = 3806110;
-    keys = [ { fingerprint = "4384 B8E1 299F C028 1641  7B8F EC30 EFBE FA7E 84A4"; } ];
-  };
   tkerber = {
     email = "tk@drwx.org";
     github = "tkerber";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9243,12 +9243,6 @@
     githubId = 57430880;
     name = "Gustavo Araiza";
   };
-  garbas = {
-    email = "rok@garbas.si";
-    github = "garbas";
-    githubId = 20208;
-    name = "Rok Garbas";
-  };
   gardspirito = {
     name = "gardspirito";
     email = "nyxoroso@gmail.com";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27176,12 +27176,6 @@
     githubId = 771193;
     name = "Matej Urbas";
   };
-  uri-canva = {
-    email = "uri@canva.com";
-    github = "uri-canva";
-    githubId = 33242106;
-    name = "Uri Baghin";
-  };
   urlordjames = {
     email = "urlordjames@gmail.com";
     github = "urlordjames";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29047,12 +29047,6 @@
     githubId = 62440012;
     name = "Zain Kergaye";
   };
-  zakame = {
-    email = "zakame@zakame.net";
-    github = "zakame";
-    githubId = 110625;
-    name = "Zak B. Elep";
-  };
   zakkor = {
     email = "edward.dalbon@gmail.com";
     github = "zakkor";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11598,12 +11598,6 @@
     githubId = 10690970;
     name = "James Duff";
   };
-  jagajaga = {
-    email = "ars.seroka@gmail.com";
-    github = "jagajaga";
-    githubId = 2179419;
-    name = "Arseniy Seroka";
-  };
   jakecleary = {
     email = "shout@jakecleary.net";
     github = "jakecleary";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15242,12 +15242,6 @@
     githubId = 5341193;
     name = "Leon Schuermann";
   };
-  lsix = {
-    email = "lsix@lancelotsix.com";
-    github = "lsix";
-    githubId = 724339;
-    name = "Lancelot SIX";
-  };
   ltavard = {
     email = "laure.tavard@univ-grenoble-alpes.fr";
     github = "ltavard";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3409,12 +3409,6 @@
     githubId = 45831883;
     name = "Brieuc Dubois";
   };
-  bhipple = {
-    email = "bhipple@protonmail.com";
-    github = "bhipple";
-    githubId = 2071583;
-    name = "Benjamin Hipple";
-  };
   bhougland = {
     email = "benjamin.hougland@gmail.com";
     github = "bhougland18";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10641,12 +10641,6 @@
     githubId = 137852;
     name = "Hraban Luyat";
   };
-  hrdinka = {
-    email = "c.nix@hrdinka.at";
-    github = "hrdinka";
-    githubId = 1436960;
-    name = "Christoph Hrdinka";
-  };
   hrhino = {
     email = "hora.rhino@gmail.com";
     github = "hrhino";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18395,12 +18395,6 @@
     githubId = 1771772;
     name = "Alexander Ben Nasrallah";
   };
-  nequissimus = {
-    email = "tim@nequissimus.com";
-    github = "NeQuissimus";
-    githubId = 628342;
-    name = "Tim Steinbach";
-  };
   nerdypepper = {
     email = "nerdy@peppe.rs";
     github = "oppiliappan";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3766,13 +3766,6 @@
     githubId = 140968250;
     keys = [ { fingerprint = "8321 ED3A 8DB9 99A5 1F3B  F80F F268 2914 EA42 DE26"; } ];
   };
-  Br1ght0ne = {
-    email = "brightone@protonmail.com";
-    github = "Br1ght0ne";
-    githubId = 12615679;
-    name = "Oleksii Filonenko";
-    keys = [ { fingerprint = "F549 3B7F 9372 5578 FDD3  D0B8 A1BC 8428 323E CFE8"; } ];
-  };
   br337 = {
     email = "brian.porumb@proton.me";
     github = "br337";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7447,12 +7447,6 @@
     githubId = 494483;
     name = "Michael Francis";
   };
-  edwtjo = {
-    email = "ed@cflags.cc";
-    github = "edwtjo";
-    githubId = 54799;
-    name = "Edward Tjörnhammar";
-  };
   eeedean = {
     github = "eeedean";
     githubId = 8173116;

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -548,7 +548,6 @@ with lib.maintainers;
   libretro = {
     members = [
       aanderse
-      hrdinka
       thiagokokada
     ];
     scope = "Maintain Libretro, RetroArch and related packages.";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -79,7 +79,6 @@ with lib.maintainers;
   bazel = {
     members = [
       mboes
-      uri-canva
       cbley
       olebedev
       groodt

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -786,7 +786,6 @@ with lib.maintainers;
     members = [
       sgo
       marcusramberg
-      zakame
     ];
     scope = "Maintain the Perl interpreter and Perl packages.";
     shortName = "Perl";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -494,7 +494,6 @@ with lib.maintainers;
 
   jetbrains = {
     members = [
-      edwtjo
       leona
       theCapypara
       thiagokokada
@@ -534,7 +533,6 @@ with lib.maintainers;
       aanderse
       cpages
       dschrempf
-      edwtjo
       kazenyuk
       minijackson
       peterhoeg
@@ -550,7 +548,6 @@ with lib.maintainers;
   libretro = {
     members = [
       aanderse
-      edwtjo
       hrdinka
       thiagokokada
     ];

--- a/nixos/modules/programs/bandwhich.nix
+++ b/nixos/modules/programs/bandwhich.nix
@@ -9,7 +9,6 @@ let
   cfg = config.programs.bandwhich;
 in
 {
-  meta.maintainers = with lib.maintainers; [ Br1ght0ne ];
 
   options = {
     programs.bandwhich = {

--- a/nixos/modules/security/dhparams.nix
+++ b/nixos/modules/security/dhparams.nix
@@ -206,5 +206,4 @@ in
     ) cfg.params;
   };
 
-  meta.maintainers = with lib.maintainers; [ ekleog ];
 }

--- a/nixos/modules/services/mail/dkimproxy-out.nix
+++ b/nixos/modules/services/mail/dkimproxy-out.nix
@@ -119,5 +119,4 @@ in
       };
     };
 
-  meta.maintainers = with lib.maintainers; [ ekleog ];
 }

--- a/nixos/modules/services/mail/rss2email.nix
+++ b/nixos/modules/services/mail/rss2email.nix
@@ -148,5 +148,4 @@ in
     };
   };
 
-  meta.maintainers = with lib.maintainers; [ ekleog ];
 }

--- a/nixos/modules/services/networking/nsd.nix
+++ b/nixos/modules/services/networking/nsd.nix
@@ -1047,6 +1047,4 @@ in
     };
 
   };
-
-  meta.maintainers = with lib.maintainers; [ hrdinka ];
 }

--- a/nixos/modules/services/networking/redsocks.nix
+++ b/nixos/modules/services/networking/redsocks.nix
@@ -292,5 +292,4 @@ in
       ) cfg.redsocks;
     };
 
-  meta.maintainers = with lib.maintainers; [ ekleog ];
 }

--- a/nixos/modules/services/search/meilisearch.nix
+++ b/nixos/modules/services/search/meilisearch.nix
@@ -54,7 +54,6 @@ let
 in
 {
   meta.maintainers = with lib.maintainers; [
-    Br1ght0ne
     happysalada
   ];
   meta.doc = ./meilisearch.md;

--- a/nixos/tests/caddy.nix
+++ b/nixos/tests/caddy.nix
@@ -3,7 +3,6 @@
   name = "caddy";
   meta = with pkgs.lib.maintainers; {
     maintainers = [
-      Br1ght0ne
       stepbrobd
     ];
   };

--- a/nixos/tests/docker.nix
+++ b/nixos/tests/docker.nix
@@ -4,7 +4,6 @@
   name = "docker";
   meta = with pkgs.lib.maintainers; {
     maintainers = [
-      nequissimus
       offline
     ];
   };

--- a/nixos/tests/env.nix
+++ b/nixos/tests/env.nix
@@ -1,9 +1,6 @@
 { pkgs, ... }:
 {
   name = "environment";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ nequissimus ];
-  };
 
   nodes.machine =
     { pkgs, lib, ... }:

--- a/nixos/tests/git/hub.nix
+++ b/nixos/tests/git/hub.nix
@@ -1,9 +1,6 @@
 { pkgs, ... }:
 {
   name = "hub";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ nequissimus ];
-  };
 
   nodes.hub =
     { pkgs, ... }:

--- a/nixos/tests/kafka/base.nix
+++ b/nixos/tests/kafka/base.nix
@@ -11,9 +11,6 @@ let
     }:
     (import ../make-test-python.nix {
       inherit name;
-      meta = with pkgs.lib.maintainers; {
-        maintainers = [ nequissimus ];
-      };
 
       nodes = {
         kafka =

--- a/nixos/tests/kernel-generic/default.nix
+++ b/nixos/tests/kernel-generic/default.nix
@@ -46,7 +46,6 @@ let
         name = "kernel-${linuxPackages.kernel.version}";
         meta = with pkgs.lib.maintainers; {
           maintainers = [
-            nequissimus
             atemu
             ma27
           ];

--- a/nixos/tests/meilisearch.nix
+++ b/nixos/tests/meilisearch.nix
@@ -12,7 +12,6 @@ let
 in
 {
   name = "meilisearch";
-  meta.maintainers = with lib.maintainers; [ Br1ght0ne ];
 
   nodes.machine =
     { ... }:

--- a/nixos/tests/minecraft-server.nix
+++ b/nixos/tests/minecraft-server.nix
@@ -6,7 +6,6 @@ in
 { lib, pkgs, ... }:
 {
   name = "minecraft-server";
-  meta.maintainers = with lib.maintainers; [ nequissimus ];
 
   node.pkgsReadOnly = false;
 

--- a/nixos/tests/shadow.nix
+++ b/nixos/tests/shadow.nix
@@ -10,9 +10,6 @@ in
 { pkgs, ... }:
 {
   name = "shadow";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ nequissimus ];
-  };
 
   nodes.shadow =
     { pkgs, ... }:

--- a/nixos/tests/xmonad.nix
+++ b/nixos/tests/xmonad.nix
@@ -57,7 +57,6 @@ in
   name = "xmonad";
   meta = with pkgs.lib.maintainers; {
     maintainers = [
-      nequissimus
       ivanbrennan
     ];
   };

--- a/nixos/tests/xterm.nix
+++ b/nixos/tests/xterm.nix
@@ -1,9 +1,6 @@
 { pkgs, ... }:
 {
   name = "xterm";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ nequissimus ];
-  };
 
   nodes.machine = {
     imports = [ ./common/x11.nix ];

--- a/nixos/tests/zookeeper.nix
+++ b/nixos/tests/zookeeper.nix
@@ -8,7 +8,6 @@ in
   name = "zookeeper";
   meta = with pkgs.lib.maintainers; {
     maintainers = [
-      nequissimus
       ztzg
     ];
   };

--- a/pkgs/applications/editors/jetbrains/bin/ides.json
+++ b/pkgs/applications/editors/jetbrains/bin/ides.json
@@ -16,7 +16,7 @@
     "meta": {
       "isOpenSource": false,
       "description": "C/C++ IDE from JetBrains",
-      "maintainers": [ "edwtjo", "mic92", "tymscar" ],
+      "maintainers": [ "mic92", "tymscar" ],
       "longDescription": "Enhancing productivity for every C and C++ developer on Linux, macOS and Windows.",
       "homepage": "https://www.jetbrains.com/clion/"
     }
@@ -73,7 +73,7 @@
     "meta": {
       "isOpenSource": true,
       "description": "Free Java, Kotlin, Groovy and Scala IDE from jetbrains",
-      "maintainers": [ "edwtjo", "gytis-ivaskevicius", "tymscar" ],
+      "maintainers": [ "gytis-ivaskevicius", "tymscar" ],
       "longDescription": "IDE for Java SE, Groovy & Scala development Powerful environment for building Google Android apps Integration with JUnit, TestNG, popular SCMs, Ant & Maven. Also known as IntelliJ.",
       "homepage": "https://www.jetbrains.com/idea/"
     }
@@ -85,7 +85,7 @@
     "meta": {
       "isOpenSource": false,
       "description": "Paid-for Java, Kotlin, Groovy and Scala IDE from jetbrains",
-      "maintainers": [ "edwtjo", "gytis-ivaskevicius", "tymscar" ],
+      "maintainers": [ "gytis-ivaskevicius", "tymscar" ],
       "longDescription": "IDE for Java SE, Groovy & Scala development Powerful environment for building Google Android apps Integration with JUnit, TestNG, popular SCMs, Ant & Maven. Also known as IntelliJ.",
       "homepage": "https://www.jetbrains.com/idea/"
     }
@@ -153,7 +153,7 @@
     "meta": {
       "isOpenSource": false,
       "description": "Ruby IDE from JetBrains",
-      "maintainers": [ "edwtjo", "tymscar"],
+      "maintainers": [ "tymscar"],
       "longDescription": "Ruby IDE from JetBrains",
       "homepage": "https://www.jetbrains.com/ruby/"
     }

--- a/pkgs/applications/editors/vim/plugins/generated.nix
+++ b/pkgs/applications/editors/vim/plugins/generated.nix
@@ -21040,12 +21040,10 @@ final: prev: {
     pname = "vim-snipmate";
     version = "2025-05-14";
     src = fetchFromGitHub {
-      owner = "garbas";
       repo = "vim-snipmate";
       rev = "1331cfe8cbf9b9d79f4b60c1afc211b77c181ad4";
       sha256 = "0dmypsgn6lxq2irxcigxh79l923ph4qk4m2hg27mjd8m079x4j2r";
     };
-    meta.homepage = "https://github.com/garbas/vim-snipmate/";
     meta.hydraPlatforms = [ ];
   };
 

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -4207,7 +4207,6 @@ assertNoAdditions {
       license = lib.licenses.gpl3;
       maintainers = with lib.maintainers; [
         marcweber
-        jagajaga
         mel
       ];
       platforms = lib.platforms.unix;

--- a/pkgs/applications/gis/qgis/unwrapped-ltr.nix
+++ b/pkgs/applications/gis/qgis/unwrapped-ltr.nix
@@ -203,7 +203,6 @@ mkDerivation rec {
     description = "Free and Open Source Geographic Information System";
     homepage = "https://www.qgis.org";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ lsix ];
     teams = [ teams.geospatial ];
     platforms = with platforms; linux;
   };

--- a/pkgs/applications/gis/qgis/unwrapped.nix
+++ b/pkgs/applications/gis/qgis/unwrapped.nix
@@ -199,7 +199,6 @@ mkDerivation rec {
     description = "Free and Open Source Geographic Information System";
     homepage = "https://www.qgis.org";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ lsix ];
     teams = [ teams.geospatial ];
     platforms = with platforms; linux;
   };

--- a/pkgs/applications/graphics/hugin/default.nix
+++ b/pkgs/applications/graphics/hugin/default.nix
@@ -95,7 +95,6 @@ stdenv.mkDerivation rec {
     homepage = "https://hugin.sourceforge.io/";
     description = "Toolkit for stitching photographs and assembling panoramas, together with an easy to use graphical front end";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ hrdinka ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/graphics/luminance-hdr/default.nix
+++ b/pkgs/applications/graphics/luminance-hdr/default.nix
@@ -86,6 +86,5 @@ stdenv.mkDerivation rec {
     description = "Complete open source solution for HDR photography";
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = [ maintainers.hrdinka ];
   };
 }

--- a/pkgs/applications/misc/sweethome3d/default.nix
+++ b/pkgs/applications/misc/sweethome3d/default.nix
@@ -24,7 +24,6 @@ let
     description = "Design and visualize your future home";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
-      edwtjo
       DimitarNestorov
     ];
     platforms = [

--- a/pkgs/applications/misc/sweethome3d/editors.nix
+++ b/pkgs/applications/misc/sweethome3d/editors.nix
@@ -93,7 +93,6 @@ let
         homepage = "http://www.sweethome3d.com/index.jsp";
         inherit description;
         inherit license;
-        maintainers = [ lib.maintainers.edwtjo ];
         platforms = lib.platforms.linux;
         mainProgram = exec;
       };

--- a/pkgs/applications/networking/irc/communi/default.nix
+++ b/pkgs/applications/networking/irc/communi/default.nix
@@ -79,7 +79,6 @@ stdenv.mkDerivation {
     mainProgram = "communi";
     homepage = "https://github.com/communi/communi-desktop";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ hrdinka ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/applications/networking/remote/teamviewer/default.nix
+++ b/pkgs/applications/networking/remote/teamviewer/default.nix
@@ -164,7 +164,6 @@ mkDerivation rec {
       "aarch64-linux"
     ];
     maintainers = with maintainers; [
-      jagajaga
       jraygauthier
       gador
       c4patino

--- a/pkgs/applications/networking/znc/modules.nix
+++ b/pkgs/applications/networking/znc/modules.nix
@@ -95,7 +95,6 @@ in
       homepage = "https://github.com/CyberShadow/znc-clientbuffer";
       license = lib.licenses.asl20;
       maintainers = with lib.maintainers; [
-        hrdinka
         szlend
         cybershadow
       ];
@@ -198,7 +197,6 @@ in
       description = "Advanced playback module for ZNC";
       homepage = "https://github.com/jpnurmi/znc-playback";
       license = lib.licenses.asl20;
-      maintainers = with lib.maintainers; [ hrdinka ];
     };
   };
 

--- a/pkgs/applications/office/cb2bib/default.nix
+++ b/pkgs/applications/office/cb2bib/default.nix
@@ -39,7 +39,6 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Rapidly extract unformatted, or unstandardized bibliographic references from email alerts, journal Web pages and PDF files";
     homepage = "http://www.molspaces.com/d_cb2bib-overview.php";
-    maintainers = with maintainers; [ edwtjo ];
     license = licenses.gpl3;
   };
 

--- a/pkgs/applications/science/machine-learning/shogun/default.nix
+++ b/pkgs/applications/science/machine-learning/shogun/default.nix
@@ -264,7 +264,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "http://shogun-toolbox.org/";
     license = if withSvmLight then licenses.unfree else licenses.gpl3Plus;
     maintainers = with maintainers; [
-      edwtjo
       smancill
     ];
   };

--- a/pkgs/build-support/build-mozilla-mach/default.nix
+++ b/pkgs/build-support/build-mozilla-mach/default.nix
@@ -180,7 +180,6 @@ in
   # > that I made in
   # > https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=815006
   # >
-  # > @garbas shared with me the list of patches applied for the Nix package.
   # > As they are just for portability and tiny modifications, they don't
   # > alter the experience of the product. In parallel, Rok also shared the
   # > build options. They seem good (even if I cannot judge the quality of the

--- a/pkgs/by-name/_3/_3mux/package.nix
+++ b/pkgs/by-name/_3/_3mux/package.nix
@@ -61,7 +61,6 @@ buildGoModule rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       aaronjanse
-      Br1ght0ne
     ];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/_6/_6tunnel/package.nix
+++ b/pkgs/by-name/_6/_6tunnel/package.nix
@@ -24,7 +24,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/wojtekka/6tunnel";
     changelog = "https://github.com/wojtekka/6tunnel/blob/${version}/ChangeLog";
     license = lib.licenses.gpl2Only;
-    maintainers = with lib.maintainers; [ Br1ght0ne ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/ab/abi-compliance-checker/package.nix
+++ b/pkgs/by-name/ab/abi-compliance-checker/package.nix
@@ -33,7 +33,6 @@ stdenv.mkDerivation rec {
     description = "Tool for checking backward API/ABI compatibility of a C/C++ library";
     mainProgram = "abi-compliance-checker";
     license = lib.licenses.lgpl21;
-    maintainers = with lib.maintainers; [ bhipple ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/ab/abi-dumper/package.nix
+++ b/pkgs/by-name/ab/abi-dumper/package.nix
@@ -41,7 +41,6 @@ stdenv.mkDerivation rec {
     description = "Dump ABI of an ELF object containing DWARF debug info";
     mainProgram = "abi-dumper";
     license = lib.licenses.lgpl21;
-    maintainers = with lib.maintainers; [ bhipple ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/ab/abook/package.nix
+++ b/pkgs/by-name/ab/abook/package.nix
@@ -47,7 +47,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "http://abook.sourceforge.net/";
     description = "Text-based addressbook program designed to use with mutt mail client";
     license = lib.licenses.gpl3Only;
-    maintainers = [ lib.maintainers.edwtjo ];
     platforms = lib.platforms.unix;
     mainProgram = "abook";
   };

--- a/pkgs/by-name/ac/acd-cli/package.nix
+++ b/pkgs/by-name/ac/acd-cli/package.nix
@@ -46,6 +46,5 @@ python3Packages.buildPythonApplication rec {
     description = "Command line interface and FUSE filesystem for Amazon Cloud Drive";
     homepage = "https://github.com/yadayada/acd_cli";
     license = lib.licenses.gpl2;
-    maintainers = with lib.maintainers; [ edwtjo ];
   };
 }

--- a/pkgs/by-name/ac/act/package.nix
+++ b/pkgs/by-name/ac/act/package.nix
@@ -46,7 +46,6 @@ buildGoModule {
     changelog = "https://github.com/nektos/act/releases/tag/v${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      Br1ght0ne
       kashw2
     ];
   };

--- a/pkgs/by-name/ak/akira-unstable/package.nix
+++ b/pkgs/by-name/ak/akira-unstable/package.nix
@@ -68,9 +68,7 @@ stdenv.mkDerivation rec {
     description = "Native Linux Design application built in Vala and GTK";
     homepage = "https://github.com/akiraux/Akira";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [
-      Br1ght0ne
-    ];
+    maintainers = [ ];
     teams = [ teams.pantheon ];
     platforms = platforms.linux;
     mainProgram = "com.github.akiraux.akira";

--- a/pkgs/by-name/al/alacritty/package.nix
+++ b/pkgs/by-name/al/alacritty/package.nix
@@ -161,7 +161,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       with lib.maintainers;
       if !withGraphics then
         [
-          Br1ght0ne
           rvdp
         ]
       else

--- a/pkgs/by-name/an/antibody/package.nix
+++ b/pkgs/by-name/an/antibody/package.nix
@@ -31,7 +31,6 @@ buildGoModule rec {
     mainProgram = "antibody";
     homepage = "https://github.com/getantibody/antibody";
     license = licenses.mit;
-    maintainers = with maintainers; [ Br1ght0ne ];
 
     # golang.org/x/sys needs to be updated due to:
     #

--- a/pkgs/by-name/ap/apache-airflow/python-package.nix
+++ b/pkgs/by-name/ap/apache-airflow/python-package.nix
@@ -336,7 +336,6 @@ buildPythonPackage rec {
     homepage = "https://airflow.apache.org/";
     license = licenses.asl20;
     maintainers = with maintainers; [
-      bhipple
       gbpdt
       ingenieroariel
     ];

--- a/pkgs/by-name/ap/apulse/package.nix
+++ b/pkgs/by-name/ap/apulse/package.nix
@@ -46,7 +46,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/i-rinat/apulse/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
-    maintainers = [ lib.maintainers.jagajaga ];
     mainProgram = "apulse";
   };
 })

--- a/pkgs/by-name/ar/aria2/package.nix
+++ b/pkgs/by-name/ar/aria2/package.nix
@@ -77,7 +77,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [
-      Br1ght0ne
       koral
       timhae
     ];

--- a/pkgs/by-name/as/asciinema-scenario/package.nix
+++ b/pkgs/by-name/as/asciinema-scenario/package.nix
@@ -17,8 +17,6 @@ rustPlatform.buildRustPackage rec {
 
   meta = with lib; {
     description = "Create asciinema videos from a text file";
-    homepage = "https://github.com/garbas/asciinema-scenario/";
-    maintainers = with maintainers; [ garbas ];
     license = with licenses; [ mit ];
     mainProgram = "asciinema-scenario";
   };

--- a/pkgs/by-name/at/attract-mode/package.nix
+++ b/pkgs/by-name/at/attract-mode/package.nix
@@ -61,7 +61,6 @@ stdenv.mkDerivation {
     description = "Frontend for arcade cabinets and media PCs";
     homepage = "http://attractmode.org";
     license = lib.licenses.gpl3Plus;
-    maintainers = [ lib.maintainers.hrdinka ];
     platforms = lib.platforms.unix;
     mainProgram = "attract";
   };

--- a/pkgs/by-name/aw/awscli2/package.nix
+++ b/pkgs/by-name/aw/awscli2/package.nix
@@ -208,7 +208,6 @@ py.pkgs.buildPythonApplication rec {
     changelog = "https://github.com/aws/aws-cli/blob/${version}/CHANGELOG.rst";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
-      bhipple
       davegallant
       devusb
       anthonyroussel

--- a/pkgs/by-name/aw/awslimitchecker/package.nix
+++ b/pkgs/by-name/aw/awslimitchecker/package.nix
@@ -57,7 +57,6 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "http://awslimitchecker.readthedocs.org";
     changelog = "https://github.com/jantman/awslimitchecker/blob/${version}/CHANGES.rst";
     license = lib.licenses.agpl3Plus;
-    maintainers = with lib.maintainers; [ zakame ];
     mainProgram = "awslimitchecker";
   };
 }

--- a/pkgs/by-name/ba/backblaze-b2/package.nix
+++ b/pkgs/by-name/ba/backblaze-b2/package.nix
@@ -105,7 +105,6 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://github.com/Backblaze/B2_Command_Line_Tool";
     changelog = "https://github.com/Backblaze/B2_Command_Line_Tool/blob/${src.tag}/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ hrdinka ];
     mainProgram = "backblaze-b2";
   };
 }

--- a/pkgs/by-name/ba/bandwhich/package.nix
+++ b/pkgs/by-name/ba/bandwhich/package.nix
@@ -48,8 +48,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/imsnif/bandwhich";
     changelog = "https://github.com/imsnif/bandwhich/blob/${src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [
-      Br1ght0ne
+    maintainers = [
     ];
     platforms = lib.platforms.unix;
     mainProgram = "bandwhich";

--- a/pkgs/by-name/ba/bazel-buildtools/package.nix
+++ b/pkgs/by-name/ba/bazel-buildtools/package.nix
@@ -41,7 +41,6 @@ buildGoModule rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       elasticdog
-      uri-canva
     ];
     teams = [ lib.teams.bazel ];
   };

--- a/pkgs/by-name/bu/bully/package.nix
+++ b/pkgs/by-name/bu/bully/package.nix
@@ -31,7 +31,6 @@ stdenv.mkDerivation rec {
     description = "Retrieve WPA/WPA2 passphrase from a WPS enabled access point";
     homepage = "https://github.com/kimocoder/bully";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ edwtjo ];
     platforms = platforms.linux;
     mainProgram = "bully";
   };

--- a/pkgs/by-name/ca/caddy/package.nix
+++ b/pkgs/by-name/ca/caddy/package.nix
@@ -94,7 +94,6 @@ buildGo125Module (finalAttrs: {
     license = lib.licenses.asl20;
     mainProgram = "caddy";
     maintainers = with lib.maintainers; [
-      Br1ght0ne
       stepbrobd
       techknowlogick
       ryan4yin

--- a/pkgs/by-name/ca/capnproto-java/package.nix
+++ b/pkgs/by-name/ca/capnproto-java/package.nix
@@ -30,7 +30,6 @@ stdenv.mkDerivation rec {
     homepage = "https://dwrensha.github.io/capnproto-java/index.html";
     license = licenses.mit;
     maintainers = with maintainers; [
-      bhipple
       solson
     ];
   };

--- a/pkgs/by-name/ca/cargo-cache/package.nix
+++ b/pkgs/by-name/ca/cargo-cache/package.nix
@@ -34,7 +34,6 @@ rustPlatform.buildRustPackage rec {
       mit
     ];
     maintainers = with maintainers; [
-      Br1ght0ne
       matthiasbeyer
     ];
   };

--- a/pkgs/by-name/ca/cargo-deb/package.nix
+++ b/pkgs/by-name/ca/cargo-deb/package.nix
@@ -53,7 +53,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/kornelski/cargo-deb";
     license = licenses.mit;
     maintainers = with maintainers; [
-      Br1ght0ne
       matthiasbeyer
     ];
   };

--- a/pkgs/by-name/ca/cargo-edit/package.nix
+++ b/pkgs/by-name/ca/cargo-edit/package.nix
@@ -38,7 +38,6 @@ rustPlatform.buildRustPackage rec {
       mit
     ];
     maintainers = with lib.maintainers; [
-      Br1ght0ne
       gerschtli
       jb55
       killercup

--- a/pkgs/by-name/ca/cargo-fuzz/package.nix
+++ b/pkgs/by-name/ca/cargo-fuzz/package.nix
@@ -28,7 +28,6 @@ rustPlatform.buildRustPackage rec {
       asl20
     ];
     maintainers = with maintainers; [
-      ekleog
       matthiasbeyer
     ];
   };

--- a/pkgs/by-name/ca/cargo-nextest/package.nix
+++ b/pkgs/by-name/ca/cargo-nextest/package.nix
@@ -45,7 +45,6 @@ rustPlatform.buildRustPackage rec {
       asl20
     ];
     maintainers = with maintainers; [
-      ekleog
       matthiasbeyer
     ];
   };

--- a/pkgs/by-name/ca/cargo-update/package.nix
+++ b/pkgs/by-name/ca/cargo-update/package.nix
@@ -67,7 +67,6 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       gerschtli
-      Br1ght0ne
       johntitor
       matthiasbeyer
     ];

--- a/pkgs/by-name/ca/catch2/package.nix
+++ b/pkgs/by-name/ca/catch2/package.nix
@@ -24,9 +24,7 @@ stdenv.mkDerivation rec {
     description = "Multi-paradigm automated test framework for C++ and Objective-C (and, maybe, C)";
     homepage = "http://catch-lib.net";
     license = licenses.boost;
-    maintainers = with maintainers; [
-      edwtjo
-    ];
+    maintainers = [ ];
     platforms = with platforms; unix ++ windows;
   };
 }

--- a/pkgs/by-name/cd/cdi2iso/package.nix
+++ b/pkgs/by-name/cd/cdi2iso/package.nix
@@ -26,7 +26,6 @@ stdenv.mkDerivation rec {
     description = "Very simple utility for converting DiscJuggler images to the standard ISO-9660 format";
     homepage = "https://sourceforge.net/projects/cdi2iso.berlios";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ hrdinka ];
     platforms = platforms.all;
     mainProgram = "cdi2iso";
   };

--- a/pkgs/by-name/cl/cloud-custodian/package.nix
+++ b/pkgs/by-name/cl/cloud-custodian/package.nix
@@ -50,7 +50,6 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://cloudcustodian.io";
     changelog = "https://github.com/cloud-custodian/cloud-custodian/releases/tag/${version}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ bhipple ];
     mainProgram = "custodian";
   };
 }

--- a/pkgs/by-name/co/colormake/package.nix
+++ b/pkgs/by-name/co/colormake/package.nix
@@ -28,6 +28,5 @@ stdenv.mkDerivation {
     homepage = "https://bre.klaki.net/programs/colormake/";
     license = licenses.gpl2;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ bhipple ];
   };
 }

--- a/pkgs/by-name/co/colpack/package.nix
+++ b/pkgs/by-name/co/colpack/package.nix
@@ -43,6 +43,5 @@ stdenv.mkDerivation rec {
     homepage = "https://cscapes.cs.purdue.edu/coloringpage/software.htm#functionalities";
     license = licenses.lgpl3Plus;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ edwtjo ];
   };
 }

--- a/pkgs/by-name/co/coursier/package.nix
+++ b/pkgs/by-name/co/coursier/package.nix
@@ -73,7 +73,6 @@ stdenv.mkDerivation rec {
     license = licenses.asl20;
     maintainers = with maintainers; [
       adelbertc
-      nequissimus
     ];
     platforms = platforms.all;
   };

--- a/pkgs/by-name/cp/cpplint/package.nix
+++ b/pkgs/by-name/cp/cpplint/package.nix
@@ -42,7 +42,6 @@ python3Packages.buildPythonApplication rec {
     description = "Static code checker for C++";
     changelog = "https://github.com/cpplint/cpplint/releases/tag/${version}";
     mainProgram = "cpplint";
-    maintainers = [ lib.maintainers.bhipple ];
     license = [ lib.licenses.bsd3 ];
   };
 }

--- a/pkgs/by-name/cr/cryptop/package.nix
+++ b/pkgs/by-name/cr/cryptop/package.nix
@@ -26,7 +26,6 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://github.com/huwwp/cryptop";
     description = "Command line Cryptocurrency Portfolio";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ bhipple ];
     mainProgram = "cryptop";
   };
 }

--- a/pkgs/by-name/dc/dcadec/package.nix
+++ b/pkgs/by-name/dc/dcadec/package.nix
@@ -22,7 +22,6 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "DTS Coherent Acoustics decoder with support for HD extensions";
     mainProgram = "dcadec";
-    maintainers = with maintainers; [ edwtjo ];
     homepage = "https://github.com/foo86/dcadec";
     license = licenses.lgpl21;
     platforms = platforms.linux;

--- a/pkgs/by-name/dj/djmount/package.nix
+++ b/pkgs/by-name/dj/djmount/package.nix
@@ -36,7 +36,6 @@ stdenv.mkDerivation rec {
     description = "UPnP AV client, mounts as a Linux filesystem the media content of compatible UPnP AV devices";
     mainProgram = "djmount";
     platforms = lib.platforms.linux;
-    maintainers = [ lib.maintainers.jagajaga ];
     license = lib.licenses.gpl2Plus;
   };
 }

--- a/pkgs/by-name/dk/dkimproxy/package.nix
+++ b/pkgs/by-name/dk/dkimproxy/package.nix
@@ -38,7 +38,6 @@ stdenv.mkDerivation rec {
     description = "SMTP-proxy that signs and/or verifies emails";
     homepage = "https://dkimproxy.sourceforge.net/";
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.ekleog ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/by-name/do/docker-slim/package.nix
+++ b/pkgs/by-name/do/docker-slim/package.nix
@@ -50,7 +50,6 @@ buildGoModule rec {
     changelog = "https://github.com/slimtoolkit/slim/raw/${version}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
-      Br1ght0ne
       mbrgm
     ];
   };

--- a/pkgs/by-name/dr/drill/package.nix
+++ b/pkgs/by-name/dr/drill/package.nix
@@ -35,7 +35,6 @@ rustPlatform.buildRustPackage rec {
     description = "HTTP load testing application inspired by Ansible syntax";
     homepage = "https://github.com/fcsonline/drill";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ Br1ght0ne ];
     mainProgram = "drill";
   };
 }

--- a/pkgs/by-name/ec/ecos/package.nix
+++ b/pkgs/by-name/ec/ecos/package.nix
@@ -50,6 +50,5 @@ stdenv.mkDerivation (finalAttrs: {
     downloadPage = "https://github.com/embotech/ecos/releases";
     license = lib.licenses.gpl3;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ bhipple ];
   };
 })

--- a/pkgs/by-name/ed/editorconfig-checker/package.nix
+++ b/pkgs/by-name/ed/editorconfig-checker/package.nix
@@ -42,7 +42,6 @@ buildGoModule (finalAttrs: {
     homepage = "https://editorconfig-checker.github.io/";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      uri-canva
       zowoq
     ];
   };

--- a/pkgs/by-name/em/emplace/package.nix
+++ b/pkgs/by-name/em/emplace/package.nix
@@ -29,7 +29,6 @@ rustPlatform.buildRustPackage rec {
     description = "Mirror installed software on multiple machines";
     homepage = "https://github.com/tversteeg/emplace";
     license = lib.licenses.agpl3Plus;
-    maintainers = with lib.maintainers; [ Br1ght0ne ];
     mainProgram = "emplace";
   };
 }

--- a/pkgs/by-name/ep/ephemeralpg/package.nix
+++ b/pkgs/by-name/ep/ephemeralpg/package.nix
@@ -30,7 +30,6 @@ stdenv.mkDerivation rec {
     homepage = "https://eradman.com/ephemeralpg/";
     platforms = platforms.all;
     maintainers = with maintainers; [
-      hrdinka
       medv
     ];
   };

--- a/pkgs/by-name/ep/epr/package.nix
+++ b/pkgs/by-name/ep/epr/package.nix
@@ -25,7 +25,6 @@ python3Packages.buildPythonApplication rec {
     mainProgram = "epr";
     homepage = "https://github.com/wustho/epr";
     license = licenses.mit;
-    maintainers = [ maintainers.Br1ght0ne ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/by-name/ez/ezquake/package.nix
+++ b/pkgs/by-name/ez/ezquake/package.nix
@@ -68,6 +68,5 @@ stdenv.mkDerivation rec {
     mainProgram = "ezquake";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ edwtjo ];
   };
 }

--- a/pkgs/by-name/f2/f2fs-tools/package.nix
+++ b/pkgs/by-name/f2/f2fs-tools/package.nix
@@ -55,8 +55,6 @@ stdenv.mkDerivation rec {
     description = "Userland tools for the f2fs filesystem";
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [
-      jagajaga
-    ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/fa/fast-cpp-csv-parser/package.nix
+++ b/pkgs/by-name/fa/fast-cpp-csv-parser/package.nix
@@ -25,6 +25,5 @@ stdenv.mkDerivation {
     description = "Small, easy-to-use and fast header-only library for reading comma separated value (CSV) files";
     homepage = "https://github.com/ben-strasser/fast-cpp-csv-parser";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ bhipple ];
   };
 }

--- a/pkgs/by-name/fa/fastJson/package.nix
+++ b/pkgs/by-name/fa/fastJson/package.nix
@@ -24,7 +24,6 @@ stdenv.mkDerivation rec {
     description = "Fast json library for C";
     homepage = "https://github.com/rsyslog/libfastjson";
     license = licenses.mit;
-    maintainers = with maintainers; [ nequissimus ];
     platforms = with platforms; unix;
   };
 }

--- a/pkgs/by-name/ff/ffmpegthumbnailer/package.nix
+++ b/pkgs/by-name/ff/ffmpegthumbnailer/package.nix
@@ -65,7 +65,6 @@ stdenv.mkDerivation (finalAttrs: {
     ";
     homepage = "https://github.com/dirkvdb/ffmpegthumbnailer";
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.jagajaga ];
     platforms = platforms.unix;
     mainProgram = "ffmpegthumbnailer";
   };

--- a/pkgs/by-name/fi/findnewest/package.nix
+++ b/pkgs/by-name/fi/findnewest/package.nix
@@ -23,6 +23,5 @@ stdenv.mkDerivation rec {
     description = "Recursively find newest file in a hierarchy and print its timestamp";
     mainProgram = "fn";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ bhipple ];
   };
 }

--- a/pkgs/by-name/fi/findomain/package.nix
+++ b/pkgs/by-name/fi/findomain/package.nix
@@ -42,9 +42,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/Findomain/Findomain";
     changelog = "https://github.com/Findomain/Findomain/releases/tag/${version}";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [
-      Br1ght0ne
-    ];
+    maintainers = [ ];
     mainProgram = "findomain";
   };
 }

--- a/pkgs/by-name/fr/frp/package.nix
+++ b/pkgs/by-name/fr/frp/package.nix
@@ -39,6 +39,5 @@ buildGoModule (finalAttrs: {
     '';
     homepage = "https://github.com/fatedier/frp";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ Br1ght0ne ];
   };
 })

--- a/pkgs/by-name/fs/fselect/package.nix
+++ b/pkgs/by-name/fs/fselect/package.nix
@@ -35,7 +35,6 @@ rustPlatform.buildRustPackage rec {
       mit
     ];
     maintainers = with maintainers; [
-      Br1ght0ne
       matthiasbeyer
     ];
     mainProgram = "fselect";

--- a/pkgs/by-name/fu/fusuma/package.nix
+++ b/pkgs/by-name/fu/fusuma/package.nix
@@ -32,7 +32,6 @@ bundlerApp rec {
     license = licenses.mit;
     maintainers = with maintainers; [
       nicknovitski
-      Br1ght0ne
     ];
     platforms = platforms.linux;
   };

--- a/pkgs/by-name/fz/fzf/package.nix
+++ b/pkgs/by-name/fz/fzf/package.nix
@@ -85,7 +85,6 @@ buildGoModule rec {
     homepage = "https://github.com/junegunn/fzf";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      Br1ght0ne
       ma27
       zowoq
     ];

--- a/pkgs/by-name/gi/gir-rs/package.nix
+++ b/pkgs/by-name/gi/gir-rs/package.nix
@@ -30,7 +30,6 @@ rustPlatform.buildRustPackage {
     description = "Tool to generate rust bindings and user API for glib-based libraries";
     homepage = "https://github.com/gtk-rs/gir/";
     license = with licenses; [ mit ];
-    maintainers = with maintainers; [ ekleog ];
     mainProgram = "gir";
   };
 }

--- a/pkgs/by-name/gi/gitmoji-cli/package.nix
+++ b/pkgs/by-name/gi/gitmoji-cli/package.nix
@@ -48,7 +48,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     mainProgram = "gitmoji";
     maintainers = with lib.maintainers; [
-      nequissimus
       yzx9
     ];
   };

--- a/pkgs/by-name/gi/gitui/package.nix
+++ b/pkgs/by-name/gi/gitui/package.nix
@@ -79,7 +79,6 @@ rustPlatform.buildRustPackage {
     license = lib.licenses.mit;
     mainProgram = "gitui";
     maintainers = with lib.maintainers; [
-      Br1ght0ne
       yanganto
       mfrw
     ];

--- a/pkgs/by-name/gl/global-platform-pro/package.nix
+++ b/pkgs/by-name/gl/global-platform-pro/package.nix
@@ -84,7 +84,6 @@ maven.buildMavenPackage rec {
       binaryBytecode # deps
     ];
     license = with licenses; [ lgpl3 ];
-    maintainers = with maintainers; [ ekleog ];
     mainProgram = "gp";
   };
 }

--- a/pkgs/by-name/gl/glow/package.nix
+++ b/pkgs/by-name/gl/glow/package.nix
@@ -41,7 +41,6 @@ buildGoModule rec {
     homepage = "https://github.com/charmbracelet/glow";
     changelog = "https://github.com/charmbracelet/glow/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ Br1ght0ne ];
     mainProgram = "glow";
   };
 }

--- a/pkgs/by-name/gr/greg/package.nix
+++ b/pkgs/by-name/gr/greg/package.nix
@@ -28,6 +28,5 @@ python3Packages.buildPythonApplication rec {
     description = "Command-line podcast aggregator";
     mainProgram = "greg";
     license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [ edwtjo ];
   };
 }

--- a/pkgs/by-name/hd/hdf5-blosc/package.nix
+++ b/pkgs/by-name/hd/hdf5-blosc/package.nix
@@ -61,6 +61,5 @@ stdenv.mkDerivation rec {
     description = "Filter for HDF5 that uses the Blosc compressor";
     homepage = "https://github.com/Blosc/hdf5-blosc";
     license = licenses.mit;
-    maintainers = with maintainers; [ bhipple ];
   };
 }

--- a/pkgs/by-name/he/hey/package.nix
+++ b/pkgs/by-name/he/hey/package.nix
@@ -21,7 +21,6 @@ buildGoModule rec {
     description = "HTTP load generator, ApacheBench (ab) replacement";
     homepage = "https://github.com/rakyll/hey";
     license = licenses.asl20;
-    maintainers = with maintainers; [ Br1ght0ne ];
     mainProgram = "hey";
   };
 }

--- a/pkgs/by-name/ht/html-tidy/package.nix
+++ b/pkgs/by-name/ht/html-tidy/package.nix
@@ -54,7 +54,6 @@ stdenv.mkDerivation rec {
     license = licenses.libpng; # very close to it - the 3 clauses are identical
     homepage = "http://html-tidy.org";
     platforms = platforms.all;
-    maintainers = with maintainers; [ edwtjo ];
     mainProgram = "tidy";
   };
 }

--- a/pkgs/by-name/ht/httpstat/package.nix
+++ b/pkgs/by-name/ht/httpstat/package.nix
@@ -30,6 +30,5 @@ python3Packages.buildPythonApplication rec {
     mainProgram = "httpstat";
     homepage = "https://github.com/reorx/httpstat";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ nequissimus ];
   };
 }

--- a/pkgs/by-name/hu/hugo/package.nix
+++ b/pkgs/by-name/hu/hugo/package.nix
@@ -81,7 +81,6 @@ buildGoModule (finalAttrs: {
     license = lib.licenses.asl20;
     mainProgram = "hugo";
     maintainers = with lib.maintainers; [
-      Br1ght0ne
       Frostman
       savtrip
     ];

--- a/pkgs/by-name/hy/hydroxide/package.nix
+++ b/pkgs/by-name/hy/hydroxide/package.nix
@@ -25,7 +25,6 @@ buildGoModule rec {
     description = "Third-party, open-source ProtonMail bridge";
     homepage = "https://github.com/emersion/hydroxide";
     license = licenses.mit;
-    maintainers = with maintainers; [ Br1ght0ne ];
     mainProgram = "hydroxide";
   };
 }

--- a/pkgs/by-name/i2/i2pd/package.nix
+++ b/pkgs/by-name/i2/i2pd/package.nix
@@ -53,7 +53,6 @@ stdenv.mkDerivation rec {
     homepage = "https://i2pd.website";
     description = "Minimal I2P router written in C++";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ edwtjo ];
     platforms = platforms.unix;
     mainProgram = "i2pd";
   };

--- a/pkgs/by-name/in/intermodal/package.nix
+++ b/pkgs/by-name/in/intermodal/package.nix
@@ -39,7 +39,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/casey/intermodal/releases/tag/v${version}";
     license = lib.licenses.cc0;
     maintainers = with lib.maintainers; [
-      Br1ght0ne
       xrelkd
     ];
     mainProgram = "imdl";

--- a/pkgs/by-name/je/jenkins/package.nix
+++ b/pkgs/by-name/je/jenkins/package.nix
@@ -81,7 +81,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     license = licenses.mit;
     maintainers = with maintainers; [
       earldouglas
-      nequissimus
     ];
     changelog = "https://www.jenkins.io/changelog-stable/#v${finalAttrs.version}";
     mainProgram = "jenkins-cli";

--- a/pkgs/by-name/kc/kcov/package.nix
+++ b/pkgs/by-name/kc/kcov/package.nix
@@ -87,7 +87,6 @@ let
 
       maintainers = with maintainers; [
         gal_bolle
-        ekleog
       ];
       platforms = platforms.linux;
     };

--- a/pkgs/by-name/ko/kondo/package.nix
+++ b/pkgs/by-name/ko/kondo/package.nix
@@ -32,7 +32,6 @@ rustPlatform.buildRustPackage rec {
     description = "Save disk space by cleaning unneeded files from software projects";
     homepage = "https://github.com/tbillington/kondo";
     license = licenses.mit;
-    maintainers = with maintainers; [ Br1ght0ne ];
     mainProgram = "kondo";
   };
 }

--- a/pkgs/by-name/la/languagetool/package.nix
+++ b/pkgs/by-name/la/languagetool/package.nix
@@ -41,7 +41,6 @@ stdenv.mkDerivation rec {
     homepage = "https://languagetool.org";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.lgpl21Plus;
-    maintainers = with maintainers; [ edwtjo ];
     platforms = jre.meta.platforms;
     description = "Proofreading program for English, French German, Polish, and more";
   };

--- a/pkgs/by-name/la/lazydocker/package.nix
+++ b/pkgs/by-name/la/lazydocker/package.nix
@@ -44,7 +44,6 @@ buildGoModule rec {
     license = licenses.mit;
     maintainers = with maintainers; [
       das-g
-      Br1ght0ne
     ];
     mainProgram = "lazydocker";
   };

--- a/pkgs/by-name/la/lazygit/package.nix
+++ b/pkgs/by-name/la/lazygit/package.nix
@@ -42,7 +42,6 @@ buildGoModule rec {
     changelog = "https://github.com/jesseduffield/lazygit/releases/tag/v${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      Br1ght0ne
       equirosa
       khaneliman
       starsep

--- a/pkgs/by-name/le/lemmeknow/package.nix
+++ b/pkgs/by-name/le/lemmeknow/package.nix
@@ -20,9 +20,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/swanandx/lemmeknow";
     changelog = "https://github.com/swanandx/lemmeknow/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [
-      Br1ght0ne
-    ];
+    maintainers = [ ];
     mainProgram = "lemmeknow";
   };
 }

--- a/pkgs/by-name/li/libcrossguid/package.nix
+++ b/pkgs/by-name/li/libcrossguid/package.nix
@@ -32,7 +32,6 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Lightweight cross platform C++ GUID/UUID library";
     license = licenses.mit;
-    maintainers = with maintainers; [ edwtjo ];
     homepage = "https://github.com/graeme-hill/crossguid";
     platforms = with platforms; linux;
   };

--- a/pkgs/by-name/li/libdigidocpp/package.nix
+++ b/pkgs/by-name/li/libdigidocpp/package.nix
@@ -74,7 +74,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     maintainers = [
       maintainers.flokli
-      maintainers.jagajaga
     ];
   };
 }

--- a/pkgs/by-name/li/libidn/package.nix
+++ b/pkgs/by-name/li/libidn/package.nix
@@ -53,6 +53,5 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.lgpl2Plus;
     pkgConfigModules = [ "libidn" ];
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ lsix ];
   };
 })

--- a/pkgs/by-name/li/lightdm-tiny-greeter/package.nix
+++ b/pkgs/by-name/li/lightdm-tiny-greeter/package.nix
@@ -62,7 +62,6 @@ stdenv.mkDerivation rec {
     mainProgram = "lightdm-tiny-greeter";
     homepage = "https://github.com/off-world/lightdm-tiny-greeter";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ edwtjo ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/li/lite/package.nix
+++ b/pkgs/by-name/li/lite/package.nix
@@ -62,7 +62,6 @@ stdenv.mkDerivation rec {
     description = "Lightweight text editor written in Lua";
     homepage = "https://github.com/rxi/lite";
     license = licenses.mit;
-    maintainers = with maintainers; [ Br1ght0ne ];
     platforms = platforms.unix;
     mainProgram = "lite";
   };

--- a/pkgs/by-name/lu/luigi/package.nix
+++ b/pkgs/by-name/lu/luigi/package.nix
@@ -42,6 +42,5 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://github.com/spotify/luigi";
     changelog = "https://github.com/spotify/luigi/releases/tag/${version}";
     license = [ lib.licenses.asl20 ];
-    maintainers = [ lib.maintainers.bhipple ];
   };
 }

--- a/pkgs/by-name/ma/mapnik/package.nix
+++ b/pkgs/by-name/ma/mapnik/package.nix
@@ -128,7 +128,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://mapnik.org";
     changelog = "https://github.com/mapnik/mapnik/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     maintainers = with lib.maintainers; [
-      hrdinka
       hummeltech
     ];
     teams = [ lib.teams.geospatial ];

--- a/pkgs/by-name/md/mdadm4/package.nix
+++ b/pkgs/by-name/md/mdadm4/package.nix
@@ -94,7 +94,6 @@ stdenv.mkDerivation rec {
     homepage = "https://git.kernel.org/pub/scm/utils/mdadm/mdadm.git";
     license = licenses.gpl2Plus;
     mainProgram = "mdadm";
-    maintainers = with maintainers; [ ekleog ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/md/mdevctl/package.nix
+++ b/pkgs/by-name/md/mdevctl/package.nix
@@ -46,7 +46,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/mdevctl/mdevctl";
     description = "Mediated device management utility for linux";
     license = licenses.lgpl21Only;
-    maintainers = with maintainers; [ edwtjo ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/me/metal-cli/package.nix
+++ b/pkgs/by-name/me/metal-cli/package.nix
@@ -50,7 +50,6 @@ buildGoModule (finalAttrs: {
     changelog = "https://github.com/equinix/metal-cli/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      Br1ght0ne
       teutat3s
     ];
     mainProgram = "metal";

--- a/pkgs/by-name/mk/mkl/package.nix
+++ b/pkgs/by-name/mk/mkl/package.nix
@@ -212,7 +212,6 @@ stdenvNoCC.mkDerivation (
         "x86_64-linux"
         "x86_64-darwin"
       ];
-      maintainers = with maintainers; [ bhipple ];
     };
   }
   // lib.optionalAttrs stdenvNoCC.hostPlatform.isDarwin {

--- a/pkgs/by-name/ml/mlmmj/package.nix
+++ b/pkgs/by-name/ml/mlmmj/package.nix
@@ -41,7 +41,6 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "http://mlmmj.org";
     description = "Mailing List Management Made Joyful";
-    maintainers = [ maintainers.edwtjo ];
     platforms = platforms.linux;
     license = licenses.mit;
   };

--- a/pkgs/by-name/mo/moc/package.nix
+++ b/pkgs/by-name/mo/moc/package.nix
@@ -162,7 +162,6 @@ stdenv.mkDerivation {
     maintainers = with maintainers; [
       aethelz
       pSub
-      jagajaga
     ];
     platforms = platforms.unix;
     mainProgram = "mocp";

--- a/pkgs/by-name/mo/monolith/package.nix
+++ b/pkgs/by-name/mo/monolith/package.nix
@@ -42,6 +42,5 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/Y2Z/monolith";
     license = licenses.cc0;
     platforms = lib.platforms.unix;
-    maintainers = with maintainers; [ Br1ght0ne ];
   };
 }

--- a/pkgs/by-name/mu/mullvad-vpn/package.nix
+++ b/pkgs/by-name/mu/mullvad-vpn/package.nix
@@ -162,7 +162,6 @@ stdenv.mkDerivation {
     platforms = lib.platforms.unix;
     badPlatforms = [ lib.systems.inspect.patterns.isDarwin ];
     maintainers = with lib.maintainers; [
-      Br1ght0ne
       ymarkus
     ];
   };

--- a/pkgs/by-name/mu/muonlang/package.nix
+++ b/pkgs/by-name/mu/muonlang/package.nix
@@ -33,7 +33,6 @@ stdenv.mkDerivation {
     description = "Modern low-level programming language";
     homepage = "https://github.com/nickmqb/muon";
     license = licenses.mit;
-    maintainers = with maintainers; [ Br1ght0ne ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/by-name/na/nano/package.nix
+++ b/pkgs/by-name/na/nano/package.nix
@@ -105,7 +105,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [
       joachifm
-      nequissimus
       sigmasquadron
     ];
     platforms = platforms.all;

--- a/pkgs/by-name/na/nanorc/package.nix
+++ b/pkgs/by-name/na/nanorc/package.nix
@@ -60,7 +60,6 @@ stdenv.mkDerivation rec {
     description = "Improved Nano Syntax Highlighting Files";
     homepage = "https://github.com/scopatz/nanorc";
     license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [ nequissimus ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/ne/nebula/package.nix
+++ b/pkgs/by-name/ne/nebula/package.nix
@@ -78,7 +78,6 @@ buildGoModule (finalAttrs: {
     changelog = "https://github.com/slackhq/nebula/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      Br1ght0ne
       numinit
     ];
   };

--- a/pkgs/by-name/ne/neo-cowsay/package.nix
+++ b/pkgs/by-name/ne/neo-cowsay/package.nix
@@ -33,7 +33,6 @@ buildGoModule rec {
       artistic1 # or
       gpl3
     ];
-    maintainers = with maintainers; [ Br1ght0ne ];
     mainProgram = "cowsay";
   };
 }

--- a/pkgs/by-name/ne/networking-ts-cxx/package.nix
+++ b/pkgs/by-name/ne/networking-ts-cxx/package.nix
@@ -27,6 +27,5 @@ stdenv.mkDerivation {
     description = "Experimental implementation of the C++ Networking Technical Specification";
     homepage = "https://github.com/chriskohlhoff/networking-ts-impl";
     license = licenses.boost;
-    maintainers = with maintainers; [ bhipple ];
   };
 }

--- a/pkgs/by-name/nh/nheko/package.nix
+++ b/pkgs/by-name/nh/nheko/package.nix
@@ -111,7 +111,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.gpl3Plus;
     mainProgram = "nheko";
     maintainers = with maintainers; [
-      ekleog
       fpletz
       rebmit
       rnhmjoj

--- a/pkgs/by-name/nn/nnn/package.nix
+++ b/pkgs/by-name/nn/nnn/package.nix
@@ -99,7 +99,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/jarun/nnn/blob/v${finalAttrs.version}/CHANGELOG";
     license = lib.licenses.bsd2;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ Br1ght0ne ];
     mainProgram = "nnn";
   };
 })

--- a/pkgs/by-name/ny/nylon/package.nix
+++ b/pkgs/by-name/ny/nylon/package.nix
@@ -33,7 +33,6 @@ stdenv.mkDerivation rec {
     homepage = "http://monkey.org/~marius/nylon";
     description = "Proxy server, supporting SOCKS 4 and 5, as well as a mirror mode";
     license = licenses.bsdOriginal;
-    maintainers = with maintainers; [ edwtjo ];
     platforms = platforms.linux;
     mainProgram = "nylon";
   };

--- a/pkgs/by-name/oh/oh-my-zsh/package.nix
+++ b/pkgs/by-name/oh/oh-my-zsh/package.nix
@@ -130,6 +130,5 @@ stdenv.mkDerivation rec {
     homepage = "https://ohmyz.sh/";
     license = licenses.mit;
     platforms = platforms.all;
-    maintainers = with maintainers; [ nequissimus ];
   };
 }

--- a/pkgs/by-name/on/oneDNN/package.nix
+++ b/pkgs/by-name/on/oneDNN/package.nix
@@ -47,7 +47,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "oneAPI Deep Neural Network Library (oneDNN)";
     homepage = "https://01.org/oneDNN";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ bhipple ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/on/onefetch/package.nix
+++ b/pkgs/by-name/on/onefetch/package.nix
@@ -70,7 +70,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/o2sh/onefetch/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      Br1ght0ne
       kloenk
     ];
     mainProgram = "onefetch";

--- a/pkgs/by-name/op/opensmtpd/package.nix
+++ b/pkgs/by-name/op/opensmtpd/package.nix
@@ -81,7 +81,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     maintainers = with maintainers; [
       obadz
-      ekleog
       vifino
     ];
   };

--- a/pkgs/by-name/oq/oq/package.nix
+++ b/pkgs/by-name/oq/oq/package.nix
@@ -42,7 +42,6 @@ crystal.buildCrystalPackage rec {
     mainProgram = "oq";
     homepage = "https://blacksmoke16.github.io/oq/";
     license = licenses.mit;
-    maintainers = with maintainers; [ Br1ght0ne ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/os/osm-gps-map/package.nix
+++ b/pkgs/by-name/os/osm-gps-map/package.nix
@@ -73,7 +73,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "GTK widget for displaying OpenStreetMap tiles";
     homepage = "https://nzjrs.github.io/osm-gps-map";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ hrdinka ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })

--- a/pkgs/by-name/ov/overcommit/package.nix
+++ b/pkgs/by-name/ov/overcommit/package.nix
@@ -34,7 +34,6 @@ bundlerApp {
     license = licenses.mit;
     mainProgram = "overcommit";
     maintainers = with maintainers; [
-      Br1ght0ne
       anthonyroussel
     ];
     platforms = platforms.unix;

--- a/pkgs/by-name/pc/pcsx2/package.nix
+++ b/pkgs/by-name/pc/pcsx2/package.nix
@@ -160,7 +160,6 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     mainProgram = "pcsx2-qt";
     maintainers = with lib.maintainers; [
       _0david0mp
-      hrdinka
       govanify
       matteopacini
     ];

--- a/pkgs/by-name/pg/pg_flame/package.nix
+++ b/pkgs/by-name/pg/pg_flame/package.nix
@@ -21,7 +21,6 @@ buildGoModule rec {
     description = "Flamegraph generator for Postgres EXPLAIN ANALYZE output";
     homepage = "https://github.com/mgartner/pg_flame";
     license = licenses.asl20;
-    maintainers = with maintainers; [ Br1ght0ne ];
     mainProgram = "pg_flame";
   };
 }

--- a/pkgs/by-name/po/poezio/package.nix
+++ b/pkgs/by-name/po/poezio/package.nix
@@ -53,6 +53,5 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://poez.io";
     changelog = "https://codeberg.org/poezio/poezio/src/tag/v${version}/CHANGELOG";
     license = lib.licenses.zlib;
-    maintainers = with lib.maintainers; [ lsix ];
   };
 }

--- a/pkgs/by-name/po/polybar/package.nix
+++ b/pkgs/by-name/po/polybar/package.nix
@@ -116,7 +116,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.mit;
     maintainers = with maintainers; [
       afldcr
-      Br1ght0ne
       moni
     ];
     mainProgram = "polybar";

--- a/pkgs/by-name/pr/procs/package.nix
+++ b/pkgs/by-name/pr/procs/package.nix
@@ -43,7 +43,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/dalance/procs/raw/v${version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      Br1ght0ne
       sciencentistguy
     ];
     mainProgram = "procs";

--- a/pkgs/by-name/pr/properties-cpp/package.nix
+++ b/pkgs/by-name/pr/properties-cpp/package.nix
@@ -51,7 +51,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://gitlab.com/ubports/development/core/lib-cpp/properties-cpp";
     description = "Very simple convenience library for handling properties and signals in C++11";
     license = licenses.lgpl3Only;
-    maintainers = with maintainers; [ edwtjo ];
     platforms = platforms.linux;
     pkgConfigModules = [
       "properties-cpp"

--- a/pkgs/by-name/py/pyenv/package.nix
+++ b/pkgs/by-name/py/pyenv/package.nix
@@ -48,7 +48,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/pyenv/pyenv";
     changelog = "https://github.com/pyenv/pyenv/blob/${src.rev}/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ tjni ];
     platforms = platforms.all;
     mainProgram = "pyenv";
   };

--- a/pkgs/by-name/qm/qmk-udev-rules/package.nix
+++ b/pkgs/by-name/qm/qmk-udev-rules/package.nix
@@ -40,6 +40,5 @@ stdenv.mkDerivation rec {
     description = "Official QMK udev rules list";
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl2Only;
-    maintainers = with lib.maintainers; [ ekleog ];
   };
 }

--- a/pkgs/by-name/qm/qmk/package.nix
+++ b/pkgs/by-name/qm/qmk/package.nix
@@ -77,9 +77,7 @@ python3.pkgs.buildPythonApplication rec {
       - ... and many more!
     '';
     license = licenses.mit;
-    maintainers = with maintainers; [
-      ekleog
-    ];
+    maintainers = [ ];
     mainProgram = "qmk";
   };
 }

--- a/pkgs/by-name/qm/qmk/package.nix
+++ b/pkgs/by-name/qm/qmk/package.nix
@@ -78,7 +78,6 @@ python3.pkgs.buildPythonApplication rec {
     '';
     license = licenses.mit;
     maintainers = with maintainers; [
-      bhipple
       ekleog
     ];
     mainProgram = "qmk";

--- a/pkgs/by-name/qp/qperf/package.nix
+++ b/pkgs/by-name/qp/qperf/package.nix
@@ -53,6 +53,5 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/linux-rdma/qperf";
     license = licenses.gpl2Only;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ edwtjo ];
   };
 }

--- a/pkgs/by-name/qt/qtpass/package.nix
+++ b/pkgs/by-name/qt/qtpass/package.nix
@@ -77,7 +77,6 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "qtpass";
     homepage = "https://qtpass.org";
     license = lib.licenses.gpl3;
-    maintainers = [ lib.maintainers.hrdinka ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/qu/quickfix/package.nix
+++ b/pkgs/by-name/qu/quickfix/package.nix
@@ -54,7 +54,6 @@ stdenv.mkDerivation rec {
     description = "C++ Fix Engine Library";
     homepage = "http://www.quickfixengine.org";
     license = licenses.free; # similar to BSD 4-clause
-    maintainers = with maintainers; [ bhipple ];
     broken = stdenv.hostPlatform.isAarch64;
   };
 }

--- a/pkgs/by-name/qu/qutebrowser/package.nix
+++ b/pkgs/by-name/qu/qutebrowser/package.nix
@@ -168,7 +168,6 @@ python3.pkgs.buildPythonApplication {
     mainProgram = "qutebrowser";
     platforms = if enableWideVine then [ "x86_64-linux" ] else qt6Packages.qtwebengine.meta.platforms;
     maintainers = with lib.maintainers; [
-      jagajaga
       rnhmjoj
       ebzzry
       dotlambda

--- a/pkgs/by-name/ra/radarr/package.nix
+++ b/pkgs/by-name/ra/radarr/package.nix
@@ -194,7 +194,6 @@ buildDotnetModule {
     changelog = "https://github.com/Radarr/Radarr/releases/tag/v${version}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
-      edwtjo
       purcell
       nyanloutre
     ];

--- a/pkgs/by-name/re/redsocks/package.nix
+++ b/pkgs/by-name/re/redsocks/package.nix
@@ -28,7 +28,6 @@ stdenv.mkDerivation rec {
     description = "Transparent redirector of any TCP connection to proxy";
     homepage = "https://darkk.net.ru/redsocks/";
     license = lib.licenses.asl20;
-    maintainers = [ lib.maintainers.ekleog ];
     platforms = lib.platforms.linux;
     mainProgram = "redsocks";
   };

--- a/pkgs/by-name/re/retrofe/package.nix
+++ b/pkgs/by-name/re/retrofe/package.nix
@@ -106,7 +106,6 @@ stdenv.mkDerivation {
     description = "Frontend for arcade cabinets and media PCs";
     homepage = "http://retrofe.nl/";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ hrdinka ];
     platforms = with platforms; linux;
   };
 }

--- a/pkgs/by-name/ri/rink/package.nix
+++ b/pkgs/by-name/ri/rink/package.nix
@@ -64,7 +64,6 @@ rustPlatform.buildRustPackage rec {
     ];
     maintainers = with maintainers; [
       sb0
-      Br1ght0ne
     ];
   };
 }

--- a/pkgs/by-name/rq/rq/package.nix
+++ b/pkgs/by-name/rq/rq/package.nix
@@ -47,6 +47,5 @@ rustPlatform.buildRustPackage (finalAttrs: {
     mainProgram = "rq";
     homepage = "https://github.com/dflemstr/rq";
     license = with lib.licenses; [ asl20 ];
-    maintainers = with lib.maintainers; [ Br1ght0ne ];
   };
 })

--- a/pkgs/by-name/rs/rss2email/package.nix
+++ b/pkgs/by-name/rs/rss2email/package.nix
@@ -75,7 +75,6 @@ python3Packages.buildPythonApplication rec {
     description = "Tool that converts RSS/Atom newsfeeds to email";
     homepage = "https://pypi.python.org/pypi/rss2email";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ ekleog ];
     mainProgram = "r2e";
   };
   passthru.tests = {

--- a/pkgs/by-name/ru/run/package.nix
+++ b/pkgs/by-name/ru/run/package.nix
@@ -25,7 +25,6 @@ buildGoModule rec {
     license = licenses.mit;
     maintainers = with maintainers; [
       rawkode
-      Br1ght0ne
     ];
   };
 }

--- a/pkgs/by-name/ru/ruplacer/package.nix
+++ b/pkgs/by-name/ru/ruplacer/package.nix
@@ -22,6 +22,5 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "ruplacer";
     homepage = "https://github.com/TankerHQ/ruplacer";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ Br1ght0ne ];
   };
 }

--- a/pkgs/by-name/ru/rustdesk-server/package.nix
+++ b/pkgs/by-name/ru/rustdesk-server/package.nix
@@ -50,7 +50,6 @@ rustPlatform.buildRustPackage rec {
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [
       gaelreyrol
-      tjni
     ];
   };
 }

--- a/pkgs/by-name/rx/rx/package.nix
+++ b/pkgs/by-name/rx/rx/package.nix
@@ -58,7 +58,6 @@ rustPlatform.buildRustPackage rec {
     license = licenses.gpl3;
     maintainers = with maintainers; [
       minijackson
-      Br1ght0ne
     ];
     platforms = [ "x86_64-linux" ];
   };

--- a/pkgs/by-name/s4/s4cmd/package.nix
+++ b/pkgs/by-name/s4/s4cmd/package.nix
@@ -42,6 +42,5 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://github.com/bloomreach/s4cmd";
     description = "Super S3 command line tool";
     license = licenses.asl20;
-    maintainers = [ maintainers.bhipple ];
   };
 }

--- a/pkgs/by-name/sb/sbt-extras/package.nix
+++ b/pkgs/by-name/sb/sbt-extras/package.nix
@@ -87,7 +87,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/paulp/sbt-extras";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
-      nequissimus
       puffnfresh
     ];
     mainProgram = "sbt";

--- a/pkgs/by-name/sc/scc/package.nix
+++ b/pkgs/by-name/sc/scc/package.nix
@@ -24,7 +24,6 @@ buildGoModule rec {
     description = "Very fast accurate code counter with complexity calculations and COCOMO estimates written in pure Go";
     maintainers = with maintainers; [
       sigma
-      Br1ght0ne
     ];
     license = with licenses; [
       mit

--- a/pkgs/by-name/sc/scs/package.nix
+++ b/pkgs/by-name/sc/scs/package.nix
@@ -67,6 +67,5 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/cvxgrp/scs/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ bhipple ];
   };
 })

--- a/pkgs/by-name/sd/sd/package.nix
+++ b/pkgs/by-name/sd/sd/package.nix
@@ -34,7 +34,6 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       amar1729
-      Br1ght0ne
     ];
   };
 }

--- a/pkgs/by-name/sl/slurm/package.nix
+++ b/pkgs/by-name/sl/slurm/package.nix
@@ -152,7 +152,6 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [
-      jagajaga
       markuskowa
     ];
   };

--- a/pkgs/by-name/so/sozu/package.nix
+++ b/pkgs/by-name/so/sozu/package.nix
@@ -41,7 +41,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/sozu-proxy/sozu/releases/tag/${version}";
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [
-      Br1ght0ne
       gaelreyrol
     ];
     mainProgram = "sozu";

--- a/pkgs/by-name/sp/spaceFM/package.nix
+++ b/pkgs/by-name/sp/spaceFM/package.nix
@@ -97,7 +97,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [
-      jagajaga
       obadz
     ];
   };

--- a/pkgs/by-name/sp/spotifyd/package.nix
+++ b/pkgs/by-name/sp/spotifyd/package.nix
@@ -79,7 +79,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       anderslundstedt
-      Br1ght0ne
       getchoo
     ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/sr/srm/package.nix
+++ b/pkgs/by-name/sr/srm/package.nix
@@ -28,7 +28,6 @@ stdenv.mkDerivation {
     '';
     homepage = "https://srm.sourceforge.net";
     license = licenses.mit;
-    maintainers = with maintainers; [ edwtjo ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/st/starship/package.nix
+++ b/pkgs/by-name/st/starship/package.nix
@@ -63,7 +63,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = lib.licenses.isc;
     maintainers = with lib.maintainers; [
       danth
-      Br1ght0ne
       Frostman
       da157
       sigmasquadron

--- a/pkgs/by-name/st/steam-unwrapped/package.nix
+++ b/pkgs/by-name/st/steam-unwrapped/package.nix
@@ -52,7 +52,6 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://store.steampowered.com/";
     license = lib.licenses.unfreeRedistributable;
-    maintainers = with lib.maintainers; [ jagajaga ];
     teams = with lib.teams; [ steam ];
     mainProgram = "steam";
   };

--- a/pkgs/by-name/st/storcli2/package.nix
+++ b/pkgs/by-name/st/storcli2/package.nix
@@ -62,7 +62,6 @@ stdenvNoCC.mkDerivation (
       description = "Storage Command Line Tool";
       sourceProvenance = with sourceTypes; [ binaryNativeCode ];
       license = licenses.unfree;
-      maintainers = with maintainers; [ edwtjo ];
       mainProgram = "storcli2";
       platforms = [
         "x86_64-linux"

--- a/pkgs/by-name/st/storm/package.nix
+++ b/pkgs/by-name/st/storm/package.nix
@@ -80,7 +80,6 @@ stdenv.mkDerivation (finalAttrs: {
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.asl20;
     maintainers = with maintainers; [
-      edwtjo
       vizanto
     ];
     platforms = with platforms; unix;

--- a/pkgs/by-name/su/subfinder/package.nix
+++ b/pkgs/by-name/su/subfinder/package.nix
@@ -43,7 +43,6 @@ buildGoModule rec {
     license = licenses.mit;
     maintainers = with maintainers; [
       fpletz
-      Br1ght0ne
       Misaka13514
     ];
     mainProgram = "subfinder";

--- a/pkgs/by-name/ta/taoup/package.nix
+++ b/pkgs/by-name/ta/taoup/package.nix
@@ -73,6 +73,5 @@ stdenv.mkDerivation rec {
     description = "Tao of Unix Programming (Ruby-powered ANSI colored fortunes)";
     homepage = "https://github.com/globalcitizen/taoup";
     license = lib.licenses.gpl3Only;
-    maintainers = [ lib.maintainers.zakame ];
   };
 }

--- a/pkgs/by-name/te/termius/package.nix
+++ b/pkgs/by-name/te/termius/package.nix
@@ -116,7 +116,6 @@ stdenv.mkDerivation rec {
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     maintainers = with maintainers; [
-      Br1ght0ne
       th0rgal
       Rishik-Y
     ];

--- a/pkgs/by-name/th/thicket/package.nix
+++ b/pkgs/by-name/th/thicket/package.nix
@@ -26,7 +26,6 @@ crystal.buildCrystalPackage rec {
     description = "Better one-line git log";
     homepage = "https://github.com/taylorthurlow/thicket";
     license = licenses.mit;
-    maintainers = with maintainers; [ Br1ght0ne ];
     mainProgram = "thicket";
   };
 }

--- a/pkgs/by-name/ti/tiny/package.nix
+++ b/pkgs/by-name/ti/tiny/package.nix
@@ -35,9 +35,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/osa1/tiny";
     changelog = "https://github.com/osa1/tiny/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [
-      Br1ght0ne
-    ];
+    maintainers = [ ];
     mainProgram = "tiny";
   };
 }

--- a/pkgs/by-name/tm/tmatrix/package.nix
+++ b/pkgs/by-name/tm/tmatrix/package.nix
@@ -39,7 +39,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/M4444/TMatrix";
     license = licenses.gpl2;
     platforms = platforms.all;
-    maintainers = with maintainers; [ Br1ght0ne ];
     mainProgram = "tmatrix";
   };
 }

--- a/pkgs/by-name/ts/tsocks/package.nix
+++ b/pkgs/by-name/ts/tsocks/package.nix
@@ -39,7 +39,6 @@ stdenv.mkDerivation rec {
     mainProgram = "tsocks";
     homepage = "https://tsocks.sourceforge.net/";
     license = lib.licenses.gpl2;
-    maintainers = with maintainers; [ edwtjo ];
     platforms = platforms.unix;
     broken = stdenv.hostPlatform.isDarwin;
   };

--- a/pkgs/by-name/tu/tuir/package.nix
+++ b/pkgs/by-name/tu/tuir/package.nix
@@ -55,7 +55,6 @@ buildPythonApplication rec {
     homepage = "https://gitlab.com/Chocimier/tuir";
     license = licenses.mit;
     maintainers = with maintainers; [
-      Br1ght0ne
       matthiasbeyer
       brokenpip3
     ];

--- a/pkgs/by-name/tu/tunnelto/package.nix
+++ b/pkgs/by-name/tu/tunnelto/package.nix
@@ -27,6 +27,5 @@ rustPlatform.buildRustPackage {
     description = "Expose your local web server to the internet with a public URL";
     homepage = "https://tunnelto.dev";
     license = licenses.mit;
-    maintainers = with maintainers; [ Br1ght0ne ];
   };
 }

--- a/pkgs/by-name/ty/tydra/package.nix
+++ b/pkgs/by-name/ty/tydra/package.nix
@@ -34,7 +34,6 @@ rustPlatform.buildRustPackage rec {
     description = "Shortcut menu-based task runner, inspired by Emacs Hydra";
     homepage = "https://github.com/Mange/tydra";
     license = licenses.mit;
-    maintainers = with maintainers; [ Br1ght0ne ];
     mainProgram = "tydra";
   };
 }

--- a/pkgs/by-name/vi/viber/package.nix
+++ b/pkgs/by-name/vi/viber/package.nix
@@ -196,6 +196,5 @@ stdenv.mkDerivation (finalAttrs: {
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
     platforms = [ "x86_64-linux" ];
-    maintainers = with lib.maintainers; [ jagajaga ];
   };
 })

--- a/pkgs/by-name/vt/vtable-dumper/package.nix
+++ b/pkgs/by-name/vt/vtable-dumper/package.nix
@@ -24,7 +24,6 @@ stdenv.mkDerivation rec {
     description = "Tool to list content of virtual tables in a C++ shared library";
     mainProgram = "vtable-dumper";
     license = licenses.lgpl21;
-    maintainers = [ maintainers.bhipple ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/by-name/vu/vultr-cli/package.nix
+++ b/pkgs/by-name/vu/vultr-cli/package.nix
@@ -38,7 +38,6 @@ buildGoModule rec {
     homepage = "https://github.com/vultr/vultr-cli";
     changelog = "https://github.com/vultr/vultr-cli/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ Br1ght0ne ];
     mainProgram = "vultr-cli";
   };
 }

--- a/pkgs/by-name/wa/wabt/package.nix
+++ b/pkgs/by-name/wa/wabt/package.nix
@@ -42,7 +42,6 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://github.com/WebAssembly/wabt";
     license = licenses.asl20;
-    maintainers = with maintainers; [ ekleog ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/wa/wasmer/package.nix
+++ b/pkgs/by-name/wa/wasmer/package.nix
@@ -68,7 +68,6 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.mit;
     platforms = with lib.platforms; linux ++ darwin;
     maintainers = with lib.maintainers; [
-      Br1ght0ne
       shamilton
       nickcao
     ];

--- a/pkgs/by-name/we/websocat/package.nix
+++ b/pkgs/by-name/we/websocat/package.nix
@@ -70,7 +70,6 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       thoughtpolice
-      Br1ght0ne
     ];
     mainProgram = "websocat";
   };

--- a/pkgs/by-name/wo/woff2/package.nix
+++ b/pkgs/by-name/wo/woff2/package.nix
@@ -58,7 +58,6 @@ stdenv.mkDerivation rec {
     description = "Webfont compression reference code";
     homepage = "https://github.com/google/woff2";
     license = licenses.mit;
-    maintainers = [ maintainers.hrdinka ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/wr/wrangler_1/package.nix
+++ b/pkgs/by-name/wr/wrangler_1/package.nix
@@ -45,6 +45,5 @@ rustPlatform.buildRustPackage rec {
       asl20 # or
       mit
     ];
-    maintainers = with maintainers; [ Br1ght0ne ];
   };
 }

--- a/pkgs/by-name/x1/x11basic/package.nix
+++ b/pkgs/by-name/x1/x11basic/package.nix
@@ -62,7 +62,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://x11-basic.codeberg.page";
     description = "Basic interpreter and compiler with graphics capabilities";
     license = lib.licenses.gpl2Only;
-    maintainers = with lib.maintainers; [ edwtjo ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/xa/xalanc/package.nix
+++ b/pkgs/by-name/xa/xalanc/package.nix
@@ -44,6 +44,5 @@ stdenv.mkDerivation {
     mainProgram = "Xalan";
     license = lib.licenses.asl20;
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
-    maintainers = [ lib.maintainers.jagajaga ];
   };
 }

--- a/pkgs/by-name/xc/xcaddy/package.nix
+++ b/pkgs/by-name/xc/xcaddy/package.nix
@@ -35,8 +35,5 @@ buildGoModule rec {
     description = "Build Caddy with plugins";
     mainProgram = "xcaddy";
     license = licenses.asl20;
-    maintainers = with maintainers; [
-      tjni
-    ];
   };
 }

--- a/pkgs/by-name/xk/xkblayout-state/package.nix
+++ b/pkgs/by-name/xk/xkblayout-state/package.nix
@@ -27,7 +27,6 @@ stdenv.mkDerivation rec {
     description = "Small command-line program to get/set the current XKB keyboard layout";
     homepage = "https://github.com/nonpop/xkblayout-state";
     license = licenses.gpl2;
-    maintainers = [ maintainers.jagajaga ];
     platforms = platforms.linux;
     mainProgram = "xkblayout-state";
   };

--- a/pkgs/by-name/xm/xml-security-c/package.nix
+++ b/pkgs/by-name/xm/xml-security-c/package.nix
@@ -41,6 +41,5 @@ stdenv.mkDerivation (finalAttrs: {
     description = "C++ Implementation of W3C security standards for XML";
     license = lib.licenses.asl20;
     platforms = lib.platforms.unix;
-    maintainers = [ lib.maintainers.jagajaga ];
   };
 })

--- a/pkgs/by-name/xt/xterm/package.nix
+++ b/pkgs/by-name/xt/xterm/package.nix
@@ -113,7 +113,6 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://invisible-island.net/xterm";
     license = with lib.licenses; [ mit ];
-    maintainers = with lib.maintainers; [ nequissimus ];
     platforms = with lib.platforms; linux ++ darwin;
     changelog = "https://invisible-island.net/xterm/xterm.log.html";
     mainProgram = "xterm";

--- a/pkgs/by-name/ya/yandex-disk/package.nix
+++ b/pkgs/by-name/ya/yandex-disk/package.nix
@@ -71,7 +71,6 @@ stdenv.mkDerivation rec {
     description = "Free cloud file storage service";
     maintainers = with lib.maintainers; [
       smironov
-      jagajaga
     ];
     platforms = [
       "i686-linux"

--- a/pkgs/development/compilers/jetbrains-jdk/17.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/17.nix
@@ -162,7 +162,7 @@ openjdk17.overrideAttrs (oldAttrs: rec {
   ]
   ++ oldAttrs.nativeBuildInputs;
 
-  meta = with lib; {
+  meta = {
     description = "OpenJDK fork which better supports Jetbrains's products";
     longDescription = ''
       JetBrains Runtime is a runtime environment for running IntelliJ Platform
@@ -176,7 +176,6 @@ openjdk17.overrideAttrs (oldAttrs: rec {
     '';
     homepage = "https://confluence.jetbrains.com/display/JBR/JetBrains+Runtime";
     inherit (openjdk17.meta) license platforms mainProgram;
-    maintainers = with maintainers; [ edwtjo ];
 
     broken = stdenv.hostPlatform.isDarwin;
   };

--- a/pkgs/development/compilers/jetbrains-jdk/default.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/default.nix
@@ -198,7 +198,6 @@ jdk.overrideAttrs (oldAttrs: rec {
     homepage = "https://confluence.jetbrains.com/display/JBR/JetBrains+Runtime";
     inherit (jdk.meta) license platforms mainProgram;
     maintainers = with maintainers; [
-      edwtjo
       aoli-al
     ];
 

--- a/pkgs/development/compilers/openjdk/generic.nix
+++ b/pkgs/development/compilers/openjdk/generic.nix
@@ -606,7 +606,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://openjdk.java.net/";
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [
-      edwtjo
       infinidoge
     ];
     teams = [ lib.teams.java ];

--- a/pkgs/development/compilers/scala/2.x.nix
+++ b/pkgs/development/compilers/scala/2.x.nix
@@ -113,7 +113,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
     branch = versions.majorMinor version;
     maintainers = with maintainers; [
-      nequissimus
       kashw2
     ];
   };

--- a/pkgs/development/libraries/hyphen/default.nix
+++ b/pkgs/development/libraries/hyphen/default.nix
@@ -50,6 +50,5 @@ stdenv.mkDerivation rec {
       lgpl21
       mpl11
     ];
-    maintainers = with maintainers; [ Br1ght0ne ];
   };
 }

--- a/pkgs/development/libraries/libcommuni/default.nix
+++ b/pkgs/development/libraries/libcommuni/default.nix
@@ -61,6 +61,5 @@ stdenv.mkDerivation rec {
     homepage = "https://communi.github.io";
     license = licenses.bsd3;
     platforms = platforms.all;
-    maintainers = with maintainers; [ hrdinka ];
   };
 }

--- a/pkgs/development/python-modules/algebraic-data-types/default.nix
+++ b/pkgs/development/python-modules/algebraic-data-types/default.nix
@@ -39,6 +39,5 @@ buildPythonPackage rec {
     description = "Algebraic data types for Python";
     homepage = "https://github.com/jspahrsummers/adt";
     license = licenses.mit;
-    maintainers = with maintainers; [ uri-canva ];
   };
 }

--- a/pkgs/development/python-modules/atom/default.nix
+++ b/pkgs/development/python-modules/atom/default.nix
@@ -39,6 +39,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/nucleic/atom";
     changelog = "https://github.com/nucleic/atom/releases/tag/${version}";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ bhipple ];
   };
 }

--- a/pkgs/development/python-modules/aws-adfs/default.nix
+++ b/pkgs/development/python-modules/aws-adfs/default.nix
@@ -70,7 +70,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/venth/aws-adfs";
     changelog = "https://github.com/venth/aws-adfs/releases/tag/${src.tag}";
     license = licenses.psfl;
-    maintainers = with maintainers; [ bhipple ];
     mainProgram = "aws-adfs";
   };
 }

--- a/pkgs/development/python-modules/bitarray/default.nix
+++ b/pkgs/development/python-modules/bitarray/default.nix
@@ -33,6 +33,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/ilanschnell/bitarray";
     changelog = "https://github.com/ilanschnell/bitarray/raw/${version}/CHANGE_LOG";
     license = licenses.psfl;
-    maintainers = with maintainers; [ bhipple ];
   };
 }

--- a/pkgs/development/python-modules/click-command-tree/default.nix
+++ b/pkgs/development/python-modules/click-command-tree/default.nix
@@ -30,6 +30,5 @@ buildPythonPackage rec {
     description = "Click plugin to show the command tree of your CLI";
     homepage = "https://github.com/whwright/click-command-tree";
     license = licenses.mit;
-    maintainers = with maintainers; [ tjni ];
   };
 }

--- a/pkgs/development/python-modules/cmake/default.nix
+++ b/pkgs/development/python-modules/cmake/default.nix
@@ -35,6 +35,5 @@ buildPythonPackage {
     '';
     homepage = "https://github.com/scikit-build/cmake-python-distributions";
     license = licenses.asl20;
-    maintainers = with maintainers; [ tjni ];
   };
 }

--- a/pkgs/development/python-modules/cvxopt/default.nix
+++ b/pkgs/development/python-modules/cvxopt/default.nix
@@ -83,7 +83,6 @@ buildPythonPackage rec {
       standard library and on the strengths of Python as a high-level
       programming language.
     '';
-    maintainers = with maintainers; [ edwtjo ];
     license = licenses.gpl3Plus;
   };
 }

--- a/pkgs/development/python-modules/dbt-bigquery/default.nix
+++ b/pkgs/development/python-modules/dbt-bigquery/default.nix
@@ -61,6 +61,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/dbt-labs/dbt-bigquery";
     changelog = "https://github.com/dbt-labs/dbt-bigquery/blob/${version}/CHANGELOG.md";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ tjni ];
   };
 }

--- a/pkgs/development/python-modules/dbt-core/default.nix
+++ b/pkgs/development/python-modules/dbt-core/default.nix
@@ -124,7 +124,6 @@ buildPythonPackage rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       mausch
-      tjni
     ];
     mainProgram = "dbt";
   };

--- a/pkgs/development/python-modules/dbt-extractor/default.nix
+++ b/pkgs/development/python-modules/dbt-extractor/default.nix
@@ -45,7 +45,6 @@ buildPythonPackage rec {
     license = licenses.asl20;
     maintainers = with maintainers; [
       mausch
-      tjni
     ];
   };
 }

--- a/pkgs/development/python-modules/dbt-postgres/default.nix
+++ b/pkgs/development/python-modules/dbt-postgres/default.nix
@@ -46,6 +46,5 @@ buildPythonPackage rec {
     description = "Plugin enabling dbt to work with a Postgres database";
     homepage = "https://github.com/dbt-labs/dbt-core";
     license = licenses.asl20;
-    maintainers = with maintainers; [ tjni ];
   };
 }

--- a/pkgs/development/python-modules/dbt-redshift/default.nix
+++ b/pkgs/development/python-modules/dbt-redshift/default.nix
@@ -52,6 +52,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/dbt-labs/dbt-redshift";
     changelog = "https://github.com/dbt-labs/dbt-redshift/blob/${version}/CHANGELOG.md";
     license = licenses.asl20;
-    maintainers = with maintainers; [ tjni ];
   };
 }

--- a/pkgs/development/python-modules/dbt-snowflake/default.nix
+++ b/pkgs/development/python-modules/dbt-snowflake/default.nix
@@ -48,6 +48,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-snowflake";
     changelog = "https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-snowflake/CHANGELOG.md";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ tjni ];
   };
 }

--- a/pkgs/development/python-modules/dill/default.nix
+++ b/pkgs/development/python-modules/dill/default.nix
@@ -44,6 +44,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/uqfoundation/dill/";
     changelog = "https://github.com/uqfoundation/dill/releases/tag/dill-${version}";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ tjni ];
   };
 }

--- a/pkgs/development/python-modules/fastcache/default.nix
+++ b/pkgs/development/python-modules/fastcache/default.nix
@@ -27,6 +27,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/pbrady/fastcache";
     changelog = "https://github.com/pbrady/fastcache/blob/v${version}/CHANGELOG";
     license = licenses.mit;
-    maintainers = with maintainers; [ bhipple ];
   };
 }

--- a/pkgs/development/python-modules/fava/default.nix
+++ b/pkgs/development/python-modules/fava/default.nix
@@ -103,7 +103,6 @@ buildPythonPackage {
     changelog = "https://beancount.github.io/fava/changelog.html";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      bhipple
       prince213
       sigmanificient
     ];

--- a/pkgs/development/python-modules/hatch-fancy-pypi-readme/default.nix
+++ b/pkgs/development/python-modules/hatch-fancy-pypi-readme/default.nix
@@ -49,6 +49,5 @@ buildPythonPackage rec {
     mainProgram = "hatch-fancy-pypi-readme";
     homepage = "https://github.com/hynek/hatch-fancy-pypi-readme";
     license = licenses.mit;
-    maintainers = with maintainers; [ tjni ];
   };
 }

--- a/pkgs/development/python-modules/hjson/default.nix
+++ b/pkgs/development/python-modules/hjson/default.nix
@@ -48,7 +48,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/hjson/hjson-py";
     changelog = "https://github.com/hjson/hjson-py/releases/tag/v${version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ bhipple ];
     mainProgram = "hjson";
   };
 }

--- a/pkgs/development/python-modules/hologram/default.nix
+++ b/pkgs/development/python-modules/hologram/default.nix
@@ -53,7 +53,6 @@ buildPythonPackage rec {
     license = licenses.mit;
     maintainers = with maintainers; [
       mausch
-      tjni
     ];
   };
 }

--- a/pkgs/development/python-modules/kubernetes/default.nix
+++ b/pkgs/development/python-modules/kubernetes/default.nix
@@ -73,6 +73,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/kubernetes-client/python";
     changelog = "https://github.com/kubernetes-client/python/releases/tag/${src.tag}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ lsix ];
   };
 }

--- a/pkgs/development/python-modules/markdown-it-py/default.nix
+++ b/pkgs/development/python-modules/markdown-it-py/default.nix
@@ -87,7 +87,6 @@ buildPythonPackage rec {
     homepage = "https://markdown-it-py.readthedocs.io/";
     changelog = "https://github.com/executablebooks/markdown-it-py/blob/${src.rev}/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ bhipple ];
     mainProgram = "markdown-it";
   };
 }

--- a/pkgs/development/python-modules/mashumaro/default.nix
+++ b/pkgs/development/python-modules/mashumaro/default.nix
@@ -54,6 +54,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/Fatal1ty/mashumaro";
     changelog = "https://github.com/Fatal1ty/mashumaro/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ tjni ];
   };
 }

--- a/pkgs/development/python-modules/measurement/default.nix
+++ b/pkgs/development/python-modules/measurement/default.nix
@@ -43,6 +43,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/coddingtonbear/python-measurement";
     changelog = "https://github.com/coddingtonbear/python-measurement/releases/tag/${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ bhipple ];
   };
 }

--- a/pkgs/development/python-modules/milc/default.nix
+++ b/pkgs/development/python-modules/milc/default.nix
@@ -65,6 +65,5 @@ buildPythonPackage rec {
     mainProgram = "milc-color";
     homepage = "https://milc.clueboard.co";
     license = licenses.mit;
-    maintainers = with maintainers; [ bhipple ];
   };
 }

--- a/pkgs/development/python-modules/minimal-snowplow-tracker/default.nix
+++ b/pkgs/development/python-modules/minimal-snowplow-tracker/default.nix
@@ -32,7 +32,6 @@ buildPythonPackage rec {
     license = licenses.asl20;
     maintainers = with maintainers; [
       mausch
-      tjni
     ];
   };
 }

--- a/pkgs/development/python-modules/mkl-service/default.nix
+++ b/pkgs/development/python-modules/mkl-service/default.nix
@@ -47,6 +47,5 @@ buildPythonPackage rec {
     description = "Python hooks for Intel(R) Math Kernel Library runtime control settings";
     homepage = "https://github.com/IntelPython/mkl-service";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ bhipple ];
   };
 }

--- a/pkgs/development/python-modules/myfitnesspal/default.nix
+++ b/pkgs/development/python-modules/myfitnesspal/default.nix
@@ -76,6 +76,5 @@ buildPythonPackage rec {
     mainProgram = "myfitnesspal";
     homepage = "https://github.com/coddingtonbear/python-myfitnesspal";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ bhipple ];
   };
 }

--- a/pkgs/development/python-modules/ninja/default.nix
+++ b/pkgs/development/python-modules/ninja/default.nix
@@ -45,7 +45,6 @@ buildPythonPackage {
     license = licenses.asl20;
     maintainers = with maintainers; [
       _999eagle
-      tjni
     ];
   };
 }

--- a/pkgs/development/python-modules/oldest-supported-numpy/default.nix
+++ b/pkgs/development/python-modules/oldest-supported-numpy/default.nix
@@ -35,6 +35,5 @@ buildPythonPackage rec {
     description = "Meta-package providing the oldest supported Numpy for a given Python version and platform";
     homepage = "https://github.com/scipy/oldest-supported-numpy";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ tjni ];
   };
 }

--- a/pkgs/development/python-modules/onetimepass/default.nix
+++ b/pkgs/development/python-modules/onetimepass/default.nix
@@ -39,6 +39,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/tadeck/onetimepass";
     changelog = "https://github.com/tadeck/onetimepass/releases/tag/v${version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ zakame ];
   };
 }

--- a/pkgs/development/python-modules/phx-class-registry/default.nix
+++ b/pkgs/development/python-modules/phx-class-registry/default.nix
@@ -28,8 +28,6 @@ buildPythonPackage rec {
     description = "Factory and registry pattern for Python classes";
     homepage = "https://class-registry.readthedocs.io/en/latest/";
     license = licenses.mit;
-    maintainers = with maintainers; [
-      hrdinka
-    ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/plaid-python/default.nix
+++ b/pkgs/development/python-modules/plaid-python/default.nix
@@ -40,6 +40,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/plaid/plaid-python";
     changelog = "https://github.com/plaid/plaid-python/blob/master/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ bhipple ];
   };
 }

--- a/pkgs/development/python-modules/protobuf3-to-dict/default.nix
+++ b/pkgs/development/python-modules/protobuf3-to-dict/default.nix
@@ -29,6 +29,5 @@ buildPythonPackage rec {
     description = "Teeny Python library for creating Python dicts from protocol buffers and the reverse";
     homepage = "https://github.com/kaporzhu/protobuf-to-dict";
     license = licenses.publicDomain;
-    maintainers = with maintainers; [ nequissimus ];
   };
 }

--- a/pkgs/development/python-modules/pymumble/default.nix
+++ b/pkgs/development/python-modules/pymumble/default.nix
@@ -49,7 +49,6 @@ buildPythonPackage {
     license = licenses.gpl3Only;
     maintainers = with maintainers; [
       thelegy
-      tjni
     ];
   };
 }

--- a/pkgs/development/python-modules/pyparted/default.nix
+++ b/pkgs/development/python-modules/pyparted/default.nix
@@ -50,6 +50,5 @@ buildPythonPackage rec {
     description = "Python interface for libparted";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ lsix ];
   };
 }

--- a/pkgs/development/python-modules/pyproj/default.nix
+++ b/pkgs/development/python-modules/pyproj/default.nix
@@ -103,7 +103,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/pyproj4/pyproj/blob/${src.rev}/docs/history.rst";
     license = licenses.mit;
     maintainers = with maintainers; [
-      lsix
       dotlambda
     ];
     teams = [ teams.geospatial ];

--- a/pkgs/development/python-modules/pyslurm/default.nix
+++ b/pkgs/development/python-modules/pyslurm/default.nix
@@ -41,7 +41,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/PySlurm/pyslurm";
     description = "Python bindings to Slurm";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ bhipple ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/pytest-ansible/default.nix
+++ b/pkgs/development/python-modules/pytest-ansible/default.nix
@@ -98,7 +98,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/ansible-community/pytest-ansible/releases/tag/${src.tag}";
     license = licenses.mit;
     maintainers = with maintainers; [
-      tjni
       robsliwi
     ];
   };

--- a/pkgs/development/python-modules/pytest/7.nix
+++ b/pkgs/development/python-modules/pytest/7.nix
@@ -109,7 +109,6 @@ let
       maintainers = with maintainers; [
         lovek323
         madjar
-        lsix
       ];
       license = licenses.mit;
     };

--- a/pkgs/development/python-modules/python-binance/default.nix
+++ b/pkgs/development/python-modules/python-binance/default.nix
@@ -85,6 +85,5 @@ buildPythonPackage rec {
     description = "Binance Exchange API python implementation for automated trading";
     homepage = "https://github.com/sammchardy/python-binance";
     license = licenses.mit;
-    maintainers = with maintainers; [ bhipple ];
   };
 }

--- a/pkgs/development/python-modules/qscintilla/default.nix
+++ b/pkgs/development/python-modules/qscintilla/default.nix
@@ -85,7 +85,6 @@ pythonPackages.buildPythonPackage {
   meta = with lib; {
     description = "Python binding to QScintilla, Qt based text editing control";
     license = licenses.lgpl21Plus;
-    maintainers = with maintainers; [ lsix ];
     homepage = "https://www.riverbankcomputing.com/software/qscintilla/";
   };
 }

--- a/pkgs/development/python-modules/repeated-test/default.nix
+++ b/pkgs/development/python-modules/repeated-test/default.nix
@@ -31,6 +31,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/epsy/repeated_test";
     changelog = "https://github.com/epsy/repeated_test/releases/tag/v${version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ tjni ];
   };
 }

--- a/pkgs/development/python-modules/sagemaker/default.nix
+++ b/pkgs/development/python-modules/sagemaker/default.nix
@@ -118,6 +118,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/aws/sagemaker-python-sdk/";
     changelog = "https://github.com/aws/sagemaker-python-sdk/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ nequissimus ];
   };
 }

--- a/pkgs/development/python-modules/setuptools-git-versioning/default.nix
+++ b/pkgs/development/python-modules/setuptools-git-versioning/default.nix
@@ -76,6 +76,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/dolfinus/setuptools-git-versioning";
     changelog = "https://github.com/dolfinus/setuptools-git-versioning/blob/${src.rev}/CHANGELOG.rst";
     license = licenses.mit;
-    maintainers = with maintainers; [ tjni ];
   };
 }

--- a/pkgs/development/python-modules/sharedmem/default.nix
+++ b/pkgs/development/python-modules/sharedmem/default.nix
@@ -21,7 +21,6 @@ buildPythonPackage rec {
   meta = {
     homepage = "http://rainwoodman.github.io/sharedmem/";
     description = "Easier parallel programming on shared memory computers";
-    maintainers = with lib.maintainers; [ edwtjo ];
     license = lib.licenses.gpl3;
   };
 }

--- a/pkgs/development/python-modules/smdebug-rulesconfig/default.nix
+++ b/pkgs/development/python-modules/smdebug-rulesconfig/default.nix
@@ -23,6 +23,5 @@ buildPythonPackage rec {
     description = "These builtin rules are available in Amazon SageMaker";
     homepage = "https://github.com/awslabs/sagemaker-debugger-rulesconfig";
     license = licenses.asl20;
-    maintainers = with maintainers; [ nequissimus ];
   };
 }

--- a/pkgs/development/python-modules/timecop/default.nix
+++ b/pkgs/development/python-modules/timecop/default.nix
@@ -34,6 +34,5 @@ buildPythonPackage rec {
     description = "Port of the most excellent TimeCop Ruby Gem for Python";
     homepage = "https://github.com/bluekelp/pytimecop";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ zakame ];
   };
 }

--- a/pkgs/development/python-modules/tiny-proxy/default.nix
+++ b/pkgs/development/python-modules/tiny-proxy/default.nix
@@ -35,6 +35,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/romis2012/tiny-proxy";
     changelog = "https://github.com/romis2012/tiny-proxy/releases/tag/v${version}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ tjni ];
   };
 }

--- a/pkgs/development/python-modules/ueberzug/default.nix
+++ b/pkgs/development/python-modules/ueberzug/default.nix
@@ -56,7 +56,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/ueber-devel/ueberzug/releases/tag/${version}";
     license = lib.licenses.gpl3Only;
     mainProgram = "ueberzug";
-    maintainers = with lib.maintainers; [ Br1ght0ne ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/versionfinder/default.nix
+++ b/pkgs/development/python-modules/versionfinder/default.nix
@@ -55,6 +55,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/jantman/versionfinder";
     changelog = "https://github.com/jantman/versionfinder/blob/${version}/CHANGES.rst";
     license = licenses.agpl3Plus;
-    maintainers = with maintainers; [ zakame ];
   };
 }

--- a/pkgs/development/python-modules/wtforms/default.nix
+++ b/pkgs/development/python-modules/wtforms/default.nix
@@ -57,6 +57,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/wtforms/wtforms";
     changelog = "https://github.com/wtforms/wtforms/blob/${version}/CHANGES.rst";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ bhipple ];
   };
 }

--- a/pkgs/development/python-modules/xtensor-python/default.nix
+++ b/pkgs/development/python-modules/xtensor-python/default.nix
@@ -43,7 +43,6 @@ toPythonModule (
       homepage = "https://github.com/xtensor-stack/xtensor-python";
       description = "Python bindings for the xtensor C++ multi-dimensional array library";
       license = lib.licenses.bsd3;
-      maintainers = with lib.maintainers; [ lsix ];
     };
   })
 )

--- a/pkgs/development/python2-modules/pytest/default.nix
+++ b/pkgs/development/python2-modules/pytest/default.nix
@@ -97,7 +97,6 @@ buildPythonPackage rec {
     maintainers = with maintainers; [
       lovek323
       madjar
-      lsix
     ];
     license = licenses.mit;
     platforms = platforms.unix;

--- a/pkgs/development/tools/ammonite/default.nix
+++ b/pkgs/development/tools/ammonite/default.nix
@@ -82,7 +82,6 @@ let
         '';
         homepage = "https://github.com/com-lihaoyi/Ammonite";
         license = licenses.mit;
-        maintainers = [ maintainers.nequissimus ];
         mainProgram = "amm";
         platforms = platforms.all;
       };

--- a/pkgs/development/tools/build-managers/sbt/default.nix
+++ b/pkgs/development/tools/build-managers/sbt/default.nix
@@ -60,7 +60,6 @@ stdenv.mkDerivation (finalAttrs: {
     ];
     description = "Build tool for Scala, Java and more";
     maintainers = with maintainers; [
-      nequissimus
       kashw2
     ];
     platforms = platforms.unix;

--- a/pkgs/development/tools/misc/gdb/default.nix
+++ b/pkgs/development/tools/misc/gdb/default.nix
@@ -217,7 +217,6 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [
       pierron
       globin
-      lsix
     ];
   };
 }

--- a/pkgs/os-specific/linux/nvidia-x11/fabricmanager.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/fabricmanager.nix
@@ -59,6 +59,5 @@ stdenv.mkDerivation rec {
     license = lib.licenses.unfreeRedistributable;
     platforms = nvidia_x11.meta.platforms;
     mainProgram = "nv-fabricmanager";
-    maintainers = with lib.maintainers; [ edwtjo ];
   };
 }

--- a/pkgs/os-specific/linux/nvidia-x11/generic.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/generic.nix
@@ -340,7 +340,6 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optionals (sha256_aarch64 != null) [ "aarch64-linux" ];
     maintainers = with maintainers; [
       kiskae
-      edwtjo
     ];
     priority = 4; # resolves collision with xorg-server's "lib/xorg/modules/extensions/libglx.so"
     inherit broken;

--- a/pkgs/servers/dns/nsd/default.nix
+++ b/pkgs/servers/dns/nsd/default.nix
@@ -85,6 +85,5 @@ stdenv.mkDerivation rec {
     description = "Authoritative only, high performance, simple and open source name server";
     license = licenses.bsd3;
     platforms = platforms.unix;
-    maintainers = [ maintainers.hrdinka ];
   };
 }

--- a/pkgs/servers/jackett/default.nix
+++ b/pkgs/servers/jackett/default.nix
@@ -58,7 +58,6 @@ buildDotnetModule rec {
     changelog = "https://github.com/Jackett/Jackett/releases/tag/v${version}";
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [
-      edwtjo
       nyanloutre
       purcell
     ];

--- a/pkgs/servers/mail/system-sendmail/default.nix
+++ b/pkgs/servers/mail/system-sendmail/default.nix
@@ -41,7 +41,6 @@ stdenv.mkDerivation {
       A sendmail wrapper that calls the system sendmail. Do not install as system-wide sendmail!
     '';
     platforms = platforms.unix;
-    maintainers = with maintainers; [ ekleog ];
     mainProgram = "sendmail";
   };
 }

--- a/pkgs/shells/nushell/default.nix
+++ b/pkgs/shells/nushell/default.nix
@@ -100,7 +100,6 @@ rustPlatform.buildRustPackage {
     homepage = "https://www.nushell.sh/";
     license = licenses.mit;
     maintainers = with maintainers; [
-      Br1ght0ne
       johntitor
       joaquintrinanes
       ryan4yin

--- a/pkgs/tools/misc/opentelemetry-collector/releases.nix
+++ b/pkgs/tools/misc/opentelemetry-collector/releases.nix
@@ -136,7 +136,6 @@ let
           '';
           license = licenses.asl20;
           maintainers = with maintainers; [
-            uri-canva
             jk
             zimbatm
           ];

--- a/pkgs/tools/security/keybase/default.nix
+++ b/pkgs/tools/security/keybase/default.nix
@@ -47,7 +47,6 @@ buildGoModule rec {
       avaq
       np
       rvolosatovs
-      Br1ght0ne
       shofius
       ryand56
     ];

--- a/pkgs/tools/security/keybase/gui.nix
+++ b/pkgs/tools/security/keybase/gui.nix
@@ -142,7 +142,6 @@ stdenv.mkDerivation rec {
       rvolosatovs
       puffnfresh
       np
-      Br1ght0ne
       shofius
       ryand56
     ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1269,7 +1269,6 @@ with self;
         artistic1
         gpl1Plus
       ];
-      maintainers = [ maintainers.zakame ];
       mainProgram = "cpm";
     };
   };
@@ -5721,7 +5720,6 @@ with self;
         artistic1
         gpl1Plus
       ];
-      maintainers = [ maintainers.zakame ];
     };
   };
 
@@ -6690,7 +6688,6 @@ with self;
         artistic1
         gpl1Plus
       ];
-      maintainers = [ maintainers.zakame ];
     };
   };
 
@@ -14482,7 +14479,6 @@ with self;
         artistic1
         gpl1Plus
       ];
-      maintainers = [ maintainers.zakame ];
     };
   };
 
@@ -14505,7 +14501,6 @@ with self;
         artistic1
         gpl1Plus
       ];
-      maintainers = [ maintainers.zakame ];
     };
   };
 
@@ -17385,7 +17380,6 @@ with self;
         artistic1
         gpl1Plus
       ];
-      maintainers = [ maintainers.zakame ];
     };
   };
 
@@ -21313,7 +21307,6 @@ with self;
         artistic1
         gpl1Plus
       ];
-      maintainers = [ maintainers.zakame ];
     };
   };
 
@@ -21759,7 +21752,6 @@ with self;
         artistic1
         gpl1Plus
       ];
-      maintainers = [ maintainers.zakame ];
     };
   };
 
@@ -22856,7 +22848,6 @@ with self;
       description = "(DISCOURAGED) Promises/A+ and flow-control helpers";
       homepage = "https://github.com/jberger/Mojo-IOLoop-Delay";
       license = with lib.licenses; [ artistic2 ];
-      maintainers = [ maintainers.zakame ];
     };
   };
 
@@ -22884,7 +22875,6 @@ with self;
         artistic1
         gpl1Plus
       ];
-      maintainers = [ maintainers.zakame ];
     };
   };
 
@@ -25156,7 +25146,6 @@ with self;
         artistic1
         gpl1Plus
       ];
-      maintainers = [ maintainers.zakame ];
     };
   };
 
@@ -25237,7 +25226,6 @@ with self;
         artistic1
         gpl1Plus
       ];
-      maintainers = [ maintainers.zakame ];
     };
   };
 
@@ -26597,7 +26585,6 @@ with self;
         artistic1
         gpl1Plus
       ];
-      maintainers = [ maintainers.zakame ];
     };
   };
 
@@ -27076,7 +27063,6 @@ with self;
         artistic1
         gpl1Plus
       ];
-      maintainers = [ maintainers.zakame ];
     };
   };
 
@@ -32358,7 +32344,6 @@ with self;
         artistic1
         gpl1Plus
       ];
-      maintainers = [ maintainers.zakame ];
     };
   };
 
@@ -39100,7 +39085,6 @@ with self;
         artistic1
         gpl1Plus
       ];
-      maintainers = [ maintainers.zakame ];
     };
   };
 
@@ -39119,7 +39103,6 @@ with self;
         artistic1
         gpl1Plus
       ];
-      maintainers = [ maintainers.zakame ];
     };
   };
 


### PR DESCRIPTION
Dropping 13 maintainers who all have in common that they have not responded to (a significant number of) maintainer pings in the last 180 days. Dropping according to the maintainer guidelines in https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status.

Ping:
@bhipple @Br1ght0ne @edwtjo @Ekleog @garbas @globin @hrdinka @jagajaga @lsix @NeQuissimus @tjni @uri-canva @zakame 

You have 1 week according to the guidelines to respond to this PR by either:
- commenting your intent to stay a maintainer, please elaborate on how you intend to maintain your packages going forward
- optionally approve the PR / your approval, although this won't speed the PR overall given the number of maintainers involved

Of course, even if you miss this notification or want to return later - you are always welcome back. This is just housekeeping, to have an up2date maintainers list. Eventually.

Thank you all for all the contributions!

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
