### PR TITLE
deltatouch: 2.22.0 -> 2.25.1

### DIFF
--- a/pkgs/by-name/de/deltatouch/package.nix
+++ b/pkgs/by-name/de/deltatouch/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchFromGitea,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   intltool,
   libdeltachat,
@@ -15,42 +14,31 @@
 
 let
   libdeltachat' = libdeltachat.overrideAttrs rec {
-    version = "2.22.0";
+    version = "2.25.0";
     src = fetchFromGitHub {
       owner = "chatmail";
       repo = "core";
       tag = "v${version}";
-      hash = "sha256-DKqqdcG3C7/RF/wz2SqaiPUjZ/7vMFJTR5DIGTXjoTY=";
+      hash = "sha256-pW1+9aljtnYJmlJOj+m0aQekYO5IsL0fduR7kIAPdN8=";
     };
     cargoDeps = rustPlatform.fetchCargoVendor {
       pname = "chatmail-core";
       inherit version src;
-      hash = "sha256-x71vytk9ytIhHlRR0lDhDcIaDNJGDdPwb6fkB1SI+NQ=";
+      hash = "sha256-iIC9wE7P2SKeCMtc/hFTRaOGXD2F7kh1TptOoes/Qi0=";
     };
   };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "deltatouch";
-  version = "2.22.0";
+  version = "2.25.1";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "lk108";
     repo = "deltatouch";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-e8kS6kAjOZ2V33XJuJbvDZ9mfRknDh9un0dn5HtD3UY=";
+    hash = "sha256-0+5wZCadYHmZjp/Za0LmK7FWq9nfyhXZFAx0lGqfRK0=";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://codeberg.org/lk108/deltatouch/commit/b19c088ce95e8ca6ff1102c36d91b1db937e3a3a.patch";
-      hash = "sha256-58WPUSFaAUqVVU3iq05tae5Gvvr405zDA145V9DbJ54=";
-    })
-    (fetchpatch {
-      url = "https://codeberg.org/lk108/deltatouch/commit/139f3a4abd772b17142a7f61ef9b442200728f4a.patch";
-      hash = "sha256-bEX4g88CCt7AFok8kTeItzCripXFoG2ED7R9lGYoCAw=";
-    })
-  ];
 
   nativeBuildInputs = [
     qt5.wrapQtAppsHook


### PR DESCRIPTION
Diff: https://codeberg.org/lk108/deltatouch/compare/v2.22.0...2.25.1

Changelog: https://codeberg.org/lk108/deltatouch/src/tag/v2.25.1/CHANGELOG


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
