### PR TITLE
nixos/postgresql: add freeformType to ensureClauses option

### DIFF
--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -73,9 +73,6 @@ let
 
   generateClauseSqlStatements =
     user:
-    let
-      filteredClauses = filterAttrs (name: value: value != null) user.ensureClauses;
-    in
     mapAttrsToList (
       n: v:
       let
@@ -87,7 +84,7 @@ let
         "${directive} '${v}'"
       else
         "${directive} ${builtins.toString v}"
-    ) filteredClauses;
+    ) user.ensureClauses;
 
   generateAlterRoleSQL =
     user:
@@ -475,9 +472,6 @@ in
                   }
                 '';
                 default = { };
-                defaultText = lib.literalMD ''
-                  The default, `null`, means that the user created will have the default permissions assigned by PostgreSQL. Subsequent server starts will not set or unset the clause, so imperative changes are preserved.
-                '';
                 type = types.submodule {
                   freeformType = types.attrsOf (
                     types.oneOf [
@@ -486,135 +480,6 @@ in
                       types.bool
                     ]
                   );
-
-                  options =
-                    let
-                      defaultText = lib.literalMD ''
-                        `null`: do not set. For newly created roles, use PostgreSQL's default. For existing roles, do not touch this clause.
-                      '';
-                    in
-                    {
-                      superuser = mkOption {
-                        type = types.nullOr types.bool;
-                        description = ''
-                          Grants the user, created by the ensureUser attr, superuser permissions. From the postgres docs:
-
-                          A database superuser bypasses all permission checks,
-                          except the right to log in. This is a dangerous privilege
-                          and should not be used carelessly; it is best to do most
-                          of your work as a role that is not a superuser. To create
-                          a new database superuser, use CREATE ROLE name SUPERUSER.
-                          You must do this as a role that is already a superuser.
-
-                          More information on postgres roles can be found [here](https://www.postgresql.org/docs/current/role-attributes.html)
-                        '';
-                        default = null;
-                        inherit defaultText;
-                      };
-                      createrole = mkOption {
-                        type = types.nullOr types.bool;
-                        description = ''
-                          Grants the user, created by the ensureUser attr, createrole permissions. From the postgres docs:
-
-                          A role must be explicitly given permission to create more
-                          roles (except for superusers, since those bypass all
-                          permission checks). To create such a role, use CREATE
-                          ROLE name CREATEROLE. A role with CREATEROLE privilege
-                          can alter and drop other roles, too, as well as grant or
-                          revoke membership in them. However, to create, alter,
-                          drop, or change membership of a superuser role, superuser
-                          status is required; CREATEROLE is insufficient for that.
-
-                          More information on postgres roles can be found [here](https://www.postgresql.org/docs/current/role-attributes.html)
-                        '';
-                        default = null;
-                        inherit defaultText;
-                      };
-                      createdb = mkOption {
-                        type = types.nullOr types.bool;
-                        description = ''
-                          Grants the user, created by the ensureUser attr, createdb permissions. From the postgres docs:
-
-                          A role must be explicitly given permission to create
-                          databases (except for superusers, since those bypass all
-                          permission checks). To create such a role, use CREATE
-                          ROLE name CREATEDB.
-
-                          More information on postgres roles can be found [here](https://www.postgresql.org/docs/current/role-attributes.html)
-                        '';
-                        default = null;
-                        inherit defaultText;
-                      };
-                      "inherit" = mkOption {
-                        type = types.nullOr types.bool;
-                        description = ''
-                          Grants the user created inherit permissions. From the postgres docs:
-
-                          A role is given permission to inherit the privileges of
-                          roles it is a member of, by default. However, to create a
-                          role without the permission, use CREATE ROLE name
-                          NOINHERIT.
-
-                          More information on postgres roles can be found [here](https://www.postgresql.org/docs/current/role-attributes.html)
-                        '';
-                        default = null;
-                        inherit defaultText;
-                      };
-                      login = mkOption {
-                        type = types.nullOr types.bool;
-                        description = ''
-                          Grants the user, created by the ensureUser attr, login permissions. From the postgres docs:
-
-                          Only roles that have the LOGIN attribute can be used as
-                          the initial role name for a database connection. A role
-                          with the LOGIN attribute can be considered the same as a
-                          “database user”. To create a role with login privilege,
-                          use either:
-
-                          CREATE ROLE name LOGIN; CREATE USER name;
-
-                          (CREATE USER is equivalent to CREATE ROLE except that
-                          CREATE USER includes LOGIN by default, while CREATE ROLE
-                          does not.)
-
-                          More information on postgres roles can be found [here](https://www.postgresql.org/docs/current/role-attributes.html)
-                        '';
-                        default = null;
-                        inherit defaultText;
-                      };
-                      replication = mkOption {
-                        type = types.nullOr types.bool;
-                        description = ''
-                          Grants the user, created by the ensureUser attr, replication permissions. From the postgres docs:
-
-                          A role must explicitly be given permission to initiate
-                          streaming replication (except for superusers, since those
-                          bypass all permission checks). A role used for streaming
-                          replication must have LOGIN permission as well. To create
-                          such a role, use CREATE ROLE name REPLICATION LOGIN.
-
-                          More information on postgres roles can be found [here](https://www.postgresql.org/docs/current/role-attributes.html)
-                        '';
-                        default = null;
-                        inherit defaultText;
-                      };
-                      bypassrls = mkOption {
-                        type = types.nullOr types.bool;
-                        description = ''
-                          Grants the user, created by the ensureUser attr, replication permissions. From the postgres docs:
-
-                          A role must be explicitly given permission to bypass
-                          every row-level security (RLS) policy (except for
-                          superusers, since those bypass all permission checks). To
-                          create such a role, use CREATE ROLE name BYPASSRLS as a
-                          superuser.
-
-                          More information on postgres roles can be found [here](https://www.postgresql.org/docs/current/role-attributes.html)
-                        '';
-                        default = null;
-                        inherit defaultText;
-                      };
-                    };
                 };
               };
             };

--- a/nixos/tests/postgresql/postgresql.nix
+++ b/nixos/tests/postgresql/postgresql.nix
@@ -195,6 +195,9 @@ let
                   login = true;
                   replication = true;
                   bypassrls = true;
+                  # SCRAM-SHA-256 hashed password for "password"
+                  password = "SCRAM-SHA-256$4096:SZEJF5Si4QZ6l4fedrZZWQ==$6u3PWVcz+dts+NdpByPIjKa4CaSnoXGG3M2vpo76bVU=:WSZ0iGUCmVtKYVvNX0pFOp/60IgsdJ+90Y67Eun+QE0=";
+                  connection_limit = 5;
                 };
               }
               {
@@ -218,8 +221,10 @@ let
               "rolcreatedb,"
               "rolcanlogin,"
               "rolreplication,"
-              "rolbypassrls"
-              "FROM pg_roles"
+              "rolbypassrls,"
+              "rolconnlimit,"
+              "rolpassword"
+              "FROM pg_authid"
               "WHERE rolname = '${user}'"
               ") row;"
             ];
@@ -243,6 +248,11 @@ let
               t.assertTrue(clauses["rolcanlogin"])
               t.assertTrue(clauses["rolreplication"])
               t.assertTrue(clauses["rolbypassrls"])
+              t.assertTrue(clauses["rolconnlimit"] == 5)
+              t.assertTrue(clauses["rolpassword"])
+              machine.succeed(
+                "PGPASSWORD='password' psql -h localhost -U all-clauses -d postgres -c \"SELECT 1\""
+              )
 
           with subtest("All user permissions default when ensureClauses is not provided"):
               clauses = json.loads(
@@ -257,6 +267,8 @@ let
               t.assertTrue(clauses["rolcanlogin"])
               t.assertFalse(clauses["rolreplication"])
               t.assertFalse(clauses["rolbypassrls"])
+              t.assertFalse(clauses["rolconnlimit"] == 5)
+              t.assertFalse(clauses["rolpassword"])
 
           machine.shutdown()
         '';


### PR DESCRIPTION
This commit adds a freeform type to accomodate for new options to use with ALTER ROLE.
It also will perform extra checking and conversion for options with parameters.
Adds documented options for password and connection limit. Converts option names into upper case with space instead of underscore.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

@Ma27 @thoughtpolice @wolfgangwalther