### PR TITLE
cosmic-ext-alternative-startup: init at 0-unstable-2024-11-24; cosmic-ext-extra-sessions: init at 0-unstable-2025-04-02

### DIFF
--- a/nixos/modules/services/desktop-managers/cosmic.nix
+++ b/nixos/modules/services/desktop-managers/cosmic.nix
@@ -50,6 +50,10 @@ in
     services.desktopManager.cosmic = {
       enable = lib.mkEnableOption "COSMIC desktop environment";
 
+      extraSessions.niri.enable = lib.mkEnableOption "niri support for the COSMIC session" // {
+        default = false;
+      };
+
       showExcludedPkgsWarning = lib.mkEnableOption "the warning for excluding core packages" // {
         default = true;
       };
@@ -102,6 +106,10 @@ in
           # User may have Flatpaks enabled but might not want the `cosmic-store` package.
           cosmic-store
         ]
+        ++ lib.optionals cfg.extraSessions.niri.enable [
+          # User may be passing `cosmic-ext-alternative-startup` store path directly in their compositor config rather than relying on it being in $PATH
+          cosmic-ext-alternative-startup
+        ]
       )
     ) config.environment.cosmic.excludePackages;
 
@@ -148,7 +156,10 @@ in
     security.polkit.enable = true;
     security.rtkit.enable = true;
     services.accounts-daemon.enable = true;
-    services.displayManager.sessionPackages = [ pkgs.cosmic-session ];
+    services.displayManager.sessionPackages = [
+      pkgs.cosmic-session
+    ]
+    ++ lib.optional cfg.extraSessions.niri.enable pkgs.cosmic-ext-extra-sessions;
     services.libinput.enable = true;
     services.upower.enable = true;
     # Required for screen locker

--- a/pkgs/by-name/co/cosmic-ext-alternative-startup/package.nix
+++ b/pkgs/by-name/co/cosmic-ext-alternative-startup/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cosmic-ext-alternative-startup";
+  version = "0-unstable-2024-11-24";
+
+  src = fetchFromGitHub {
+    owner = "Drakulix";
+    repo = "cosmic-ext-alternative-startup";
+    rev = "8ceda00197c7ec0905cf1dccdc2d67d738e45417";
+    hash = "sha256-0kqn3hZ58uQMl39XXF94yQS1EWmGIK45/JFTAigg/3M=";
+  };
+
+  cargoHash = "sha256-DeMkAG2iINGden0Up013M9mWDN4QHrF+FXoNqpGB+mg=";
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  meta = {
+    mainProgram = "cosmic-ext-alternative-startup";
+    description = "Alternative entry point for cosmic-sessions compositor IPC interface";
+    homepage = "https://github.com/Drakulix/cosmic-ext-alternative-startup";
+    license = lib.licenses.gpl3;
+    maintainers = [ lib.teams.cosmic ];
+  };
+})

--- a/pkgs/by-name/co/cosmic-ext-extra-sessions/package.nix
+++ b/pkgs/by-name/co/cosmic-ext-extra-sessions/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenvNoCC,
+  nix-update-script,
+
+  systemd,
+  bash,
+  dbus,
+  cosmic-session,
+  niri,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "cosmic-ext-extra-sessions";
+  version = "0-unstable-2025-04-02";
+
+  src = fetchFromGitHub {
+    owner = "Drakulix";
+    repo = "cosmic-ext-extra-sessions";
+    rev = "66e065728d81eab86171e542dad08fb628c88494";
+    hash = "sha256-6JiWdBry63NrnmK3mt9gGSDAcyx/f6L5QsIgZSUakQI=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm0644 $src/niri/cosmic-ext-niri.desktop $out/share/wayland-sessions/cosmic-ext-niri.desktop
+    install -Dm0755 $src/niri/start-cosmic-ext-niri $out/bin/start-cosmic-ext-niri
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    substituteInPlace $out/share/wayland-sessions/cosmic-ext-niri.desktop \
+    --replace-fail "/usr/local/bin/start-cosmic-ext-niri" "$out/bin/start-cosmic-ext-niri"
+
+    substituteInPlace $out/bin/start-cosmic-ext-niri \
+    --replace-fail "systemctl" "${systemd}/bin/systemctl" \
+    --replace-fail "exec bash" "exec ${lib.getExe bash}" \
+    --replace-fail "/usr/bin/dbus-run-session" "${dbus}/bin/dbus-run-session" \
+    --replace-fail "/usr/bin/cosmic-session niri" "${lib.getExe cosmic-session} ${lib.getExe niri}"
+  '';
+
+  passthru = {
+    providedSessions = [ "cosmic-ext-niri" ];
+
+    updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+  };
+
+  meta = {
+    mainProgram = "cosmic-ext-extra-sessions";
+    description = "Inofficial session variants for cosmic-epoch";
+    homepage = "https://github.com/Drakulix/cosmic-ext-extra-sessions";
+    license = lib.licenses.gpl3;
+    maintainers = [ lib.teams.cosmic ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
