### PR TITLE
mupdf: fix build of vendored freeglut with gcc15

### DIFF
--- a/pkgs/by-name/mu/mupdf/package.nix
+++ b/pkgs/by-name/mu/mupdf/package.nix
@@ -55,7 +55,15 @@ let
       hash = "sha256-0fuE0lm9rlAaok2Qe0V1uUrgP4AjMWgp3eTbw8G6PMM=";
     };
 
-    patches = [ ];
+    patches = [
+      # Fix build with gcc15
+      # https://github.com/freeglut/freeglut/pull/187
+      (fetchpatch {
+        name = "freeglut-fix-fgPlatformDestroyContext-prototype-for-C23.patch";
+        url = "https://github.com/freeglut/freeglut/commit/800772e993a3ceffa01ccf3fca449d3279cde338.patch";
+        hash = "sha256-agXw3JHq81tx5514kkorvuU5mX4E3AV930hy1OJl4L0=";
+      })
+    ];
 
     # cmake 4 compatibility, upstream is dead
     postPatch = ''


### PR DESCRIPTION
- add patch from `freeglut` upstream to vendored fork version:
https://www.github.com/freeglut/freeglut/pull/187

Fixes build failure with gcc15:
```
/build/source/src/x11/fg_init_x11.c:348:6: error: conflicting types for
'fgPlatformDestroyContext'; have 'void(SFG_PlatformDisplay,  struct __GLXcontextRec *)'
{aka 'void(struct tagSFG_PlatformDisplay,  struct __GLXcontextRec *)'}
  348 | void fgPlatformDestroyContext ( SFG_PlatformDisplay pDisplay, SFG_WindowContextType MContext )
      |      ^~~~~~~~~~~~~~~~~~~~~~~~
In file included from /build/source/src/x11/fg_init_x11.c:34:
/build/source/src/egl/fg_init_egl.h:31:13: note: previous declaration of
'fgPlatformDestroyContext' with type 'void(void)'
   31 | extern void fgPlatformDestroyContext();
      |             ^~~~~~~~~~~~~~~~~~~~~~~~
```

---

Similar to https://github.com/NixOS/nixpkgs/pull/446347

Tested build with:
```bash
nix-build --expr 'with import ./. {}; mupdf.override { freeglut = freeglut.override { stdenv = gcc15Stdenv; }; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
