### PR TITLE
prometheus-fastcom-exporter: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -32,6 +32,8 @@
 
 - [mail-tlsa-check-exporter](https://github.com/ietf-tools/mail-tlsa-check-exporter), validates SMTP / IMAP server certificates against a TLSA record as a Prometheus exporter. Available as [services.prometheus.exporters.mail-tlsa-check](#opt-services.prometheus.exporters.mail-tlsa-check.enable).
 
+- [fastcom-exporter](https://github.com/caarlos0/fastcom-exporter), exports Fast.com speedtest results as a Prometheus exporter. Available as [services.prometheus.exporters.fastcom](#opt-services.prometheus.exporters.fastcom.enable).
+
 - [CastSponsorSkip](https://github.com/gabe565/CastSponsorSkip/), skips YouTube sponsorships (and sometimes ads) on all local Google Cast devices.
 
 - [Stump](https://www.stumpapp.dev/), a free and open source comics, manga and digital book server with OPDS support. Available as [services.stump](#opt-services.stump.enable).

--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -66,6 +66,7 @@ let
         "domain"
         "dovecot"
         "ebpf"
+        "fastcom"
         "fastly"
         "flow"
         "fritz"

--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -64,6 +64,7 @@ let
         "ebpf"
         "elasticsearch"
         "fail2ban"
+        "fastcom"
         "fastly"
         "flow"
         "fritz"

--- a/nixos/modules/services/monitoring/prometheus/exporters/fastcom.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/fastcom.nix
@@ -1,0 +1,54 @@
+{
+  config,
+  lib,
+  pkgs,
+  utils,
+  ...
+}:
+
+let
+  inherit (lib)
+    concatStringsSep
+    mkOption
+    optionalString
+    types
+    ;
+
+  cfg = config.services.prometheus.exporters.fastcom;
+in
+{
+  port = 9877;
+
+  extraOpts = with types; {
+    debug = mkOption {
+      type = bool;
+      default = false;
+      description = ''
+        Print debug information.
+      '';
+    };
+
+    refreshInterval = mkOption {
+      type = str;
+      default = "30m";
+      example = "1h";
+      description = ''
+        Refresh interval for the Fast.com speedtest. It will cache the results for the given duration.
+      '';
+    };
+  };
+
+  serviceOpts = {
+    serviceConfig = {
+      ExecStart = concatStringsSep " " (
+        [
+          "${pkgs.prometheus-fastcom-exporter}/bin/fastcom-exporter"
+          "--bind ${cfg.listenAddress}:${toString cfg.port}"
+          "--refresh.interval ${cfg.refreshInterval}"
+          (optionalString cfg.debug "--debug")
+        ]
+        ++ cfg.extraFlags
+      );
+    };
+  };
+}

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -420,10 +420,146 @@ let
         '';
       };
 
-    ebpf =
-      { ... }:
-      {
-        exporterConfig = {
+    ebpf = {
+      exporterConfig = {
+        enable = true;
+        names = [ "timers" ];
+      };
+      exporterTest = ''
+        wait_for_unit("prometheus-ebpf-exporter.service")
+        wait_for_open_port(9435)
+        succeed(
+            "curl -sSf http://localhost:9435/metrics | grep 'ebpf_exporter_enabled_configs{name=\"timers\"} 1'"
+        )
+      '';
+    };
+
+    fastcom = {
+      exporterConfig = {
+        enable = true;
+        debug = true;
+        refreshInterval = "1h";
+      };
+
+      exporterTest = ''
+        wait_for_unit("prometheus-fastcom-exporter.service")
+        wait_for_open_port(9877)
+        succeed("curl -sSf http://localhost:9877")
+      '';
+    };
+
+    fastly = {
+      exporterConfig = {
+        enable = true;
+        environmentFile = pkgs.writeText "fastly-exporter-env" "FASTLY_API_TOKEN=abc123";
+      };
+
+      exporterTest = ''
+        wait_for_unit("prometheus-fastly-exporter.service")
+        wait_for_open_port(9118)
+      '';
+    };
+
+    fritzbox = {
+      # TODO add proper test case
+      exporterConfig = {
+        enable = true;
+      };
+      exporterTest = ''
+        wait_for_unit("prometheus-fritzbox-exporter.service")
+        wait_for_open_port(9133)
+        succeed(
+            "curl -sSf http://localhost:9133/metrics | grep 'fritzbox_exporter_collect_errors 0'"
+        )
+      '';
+    };
+
+    graphite = {
+      exporterConfig = {
+        enable = true;
+        port = 9108;
+        graphitePort = 9109;
+        mappingSettings.mappings = [
+          {
+            match = "test.*.*";
+            name = "testing";
+            labels = {
+              protocol = "$1";
+              author = "$2";
+            };
+          }
+        ];
+      };
+      exporterTest = ''
+        wait_for_unit("prometheus-graphite-exporter.service")
+        wait_for_open_port(9108)
+        wait_for_open_port(9109)
+        succeed("echo test.tcp.foo-bar 1234 $(date +%s) | nc -w1 localhost 9109")
+        succeed("curl -sSf http://localhost:9108/metrics | grep 'testing{author=\"foo-bar\",protocol=\"tcp\"} 1234'")
+      '';
+    };
+
+    idrac = {
+      exporterConfig = {
+        enable = true;
+        port = 9348;
+        configuration = {
+          hosts = {
+            default = {
+              username = "username";
+              password = "password";
+            };
+          };
+        };
+      };
+      exporterTest = ''
+        wait_for_unit("prometheus-idrac-exporter.service")
+        wait_for_open_port(9348)
+        wait_until_succeeds("curl localhost:9348")
+      '';
+    };
+
+    influxdb = {
+      exporterConfig = {
+        enable = true;
+        sampleExpiry = "3s";
+      };
+      exporterTest = ''
+        wait_for_unit("prometheus-influxdb-exporter.service")
+        wait_for_open_port(9122)
+        succeed(
+          "curl -XPOST http://localhost:9122/write --data-binary 'influxdb_exporter,distro=nixos,added_in=21.09 value=1'"
+        )
+        succeed(
+          "curl -sSf http://localhost:9122/metrics | grep 'nixos'"
+        )
+        execute("sleep 5")
+        fail(
+          "curl -sSf http://localhost:9122/metrics | grep 'nixos'"
+        )
+      '';
+    };
+
+    ipmi = {
+      exporterConfig = {
+        enable = true;
+      };
+      exporterTest = ''
+        wait_for_unit("prometheus-ipmi-exporter.service")
+        wait_for_open_port(9290)
+        succeed(
+          "curl -sSf http://localhost:9290/metrics | grep 'ipmi_scrape_duration_seconds'"
+        )
+      '';
+    };
+
+    jitsi = {
+      exporterConfig = {
+        enable = true;
+      };
+      metricProvider = {
+        systemd.services.prometheus-jitsi-exporter.after = [ "jitsi-videobridge2.service" ];
+        services.jitsi-videobridge = {
           enable = true;
           names = [ "timers" ];
         };

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -490,6 +490,22 @@ let
         '';
       };
 
+    fastcom =
+      { ... }:
+      {
+        exporterConfig = {
+          enable = true;
+          debug = true;
+          refreshInterval = "1h";
+        };
+
+        exporterTest = ''
+          wait_for_unit("prometheus-fastcom-exporter.service")
+          wait_for_open_port(9877)
+          succeed("curl -sSf http://localhost:9877")
+        '';
+      };
+
     fastly =
       { pkgs, ... }:
       {

--- a/pkgs/by-name/pr/prometheus-fastcom-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-fastcom-exporter/package.nix
@@ -1,0 +1,39 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+  nixosTests,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "prometheus-fastcom-exporter";
+  version = "1.3.3";
+
+  src = fetchFromGitHub {
+    owner = "caarlos0";
+    repo = "fastcom-exporter";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-fWHEAhdkNGGPvUybanaaUJu4vZ2iwIgOcoU8iHRTrI4=";
+  };
+
+  vendorHash = "sha256-B7Wc1htpXN7yRoKTEEWvfH8QST52ZfgHLBZPfBSTsD0=";
+
+  passthru.tests = { inherit (nixosTests.prometheus-exporters) fastcom; };
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.builtBy=nixpkgs"
+    "-X main.commit=unknown"
+    "-X main.date=unknown"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  meta = {
+    homepage = "https://github.com/caarlos0/fastcom-exporter";
+    description = "Exports Fast.com speedtest results as prometheus metrics";
+    mainProgram = "fastcom-exporter";
+    maintainers = with lib.maintainers; [ emaiax ];
+    license = lib.licenses.asl20;
+  };
+})

--- a/pkgs/by-name/pr/prometheus-fastcom-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-fastcom-exporter/package.nix
@@ -1,0 +1,40 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+  nixosTests,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "prometheus-fastcom-exporter";
+  version = "1.3.3";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "caarlos0";
+    repo = "fastcom-exporter";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-fWHEAhdkNGGPvUybanaaUJu4vZ2iwIgOcoU8iHRTrI4=";
+  };
+
+  vendorHash = "sha256-B7Wc1htpXN7yRoKTEEWvfH8QST52ZfgHLBZPfBSTsD0=";
+
+  passthru.tests = { inherit (nixosTests.prometheus-exporters) fastcom; };
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.builtBy=nixpkgs"
+    "-X main.commit=unknown"
+    "-X main.date=unknown"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  meta = {
+    homepage = "https://github.com/caarlos0/fastcom-exporter";
+    description = "Exports Fast.com speedtest results as prometheus metrics";
+    mainProgram = "fastcom-exporter";
+    maintainers = with lib.maintainers; [ emaiax ];
+    license = lib.licenses.asl20;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR introduces the `prometheus-fastcom-exporter` package and nixos module for configuring the Prometheus fastcom-exporter. This enables monitoring of network speed metrics via Prometheus using Fast.com.

ref: https://github.com/caarlos0/fastcom-exporter

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

