### PR TITLE
gita: 0.16.6.1 -> 0.16.8.2 

### DIFF
--- a/pkgs/by-name/gi/gita/package.nix
+++ b/pkgs/by-name/gi/gita/package.nix
@@ -1,8 +1,10 @@
 {
   lib,
+  git,
   python3Packages,
   fetchFromGitHub,
   installShellFiles,
+  writableTmpDirAsHomeHook,
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -23,8 +25,28 @@ python3Packages.buildPythonApplication rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  # 3 of the tests are failing
-  doCheck = false;
+  nativeCheckInputs = [
+    git
+    python3Packages.pytestCheckHook
+    writableTmpDirAsHomeHook
+  ];
+
+  enabledTestPaths = [
+    "${src}/tests"
+  ];
+
+  disabledTests = [
+    # This test fails as it tries to write to the Nix store.
+    "test_set_first_time"
+  ];
+
+  # The test suite assumes that it is ran from a directory called "gita" that is
+  # a git repository.
+  preCheck = ''
+    mkdir $TMPDIR/gita
+    git init $TMPDIR/gita
+    cd $TMPDIR/gita
+  '';
 
   postInstall = ''
     installShellCompletion --bash --name gita auto-completion/bash/.gita-completion.bash

--- a/pkgs/by-name/gi/gita/package.nix
+++ b/pkgs/by-name/gi/gita/package.nix
@@ -6,19 +6,19 @@
 }:
 
 python3Packages.buildPythonApplication rec {
-  version = "0.16.6.1";
+  version = "0.16.8.2";
   format = "setuptools";
   pname = "gita";
 
   src = fetchFromGitHub {
-    sha256 = "sha256-kPyk13yd4rc63Nh73opuHsCTj4DgYAVfro8To96tteA=";
+    sha256 = "sha256-JzfGj17YCYXmpGV2jSsGLsG1oqO5ynj7r3u/mkSBRBg=";
     rev = "v${version}";
     repo = "gita";
     owner = "nosarthur";
   };
 
   dependencies = with python3Packages; [
-    pyyaml
+    argcomplete
     setuptools
   ];
 
@@ -28,8 +28,8 @@ python3Packages.buildPythonApplication rec {
   doCheck = false;
 
   postInstall = ''
-    installShellCompletion --bash --name gita ${src}/.gita-completion.bash
-    installShellCompletion --zsh --name gita ${src}/.gita-completion.zsh
+    installShellCompletion --bash --name gita auto-completion/bash/.gita-completion.bash
+    installShellCompletion --zsh --name gita auto-completion/zsh/.gita-completion.zsh
   '';
 
   meta = {

--- a/pkgs/by-name/gi/gita/package.nix
+++ b/pkgs/by-name/gi/gita/package.nix
@@ -29,6 +29,7 @@ python3Packages.buildPythonApplication rec {
 
   postInstall = ''
     installShellCompletion --bash --name gita auto-completion/bash/.gita-completion.bash
+    installShellCompletion --fish --name gita auto-completion/fish/gita.fish
     installShellCompletion --zsh --name gita auto-completion/zsh/.gita-completion.zsh
   '';
 

--- a/pkgs/by-name/gi/gita/package.nix
+++ b/pkgs/by-name/gi/gita/package.nix
@@ -6,21 +6,20 @@
 }:
 
 python3Packages.buildPythonApplication rec {
-  version = "0.16.8.2";
-  format = "setuptools";
   pname = "gita";
+  version = "0.16.8.2";
+  pyproject = true;
 
   src = fetchFromGitHub {
-    sha256 = "sha256-JzfGj17YCYXmpGV2jSsGLsG1oqO5ynj7r3u/mkSBRBg=";
-    rev = "v${version}";
     repo = "gita";
     owner = "nosarthur";
+    tag = "v${version}";
+    hash = "sha256-JzfGj17YCYXmpGV2jSsGLsG1oqO5ynj7r3u/mkSBRBg=";
   };
 
-  dependencies = with python3Packages; [
-    argcomplete
-    setuptools
-  ];
+  build-system = [ python3Packages.setuptools ];
+
+  dependencies = [ python3Packages.argcomplete ];
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -36,6 +35,7 @@ python3Packages.buildPythonApplication rec {
   meta = {
     description = "Command-line tool to manage multiple git repos";
     homepage = "https://github.com/nosarthur/gita";
+    changelog = "https://github.com/nosarthur/gita/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ seqizz ];
     mainProgram = "gita";


### PR DESCRIPTION
### gita: 0.16.6.1 -> 0.16.8.2

- Diff: [nosarthur/gita@v0.16.6.1...v0.16.8.2](https://github.com/nosarthur/gita/compare/v0.16.6.1...v0.16.8.2)
- Release: https://github.com/nosarthur/gita/releases/tag/v0.16.8.2

#### Other Changes
- I have enabled the test suite again and specifically disabled one test that tries to write to the Nix store.
- I have added the auto-completions for Fish.
- I have updated the package definition in accordance with current practice.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
