### PR TITLE
[Backport release-25.11] nest-cli: 11.0.11 -> 11.0.14

### DIFF
--- a/pkgs/by-name/ne/nest-cli/package.nix
+++ b/pkgs/by-name/ne/nest-cli/package.nix
@@ -7,16 +7,16 @@
 
 buildNpmPackage rec {
   pname = "nest-cli";
-  version = "11.0.11";
+  version = "11.0.12";
 
   src = fetchFromGitHub {
     owner = "nestjs";
     repo = "nest-cli";
     tag = version;
-    hash = "sha256-A/R0y1NAKR85TrOt8DJaqZ8gMyGfrTc6T7dvzN0T8do=";
+    hash = "sha256-bi9kHxAio5ya2slmrm4U/uj9+UZondI/7aEde6rHGgM=";
   };
 
-  npmDepsHash = "sha256-+QGeOUIF36CLGUGi7QUEM/UE/kvpW4ZucjSFAXZbo4M=";
+  npmDepsHash = "sha256-rsgLe2wZPPHKR8ORI5ICTc5/A03x+ICetvKnltTje4k=";
   npmFlags = [ "--legacy-peer-deps" ];
 
   env = {

--- a/pkgs/by-name/ne/nest-cli/package.nix
+++ b/pkgs/by-name/ne/nest-cli/package.nix
@@ -7,16 +7,16 @@
 
 buildNpmPackage rec {
   pname = "nest-cli";
-  version = "11.0.12";
+  version = "11.0.14";
 
   src = fetchFromGitHub {
     owner = "nestjs";
     repo = "nest-cli";
     tag = version;
-    hash = "sha256-bi9kHxAio5ya2slmrm4U/uj9+UZondI/7aEde6rHGgM=";
+    hash = "sha256-FvZRqQ/wDjEBhug99MZa/ZKcQXCF3I8fXom8hi2AQm4=";
   };
 
-  npmDepsHash = "sha256-rsgLe2wZPPHKR8ORI5ICTc5/A03x+ICetvKnltTje4k=";
+  npmDepsHash = "sha256-KnvcJqTSiW9pCt1MhwsTJmmmvwgtVK5hoLAs/B709MI=";
   npmFlags = [ "--legacy-peer-deps" ];
 
   env = {


### PR DESCRIPTION
 Manual backport to release-25.11, for https://github.com/NixOS/nixpkgs/pull/464936 and https://github.com/NixOS/nixpkgs/pull/466840.

Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md?rgh-link-date=2025-12-02T12%3A09%3A08Z#changes-acceptable-for-releases).

Even as a non-committer, if you find that it is not acceptable, leave a comment.