### PR TITLE
oxwm: init at 0.9.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26575,6 +26575,12 @@
     githubId = 6740669;
     name = "Tom Smeets";
   };
+  tonybanters = {
+    email = "tony@tonybtw.com";
+    github = "tonybanters";
+    githubId = 27378358;
+    name = "tony";
+  };
   toonn = {
     email = "nixpkgs@toonn.io";
     matrix = "@toonn:matrix.org";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1810,6 +1810,7 @@
   ./services/x11/window-managers/metacity.nix
   ./services/x11/window-managers/nimdow.nix
   ./services/x11/window-managers/none.nix
+  ./services/x11/window-managers/oxwm.nix
   ./services/x11/window-managers/twm.nix
   ./services/x11/window-managers/windowlab.nix
   ./services/x11/window-managers/wmii.nix

--- a/nixos/modules/services/x11/window-managers/oxwm.nix
+++ b/nixos/modules/services/x11/window-managers/oxwm.nix
@@ -1,0 +1,24 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.xserver.windowManager.oxwm;
+in
+{
+  options.services.xserver.windowManager.oxwm = {
+    enable = lib.mkEnableOption "oxwm";
+    package = lib.mkPackageOption pkgs "oxwm" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.displayManager.sessionPackages = [ cfg.package ];
+    environment.systemPackages = [ cfg.package ];
+    environment.pathsToLink = [
+      "/share/oxwm"
+      "/share/xsessions"
+    ];
+  };
+}

--- a/pkgs/by-name/ox/oxwm/package.nix
+++ b/pkgs/by-name/ox/oxwm/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  libX11,
+  libXft,
+  libXrender,
+  freetype,
+  fontconfig,
+  versionCheckHook,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "oxwm";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "tonybanters";
+    repo = "oxwm";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-zVYYRGe5ZIR1AJgKZi9s403NKM7hKAqhEbNWYSkgpT0=";
+  };
+
+  cargoHash = "sha256-Rs8eGR8WY7qOPM0rfu6lTNDl6TVMR+rrIc6Ub+M7vfs=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libX11
+    libXft
+    libXrender
+    freetype
+    fontconfig
+  ];
+
+  # tests require a running X server
+  doCheck = false;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  postInstall = ''
+    install -Dm644 resources/oxwm.desktop -t $out/share/xsessions
+    install -Dm644 resources/oxwm.1 -t $out/share/man/man1
+    install -Dm644 templates/oxwm.lua -t $out/share/oxwm
+  '';
+
+  passthru.providedSessions = [ "oxwm" ];
+
+  meta = {
+    description = "Dynamic window manager written in Rust, inspired by dwm";
+    homepage = "https://github.com/tonybanters/oxwm";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ tonybanters ];
+    platforms = lib.platforms.linux;
+    mainProgram = "oxwm";
+  };
+})


### PR DESCRIPTION
Add oxwm, a dynamic X11 window manager written in Rust, inspired by
  dwm.

  - Package: `pkgs.oxwm`
  - NixOS module: `services.xserver.windowManager.oxwm`
  - Homepage: https://github.com/tonybanters/oxwm
  
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core"
functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in
`./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md]
and other READMEs.

[NixOS tests]:
https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]:
https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]:
https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]:
https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test