### PR TITLE
ocamlPackages.melange: 6.0.0 → 6.0.1

### DIFF
--- a/pkgs/development/tools/ocaml/melange/default.nix
+++ b/pkgs/development/tools/ocaml/melange/default.nix
@@ -23,13 +23,13 @@ let
   versionHash =
     if lib.versionAtLeast ocaml.version "5.4" then
       {
-        version = "6.0.0-54";
-        hash = "sha256-689OK37ObYhopfcaJ3AmkScGC4lCu3ZOTEM6N+Npvzs=";
+        version = "6.0.1-54";
+        hash = "sha256-bV5TD8qlLt7wQdm9W0TyhDDBFFo/PdJXGgiscnsBFmc=";
       }
     else if lib.versionAtLeast ocaml.version "5.3" then
       {
-        version = "6.0.0-53";
-        hash = "sha256-jPTQvV095BPB4EDepwGJTZ9sB/60VTO4YJTj2wI39jc=";
+        version = "6.0.1-53";
+        hash = "sha256-e1/RIsFsKeAbc2wgQf1Hhta+nyAXIuEP7uatXrU9cLs=";
       }
     else if lib.versionAtLeast ocaml.version "5.2" then
       {


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
