### PR TITLE
evince: fix build with gcc15

### DIFF
--- a/pkgs/by-name/ev/evince/package.nix
+++ b/pkgs/by-name/ev/evince/package.nix
@@ -120,6 +120,12 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dmultimedia=disabled"
   ];
 
+  # Fix build with gcc15
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-DHAVE_STRING_H"
+    "-DHAVE_STDLIB_H"
+  ];
+
   preFixup = ''
     gappsWrapperArgs+=(--prefix XDG_DATA_DIRS : "${shared-mime-info}/share")
   '';


### PR DESCRIPTION
- add "-DHAVE_STRING_H" and "-DHAVE_STDLIB_H" to `env.NIX_CFLAGS_COMPILE`, similar to what archlinux did in:
https://gitlab.archlinux.org/archlinux/packaging/packages/evince/-/blob/d15c1c165edcb39b3a3a15434a1fdb8ca63b91be/PKGBUILD#L73-74

Alternative would be to patch these declarations out of `kpathsea` source: https://gitweb.gentoo.org/repo/gentoo.git/plain/dev-libs/kpathsea/files/kpathsea-6.4.0_p20240311-c23.patch?id=d36d6a45aa033cb28dd5850a0fcce501cb9d85a9
or wait for next `texlive` update that includes these fixes:
https://github.com/TeX-Live/texlive-source/commit/cc687b6c0ae8c6a4b566646282a7bc702d822e6d
https://github.com/TeX-Live/texlive-source/commit/4451d937bea57c29b5f9775c5920b9a21a1f140a

Fixes build failure with gcc15:
```
/nix/store/a769c9g0af5g4l4mhh3rcf6ayzmyaakf-texlive-bin-2025-dev/include/kpathsea/c-memstr.h:57:14:
error: conflicting types for 'strtok'; have 'char *(void)'
   57 | extern char *strtok ();
      |              ^~~~~~
In file included from ../backend/dvi/mdvi-lib/paper.c:20:
/nix/store/i1qha7him4faq593wwl1zmhg2pc6lz98-glibc-2.40-66-dev/include/string.h:356:14:
note: previous declaration of 'strtok' with type 'char *(char * restrict,  const char * restrict)'
  356 | extern char *strtok (char *__restrict __s, const char *__restrict __delim)
      |              ^~~~~~
/nix/store/a769c9g0af5g4l4mhh3rcf6ayzmyaakf-texlive-bin-2025-dev/include/kpathsea/c-memstr.h:59:14:
error: conflicting types for 'strstr'; have 'char *(void)'
   59 | extern char *strstr ();
      |              ^~~~~~
/nix/store/i1qha7him4faq593wwl1zmhg2pc6lz98-glibc-2.40-66-dev/include/string.h:350:14:
note: previous declaration of 'strstr' with type 'char *(const char *, const char *)'
  350 | extern char *strstr (const char *__haystack, const char *__needle)
      |              ^~~~~~
/nix/store/a769c9g0af5g4l4mhh3rcf6ayzmyaakf-texlive-bin-2025-dev/include/kpathsea/c-std.h:48:14:
error: conflicting types for 'getenv'; have 'char *(void)'
   48 | extern char *getenv ();
      |              ^~~~~~
In file included from ../backend/dvi/mdvi-lib/tfm.c:20:
/nix/store/i1qha7him4faq593wwl1zmhg2pc6lz98-glibc-2.40-66-dev/include/stdlib.h:773:14:
note: previous declaration of 'getenv' with type 'char *(const char *)'
  773 | extern char *getenv (const char *__name) __THROW __nonnull ((1)) __wur;
      |              ^~~~~~
```

---

Tested build with:

```bash
nix-build --expr 'with import ./. {}; evince.override { stdenv = gcc15Stdenv; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
