### PR TITLE
rumdl: disable checkPhase on Darwin

### DIFF
--- a/pkgs/by-name/ru/rumdl/package.nix
+++ b/pkgs/by-name/ru/rumdl/package.nix
@@ -2,6 +2,7 @@
   lib,
   fetchFromGitHub,
   rustPlatform,
+  stdenvNoCC,
   versionCheckHook,
   nix-update-script,
 }:
@@ -23,7 +24,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--bin=rumdl"
   ];
 
-  __darwinAllowLocalNetworking = true; # required for LSP tests
+  # Non-specific tests often fail on Darwin (especially aarch64-darwin),
+  # on both Hydra and GitHub-hosted runners, even with __darwinAllowLocalNetworking enabled.
+  doCheck = !stdenvNoCC.hostPlatform.isDarwin;
 
   useNextest = true;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Background: https://github.com/NixOS/nixpkgs/pull/464300#pullrequestreview-3497893366, https://github.com/NixOS/nixpkgs/pull/466389#pullrequestreview-3520870188

I want this change to stabilize results on Hydra and remove the unnecessary review noise when using `nixpkgs-review` on GHA.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux # no-rebuild
  - [x] aarch64-linux # no-rebuild
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc: @Hasnep 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
