### PR TITLE
tiledb: fix build with gcc15

### DIFF
--- a/pkgs/by-name/ti/tiledb/package.nix
+++ b/pkgs/by-name/ti/tiledb/package.nix
@@ -56,6 +56,14 @@ stdenv.mkDerivation rec {
       extraPrefix = "tiledb/sm/serialization/";
       hash = "sha256-5z/eJEHl+cnWRf1sMULodJyhmNh5KinDLlL1paMNiy4=";
     })
+
+    # Fix build with gcc15
+    # https://github.com/TileDB-Inc/TileDB/pull/5612
+    (fetchpatch {
+      name = "tiledb-set-c-version-to-c99.patch";
+      url = "https://github.com/TileDB-Inc/TileDB/commit/4f946ad57fe823c3f53c06bf29dc18799ec6395a.patch";
+      hash = "sha256-chdaa6Ysqeb3p+FcWp7GTnAzgShoPGSCErmIGn+Q4tA=";
+    })
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ ./generate_embedded_data_header.patch ];
 


### PR DESCRIPTION
- add patch from merged upstream PR:
https://www.github.com/TileDB-Inc/TileDB/pull/5612
https://github.com/TileDB-Inc/TileDB/commit/4f946ad57fe823c3f53c06bf29dc18799ec6395a

Fixes build failure with gcc15:
```
/build/source/external/blosc/src/shuffle.c:30:15: error: 'bool' cannot
be defined via 'typedef'
   30 | typedef _Bool bool;
      |               ^~~~
/build/source/external/blosc/src/shuffle.c:30:15: note: 'bool' is a
keyword with '-std=c23' onwards
```

---

Tested build with:

```bash
nix-build --expr 'with import ./. {}; tiledb.override { stdenv = gcc15Stdenv; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
