### PR TITLE
cvs: build with openssh

### DIFF
--- a/pkgs/by-name/cv/cvs/package.nix
+++ b/pkgs/by-name/cv/cvs/package.nix
@@ -6,6 +6,7 @@
   texinfo,
   nano,
   autoreconfHook,
+  openssh,
 }:
 
 let
@@ -48,6 +49,7 @@ stdenv.mkDerivation {
 
   configureFlags = [
     "--with-editor=${nano}/bin/nano"
+    "--with-rsh=${openssh}/bin/ssh"
 
     # Required for cross-compilation.
     "cvs_cv_func_printf_ptr=yes"


### PR DESCRIPTION
This change adds openssh as a dependency of cvs and builds cvs with a fully qualified path to the ssh binary it should use. Without openssh, cvs tries to use rsh to access remote repositories, so other modern distributions (Ubuntu for example) specify something like `--with-rsh=/usr/bin/ssh` when configuring cvs.

I tried to get this change introduced a while back in #347374, but it must've gotten lost in the weeds. I've been using a custom overlay all this time so I never noticed the standard cvs package still can't use ssh.

Although this pull request has the same end goal as the previous one, I think this one is a much better approach.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
