### PR TITLE
geoserver: 2.27.2 -> 2.28.1

### DIFF
--- a/nixos/tests/geoserver.nix
+++ b/nixos/tests/geoserver.nix
@@ -76,9 +76,11 @@ in
       _, stdout = machine.execute(f"cat {log_file}")
       print(stdout.replace("\\n", "\n"))
       assert "GDAL Native Library loaded" in stdout, "gdal"
-      assert "The turbo jpeg encoder is available for usage" in stdout, "libjpeg-turbo"
       assert "org.geotools.imageio.netcdf.utilities.NetCDFUtilities" in stdout, "netcdf"
       assert "Unable to load library 'netcdf'" not in stdout, "netcdf"
+
+      # libjpeg-turbo is disabled as of 2.28.1.
+      # assert "The turbo jpeg encoder is available for usage" in stdout, "libjpeg-turbo"
 
   '';
 }

--- a/pkgs/by-name/ge/geoserver/extensions.nix
+++ b/pkgs/by-name/ge/geoserver/extensions.nix
@@ -21,7 +21,7 @@ let
       inherit buildInputs version;
 
       src = fetchzip {
-        url = "mirror://sourceforge/geoserver/GeoServer/${version}/extensions/geoserver-${version}-${name}-plugin.zip";
+        url = "https://sourceforge.net/projects/geoserver/files/GeoServer/${version}/extensions/geoserver-${version}-${name}-plugin.zip";
         inherit hash;
         # We expect several files.
         stripRoot = false;

--- a/pkgs/by-name/ge/geoserver/extensions.nix
+++ b/pkgs/by-name/ge/geoserver/extensions.nix
@@ -42,325 +42,331 @@ in
 {
   app-schema = mkGeoserverExtension {
     name = "app-schema";
-    version = "2.27.2"; # app-schema
-    hash = "sha256-XJbuRdqvkusT1hZEuFoogTEB8vHOsX9cQxA0Mzhg1+8="; # app-schema
+    version = "2.28.1"; # app-schema
+    hash = "sha256-PwZW9hFRiZIxgil75DXMsq0ymo7jPYX4Boj+hkXW8NI="; # app-schema
   };
 
   authkey = mkGeoserverExtension {
     name = "authkey";
-    version = "2.27.2"; # authkey
-    hash = "sha256-e43HG4iPgj9vj7lq0c9ATmWVumqHdtM9DrAwbQJqUcg="; # authkey
+    version = "2.28.1"; # authkey
+    hash = "sha256-Zg3Db5QG4w+yMZ75MqtHt1Kri8peDGMZ0va5ZwI+6dw="; # authkey
   };
 
   cas = mkGeoserverExtension {
     name = "cas";
-    version = "2.27.2"; # cas
-    hash = "sha256-kDYC8z5sRAycw6ZCKJ105XoYF5/ss4YTguqQ8pbnJls="; # cas
+    version = "2.28.1"; # cas
+    hash = "sha256-YMnaRVPLn98mXm2sErKSRlzmvQbnU9MGMDXuYgwm+H0="; # cas
   };
 
   charts = mkGeoserverExtension {
     name = "charts";
-    version = "2.27.2"; # charts
-    hash = "sha256-zI+F21bQHcE4Lbh26bHeCTjTRJdswkUmmz+qAsP2t4k="; # charts
+    version = "2.28.1"; # charts
+    hash = "sha256-LM75iq2xvSQjVxGnngoLCz5IkSI9/YqAqOqgSUlkrUA="; # charts
   };
 
   control-flow = mkGeoserverExtension {
     name = "control-flow";
-    version = "2.27.2"; # control-flow
-    hash = "sha256-5XW3l9MFEUeYuhOKqN4EqjwpRlMc8P8Tn46A2Z89Jks="; # control-flow
+    version = "2.28.1"; # control-flow
+    hash = "sha256-ZO04mls+OapOK/fi5IBy0mVJ5cF0fyQ1RgFhWt0AuEw="; # control-flow
   };
 
   css = mkGeoserverExtension {
     name = "css";
-    version = "2.27.2"; # css
-    hash = "sha256-1fpP70Ed4iUrUyMMiMFhkykuPCzBV5+lWFicl9sUjAg="; # css
+    version = "2.28.1"; # css
+    hash = "sha256-2PcZhxkHXEOAs46fnt37VhupVOfRNWaRynNlLGviAho="; # css
   };
 
   csw = mkGeoserverExtension {
     name = "csw";
-    version = "2.27.2"; # csw
-    hash = "sha256-4BYSY6tldkjd8KDlM/D+MNb9I8Ji0CVjyJcsBzRxC1Y="; # csw
+    version = "2.28.1"; # csw
+    hash = "sha256-6TmSWnny0OedvnLu+HnKpVxdfcicp1D//isFFOclcmk="; # csw
   };
 
   csw-iso = mkGeoserverExtension {
     name = "csw-iso";
-    version = "2.27.2"; # csw-iso
-    hash = "sha256-/0soY61A1d4yKJolRtymoFOsKf42B/RacUSUqN/7uXo="; # csw-iso
+    version = "2.28.1"; # csw-iso
+    hash = "sha256-BlnIS8gpWwBuiwdIqvq3UpJrdKPULvJxR7o3XJtI5tQ="; # csw-iso
   };
 
   db2 = mkGeoserverExtension {
     name = "db2";
-    version = "2.27.2"; # db2
-    hash = "sha256-agZZHkwAx5YTOCzDlhpiTWxBTyhAoIW1BgW3QfV/kug="; # db2
+    version = "2.28.1"; # db2
+    hash = "sha256-Ga4Db6G+LxRN+casjs0nYD6TFN1YrDjgOIlu46/0RgQ="; # db2
   };
 
   # Needs wps extension.
   dxf = mkGeoserverExtension {
     name = "dxf";
-    version = "2.27.2"; # dxf
-    hash = "sha256-F93QOpe0nBQDD+8iDnenacNJ87h+jCqytJ3uz7weCcg="; # dxf
+    version = "2.28.1"; # dxf
+    hash = "sha256-703y8CBd9oYsryGgAftXq5Cr1lUeyws1Alx0tSwzZo8="; # dxf
   };
 
   excel = mkGeoserverExtension {
     name = "excel";
-    version = "2.27.2"; # excel
-    hash = "sha256-CYW9JBhDOLqxNKnlxNDy03sZzmGPLn9KaK4LScGMIIg="; # excel
+    version = "2.28.1"; # excel
+    hash = "sha256-9ti+J7e9QieVbCFQ2xxuqX8TvQCcLPw0tPUNVqGG9+0="; # excel
   };
 
   feature-pregeneralized = mkGeoserverExtension {
     name = "feature-pregeneralized";
-    version = "2.27.2"; # feature-pregeneralized
-    hash = "sha256-0MuzhZ8Y/yy/AJ6vTvfJxXPgnf+fTJPfB8wNTboYHOw="; # feature-pregeneralized
+    version = "2.28.1"; # feature-pregeneralized
+    hash = "sha256-eGayG9FUJabhP60iypib1gLcRStqz5J4PMTuSB+xL60="; # feature-pregeneralized
   };
 
   # Note: The extension name ("gdal") clashes with pkgs.gdal.
   gdal = mkGeoserverExtension {
     name = "gdal";
-    version = "2.27.2"; # gdal
+    version = "2.28.1"; # gdal
     buildInputs = [ pkgs.gdal ];
-    hash = "sha256-Krdj96ddLsrA8J6B8ap3BBBe/+flVX7/GJRLN4UnKiY="; # gdal
+    hash = "sha256-sVI9o2xwbvez7Gm8gY9DAbEr5TUluVGDoC7ZweK4BUE="; # gdal
   };
 
   # Throws "java.io.FileNotFoundException: URL [jar:file:/nix/store/.../WEB-INF/lib/gs-geofence-server-2.24.1.jar!/geofence-default-override.properties] cannot be resolved to absolute file path because it does not reside in the file system: jar:file:/nix/store/.../WEB-INF/lib/gs-geofence-server-2.24.1.jar!/geofence-default-override.properties" but seems to work out of the box.
   #geofence = mkGeoserverExtension {
   #  name = "geofence";
-  #  version = "2.27.2"; # geofence
-  #  hash = "sha256-Rzi8oZFy+SglTuPSYBFi/Wge4pOVY5yE50c8+jRI+4Y="; # geofence
+  #  version = "2.28.1"; # geofence
+  #  hash = "sha256-POBOhg3d8HlA3qF2W41UTVhISM5vAQi74cI+y+Rj+Ic="; # geofence
   #};
 
-  #geofence-server = mkGeoserverExtension {
-  #  name = "geofence-server";
-  #  version = "2.27.2"; # geofence-server
-  #  hash = ""; # geofence-server
+  #geofence-server-h2 = mkGeoserverExtension {
+  #  name = "geofence-server-h2";
+  #  version = "2.28.1"; # geofence-server
+  #  hash = "sha256-8lY+wrCD7PizeNvh9hDRhxdFxT7n1SVKD8TVU80iiZk="; # geofence-server-h2
+  #};
+
+  #geofence-server-postgres = mkGeoserverExtension {
+  #  name = "geofence-server-postgres";
+  #  version = "2.28.1"; # geofence-server
+  #  hash = "sha256-DB3OK2dvPrDtlRRHaDUXqQW7AlOhN4zFm2t0N1+B3rk="; # geofence-server-postgres
   #};
 
   #geofence-wps = mkGeoserverExtension {
   #  name = "geofence-wps";
-  #  version = "2.27.2"; # geofence-wps
-  #  hash = "sha256-dry787XPCVBPi4TXKyFL85QZwX0WdWfiXqz/yriMiWc="; # geofence-wps
+  #  version = "2.28.1"; # geofence-wps
+  #  hash = "sha256-tP3hnN0kXKFIdgKrS7juyrCh1OoQD0Bx54/xq6nUzWA="; # geofence-wps
   #};
 
   geopkg-output = mkGeoserverExtension {
     name = "geopkg-output";
-    version = "2.27.2"; # geopkg-output
-    hash = "sha256-LlYjYTa0mjOh+q2ILJORTAUlWy3mW9lEMd1vUyyhDV8="; # geopkg-output
+    version = "2.28.1"; # geopkg-output
+    hash = "sha256-6ARKLmhc5lhqi841Ou5ZrBuj6bdOwQDSGPwzGcBTNJw="; # geopkg-output
   };
 
   grib = mkGeoserverExtension {
     name = "grib";
-    version = "2.27.2"; # grib
-    hash = "sha256-/OBhwToUuJfDcRnx4aJbXDb6HdGGtM8SCkjmFgfX65s="; # grib
+    version = "2.28.1"; # grib
+    hash = "sha256-AW/i+vRthQct3U45EGw/6uPDZNdS9z816nnKVIGCg/k="; # grib
     buildInputs = [ netcdf ];
   };
 
   gwc-s3 = mkGeoserverExtension {
     name = "gwc-s3";
-    version = "2.27.2"; # gwc-s3
-    hash = "sha256-A0I2/+pRuvcXCVduTNn/e1nDZnNkt7cKtPNNO3Yo8Bk="; # gwc-s3
+    version = "2.28.1"; # gwc-s3
+    hash = "sha256-wVLW7qbKDRmf1okTI0PDREQ5eoJOVGMVLS+uusY2+cM="; # gwc-s3
   };
 
   h2 = mkGeoserverExtension {
     name = "h2";
-    version = "2.27.2"; # h2
-    hash = "sha256-kGXqb5xH4Jn6nhN8nfhldUcHtQodBUp9y3bviPim1Ak="; # h2
+    version = "2.28.1"; # h2
+    hash = "sha256-zEjNN1dCmNR/5st/yNpWP1G3P6Zqf3RSFdUKOgdwff4="; # h2
   };
 
   iau = mkGeoserverExtension {
     name = "iau";
-    version = "2.27.2"; # iau
-    hash = "sha256-KVkpQ92cvmc3nIsBygUU58vsIY8BZXEEXQrUeH/eEyM="; # iau
+    version = "2.28.1"; # iau
+    hash = "sha256-zn4FlC/vVvq1K6mSplOKarHHUWLNev5IW76wSiTvBuE="; # iau
   };
 
   importer = mkGeoserverExtension {
     name = "importer";
-    version = "2.27.2"; # importer
-    hash = "sha256-Sumh9148zqwLCbpiknwLyVpxqufkoizMgszy//qC5dA="; # importer
+    version = "2.28.1"; # importer
+    hash = "sha256-7v5MvpvVbVKOBxUlEwem8MzPUTtBc8z+1JAEqeHUmYI="; # importer
   };
 
   inspire = mkGeoserverExtension {
     name = "inspire";
-    version = "2.27.2"; # inspire
-    hash = "sha256-IDX93Cu7BgrkmI5QcdYu++XzVwHOeCM17eXgqhDPSRQ="; # inspire
+    version = "2.28.1"; # inspire
+    hash = "sha256-kgqwO3elSnT/4M9G+OgULaW+i/nDNGhvHblmWZRjTTA="; # inspire
   };
 
   # Needs Kakadu plugin from
   # https://github.com/geosolutions-it/imageio-ext
   #jp2k = mkGeoserverExtension {
   #  name = "jp2k";
-  #  version = "2.27.2"; # jp2k
-  #  hash = "sha256-Ar+mVXZqYfP6OGISdRzBntWRo2msL5RN44bgPeMOqQw="; # jp2k
+  #  version = "2.28.1"; # jp2k
+  #  hash = "sha256-sLUgsMXymnTuceCRLzqIAPmk4/Q3BO+A+7BLQoc3iP0="; # jp2k
   #};
 
   libjpeg-turbo = mkGeoserverExtension {
     name = "libjpeg-turbo";
-    version = "2.27.2"; # libjpeg-turbo
-    hash = "sha256-6e9Bdy/Lh7ZXPzHVGX/f/qa53v1JWrUshlrtcziIbQs="; # libjpeg-turbo
+    version = "2.28.1"; # libjpeg-turbo
+    hash = "sha256-fn1ItYvLMfvRLpCE8rEpTpBmkk8zkN3QtBO/RN4RXfo="; # libjpeg-turbo
     buildInputs = [ libjpeg.out ];
   };
 
   mapml = mkGeoserverExtension {
     name = "mapml";
-    version = "2.27.2"; # mapml
-    hash = "sha256-QTAoesynmxv+9bYwak6jat6J3In5ULdsy2ozjMbsoXI="; # mapml
+    version = "2.28.1"; # mapml
+    hash = "sha256-AonH/wBRh0oVs8psJ+XRutkSwybN3fs505SI/0qzG3o="; # mapml
   };
 
   mbstyle = mkGeoserverExtension {
     name = "mbstyle";
-    version = "2.27.2"; # mbstyle
-    hash = "sha256-zKdX77zy72lkMB928XIjU0pYZ7zFVEI7OfbJ2ozFIHk="; # mbstyle
+    version = "2.28.1"; # mbstyle
+    hash = "sha256-SvgvBkp6dS6v1JjQxpa7m7tqc2c63hruWCcFcouHXaQ="; # mbstyle
   };
 
   metadata = mkGeoserverExtension {
     name = "metadata";
-    version = "2.27.2"; # metadata
-    hash = "sha256-VLBuqh9qfcv2BRHhjF1tAc6ACCOUPQcY4Yc0Vko/2l0="; # metadata
+    version = "2.28.1"; # metadata
+    hash = "sha256-M3HcgrPGZBBotNm6dsw4UjrH1onIQHDMdxuwNVuqO84="; # metadata
   };
 
   mongodb = mkGeoserverExtension {
     name = "mongodb";
-    version = "2.27.2"; # mongodb
-    hash = "sha256-xXgiOEMQhPbw6GorrkEiyV7isgmSuimzT/LK41c0bzA="; # mongodb
+    version = "2.28.1"; # mongodb
+    hash = "sha256-Urp8d0i6Xlk2muNKKioJTnrEvzC05tqiipLT162L7uk="; # mongodb
   };
 
   monitor = mkGeoserverExtension {
     name = "monitor";
-    version = "2.27.2"; # monitor
-    hash = "sha256-1x+Rz8wXl3cAsX5rHgMEe1+h17QS7PDBJGDFmKf+SMY="; # monitor
+    version = "2.28.1"; # monitor
+    hash = "sha256-Qo9aFOjbg9s1RZVqa/z1ka+QmFrPZJgrH8qMcstCywQ="; # monitor
   };
 
   mysql = mkGeoserverExtension {
     name = "mysql";
-    version = "2.27.2"; # mysql
-    hash = "sha256-mmquP4u3YqqbGVK2jkbNtGiqVMENCThpRTWOz6f74Pk="; # mysql
+    version = "2.28.1"; # mysql
+    hash = "sha256-5/xP8vPNhOYN9YXL4sZk16652ZBB7Ivm7Cq05fYi7wI="; # mysql
   };
 
   netcdf = mkGeoserverExtension {
     name = "netcdf";
-    version = "2.27.2"; # netcdf
-    hash = "sha256-GhPde3Fw04lutbgPmDyxO/C7wkZO1ttASqqj2g6JuCM="; # netcdf
+    version = "2.28.1"; # netcdf
+    hash = "sha256-qKgSyFrKI7JVMNt/qjgJ5puLaTsU406P5VyUpncMHOg="; # netcdf
     buildInputs = [ netcdf ];
   };
 
   netcdf-out = mkGeoserverExtension {
     name = "netcdf-out";
-    version = "2.27.2"; # netcdf-out
-    hash = "sha256-r4CyrlRm04tE3+vJfF+KlHAczrOy+dsTHXBG++GG0ys="; # netcdf-out
+    version = "2.28.1"; # netcdf-out
+    hash = "sha256-Xk3cTve45U9LDv8lWugtGpfid4yr5yDWh7H7daVlAc8="; # netcdf-out
     buildInputs = [ netcdf ];
   };
 
   ogr-wfs = mkGeoserverExtension {
     name = "ogr-wfs";
-    version = "2.27.2"; # ogr-wfs
+    version = "2.28.1"; # ogr-wfs
     buildInputs = [ pkgs.gdal ];
-    hash = "sha256-EI0FNYFwcmsLYiYauvCAvweAIn6bI7WaCVPcCtkGrys="; # ogr-wfs
+    hash = "sha256-ykFfqoLXeGigAdCLnDCKiCGD++n7jiOivua8Oh2DwU8="; # ogr-wfs
   };
 
   # Needs ogr-wfs extension.
   ogr-wps = mkGeoserverExtension {
     name = "ogr-wps";
-    version = "2.27.2"; # ogr-wps
+    version = "2.28.1"; # ogr-wps
     # buildInputs = [ pkgs.gdal ];
-    hash = "sha256-CtsaQg9IZxlRW4oQwmdBA+VLWtsNP3+jS1Mj2RxAJw4="; # ogr-wps
+    hash = "sha256-WxOZ5WDNxV1HAT9cfCPm9DwoU/96OobuODOjd5dGN94="; # ogr-wps
   };
 
   oracle = mkGeoserverExtension {
     name = "oracle";
-    version = "2.27.2"; # oracle
-    hash = "sha256-8cRDvWWFJHZZGmbZEruvp1whfhXZ/c7TYha4Fa5DuzM="; # oracle
+    version = "2.28.1"; # oracle
+    hash = "sha256-lj53CC6f9vXatH9vxHaFZvEGDpplTZSYy56fz4d4Qs0="; # oracle
   };
 
   params-extractor = mkGeoserverExtension {
     name = "params-extractor";
-    version = "2.27.2"; # params-extractor
-    hash = "sha256-Y7tt0F//dANcKds/mU6702S5PMJNVLcxxc+hYFNOt5M="; # params-extractor
+    version = "2.28.1"; # params-extractor
+    hash = "sha256-1Znwqb+PHFlsuQIs8pMqo08s4uSc7wLZRYE+hVZzoQY="; # params-extractor
   };
 
   printing = mkGeoserverExtension {
     name = "printing";
-    version = "2.27.2"; # printing
-    hash = "sha256-I5vVlpX2kXof3wuyRs2QvhWdx0Okm7StYvY8I/AL8Ug="; # printing
+    version = "2.28.1"; # printing
+    hash = "sha256-OeMHkx4d7/FwNigQ8Mnz9UlqFJbMZFGmxZT8kJ3iPp8="; # printing
   };
 
   pyramid = mkGeoserverExtension {
     name = "pyramid";
-    version = "2.27.2"; # pyramid
-    hash = "sha256-/iIwS5iw95qotmmLWGU11br36dVc+o5LmwTDXBL7zaY="; # pyramid
+    version = "2.28.1"; # pyramid
+    hash = "sha256-fLe2SeRSNvj6qqh6CMDu2w0gubf+xi3Ez7jO2fEbpjc="; # pyramid
   };
 
   querylayer = mkGeoserverExtension {
     name = "querylayer";
-    version = "2.27.2"; # querylayer
-    hash = "sha256-G66AkPkytzXvEi9hbudvBphFKrvMrhUbPSVvexXRJh4="; # querylayer
+    version = "2.28.1"; # querylayer
+    hash = "sha256-QM5DAoTFsn6JTLubQy4p0qsA91DcfU7C74cb80jzzWM="; # querylayer
   };
 
   sldservice = mkGeoserverExtension {
     name = "sldservice";
-    version = "2.27.2"; # sldservice
-    hash = "sha256-djERawjM06NtZK6RnNh/qIS/x5ZjSWeUMHlUSF4/5aA="; # sldservice
+    version = "2.28.1"; # sldservice
+    hash = "sha256-u5uzwyrwBzz5qcEtRS+ZIbmis9kVuGPt6+qo19K1HCM="; # sldservice
   };
 
   sqlserver = mkGeoserverExtension {
     name = "sqlserver";
-    version = "2.27.2"; # sqlserver
-    hash = "sha256-Kad2wJmN/67xlLDViFfYWxvsSjmW+j3/iQEAvwEMZW4="; # sqlserver
+    version = "2.28.1"; # sqlserver
+    hash = "sha256-19KyMBZEYBeUKiogxux8jrc8VgNDdCnvhrEV8Q84SG0="; # sqlserver
   };
 
   vectortiles = mkGeoserverExtension {
     name = "vectortiles";
-    version = "2.27.2"; # vectortiles
-    hash = "sha256-S5ujjj8JLXbybbjpA8qLF4sapVIECDZ8l+iqqUoVHuc="; # vectortiles
+    version = "2.28.1"; # vectortiles
+    hash = "sha256-tT4phUdL8yMKzobxWNivMpHJYu6KQmPiNECK9TtJgjg="; # vectortiles
   };
 
   wcs2_0-eo = mkGeoserverExtension {
     name = "wcs2_0-eo";
-    version = "2.27.2"; # wcs2_0-eo
-    hash = "sha256-S2d3Yel0B0DJubuMUywPB2gDiWIpdkniDksZcq8j9BI="; # wcs2_0-eo
+    version = "2.28.1"; # wcs2_0-eo
+    hash = "sha256-HawDOyymB01x7PaFg5QKQhTSFdybeY5oAAusaG95To8="; # wcs2_0-eo
   };
 
   web-resource = mkGeoserverExtension {
     name = "web-resource";
-    version = "2.27.2"; # web-resource
-    hash = "sha256-HJ+GPrprrCPlzh9q+PZr0QEJE/YVXaqgxhUlYHPkgho="; # web-resource
+    version = "2.28.1"; # web-resource
+    hash = "sha256-FkuxR3WN95jyorpcv4ShT9J6jmUi0Z9NNwLEW3OKzx0="; # web-resource
   };
 
   wmts-multi-dimensional = mkGeoserverExtension {
     name = "wmts-multi-dimensional";
-    version = "2.27.2"; # wmts-multi-dimensional
-    hash = "sha256-de+0UEsRJyl9plnmOaWSI8xNc6RG+U7uJVEyvgwng4Q="; # wmts-multi-dimensional
+    version = "2.28.1"; # wmts-multi-dimensional
+    hash = "sha256-tJP9pPKKYFLGbLWZEV5gWSaQdTbml3OKiIPM1sqhekY="; # wmts-multi-dimensional
   };
 
   wps = mkGeoserverExtension {
     name = "wps";
-    version = "2.27.2"; # wps
-    hash = "sha256-Fn0XWncwqUmMub9eBxb5GN2cc3eMdyB55NB9AUvVQpQ="; # wps
+    version = "2.28.1"; # wps
+    hash = "sha256-aYAN89XFpwzsW5aRBKSnixks3bxCAfOOznFDpoIvbIk="; # wps
   };
 
   # Needs hazelcast (https://github.com/hazelcast/hazelcast (?)) which is not
   # available in nixpgs as of 2024/01.
   #wps-cluster-hazelcast = mkGeoserverExtension {
   #  name = "wps-cluster-hazelcast";
-  #  version = "2.27.2"; # wps-cluster-hazelcast
-  #  hash = "sha256-xV6JddIC5Uq8H3RaE9tqCMK+5OA5WrXfh6O82BVw+P0="; # wps-cluster-hazelcast
+  #  version = "2.28.1"; # wps-cluster-hazelcast
+  #  hash = "sha256-hO1/7OG9J5Ot5xKhMUbTAqm7B6TlecqNGxxbIuFCpCc="; # wps-cluster-hazelcast
   #};
 
   wps-download = mkGeoserverExtension {
     name = "wps-download";
-    version = "2.27.2"; # wps-download
-    hash = "sha256-loP1oYqie2U00RWOwlLzprECfnBTG2MeJNhPZJx8Q1o="; # wps-download
+    version = "2.28.1"; # wps-download
+    hash = "sha256-qB1vtczNULOsEjZaof9cA5YKPDE0Dwcz6mlUtzCanPQ="; # wps-download
   };
 
   # Needs Postrgres configuration or similar.
   # See https://docs.geoserver.org/main/en/user/extensions/wps-jdbc/index.html
   wps-jdbc = mkGeoserverExtension {
     name = "wps-jdbc";
-    version = "2.27.2"; # wps-jdbc
-    hash = "sha256-LpxGscFx7DCeM90VGs4lAMoKNXJVDnSCptdC9VeeU/o="; # wps-jdbc
+    version = "2.28.1"; # wps-jdbc
+    hash = "sha256-9S6/TXK9YFzPD8u/S7SQuBcIGjUTalY69kzG4xbIU3g="; # wps-jdbc
   };
 
   ysld = mkGeoserverExtension {
     name = "ysld";
-    version = "2.27.2"; # ysld
-    hash = "sha256-1yOaJcPyLOm/lYdOazHU5DjfahSjuN00yYvxgsE5RKM="; # ysld
+    version = "2.28.1"; # ysld
+    hash = "sha256-qLWnujvB32U0EW7xW12GaAx6mPHkrU5Pa3S+T8+19r8="; # ysld
   };
 
 }

--- a/pkgs/by-name/ge/geoserver/extensions.nix
+++ b/pkgs/by-name/ge/geoserver/extensions.nix
@@ -197,12 +197,15 @@ in
   #  hash = "sha256-sLUgsMXymnTuceCRLzqIAPmk4/Q3BO+A+7BLQoc3iP0="; # jp2k
   #};
 
-  libjpeg-turbo = mkGeoserverExtension {
-    name = "libjpeg-turbo";
-    version = "2.28.1"; # libjpeg-turbo
-    hash = "sha256-fn1ItYvLMfvRLpCE8rEpTpBmkk8zkN3QtBO/RN4RXfo="; # libjpeg-turbo
-    buildInputs = [ libjpeg.out ];
-  };
+  # Throws "java.lang.UnsatisfiedLinkError: 'void org.libjpegturbo.turbojpeg.TJDecompressor.init()'"
+  # as of 2.28.1.
+  # NOTE: When re-enabling this, RE-ENABLE THE CORRESPONDING TEST, TOO! (See tests/geoserver.nix)
+  #libjpeg-turbo = mkGeoserverExtension {
+  #  name = "libjpeg-turbo";
+  #  version = "2.28.1"; # libjpeg-turbo
+  #  hash = "sha256-fn1ItYvLMfvRLpCE8rEpTpBmkk8zkN3QtBO/RN4RXfo="; # libjpeg-turbo
+  #  buildInputs = [ libjpeg.out ];
+  #};
 
   mapml = mkGeoserverExtension {
     name = "mapml";

--- a/pkgs/by-name/ge/geoserver/package.nix
+++ b/pkgs/by-name/ge/geoserver/package.nix
@@ -10,11 +10,11 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "geoserver";
-  version = "2.27.2";
+  version = "2.28.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/geoserver/GeoServer/${finalAttrs.version}/geoserver-${finalAttrs.version}-bin.zip";
-    hash = "sha256-yzejVi+0FzTCtUirCvn3PsxLLmoIUSxS2sA1KWWo30U=";
+    hash = "sha256-wll05KPMVfpZGnybBxLeGH3pan8q4eWy8F4v5y5N3Gk=";
   };
 
   sourceRoot = ".";

--- a/pkgs/by-name/ge/geoserver/update.sh
+++ b/pkgs/by-name/ge/geoserver/update.sh
@@ -2,7 +2,7 @@
 #!nix-shell -I ./. -i bash -p common-updater-scripts jq
 
 set -eEuo pipefail
-test ${DEBUG:-0} -eq 1 && set -x
+test "${DEBUG:-0}" -eq 1 && set -x
 
 # Current version.
 LATEST_NIXPKGS_VERSION=$(nix eval --raw .#geoserver.version 2>/dev/null)
@@ -12,7 +12,7 @@ UPDATE_NIX_OLD_VERSION=${UPDATE_NIX_OLD_VERSION:-$LATEST_NIXPKGS_VERSION}
 LATEST_GITHUB_VERSION=$(curl -s "https://api.github.com/repos/geoserver/geoserver/releases/latest" | jq -r '.tag_name')
 UPDATE_NIX_NEW_VERSION=${UPDATE_NIX_NEW_VERSION:-$LATEST_GITHUB_VERSION}
 
-SMALLEST_VERSION=$(printf "$UPDATE_NIX_OLD_VERSION\n$UPDATE_NIX_NEW_VERSION" | sort --version-sort | head -n 1)
+SMALLEST_VERSION=$(printf "%s\n%s" "$UPDATE_NIX_OLD_VERSION" "$UPDATE_NIX_NEW_VERSION" | sort --version-sort | head -n 1)
 
 if [[ "$SMALLEST_VERSION" == "$UPDATE_NIX_NEW_VERSION" ]]; then
   echo "geoserver is up-to-date: $SMALLEST_VERSION"
@@ -24,18 +24,18 @@ update-source-version geoserver "$UPDATE_NIX_NEW_VERSION"
 
 cd "$(dirname "$(readlink -f "$0")")"
 
-EXT_NAMES=($(grep -o -E "hash = .*?; # .*$" ./extensions.nix | sed 's/.* # //' | sort))
+mapfile -t EXT_NAMES < <(grep -o -E "hash = .*?; # .*$" ./extensions.nix | sed 's/.* # //' | sort)
 
-if [[ $# -gt 0 ]] ; then
-    EXT_NAMES=(${@:1})
+if [[ $# -gt 0 ]]; then
+  EXT_NAMES=("${@:1}")
 fi
 
-for EXT_NAME in "${EXT_NAMES[@]}" ; do
-    echo "Updating extension $EXT_NAME..."
-    URL="mirror://sourceforge/geoserver/GeoServer/${UPDATE_NIX_NEW_VERSION}/extensions/geoserver-${UPDATE_NIX_NEW_VERSION}-${EXT_NAME}-plugin.zip"
-    HASH=$(nix-hash --to-sri --type sha256 $(nix-prefetch-url --unpack "$URL"))
-    sed -i "s@version = \".*\"; # $EXT_NAME@version = \"$UPDATE_NIX_NEW_VERSION\"; # $EXT_NAME@" ./extensions.nix
-    sed -i "s@hash = \".*\"; # $EXT_NAME@hash = \"$HASH\"; # $EXT_NAME@" ./extensions.nix
+for EXT_NAME in "${EXT_NAMES[@]}"; do
+  echo "Updating extension $EXT_NAME..."
+  URL="mirror://sourceforge/geoserver/GeoServer/${UPDATE_NIX_NEW_VERSION}/extensions/geoserver-${UPDATE_NIX_NEW_VERSION}-${EXT_NAME}-plugin.zip"
+  HASH=$(nix-hash --to-sri --type sha256 "$(nix-prefetch-url --unpack "$URL")")
+  sed -i "s@version = \".*\"; # $EXT_NAME@version = \"$UPDATE_NIX_NEW_VERSION\"; # $EXT_NAME@" ./extensions.nix
+  sed -i "s@hash = \".*\"; # $EXT_NAME@hash = \"$HASH\"; # $EXT_NAME@" ./extensions.nix
 done
 
 cd -

--- a/pkgs/by-name/ge/geoserver/update.sh
+++ b/pkgs/by-name/ge/geoserver/update.sh
@@ -32,7 +32,7 @@ fi
 
 for EXT_NAME in "${EXT_NAMES[@]}"; do
   echo "Updating extension $EXT_NAME..."
-  URL="mirror://sourceforge/geoserver/GeoServer/${UPDATE_NIX_NEW_VERSION}/extensions/geoserver-${UPDATE_NIX_NEW_VERSION}-${EXT_NAME}-plugin.zip"
+  URL="https://sourceforge.net/projects/geoserver/files/GeoServer/${UPDATE_NIX_NEW_VERSION}/extensions/geoserver-${UPDATE_NIX_NEW_VERSION}-${EXT_NAME}-plugin.zip"
   HASH=$(nix-hash --to-sri --type sha256 "$(nix-prefetch-url --unpack "$URL")")
   sed -i "s@version = \".*\"; # $EXT_NAME@version = \"$UPDATE_NIX_NEW_VERSION\"; # $EXT_NAME@" ./extensions.nix
   sed -i "s@hash = \".*\"; # $EXT_NAME@hash = \"$HASH\"; # $EXT_NAME@" ./extensions.nix


### PR DESCRIPTION
This PR updates geoserver.nix to version 2.28.1.

In order to do this, I
- formatted/linted the update shell script
- updated the sourceforge URL (see also this [comment](https://github.com/NixOS/nixpkgs/pull/409110/files#r2584083247))
- split up the geofence-server in to geofence-server-h2 & geofence-server-postgres (both not used as geofence-server wasn't neither)
- disabled the libjpeg-turbo extension because of Java errors (which I havent' looked into furthermore).

Tests are passing for me (`nix build -L .#geoserver.tests.geoserver`)

This PR supersedes https://github.com/NixOS/nixpkgs/pull/452631 which can be close now.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
