### PR TITLE
peering-manager: 1.9.7 -> 1.10.1, use django 5.2

### DIFF
--- a/pkgs/by-name/pe/peering-manager/package.nix
+++ b/pkgs/by-name/pe/peering-manager/package.nix
@@ -7,21 +7,28 @@
   plugins ? ps: [ ],
 }:
 
-python3.pkgs.buildPythonApplication rec {
+let
+  python = python3.override {
+    packageOverrides = final: prev: {
+      django = prev.django_5_2;
+    };
+  };
+in
+python.pkgs.buildPythonApplication rec {
   pname = "peering-manager";
-  version = "1.9.7";
+  version = "1.10.1";
 
   src = fetchFromGitHub {
     owner = "peering-manager";
     repo = "peering-manager";
     tag = "v${version}";
-    sha256 = "sha256-lxelWtiMO6w8Tt7zK/NDdmc3PaKlGibKjSfhD+tGrCU=";
+    sha256 = "sha256-ByECaQ6NW1Su+k/j/bcKJqFf7bStdWZxOZn95GJEqBg=";
   };
 
   format = "other";
 
   propagatedBuildInputs =
-    with python3.pkgs;
+    with python.pkgs;
     [
       django
       django-debug-toolbar
@@ -46,9 +53,10 @@ python3.pkgs.buildPythonApplication rec {
       pyyaml
       requests
       social-auth-app-django
+      pytz
       tzdata
     ]
-    ++ plugins python3.pkgs;
+    ++ plugins python.pkgs;
 
   buildPhase = ''
     runHook preBuild
@@ -70,8 +78,8 @@ python3.pkgs.buildPythonApplication rec {
 
   passthru = {
     # PYTHONPATH of all dependencies used by the package
-    python = python3;
-    pythonPath = python3.pkgs.makePythonPath propagatedBuildInputs;
+    inherit python;
+    pythonPath = python.pkgs.makePythonPath propagatedBuildInputs;
 
     tests = {
       inherit (nixosTests) peering-manager;


### PR DESCRIPTION
Changelog: https://github.com/peering-manager/peering-manager/releases/tag/v1.10.1
Diff: https://github.com/peering-manager/peering-manager/compare/v1.9.7...v1.10.1

peering-manager 1.9.x should use django 5.1, peering-manager 1.10.x should use django 5.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
