### PR TITLE
dracula-icon-theme: 0-unstable-2024-05-26 -> 0-unstable-2025-08-2

### DIFF
--- a/pkgs/by-name/dr/dracula-icon-theme/package.nix
+++ b/pkgs/by-name/dr/dracula-icon-theme/package.nix
@@ -7,13 +7,13 @@
 
 stdenvNoCC.mkDerivation {
   pname = "dracula-icon-theme";
-  version = "0-unstable-2024-05-26";
+  version = "0-unstable-2025-08-2";
 
   src = fetchFromGitHub {
-    owner = "m4thewz";
-    repo = "dracula-icons";
-    rev = "6232e5217429a3ae6396c9e054f5338cecdbb7a5";
-    hash = "sha256-u2cIUTLWYs8VIqg6ZAUyz0nmzuFAZC4oh7bE67+B1Vg=";
+    owner  = "m4thewz";
+    repo   = "dracula-icons";
+    rev    = "de2a8edd94608ba0ac4dcf5a187af0ffaa511ebc";
+    sha256 = "sha256-JUjC6oalD7teSzzdMqLTXn7eJTZQbPP/oDeLBC7bG6E=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Upgrade to latest Dracula icon theme. Adds missing folder icons and updates folder style.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
