### PR TITLE
svt-vp9: init at 0.3.1

### DIFF
--- a/pkgs/by-name/sv/svt-vp9/package.nix
+++ b/pkgs/by-name/sv/svt-vp9/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  yasm,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "svt-vp9";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "OpenVisualCloud";
+    repo = "SVT-VP9";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-M7XpHCqTxGgk/UOlMR0jEXist6vGie6abRYLnVvC6sg=";
+  };
+
+  outputs = [
+    "bin"
+    "out"
+    "dev"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    yasm
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "VP9-compliant encoder targeting performance levels applicable to both VOD and live video applications";
+    changelog = "https://github.com/OpenVisualCloud/SVT-VP9/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/OpenVisualCloud/SVT-VP9";
+    license = lib.licenses.bsd2Patent;
+    maintainers = with lib.maintainers; [
+      niklaskorz
+    ];
+    mainProgram = "SvtVp9EncApp";
+    platforms = [ "x86_64-linux" ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is a preparation to bring svt-vp9 support to ffmpeg.
The package is already useful by itself thanks to the `SvtVp9EncApp` CLI, so it makes sense to init it independently of the ffmpeg support.
I know interest in VP9 has waned thanks to AV1, but VP9 still has much more widespread hardware decoding support than AV1 and is a great improvement over H264, comparable to HEVC but with fewer patent issues (as of now, I am not aware of any _successful_ VP9-related patent lawsuits).

For a performance comparison, on my 16 core AMD 7950X3D for a 1920x1080 video, svt-vp9 has a speed factor of 5.1x and vpx-vp9 a mere 0.3x on default settings, at best 1x with settings improving parallelization at the expense of quality (I haven't done any qualitative comparison myself, but in ~5 year old comparisons, vpx-vp9 does fare slightly better in visual quality than svt-vp9, although at a very high performance cost).

I'm postponing the ffmpeg PR until it's clear whether upstreaming svt-vp9's ffmpeg patch is acceptable (it's rather small, so I don't see any blockers per se, but I'm awaiting feedback in https://github.com/OpenVisualCloud/SVT-VP9/issues/139 since I doubt @atemu @jopejoe1 @emilazy would accept an out-of-tree feature patch). Until then feel free to try it out on ffmpeg using my changes in https://github.com/niklaskorz/nixpkgs/commit/38c2b1ab04795b33db92b20a7e24d88352c27516.

Usage:

```
# General usage of SvtVp9EncApp
SvtVp9EncApp -i [in.yuv] -w [width] -h [height] -b [out.ivf]
ffmpeg -i [input.mp4] -nostdin -f rawvideo -pix_fmt yuv420p - | SvtVp9EncApp -i stdin -n [number_of_frames_to_encode] -w [width] -h [height]

# Upstream libsvt_vp9 ffmpeg example
ffmpeg -f lavfi -i testsrc=duration=1:size=1280x720:rate=30 -c:v libsvt_vp9 -rc 1 -b:v 10M -preset 1 -y test.ivf
ffmpeg -f lavfi -i testsrc=duration=1:size=1280x720:rate=30 -vframes 1000 -c:v libsvt_vp9 -y test.mp4
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
