### PR TITLE
nixos/unl0kr: add libinput quirks to initrd

### DIFF
--- a/nixos/modules/system/boot/unl0kr.nix
+++ b/nixos/modules/system/boot/unl0kr.nix
@@ -87,6 +87,7 @@ in
       contents."/etc/unl0kr.conf".source = settingsFormat.generate "unl0kr.conf" cfg.settings;
       storePaths = with pkgs; [
         libinput
+        libinput.out
         xkeyboard_config
         (lib.getExe' cfg.package "unl0kr")
         "${cfg.package}/libexec/unl0kr-agent"


### PR DESCRIPTION
Fixes libinput quirks not found in initrd as seen in log:

  unl0kr-agent: libinput error: Failed to load the device quirks

## Things done

Added `pkgs.libinput.out` to `boot.initrd.systemd.storePaths` so that the quirks files are added to `initrd` and can be found by `libinput` as used by `unl0kr`.

This fixes the following errors:

```
Dez 03 13:45:18 plato unl0kr-agent[185]: libinput error: /nix/store/zv7jdwm1mk54q39rmnz65kmkh5fb72f6-libinput-1.29.2/share/libinput: failed to find data files
Dez 03 13:45:18 plato unl0kr-agent[185]: libinput error: Failed to load the device quirks from /nix/store/zv7jdwm1mk54q39rmnz65kmkh5fb72f6-libinput-1.29.2/share/libinput. This will negatively affect device behavior. See https://wayland.freedesktop.org/libinput/doc/1.29.2/device-quirks.html for details.
```

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
