### PR TITLE
android-unpinner: init at 0-unstable-2025-10-30

### DIFF
--- a/pkgs/by-name/an/android-unpinner/package.nix
+++ b/pkgs/by-name/an/android-unpinner/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  autoPatchelfHook,
+  android-tools,
+  androidenv,
+  frida-tools,
+  libfrida-core,
+  aapt,
+  apksigner,
+}:
+let
+  inherit (python3Packages) buildPythonApplication hatchling rich-click;
+  buildToolsVersion = "33.0.2";
+  androidComposition = androidenv.composeAndroidPackages {
+    buildToolsVersions = [ buildToolsVersion ];
+  };
+in
+buildPythonApplication {
+  pname = "android-unpinner";
+  version = "0-unstable-2025-10-30";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "mitmproxy";
+    repo = "android-unpinner";
+    rev = "60cbfee4d43cedaff622d72c27d87e418a111413";
+    sha256 = "sha256-nEkGn7RCraZuRSKp9hsVcRgE1EW6nRqEzxsGXprEd9Q=";
+  };
+
+  build-system = [ hatchling ];
+
+  preBuild = ''
+    ln -sf ${lib.getExe apksigner} android_unpinner/vendor/build_tools/linux/apksigner
+    ln -sf ${lib.getExe' aapt "aapt2"} android_unpinner/vendor/build_tools/linux/aapt2
+    ln -sf ${androidComposition.androidsdk}/libexec/android-sdk/build-tools/${buildToolsVersion}/zipalign android_unpinner/vendor/build_tools/linux/zipalign
+    ln -sf ${lib.getExe' android-tools "adb"} android_unpinner/vendor/platform_tools/linux/adb
+  '';
+
+  dependencies = [
+    rich-click
+
+    # https://github.com/mitmproxy/android-unpinner/tree/main/android_unpinner/vendor
+    frida-tools
+    libfrida-core
+    #androidenv.androidPkgs.ndk-bundle
+  ];
+
+  # https://github.com/NixOS/nixpkgs/pull/442819
+  pythonRelaxDeps = [ "rich-click" ];
+
+  pythonImportsCheck = [ "android_unpinner" ];
+
+  meta = {
+    description = "Remove Certificate Pinning from APKs";
+    homepage = "https://github.com/mitmproxy/android-unpinner";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+}


### PR DESCRIPTION
dependency relaxing can be removed after https://github.com/NixOS/nixpkgs/pull/442819 has been merged
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
