### PR TITLE
nixos/tests: fix meta.maintainers types

### DIFF
--- a/nixos/tests/blint.nix
+++ b/nixos/tests/blint.nix
@@ -7,10 +7,12 @@
 {
   name = "owasp blint test";
 
-  meta.maintainers = with lib; [
-    maintainers.ethancedwards8
-    teams.ngi
-  ];
+  meta.maintainers =
+    with lib;
+    [
+      maintainers.ethancedwards8
+    ]
+    ++ teams.ngi.members;
 
   nodes.machine = {
     environment.systemPackages = with pkgs; [

--- a/nixos/tests/corteza.nix
+++ b/nixos/tests/corteza.nix
@@ -4,7 +4,7 @@ let
 in
 {
   name = "corteza";
-  meta.maintainers = [ lib.teams.ngi.members ];
+  meta.maintainers = lib.teams.ngi.members;
 
   nodes.machine = {
     services.corteza = {

--- a/nixos/tests/dep-scan.nix
+++ b/nixos/tests/dep-scan.nix
@@ -7,10 +7,12 @@
 {
   name = "owasp dep-scan test";
 
-  meta.maintainers = with lib; [
-    maintainers.ethancedwards8
-    teams.ngi
-  ];
+  meta.maintainers =
+    with lib;
+    [
+      maintainers.ethancedwards8
+    ]
+    ++ teams.ngi.members;
 
   nodes.machine = {
     environment.systemPackages = with pkgs; [

--- a/nixos/tests/geoserver.nix
+++ b/nixos/tests/geoserver.nix
@@ -19,7 +19,7 @@ in
 
   name = "geoserver";
   meta = {
-    maintainers = with lib; [ teams.geospatial.members ];
+    maintainers = lib.teams.geospatial.members;
   };
 
   nodes = {

--- a/nixos/tests/mitmproxy.nix
+++ b/nixos/tests/mitmproxy.nix
@@ -9,7 +9,7 @@ let
 in
 {
   name = "mitmproxy";
-  meta.maintainers = [ lib.teams.ngi.members ];
+  meta.maintainers = lib.teams.ngi.members;
 
   nodes.machine =
     { pkgs, ... }:

--- a/nixos/tests/nominatim.nix
+++ b/nixos/tests/nominatim.nix
@@ -10,10 +10,7 @@ in
 {
   name = "nominatim";
   meta = {
-    maintainers = with lib.teams; [
-      geospatial.members
-      ngi.members
-    ];
+    maintainers = with lib.teams; geospatial.members ++ ngi.members;
   };
 
   nodes = {

--- a/nixos/tests/qgis.nix
+++ b/nixos/tests/qgis.nix
@@ -15,7 +15,7 @@ import ./make-test-python.nix (
   {
     name = "qgis";
     meta = {
-      maintainers = with lib; [ teams.geospatial.members ];
+      maintainers = lib.teams.geospatial.members;
     };
 
     nodes = {


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
