### PR TITLE
obs-studio-plugins.obs-wayland-hotkeys: init at 1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25751,6 +25751,11 @@
     githubId = 3889585;
     name = "Cheng Shao";
   };
+  terrorw0lf = {
+    name = "duckling";
+    github = "TERRORW0LF";
+    githubId = 61637480;
+  };
   terryg = {
     name = "Terry Garcia";
     email = "terry@terryg.org";

--- a/pkgs/applications/video/obs-studio/plugins/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/default.nix
@@ -106,6 +106,8 @@
 
   obs-vnc = callPackage ./obs-vnc.nix { };
 
+  obs-wayland-hotkeys = qt6Packages.callPackage ./obs-wayland-hotkeys { };
+
   obs-websocket = qt6Packages.callPackage ./obs-websocket.nix { }; # Websocket 4.x compatibility for OBS Studio 28+
 
   pixel-art = callPackage ./pixel-art.nix { };

--- a/pkgs/applications/video/obs-studio/plugins/obs-wayland-hotkeys/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-wayland-hotkeys/default.nix
@@ -1,0 +1,41 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  obs-studio,
+  pkg-config,
+  qtbase,
+}:
+
+stdenv.mkDerivation (finalAttr: {
+  pname = "obs-wayland-hotkeys";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "leia-uwu";
+    repo = "obs-wayland-hotkeys";
+    tag = "v${finalAttr.version}";
+    hash = "sha256-vOQfOEAnxn5vCaWpwDED1C107BB/d7T10kmKTXJ4k8k=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    obs-studio
+    qtbase
+  ];
+
+  dontWrapQtApps = true;
+
+  meta = {
+    description = "OBS Studio plugin to integrate OBS hotkeys with the Wayland global shortcuts portal";
+    homepage = "https://github.com/leia-uwu/obs-wayland-hotkeys";
+    maintainers = with lib.maintainers; [ terrorw0lf ];
+    license = lib.licenses.gpl2;
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Added the obs-wayland-hotkeys obs-studio plugin.

Integrates obs-studio with the gobal-shortcut wayland portal. https://github.com/leia-uwu/obs-wayland-hotkeys
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
