### PR TITLE
haskellPackages.http2-tls: fix build, unmark broken

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -3032,6 +3032,17 @@ with haskellLib;
     })
   ] (doJailbreak super.http2-client);
 
+  # Needs tls >= 2.1.10
+  http2-tls =
+    lib.warnIf (lib.versionAtLeast self.tls.version "2.1.10")
+      "haskellPackages.http2-tls: tls override can be removed"
+      (super.http2-tls.override { tls = self.tls_2_1_12; });
+
+  # Relax http2 version bound (5.3.9 -> 5.3.10)
+  # https://github.com/well-typed/grapesy/issues/297
+  # Tests fail with duplicate IsLabel instance error
+  grapesy = dontCheck (doJailbreak super.grapesy);
+
   # doctests are failing https://github.com/alpmestan/taggy-lens/issues/8
   taggy-lens = dontCheck super.taggy-lens;
 

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -3163,7 +3163,6 @@ broken-packages:
   - http-wget # failure in job https://hydra.nixos.org/build/233236793 at 2023-09-02
   - http2-client-exe # failure in job https://hydra.nixos.org/build/260189666 at 2024-05-19
   - http2-grpc-types # failure in job https://hydra.nixos.org/build/233197769 at 2023-09-02
-  - http2-tls # failure in job https://hydra.nixos.org/build/233227095 at 2023-09-02
   - httpstan # failure in job https://hydra.nixos.org/build/233202072 at 2023-09-02
   - htune # failure in job https://hydra.nixos.org/build/234447885 at 2023-09-13
   - htvm # failure in job https://hydra.nixos.org/build/233218993 at 2023-09-02

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -896,7 +896,6 @@ dont-distribute-packages:
  - eventful-sql-common
  - eventful-sqlite
  - eventful-test-helpers
- - eventlog-live-otelcol
  - EventSocket
  - eventsource-geteventstore-store
  - eventsource-store-specs
@@ -1213,7 +1212,6 @@ dont-distribute-packages:
  - grapefruit-records
  - grapefruit-ui
  - grapefruit-ui-gtk
- - grapesy
  - grapesy-etcd
  - graph-rewriting-cl
  - graph-rewriting-gl


### PR DESCRIPTION
- Use tls_2_1_12 to satisfy the tls >= 2.1.10 requirement
- Add grapesy override to relax http2 version bound and skip failing tests

This fixes the build of eventlog-live-otelcol and other packages depending on http2-tls.

Can go directly to master, since it affects only a handful of haskell packages that used not to build.