### PR TITLE
mindustry: 152.2 -> 153, fix `buildPhase`

### DIFF
--- a/pkgs/by-name/mi/mindustry/deps.json
+++ b/pkgs/by-name/mi/mindustry/deps.json
@@ -2,8 +2,8 @@
  "!comment": "This is a nixpkgs Gradle dependency lockfile. For more details, refer to the Gradle section in the nixpkgs manual.",
  "!version": 1,
  "https://download.savannah.gnu.org": {
-  "releases/freetype/freetype-2.10.4": {
-   "tar.gz": "sha256-Xqt5XrsjrHcAHPtot9TVC11sdGkkewsBsslTJp9ljaw="
+  "releases/freetype/freetype-2.14.1": {
+   "tar.gz": "sha256-F02eU0AuG/nscnfiLsGZuj5Vpr4sB0DLGMDumFD8jDQ="
   }
  },
  "https://github.com": {
@@ -26,27 +26,34 @@
    "jar": "sha256-YbaPhCjWtlExwQ1dFNA6JrkiAfQYWxJ0VRV9rLnoYhY=",
    "pom": "sha256-ktvhk8s3T1zswrYWuXz+cWHRyK3YbkikD5Sv/gjcfz4="
   },
-  "libgdx/gdx-jnigen#gdx-jnigen-gradle/dffc32eecbf77aad264991ea44f1767a58cbee9d": {
-   "jar": "sha256-nuUxM4zDV48+8Z+Rsn2dhEhkH4wOcfG62lz84BUhDH0=",
-   "module": "sha256-OU9DEb3A9A7OtnJ6jQkS32KImMlNn9NX7eKMX4YVh5E=",
-   "pom": "sha256-0THLPDNZDZe9PbIEPl71pGwL7E6Oq2Y5LiVevltdbP8="
+  "libgdx/gdx-jnigen#gdx-jnigen-gradle/2.5.1": {
+   "jar": "sha256-58CVbO1KcCD3O1KssA1fjFtmFv/w1ELaKjpxYQy4uOo=",
+   "module": "sha256-ed8mnMRwzTx8sz6m1K00O/m5TUClRgFBr7Z52QTvMYI=",
+   "pom": "sha256-39d36SZMtgx/Lcu44RQbayrsHGmqq+7mUbHyZul96fc="
   },
-  "libgdx/gdx-jnigen#gdx-jnigen/28dd11fa4c33a7ae9e58897912b52ba7d53d54fe": {
-   "jar": "sha256-fPszziBPrTDACbBuL6OxJ2oK1iA4izBk4TMHK53b+GQ=",
-   "module": "sha256-0RR9vgSqD1ISADHSO5OV7rxi+6HM9h0ZO4kEYw/Ao4Y=",
-   "pom": "sha256-vnz59i+3/wY9RizYWGMOuebfrZO4HrpOYV73ShIFH2g="
+  "libgdx/gdx-jnigen#gdx-jnigen-loader/2.5.1": {
+   "jar": "sha256-6I+6THOtnaVYhOB4feFo1xkdF25G6T5iJfQyPCTc+Wo=",
+   "module": "sha256-Sdga7alkfzS4Loy6XAGXvw/+E0AoS6I1HcWD3cBPej4=",
+   "pom": "sha256-ieP1KOe4XwibX7rqHWJat1iH0saLcvfGjosSbODwKcc="
   },
-  "libgdx/gdx-jnigen#gdx-jnigen/dffc32eecbf77aad264991ea44f1767a58cbee9d": {
-   "jar": "sha256-bd8xr4/YgvQbvdFkayXdJKpMvYwE9XlISof20vsfcSU=",
-   "module": "sha256-zQ1DewRtrsdTgxXINq7pOa+UJwnDNrGsVKnX0K/AWRQ=",
-   "pom": "sha256-HWFvvs+x6DyJioqkRDDVvf0GCKfxPTjhdec8JC2PZvA="
+  "libgdx/gdx-jnigen#gdx-jnigen/2.5.1": {
+   "jar": "sha256-OeLq815DT4ZtC8d7Ko/3VtV3u7R8Rj8HGX8mQb0eAZw=",
+   "module": "sha256-nicta1Y8N7VYMmNINhN4BRjsUCljtHv+g1lphUuKno8=",
+   "pom": "sha256-lpq6D25HGTFHWR3WDgKd4G2irqsk1rnjvMQlqKL1/NM="
   }
  },
- "https://plugins.gradle.org/m2/org/jetbrains/kotlin": {
-  "jvm#org.jetbrains.kotlin.jvm.gradle.plugin/2.1.10": {
+ "https://plugins.gradle.org/m2": {
+  "de/undercouch#gradle-download-task/5.0.1": {
+   "jar": "sha256-7VONXLvRug+MUcCRaEVg0S4JPuJwyFvDN6emaj97Rcc=",
+   "pom": "sha256-AkX+RSGxdvwB9LLDtWi08AGYjBxHtCg7cm2rRqhqC4g="
+  },
+  "de/undercouch/download#de.undercouch.download.gradle.plugin/5.0.1": {
+   "pom": "sha256-GR8NCdz7n02v4EMwQRsdllH9IUpaZ5FoGnfOzSPCQ7A="
+  },
+  "org/jetbrains/kotlin/jvm#org.jetbrains.kotlin.jvm.gradle.plugin/2.1.10": {
    "pom": "sha256-KoiNElh3d5C3j7zg6xTZUFBwv1uLzKS7YB4s6/pCPtA="
   },
-  "kapt#org.jetbrains.kotlin.kapt.gradle.plugin/2.1.10": {
+  "org/jetbrains/kotlin/kapt#org.jetbrains.kotlin.kapt.gradle.plugin/2.1.10": {
    "pom": "sha256-HzOk8LbO3qaMYhC518PU/t7EGF2dUIqsqs0933q2Ti8="
   }
  },

--- a/pkgs/by-name/mi/mindustry/package.nix
+++ b/pkgs/by-name/mi/mindustry/package.nix
@@ -155,16 +155,20 @@ stdenv.mkDerivation {
   ''
   + lib.optionalString enableClient ''
     pushd ../Arc
-    gradle jnigenBuild
+    # unsupported platforms need to be excluded because their native build tools aren't available
+    gradle jnigenBuild -x jnigenBuildAndroid -x jnigenBuildWindows -x jnigenBuildWindows64
     gradle jnigenJarNativesDesktop
     glewlib=${lib.getLib glew}/lib/libGLEW.so
     sdllib=${lib.getLib SDL2}/lib/libSDL2.so
-    patchelf backends/backend-sdl/libs/linux64/libsdl-arc*.so \
-      --add-needed $glewlib \
-      --add-needed $sdllib
+    patchelf backends/backend-sdl/build/Arc/backends/backend-sdl/libs/linux64/libsdl-arc*.so \
+      --add-needed "$glewlib" \
+      --add-needed "$sdllib"
     # Put the freshly-built libraries where the pre-built libraries used to be:
-    cp arc-core/libs/*/* natives/natives-desktop/libs/
-    cp extensions/freetype/libs/*/* natives/natives-freetype-desktop/libs/
+    cp arc-core/build/Arc/arc-core/libs/*/* natives/natives-desktop/libs/
+    cp backends/backend-sdl/build/Arc/backends/backend-sdl/libs/*/* natives/natives-desktop/libs/
+    # below target dirs are based on Arc upstream: Arc/extensions/../build.gradle
+    cp extensions/freetype/build/Arc/extensions/freetype/libs/*/* natives/natives-freetype-desktop/libs/
+    cp extensions/filedialogs/build/Arc/extensions/filedialogs/libs/*/* natives/natives-filedialogs/libs/
     popd
 
     gradle desktop:dist

--- a/pkgs/by-name/mi/mindustry/package.nix
+++ b/pkgs/by-name/mi/mindustry/package.nix
@@ -38,7 +38,7 @@
 
 let
   pname = "mindustry";
-  version = "152.2";
+  version = "153";
   buildVersion = makeBuildVersion version;
 
   jdk = jdk17;
@@ -48,14 +48,14 @@ let
     owner = "Anuken";
     repo = "Mindustry";
     tag = "v${version}";
-    hash = "sha256-DRH6Gd/NOXvTZAMu3qcpEk6Ii1l7NMPLd8+RLUyt7yE=";
+    hash = "sha256-yVrOHZOCZrI5SsmMdo7Eh+zS0PXv2X67zLCdLOWcPVc=";
   };
   Arc = fetchFromGitHub {
     name = "Arc-source";
     owner = "Anuken";
     repo = "Arc";
     tag = "v${version}";
-    hash = "sha256-TfDgzApR9LlnVVUOgIZu5pSLzbGlqrsXqzUN88lYN8s=";
+    hash = "sha256-JyiFxzdZtU0ILytTCfZrhBU2oZ3gF1kzMbSdjxqvTYs=";
   };
   soloud = fetchFromGitHub {
     owner = "Anuken";


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/465190

[Changelog](https://github.com/Anuken/Mindustry/releases/tag/v153)

### Commit 1: version 152.2 -> 153
- [x] updates semver and hashes
- [x] updates gradle deps

### Commit 2: fixes native lib installation for v153
- [x] excludes Android and Windows in `jnigenBuild` to end build errors
- [x] adds/updates source paths for copying [`arc-core`](https://github.com/Anuken/Arc/blob/52269919b2644144eef5e4bb948b465d36f58d19/arc-core/build.gradle#L175C1-L179C10), `backend-sdl`, [`freetype`](https://github.com/Anuken/Arc/blob/master/extensions/freetype/build.gradle) and [`filedialog`](https://github.com/Anuken/Arc/blob/master/extensions/filedialogs/build.gradle) native libs from during `buildPhase` based on upstream `gradle.build` paths (linked) 

<img width="1920" height="1080" alt="mindustry" src="https://github.com/user-attachments/assets/6ceb40e1-2e31-4861-87a3-c6330e9a3016" />
<img width="745" height="158" alt="mindustry-server" src="https://github.com/user-attachments/assets/10d8b381-d050-4689-b3d4-170660352ead" />



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
