### PR TITLE
pkgsStatic.haskellPackages.ghc: 9.4 -> 9.12

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4778,10 +4778,9 @@ with pkgs;
 
   haskellPackages = recurseIntoAttrs (
     # Prefer native-bignum to avoid linking issues with gmp;
-    # TemplateHaskell doesn't work with hadrian built GHCs yet
-    # https://github.com/NixOS/nixpkgs/issues/275304
+    # GHC 9.10 doesn't work too well with iserv-proxy.
     if stdenv.hostPlatform.isStatic then
-      haskell.packages.native-bignum.ghc94
+      haskell.packages.native-bignum.ghc912
     # JS backend can't use gmp
     else if stdenv.hostPlatform.isGhcjs then
       haskell.packages.native-bignum.ghc910

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -431,26 +431,6 @@ let
           };
 
       pkgsCross = {
-        aarch64-android-prebuilt.pkgsStatic =
-          removePlatforms
-            [
-              # Android NDK package doesn't support building on
-              "aarch64-darwin"
-              "aarch64-linux"
-
-              "x86_64-darwin"
-            ]
-            {
-              haskell.packages.ghc912 = {
-                inherit
-                  (packagePlatforms pkgs.pkgsCross.aarch64-android-prebuilt.pkgsStatic.haskell.packages.ghc912)
-                  ghc
-                  hello
-                  microlens
-                  ;
-              };
-            };
-
         ghcjs =
           removePlatforms
             [

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -428,15 +428,6 @@ let
                 postgrest
                 ;
             };
-
-            haskell.packages.native-bignum.ghc9103 = {
-              inherit (packagePlatforms pkgs.pkgsStatic.haskell.packages.native-bignum.ghc9103)
-                hello
-                random
-                QuickCheck
-                terminfo # isn't bundled for cross
-                ;
-            };
           };
 
       pkgsCross = {


### PR DESCRIPTION
We recently merged changes to build TemplateHaskell with iserv-proxy, which allows us to bump pkgsStatic from GHC 9.4 to GHC 9.8+. Currently, GHC 9.10 would be the default, but it fails some builds with TH (for example `pkgsStatic.haskell.packages.native-bignum.ghc910.jose`), which succeed with GHC 9.12.

Resolves #275304

## Things done

- Built `pkgsStatic.postgrest` on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
