### PR TITLE
beets: revert "make ffmpeg overridable"

### DIFF
--- a/pkgs/by-name/be/beets/package.nix
+++ b/pkgs/by-name/be/beets/package.nix
@@ -1,10 +1,5 @@
 {
-  ffmpeg,
-  python3Packages,
+  python3,
 }:
 
-python3Packages.toPythonApplication (
-  python3Packages.beets.override {
-    inherit ffmpeg;
-  }
-)
+python3.pkgs.toPythonApplication python3.pkgs.beets


### PR DESCRIPTION
This PR reverts NixOS/nixpkgs#467015, here's why:

`ffmpeg` is not the only top-level package that is used in `beets`' expression. Overriding `beets` is documented in `python-packages/beets/default.nix`, and in general should be done by overriding `python3.pkgs.beets` and not top-level `beets`. Treating `ffmpeg` specially in the top-level expression is odd and inconsistent with the others. See discussion at:

- https://github.com/NixOS/nixpkgs/pull/454559