### PR TITLE
python3Packages.pytest_9: init at 9.0.1

### DIFF
--- a/pkgs/development/python-modules/pytest/9.nix
+++ b/pkgs/development/python-modules/pytest/9.nix
@@ -1,0 +1,117 @@
+{
+  buildPythonPackage,
+  callPackage,
+  fetchFromGitHub,
+  lib,
+  pytest_9,
+  pythonOlder,
+  writeText,
+
+  # build-system
+  setuptools,
+  setuptools-scm,
+
+  # dependencies
+  attrs,
+  exceptiongroup,
+  iniconfig,
+  packaging,
+  pluggy,
+  tomli,
+
+  # optional-dependencies
+  argcomplete,
+  hypothesis,
+  mock,
+  pygments,
+  requests,
+  xmlschema,
+}:
+
+buildPythonPackage rec {
+  pname = "pytest";
+  version = "9.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "pytest-dev";
+    repo = "pytest";
+    tag = version;
+    hash = "sha256-kZSEv/6/ByMoydp/RuBdKU6ITJlDWA2lt4myPbojAMU=";
+  };
+
+  outputs = [
+    "out"
+    "testout"
+  ];
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    iniconfig
+    packaging
+    pluggy
+    pygments
+  ]
+  ++ lib.optionals (pythonOlder "3.11") [
+    exceptiongroup
+    tomli
+  ];
+
+  optional-dependencies = {
+    testing = [
+      argcomplete
+      attrs
+      hypothesis
+      mock
+      requests
+      setuptools
+      xmlschema
+    ];
+  };
+
+  postInstall = ''
+    mkdir $testout
+    cp -R testing $testout/testing
+  '';
+
+  doCheck = false;
+  passthru.tests.pytest = callPackage ./tests.nix {
+    pytest = pytest_9;
+  };
+
+  # Remove .pytest_cache when using py.test in a Nix build
+  setupHook = writeText "pytest-hook" ''
+    pytestcachePhase() {
+        find $out -name .pytest_cache -type d -exec rm -rf {} +
+    }
+    appendToVar preDistPhases pytestcachePhase
+
+    # pytest generates it's own bytecode files to improve assertion messages.
+    # These files similar to cpython's bytecode files but are never laoded
+    # by python interpreter directly. We remove them for a few reasons:
+    # - files are non-deterministic: https://github.com/NixOS/nixpkgs/issues/139292
+    #   (file headers are generatedt by pytest directly and contain timestamps)
+    # - files are not needed after tests are finished
+    pytestRemoveBytecodePhase () {
+        # suffix is defined at:
+        #    https://github.com/pytest-dev/pytest/blob/7.2.1/src/_pytest/assertion/rewrite.py#L51-L53
+        find $out -name "*-pytest-*.py[co]" -delete
+    }
+    appendToVar preDistPhases pytestRemoveBytecodePhase
+  '';
+
+  pythonImportsCheck = [ "pytest" ];
+
+  meta = {
+    changelog = "https://github.com/pytest-dev/pytest/blob/${src.tag}/doc/en/changelog.rst";
+    description = "Framework for writing tests";
+    homepage = "https://docs.pytest.org";
+    license = lib.licenses.mit;
+    mainProgram = "pytest";
+    teams = [ lib.teams.python ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14997,6 +14997,8 @@ self: super: with self; {
 
   pytest_8_3 = callPackage ../development/python-modules/pytest/8_3.nix { };
 
+  pytest_9 = callPackage ../development/python-modules/pytest/9.nix { };
+
   pytestcache = callPackage ../development/python-modules/pytestcache { };
 
   pythinkingcleaner = callPackage ../development/python-modules/pythinkingcleaner { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14993,6 +14993,8 @@ self: super: with self; {
 
   pytest8_3CheckHook = pytestCheckHook.override { pytest = pytest_8_3; };
 
+  pytest9CheckHook = pytestCheckHook.override { pytest = pytest_9; };
+
   pytest_7 = callPackage ../development/python-modules/pytest/7.nix { };
 
   pytest_8_3 = callPackage ../development/python-modules/pytest/8_3.nix { };


### PR DESCRIPTION
`python3Packages.pytest_9.passthru.tests` fails but so does `python3Packages.pytest.passthru.tests`
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
