### PR TITLE
[25.11] julia_111{,-bin}: mark as vulnerable

### DIFF
--- a/pkgs/development/compilers/julia/generic-bin.nix
+++ b/pkgs/development/compilers/julia/generic-bin.nix
@@ -153,5 +153,10 @@ stdenv.mkDerivation {
       "aarch64-darwin"
     ];
     mainProgram = "julia";
+    knownVulnerabilities = lib.optionals (lib.versions.majorMinor version == "1.11") [
+      ''
+        julia 1.11 has reached its end-of-life. Please use a supported version.
+      ''
+    ];
   };
 }

--- a/pkgs/development/compilers/julia/generic.nix
+++ b/pkgs/development/compilers/julia/generic.nix
@@ -165,5 +165,10 @@ stdenv.mkDerivation rec {
       "x86_64-linux"
       "aarch64-linux"
     ];
+    knownVulnerabilities = lib.optionals (lib.versions.majorMinor version == "1.11") [
+      ''
+        julia 1.11 has reached its end-of-life. Please use a supported version.
+      ''
+    ];
   };
 }


### PR DESCRIPTION
julia 1.11 is EOL since a month ago [1]
I went for this approach as no other version will become EOL in the support period of NixOS 25.05 or 25.11.

[1] https://endoflife.date/julia

non-breaking backport of #467579

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
