### PR TITLE
nix: Fix splicing

### DIFF
--- a/pkgs/tools/package-management/nix/modular/doc/manual/package.nix
+++ b/pkgs/tools/package-management/nix/modular/doc/manual/package.nix
@@ -30,8 +30,7 @@ mkMesonDerivation (finalAttrs: {
     "man"
   ];
 
-  # Hack for sake of the dev shell
-  passthru.externalNativeBuildInputs = [
+  nativeBuildInputs = [
     meson
     ninja
     (lib.getBin lowdown-unsandboxed)
@@ -43,9 +42,8 @@ mkMesonDerivation (finalAttrs: {
   ]
   ++ lib.optional (lib.versionAtLeast (lib.versions.majorMinor version) "2.33") [
     json-schema-for-humans
-  ];
-
-  nativeBuildInputs = finalAttrs.passthru.externalNativeBuildInputs ++ [
+  ]
+  ++ [
     nix-cli
   ];
 

--- a/pkgs/tools/package-management/nix/modular/src/libexpr/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libexpr/package.nix
@@ -51,11 +51,6 @@ mkMesonLibrary (finalAttrs: {
     nix-util
     nix-store
     nix-fetchers
-  ]
-  ++ finalAttrs.passthru.externalPropagatedBuildInputs;
-
-  # Hack for sake of the dev shell
-  passthru.externalPropagatedBuildInputs = [
     boost
     nlohmann_json
   ]

--- a/pkgs/tools/package-management/nix/modular/src/libstore-tests/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libstore-tests/package.nix
@@ -26,14 +26,11 @@ mkMesonExecutable (finalAttrs: {
 
   workDir = ./.;
 
-  # Hack for sake of the dev shell
-  passthru.externalBuildInputs = [
+  buildInputs = [
     sqlite
     rapidcheck
     gtest
-  ];
 
-  buildInputs = finalAttrs.passthru.externalBuildInputs ++ [
     nix-store
     nix-store-c
     nix-store-test-support

--- a/pkgs/tools/package-management/nix/modular/src/perl/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/perl/package.nix
@@ -27,11 +27,6 @@ perl.pkgs.toPerlModule (
 
     buildInputs = [
       nix-store
-    ]
-    ++ finalAttrs.passthru.externalBuildInputs;
-
-    # Hack for sake of the dev shell
-    passthru.externalBuildInputs = [
       bzip2
       libsodium
     ];

--- a/pkgs/tools/package-management/nix/modular/tests/functional/package.nix
+++ b/pkgs/tools/package-management/nix/modular/tests/functional/package.nix
@@ -35,8 +35,7 @@ mkMesonDerivation (
 
     workDir = ./.;
 
-    # Hack for sake of the dev shell
-    passthru.externalNativeBuildInputs = [
+    nativeBuildInputs = [
       meson
       ninja
       pkg-config
@@ -53,9 +52,8 @@ mkMesonDerivation (
       # For `script` command (ensuring a TTY)
       # TODO use `unixtools` to be precise over which executables instead?
       util-linux
-    ];
-
-    nativeBuildInputs = finalAttrs.passthru.externalNativeBuildInputs ++ [
+    ]
+    ++ [
       nix-cli
     ];
 


### PR DESCRIPTION
This is a port of https://github.com/nixos/nix/commit/cb5b0c30aa5733b40cc70089fe3829cb1046c352 from https://github.com/NixOS/nix/pull/14489 but adopted to preserve dependency order, and this not cause rebuilds.

We only need the one commit of that PR because we don't care about a dev shell for Nix in Nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
