### PR TITLE
tests.fetchtorrent: don't run these tests on Hydra, take 2

### DIFF
--- a/pkgs/build-support/fetchtorrent/tests.nix
+++ b/pkgs/build-support/fetchtorrent/tests.nix
@@ -29,11 +29,6 @@ let
     '';
     license = lib.licenses.cc-by-30;
     homepage = "https://durian.blender.org/";
-
-    # Reported in https://github.com/NixOS/nixpkgs/pull/458193#issuecomment-3575753211 that these
-    # tests are causing Hydra to spin for hours. They all pass locally, and we don't care too much
-    # about running them on Hydra.
-    hydraPlatforms = [ ];
   };
 
   # Via https://webtorrent.io/free-torrents
@@ -64,10 +59,20 @@ let
     popd
   '';
 
-  # Fixed output derivation hash is identical for all derivations: the empty
-  # directory.
   fetchtorrentWithHash =
-    args: fetchtorrent ({ hash = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo="; } // args);
+    args:
+    fetchtorrent (
+      {
+        # Fixed output derivation hash is identical for all derivations: the empty directory.
+        hash = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
+
+        # Reported in https://github.com/NixOS/nixpkgs/pull/458193#issuecomment-3575753211
+        # that these tests are causing Hydra to spin for hours on macOS.
+        # They all pass locally, and we don't care too much about running them on Hydra.
+        meta.hydraPlatforms = [ ];
+      }
+      // args
+    );
 in
 # Seems almost but not quite worth using lib.mapCartesianProduct...
 builtins.mapAttrs (n: v: testers.invalidateFetcherByDrvHash fetchtorrentWithHash v) {


### PR DESCRIPTION
As reported in https://github.com/NixOS/nixpkgs/pull/464999#issuecomment-3593574707, I landed this on the wrong attrset and didn't check it.

Now validated with `nix-instantiate --strict  --json --eval -A tests.fetchtorrent.http-link.meta.hydraPlatforms`


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test