### PR TITLE
stevia: init at 0.51.0

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/phosh.nix
+++ b/nixos/modules/services/x11/desktop-managers/phosh.nix
@@ -7,25 +7,6 @@
 let
   cfg = config.services.xserver.desktopManager.phosh;
 
-  # Based on https://source.puri.sm/Librem5/librem5-base/-/blob/4596c1056dd75ac7f043aede07887990fd46f572/default/sm.puri.OSK0.desktop
-  oskItem = pkgs.makeDesktopItem {
-    name = "sm.puri.OSK0";
-    desktopName = "On-screen keyboard";
-    exec = "${pkgs.squeekboard}/bin/squeekboard";
-    categories = [
-      "GNOME"
-      "Core"
-    ];
-    onlyShowIn = [ "GNOME" ];
-    noDisplay = true;
-    extraConfig = {
-      X-GNOME-Autostart-Phase = "Panel";
-      X-GNOME-Provides = "inputmethod";
-      X-GNOME-Autostart-Notify = "true";
-      X-GNOME-AutoRestart = "true";
-    };
-  };
-
   phocConfigType = lib.types.submodule {
     options = {
       xwayland = lib.mkOption {
@@ -245,8 +226,7 @@ in
     environment.systemPackages = [
       pkgs.phoc
       cfg.package
-      pkgs.squeekboard
-      oskItem
+      pkgs.stevia
     ];
 
     systemd.packages = [ cfg.package ];

--- a/pkgs/by-name/st/stevia/package.nix
+++ b/pkgs/by-name/st/stevia/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  meson,
+  ninja,
+  pkg-config,
+  python3,
+  wayland-scanner,
+  wrapGAppsHook3,
+  appstream,
+  cmake,
+  feedbackd,
+  fzf,
+  glib,
+  gmobile,
+  gnome-desktop,
+  gtk3,
+  hunspell,
+  json-glib,
+  libhandy,
+  libxkbcommon,
+  systemd,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "stevia";
+  version = "0.51.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "World/Phosh";
+    repo = "stevia";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-dRygDUHXpXjEuwNNfgVy742jfIhT9erN7IcmaMImuYw=";
+  };
+
+  mesonFlags = [
+    "-Dc_args=-I${glib.dev}/include/gio-unix-2.0"
+    "-Dsystemd_user_unit_dir=${placeholder "out"}/lib/systemd/user"
+  ];
+
+  postPatch = ''
+    patchShebangs --build tools/write-layout-info.py
+  '';
+
+  nativeBuildInputs = [
+    meson
+    cmake
+    ninja
+    pkg-config
+    python3
+    wayland-scanner
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    appstream
+    feedbackd
+    fzf
+    glib.dev
+    gmobile
+    gnome-desktop
+    gtk3
+    hunspell
+    json-glib
+    libhandy
+    libxkbcommon
+    systemd
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "User friendly on screen keyboard for Phosh";
+    homepage = "https://gitlab.gnome.org/World/Phosh/stevia";
+    changelog = "https://gitlab.gnome.org/World/Phosh/stevia/-/releases/v${finalAttrs.version}";
+    license = with lib.licenses; [ gpl3Plus ];
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      ungeskriptet
+      armelclo
+    ];
+    mainProgram = "phosh-osk-stevia";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Supercedes https://github.com/NixOS/nixpkgs/pull/466897, needs to be done in one PR

The phosh people are dropping squeekboard in favour of stevia since squeekboard is becoming unmaintained

https://phosh.mobi/releases/rel-0.51.0/#core-components
https://gitlab.gnome.org/World/Phosh/squeekboard/-/merge_requests/712

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
