### PR TITLE
[release-25.11] nixos/ollama: give `package` priority over `acceleration`

### DIFF
--- a/nixos/tests/ollama-cuda.nix
+++ b/nixos/tests/ollama-cuda.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib, pkgs, ... }:
 {
   name = "ollama-cuda";
   meta.maintainers = with lib.maintainers; [ abysssol ];
@@ -7,7 +7,7 @@
     { ... }:
     {
       services.ollama.enable = true;
-      services.ollama.acceleration = "cuda";
+      services.ollama.package = pkgs.ollama-cuda;
     };
 
   testScript = ''

--- a/nixos/tests/ollama-rocm.nix
+++ b/nixos/tests/ollama-rocm.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib, pkgs, ... }:
 {
   name = "ollama-rocm";
   meta.maintainers = with lib.maintainers; [ abysssol ];
@@ -7,7 +7,7 @@
     { ... }:
     {
       services.ollama.enable = true;
-      services.ollama.acceleration = "rocm";
+      services.ollama.package = pkgs.ollama-rocm;
     };
 
   testScript = ''

--- a/nixos/tests/ollama-vulkan.nix
+++ b/nixos/tests/ollama-vulkan.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib, pkgs, ... }:
 {
   name = "ollama-vulkan";
   meta.maintainers = with lib.maintainers; [ abysssol ];
@@ -7,7 +7,7 @@
     { ... }:
     {
       services.ollama.enable = true;
-      services.ollama.acceleration = "vulkan";
+      services.ollama.package = pkgs.ollama-vulkan;
     };
 
   testScript = ''

--- a/pkgs/by-name/ol/ollama/package.nix
+++ b/pkgs/by-name/ol/ollama/package.nix
@@ -57,7 +57,7 @@ let
 
   rocmRequested = shouldEnable "rocm" config.rocmSupport;
   cudaRequested = shouldEnable "cuda" config.cudaSupport;
-  vulkanRequested = shouldEnable "vulkan" false;
+  vulkanRequested = acceleration == "vulkan";
 
   enableRocm = rocmRequested && stdenv.hostPlatform.isLinux;
   enableCuda = cudaRequested && stdenv.hostPlatform.isLinux;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -390,6 +390,7 @@ with pkgs;
 
   oletools = with python3.pkgs; toPythonApplication oletools;
 
+  ollama-cpu = callPackage ../by-name/ol/ollama/package.nix { acceleration = false; };
   ollama-rocm = callPackage ../by-name/ol/ollama/package.nix { acceleration = "rocm"; };
   ollama-cuda = callPackage ../by-name/ol/ollama/package.nix { acceleration = "cuda"; };
   ollama-vulkan = callPackage ../by-name/ol/ollama/package.nix { acceleration = "vulkan"; };


### PR DESCRIPTION
This makes `acceleration` set the default `package`, but allow `package` to override `acceleration`. This isn't strictly backwards compatible, but is backwards compatible in the typical case of setting `acceleration` while not setting `package`, thus is unlikely to be disruptive to existing users.

This is a partial backport of #466004 with a similar goal of prioritizing use of `package` to select hardware acceleration, but without removing the `acceleration` option.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
