### PR TITLE
step-ca: 0.28.4 -> 0.29.0, nixos/step-ca: Set systemd Type=notify

### DIFF
--- a/nixos/modules/services/security/step-ca.nix
+++ b/nixos/modules/services/security/step-ca.nix
@@ -94,6 +94,7 @@ in
           ConditionFileNotEmpty = ""; # override upstream
         };
         serviceConfig = {
+          Type = "notify";
           User = "step-ca";
           Group = "step-ca";
           UMask = "0077";

--- a/pkgs/by-name/st/step-ca/package.nix
+++ b/pkgs/by-name/st/step-ca/package.nix
@@ -13,7 +13,7 @@
 
 buildGoModule rec {
   pname = "step-ca";
-  version = "0.28.4";
+  version = "0.29.0";
 
   src = fetchFromGitHub {
     owner = "smallstep";
@@ -24,20 +24,10 @@ buildGoModule rec {
     # Use forceFetchGit to fetch the source as git repo, as fetchGit isn't effected,
     # see https://github.com/NixOS/nixpkgs/issues/84312#issuecomment-2475948960.
     forceFetchGit = true;
-    hash = "sha256-ZIpsSNdQVkelo5b3H03N8qToHU7z+lalAE7Ur6m2YwY=";
+    hash = "sha256-TFpgVE394r6FkRWovlmDd3v/tGic2CekmO1Hp7S6KCE=";
   };
 
-  patches = [
-    # fix broken test TestHandler_RevokeCert
-    # https://github.com/smallstep/certificates/pull/2370
-    # TODO: remove at next release
-    (fetchpatch2 {
-      url = "https://github.com/smallstep/certificates/commit/b7e59c97f3b8a95a24153aeb85959118953f2bb4.patch?full_index=1";
-      hash = "sha256-GKGKUj4hpS4jo6sMvUhnD3BeE+f5vnxY5tK0a2pwpNM=";
-    })
-  ];
-
-  vendorHash = "sha256-gGPrrl5J8UrjUpof2DaSs1fAQsMSsyAMlC67h5V75+k=";
+  vendorHash = "sha256-9PlJaB3BCwoE+uFo5jUggANSH7ZWnintZYBgFL21LZ4=";
 
   ldflags = [
     "-w"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[I added sd_notify support in step-ca](https://github.com/smallstep/certificates/pull/2463), so the module can make use of it now.

CC @CMCDragonkai @techknowlogick

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
