### PR TITLE
busybox: add tests

### DIFF
--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -13,6 +13,13 @@
   useMusl ? stdenv.hostPlatform.libc == "musl",
   musl,
   extraConfig ? "",
+
+  # For tests
+  hostname,
+  coreutils,
+  zip,
+  which,
+  simple-http-server,
 }:
 
 assert stdenv.hostPlatform.libc == "musl" -> useMusl;
@@ -50,11 +57,13 @@ let
   };
   debianDispatcherScript = "${debianSource}/debian/tree/udhcpc/etc/udhcpc/default.script";
   outDispatchPath = "$out/default.script";
-in
 
-stdenv.mkDerivation rec {
   pname = "busybox";
   version = "1.37.0";
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  inherit pname version;
 
   # Note to whoever is updating busybox: please verify that:
   # nix-build pkgs/stdenv/linux/make-bootstrap-tools.nix -A test
@@ -183,9 +192,77 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  doCheck = false; # tries to access the net
+  doCheck = false; # Takes a while, requires extra dependencies
+  passthru = {
+    shellPath = "/bin/ash";
 
-  passthru.shellPath = "/bin/ash";
+    tests.withCheck = finalAttrs.finalPackage.overrideAttrs (_: {
+      doCheck = true;
+
+      nativeCheckInputs = [
+        hostname
+        zip
+        which
+        simple-http-server
+      ];
+
+      preCheck = ''
+        # Replace hard-coded dependencies on /bin
+        sed -i 's|/bin/date|${lib.getExe' coreutils "date"}|' testsuite/date/date-works-1
+
+        # wget tests rely on network access, use simple-http-server instead
+        simple-http-server --index &
+        sed -i 's|http://www.google.com|http://127.0.0.1:8000|' testsuite/wget/*
+
+        skip-files() {
+          for file in "$@"; do
+            echo "echo SKIPPED $file; exit 0" > $file
+          done
+        }
+
+        skip-testcase() {
+          sed -i "s@testing \"$2\"@echo SKIPPED $2 || testing \"$2\"@" "$1"
+        }
+
+        # Skip known-broken tests
+        export SKIP_KNOWN_BUGS=y
+
+        # There are some semi-expected locale-related issues, disable tests that rely on it
+        export CONFIG_UNICODE_USING_LOCALE=y
+
+        # DISABLE SOME TESTS
+        # TODO(balsoft): fix the tests instead of skipping
+
+        pushd testsuite
+
+        # Weird failures, may or may not be related to locales
+        skip-files du/du-{h,k,l}-works
+
+        # Relies on a default PATH (/bin/ls in particular)
+        skip-files which/which-uses-default-path
+
+        # Hangs indefinitely if run from sandbox
+        skip-files md5sum.tests
+
+        # Doesn't work with coreutils's "false"
+        skip-testcase start-stop-daemon.tests "start-stop-daemon with both -x and -a"
+
+        # Relies on /usr/bin
+        skip-testcase cpio.tests "cpio -p with absolute paths"
+
+        # Relies on suid/guid bits
+        skip-testcase cpio.tests "cpio restores suid/sgid bits"
+
+        # Weird failures, looks related to our sandbox
+        skip-testcase tar.tests "tar does not extract into symlinks"
+        skip-testcase tar.tests "tar -k does not extract into symlinks"
+        skip-testcase tar.tests "tar Symlink attack: create symlink and then write through it"
+        skip-testcase tar.tests "tar Symlinks and hardlinks coexist"
+
+        popd
+      '';
+    });
+  };
 
   meta = {
     description = "Tiny versions of common UNIX utilities in a single small executable";
@@ -201,4 +278,4 @@ stdenv.mkDerivation rec {
     priority = 15; # below systemd (halt, init, poweroff, reboot) and coreutils
     identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "busybox" version;
   };
-}
+})


### PR DESCRIPTION
Adds the upstream test suite as passthru.tests.withCheck.

We have to fix up some tests due to our constraints (no FHS, no internet), and some tests are too hard to fix and are disabled for now.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
