### PR TITLE
python3Packages.mmengine: disable tests that fail due to resource conflicts on Darwin

### DIFF
--- a/pkgs/development/python-modules/mmengine/default.nix
+++ b/pkgs/development/python-modules/mmengine/default.nix
@@ -128,6 +128,33 @@ buildPythonPackage rec {
     # ValueError: User specified autocast device_type must be cuda or cpu, but got mps
     "tests/test_runner/test_runner.py::TestRunner::test_test"
     "tests/test_runner/test_runner.py::TestRunner::test_val"
+
+    # Fails in pytestCheckHook due to multiple copies accessing the same resources (nixpkgs-review
+    "tests/test_hooks/test_ema_hook.py::TestEMAHook::test_after_test_epoch"
+    "tests/test_hooks/test_ema_hook.py::TestEMAHook::test_after_val_epoch"
+    "tests/test_hooks/test_ema_hook.py::TestEMAHook::test_before_test_epoch"
+    "tests/test_hooks/test_ema_hook.py::TestEMAHook::test_before_val_epoch"
+    "tests/test_infer/test_infer.py"
+    "tests/test_runner/test_runner.py::TestRunner::test_checkpoint"
+
+    # torch.distributed.DistNetworkError: [...] message: address already in use
+    # Happens in nixpkgs-review due to the lack of network namespacing
+    # Note: These all worked fine in nix-build
+    "tests/test_dist/test_dist.py"
+    "tests/test_dist/test_utils.py" # fails in _init_dist_env
+    "tests/test_hooks/test_sync_buffers_hook.py::TestSyncBuffersHook::test_sync_buffers_hook"
+    "tests/test_model/test_model_utils.py::test_is_model_wrapper"
+    "tests/test_model/test_wrappers/test_model_wrapper.py::TestDistributedDataParallel"
+    "tests/test_optim/test_optimizer/test_optimizer.py::TestZeroOptimizer::test_zero_redundancy_optimizer"
+    "tests/test_runner/test_runner.py::TestRunner::test_custom_loop"
+    "tests/test_runner/test_runner.py::TestRunner::test_default_scope"
+    "tests/test_runner/test_runner.py::TestRunner::test_init"
+    "tests/test_runner/test_runner.py::TestRunner::test_train"
+    "tests/test_optim/test_optimizer/test_optimizer_wrapper.py::TestOptimWrapper::test_optim_context"
+    "tests/test_testing/test_runner_test_case.py"
+
+    # TypeError: 'BaseDataset' object is not callable
+    "tests/test_dataset/test_base_dataset.py::TestBaseDataset::test_get_subset[False-True]"
   ];
 
   disabledTests = [
@@ -149,10 +176,10 @@ buildPythonPackage rec {
     # Fails when max-jobs is set to use fewer processes than cores
     # for example `AssertionError: assert 14 == 4`
     "test_setup_multi_processes"
-  ];
 
-  # torch.distributed.DistNetworkError: The server socket has failed to bind.
-  __darwinAllowLocalNetworking = true;
+    # Crashes in pytestCheckHook due to MPS incompatibility in torch
+    "test_with_runner"
+  ];
 
   meta = {
     description = "Library for training deep learning models based on PyTorch";


### PR DESCRIPTION
These tests are fine under nix-build but fail under nixpkgs-review due to port conflicts and torch access conflicts.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
