### PR TITLE
copyparty: 1.19.20 -> 1.19.21 and stop nixpkgs-update

### DIFF
--- a/pkgs/by-name/co/copyparty-full-buggy/package.nix
+++ b/pkgs/by-name/co/copyparty-full-buggy/package.nix
@@ -1,5 +1,5 @@
 { copyparty }:
-copyparty.override {
+(copyparty.override {
   withHashedPasswords = true;
   withCertgen = true;
   withThumbnails = true;
@@ -14,4 +14,16 @@ copyparty.override {
   withSMB = true;
   nameSuffix = "-full-buggy";
   longDescription = "Full variant, all dependencies and features including those marked buggy";
-}
+}).overrideAttrs
+  (old: {
+    # don't try to update this package, just update `copyparty`
+    # nixpkgs-update: no auto update
+    passthru = old.passthru // {
+      updateScript = null;
+    };
+
+    meta = old.meta // {
+      # this serves two purposes: it changes the description, but also makes meta.position point to this file so that the 'no auto update' works
+      description = old.meta.description + " - full variant";
+    };
+  })

--- a/pkgs/by-name/co/copyparty-min/package.nix
+++ b/pkgs/by-name/co/copyparty-min/package.nix
@@ -1,5 +1,5 @@
 { copyparty }:
-copyparty.override {
+(copyparty.override {
   withHashedPasswords = false;
   withCertgen = false;
   withThumbnails = false;
@@ -14,4 +14,16 @@ copyparty.override {
   withMagic = false;
   nameSuffix = "-min";
   longDescription = "Minimal variant, minimal dependencies and fewest features";
-}
+}).overrideAttrs
+  (old: {
+    # don't try to update this package, just update `copyparty`
+    # nixpkgs-update: no auto update
+    passthru = old.passthru // {
+      updateScript = null;
+    };
+
+    meta = old.meta // {
+      # this serves two purposes: it changes the description, but also makes meta.position point to this file so that the 'no auto update' works
+      description = old.meta.description + " - minimal variant";
+    };
+  })

--- a/pkgs/by-name/co/copyparty-most/package.nix
+++ b/pkgs/by-name/co/copyparty-most/package.nix
@@ -1,5 +1,5 @@
 { copyparty }:
-copyparty.override {
+(copyparty.override {
   withHashedPasswords = true;
   withCertgen = true;
   withThumbnails = true;
@@ -14,4 +14,16 @@ copyparty.override {
   withMagic = true;
   nameSuffix = "-most";
   longDescription = "Almost-full variant, all dependencies and features except those marked buggy";
-}
+}).overrideAttrs
+  (old: {
+    # don't try to update this package, just update `copyparty`
+    # nixpkgs-update: no auto update
+    passthru = old.passthru // {
+      updateScript = null;
+    };
+
+    meta = old.meta // {
+      # this serves two purposes: it changes the description, but also makes meta.position point to this file so that the 'no auto update' works
+      description = old.meta.description + " - most variant";
+    };
+  })

--- a/pkgs/by-name/co/copyparty/package.nix
+++ b/pkgs/by-name/co/copyparty/package.nix
@@ -71,11 +71,11 @@ in
 
 python3Packages.buildPythonApplication rec {
   pname = "copyparty${nameSuffix}";
-  version = "1.19.20";
+  version = "1.19.21";
 
   src = fetchurl {
     url = "https://github.com/9001/copyparty/releases/download/v${version}/copyparty-${version}.tar.gz";
-    hash = "sha256-BQzMNFVOWSEKynpn2HoYbmmz9NvgE9XuLxGiLCWagqY=";
+    hash = "sha256-RHI6gj8hjlKq7GB1aVlzp1uGY8kgLID9c/SOUsYazUI=";
   };
 
   pyproject = true;


### PR DESCRIPTION
[Release notes for 1.19.21](https://github.com/9001/copyparty/releases/tag/v1.19.21)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
