### PR TITLE
helm-values-schema-json: init at 2.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23833,6 +23833,12 @@
     githubId = 526260;
     name = "Scott Stephens";
   };
+  scout3r = {
+    email = "iam@theguy.io";
+    github = "scout3r";
+    githubId = 18079;
+    name = "Mate Gabri";
+  };
   scraptux = {
     email = "git@thomasjasny.de";
     github = "scraptux";

--- a/pkgs/applications/networking/cluster/helm/plugins/default.nix
+++ b/pkgs/applications/networking/cluster/helm/plugins/default.nix
@@ -18,4 +18,6 @@
   helm-schema = callPackage ./helm-schema.nix { };
 
   helm-unittest = callPackage ./helm-unittest.nix { };
+
+  helm-values-schema-json = callPackage ./helm-values-schema-json.nix { };
 }

--- a/pkgs/applications/networking/cluster/helm/plugins/helm-values-schema-json.nix
+++ b/pkgs/applications/networking/cluster/helm/plugins/helm-values-schema-json.nix
@@ -1,0 +1,45 @@
+{
+ buildGoModule,
+ fetchFromGitHub,
+ lib,
+}:
+
+buildGoModule rec {
+  pname = "helm-values-schema-json";
+  version = "2.3.1";
+
+  src = fetchFromGitHub {
+    owner = "losisin";
+    repo = "helm-values-schema-json";
+    tag = "v${version}";
+    hash = "sha256-F4tfPZnvvagWEO25JOjtYPYDn+8k6sRH0k1UvHIQRzg=";
+  };
+
+  vendorHash = "sha256-2HnbASIZqOPM9WOlZeEQKYbkBHXBjV0JaeKKYAAwQ3w=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/losisin/helm-values-schema-json/v2/cmd.Version=${version}"
+  ];
+
+  # NOTE: Remove the install and upgrade hooks.
+  postPatch = ''
+    sed -i '/^hooks:/,+2 d' plugin.yaml
+  '';
+
+  postInstall = ''
+    install -dm755 $out/helm-schema
+    mv $out/bin $out/helm-schema/
+    mv $out/helm-schema/bin/{helm-values-schema-json,../schema}
+    install -m644 -Dt $out/helm-schema plugin.yaml
+    install -m644 -Dt $out/helm-schema plugin.complete
+  '';
+
+  meta = {
+    description = "Helm plugin for generating values.schema.json from multiple values files";
+    homepage = "https://github.com/losisin/helm-values-schema-json";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ scout3r ];
+  };
+}


### PR DESCRIPTION
A Helm plugin to easily generate schema for `values.yaml`.

https://github.com/losisin/helm-values-schema-json

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
