### PR TITLE
Bazarr: Add missing webrtcvad dependency

### DIFF
--- a/pkgs/by-name/ba/bazarr/package.nix
+++ b/pkgs/by-name/ba/bazarr/package.nix
@@ -36,6 +36,7 @@ stdenv.mkDerivation rec {
       ps.pillow
       ps.setuptools
       ps.psycopg2
+      ps.webrtcvad
     ]))
   ]
   ++ runtimeProgDeps;


### PR DESCRIPTION
For a while I was wondering why everybody was praising bazarr's subtitle sync, while in my setup it was unreliable. Today I pulled up my sleeves and figured out why - it's a missing dependency, making bazarr choose less reliable algorithms.

See https://github.com/morpheus65535/bazarr/blob/v1.5.3/bazarr/subtitles/tools/subsyncer.py#L25-L30

## Things done

This improves reliability of subtitle auto syncing mechanism. In Nix package, because of this missing dependency bazarr/ffsubsync had to fall back to less reliable audiotok algorithm for analyzing the audio layer of video files.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc