### PR TITLE
lomiri-qt6: init

### DIFF
--- a/nixos/modules/services/desktop-managers/lomiri.nix
+++ b/nixos/modules/services/desktop-managers/lomiri.nix
@@ -99,6 +99,10 @@ in
             libayatana-common
             ubports-click
           ])
+          # Qt5 qtwebengine is not secure: https://github.com/NixOS/nixpkgs/pull/435067
+          ++ (with pkgs.lomiri-qt6; [
+            morph-browser
+          ])
           ++ (with pkgs.lomiri; [
             hfd-service
             libusermetrics
@@ -125,10 +129,6 @@ in
             lomiri-thumbnailer
             lomiri-url-dispatcher
             mediascanner2 # TODO possibly needs to be kicked off by graphical-session.target
-            # Qt5 qtwebengine is not secure: https://github.com/NixOS/nixpkgs/pull/435067
-            # morph-browser
-            # Adding another browser that is known-working until Morph Browser can migrate to Qt6
-            pkgs.epiphany
             qtmir # not having its desktop file for Xwayland available causes any X11 application to crash the session
             teleports
           ]);

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -992,7 +992,7 @@ in
   moonraker = runTest ./moonraker.nix;
   moosefs = runTest ./moosefs.nix;
   mopidy = runTest ./mopidy.nix;
-  morph-browser = runTest ./morph-browser.nix;
+  morph-browser = discoverTests (import ./morph-browser.nix);
   mosquitto = runTest ./mosquitto.nix;
   movim = import ./web-apps/movim {
     inherit runTest;

--- a/nixos/tests/lomiri.nix
+++ b/nixos/tests/lomiri.nix
@@ -507,16 +507,15 @@ in
               machine.send_key("alt-f4")
 
           # Morph is how we go online
-          # Qt5 qtwebengine is not secure: https://github.com/NixOS/nixpkgs/pull/435067
-          # with subtest("morph browser works"):
-          #     open_starter()
-          #     machine.send_chars("Morph\n")
-          #     wait_for_text(r"(Bookmarks|address|site|visited any)")
-          #     machine.screenshot("morph_open")
-          #
-          #     # morph-browser has a separate VM test to test its basic functionalities
-          #
-          #     machine.send_key("alt-f4")
+          with subtest("morph browser works"):
+              open_starter()
+              machine.send_chars("Morph\n")
+              wait_for_text(r"(Bookmarks|address|site|visited any)")
+              machine.screenshot("morph_open")
+
+              # morph-browser has a separate VM test to test its basic functionalities
+
+              machine.send_key("alt-f4")
 
           # LSS provides DE settings
           with subtest("system settings open"):

--- a/nixos/tests/lomiri.nix
+++ b/nixos/tests/lomiri.nix
@@ -688,7 +688,7 @@ in
               machine.screenshot("settings_lomiri-content-hub_peers")
 
               # Select Gallery as content source
-              mouse_click(460, 80)
+              mouse_click(540, 80)
 
               # Expect Gallery to be brought into the foreground, with its sharing page open
               wait_for_text("Photos")

--- a/nixos/tests/morph-browser.nix
+++ b/nixos/tests/morph-browser.nix
@@ -1,64 +1,81 @@
-{ pkgs, lib, ... }:
-{
-  name = "morph-browser-standalone";
-  meta.maintainers = lib.teams.lomiri.members;
-
-  nodes.machine =
-    { config, pkgs, ... }:
+let
+  makeTest = import ./make-test-python.nix;
+  generic =
     {
-      imports = [
-        ./common/x11.nix
-      ];
+      withQt6,
+    }:
+    makeTest (
+      { pkgs, lib, ... }:
+      {
+        name = "morph-browser-${if withQt6 then "qt6" else "qt5"}-standalone";
+        meta.maintainers = lib.teams.lomiri.members;
 
-      services.xserver.enable = true;
+        nodes.machine =
+          {
+            config,
+            pkgs,
+            ...
+          }:
+          {
+            imports = [
+              ./common/x11.nix
+            ];
 
-      environment = {
-        systemPackages = with pkgs.lomiri; [
-          suru-icon-theme
-          morph-browser
-        ];
-        variables = {
-          UITK_ICON_THEME = "suru";
-        };
-      };
+            services.xserver.enable = true;
 
-      i18n.supportedLocales = [ "all" ];
+            environment = {
+              systemPackages = with (if withQt6 then pkgs.lomiri-qt6 else pkgs.lomiri); [
+                suru-icon-theme
+                morph-browser
+              ];
+              variables = {
+                UITK_ICON_THEME = "suru";
+              };
+            };
 
-      fonts.packages = with pkgs; [
-        # Intended font & helps with OCR
-        ubuntu-classic
-      ];
-    };
+            i18n.supportedLocales = [ "all" ];
 
-  enableOCR = true;
+            fonts.packages = with pkgs; [
+              # Intended font & helps with OCR
+              ubuntu-classic
+            ];
+          };
 
-  testScript = ''
-    machine.wait_for_x()
+        enableOCR = true;
 
-    with subtest("morph browser launches"):
-        machine.succeed("morph-browser >&2 &")
-        machine.sleep(10)
-        machine.send_key("alt-f10")
-        machine.sleep(5)
-        machine.wait_for_text(r"Web Browser|New|sites|Bookmarks")
-        machine.screenshot("morph_open")
+        testScript = ''
+          machine.wait_for_x()
 
-    with subtest("morph browser displays HTML"):
-        machine.send_chars("file://${pkgs.valgrind.doc}/share/doc/valgrind/html/index.html\n")
-        machine.wait_for_text("Valgrind Documentation")
-        machine.screenshot("morph_htmlcontent")
+          with subtest("morph browser launches"):
+              machine.succeed("morph-browser >&2 &")
+              machine.sleep(10)
+              machine.send_key("alt-f10")
+              machine.sleep(5)
+              machine.wait_for_text(r"Web Browser|New|sites|Bookmarks")
+              machine.screenshot("morph_open")
 
-    machine.succeed("pkill -f morph-browser")
+          with subtest("morph browser displays HTML"):
+              machine.send_chars("file://${pkgs.valgrind.doc}/share/doc/valgrind/html/index.html\n")
+              machine.wait_for_text("Valgrind Documentation")
+              machine.screenshot("morph_htmlcontent")
 
-    # Get rid of saved tabs, to show localised start page
-    machine.succeed("rm -r /root/.local/share/morph-browser")
+          machine.succeed("pkill -f morph-browser")
 
-    with subtest("morph browser localisation works"):
-        machine.succeed("env LANG=de_DE.UTF-8 morph-browser >&2 &")
-        machine.sleep(10)
-        machine.send_key("alt-f10")
-        machine.sleep(5)
-        machine.wait_for_text(r"Web-Browser|Neuer|Seiten|Lesezeichen")
-        machine.screenshot("morph_localised")
-  '';
+          # Get rid of saved tabs, to show localised start page
+          machine.succeed("rm -r /root/.local/share/morph-browser")
+
+          with subtest("morph browser localisation works"):
+              machine.succeed("env LANG=de_DE.UTF-8 morph-browser >&2 &")
+              machine.sleep(10)
+              machine.send_key("alt-f10")
+              machine.sleep(5)
+              machine.wait_for_text(r"Web-Browser|Neuer|Seiten|Lesezeichen")
+              machine.screenshot("morph_localised")
+        '';
+      }
+    );
+in
+{
+  qt5 = generic { withQt6 = false; };
+  qt6 = generic { withQt6 = true; };
 }

--- a/pkgs/by-name/ay/ayatana-indicator-display/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-display/package.nix
@@ -15,8 +15,6 @@
   intltool,
   libayatana-common,
   libgudev,
-  libqtdbusmock,
-  libqtdbustest,
   librda,
   libsForQt5,
   lomiri,
@@ -91,8 +89,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   checkInputs = [
     gtest
-    libqtdbusmock
-    libqtdbustest
+    libsForQt5.libqtdbusmock
+    libsForQt5.libqtdbustest
     properties-cpp
   ];
 

--- a/pkgs/by-name/ay/ayatana-indicator-sound/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-sound/package.nix
@@ -16,8 +16,6 @@
   libgee,
   libnotify,
   libpulseaudio,
-  libqtdbusmock,
-  libqtdbustest,
   libsForQt5,
   libxml2,
   lomiri,
@@ -99,8 +97,8 @@ stdenv.mkDerivation (finalAttrs: {
     dbus-test-runner
     gtest
     libsForQt5.qtbase
-    libqtdbusmock
-    libqtdbustest
+    libsForQt5.libqtdbusmock
+    libsForQt5.libqtdbustest
     lomiri.gmenuharness
   ];
 

--- a/pkgs/desktops/lomiri/applications/morph-browser/default.nix
+++ b/pkgs/desktops/lomiri/applications/morph-browser/default.nix
@@ -159,10 +159,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     updateScript = gitUpdater { };
-    tests = lib.optionalAttrs (!withQt6) {
+    tests = {
       # Test of morph-browser itself
-      standalone = nixosTests.morph-browser;
-
+      standalone = if withQt6 then nixosTests.morph-browser.qt6 else nixosTests.morph-browser.qt5;
+    }
+    // lib.optionalAttrs (!withQt6) {
       # Interactions between the Lomiri ecosystem and this browser
       inherit (nixosTests.lomiri) desktop-basics desktop-appinteractions;
     };

--- a/pkgs/desktops/lomiri/applications/morph-browser/default.nix
+++ b/pkgs/desktops/lomiri/applications/morph-browser/default.nix
@@ -15,18 +15,21 @@
   lomiri-ui-toolkit,
   mesa,
   pkg-config,
-  qqc2-suru-style,
+  qqc2-suru-style ? null,
+  qt5compat ? null,
   qtbase,
   qtdeclarative,
-  qtquickcontrols2,
-  qtsystems,
+  qtquickcontrols2 ? null,
+  qtsystems ? null,
   qttools,
   qtwebengine,
   wrapQtAppsHook,
   xvfb-run,
+  withDocumentation ? true,
 }:
 
 let
+  withQt6 = lib.strings.versionAtLeast qtbase.version "6";
   listToQtVar = suffix: lib.makeSearchPathOutput "bin" suffix;
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -42,6 +45,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   outputs = [
     "out"
+  ]
+  ++ lib.optionals withDocumentation [
     "doc"
   ];
 
@@ -55,16 +60,22 @@ stdenv.mkDerivation (finalAttrs: {
 
     substituteInPlace doc/CMakeLists.txt \
       --replace-fail 'COMMAND ''${QDOC_BIN} -qt5' 'COMMAND ''${QDOC_BIN}'
+  ''
+  + lib.optionalString (!withDocumentation) ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'add_subdirectory(doc)' 'message(WARNING "[Nix] Not building documentation")'
   '';
 
-  strictDeps = true;
+  strictDeps = !withQt6;
 
   nativeBuildInputs = [
     cmake
     gettext
     pkg-config
-    qttools # qdoc
     wrapQtAppsHook
+  ]
+  ++ lib.optionals withDocumentation [
+    qttools # qdoc
   ];
 
   buildInputs = [
@@ -79,9 +90,20 @@ stdenv.mkDerivation (finalAttrs: {
     lomiri-content-hub
     lomiri-ui-extras
     lomiri-ui-toolkit
+  ]
+  ++ lib.optionals (!withQt6) [
+    # Not ported to Qt6 yet, explicitly disabled in the Qt6 build
+    # https://gitlab.com/ubports/development/core/morph-browser/-/blob/4f20c943e78694818d1b80b5563bd89901230e75/src/app/browserapplication.cpp#L196
     qqc2-suru-style
+
+    # Folded into qtdeclarative in Qt6
     qtquickcontrols2
+
+    # Will prolly want this in the future, but needs porting to Qt6
     qtsystems
+  ]
+  ++ lib.optionals withQt6 [
+    qt5compat
   ];
 
   nativeCheckInputs = [
@@ -92,11 +114,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeBool "CLICK_MODE" false)
-    (lib.cmakeBool "ENABLE_QT6" (lib.strings.versionAtLeast qtbase.version "6"))
-    (lib.cmakeBool "WERROR" true)
+    (lib.cmakeBool "ENABLE_QT6" withQt6)
+    (lib.cmakeBool "WERROR" (!withQt6)) # Porting WIP
   ];
 
-  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+  doCheck =
+    stdenv.buildPlatform.canExecute stdenv.hostPlatform
+    # Hard dependency on Qt5 still
+    && (!withQt6);
 
   disabledTests = [
     # Don't care about linter failures
@@ -115,6 +140,8 @@ stdenv.mkDerivation (finalAttrs: {
           lomiri-ui-toolkit
           qtwebengine
           qtdeclarative
+        ]
+        ++ lib.optionals (!withQt6) [
           qtquickcontrols2
           qtsystems
         ]
@@ -132,7 +159,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     updateScript = gitUpdater { };
-    tests = {
+    tests = lib.optionalAttrs (!withQt6) {
       # Test of morph-browser itself
       standalone = nixosTests.morph-browser;
 

--- a/pkgs/desktops/lomiri/applications/morph-browser/default.nix
+++ b/pkgs/desktops/lomiri/applications/morph-browser/default.nix
@@ -163,7 +163,7 @@ stdenv.mkDerivation (finalAttrs: {
       # Test of morph-browser itself
       standalone = if withQt6 then nixosTests.morph-browser.qt6 else nixosTests.morph-browser.qt5;
     }
-    // lib.optionalAttrs (!withQt6) {
+    // lib.optionalAttrs withQt6 {
       # Interactions between the Lomiri ecosystem and this browser
       inherit (nixosTests.lomiri) desktop-basics desktop-appinteractions;
     };

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -27,6 +27,7 @@ let
       deviceinfo = callPackage ./development/deviceinfo { };
 
       #### QML / QML-related
+      lomiri-ui-extras = callPackage ./qml/lomiri-ui-extras { };
       lomiri-ui-toolkit = callPackage ./qml/lomiri-ui-toolkit { };
     }
     // lib.optionalAttrs (!useQt6) {
@@ -66,7 +67,6 @@ let
       lomiri-notifications = callPackage ./qml/lomiri-notifications { };
       lomiri-push-qml = callPackage ./qml/lomiri-push-qml { };
       lomiri-settings-components = callPackage ./qml/lomiri-settings-components { };
-      lomiri-ui-extras = callPackage ./qml/lomiri-ui-extras { };
       qqc2-suru-style = callPackage ./qml/qqc2-suru-style { };
 
       #### Services

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -25,6 +25,9 @@ let
       #### Development tools / libraries
       cmake-extras = callPackage ./development/cmake-extras { };
       deviceinfo = callPackage ./development/deviceinfo { };
+
+      #### QML / QML-related
+      lomiri-ui-toolkit = callPackage ./qml/lomiri-ui-toolkit { };
     }
     // lib.optionalAttrs (!useQt6) {
       #### Core Apps
@@ -64,7 +67,6 @@ let
       lomiri-push-qml = callPackage ./qml/lomiri-push-qml { };
       lomiri-settings-components = callPackage ./qml/lomiri-settings-components { };
       lomiri-ui-extras = callPackage ./qml/lomiri-ui-extras { };
-      lomiri-ui-toolkit = callPackage ./qml/lomiri-ui-toolkit { };
       qqc2-suru-style = callPackage ./qml/qqc2-suru-style { };
 
       #### Services

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -25,6 +25,7 @@ let
       #### Development tools / libraries
       cmake-extras = callPackage ./development/cmake-extras { };
       deviceinfo = callPackage ./development/deviceinfo { };
+      lomiri-api = callPackage ./development/lomiri-api { };
 
       #### QML / QML-related
       lomiri-ui-extras = callPackage ./qml/lomiri-ui-extras { };
@@ -56,7 +57,6 @@ let
       gmenuharness = callPackage ./development/gmenuharness { };
       gsettings-qt = callPackage ./development/gsettings-qt { };
       libusermetrics = callPackage ./development/libusermetrics { };
-      lomiri-api = callPackage ./development/lomiri-api { };
       lomiri-app-launch = callPackage ./development/lomiri-app-launch { };
       qtmir = callPackage ./development/qtmir { };
       trust-store = callPackage ./development/trust-store { };

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -16,6 +16,8 @@ let
       inherit (self) callPackage;
     in
     {
+      #### Development tools / libraries
+      cmake-extras = callPackage ./development/cmake-extras { };
     }
     // lib.optionalAttrs (!useQt6) {
       #### Core Apps
@@ -43,7 +45,6 @@ let
       suru-icon-theme = callPackage ./data/suru-icon-theme { };
 
       #### Development tools / libraries
-      cmake-extras = callPackage ./development/cmake-extras { };
       deviceinfo = callPackage ./development/deviceinfo { };
       geonames = callPackage ./development/geonames { };
       gmenuharness = callPackage ./development/gmenuharness { };

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -3,16 +3,21 @@
   lib,
   pkgs,
   ayatana-indicator-datetime,
+  useQt6 ? false,
   libsForQt5,
+  qt6Packages,
 }:
 
 let
+  qtPackages = if useQt6 then qt6Packages else libsForQt5;
   packages =
     self:
     let
       inherit (self) callPackage;
     in
     {
+    }
+    // lib.optionalAttrs (!useQt6) {
       #### Core Apps
       lomiri = callPackage ./applications/lomiri { };
       lomiri-calculator-app = callPackage ./applications/lomiri-calculator-app { };
@@ -74,8 +79,8 @@ let
       mediascanner2 = callPackage ./services/mediascanner2 { };
     };
 in
-lib.makeScope libsForQt5.newScope packages
-// lib.optionalAttrs config.allowAliases {
+lib.makeScope qtPackages.newScope packages
+// lib.optionalAttrs (config.allowAliases && !useQt6) {
   content-hub = lib.warnOnInstantiate "`content-hub` was renamed to `lomiri-content-hub`." pkgs.lomiri.lomiri-content-hub; # Added on 2024-09-11
   history-service = lib.warnOnInstantiate "`history-service` was renamed to `lomiri-history-service`." pkgs.lomiri.lomiri-history-service; # Added on 2024-11-11
   lomiri-system-settings-security-privacy = lib.warnOnInstantiate "`lomiri-system-settings-security-privacy` upstream was merged into `lomiri-system-settings`. Please use `pkgs.lomiri.lomiri-system-settings-unwrapped` if you need to directly access the plugins that belonged to this project." pkgs.lomiri.lomiri-system-settings-unwrapped; # Added on 2024-08-08

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -18,6 +18,7 @@ let
     {
       #### Data
       lomiri-schemas = callPackage ./data/lomiri-schemas { };
+      lomiri-sounds = callPackage ./data/lomiri-sounds { };
       suru-icon-theme = callPackage ./data/suru-icon-theme { };
 
       #### Development tools / libraries
@@ -44,7 +45,6 @@ let
 
       #### Data
       lomiri-session = callPackage ./data/lomiri-session { };
-      lomiri-sounds = callPackage ./data/lomiri-sounds { };
       lomiri-wallpapers = callPackage ./data/lomiri-wallpapers { };
 
       #### Development tools / libraries

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -18,6 +18,7 @@ let
     {
       #### Data
       lomiri-schemas = callPackage ./data/lomiri-schemas { };
+      suru-icon-theme = callPackage ./data/suru-icon-theme { };
 
       #### Development tools / libraries
       cmake-extras = callPackage ./development/cmake-extras { };
@@ -45,7 +46,6 @@ let
       lomiri-session = callPackage ./data/lomiri-session { };
       lomiri-sounds = callPackage ./data/lomiri-sounds { };
       lomiri-wallpapers = callPackage ./data/lomiri-wallpapers { };
-      suru-icon-theme = callPackage ./data/suru-icon-theme { };
 
       #### Development tools / libraries
       geonames = callPackage ./development/geonames { };

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -16,6 +16,9 @@ let
       inherit (self) callPackage;
     in
     {
+      #### Data
+      lomiri-schemas = callPackage ./data/lomiri-schemas { };
+
       #### Development tools / libraries
       cmake-extras = callPackage ./development/cmake-extras { };
       deviceinfo = callPackage ./development/deviceinfo { };
@@ -39,7 +42,6 @@ let
       teleports = callPackage ./applications/teleports { };
 
       #### Data
-      lomiri-schemas = callPackage ./data/lomiri-schemas { };
       lomiri-session = callPackage ./data/lomiri-session { };
       lomiri-sounds = callPackage ./data/lomiri-sounds { };
       lomiri-wallpapers = callPackage ./data/lomiri-wallpapers { };

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -19,6 +19,7 @@ let
       #### Data
       lomiri-schemas = callPackage ./data/lomiri-schemas { };
       lomiri-sounds = callPackage ./data/lomiri-sounds { };
+      lomiri-wallpapers = callPackage ./data/lomiri-wallpapers { };
       suru-icon-theme = callPackage ./data/suru-icon-theme { };
 
       #### Development tools / libraries
@@ -45,7 +46,6 @@ let
 
       #### Data
       lomiri-session = callPackage ./data/lomiri-session { };
-      lomiri-wallpapers = callPackage ./data/lomiri-wallpapers { };
 
       #### Development tools / libraries
       geonames = callPackage ./development/geonames { };

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -18,6 +18,7 @@ let
     {
       #### Development tools / libraries
       cmake-extras = callPackage ./development/cmake-extras { };
+      deviceinfo = callPackage ./development/deviceinfo { };
     }
     // lib.optionalAttrs (!useQt6) {
       #### Core Apps
@@ -45,7 +46,6 @@ let
       suru-icon-theme = callPackage ./data/suru-icon-theme { };
 
       #### Development tools / libraries
-      deviceinfo = callPackage ./development/deviceinfo { };
       geonames = callPackage ./development/geonames { };
       gmenuharness = callPackage ./development/gmenuharness { };
       gsettings-qt = callPackage ./development/gsettings-qt { };

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -25,6 +25,7 @@ let
       #### Development tools / libraries
       cmake-extras = callPackage ./development/cmake-extras { };
       deviceinfo = callPackage ./development/deviceinfo { };
+      gsettings-qt = callPackage ./development/gsettings-qt { };
       lomiri-api = callPackage ./development/lomiri-api { };
 
       #### QML / QML-related
@@ -65,7 +66,6 @@ let
       #### Development tools / libraries
       geonames = callPackage ./development/geonames { };
       gmenuharness = callPackage ./development/gmenuharness { };
-      gsettings-qt = callPackage ./development/gsettings-qt { };
       libusermetrics = callPackage ./development/libusermetrics { };
       lomiri-app-launch = callPackage ./development/lomiri-app-launch { };
       qtmir = callPackage ./development/qtmir { };

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -27,6 +27,7 @@ let
       deviceinfo = callPackage ./development/deviceinfo { };
       gsettings-qt = callPackage ./development/gsettings-qt { };
       lomiri-api = callPackage ./development/lomiri-api { };
+      lomiri-app-launch = callPackage ./development/lomiri-app-launch { };
 
       #### QML / QML-related
       lomiri-action-api = callPackage ./qml/lomiri-action-api {
@@ -67,7 +68,6 @@ let
       geonames = callPackage ./development/geonames { };
       gmenuharness = callPackage ./development/gmenuharness { };
       libusermetrics = callPackage ./development/libusermetrics { };
-      lomiri-app-launch = callPackage ./development/lomiri-app-launch { };
       qtmir = callPackage ./development/qtmir { };
       trust-store = callPackage ./development/trust-store { };
       u1db-qt = callPackage ./development/u1db-qt { };

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -44,6 +44,7 @@ let
       lomiri-ui-toolkit = callPackage ./qml/lomiri-ui-toolkit { };
 
       #### Services
+      biometryd = callPackage ./services/biometryd { };
       lomiri-content-hub = callPackage ./services/lomiri-content-hub {
         # Check for working qdoc: not found
         withDocumentation = !useQt6;
@@ -88,7 +89,6 @@ let
       qqc2-suru-style = callPackage ./qml/qqc2-suru-style { };
 
       #### Services
-      biometryd = callPackage ./services/biometryd { };
       hfd-service = callPackage ./services/hfd-service { };
       lomiri-history-service = callPackage ./services/lomiri-history-service { };
       lomiri-indicator-datetime = ayatana-indicator-datetime.override { enableLomiriFeatures = true; };

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -28,6 +28,10 @@ let
       lomiri-api = callPackage ./development/lomiri-api { };
 
       #### QML / QML-related
+      lomiri-action-api = callPackage ./qml/lomiri-action-api {
+        # The dependency target "qmldoc" of target "doc" does not exist.
+        withDocumentation = !useQt6;
+      };
       lomiri-ui-extras = callPackage ./qml/lomiri-ui-extras { };
       lomiri-ui-toolkit = callPackage ./qml/lomiri-ui-toolkit { };
     }
@@ -63,7 +67,6 @@ let
       u1db-qt = callPackage ./development/u1db-qt { };
 
       #### QML / QML-related
-      lomiri-action-api = callPackage ./qml/lomiri-action-api { };
       lomiri-notifications = callPackage ./qml/lomiri-notifications { };
       lomiri-push-qml = callPackage ./qml/lomiri-push-qml { };
       lomiri-settings-components = callPackage ./qml/lomiri-settings-components { };

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -34,6 +34,12 @@ let
       };
       lomiri-ui-extras = callPackage ./qml/lomiri-ui-extras { };
       lomiri-ui-toolkit = callPackage ./qml/lomiri-ui-toolkit { };
+
+      #### Services
+      lomiri-download-manager = callPackage ./services/lomiri-download-manager {
+        # Check for working qdoc: not found
+        withDocumentation = !useQt6;
+      };
     }
     // lib.optionalAttrs (!useQt6) {
       #### Core Apps
@@ -76,7 +82,6 @@ let
       biometryd = callPackage ./services/biometryd { };
       lomiri-content-hub = callPackage ./services/lomiri-content-hub { };
       hfd-service = callPackage ./services/hfd-service { };
-      lomiri-download-manager = callPackage ./services/lomiri-download-manager { };
       lomiri-history-service = callPackage ./services/lomiri-history-service { };
       lomiri-indicator-datetime = ayatana-indicator-datetime.override { enableLomiriFeatures = true; };
       lomiri-indicator-network = callPackage ./services/lomiri-indicator-network { };

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -38,6 +38,10 @@ let
       lomiri-ui-toolkit = callPackage ./qml/lomiri-ui-toolkit { };
 
       #### Services
+      lomiri-content-hub = callPackage ./services/lomiri-content-hub {
+        # Check for working qdoc: not found
+        withDocumentation = !useQt6;
+      };
       lomiri-download-manager = callPackage ./services/lomiri-download-manager {
         # Check for working qdoc: not found
         withDocumentation = !useQt6;
@@ -80,7 +84,6 @@ let
 
       #### Services
       biometryd = callPackage ./services/biometryd { };
-      lomiri-content-hub = callPackage ./services/lomiri-content-hub { };
       hfd-service = callPackage ./services/hfd-service { };
       lomiri-history-service = callPackage ./services/lomiri-history-service { };
       lomiri-indicator-datetime = ayatana-indicator-datetime.override { enableLomiriFeatures = true; };

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -16,6 +16,12 @@ let
       inherit (self) callPackage;
     in
     {
+      #### Core Apps
+      morph-browser = callPackage ./applications/morph-browser {
+        # get_target_property() called with non-existent target "Qt6::qdoc".
+        withDocumentation = !useQt6;
+      };
+
       #### Data
       lomiri-schemas = callPackage ./data/lomiri-schemas { };
       lomiri-sounds = callPackage ./data/lomiri-sounds { };
@@ -62,7 +68,6 @@ let
       lomiri-system-settings-unwrapped = callPackage ./applications/lomiri-system-settings { };
       lomiri-system-settings = callPackage ./applications/lomiri-system-settings/wrapper.nix { };
       lomiri-terminal-app = callPackage ./applications/lomiri-terminal-app { };
-      morph-browser = callPackage ./applications/morph-browser { };
       teleports = callPackage ./applications/teleports { };
 
       #### Data

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -53,6 +53,7 @@ let
         # Check for working qdoc: not found
         withDocumentation = !useQt6;
       };
+      lomiri-indicator-network = callPackage ./services/lomiri-indicator-network { };
       lomiri-url-dispatcher = callPackage ./services/lomiri-url-dispatcher { };
     }
     // lib.optionalAttrs (!useQt6) {
@@ -93,7 +94,6 @@ let
       hfd-service = callPackage ./services/hfd-service { };
       lomiri-history-service = callPackage ./services/lomiri-history-service { };
       lomiri-indicator-datetime = ayatana-indicator-datetime.override { enableLomiriFeatures = true; };
-      lomiri-indicator-network = callPackage ./services/lomiri-indicator-network { };
       lomiri-polkit-agent = callPackage ./services/lomiri-polkit-agent { };
       lomiri-telephony-service = callPackage ./services/lomiri-telephony-service { };
       lomiri-thumbnailer = callPackage ./services/lomiri-thumbnailer { };

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -53,6 +53,7 @@ let
         # Check for working qdoc: not found
         withDocumentation = !useQt6;
       };
+      lomiri-url-dispatcher = callPackage ./services/lomiri-url-dispatcher { };
     }
     // lib.optionalAttrs (!useQt6) {
       #### Core Apps
@@ -96,7 +97,6 @@ let
       lomiri-polkit-agent = callPackage ./services/lomiri-polkit-agent { };
       lomiri-telephony-service = callPackage ./services/lomiri-telephony-service { };
       lomiri-thumbnailer = callPackage ./services/lomiri-thumbnailer { };
-      lomiri-url-dispatcher = callPackage ./services/lomiri-url-dispatcher { };
       mediascanner2 = callPackage ./services/mediascanner2 { };
     };
 in

--- a/pkgs/desktops/lomiri/development/gsettings-qt/default.nix
+++ b/pkgs/desktops/lomiri/development/gsettings-qt/default.nix
@@ -7,11 +7,15 @@
   cmake,
   cmake-extras,
   glib,
+  libglvnd,
   pkg-config,
   qtbase,
   qtdeclarative,
 }:
 
+let
+  withQt6 = lib.strings.versionAtLeast qtbase.version "6";
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gsettings-qt";
   version = "1.1.1";
@@ -39,6 +43,9 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     cmake-extras
     glib
+  ]
+  ++ lib.optionals withQt6 [
+    libglvnd
   ];
 
   # Library
@@ -60,6 +67,11 @@ stdenv.mkDerivation (finalAttrs: {
     + ''
       substituteInPlace GSettings/CMakeLists.txt \
         --replace-fail "\''${CMAKE_INSTALL_LIBDIR}/qt\''${QT_VERSION_MAJOR}/qml" '${placeholder "out"}/${qtbase.qtQmlPrefix}'
+    ''
+    # Need QtQuick.Window in QML2_IMPORT_PATH
+    + ''
+      substituteInPlace tests/CMakeLists.txt \
+        --replace-fail 'QML2_IMPORT_PATH=' 'QML2_IMPORT_PATH=${lib.getBin qtdeclarative}/${qtbase.qtQmlPrefix}:'
     '';
 
   preBuild =
@@ -69,7 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
 
   cmakeFlags = [
-    (lib.cmakeBool "ENABLE_QT6" (lib.strings.versionAtLeast qtbase.version "6"))
+    (lib.cmakeBool "ENABLE_QT6" withQt6)
     (lib.cmakeBool "ENABLE_WERROR" true)
   ];
 
@@ -96,7 +108,7 @@ stdenv.mkDerivation (finalAttrs: {
     teams = [ lib.teams.lomiri ];
     platforms = lib.platforms.linux;
     pkgConfigModules = [
-      "gsettings-qt"
+      "gsettings-qt${lib.optionalString withQt6 "6"}"
     ];
   };
 })

--- a/pkgs/desktops/lomiri/development/lomiri-api/default.nix
+++ b/pkgs/desktops/lomiri/development/lomiri-api/default.nix
@@ -17,8 +17,12 @@
   python3,
   qtbase,
   qtdeclarative,
+  withDocumentation ? true,
 }:
 
+let
+  withQt6 = lib.strings.versionAtLeast qtbase.version "6";
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri-api";
   version = "0.3.0";
@@ -33,6 +37,8 @@ stdenv.mkDerivation (finalAttrs: {
   outputs = [
     "out"
     "dev"
+  ]
+  ++ lib.optionals withDocumentation [
     "doc"
   ];
 
@@ -53,10 +59,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
-    doxygen
-    graphviz
     pkg-config
     qtdeclarative
+  ]
+  ++ lib.optionals withDocumentation [
+    doxygen
+    graphviz
   ];
 
   buildInputs = [
@@ -76,7 +84,8 @@ stdenv.mkDerivation (finalAttrs: {
   dontWrapQtApps = true;
 
   cmakeFlags = [
-    (lib.cmakeBool "ENABLE_QT6" (lib.strings.versionAtLeast qtbase.version "6"))
+    (lib.cmakeBool "ENABLE_QT6" withQt6)
+    (lib.cmakeBool "NO_TESTS" (!finalAttrs.finalPackage.doCheck))
   ];
 
   env.FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ ]; };
@@ -95,7 +104,10 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    # https://gitlab.com/ubports/development/core/lomiri-api/-/issues/5
+    tests = lib.optionalAttrs (!withQt6) {
+      pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    };
     updateScript = gitUpdater { };
   };
 
@@ -113,10 +125,10 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.linux;
     pkgConfigModules = [
       "liblomiri-api"
-      "lomiri-shell-api"
-      "lomiri-shell-application"
-      "lomiri-shell-launcher"
-      "lomiri-shell-notifications"
+      "lomiri-shell-api${lib.optionalString withQt6 "-qt6"}"
+      "lomiri-shell-application${lib.optionalString withQt6 "-qt6"}"
+      "lomiri-shell-launcher${lib.optionalString withQt6 "-qt6"}"
+      "lomiri-shell-notifications${lib.optionalString withQt6 "-qt6"}"
     ];
   };
 })

--- a/pkgs/desktops/lomiri/qml/lomiri-ui-toolkit/2002-Nixpkgs-versioned-QML-path.patch.in
+++ b/pkgs/desktops/lomiri/qml/lomiri-ui-toolkit/2002-Nixpkgs-versioned-QML-path.patch.in
@@ -1,29 +1,20 @@
-From ca4c52a80532732243067eb00ec12b4ef84010a6 Mon Sep 17 00:00:00 2001
-From: OPNA2608 <opna2608@protonmail.com>
-Date: Tue, 30 Jan 2024 19:46:09 +0100
-Subject: [PATCH] Nixpkgs versioned QML path
-
----
- src/LomiriToolkit/uctheme.cpp | 6 ++++++
- 1 file changed, 6 insertions(+)
-
-diff --git a/src/LomiriToolkit/uctheme.cpp b/src/LomiriToolkit/uctheme.cpp
-index a10c89344..4b0653589 100644
---- a/src/LomiriToolkit/uctheme.cpp
-+++ b/src/LomiriToolkit/uctheme.cpp
-@@ -180,6 +180,12 @@ QStringList themeSearchPath()
+diff '--color=auto' -ruN a/src/LomiriToolkit/uctheme.cpp b/src/LomiriToolkit/uctheme.cpp
+--- a/src/LomiriToolkit/uctheme.cpp	2025-12-04 00:43:06.543074583 +0100
++++ b/src/LomiriToolkit/uctheme.cpp	2025-12-04 00:45:35.424986792 +0100
+@@ -192,6 +192,16 @@
          pathList << QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation);
      }
 
 +    // append versioned QML import path from Nixpkgs
 +    const QString nixpkgsQmlImportPath = QString::fromLocal8Bit(getenv("NIXPKGS_QT@qtVersion@_QML_IMPORT_PATH"));
 +    if (!nixpkgsQmlImportPath.isEmpty()) {
++#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
 +        pathList << nixpkgsQmlImportPath.split(':', QString::SkipEmptyParts);
++#else
++        pathList << nixpkgsQmlImportPath.split(':', Qt::SkipEmptyParts);
++#endif
 +    }
 +
      // append QML import path(s); we must explicitly support env override here
      const QString qml2ImportPath = QString::fromLocal8Bit(getenv("QML2_IMPORT_PATH"));
      if (!qml2ImportPath.isEmpty()) {
---
-2.42.0
-

--- a/pkgs/desktops/lomiri/qml/lomiri-ui-toolkit/default.nix
+++ b/pkgs/desktops/lomiri/qml/lomiri-ui-toolkit/default.nix
@@ -45,13 +45,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri-ui-toolkit";
-  version = "1.3.5903";
+  version = "1.3.5904";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/lomiri-ui-toolkit";
     rev = finalAttrs.version;
-    hash = "sha256-NdEYXv1LVblUgOu/P8z+vYnd/jNDS+/LFsh63ojJ2KA=";
+    hash = "sha256-lrytLk7+RpD3V4g9m7JruqOfLggJO9sGLzt5UrGbs/Q=";
   };
 
   outputs = [

--- a/pkgs/desktops/lomiri/qml/lomiri-ui-toolkit/default.nix
+++ b/pkgs/desktops/lomiri/qml/lomiri-ui-toolkit/default.nix
@@ -5,10 +5,14 @@
   gitUpdater,
   replaceVars,
   testers,
+  bluez,
+  cmake,
   dbus-test-runner,
   dpkg,
   gdb,
   glib,
+  kdePackages,
+  libevdev,
   lttng-ust,
   mesa,
   perl,
@@ -17,13 +21,15 @@
   qmake,
   qtbase,
   qtdeclarative,
-  qtfeedback,
-  qtgraphicaleffects,
-  qtpim,
-  qtquickcontrols2,
+  qtfeedback ? null,
+  qtgraphicaleffects ? null,
+  qtpim ? null,
+  qtquickcontrols2 ? null,
   qtsvg,
-  qtsystems,
+  qtsystems ? null,
   qttools,
+  qt5compat ? null,
+  spirv-tools,
   suru-icon-theme,
   validatePkgConfig,
   wrapQtAppsHook,
@@ -31,17 +37,30 @@
 }:
 
 let
+  withQt6 = lib.strings.versionAtLeast qtbase.version "6";
   listToQtVar = suffix: lib.makeSearchPathOutput "bin" suffix;
-  qtPluginPaths = listToQtVar qtbase.qtPluginPrefix [
-    qtbase
-    qtpim
-    qtsvg
-  ];
-  qtQmlPaths = listToQtVar qtbase.qtQmlPrefix [
-    qtdeclarative
-    qtfeedback
-    qtgraphicaleffects
-  ];
+  qtPluginPaths = listToQtVar qtbase.qtPluginPrefix (
+    [
+      qtbase
+      qtsvg
+    ]
+    ++ lib.optionals (!withQt6) [
+      # Will prolly want this in the future, but needs porting to Qt6
+      qtpim
+    ]
+  );
+  qtQmlPaths = listToQtVar qtbase.qtQmlPrefix (
+    [
+      qtdeclarative
+    ]
+    ++ lib.optionals (!withQt6) [
+      # Deprecated in Qt6
+      qtgraphicaleffects
+
+      # Will prolly want this in the future, but needs porting to Qt6
+      qtfeedback
+    ]
+  );
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri-ui-toolkit";
@@ -57,6 +76,8 @@ stdenv.mkDerivation (finalAttrs: {
   outputs = [
     "out"
     "dev"
+  ]
+  ++ lib.optionals (!withQt6) [
     "doc"
   ];
 
@@ -70,23 +91,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     patchShebangs documentation/docs.sh tests/
-
-    for subproject in po app-launch-profiler lomiri-ui-toolkit-launcher; do
-      substituteInPlace $subproject/$subproject.pro \
-        --replace-fail "\''$\''$[QT_INSTALL_PREFIX]" "$out" \
-        --replace-warn "\''$\''$[QT_INSTALL_LIBS]" "$out/lib"
-    done
-
-    # Install apicheck tool into bin
-    substituteInPlace apicheck/apicheck.pro \
-      --replace-fail "\''$\''$[QT_INSTALL_LIBS]/lomiri-ui-toolkit" "$out/bin"
-
-    substituteInPlace documentation/documentation.pro \
-      --replace-fail '/usr/share/doc' '$$PREFIX/share/doc' \
-      --replace-fail '$$[QT_INSTALL_DOCS]' '$$PREFIX/share/doc/lomiri-ui-toolkit'
-
-    # Causes redefinition error with our own fortify hardening
-    sed -i '/DEFINES += _FORTIFY_SOURCE/d' features/lomiri_common.prf
 
     # Reverse dependencies (and their reverse dependencies too) access the function patched here to register their gettext catalogues,
     # so hardcoding any prefix here will make only catalogues in that prefix work. APP_DIR envvar will override this, but with domains from multiple derivations being
@@ -113,19 +117,50 @@ stdenv.mkDerivation (finalAttrs: {
       tests/unit/visual/tst_icon.{11,13}.qml \
       tests/unit/visual/tst_imageprovider.11.qml \
       --replace-fail '/usr/share' '${suru-icon-theme}/share'
+  ''
+  + lib.optionalString (!withQt6) ''
+    for subproject in po app-launch-profiler lomiri-ui-toolkit-launcher; do
+      substituteInPlace $subproject/$subproject.pro \
+        --replace-fail "\''$\''$[QT_INSTALL_PREFIX]" "$out" \
+        --replace-warn "\''$\''$[QT_INSTALL_LIBS]" "$out/lib"
+    done
+
+    # Install apicheck tool into bin
+    substituteInPlace apicheck/apicheck.pro \
+      --replace-fail "\''$\''$[QT_INSTALL_LIBS]/lomiri-ui-toolkit" "$out/bin"
+
+    substituteInPlace documentation/documentation.pro \
+      --replace-fail '/usr/share/doc' '$$PREFIX/share/doc' \
+      --replace-fail '$$[QT_INSTALL_DOCS]' '$$PREFIX/share/doc/lomiri-ui-toolkit'
+
+    # Causes redefinition error with our own fortify hardening
+    sed -i '/DEFINES += _FORTIFY_SOURCE/d' features/lomiri_common.prf
+  ''
+  + lib.optionalString withQt6 ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "\''${CMAKE_INSTALL_LIBDIR}/qt\''${QT_VERSION_MAJOR}/qml" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}" \
+      --replace-fail "\''${CMAKE_INSTALL_LIBDIR}/qt\''${QT_VERSION_MAJOR}/plugins" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtPluginPrefix}"
   '';
 
-  # With strictDeps, QMake only picks up Qt dependencies from nativeBuildInputs
+  # With strictDeps
+  # - QMake only picks up Qt dependencies from nativeBuildInputs
+  # - Qt6's CMake module seems to struggle with picking up other Qt modules from buildInputs
   strictDeps = false;
 
   nativeBuildInputs = [
     perl
     pkg-config
     python3
-    qmake
     qttools # qdoc, qhelpgenerator
     validatePkgConfig
     wrapQtAppsHook
+  ]
+  ++ lib.optionals withQt6 [
+    cmake
+    spirv-tools
+  ]
+  ++ lib.optionals (!withQt6) [
+    qmake
   ];
 
   buildInputs = [
@@ -133,15 +168,34 @@ stdenv.mkDerivation (finalAttrs: {
     lttng-ust
     qtbase
     qtdeclarative
-    qtpim
+  ]
+  ++ lib.optionals (!withQt6) [
+    # Folded into qtdeclarative in Qt6
     qtquickcontrols2
+
+    # Will prolly want this in the future, but needs porting to Qt6
+    qtpim
     qtsystems
+  ]
+  ++ lib.optionals withQt6 [
+    bluez
+    kdePackages.extra-cmake-modules
+    libevdev
   ];
 
   propagatedBuildInputs = [
-    qtfeedback
-    qtgraphicaleffects
     qtsvg
+  ]
+  ++ lib.optionals withQt6 [
+    # Qt5Compat.GraphicalEffects
+    qt5compat
+  ]
+  ++ lib.optionals (!withQt6) [
+    # Deprecated in Qt6
+    qtgraphicaleffects
+
+    # Will prolly want this in the future, but needs porting to Qt6
+    qtfeedback
   ];
 
   nativeCheckInputs = [
@@ -152,7 +206,7 @@ stdenv.mkDerivation (finalAttrs: {
     xvfb-run
   ];
 
-  qmakeFlags = [
+  qmakeFlags = lib.optionals (!withQt6) [
     # Ubuntu UITK compatibility, for older / not-yet-migrated applications
     "CONFIG+=ubuntu-uitk-compat"
     "QMAKE_PKGCONFIG_PREFIX=${placeholder "out"}"
@@ -180,12 +234,14 @@ stdenv.mkDerivation (finalAttrs: {
 
     export UITK_BUILD_ROOT=$PWD
 
-    tests/xvfb.sh make check ''${enableParallelChecking:+-j''${NIX_BUILD_CORES}}
+    ${lib.optionalString withQt6 "../"}tests/xvfb.sh make ${
+      if withQt6 then "test" else "check"
+    } ''${enableParallelChecking:+-j''${NIX_BUILD_CORES}}
 
     runHook postCheck
   '';
 
-  preInstall = ''
+  preInstall = lib.optionalString (!withQt6) ''
     # wrapper script calls qmlplugindump, crashes due to lack of minimal platform plugin
     # Could not find the Qt platform plugin "minimal" in ""
     # Available platform plugins are: wayland-egl, wayland, wayland-xcomposite-egl, wayland-xcomposite-glx.
@@ -198,20 +254,24 @@ stdenv.mkDerivation (finalAttrs: {
     done
   '';
 
-  postInstall = ''
-    # Code loads Qt's qt_module.prf, which force-overrides all QMAKE_PKGCONFIG_* variables except PREFIX for QMake-generated pkg-config files
-    for pcFile in Lomiri{Gestures,Metrics,Toolkit}.pc; do
-      substituteInPlace $out/lib/pkgconfig/$pcFile \
-        --replace-fail "${lib.getLib qtbase}/lib" "\''${prefix}/lib" \
-        --replace-fail "${lib.getDev qtbase}/include" "\''${prefix}/include"
-    done
-
-    # These are all dev-related tools, but declaring a bin output also moves around the QML modules
-    moveToOutput "bin" "$dev"
-  '';
+  postInstall =
+    lib.optionalString (!withQt6) ''
+      # Code loads Qt's qt_module.prf, which force-overrides all QMAKE_PKGCONFIG_* variables except PREFIX for QMake-generated pkg-config files
+      for pcFile in Lomiri{Gestures,Metrics,Toolkit}${lib.optionalString withQt6 "-Qt6"}.pc; do
+        substituteInPlace $out/lib/pkgconfig/$pcFile \
+          --replace-fail "${lib.getLib qtbase}/lib" "\''${prefix}/lib" \
+          --replace-fail "${lib.getDev qtbase}/include" "\''${prefix}/include"
+      done
+    ''
+    + ''
+      # These are all dev-related tools, but declaring a bin output also moves around the QML modules
+      moveToOutput "bin" "$dev"
+    '';
 
   postFixup = ''
-    for qtBin in $dev/bin/{apicheck,lomiri-ui-toolkit-launcher}; do
+    for qtBin in ${
+      if withQt6 then "$out/libexec/lomiri-ui-toolkit/qt6" else "$dev/bin"
+    }/apicheck $dev/bin/lomiri-ui-toolkit-launcher${lib.optionalString withQt6 "-qt6"}; do
       wrapQtApp $qtBin
     done
   '';
@@ -246,9 +306,9 @@ stdenv.mkDerivation (finalAttrs: {
     teams = [ lib.teams.lomiri ];
     platforms = lib.platforms.linux;
     pkgConfigModules = [
-      "LomiriGestures"
-      "LomiriMetrics"
-      "LomiriToolkit"
+      "LomiriGestures${lib.optionalString withQt6 "-Qt6"}"
+      "LomiriMetrics${lib.optionalString withQt6 "-Qt6"}"
+      "LomiriToolkit${lib.optionalString withQt6 "-Qt6"}"
     ];
   };
 })

--- a/pkgs/desktops/lomiri/services/biometryd/default.nix
+++ b/pkgs/desktops/lomiri/services/biometryd/default.nix
@@ -23,6 +23,11 @@
   validatePkgConfig,
 }:
 
+let
+  withQt6 = lib.strings.versionAtLeast qtbase.version "6";
+  listToQtVar = suffix: lib.makeSearchPathOutput "bin" suffix;
+  qtQmlPaths = listToQtVar qtbase.qtQmlPrefix [ qtdeclarative ];
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "biometryd";
   version = "0.4.0";
@@ -60,6 +65,12 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace data/biometryd.pc.in \
       --replace-fail 'libdir=''${exec_prefix}' 'libdir=''${prefix}' \
       --replace-fail 'includedir=''${exec_prefix}' 'includedir=''${prefix}' \
+
+    # Suffix our QML2_IMPORT_PATH
+    substituteInPlace tests/CMakeLists.txt \
+      --replace-fail \
+        'QML2_IMPORT_PATH=''${CMAKE_BINARY_DIR}/src/biometry/qml;' \
+        'QML2_IMPORT_PATH=''${CMAKE_BINARY_DIR}/src/biometry/qml:${qtQmlPaths};'
   ''
   + lib.optionalString (!finalAttrs.finalPackage.doCheck) ''
     sed -i -e '/add_subdirectory(tests)/d' CMakeLists.txt
@@ -96,14 +107,14 @@ stdenv.mkDerivation (finalAttrs: {
   dontWrapQtApps = true;
 
   cmakeFlags = [
-    (lib.cmakeBool "ENABLE_QT6" (lib.strings.versionAtLeast qtbase.version "6"))
+    (lib.cmakeBool "ENABLE_QT6" withQt6)
     (lib.cmakeBool "ENABLE_WERROR" true)
     (lib.cmakeBool "WITH_HYBRIS" false)
   ];
 
   preBuild = ''
     # Generating plugins.qmltypes (also used in checkPhase?)
-    export QT_PLUGIN_PATH=${lib.getBin qtbase}/${qtbase.qtPluginPrefix}
+    export QT_PLUGIN_PATH=${listToQtVar qtbase.qtPluginPrefix [ qtbase ]}
   '';
 
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;

--- a/pkgs/desktops/lomiri/services/lomiri-content-hub/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-content-hub/default.nix
@@ -23,14 +23,18 @@
   properties-cpp,
   qtbase,
   qtdeclarative,
-  qtfeedback,
-  qtgraphicaleffects,
+  qtfeedback ? null,
+  qtgraphicaleffects ? null,
   qttools,
   validatePkgConfig,
   wrapGAppsHook3,
   xvfb-run,
+  withDocumentation ? true,
 }:
 
+let
+  withQt6 = lib.strings.versionAtLeast qtbase.version "6";
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri-content-hub";
   version = "2.2.2";
@@ -45,8 +49,10 @@ stdenv.mkDerivation (finalAttrs: {
   outputs = [
     "out"
     "dev"
-    "doc"
     "examples"
+  ]
+  ++ lib.optionals withDocumentation [
+    "doc"
   ];
 
   patches = [
@@ -69,6 +75,11 @@ stdenv.mkDerivation (finalAttrs: {
     # Don't override default theme search path (which honours XDG_DATA_DIRS) with a FHS assumption
     substituteInPlace import/Lomiri/Content/contenthubplugin.cpp \
       --replace-fail 'QIcon::setThemeSearchPaths(QStringList() << ("/usr/share/icons/"));' ""
+  ''
+  # Need QtQuick.Window on QML2_IMPORT_PATH
+  + ''
+    substituteInPlace tests/qml6-tests/CMakeLists.txt \
+      --replace-fail 'QML2_IMPORT_PATH=' 'QML2_IMPORT_PATH=${lib.getBin qtdeclarative}/${qtbase.qtQmlPrefix}:'
   '';
 
   strictDeps = true;
@@ -78,9 +89,11 @@ stdenv.mkDerivation (finalAttrs: {
     gettext
     pkg-config
     qtdeclarative # qmlplugindump
-    qttools # qdoc
     validatePkgConfig
     wrapGAppsHook3
+  ]
+  ++ lib.optionals withDocumentation [
+    qttools # qdoc
   ];
 
   buildInputs = [
@@ -96,8 +109,13 @@ stdenv.mkDerivation (finalAttrs: {
     properties-cpp
     qtbase
     qtdeclarative
-    qtfeedback
+  ]
+  ++ lib.optionals (!withQt6) [
+    # Deprecated in Qt6
     qtgraphicaleffects
+
+    # Will prolly want this in the future, but needs porting to Qt6
+    qtfeedback
   ];
 
   nativeCheckInputs = [
@@ -112,11 +130,13 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "GSETTINGS_COMPILE" true)
     (lib.cmakeBool "GSETTINGS_LOCALINSTALL" true)
-    (lib.cmakeBool "ENABLE_QT6" (lib.strings.versionAtLeast qtbase.version "6"))
+    (lib.cmakeBool "ENABLE_QT6" withQt6)
     (lib.cmakeBool "ENABLE_TESTS" finalAttrs.finalPackage.doCheck)
-    (lib.cmakeBool "ENABLE_DOC" true)
-    (lib.cmakeBool "ENABLE_UBUNTU_COMPAT" true) # in case something still depends on it
-    (lib.cmakeBool "ENABLE_WERROR" true)
+    (lib.cmakeBool "ENABLE_DOC" withDocumentation)
+    # in case something still depends on it
+    # no longer available in the Qt6 build
+    (lib.cmakeBool "ENABLE_UBUNTU_COMPAT" (!withQt6))
+    (lib.cmakeBool "ENABLE_WERROR" (!withQt6)) # Known issues on Qt6
   ];
 
   preBuild =
@@ -128,12 +148,19 @@ stdenv.mkDerivation (finalAttrs: {
       # Executes qmlplugindump
       export QT_PLUGIN_PATH=${listToQtVar [ qtbase ] qtbase.qtPluginPrefix}
       export QML2_IMPORT_PATH=${
-        listToQtVar [
-          qtdeclarative
-          lomiri-ui-toolkit
-          qtfeedback
-          qtgraphicaleffects
-        ] qtbase.qtQmlPrefix
+        listToQtVar (
+          [
+            qtdeclarative
+            lomiri-ui-toolkit
+          ]
+          ++ lib.optionals (!withQt6) [
+            # Deprecated in Qt6
+            qtgraphicaleffects
+
+            # Will prolly want this in the future, but needs porting to Qt6
+            qtfeedback
+          ]
+        ) qtbase.qtQmlPrefix
       }
     '';
 
@@ -160,6 +187,8 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     tests = {
       pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    }
+    // lib.optionalAttrs (!withQt6) {
       # Tests content-hub functionality, up to the point where one app receives a content exchange request
       # from another and changes into a mode to pick the content to send
       vm = nixosTests.lomiri.desktop-appinteractions;
@@ -183,7 +212,7 @@ stdenv.mkDerivation (finalAttrs: {
     teams = [ lib.teams.lomiri ];
     platforms = lib.platforms.linux;
     pkgConfigModules = [
-      "liblomiri-content-hub"
+      "liblomiri-content-hub${lib.optionalString withQt6 "-qt6"}"
       "liblomiri-content-hub-glib"
     ];
   };

--- a/pkgs/desktops/lomiri/services/lomiri-indicator-network/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-indicator-network/default.nix
@@ -12,11 +12,11 @@
   doxygen,
   gettext,
   glib,
-  gmenuharness,
+  gmenuharness ? null, # not ported to Qt6 yet
   gtest,
   intltool,
   libsecret,
-  libqofono,
+  libqofono ? null, # not ported to Qt6 yet
   libqtdbusmock,
   libqtdbustest,
   lomiri-api,
@@ -25,12 +25,15 @@
   ofono,
   pkg-config,
   python3,
-  qtdeclarative,
   qtbase,
+  qtdeclarative,
   qttools,
   validatePkgConfig,
 }:
 
+let
+  withQt6 = lib.strings.versionAtLeast qtbase.version "6";
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri-indicator-network";
   version = "1.2.0";
@@ -45,6 +48,8 @@ stdenv.mkDerivation (finalAttrs: {
   outputs = [
     "out"
     "dev"
+  ]
+  ++ lib.optionals (!withQt6) [
     "doc"
   ];
 
@@ -59,26 +64,33 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
-    doxygen
     gettext
-    intltool
     pkg-config
     qtdeclarative
-    qttools # qdoc
     validatePkgConfig
+  ]
+  ++ lib.optionals (!withQt6) [
+    doxygen
+    intltool
+    qttools # qdoc
   ];
 
   buildInputs = [
     cmake-extras
+    lomiri-api
+    qtbase
+  ]
+  ++ lib.optionals withQt6 [
+    qtdeclarative
+  ]
+  ++ lib.optionals (!withQt6) [
     dbus
     glib
     libqofono
     libsecret
-    lomiri-api
     lomiri-url-dispatcher
     networkmanager
     ofono
-    qtbase
   ];
 
   nativeCheckInputs = [ (python3.withPackages (ps: with ps; [ python-dbusmock ])) ];
@@ -93,37 +105,45 @@ stdenv.mkDerivation (finalAttrs: {
   dontWrapQtApps = true;
 
   cmakeFlags = [
-    (lib.cmakeBool "BUILD_DOC" true)
-    (lib.cmakeBool "BUILD_LIBCONNECTIVITY_ONLY" false)
+    (lib.cmakeBool "BUILD_DOC" (!withQt6))
+    # Indicator is not ported to Qt6 yet
+    (lib.cmakeBool "BUILD_LIBCONNECTIVITY_ONLY" withQt6)
     (lib.cmakeBool "ENABLE_COVERAGE" false)
-    (lib.cmakeBool "ENABLE_QT6" (lib.strings.versionAtLeast qtbase.version "6"))
+    (lib.cmakeBool "ENABLE_QT6" withQt6)
     (lib.cmakeBool "ENABLE_TESTS" finalAttrs.finalPackage.doCheck)
-    (lib.cmakeBool "ENABLE_UBUNTU_COMPAT" (!lib.strings.versionAtLeast qtbase.version "6"))
-    (lib.cmakeBool "GSETTINGS_COMPILE" true)
-    (lib.cmakeBool "GSETTINGS_LOCALINSTALL" true)
-    (lib.cmakeBool "USE_SYSTEMD" true)
+    (lib.cmakeBool "ENABLE_UBUNTU_COMPAT" (!withQt6))
+    (lib.cmakeBool "GSETTINGS_COMPILE" (!withQt6))
+    (lib.cmakeBool "GSETTINGS_LOCALINSTALL" (!withQt6))
+    (lib.cmakeBool "USE_SYSTEMD" (!withQt6))
   ];
 
-  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+  doCheck =
+    stdenv.buildPlatform.canExecute stdenv.hostPlatform
+    # Indicator is not ported to Qt6 yet, tests only cover indicator
+    && !withQt6;
 
   # Multiple tests spin up & speak to D-Bus, avoid cross-talk causing failures
   enableParallelChecking = false;
 
-  postInstall = ''
+  postInstall = lib.optionalString (!withQt6) ''
     substituteInPlace $out/etc/dbus-1/services/com.lomiri.connectivity1.service \
       --replace-fail '/bin/false' '${lib.getExe' coreutils "false"}'
   '';
 
   passthru = {
-    ayatana-indicators = {
-      lomiri-indicator-network = [ "lomiri" ];
-    };
     tests = {
       pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    }
+    // lib.optionalAttrs (!withQt6) {
       startup = nixosTests.ayatana-indicators;
       lomiri = nixosTests.lomiri.desktop-ayatana-indicator-network;
     };
     updateScript = gitUpdater { };
+  }
+  // lib.optionalAttrs (!withQt6) {
+    ayatana-indicators = {
+      lomiri-indicator-network = [ "lomiri" ];
+    };
   };
 
   meta = {
@@ -135,6 +155,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Only;
     teams = [ lib.teams.lomiri ];
     platforms = lib.platforms.linux;
-    pkgConfigModules = [ "lomiri-connectivity-qt1" ];
+    pkgConfigModules = [ "lomiri-connectivity-qt${if withQt6 then "6" else "1"}" ];
   };
 })

--- a/pkgs/desktops/lomiri/services/lomiri-url-dispatcher/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-url-dispatcher/default.nix
@@ -28,6 +28,9 @@
   wrapQtAppsHook,
 }:
 
+let
+  withQt6 = lib.strings.versionAtLeast qtbase.version "6";
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri-url-dispatcher";
   version = "0.1.4";
@@ -93,7 +96,6 @@ stdenv.mkDerivation (finalAttrs: {
     libapparmor
     lomiri-app-launch
     lomiri-ui-toolkit
-    qtdeclarative
     sqlite
     systemd
     libxkbcommon
@@ -128,13 +130,19 @@ stdenv.mkDerivation (finalAttrs: {
 
     wrapProgram $out/bin/lomiri-url-dispatcher-dump \
       --prefix PATH : ${lib.makeBinPath [ sqlite ]}
-
+  ''
+  # https://gitlab.com/ubports/development/core/lomiri-url-dispatcher/-/work_items/13
+  + lib.optionalString withQt6 ''
+    rm $out/bin/lomiri-url-dispatcher-gui
+    rm -r $out/share/lomiri-url-dispatcher/gui
+  ''
+  + lib.optionalString (!withQt6) ''
     mkdir -p $out/share/icons/hicolor/scalable/apps
     ln -s $out/share/lomiri-url-dispatcher/gui/lomiri-url-dispatcher-gui.svg $out/share/icons/hicolor/scalable/apps/
 
     # Calls qmlscene from PATH, needs Qt plugins & QML components
     qtWrapperArgs+=(
-      --prefix PATH : ${lib.makeBinPath [ qtdeclarative.dev ]}
+      --prefix PATH : ${lib.makeBinPath [ (if withQt6 then qtdeclarative.out else qtdeclarative.dev) ]}
     )
     wrapQtApp $out/bin/lomiri-url-dispatcher-gui
   '';

--- a/pkgs/development/libraries/libqtdbusmock/default.nix
+++ b/pkgs/development/libraries/libqtdbusmock/default.nix
@@ -16,6 +16,9 @@
   qtbase,
 }:
 
+let
+  withQt6 = lib.strings.versionAtLeast qtbase.version "6";
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "libqtdbusmock";
   version = "0.10.0";
@@ -68,7 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
   dontWrapQtApps = true;
 
   cmakeFlags = [
-    (lib.cmakeBool "ENABLE_QT6" (lib.strings.versionAtLeast qtbase.version "6"))
+    (lib.cmakeBool "ENABLE_QT6" withQt6)
   ];
 
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
@@ -95,7 +98,7 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.unix;
     teams = [ lib.teams.lomiri ];
     pkgConfigModules = [
-      "libqtdbusmock-1"
+      "libqtdbusmock${lib.optionalString withQt6 "-qt6"}-1"
     ];
   };
 })

--- a/pkgs/development/libraries/libqtdbustest/default.nix
+++ b/pkgs/development/libraries/libqtdbustest/default.nix
@@ -16,6 +16,9 @@
   qtbase,
 }:
 
+let
+  withQt6 = lib.strings.versionAtLeast qtbase.version "6";
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "libqtdbustest";
   version = "0.4.0";
@@ -79,6 +82,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   dontWrapQtApps = true;
 
+  cmakeFlags = [
+    (lib.cmakeBool "ENABLE_QT6" withQt6)
+  ];
+
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   enableParallelChecking = false;
@@ -104,7 +111,7 @@ stdenv.mkDerivation (finalAttrs: {
     teams = [ lib.teams.lomiri ];
     mainProgram = "qdbus-simple-test-runner";
     pkgConfigModules = [
-      "libqtdbustest-1"
+      "libqtdbustest-${if withQt6 then "qt6" else "1"}"
     ];
   };
 })

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1681,6 +1681,7 @@ mapAliases {
   qflipper = throw "'qflipper' has been renamed to/replaced by 'qFlipper'"; # Converted to throw 2025-10-27
   qMasterPassword = warnAlias "'qMasterPassword' has been renamed to/replaced by 'qmasterpassword'" qmasterpassword; # Added 2026-02-01
   qMasterPassword-wayland = warnAlias "'qMasterPassword-wayland' has been renamed to/replaced by 'qmasterpassword-wayland'" qmasterpassword-wayland; # Added 2026-02-01
+  qmenumodel = warnAlias "'qmenumodel' has been renamed to 'libsForQt5.qmenumodel'"; # Added 2026-03-26
   qnial = throw "'qnial' has been removed due to failing to build and being unmaintained"; # Added 2025-06-26
   qrscan = throw "qrscan has been removed, as it does not build with supported LLVM versions"; # Added 2025-08-19
   qscintilla = throw "'qscintilla' has been renamed to/replaced by 'libsForQt5.qscintilla'"; # Converted to throw 2025-10-27

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1066,6 +1066,8 @@ mapAliases {
   libpthreadstubs = libpthread-stubs; # Added 2025-02-04
   libpulseaudio-vanilla = throw "'libpulseaudio-vanilla' has been renamed to/replaced by 'libpulseaudio'"; # Converted to throw 2025-10-27
   libqt5pas = throw "'libqt5pas' has been renamed to/replaced by 'libsForQt5.libqtpas'"; # Converted to throw 2025-10-27
+  libqtdbusmock = warnAlias "'libqtdbusmock' has been renamed to 'libsForQt5.libqtdbusmock'"; # Added 2026-03-10
+  libqtdbustest = warnAlias "'libqtdbustest' has been renamed to 'libsForQt5.libqtdbustest'"; # Added 2026-03-10
   libquotient = throw "'libquotient' for qt5 was removed as upstream removed qt5 support. Consider explicitly upgrading to qt6 'libquotient'"; # Converted to throw 2025-07-04
   LibreArp = throw "'LibreArp' has been renamed to/replaced by 'librearp'"; # Converted to throw 2025-10-27
   LibreArp-lv2 = throw "'LibreArp-lv2' has been renamed to/replaced by 'librearp-lv2'"; # Converted to throw 2025-10-27

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11434,6 +11434,7 @@ with pkgs;
   gnome-session-ctl = callPackage ../by-name/gn/gnome-session/ctl.nix { };
 
   lomiri = recurseIntoAttrs (callPackage ../desktops/lomiri { });
+  lomiri-qt6 = recurseIntoAttrs (callPackage ../desktops/lomiri { useQt6 = true; });
 
   lumina = recurseIntoAttrs (callPackage ../desktops/lumina { });
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7280,10 +7280,6 @@ with pkgs;
 
   qdjango = libsForQt5.callPackage ../development/libraries/qdjango { };
 
-  qmenumodel = libsForQt5.callPackage ../development/libraries/qmenumodel {
-    inherit (lomiri) cmake-extras;
-  };
-
   quarto = callPackage ../development/libraries/quarto { };
 
   quartoMinimal = callPackage ../development/libraries/quarto {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6724,14 +6724,6 @@ with pkgs;
   inherit (callPackage ../development/libraries/libliftoff { }) libliftoff_0_4 libliftoff_0_5;
   libliftoff = libliftoff_0_5;
 
-  libqtdbusmock = libsForQt5.callPackage ../development/libraries/libqtdbusmock {
-    inherit (lomiri) cmake-extras;
-  };
-
-  libqtdbustest = libsForQt5.callPackage ../development/libraries/libqtdbustest {
-    inherit (lomiri) cmake-extras;
-  };
-
   libretranslate = with python3.pkgs; toPythonApplication libretranslate;
 
   librsb = callPackage ../development/libraries/librsb {

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -116,6 +116,14 @@ makeScopeWithSplicing' {
 
         libqofono = callPackage ../development/libraries/libqofono { };
 
+        libqtdbusmock = callPackage ../development/libraries/libqtdbusmock {
+          inherit (pkgs.lomiri) cmake-extras;
+        };
+
+        libqtdbustest = callPackage ../development/libraries/libqtdbustest {
+          inherit (pkgs.lomiri) cmake-extras;
+        };
+
         libqtpas = callPackage ../development/compilers/fpc/libqtpas.nix { };
 
         libqaccessibilityclient = callPackage ../development/libraries/libqaccessibilityclient { };

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -169,6 +169,10 @@ makeScopeWithSplicing' {
 
         qjson = callPackage ../development/libraries/qjson { };
 
+        qmenumodel = callPackage ../development/libraries/qmenumodel {
+          inherit (pkgs.lomiri) cmake-extras;
+        };
+
         qmltermwidget = callPackage ../development/libraries/qmltermwidget { };
 
         qoauth = callPackage ../development/libraries/qoauth { };

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -75,6 +75,10 @@ makeScopeWithSplicing' {
 
       libqtpas = callPackage ../development/compilers/fpc/libqtpas.nix { };
 
+      libqtdbusmock = callPackage ../development/libraries/libqtdbusmock {
+        inherit (pkgs.lomiri-qt6) cmake-extras;
+      };
+
       libqtdbustest = callPackage ../development/libraries/libqtdbustest {
         inherit (pkgs.lomiri-qt6) cmake-extras;
       };

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -75,6 +75,10 @@ makeScopeWithSplicing' {
 
       libqtpas = callPackage ../development/compilers/fpc/libqtpas.nix { };
 
+      libqtdbustest = callPackage ../development/libraries/libqtdbustest {
+        inherit (pkgs.lomiri-qt6) cmake-extras;
+      };
+
       libquotient = callPackage ../development/libraries/libquotient { };
       mlt = pkgs.mlt.override {
         qt = qt6;


### PR DESCRIPTION
This is actively being worked on upstream - not everything is migrated yet, and issues are being worked on.

https://ubports.com/lomiri-roadmap

Goal for now is at least Morph Browser, so that there's a Lomiri browser without security vulnerabilities. Support for this was added in [version 1.99.0](https://gitlab.com/ubports/development/core/morph-browser/-/blob/1.99.0/ChangeLog).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
