### PR TITLE
scx.full: 1.0.18 -> 1.0.19

### DIFF
--- a/pkgs/os-specific/linux/scx/scx_rustscheds.nix
+++ b/pkgs/os-specific/linux/scx/scx_rustscheds.nix
@@ -11,19 +11,27 @@
   libseccomp,
   nix-update-script,
   nixosTests,
+  fetchpatch,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "scx_rustscheds";
-  version = "1.0.18";
+  version = "1.0.19";
 
   src = fetchFromGitHub {
     owner = "sched-ext";
     repo = "scx";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-RkTY7gDcKbkNUKl7NJDX3Ac/I+dRG1Gj8rRHynbbxUU=";
+    hash = "sha256-bOldw2Sob5aANmVzw6VwCgJ4+VzEsohKUxOxntow7VY=";
   };
 
-  cargoHash = "sha256-tuZhqDT1xMP+Pufwz6SBt44qNzHuGzcU9QmVNIg2zS0=";
+  cargoHash = "sha256-ik05X+5jIdxtXYhN6fb1URW8TKKzgFuevi5+Wm2j15Y=";
+
+  patches = [
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/sched-ext/scx/pull/3127.patch";
+      hash = "sha256-HpGJR3eBZKE+VsqGivjJp1n7JIORhZUxG87AsP1WWi0=";
+    })
+  ];
 
   nativeBuildInputs = [
     pkg-config
@@ -59,6 +67,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--skip=cpumask"
     "--skip=topology"
     "--skip=proc_data::tests::test_thread_operations"
+    "--skip=json::tests::test_with_resources"
+    "--skip=json::tests::test_with_dir"
   ];
 
   passthru.tests.basic = nixosTests.scx;


### PR DESCRIPTION
The patch is needed to fix a failing test:
```
running 3 tests
test rust/scx_cargo/src/bpf_builder.rs - bpf_builder::BpfBuilder (line 114) ... ignored
test rust/scx_cargo/src/bpf_builder.rs - bpf_builder::BpfBuilder (line 127) ... ignored
test rust/scx_cargo/src/bpf_builder.rs - bpf_builder::BpfBuilder (line 98) ... FAILED

failures:

---- rust/scx_cargo/src/bpf_builder.rs - bpf_builder::BpfBuilder (line 98) stdout ----
error[E0433]: failed to resolve: use of unresolved module or unlinked crate `scx_utils`
 --> rust/scx_cargo/src/bpf_builder.rs:100:5
  |
3 |     scx_utils::BpfBuilder::new()
  |     ^^^^^^^^^ use of unresolved module or unlinked crate `scx_utils`
  |
  = help: if you wanted to use a crate named `scx_utils`, use `cargo add scx_utils` to add it to your `Cargo.toml`
help: consider importing this struct
  |
2 + use scx_cargo::BpfBuilder;
  |
help: if you import `BpfBuilder`, refer to it directly
  |
3 -     scx_utils::BpfBuilder::new()
3 +     BpfBuilder::new()
  |

error: aborting due to 1 previous error

For more information about this error, try `rustc --explain E0433`.
Couldn't compile the test.

failures:
    rust/scx_cargo/src/bpf_builder.rs - bpf_builder::BpfBuilder (line 98)

test result: FAILED. 0 passed; 1 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.05s

error: doctest failed, to rerun pass `-p scx_cargo --doc`
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
