### PR TITLE
Fix `vapoursynth` Python-based plugins on Darwin

### DIFF
--- a/pkgs/by-name/va/vapoursynth/plugin-interface.nix
+++ b/pkgs/by-name/va/vapoursynth/plugin-interface.nix
@@ -57,6 +57,11 @@ if stdenv.hostPlatform.isDarwin then
     configureFlags = (previousAttrs.configureFlags or [ ]) ++ [
       "--with-plugindir=${pluginsEnv}/lib/vapoursynth"
     ];
+    postInstall = vapoursynth.postInstall + ''
+      for pythonPlugin in ${pythonEnvironment}/${python3.sitePackages}/*; do
+          ln -s $pythonPlugin $out/''${pythonPlugin#"${pythonEnvironment}/"}
+      done
+    '';
   })
 else
   runCommand "${vapoursynth.name}-with-plugins"


### PR DESCRIPTION
On Darwin, the Vapoursynth package did not symlink Python plugins.

CC maintainers @rnhmjoj @sbruder @snaki

## Things done

This adds a `postInstall` hook that symlinks Python plugins, similarly to how it's done on Linux.
The Linux branch of code remains unchanged.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
