### PR TITLE
anyrun-provider: init at 25.12.0; anyrun: 25.9.3 -> 25.12.0

### DIFF
--- a/pkgs/by-name/an/anyrun-provider/package.nix
+++ b/pkgs/by-name/an/anyrun-provider/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "anyrun-provider";
+  version = "25.12.0";
+
+  src = fetchFromGitHub {
+    owner = "anyrun-org";
+    repo = "anyrun-provider";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-4rN2vWicM6Pn6eTo3Nu7IB5isbkc9u4arNMnY2+S8iM=";
+  };
+
+  cargoHash = "sha256-xd1FnYsIjWuAYGfqTdRhzje3ALis5VaHIKeImlAjVVI=";
+
+  strictDeps = true;
+  enableParallelBuilding = true;
+  doCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Simple program to load Anyrun plugins and interact with them";
+    homepage = "https://github.com/anyrun-org/anyrun-provider";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      khaneliman
+      NotAShelf
+    ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/an/anyrun/package.nix
+++ b/pkgs/by-name/an/anyrun/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   pkg-config,
   wrapGAppsHook4,
+  anyrun-provider,
   cairo,
   gdk-pixbuf,
   glib,
@@ -16,16 +17,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "anyrun";
-  version = "25.9.3";
+  version = "25.12.0";
 
   src = fetchFromGitHub {
     owner = "anyrun-org";
     repo = "anyrun";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-IlnFA/a9Clgbt+FuavIKWtauhtH4Fo/rGJIjJDDeYRs=";
+    hash = "sha256-KEEJLERvo04AsPo/SWHFJUmHaGGOVjUoGwA9e8GVIQQ=";
   };
 
-  cargoHash = "sha256-gP324zqfoNSYKIuTJFTWRr2fKBreVZFfZNR+jUasp/8=";
+  cargoHash = "sha256-IDrDgmksDdKw5JYY/kw+CCEIDJ6S2KARxUDSul713pw=";
 
   strictDeps = true;
   enableParallelBuilding = true;
@@ -48,6 +49,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   preFixup = ''
     gappsWrapperArgs+=(
+     --prefix PATH ":" ${lib.makeBinPath [ anyrun-provider ]}
      --prefix ANYRUN_PLUGINS : $out/lib
     )
   '';
@@ -56,7 +58,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     install -Dm444 anyrun/res/style.css examples/config.ron -t $out/share/doc/anyrun/examples/
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+    # This is used for detecting whether or not an Anyrun package has the provider
+    inherit anyrun-provider;
+  };
 
   meta = {
     description = "Wayland-native, highly customizable runner";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Just was running my maintainer update script and saw a version bump, looks like it requires a new package for plugins so copied over the derivation from upstream to bump anyrun. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
