### PR TITLE
Justfile: Initialise Justfile with common commands

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,42 @@
+# Format
+#
+# Formats all files
+fmt:
+	nix fmt
+
+# Build {{PACKAGE}}
+#
+# Builds a package
+build PACKAGE:
+	nix-build \
+	  --verbose \
+	  --attr {{PACKAGE}}
+
+
+# Update {{PACKAGE}}
+#
+# Requires it defining its own UpdateScript
+# - https://wiki.nixos.org/wiki/Nixpkgs/Update_Scripts
+#
+# Updates a package
+update PACKAGE:
+	nix-shell maintainers/scripts/update.nix \
+	  --argstr skip-prompt true \
+	  --argstr package {{PACKAGE}}
+
+# Update and Commit {{PACKAGE}}
+#
+# Requires it defining its own UpdateScript
+# - https://wiki.nixos.org/wiki/Nixpkgs/Update_Scripts
+#
+# Updates a package and creates its update commit
+update_and_commit PACKAGE:
+	nix-shell maintainers/scripts/update.nix \
+	  --argstr commit true \
+	  --argstr skip-prompt true \
+	  --argstr package {{PACKAGE}}
+
+# Review a nixpkgs Pull Request
+pull_request_review PR:
+	nixpkgs-review pr {{PR}}
+


### PR DESCRIPTION
## Things done

Added a simple `Justfile` to help discover and use common commands.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
