### PR TITLE
home-assistant-custom-components.mypyllant: init at 0.9.9

### DIFF
--- a/pkgs/development/python-modules/country-list/default.nix
+++ b/pkgs/development/python-modules/country-list/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  poetry-core,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "country-list";
+  version = "1.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "bulv1ne";
+    repo = "country_list";
+    tag = "v${version}";
+    hash = "sha256-jG2AC8c6mgWjHVBX7XW021PLPliLTwEBkN6+HSecfL4=";
+    fetchSubmodules = true;
+  };
+
+  build-system = [
+    poetry-core
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [
+    "tests.py"
+  ];
+
+  pythonImportsCheck = [
+    "country_list"
+  ];
+
+  meta = {
+    description = "List of all countries with names and ISO 3166-1 codes in all languages";
+    homepage = "https://github.com/bulv1ne/country_list";
+    changelog = "https://github.com/bulv1ne/country_list/blob/${src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ urbas ];
+  };
+}

--- a/pkgs/development/python-modules/mypyllant/default.nix
+++ b/pkgs/development/python-modules/mypyllant/default.nix
@@ -1,0 +1,73 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+
+  # build-system
+  hatch-vcs,
+  hatchling,
+
+  # dependencies
+  aiohttp,
+  pydantic,
+
+  # tests
+  aioresponses,
+  country-list,
+  freezegun,
+  pytest-asyncio,
+  pytest-cov-stub,
+  pytest-mock,
+  pytest-xdist,
+  pytestCheckHook,
+  pyyaml,
+  requests,
+}:
+
+buildPythonPackage rec {
+  pname = "mypyllant";
+  version = "0.9.8";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "signalkraft";
+    repo = "myPyllant";
+    tag = "v${version}";
+    hash = "sha256-eneAFJ4xRL8EKj8Act/YcW7Gx0B85u0g3LTWPlI/B/0=";
+  };
+
+  build-system = [
+    hatch-vcs
+    hatchling
+  ];
+
+  dependencies = [
+    aiohttp
+    pydantic
+  ];
+
+  nativeCheckInputs = [
+    aioresponses
+    country-list
+    freezegun
+    pytest-asyncio
+    pytest-cov-stub
+    pytest-mock
+    pytest-xdist
+    pytestCheckHook
+    pyyaml
+    requests
+  ];
+
+  pythonImportsCheck = [
+    "myPyllant"
+  ];
+
+  meta = {
+    description = "Python library to interact with the API behind the myVAILLANT app";
+    homepage = "https://github.com/signalkraft/myPyllant";
+    changelog = "https://github.com/signalkraft/myPyllant/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ urbas ];
+  };
+}

--- a/pkgs/servers/home-assistant/custom-components/mypyllant/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/mypyllant/package.nix
@@ -1,0 +1,52 @@
+{
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  lib,
+
+  # dependencies
+  mypyllant,
+  voluptuous,
+
+  # tests
+  aioresponses,
+  polyfactory,
+  pytest-cov-stub,
+  pytest-homeassistant-custom-component,
+  pytest-xdist,
+  pytestCheckHook,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "signalkraft";
+  domain = "mypyllant";
+  version = "0.9.9";
+
+  src = fetchFromGitHub {
+    owner = "signalkraft";
+    repo = "mypyllant-component";
+    tag = "v${version}";
+    hash = "sha256-6T8SGAP2535VqZmvSeITpMIa0SBJhnWsOKM1Y66WhHE=";
+  };
+
+  dependencies = [
+    mypyllant
+    voluptuous
+  ];
+
+  nativeCheckInputs = [
+    aioresponses
+    polyfactory
+    pytest-cov-stub
+    pytest-homeassistant-custom-component
+    pytest-xdist
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Unofficial Home Assistant integration for interacting with myVAILLANT";
+    changelog = "https://github.com/signalkraft/mypyllant-component/releases/tag/${src.tag}";
+    homepage = "https://github.com/signalkraft/mypyllant-component";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ urbas ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10433,6 +10433,8 @@ self: super: with self; {
 
   mypy-protobuf = callPackage ../development/python-modules/mypy-protobuf { };
 
+  mypyllant = callPackage ../development/python-modules/mypyllant { };
+
   mysql-connector = callPackage ../development/python-modules/mysql-connector { };
 
   mysqlclient = callPackage ../development/python-modules/mysqlclient { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3136,6 +3136,8 @@ self: super: with self; {
 
   cot = callPackage ../development/python-modules/cot { inherit (pkgs) qemu; };
 
+  country-list = callPackage ../development/python-modules/country-list { };
+
   countryguess = callPackage ../development/python-modules/countryguess { };
 
   courlan = callPackage ../development/python-modules/courlan { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds [the mypyllant Home Assistant custom component](https://github.com/signalkraft/mypyllant-component/) and its dependencies.

This PR adds two previously unpackaged dependencies:
1. [mypyllant](https://github.com/signalkraft/mypyllant): a Python package (direct dependency of the mypyllant HA component)
2. [country-list](https://github.com/bulv1ne/country_list): a Python package (direct dependency of the mypyllant Python package)

The `country-list` package unfortunately comes without tests, but the other two have tests and they are running as part of their builds.

I verified that the mypyllant Home Assistant component runs correctly in my own Home Assistant setup (see screenshot below).

<img width="1688" height="611" alt="mypyllant-home-assistnat-screenshot" src="https://github.com/user-attachments/assets/7165a90f-4d06-455b-a8c4-5f9e192d89ce" />


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
