### PR TITLE
flyspray: init at 1.0-rc11

### DIFF
--- a/pkgs/by-name/fl/flyspray/package.nix
+++ b/pkgs/by-name/fl/flyspray/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  fetchzip,
+  stdenv,
+  php,
+  phpCfg ? null,
+  withMariaDB ? false,
+  withPostgreSQL ? true,
+}:
+
+assert lib.assertMsg (
+  withPostgreSQL || withMariaDB
+) "At least one Flyspray database driver required";
+
+# The src tarball has the dependencies vendored. Considering that there is
+# no composer.lock, the easier option is using stdenv.mkDerivation over
+# php.buildComposerProject2 + building from source.
+stdenv.mkDerivation (finalAttrs: {
+  pname = "flyspray";
+  version = "1.0-rc11";
+
+  src = fetchzip {
+    url = "https://github.com/flyspray/flyspray/releases/download/v${finalAttrs.version}/flyspray-${finalAttrs.version}.tgz";
+    hash = "sha256-VNukYtHqf1OqWoyR+GXxgoX2GjTD4RfJ0SaGoDyHLJ4=";
+  };
+
+  php =
+    php.buildEnv {
+      # https://www.flyspray.org/docs/requirements/
+      extensions = (
+        { all, enabled }:
+        enabled
+        ++ [
+          all.gd
+          all.pdo
+          all.xml
+        ]
+        ++ lib.optionals withPostgreSQL [
+          all.pdo_pgsql
+          all.pgsql
+        ]
+        ++ lib.optionals withMariaDB [
+          all.mysqli
+          all.mysqlnd
+          all.pdo_mysql
+        ]
+      );
+    }
+    // lib.optionalAttrs (phpCfg != null) {
+      extraConfig = phpCfg;
+    };
+
+  postInstall = ''
+    DIR="$out/share/php/flyspray"
+    mkdir -p "$DIR"
+    cp -Tr "$src" "$DIR"
+  '';
+
+  meta = {
+    description = "Lightweight, web-based bug tracking system written in PHP for assisting with software development and project managements";
+    homepage = "https://www.flyspray.org";
+    license = lib.licenses.lgpl21;
+    maintainers = with lib.maintainers; [ toastal ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
