### PR TITLE
kaidan: fix compatibility with qt 6.10

### DIFF
--- a/pkgs/by-name/ka/kaidan/0001-Fix-compatibility-with-qt-6.10.patch
+++ b/pkgs/by-name/ka/kaidan/0001-Fix-compatibility-with-qt-6.10.patch
@@ -1,0 +1,29 @@
+From df4f62ed4c4e54d528950f9204623ec3054d3ff9 Mon Sep 17 00:00:00 2001
+From: eljamm <fedi.jamoussi@protonmail.ch>
+Date: Thu, 4 Dec 2025 10:29:49 +0100
+Subject: [PATCH] Fix compatibility with qt 6.10
+
+See: https://doc.qt.io/qt-6/whatsnew610.html#build-system-changes
+From: https://invent.kde.org/network/kaidan/-/commit/26942b401070
+---
+ CMakeLists.txt | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 027530bc..ee57c6f6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -59,6 +59,10 @@ if (NOT ANDROID)
+    find_package(KF6WindowSystem ${KF_MIN_VERSION} CONFIG REQUIRED)
+ endif()
+ 
++if(Qt6Gui_VERSION VERSION_GREATER_EQUAL "6.10.0" AND NOT WIN32 AND NOT APPLE)
++    find_package(Qt6GuiPrivate ${QT_MIN_VERSION} REQUIRED NO_MODULE)
++endif()
++
+ find_package(KF6KirigamiAddons 1.4.0 REQUIRED)
+ find_package(QXmppQt6 1.11.0 REQUIRED COMPONENTS Omemo)
+ 
+-- 
+2.50.1
+

--- a/pkgs/by-name/ka/kaidan/package.nix
+++ b/pkgs/by-name/ka/kaidan/package.nix
@@ -25,6 +25,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-4+jW3fuUi1OpwbcGccxvrPro/fiW9yBOlhc2KUbUExc=";
   };
 
+  patches = [
+    ./0001-Fix-compatibility-with-qt-6.10.patch
+  ];
+
   nativeBuildInputs = [
     cmake
     extra-cmake-modules


### PR DESCRIPTION
Kaidan [currently breaks](https://hydra.nixos.org/build/314377032) due to incompatibility with qt 6.10, which [has been fixed](https://invent.kde.org/network/kaidan/-/commit/26942b401070) upstream, which is applied here.

Related: https://github.com/ngi-nix/projects/issues/1580 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
