### PR TITLE
rocmPackages.rocm-runtime: fix build with gcc15

### DIFF
--- a/pkgs/development/rocm-modules/6/rocm-runtime/default.nix
+++ b/pkgs/development/rocm-modules/6/rocm-runtime/default.nix
@@ -79,6 +79,12 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/ROCm/ROCR-Runtime/commit/41bfc66aef437a5b349f71105fa4b907cc7e17d5.patch";
       hash = "sha256-A7VhPR3eSsmjq2cTBSjBIz9i//WiNjoXm0EsRKtF+ns=";
     })
+    # Fix build with gcc15
+    (fetchpatch {
+      # [PATCH] rocr:Add missing cstdint include
+      url = "https://github.com/ROCm/ROCR-Runtime/commit/5cc61b714d5b59ed5405639a37a582d839e6ebe9.patch";
+      hash = "sha256-IPxDShpoFB0PjCG+zwFbnW9IBTCG3G2o9sfITGs+bN4=";
+    })
     # This causes a circular dependency, aqlprofile relies on hsa-runtime64
     # which is part of rocm-runtime
     # Worked around by having rocprofiler load aqlprofile directly


### PR DESCRIPTION
- add patch from upstream commit:
https://github.com/ROCm/ROCR-Runtime/commit/5cc61b714d5b59ed5405639a37a582d839e6ebe9

Fixes build failure with gcc15:
```
In file included from /build/source/runtime/hsa-runtime/libamdhsacode/amd_elf_image.cpp:43:
/build/source/runtime/hsa-runtime/core/inc/amd_elf_image.hpp:62:15:
error: 'uint64_t' does not name a type
   62 |       virtual uint64_t type() const = 0;
      |               ^~~~~~~~
/build/source/runtime/hsa-runtime/core/inc/amd_elf_image.hpp:50:1:
note: 'uint64_t' is defined in header '<cstdint>'; this is probably
fixable by adding '#include <cs>
   49 | #include <memory>
  +++ |+#include <cstdint>
   50 |
```

---

Tested build on `master` with https://github.com/NixOS/nixpkgs/pull/440456 on top.
And on current `staging` (82888d98e49a8e25df02af7bbd6bb7dc5a76fc46) that has https://github.com/NixOS/nixpkgs/pull/440456 merged.

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
