### PR TITLE
nixos/headscale: dns split & extra_records options

### DIFF
--- a/nixos/modules/services/networking/headscale.nix
+++ b/nixos/modules/services/networking/headscale.nix
@@ -329,6 +329,49 @@ in
                 };
               };
 
+              split = lib.mkOption {
+                type = lib.types.attrsOf (lib.types.listOf lib.types.str);
+                default = { };
+                description = ''
+                  Split DNS configuration (map of domains and which DNS server to use for each).
+                  See <https://tailscale.com/kb/1054/dns/>.
+                '';
+                example = {
+                  "foo.bar.com" = [ "1.1.1.1" ];
+                };
+              };
+
+              extra_records = lib.mkOption {
+                type = lib.types.listOf (
+                  lib.types.submodule {
+                    options = {
+                      name = lib.mkOption {
+                        type = lib.types.str;
+                        description = "DNS record name.";
+                        example = "grafana.tailnet.example.com";
+                      };
+                      type = lib.mkOption {
+                        type = lib.types.enum [
+                          "A"
+                          "AAAA"
+                        ];
+                        description = "DNS record type.";
+                        example = "A";
+                      };
+                      value = lib.mkOption {
+                        type = lib.types.str;
+                        description = "DNS record value (IP address).";
+                        example = "100.64.0.3";
+                      };
+                    };
+                  }
+                );
+                default = [ ];
+                description = ''
+                  Extra DNS records to expose to clients.
+                '';
+              };
+
               search_domains = lib.mkOption {
                 type = lib.types.listOf lib.types.str;
                 default = [ ];

--- a/nixos/modules/services/networking/headscale.nix
+++ b/nixos/modules/services/networking/headscale.nix
@@ -370,6 +370,13 @@ in
                 description = ''
                   Extra DNS records to expose to clients.
                 '';
+                example = ''
+                  [ {
+                    name = "grafana.tailnet.example.com";
+                    type = "A";
+                    example = "100.64.0.3";
+                  } ]
+                '';
               };
 
               search_domains = lib.mkOption {


### PR DESCRIPTION
Add documented options to `services.headscale.settings.dns` that exist in upstream valid headscale configurations, but were not documented with examples in the NixOS module:

- `split` - for split DNS configuration (see https://github.com/juanfont/headscale/blob/eb788cd007119472b99787c8c3af6d6204e8b834/config-example.yaml#L296)
- `extra_records` - for extra DNS records (see https://github.com/juanfont/headscale/blob/eb788cd007119472b99787c8c3af6d6204e8b834/config-example.yaml#L313)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
