### PR TITLE
oxidized: 0.34.3 -> 0.35.0

### DIFF
--- a/pkgs/by-name/ox/oxidized/Gemfile
+++ b/pkgs/by-name/ox/oxidized/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'oxidized', '0.34.3'
-gem 'oxidized-web', '0.17.1'
+gem 'oxidized', '0.35.0'
+gem 'oxidized-web', '0.18.0'
 gem 'oxidized-script', '0.7.0'
 gem 'psych', '~> 5.0'

--- a/pkgs/by-name/ox/oxidized/Gemfile.lock
+++ b/pkgs/by-name/ox/oxidized/Gemfile.lock
@@ -31,7 +31,7 @@ GEM
     net-ssh (7.3.0)
     net-telnet (0.2.0)
     nio4r (2.7.4)
-    oxidized (0.34.3)
+    oxidized (0.35.0)
       asetus (~> 0.4)
       bcrypt_pbkdf (~> 1.0)
       ed25519 (~> 1.2)
@@ -49,16 +49,16 @@ GEM
     oxidized-script (0.7.0)
       oxidized (~> 0.29)
       slop (~> 4.6)
-    oxidized-web (0.17.1)
+    oxidized-web (0.18.0)
       charlock_holmes (>= 0.7.5, < 0.8.0)
       emk-sinatra-url-for (~> 0.2)
-      haml (>= 6.0.0, < 6.4.0)
-      htmlentities (>= 4.3.0, < 4.4.0)
-      json (>= 2.3.0, < 2.14.0)
-      oxidized (~> 0.34.1)
-      puma (~> 6.6.0)
-      sinatra (~> 4.1.1)
-      sinatra-contrib (~> 4.1.1)
+      haml (>= 6.0.0, < 7.0.0)
+      htmlentities (>= 4.3.0, < 4.5.0)
+      json (>= 2.3.0, < 2.17.0)
+      oxidized (>= 0.34.1)
+      puma (>= 6.6, < 7.2)
+      sinatra (>= 4.1.1, < 4.3.0)
+      sinatra-contrib (>= 4.1.1, < 4.3.0)
     psych (5.2.6)
       date
       stringio
@@ -105,9 +105,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  oxidized (= 0.34.3)
+  oxidized (= 0.35.0)
   oxidized-script (= 0.7.0)
-  oxidized-web (= 0.17.1)
+  oxidized-web (= 0.18.0)
   psych (~> 5.0)
 
 BUNDLED WITH

--- a/pkgs/by-name/ox/oxidized/gemset.nix
+++ b/pkgs/by-name/ox/oxidized/gemset.nix
@@ -243,10 +243,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "16k60qxp2lw8l4ny21rk0m6vx3lipdhxp0lslmwn7gqi8wyw6ra8";
+      sha256 = "1s7v9w357bc5xb89an4kclqmfjv2j6p9gnvsf7s2mnrgg482j76v";
       type = "gem";
     };
-    version = "0.34.3";
+    version = "0.35.0";
   };
   oxidized-script = {
     dependencies = [
@@ -278,10 +278,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1kcc7qlz3w530ssfnc7rgqhcwc4f4k3lbgayffwhnzl73s8mdld9";
+      sha256 = "19sz075liiqim98jvnb3jawxdpd8kk146bwvqzwvmimbgdzf8xfr";
       type = "gem";
     };
-    version = "0.17.1";
+    version = "0.18.0";
   };
   psych = {
     dependencies = [


### PR DESCRIPTION
Changelog : https://github.com/ytti/oxidized/releases/tag/0.35.0
Diff : https://github.com/ytti/oxidized/compare/0.34.3...0.35.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
