### PR TITLE
angrr: 0.1.3 -> 0.1.5

### DIFF
--- a/nixos/tests/angrr.nix
+++ b/nixos/tests/angrr.nix
@@ -32,38 +32,38 @@
 
     # Creates some auto gc roots
     # Use /run/current-system so that we do not need to build anything new
-    machine.succeed("nix build /run/current-system --out-link /tmp/root-auto-gc-root-1")
-    machine.succeed("nix build /run/current-system --out-link /tmp/root-auto-gc-root-2")
-    machine.succeed("su normal --command 'nix build /run/current-system --out-link /tmp/user-auto-gc-root-1'")
-    machine.succeed("su normal --command 'nix build /run/current-system --out-link /tmp/user-auto-gc-root-2'")
+    machine.succeed("nix build /run/current-system --out-link /tmp/result-root-auto-gc-root-1")
+    machine.succeed("nix build /run/current-system --out-link /tmp/result-root-auto-gc-root-2")
+    machine.succeed("su normal --command 'nix build /run/current-system --out-link /tmp/result-user-auto-gc-root-1'")
+    machine.succeed("su normal --command 'nix build /run/current-system --out-link /tmp/result-user-auto-gc-root-2'")
 
     machine.systemctl("start nix-gc.service")
     # Not auto gc root will be removed
-    machine.succeed("readlink /tmp/root-auto-gc-root-1")
-    machine.succeed("readlink /tmp/root-auto-gc-root-2")
-    machine.succeed("readlink /tmp/user-auto-gc-root-1")
-    machine.succeed("readlink /tmp/user-auto-gc-root-2")
+    machine.succeed("readlink /tmp/result-root-auto-gc-root-1")
+    machine.succeed("readlink /tmp/result-root-auto-gc-root-2")
+    machine.succeed("readlink /tmp/result-user-auto-gc-root-1")
+    machine.succeed("readlink /tmp/result-user-auto-gc-root-2")
 
     # Change time to 8 days after (greater than 7d)
     machine.succeed("date -s '8 days'")
 
     # Touch GC roots `-2`
-    machine.succeed("touch /tmp/root-auto-gc-root-2 --no-dereference")
-    machine.succeed("touch /tmp/user-auto-gc-root-2 --no-dereference")
+    machine.succeed("touch /tmp/result-root-auto-gc-root-2 --no-dereference")
+    machine.succeed("touch /tmp/result-user-auto-gc-root-2 --no-dereference")
 
     machine.systemctl("start nix-gc.service")
     # Only GC roots `-1` are removed
-    machine.succeed("test ! -f /tmp/root-auto-gc-root-1")
-    machine.succeed("readlink  /tmp/root-auto-gc-root-2")
-    machine.succeed("test ! -f /tmp/user-auto-gc-root-1")
-    machine.succeed("readlink  /tmp/user-auto-gc-root-2")
+    machine.succeed("test ! -e /tmp/result-root-auto-gc-root-1")
+    machine.succeed("readlink  /tmp/result-root-auto-gc-root-2")
+    machine.succeed("test ! -e /tmp/result-user-auto-gc-root-1")
+    machine.succeed("readlink  /tmp/result-user-auto-gc-root-2")
 
     # Change time again
     machine.succeed("date -s '8 days'")
     machine.systemctl("start nix-gc.service")
     # All auto GC roots are removed
-    machine.succeed("test ! -f /tmp/root-auto-gc-root-2")
-    machine.succeed("test ! -f /tmp/user-auto-gc-root-2")
+    machine.succeed("test ! -e /tmp/result-root-auto-gc-root-2")
+    machine.succeed("test ! -e /tmp/result-user-auto-gc-root-2")
 
     # Direnv integration test
     machine.succeed("mkdir /tmp/test-direnv")
@@ -74,7 +74,7 @@
     # The root will be removed if we does not use the direnv recently
     machine.succeed("date -s '8 days'")
     machine.systemctl("start nix-gc.service")
-    machine.succeed("test ! -f /tmp/test-direnv/.direnv/gc-root")
+    machine.succeed("test ! -e /tmp/test-direnv/.direnv/gc-root")
 
     # Recreate the root
     machine.succeed("nix build /run/current-system --out-link /tmp/test-direnv/.direnv/gc-root")

--- a/pkgs/by-name/an/angrr/package.nix
+++ b/pkgs/by-name/an/angrr/package.nix
@@ -11,26 +11,32 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "angrr";
-  version = "0.1.3";
+  version = "0.1.5";
 
   src = fetchFromGitHub {
     owner = "linyinfeng";
     repo = "angrr";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-pBVbzrTy/IWIo6WlhM1qgowfxSU31awyHcRDHNArBMo=";
+    hash = "sha256-PT3oCNPRvEroyVNiICeO0hSHDzKUC6KcP9HnIw1kMQE=";
   };
 
-  cargoHash = "sha256-DoQIJCs36ZmTxdsDCzquKAeOSIUBbo2V+DTx68FZiu4=";
+  cargoHash = "sha256-lDOH4Ceap69fX6VWbgQoQfmYWZI+jPE0LJiXmqrTRn8=";
+
+  buildAndTestSubdir = "angrr";
 
   nativeBuildInputs = [ installShellFiles ];
+  postBuild = ''
+    mkdir --parents build/{man-pages,shell-completions}
+    cargo xtask man-pages --out build/man-pages
+    cargo xtask shell-completions --out build/shell-completions
+  '';
   postInstall = ''
     install -m400 -D ./direnv/angrr.sh $out/share/direnv/lib/angrr.sh
-  ''
-  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installManPage build/man-pages/*
     installShellCompletion --cmd angrr \
-      --bash <($out/bin/angrr completion bash) \
-      --fish <($out/bin/angrr completion fish) \
-      --zsh  <($out/bin/angrr completion zsh)
+      --bash build/shell-completions/angrr.bash \
+      --fish build/shell-completions/angrr.fish \
+      --zsh  build/shell-completions/_angrr
   '';
 
   passthru = {
@@ -44,7 +50,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   meta = {
-    description = "Tool for auto Nix GC roots retention";
+    description = "Temporary GC Roots Cleaner";
     homepage = "https://github.com/linyinfeng/angrr";
     license = [ lib.licenses.mit ];
     maintainers = with lib.maintainers; [ yinfeng ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelogs:

- https://github.com/linyinfeng/angrr/releases/tag/v0.1.4
- https://github.com/linyinfeng/angrr/releases/tag/v0.1.5

In version `0.1.5`, this package migrated to the [matklad/cargo-xtask](https://github.com/matklad/cargo-xtask) way for generating shell completions and added generated man pages. So, the package definition has been updated accordingly to build and install these files.

`meta.description` is updated to clarify the scope of the tool (<https://github.com/linyinfeng/angrr/issues/30>).

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review --package nixosTests.angrr --package angrr --package angrr.tests.version`
Commit: `6f7da657d628e1903407377d16255eba04e3c19d`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 test built:</summary>
  <ul>
    <li>nixosTests.angrr</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>angrr</li>
    <li>angrr.tests.version</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
