### PR TITLE
freefilesync: 14.5 -> 14.6

### DIFF
--- a/pkgs/by-name/fr/freefilesync/Makefile.patch
+++ b/pkgs/by-name/fr/freefilesync/Makefile.patch
@@ -9,15 +9,13 @@ index 9d81055..aed0f30 100644
  
  CXXFLAGS += -std=c++23 -pipe -DWXINTL_NO_GETTEXT_MACRO -I../.. -I../../zenXml -include "zen/i18n.h" -include "zen/warn_static.h" \
             -Wall -Wfatal-errors -Wmissing-include-dirs -Wswitch-enum -Wcast-align -Wnon-virtual-dtor -Wno-unused-function -Wshadow -Wno-maybe-uninitialized \
-@@ -17,9 +17,10 @@ LDFLAGS  += `pkg-config --libs libcurl` -lidn2
- CXXFLAGS += `pkg-config --cflags libssh2`
+@@ -21,8 +21,9 @@ CXXFLAGS += `pkg-config --cflags libssh2`
  LDFLAGS  += `pkg-config --libs libssh2`
  
--CXXFLAGS += `pkg-config --cflags gtk+-2.0`
-+CXXFLAGS += `pkg-config --cflags gtk+-3.0`
+ CXXFLAGS += `pkg-config --cflags gtk+-3.0`
 +LDFLAGS += `pkg-config --libs gtk+-3.0`
  #treat as system headers so that warnings are hidden:
--CXXFLAGS += -isystem/usr/include/gtk-2.0
+-CXXFLAGS += -isystem/usr/include/gtk-3.0
 +CXXFLAGS += -isystem@gtk3-dev@/include/gtk-3.0
  
  #support for SELinux (optional)
@@ -33,15 +31,13 @@ index 0be46c9..f510284 100644
  
  CXXFLAGS += -std=c++23 -pipe -DWXINTL_NO_GETTEXT_MACRO -I../../.. -I../../../zenXml -include "zen/i18n.h" -include "zen/warn_static.h" \
             -Wall -Wfatal-errors -Wmissing-include-dirs -Wswitch-enum -Wcast-align -Wnon-virtual-dtor -Wno-unused-function -Wshadow -Wno-maybe-uninitialized \
-@@ -8,9 +8,10 @@ CXXFLAGS += -std=c++23 -pipe -DWXINTL_NO_GETTEXT_MACRO -I../../.. -I../../../zen
- LDFLAGS += -s `wx-config --libs std, aui, richtext --debug=no` -pthread
+@@ -9,8 +9,9 @@ LDFLAGS += -s `wx-config --libs std, aui, richtext --debug=no` -pthread
  
  
--CXXFLAGS += `pkg-config --cflags gtk+-2.0`
-+CXXFLAGS += `pkg-config --cflags gtk+-3.0`
+ CXXFLAGS += `pkg-config --cflags gtk+-3.0`
 +LDFLAGS += `pkg-config --libs gtk+-3.0`
  #treat as system headers so that warnings are hidden:
--CXXFLAGS += -isystem/usr/include/gtk-2.0
+-CXXFLAGS += -isystem/usr/include/gtk-3.0
 +CXXFLAGS += -isystem@gtk3-dev@/include/gtk-3.0
  
  cppFiles=

--- a/pkgs/by-name/fr/freefilesync/package.nix
+++ b/pkgs/by-name/fr/freefilesync/package.nix
@@ -29,7 +29,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "freefilesync";
-  version = "14.5";
+  version = "14.6";
 
   src = fetchurl {
     url = "https://freefilesync.org/download/FreeFileSync_${finalAttrs.version}_Source.zip";
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
       rm -f "$out"
       tryDownload "$url" "$out"
     '';
-    hash = "sha256-+qfj1zf3V5xxtvXgCa0QDDRhEPQ3Qzii5eKiMySuUUY=";
+    hash = "sha256-OST2QIhPhKl9Qh4nHIno5XAJmLPNki0bU5A1ZXcUVTw=";
   };
 
   sourceRoot = ".";
@@ -59,6 +59,10 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-Fem7eDDKSqPFU/t12Jco8OmYC8FM9JgB4/QVy/ouvbI=";
     })
   ];
+
+  postPatch = ''
+    touch zen/warn_static.h
+  '';
 
   nativeBuildInputs = [
     copyDesktopItems


### PR DESCRIPTION
https://freefilesync.org/download.php

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
