### PR TITLE
ocamlPackages.frama-c-lannotate: init at 0.2.4

### DIFF
--- a/pkgs/by-name/fr/framac/package.nix
+++ b/pkgs/by-name/fr/framac/package.nix
@@ -73,6 +73,7 @@ stdenv.mkDerivation rec {
   ]);
 
   buildInputs = with ocamlPackages; [
+    camlzip
     dune-site
     dune-configurator
     ocamlgraph

--- a/pkgs/development/ocaml-modules/frama-c-lannotate/default.nix
+++ b/pkgs/development/ocaml-modules/frama-c-lannotate/default.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  buildDunePackage,
+  dune-site,
+  fetchzip,
+  frama-c,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "frama-c-lannotate";
+  version = "0.2.4";
+
+  src = fetchzip {
+    url = "https://git.frama-c.com/pub/ltest/lannotate/-/archive/${finalAttrs.version}/lannotate-${finalAttrs.version}.tar.bz2";
+    hash = "sha256-JoD2M3R3/DcUMt33QOvwqHg4eToCgjB8riKc09TWdyc=";
+  };
+
+  propagatedBuildInputs = [
+    dune-site
+    frama-c
+  ];
+
+  meta = {
+    description = "Lannotate plugin of Frama-C, part of the LTest suite";
+    homepage = "https://frama-c.com/fc-plugins/ltest.html";
+    license = lib.licenses.lgpl2;
+    maintainers = with lib.maintainers; [ redianthus ];
+  };
+})

--- a/pkgs/development/ocaml-modules/frama-c/default.nix
+++ b/pkgs/development/ocaml-modules/frama-c/default.nix
@@ -1,0 +1,43 @@
+{
+  stdenv,
+  pkgs,
+  ocaml,
+  findlib,
+  framac,
+  camlzip,
+  ocamlgraph,
+  menhirLib,
+  ppx_deriving,
+  yaml,
+  yojson,
+  zarith,
+}:
+
+stdenv.mkDerivation {
+  pname = "ocaml${ocaml.version}-frama-c";
+  inherit (framac) version meta;
+
+  dontUnpack = true;
+
+  buildInputs = [ findlib ];
+
+  propagatedBuildInputs = [
+    camlzip
+    menhirLib
+    ocamlgraph
+    ppx_deriving
+    yaml
+    yojson
+    zarith
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $OCAMLFIND_DESTDIR
+    for p in ${framac}/lib/*
+    do
+      ln -s $p $OCAMLFIND_DESTDIR/
+    done
+    runHook postInstall
+  '';
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -649,6 +649,10 @@ let
 
         fpath = callPackage ../development/ocaml-modules/fpath { };
 
+        frama-c = callPackage ../development/ocaml-modules/frama-c {
+          framac = pkgs.framac.override { ocamlPackages = self; };
+        };
+
         frei0r = callPackage ../development/ocaml-modules/frei0r {
           inherit (pkgs) frei0r;
         };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -653,6 +653,8 @@ let
           framac = pkgs.framac.override { ocamlPackages = self; };
         };
 
+        frama-c-lannotate = callPackage ../development/ocaml-modules/frama-c-lannotate { };
+
         frei0r = callPackage ../development/ocaml-modules/frei0r {
           inherit (pkgs) frei0r;
         };


### PR DESCRIPTION
Hi,

I am having issues with this one. Here's what I get when testing:

```shell-session
$ nix-build -A ocamlPackages.frama-c-lannotate
this derivation will be built:
  /nix/store/gy0l46rbk6zammfs1dwxfv7wvjj52gzz-ocaml5.3.0-frama-c-lannotate-0.2.4.drv
building '/nix/store/gy0l46rbk6zammfs1dwxfv7wvjj52gzz-ocaml5.3.0-frama-c-lannotate-0.2.4.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/lrzfkrw3q18ppb6sf3d6iy0gbb843f3y-lannotate-0.2.4.tar.bz2
source root is lannotate-0.2.4
setting SOURCE_DATE_EPOCH to timestamp 1751891069 of file "lannotate-0.2.4/visibility.mli"
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
no configure script, doing nothing
Running phase: buildPhase
Warning: Cache directories could not be created: Permission denied; disabling
cache
Hint: Make sure the directory /homeless-shelter/.cache/dune/db/temp can be
created
File "share/dune", line 25, characters 16-31:
25 |  (section (site (frama-c share)))
                     ^^^^^^^^^^^^^^^
Error: The package frama-c is not found
error: builder for '/nix/store/gy0l46rbk6zammfs1dwxfv7wvjj52gzz-ocaml5.3.0-frama-c-lannotate-0.2.4.drv' failed with exit code 1;
       last 17 log lines:
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/lrzfkrw3q18ppb6sf3d6iy0gbb843f3y-lannotate-0.2.4.tar.bz2
       > source root is lannotate-0.2.4
       > setting SOURCE_DATE_EPOCH to timestamp 1751891069 of file "lannotate-0.2.4/visibility.mli"
       > Running phase: patchPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > no configure script, doing nothing
       > Running phase: buildPhase
       > Warning: Cache directories could not be created: Permission denied; disabling
       > cache
       > Hint: Make sure the directory /homeless-shelter/.cache/dune/db/temp can be
       > created
       > File "share/dune", line 25, characters 16-31:
       > 25 |  (section (site (frama-c share)))
       >                      ^^^^^^^^^^^^^^^
       > Error: The package frama-c is not found
       For full logs, run:
         nix-store -l /nix/store/gy0l46rbk6zammfs1dwxfv7wvjj52gzz-ocaml5.3.0-frama-c-lannotate-0.2.4.drv
```

But it is unclear to me how I am supposed to fix it. I don't konw if something is missing in the packaging of `framac` or if I should add something to the packaging here so that it finds the dune-site `frama-c` exposed by `framac`.

cc @stepbrobd, @vbgl and @AllanBlanchard in case you have any idea about it :)

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
