### PR TITLE
gamedig: init at unstable-2026-05-26

### DIFF
--- a/pkgs/build-support/node/build-npm-package/hooks/npm-config-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-config-hook.sh
@@ -28,6 +28,8 @@ npmConfigHook() {
         exit 1
     fi
 
+    export npmDeps
+
     if [[ -e "$npmDeps/.fetcher-version" ]]; then
       local -r fetcherVersion=$(cat "$npmDeps/.fetcher-version")
     else

--- a/pkgs/by-name/ga/gamedig/package.nix
+++ b/pkgs/by-name/ga/gamedig/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "gamedig";
+  version = "unstable-2026-04-23";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "gamedig";
+    repo = "node-gamedig";
+    rev = "8504291b8041cd9efd7a1cea6be3292fc3e1ebe5";
+    hash = "sha256-GBJLozTGKztd1sSAH6W6MKpI2cJPgFUpGQd5GUvHa2A=";
+  };
+
+  npmDepsHash = "sha256-1LxSIn+vSr/tD3fAEq5byuaaaX0ibbjN+7YJ1abJnQk=";
+
+  meta = {
+    changelog = "https://github.com/gamedig/node-gamedig/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    description = "Open Source Libraries for Game Server Queries";
+    homepage = "https://gamedig.github.io";
+    downloadPage = "https://github.com/gamedig/node-gamedig";
+    license = lib.licenses.mit;
+    mainProgram = "gamedig";
+    maintainers = [ lib.maintainers.rhoriguchi ];
+  };
+})

--- a/pkgs/by-name/ga/gamedig/package.nix
+++ b/pkgs/by-name/ga/gamedig/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "gamedig";
+  version = "unstable-2026-05-26";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "gamedig";
+    repo = "node-gamedig";
+    rev = "11dc4af80ad31444f6c4eeb4885862b3565240e1";
+    hash = "sha256-Zu6CJqOwnzyPqJY3cqys1EMXSIgJ0rAJlcZkcuQxiX0=";
+  };
+
+  npmDepsHash = "sha256-seGzkiJFXKdV+p4wp9+Azbppwm8z276Da6DFO3PFtOo=";
+
+  meta = {
+    changelog = "https://github.com/gamedig/node-gamedig/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    description = "Open Source Libraries for Game Server Queries";
+    homepage = "https://gamedig.github.io";
+    downloadPage = "https://github.com/gamedig/node-gamedig";
+    license = lib.licenses.mit;
+    mainProgram = "gamedig";
+    maintainers = [ lib.maintainers.rhoriguchi ];
+  };
+})


### PR DESCRIPTION
This application seems to have versions but no tags or releases.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
