### PR TITLE
nixos/chromium: implementing chromium browser/prefs via options

### DIFF
--- a/nixos/modules/programs/chromium.nix
+++ b/nixos/modules/programs/chromium.nix
@@ -9,14 +9,8 @@ let
   cfg = config.programs.chromium;
 
   defaultProfile = lib.filterAttrs (_: v: v != null) {
-    HomepageLocation = cfg.homepageLocation;
-    DefaultSearchProviderEnabled = cfg.defaultSearchProviderEnabled;
-    DefaultSearchProviderSearchURL = cfg.defaultSearchProviderSearchURL;
-    DefaultSearchProviderSuggestURL = cfg.defaultSearchProviderSuggestURL;
     ExtensionInstallForcelist = cfg.extensions;
   };
-
-  mergedExtraOpts = cfg.policies // cfg.extraOpts;
 
   chromiumEtcConfig = {
     # Plasma integration
@@ -31,8 +25,8 @@ let
       text = builtins.toJSON defaultProfile;
     };
 
-    "chromium/policies/managed/extra.json" = lib.mkIf (mergedExtraOpts != { }) {
-      text = builtins.toJSON mergedExtraOpts;
+    "chromium/policies/managed/extra.json" = lib.mkIf (cfg.policies != { }) {
+      text = builtins.toJSON cfg.policies;
     };
 
     # First-run preferences
@@ -42,6 +36,8 @@ let
   };
 in
 {
+  disabledModules = [ "programs/chromium.nix" ];
+
   options.programs.chromium = {
     enable = lib.mkEnableOption "Enable Chromium browser";
 
@@ -66,44 +62,6 @@ in
         Chromium extension force-install list.
         Extension IDs come from Chrome Web Store URLs.
       '';
-    };
-
-    homepageLocation = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
-      default = null;
-      description = ''
-        Sets the URL that Chromium will load when the Home button is clicked or when a new window/tab is opened (depending on user settings). This corresponds to the Chromium HomepageLocation [Managed Policy](https://chromeenterprise.google/policies/#HomepageLocation). Setting it to null allows the user to configure the value or uses Chromium's internal defaults.
-      '';
-    };
-
-    defaultSearchProviderEnabled = lib.mkOption {
-      type = lib.types.nullOr lib.types.bool;
-      default = null;
-      description = ''
-        Controls whether the default search provider is enforced. This corresponds to the Chromium DefaultSearchProviderEnabled [Managed Policy](https://chromeenterprise.google/policies/#DefaultSearchProviderEnabled). Setting to true enables the provider configured by defaultSearchProviderSearchURL, and false disables it. Set to null to use Chromium's default behavior (which is typically enabled).
-      '';
-    };
-
-    defaultSearchProviderSearchURL = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
-      default = null;
-      description = ''
-        Sets the URL pattern to be used by the default search provider when performing a search. This corresponds to the Chromium DefaultSearchProviderSearchURL [Managed Policy](https://chromeenterprise.google/policies/#DefaultSearchProviderSearchURL). This option only takes effect if programs.chromium.defaultSearchProviderEnabled is set to true. The URL must include the placeholder {searchTerms}.
-      '';
-    };
-
-    defaultSearchProviderSuggestURL = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
-      default = null;
-      description = ''
-        Sets the URL pattern for fetching search suggestions from the default search provider as the user types. This corresponds to the Chromium DefaultSearchProviderSuggestURL [Managed Policy](https://chromeenterprise.google/policies/#DefaultSearchProviderSuggestURL). This option only takes effect if programs.chromium.defaultSearchProviderEnabled is set to true. The URL must include the placeholder {searchTerms}.
-      '';
-    };
-
-    extraOpts = lib.mkOption {
-      type = lib.types.attrs;
-      default = { };
-      description = "Additional Chromium enterprise policy settings.";
     };
 
     initialPrefs = lib.mkOption {

--- a/nixos/modules/programs/chromium.nix
+++ b/nixos/modules/programs/chromium.nix
@@ -8,161 +8,124 @@
 let
   cfg = config.programs.chromium;
 
-  defaultProfile = lib.filterAttrs (k: v: v != null) {
+  defaultProfile = lib.filterAttrs (_: v: v != null) {
     HomepageLocation = cfg.homepageLocation;
     DefaultSearchProviderEnabled = cfg.defaultSearchProviderEnabled;
     DefaultSearchProviderSearchURL = cfg.defaultSearchProviderSearchURL;
     DefaultSearchProviderSuggestURL = cfg.defaultSearchProviderSuggestURL;
     ExtensionInstallForcelist = cfg.extensions;
   };
+
+  mergedExtraOpts = cfg.policies // cfg.extraOpts;
+
+  chromiumEtcConfig = {
+    # Plasma integration
+    "chromium/native-messaging-hosts/org.kde.plasma.browser_integration.json" =
+      lib.mkIf (cfg.enablePlasmaBrowserIntegration)
+        {
+          source = "${cfg.plasmaBrowserIntegrationPackage}/etc/chromium/native-messaging-hosts/org.kde.plasma.browser_integration.json";
+        };
+
+    # Managed policy files
+    "chromium/policies/managed/default.json" = lib.mkIf (defaultProfile != { }) {
+      text = builtins.toJSON defaultProfile;
+    };
+
+    "chromium/policies/managed/extra.json" = lib.mkIf (mergedExtraOpts != { }) {
+      text = builtins.toJSON mergedExtraOpts;
+    };
+
+    # First-run preferences
+    "chromium/initial_preferences" = lib.mkIf (cfg.initialPrefs != { }) {
+      text = builtins.toJSON cfg.initialPrefs;
+    };
+  };
 in
-
 {
-  ###### interface
+  options.programs.chromium = {
+    enable = lib.mkEnableOption "Enable Chromium browser";
 
-  options = {
-    programs.chromium = {
-      enable = lib.mkEnableOption "policies for chromium based browsers like Chromium, Google Chrome or Brave";
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.chromium;
+      description = "Chromium browser package to install.";
+      defaultText = lib.literalExpression "pkgs.chromium";
+    };
 
-      enablePlasmaBrowserIntegration = lib.mkEnableOption "Native Messaging Host for Plasma Browser Integration";
+    enablePlasmaBrowserIntegration = lib.mkEnableOption "Native Messaging Host for Plasma Browser Integration";
 
-      plasmaBrowserIntegrationPackage = lib.mkPackageOption pkgs [
-        "kdePackages"
-        "plasma-browser-integration"
-      ] { };
+    plasmaBrowserIntegrationPackage = lib.mkPackageOption pkgs [
+      "kdePackages"
+      "plasma-browser-integration"
+    ] { };
 
-      extensions = lib.mkOption {
-        type = with lib.types; nullOr (listOf str);
-        description = ''
-          List of chromium extensions to install.
-          For list of plugins ids see id in url of extensions on
-          [chrome web store](https://chrome.google.com/webstore/category/extensions)
-          page. To install a chromium extension not included in the chrome web
-          store, append to the extension id a semicolon ";" followed by a URL
-          pointing to an Update Manifest XML file. See
-          [ExtensionInstallForcelist](https://cloud.google.com/docs/chrome-enterprise/policies/?policy=ExtensionInstallForcelist)
-          for additional details.
-        '';
-        default = null;
-        example = lib.literalExpression ''
-          [
-            "chlffgpmiacpedhhbkiomidkjlcfhogd" # pushbullet
-            "mbniclmhobmnbdlbpiphghaielnnpgdp" # lightshot
-            "gcbommkclmclpchllfjekcdonpmejbdp" # https everywhere
-            "cjpalhdlnbpafiamejdnhcphjbkeiagm" # ublock origin
-          ]
-        '';
-      };
+    extensions = lib.mkOption {
+      type = with lib.types; nullOr (listOf str);
+      default = null;
+      description = ''
+        Chromium extension force-install list.
+        Extension IDs come from Chrome Web Store URLs.
+      '';
+    };
 
-      homepageLocation = lib.mkOption {
-        type = lib.types.nullOr lib.types.str;
-        description = "Chromium default homepage";
-        default = null;
-        example = "https://nixos.org";
-      };
+    homepageLocation = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        Sets the URL that Chromium will load when the Home button is clicked or when a new window/tab is opened (depending on user settings). This corresponds to the Chromium HomepageLocation [Managed Policy](https://chromeenterprise.google/policies/#HomepageLocation). Setting it to null allows the user to configure the value or uses Chromium's internal defaults.
+      '';
+    };
 
-      defaultSearchProviderEnabled = lib.mkOption {
-        type = lib.types.nullOr lib.types.bool;
-        description = "Enable the default search provider.";
-        default = null;
-        example = true;
-      };
+    defaultSearchProviderEnabled = lib.mkOption {
+      type = lib.types.nullOr lib.types.bool;
+      default = null;
+      description = ''
+        Controls whether the default search provider is enforced. This corresponds to the Chromium DefaultSearchProviderEnabled [Managed Policy](https://chromeenterprise.google/policies/#DefaultSearchProviderEnabled). Setting to true enables the provider configured by defaultSearchProviderSearchURL, and false disables it. Set to null to use Chromium's default behavior (which is typically enabled).
+      '';
+    };
 
-      defaultSearchProviderSearchURL = lib.mkOption {
-        type = lib.types.nullOr lib.types.str;
-        description = "Chromium default search provider url.";
-        default = null;
-        example = "https://encrypted.google.com/search?q={searchTerms}&{google:RLZ}{google:originalQueryForSuggestion}{google:assistedQueryStats}{google:searchFieldtrialParameter}{google:searchClient}{google:sourceId}{google:instantExtendedEnabledParameter}ie={inputEncoding}";
-      };
+    defaultSearchProviderSearchURL = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        Sets the URL pattern to be used by the default search provider when performing a search. This corresponds to the Chromium DefaultSearchProviderSearchURL [Managed Policy](https://chromeenterprise.google/policies/#DefaultSearchProviderSearchURL). This option only takes effect if programs.chromium.defaultSearchProviderEnabled is set to true. The URL must include the placeholder {searchTerms}.
+      '';
+    };
 
-      defaultSearchProviderSuggestURL = lib.mkOption {
-        type = lib.types.nullOr lib.types.str;
-        description = "Chromium default search provider url for suggestions.";
-        default = null;
-        example = "https://encrypted.google.com/complete/search?output=chrome&q={searchTerms}";
-      };
+    defaultSearchProviderSuggestURL = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        Sets the URL pattern for fetching search suggestions from the default search provider as the user types. This corresponds to the Chromium DefaultSearchProviderSuggestURL [Managed Policy](https://chromeenterprise.google/policies/#DefaultSearchProviderSuggestURL). This option only takes effect if programs.chromium.defaultSearchProviderEnabled is set to true. The URL must include the placeholder {searchTerms}.
+      '';
+    };
 
-      extraOpts = lib.mkOption {
-        type = lib.types.attrs;
-        description = ''
-          Extra chromium policy options. A list of available policies
-          can be found in the Chrome Enterprise documentation:
-          <https://cloud.google.com/docs/chrome-enterprise/policies/>
-          Make sure the selected policy is supported on Linux and your browser version.
-        '';
-        default = { };
-        example = lib.literalExpression ''
-          {
-            "BrowserSignin" = 0;
-            "SyncDisabled" = true;
-            "PasswordManagerEnabled" = false;
-            "SpellcheckEnabled" = true;
-            "SpellcheckLanguage" = [
-              "de"
-              "en-US"
-            ];
-          }
-        '';
-      };
+    extraOpts = lib.mkOption {
+      type = lib.types.attrs;
+      default = { };
+      description = "Additional Chromium enterprise policy settings.";
+    };
 
-      initialPrefs = lib.mkOption {
-        type = lib.types.attrs;
-        description = ''
-          Initial preferences are used to configure the browser for the first run.
-          Unlike {option}`programs.chromium.extraOpts`, initialPrefs can be changed by users in the browser settings.
-          More information can be found in the Chromium documentation:
-          <https://www.chromium.org/administrators/configuring-other-preferences/>
-        '';
-        default = { };
-        example = lib.literalExpression ''
-          {
-            "first_run_tabs" = [
-              "https://nixos.org/"
-            ];
-          }
-        '';
+    initialPrefs = lib.mkOption {
+      type = lib.types.attrs;
+      default = { };
+      description = "Initial (first-run) Chromium preferences.";
+    };
+
+    policies = lib.mkOption {
+      type = lib.types.attrs;
+      default = { };
+      description = "Browser-specific policy tree (Chromium only).";
+      example = {
+        SyncDisabled = true;
       };
     };
   };
 
-  ###### implementation
-
-  config = {
-    environment.etc = lib.mkIf cfg.enable {
-      # for chromium
-      "chromium/native-messaging-hosts/org.kde.plasma.browser_integration.json" =
-        lib.mkIf cfg.enablePlasmaBrowserIntegration
-          {
-            source = "${cfg.plasmaBrowserIntegrationPackage}/etc/chromium/native-messaging-hosts/org.kde.plasma.browser_integration.json";
-          };
-      "chromium/policies/managed/default.json" = lib.mkIf (defaultProfile != { }) {
-        text = builtins.toJSON defaultProfile;
-      };
-      "chromium/policies/managed/extra.json" = lib.mkIf (cfg.extraOpts != { }) {
-        text = builtins.toJSON cfg.extraOpts;
-      };
-      "chromium/initial_preferences" = lib.mkIf (cfg.initialPrefs != { }) {
-        text = builtins.toJSON cfg.initialPrefs;
-      };
-      # for google-chrome https://www.chromium.org/administrators/linux-quick-start
-      "opt/chrome/native-messaging-hosts/org.kde.plasma.browser_integration.json" =
-        lib.mkIf cfg.enablePlasmaBrowserIntegration
-          {
-            source = "${cfg.plasmaBrowserIntegrationPackage}/etc/opt/chrome/native-messaging-hosts/org.kde.plasma.browser_integration.json";
-          };
-      "opt/chrome/policies/managed/default.json" = lib.mkIf (defaultProfile != { }) {
-        text = builtins.toJSON defaultProfile;
-      };
-      "opt/chrome/policies/managed/extra.json" = lib.mkIf (cfg.extraOpts != { }) {
-        text = builtins.toJSON cfg.extraOpts;
-      };
-      # for brave
-      "brave/policies/managed/default.json" = lib.mkIf (defaultProfile != { }) {
-        text = builtins.toJSON defaultProfile;
-      };
-      "brave/policies/managed/extra.json" = lib.mkIf (cfg.extraOpts != { }) {
-        text = builtins.toJSON cfg.extraOpts;
-      };
+  config = lib.mkIf cfg.enable {
+    environment = {
+      etc = chromiumEtcConfig;
+      systemPackages = [ cfg.package ];
     };
   };
 }

--- a/nixos/modules/programs/chromium.nix
+++ b/nixos/modules/programs/chromium.nix
@@ -8,195 +8,80 @@
 let
   cfg = config.programs.chromium;
 
-  defaultProfile = lib.filterAttrs (k: v: v != null) {
-    HomepageLocation = cfg.homepageLocation;
-    DefaultSearchProviderEnabled = cfg.defaultSearchProviderEnabled;
-    DefaultSearchProviderSearchURL = cfg.defaultSearchProviderSearchURL;
-    DefaultSearchProviderSuggestURL = cfg.defaultSearchProviderSuggestURL;
+  defaultProfile = lib.filterAttrs (_: v: v != null) {
     ExtensionInstallForcelist = cfg.extensions;
   };
+
+  chromiumEtcConfig = {
+    # Plasma integration
+    "chromium/native-messaging-hosts/org.kde.plasma.browser_integration.json" =
+      lib.mkIf (cfg.enablePlasmaBrowserIntegration)
+        {
+          source = "${cfg.plasmaBrowserIntegrationPackage}/etc/chromium/native-messaging-hosts/org.kde.plasma.browser_integration.json";
+        };
+
+    # Managed policy files
+    "chromium/policies/managed/default.json" = lib.mkIf (defaultProfile != { }) {
+      text = builtins.toJSON defaultProfile;
+    };
+
+    "chromium/policies/managed/extra.json" = lib.mkIf (cfg.policies != { }) {
+      text = builtins.toJSON cfg.policies;
+    };
+
+    # First-run preferences
+    "chromium/initial_preferences" = lib.mkIf (cfg.initialPrefs != { }) {
+      text = builtins.toJSON cfg.initialPrefs;
+    };
+  };
 in
-
 {
-  ###### interface
+  options.programs.chromium = {
+    enable = lib.mkEnableOption "Enable Chromium browser";
 
-  options = {
-    programs.chromium = {
-      enable = lib.mkEnableOption "policies for chromium based browsers like Chromium, Google Chrome or Brave";
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.chromium;
+      description = "Chromium browser package to install.";
+      defaultText = lib.literalExpression "pkgs.chromium";
+    };
 
-      enablePlasmaBrowserIntegration = lib.mkEnableOption "Native Messaging Host for Plasma Browser Integration";
+    enablePlasmaBrowserIntegration = lib.mkEnableOption "Native Messaging Host for Plasma Browser Integration";
 
-      plasmaBrowserIntegrationPackage = lib.mkPackageOption pkgs [
-        "kdePackages"
-        "plasma-browser-integration"
-      ] { };
+    plasmaBrowserIntegrationPackage = lib.mkPackageOption pkgs [
+      "kdePackages"
+      "plasma-browser-integration"
+    ] { };
 
-      extensions = lib.mkOption {
-        type = with lib.types; nullOr (listOf str);
-        description = ''
-          List of chromium extensions to install.
-          For list of plugins ids see id in url of extensions on
-          [chrome web store](https://chrome.google.com/webstore/category/extensions)
-          page. To install a chromium extension not included in the chrome web
-          store, append to the extension id a semicolon ";" followed by a URL
-          pointing to an Update Manifest XML file. See
-          [ExtensionInstallForcelist](https://cloud.google.com/docs/chrome-enterprise/policies/?policy=ExtensionInstallForcelist)
-          for additional details.
-        '';
-        default = null;
-        example = lib.literalExpression ''
-          [
-            "chlffgpmiacpedhhbkiomidkjlcfhogd" # pushbullet
-            "mbniclmhobmnbdlbpiphghaielnnpgdp" # lightshot
-            "gcbommkclmclpchllfjekcdonpmejbdp" # https everywhere
-            "cjpalhdlnbpafiamejdnhcphjbkeiagm" # ublock origin
-          ]
-        '';
-      };
+    extensions = lib.mkOption {
+      type = with lib.types; nullOr (listOf str);
+      default = null;
+      description = ''
+        Chromium extension force-install list.
+        Extension IDs come from Chrome Web Store URLs.
+      '';
+    };
 
-      homepageLocation = lib.mkOption {
-        type = lib.types.nullOr lib.types.str;
-        description = "Chromium default homepage";
-        default = null;
-        example = "https://nixos.org";
-      };
+    initialPrefs = lib.mkOption {
+      type = lib.types.attrs;
+      default = { };
+      description = "Initial (first-run) Chromium preferences.";
+    };
 
-      defaultSearchProviderEnabled = lib.mkOption {
-        type = lib.types.nullOr lib.types.bool;
-        description = "Enable the default search provider.";
-        default = null;
-        example = true;
-      };
-
-      defaultSearchProviderSearchURL = lib.mkOption {
-        type = lib.types.nullOr lib.types.str;
-        description = "Chromium default search provider url.";
-        default = null;
-        example = "https://encrypted.google.com/search?q={searchTerms}&{google:RLZ}{google:originalQueryForSuggestion}{google:assistedQueryStats}{google:searchFieldtrialParameter}{google:searchClient}{google:sourceId}{google:instantExtendedEnabledParameter}ie={inputEncoding}";
-      };
-
-      defaultSearchProviderSuggestURL = lib.mkOption {
-        type = lib.types.nullOr lib.types.str;
-        description = "Chromium default search provider url for suggestions.";
-        default = null;
-        example = "https://encrypted.google.com/complete/search?output=chrome&q={searchTerms}";
-      };
-
-      extraOpts = lib.mkOption {
-        type = lib.types.attrs;
-        description = ''
-          Extra chromium policy options. These settings are locked and the user cannot change them in the browser later.
-          A list of available policies
-          can be found in the Chrome Enterprise documentation:
-          <https://cloud.google.com/docs/chrome-enterprise/policies/>
-          Make sure the selected policy is supported on Linux and your browser version.
-        '';
-        default = { };
-        example = lib.literalExpression ''
-          {
-            "BrowserSignin" = 0;
-            "SyncDisabled" = true;
-            "PasswordManagerEnabled" = false;
-            "SpellcheckEnabled" = true;
-            "SpellcheckLanguage" = [
-              "de"
-              "en-US"
-            ];
-          }
-        '';
-      };
-
-      extraOptsRecommended = lib.mkOption {
-        type = lib.types.attrs;
-        description = ''
-          Extra chromium policy options in recommended. These are default settings. The user can change them in the browser later if they want to.
-          A list of available policies
-          can be found in the Chrome Enterprise documentation:
-          <https://cloud.google.com/docs/chrome-enterprise/policies/>
-          Make sure the selected policy is supported on Linux and your browser version.
-        '';
-        default = { };
-        example = lib.literalExpression ''
-          {
-            "BrowserSignin" = 0;
-            "SyncDisabled" = true;
-            "PasswordManagerEnabled" = false;
-            "SpellcheckEnabled" = true;
-            "SpellcheckLanguage" = [
-              "de"
-              "en-US"
-            ];
-          }
-        '';
-      };
-
-      initialPrefs = lib.mkOption {
-        type = lib.types.attrs;
-        description = ''
-          Initial preferences are used to configure the browser for the first run.
-          Unlike {option}`programs.chromium.extraOpts`, initialPrefs can be changed by users in the browser settings.
-          More information can be found in the Chromium documentation:
-          <https://www.chromium.org/administrators/configuring-other-preferences/>
-        '';
-        default = { };
-        example = lib.literalExpression ''
-          {
-            "first_run_tabs" = [
-              "https://nixos.org/"
-            ];
-          }
-        '';
+    policies = lib.mkOption {
+      type = lib.types.attrs;
+      default = { };
+      description = "Browser-specific policy tree (Chromium only).";
+      example = {
+        SyncDisabled = true;
       };
     };
   };
 
-  ###### implementation
-
-  config = {
-    environment.etc = lib.mkIf cfg.enable {
-      # for chromium
-      "chromium/native-messaging-hosts/org.kde.plasma.browser_integration.json" =
-        lib.mkIf cfg.enablePlasmaBrowserIntegration
-          {
-            source = "${cfg.plasmaBrowserIntegrationPackage}/etc/chromium/native-messaging-hosts/org.kde.plasma.browser_integration.json";
-          };
-      "chromium/policies/managed/default.json" = lib.mkIf (defaultProfile != { }) {
-        text = builtins.toJSON defaultProfile;
-      };
-      "chromium/policies/managed/extra.json" = lib.mkIf (cfg.extraOpts != { }) {
-        text = builtins.toJSON cfg.extraOpts;
-      };
-      "chromium/policies/recommended/extra.json" = lib.mkIf (cfg.extraOptsRecommended != { }) {
-        text = builtins.toJSON cfg.extraOptsRecommended;
-      };
-      "chromium/initial_preferences" = lib.mkIf (cfg.initialPrefs != { }) {
-        text = builtins.toJSON cfg.initialPrefs;
-      };
-      # for google-chrome https://www.chromium.org/administrators/linux-quick-start
-      "opt/chrome/native-messaging-hosts/org.kde.plasma.browser_integration.json" =
-        lib.mkIf cfg.enablePlasmaBrowserIntegration
-          {
-            source = "${cfg.plasmaBrowserIntegrationPackage}/etc/opt/chrome/native-messaging-hosts/org.kde.plasma.browser_integration.json";
-          };
-      "opt/chrome/policies/managed/default.json" = lib.mkIf (defaultProfile != { }) {
-        text = builtins.toJSON defaultProfile;
-      };
-      "opt/chrome/policies/managed/extra.json" = lib.mkIf (cfg.extraOpts != { }) {
-        text = builtins.toJSON cfg.extraOpts;
-      };
-      "opt/chrome/policies/recommended/extra.json" = lib.mkIf (cfg.extraOptsRecommended != { }) {
-        text = builtins.toJSON cfg.extraOptsRecommended;
-      };
-      # for brave
-      "brave/policies/managed/default.json" = lib.mkIf (defaultProfile != { }) {
-        text = builtins.toJSON defaultProfile;
-      };
-      "brave/policies/managed/extra.json" = lib.mkIf (cfg.extraOpts != { }) {
-        text = builtins.toJSON cfg.extraOpts;
-      };
-      "brave/policies/recommended/extra.json" = lib.mkIf (cfg.extraOptsRecommended != { }) {
-        text = builtins.toJSON cfg.extraOptsRecommended;
-      };
+  config = lib.mkIf cfg.enable {
+    environment = {
+      etc = chromiumEtcConfig;
+      systemPackages = [ cfg.package ];
     };
   };
 }


### PR DESCRIPTION
Yet another take on chromium by me :p

Given that i am no good at nix but im willing to learn/contribute and make this better for everyone so here's a fresh start from my side.

This PR aims to implement options to configure, install and handle chromium browser and chromium browser only. In my previous PR a detailed note by emily helped point out all the potential mistakes (which is what should have been done in the very start) which I plan to fix as we move forward. I hope there are no issues with this freshly made PR. I have tested these options and they are working on my NixOS installation. Let me know what you guys think about it :)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
