### PR TITLE
treewide: fix nix-env eval in cross

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -125,8 +125,12 @@ let
   libc_bin = optionalString (libc != null) (getBin libc);
   libc_dev = optionalString (libc != null) (getDev libc);
   libc_lib = optionalString (libc != null) (getLib libc);
-  cc_solib = getLib cc + optionalString (targetPlatform != hostPlatform) "/${targetPlatform.config}";
-  cc_bin = getBin cc + optionalString (targetPlatform != hostPlatform) "/${targetPlatform.config}";
+  cc_solib =
+    optionalString (!nativeTools) (getLib cc)
+    + optionalString (targetPlatform != hostPlatform) "/${targetPlatform.config}";
+  cc_bin =
+    optionalString (!nativeTools) (getBin cc)
+    + optionalString (targetPlatform != hostPlatform) "/${targetPlatform.config}";
 
   # The wrapper scripts use 'cat' and 'grep', so we may need coreutils.
   coreutils_bin = optionalString (!nativeTools) (getBin coreutils);

--- a/pkgs/by-name/ai/aircrack-ng/package.nix
+++ b/pkgs/by-name/ai/aircrack-ng/package.nix
@@ -89,7 +89,7 @@ stdenv.mkDerivation rec {
       ethtool
       pciutils
     ]
-    ++ lib.optional (stdenv.hostPlatform.isCygwin && stdenv.hostPlatform.isClang) libiconv
+    ++ lib.optional (stdenv.hostPlatform.isCygwin && stdenv.cc.isClang) libiconv
     ++ lib.optional enableAirolib sqlite
     ++ lib.optional enableRegex pcre2
     ++ lib.optional useAirpcap airpcap-sdk;

--- a/pkgs/by-name/am/amazon-ssm-agent/package.nix
+++ b/pkgs/by-name/am/amazon-ssm-agent/package.nix
@@ -6,7 +6,7 @@
   darwin,
   fetchFromGitHub,
   coreutils,
-  net-tools,
+  unixtools,
   util-linux,
   stdenv,
   dmidecode,
@@ -90,7 +90,7 @@ buildGoModule rec {
 
     substituteInPlace agent/platform/platform_unix.go \
       --replace-fail "/usr/bin/uname" "${coreutils}/bin/uname" \
-      --replace-fail '"/bin", "hostname"' '"${net-tools}/bin/hostname"' \
+      --replace-fail '"/bin", "hostname"' '"${unixtools.hostname}/bin/hostname"' \
       --replace-fail '"lsb_release"' '"${fake-lsb-release}/bin/lsb_release"'
 
     substituteInPlace agent/session/shell/shell_unix.go \

--- a/pkgs/by-name/ar/argo-workflows/package.nix
+++ b/pkgs/by-name/ar/argo-workflows/package.nix
@@ -46,7 +46,7 @@ buildGoModule rec {
         if (stdenv.buildPlatform == stdenv.hostPlatform) then
           "$out/bin/argo"
         else
-          "${pkgsBuildBuild.argo}/bin/argo"
+          "${pkgsBuildBuild.argo-workflows}/bin/argo"
       } completion $shell > argo.$shell
       installShellCompletion argo.$shell
     done

--- a/pkgs/by-name/hy/hydra/package.nix
+++ b/pkgs/by-name/hy/hydra/package.nix
@@ -123,7 +123,7 @@ let
         UUID4Tiny
         XMLSimple
         YAML
-        (nix.libs.nix-perl-bindings or nix.perl-bindings)
+        (nix.libs.nix-perl-bindings or nix.perl-bindings or null)
         git
       ];
   };

--- a/pkgs/by-name/li/libcosmicAppHook/package.nix
+++ b/pkgs/by-name/li/libcosmicAppHook/package.nix
@@ -11,6 +11,8 @@
   makeBinaryWrapper,
   pkg-config,
   targetPackages,
+  cosmic-icons,
+  cosmic-settings,
   libGL,
   libxkbcommon,
   xorg,
@@ -49,11 +51,11 @@ makeSetupHook {
       let
         fallbackThemes = runCommand "cosmic-fallback-themes" { } ''
           mkdir -p $out/share
-          ln -s ${targetPackages.cosmic-settings}/share/cosmic $out/share/cosmic
+          ln -s ${targetPackages.cosmic-settings or cosmic-settings}/share/cosmic $out/share/cosmic
         '';
       in
       lib.makeSearchPath "share" (
-        lib.optionals includeSettings [ fallbackThemes ] ++ [ targetPackages.cosmic-icons ]
+        lib.optionals includeSettings [ fallbackThemes ] ++ [ targetPackages.cosmic-icons or cosmic-icons ]
       );
     # Temporarily using RUSTFLAGS: https://github.com/NixOS/nixpkgs/issues/464392
     # See ./libcosmic-app-hook.sh

--- a/pkgs/by-name/ni/nix-serve/package.nix
+++ b/pkgs/by-name/ni/nix-serve/package.nix
@@ -12,7 +12,6 @@
 let
   rev = "a7e046db4b29d422fc9aac60ea6b82b31399951a";
   sha256 = "sha256-6ZQ0OLijq6UtOtUqRdFC19+helhU0Av6MvGCZf6XmcQ=";
-  inherit (nix.libs) nix-perl-bindings;
 in
 
 stdenv.mkDerivation {
@@ -37,7 +36,7 @@ stdenv.mkDerivation {
         p.DBDSQLite
         p.Plack
         p.Starman
-        nix-perl-bindings
+        nix.libs.nix-perl-bindings or null
       ])
     }/bin/starman $out/bin/nix-serve \
       --prefix PATH : "${

--- a/pkgs/development/compilers/fpc/binary.nix
+++ b/pkgs/development/compilers/fpc/binary.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     else if stdenv.hostPlatform.isDarwin then
       ./binary-builder-darwin.sh
     else
-      throw "Not supported on ${stdenv.hostPlatform}.";
+      throw "Not supported on ${stdenv.hostPlatform.system}.";
 
   meta = {
     description = "Free Pascal Compiler from a binary distribution";

--- a/pkgs/development/compilers/llvm/common/default.nix
+++ b/pkgs/development/compilers/llvm/common/default.nix
@@ -3,6 +3,7 @@
   targetPackages,
   lib,
   stdenv,
+  preLibcHeaders,
   fetchFromGitHub,
   overrideCC,
   wrapCCWith,
@@ -278,7 +279,7 @@ makeScopeWithSplicing' {
 
       bintoolsNoLibc = wrapBintoolsWith {
         bintools = self.bintools-unwrapped;
-        libc = targetPackages.preLibcHeaders;
+        libc = targetPackages.preLibcHeaders or preLibcHeaders;
       };
 
       bintools = wrapBintoolsWith {

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -668,7 +668,7 @@ with haskellLib;
       # the path to the (host) tools at build time from PATH,
       # so we instruct it to check at runtime.
       enableCabalFlag "allow-relative-paths" (
-        super.nix-paths {
+        super.nix-paths.override {
           nix-build = null;
           nix-env = null;
           nix-hash = null;

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -572,7 +572,7 @@ let
 
           psqlSchema = lib.versions.major version;
 
-          withJIT = this.withPackages (_: [ this.jit ]);
+          withJIT = if jitSupport then this.withPackages (_: [ this.jit ]) else null;
           withoutJIT = this;
 
           pkgs =

--- a/pkgs/stdenv/native/default.nix
+++ b/pkgs/stdenv/native/default.nix
@@ -178,12 +178,16 @@ in
           name = "cc-native";
           nativeTools = true;
           nativeLibc = true;
+          expand-response-params = "";
           inherit lib nativePrefix;
+          runtimeShell = shell;
           bintools = import ../../build-support/bintools-wrapper {
             name = "bintools";
             inherit lib stdenvNoCC nativePrefix;
             nativeTools = true;
             nativeLibc = true;
+            expand-response-params = "";
+            runtimeShell = shell;
           };
           inherit stdenvNoCC;
         };

--- a/pkgs/test/stdenv/default.nix
+++ b/pkgs/test/stdenv/default.nix
@@ -10,12 +10,12 @@
 
 let
   # early enough not to rebuild gcc but late enough to have patchelf
-  earlyPkgs = stdenv.__bootPackages.stdenv.__bootPackages;
+  earlyPkgs = stdenv.__bootPackages.stdenv.__bootPackages or pkgs;
   earlierPkgs =
-    stdenv.__bootPackages.stdenv.__bootPackages.stdenv.__bootPackages.stdenv.__bootPackages.stdenv.__bootPackages;
+    stdenv.__bootPackages.stdenv.__bootPackages.stdenv.__bootPackages.stdenv.__bootPackages.stdenv.__bootPackages
+      or earlyPkgs;
   # use a early stdenv so when hacking on stdenv this test can be run quickly
-  bootStdenv =
-    stdenv.__bootPackages.stdenv.__bootPackages.stdenv.__bootPackages.stdenv.__bootPackages.stdenv;
+  bootStdenv = earlyPkgs.stdenv.__bootPackages.stdenv.__bootPackages.stdenv or earlyPkgs.stdenv;
   pkgsStructured = import pkgs.path {
     config = {
       structuredAttrsByDefault = true;
@@ -23,7 +23,8 @@ let
     inherit (stdenv.hostPlatform) system;
   };
   bootStdenvStructuredAttrsByDefault =
-    pkgsStructured.stdenv.__bootPackages.stdenv.__bootPackages.stdenv.__bootPackages.stdenv.__bootPackages.stdenv;
+    pkgsStructured.stdenv.__bootPackages.stdenv.__bootPackages.stdenv.__bootPackages.stdenv.__bootPackages.stdenv
+      or pkgsStructured.stdenv;
 
   runCommand = earlierPkgs.runCommand;
 

--- a/pkgs/test/stdenv/patch-shebangs.nix
+++ b/pkgs/test/stdenv/patch-shebangs.nix
@@ -10,6 +10,10 @@
 # strictDeps has to be disabled because the shell isn't in buildInputs
 
 let
+  earlyBash =
+    stdenv.__bootPackages.stdenv.__bootPackages.bashNonInteractive or pkgs.bashNonInteractive;
+  earlyCoreutils = stdenv.__bootPackages.stdenv.__bootPackages.coreutils or pkgs.coreutils;
+
   tests = {
     bad-shebang = stdenv.mkDerivation {
       name = "bad-shebang";
@@ -110,9 +114,9 @@ let
       (derivation {
         name = "read-only-script";
         system = stdenv.buildPlatform.system;
-        builder = "${stdenv.__bootPackages.stdenv.__bootPackages.bashNonInteractive}/bin/bash";
+        builder = "${earlyBash}/bin/bash";
         initialPath = [
-          stdenv.__bootPackages.stdenv.__bootPackages.coreutils
+          earlyCoreutils
         ];
         strictDeps = false;
         args = [
@@ -138,9 +142,9 @@ let
       (derivation {
         name = "preserves-read-only";
         system = stdenv.buildPlatform.system;
-        builder = "${stdenv.__bootPackages.stdenv.__bootPackages.bashNonInteractive}/bin/bash";
+        builder = "${earlyBash}/bin/bash";
         initialPath = [
-          stdenv.__bootPackages.stdenv.__bootPackages.coreutils
+          earlyCoreutils
         ];
         strictDeps = false;
         args = [
@@ -173,9 +177,9 @@ let
       (derivation {
         name = "preserves-timestamp";
         system = stdenv.buildPlatform.system;
-        builder = "${stdenv.__bootPackages.stdenv.__bootPackages.bashNonInteractive}/bin/bash";
+        builder = "${earlyBash}/bin/bash";
         initialPath = [
-          stdenv.__bootPackages.stdenv.__bootPackages.coreutils
+          earlyCoreutils
         ];
         strictDeps = false;
         args = [
@@ -209,9 +213,9 @@ let
       (derivation {
         name = "preserves-binary-data";
         system = stdenv.buildPlatform.system;
-        builder = "${stdenv.__bootPackages.stdenv.__bootPackages.bashNonInteractive}/bin/bash";
+        builder = "${earlyBash}/bin/bash";
         initialPath = [
-          stdenv.__bootPackages.stdenv.__bootPackages.coreutils
+          earlyCoreutils
         ];
         strictDeps = false;
         args = [

--- a/pkgs/tools/package-management/nix/modular/doc/manual/package.nix
+++ b/pkgs/tools/package-management/nix/modular/doc/manual/package.nix
@@ -41,7 +41,7 @@ mkMesonDerivation (finalAttrs: {
     python3
     rsync
   ]
-  ++ lib.optional (lib.versionAtLeast (lib.versions.majorMinor version) "2.33") [
+  ++ lib.optionals (lib.versionAtLeast (lib.versions.majorMinor version) "2.33") [
     json-schema-for-humans
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10026,7 +10026,9 @@ with pkgs;
   );
 
   net-tools =
-    if stdenv.hostPlatform.isLinux then
+    # some platforms refer back to this from unixtools, so this is needed to
+    # break the cycle
+    if stdenv.hostPlatform.isLinux || stdenv.hostPlatform.isCygwin then
       callPackage ../os-specific/linux/net-tools { }
     else
       unixtools.net-tools;
@@ -10050,7 +10052,9 @@ with pkgs;
   # pam_bioapi ( see http://www.thinkwiki.org/wiki/How_to_enable_the_fingerprint_reader )
 
   procps =
-    if stdenv.hostPlatform.isLinux then
+    # some platforms refer back to this from unixtools, so this is needed to
+    # break the cycle
+    if stdenv.hostPlatform.isLinux || stdenv.hostPlatform.isCygwin then
       callPackage ../os-specific/linux/procps-ng { }
     else
       unixtools.procps;

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -3,6 +3,9 @@
   buildPackages,
   pkgs,
   targetPackages,
+  libc,
+  preLibcHeaders,
+  darwin,
   generateSplicesForMkScope,
   makeScopeWithSplicing',
   stdenv,
@@ -53,7 +56,7 @@ makeScopeWithSplicing' {
         };
 
         binutils = pkgs.wrapBintoolsWith {
-          inherit (targetPackages) libc;
+          libc = targetPackages.libc or libc;
           bintools = self.binutils-unwrapped;
         };
 
@@ -84,7 +87,7 @@ makeScopeWithSplicing' {
         };
 
         binutilsNoLibc = pkgs.wrapBintoolsWith {
-          libc = targetPackages.preLibcHeaders;
+          libc = targetPackages.preLibcHeaders or preLibcHeaders;
           bintools = self.binutils-unwrapped;
         };
 
@@ -110,7 +113,7 @@ makeScopeWithSplicing' {
 
         iosSdkPkgs = callPackage ../os-specific/darwin/xcode/sdk-pkgs.nix {
           buildIosSdk = buildPackages.darwin.iosSdkPkgs.sdk;
-          targetIosSdkPkgs = targetPackages.darwin.iosSdkPkgs;
+          targetIosSdkPkgs = (targetPackages.darwin or darwin).iosSdkPkgs;
           inherit (pkgs.llvmPackages) clang-unwrapped;
         };
 


### PR DESCRIPTION
Cc: @Ericson2314 

this came from trying to nixpkgs-review with `crossSystem = "x86_64-cygwin"`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
