### PR TITLE
nixos/virtualisation/podman: fix broken evaluation

### DIFF
--- a/nixos/modules/virtualisation/podman/default.nix
+++ b/nixos/modules/virtualisation/podman/default.nix
@@ -24,23 +24,25 @@ let
         inherit (cfg.package) meta;
         preferLocalBuild = true;
       }
-      ''
-        mkdir -p $out/bin
-        ln -s ${cfg.package}/bin/podman $out/bin/docker
+      (
+        ''
+          mkdir -p $out/bin
+          ln -s ${cfg.package}/bin/podman $out/bin/docker
 
-        mkdir -p $man/share/man/man1
-        for f in ${cfg.package.man}/share/man/man1/*; do
-          basename=$(basename $f | sed s/podman/docker/g)
-          ln -s $f $man/share/man/man1/$basename
-        done
-      ''
-    + lib.optionalString (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
-      export HOME=$(mktemp -d) # work around `docker <cmd>`
-      installShellCompletion --cmd docker \
-        --bash <($out/bin/docker completion bash) \
-        --zsh <($out/bin/docker completion zsh) \
-        --fish <($out/bin/docker completion fish)
-    '';
+          mkdir -p $man/share/man/man1
+          for f in ${cfg.package.man}/share/man/man1/*; do
+            basename=$(basename $f | sed s/podman/docker/g)
+            ln -s $f $man/share/man/man1/$basename
+          done
+        ''
+        + lib.optionalString (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+          export HOME=$(mktemp -d) # work around `docker <cmd>`
+          installShellCompletion --cmd docker \
+            --bash <($out/bin/docker completion bash) \
+            --zsh <($out/bin/docker completion zsh) \
+            --fish <($out/bin/docker completion fish)
+        ''
+      );
 
 in
 {

--- a/nixos/modules/virtualisation/podman/default.nix
+++ b/nixos/modules/virtualisation/podman/default.nix
@@ -35,7 +35,7 @@ let
             ln -s $f $man/share/man/man1/$basename
           done
         ''
-        + lib.optionalString (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+        + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
           export HOME=$(mktemp -d) # work around `docker <cmd>`
           installShellCompletion --cmd docker \
             --bash <($out/bin/docker completion bash) \


### PR DESCRIPTION
### nixos/virtualisation/podman: fix broken evaluation

- The following error occurs when building:

```
error: A definition for option `environment.systemPackages."[definition 8-entry 2]"' is not of type `package'.
Definition values:
In `/nix/store/...-source/nixos/modules/virtualisation/podman/default.nix':
  '' /nix/store/...-podman-docker-compat-5.7.0export HOME=$(mktemp -d) # work around `docker <cmd>`
installShellCompletion --cmd docker \
  --bash <($out/bin/docker completion bash) \
  --zsh <($out/bin/docker completion zsh) \
```

- This error occurs because the string is being concatenated to the output of the function evaluation of `pkgs.runCommand` instead of being concatenated to the string input of the function.

- Tested locally and the build works again.

- Also done, removed negation of `stdenv.buildPlatform.canExecute` as the logic is incorrect otherwise.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
