### PR TITLE
freerdp: compile with SDL3

### DIFF
--- a/pkgs/by-name/fr/freerdp/package.nix
+++ b/pkgs/by-name/fr/freerdp/package.nix
@@ -43,9 +43,9 @@
   libpulseaudio,
   cups,
   pcsclite,
-  SDL2,
-  SDL2_ttf,
-  SDL2_image,
+  sdl3,
+  sdl3-ttf,
+  sdl3-image,
   systemd,
   libjpeg_turbo,
   libkrb5,
@@ -79,10 +79,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     substituteInPlace "libfreerdp/freerdp.pc.in" \
       --replace-fail "Requires:" "Requires: @WINPR_PKG_CONFIG_FILENAME@"
-
-    substituteInPlace client/SDL/SDL2/dialogs/{sdl_input.cpp,sdl_select.cpp,sdl_widget.cpp,sdl_widget.hpp} \
-      --replace-fail "<SDL_ttf.h>" "<SDL2/SDL_ttf.h>"
   ''
+
   + lib.optionalString (pcsclite != null) ''
     substituteInPlace "winpr/libwinpr/smartcard/smartcard_pcsc.c" \
       --replace-fail "libpcsclite.so" "${lib.getLib pcsclite}/lib/libpcsclite.so"
@@ -134,9 +132,9 @@ stdenv.mkDerivation (finalAttrs: {
     pcre2
     pcsclite
     pkcs11helper
-    SDL2
-    SDL2_ttf
-    SDL2_image
+    sdl3
+    sdl3-ttf
+    sdl3-image
     uriparser
     zlib
   ]


### PR DESCRIPTION
With SDL2, sdl-freerdp prints the following warning: "As replacement there is a SDL3 based client available." "If you are interested in keeping %s alive get in touch with the developers"

This very small change is just changes the used library from SDL2 to sdl3.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.