### PR TITLE
rtl88x2bu: unstable-2025-05-29 -> unstable-2025-12-4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4921,9 +4921,11 @@
     github = "claymorwan";
     githubId = 86072589;
     email = "claymorwan@fembois.dev";
-    keys = [{
-      fingerprint = "AA7C 29C3 A26A DB2F 80E5  294D CC5E 1DF0 6FB7 8249";
-    }];
+    keys = [
+      {
+        fingerprint = "AA7C 29C3 A26A DB2F 80E5  294D CC5E 1DF0 6FB7 8249";
+      }
+    ];
   };
   clebs = {
     email = "borja.clemente@gmail.com";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4916,6 +4916,15 @@
     githubId = 9336788;
     name = "Claes Hallström";
   };
+  claymorwan = {
+    name = "claymorwan";
+    github = "claymorwan";
+    githubId = 86072589;
+    email = "claymorwan@fembois.dev";
+    keys = [{
+      fingerprint = "AA7C 29C3 A26A DB2F 80E5  294D CC5E 1DF0 6FB7 8249";
+    }];
+  };
   clebs = {
     email = "borja.clemente@gmail.com";
     github = "clebs";

--- a/pkgs/os-specific/linux/rtl88x2bu/default.nix
+++ b/pkgs/os-specific/linux/rtl88x2bu/default.nix
@@ -12,10 +12,10 @@ stdenv.mkDerivation {
   version = "${kernel.version}-unstable-2025-05-29";
 
   src = fetchFromGitHub {
-    owner = "morrownr";
-    repo = "88x2bu-20210702";
-    rev = "fe48647496798cac77976e310ee95da000b436c9";
-    hash = "sha256-h20vwCgLOiNh0LN3MGwPl3F/PSWGc2XS4t1sdeFAOko=";
+    owner = "RinCat";
+    repo = "RTL88x2BU-Linux-Driver";
+    rev = "825556e195ecde9ce8f5f4cbad9953f398c8598e";
+    hash = "sha256-MkvVCWyMOCBzCRufbKMuaaFOPhokZdFnXHYnrAwBe6M=";
   };
 
   hardeningDisable = [ "pic" ];
@@ -38,10 +38,9 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Realtek rtl88x2bu driver";
-    homepage = "https://github.com/morrownr/88x2bu-20210702";
-    license = licenses.gpl2Only;
+    homepage = "https://github.com/RinCat/RTL88x2BU-Linux-Driver";
+    license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ otavio ];
-    broken = kernel.kernelAtLeast "6.17";
+    maintainers = with maintainers; [ otavio claymorwan ];
   };
 }

--- a/pkgs/os-specific/linux/rtl88x2bu/default.nix
+++ b/pkgs/os-specific/linux/rtl88x2bu/default.nix
@@ -9,7 +9,7 @@
 
 stdenv.mkDerivation {
   pname = "rtl88x2bu";
-  version = "${kernel.version}-unstable-2025-12-4";
+  version = "${kernel.version}-unstable-2025-12-04";
 
   src = fetchFromGitHub {
     owner = "RinCat";
@@ -39,8 +39,11 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "Realtek rtl88x2bu driver";
     homepage = "https://github.com/RinCat/RTL88x2BU-Linux-Driver";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ otavio claymorwan ];
+    maintainers = with maintainers; [
+      otavio
+      claymorwan
+    ];
   };
 }

--- a/pkgs/os-specific/linux/rtl88x2bu/default.nix
+++ b/pkgs/os-specific/linux/rtl88x2bu/default.nix
@@ -9,7 +9,7 @@
 
 stdenv.mkDerivation {
   pname = "rtl88x2bu";
-  version = "${kernel.version}-unstable-2025-05-29";
+  version = "${kernel.version}-unstable-2025-12-4";
 
   src = fetchFromGitHub {
     owner = "RinCat";

--- a/pkgs/os-specific/linux/rtl88x2bu/default.nix
+++ b/pkgs/os-specific/linux/rtl88x2bu/default.nix
@@ -45,5 +45,6 @@ stdenv.mkDerivation {
       otavio
       claymorwan
     ];
+    broken = kernel.kernelOlder "5.11";
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Replaced the package's source to a working one to unbreak it.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
