### PR TITLE
disktui: init at 1.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11142,6 +11142,11 @@
     githubId = 3698237;
     name = "ImUrX";
   };
+  Inarizxc = {
+    name = "Inarizxc";
+    github = "Inarizxc";
+    githubId = 128096405;
+  };
   inclyc = {
     email = "i@lyc.dev";
     github = "inclyc";

--- a/pkgs/by-name/di/disktui/package.nix
+++ b/pkgs/by-name/di/disktui/package.nix
@@ -1,0 +1,25 @@
+{
+  fetchFromGitHub,
+  rustPlatform,
+  lib,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "disktui";
+  version = "1.2.0";
+  src = fetchFromGitHub {
+    owner = "Maciejonos";
+    repo = "disktui";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-FDpdOpyvdU2Uw22am/Vkdls+s6ZdmodNt3WAQd8L53I=";
+  };
+  cargoHash = "sha256-CBSd/zeThyhmsaKx8Pg+u14QEQVq5nPLcRKet9n8WC8=";
+
+  meta = {
+    description = "TUI for disk management on Linux";
+    homepage = "https://github.com/Maciejonos/disktui";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ Inarizxc ];
+    platforms = lib.platforms.linux;
+    mainProgram = "disktui";
+  };
+})


### PR DESCRIPTION
https://github.com/Maciejonos/disktui

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
