### PR TITLE
libguestfs-appliance-nixos: init 

### DIFF
--- a/pkgs/by-name/li/libguestfs-appliance-fedora/package.nix
+++ b/pkgs/by-name/li/libguestfs-appliance-fedora/package.nix
@@ -8,6 +8,9 @@ stdenvNoCC.mkDerivation rec {
   pname = "libguestfs-appliance-fedora";
   version = "1.56.0";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   src = fetchurl {
     url = "https://download.libguestfs.org/binaries/appliance/appliance-${version}.tar.xz";
     hash = "sha256-YbJlNaogMyutdtc7d+etyJvdd//yE8tedsZfkGXJr54=";

--- a/pkgs/by-name/li/libguestfs-appliance-fedora/package.nix
+++ b/pkgs/by-name/li/libguestfs-appliance-fedora/package.nix
@@ -5,7 +5,7 @@
 }:
 
 stdenvNoCC.mkDerivation rec {
-  pname = "libguestfs-appliance";
+  pname = "libguestfs-appliance-fedora";
   version = "1.56.0";
 
   src = fetchurl {
@@ -23,17 +23,15 @@ stdenvNoCC.mkDerivation rec {
   '';
 
   meta = {
-    description = "VM appliance disk image used in libguestfs package";
+    description = "Fedora-based upstream VM appliance disk image used in libguestfs package";
     homepage = "https://libguestfs.org";
-    license = with lib.licenses; [
-      gpl2Plus
-      lgpl2Plus
-    ];
+    license = lib.licenses.free;
     maintainers = with lib.maintainers; [ lukts30 ];
     platforms = [
       "i686-linux"
       "x86_64-linux"
     ];
+    sourceProvenance = [ ];
     hydraPlatforms = [ ]; # Hydra fails with "Output limit exceeded"
   };
 }

--- a/pkgs/by-name/li/libguestfs-appliance-nixos/package.nix
+++ b/pkgs/by-name/li/libguestfs-appliance-nixos/package.nix
@@ -224,6 +224,9 @@ stdenvNoCC.mkDerivation {
   name = "libguestfs-appliance-nixos";
   version = libguestfs.version;
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   phases = [
     "buildPhase"
     "installPhase"

--- a/pkgs/by-name/li/libguestfs-appliance-nixos/package.nix
+++ b/pkgs/by-name/li/libguestfs-appliance-nixos/package.nix
@@ -1,0 +1,248 @@
+{
+  lib,
+  writeTextFile,
+  writeScript,
+  supermin,
+  fetchpatch,
+  fakeroot,
+  stdenvNoCC,
+  buildEnv,
+  runCommand,
+  closureInfo,
+  buildFHSEnv,
+
+  linux,
+  libguestfs,
+
+  bash,
+  coreutils,
+  gnugrep,
+  util-linux,
+  kmod,
+  file,
+  xz,
+  zstd,
+  ntfs3g,
+  fuse3,
+  fuse,
+  gnutar,
+  gnused,
+  mdadm,
+  findutils,
+  iproute2,
+  cdrkit,
+  gptfdisk,
+  mtools,
+  parted,
+  gawk,
+  cpio,
+  bzip2,
+  acl,
+  attr,
+  lvm2,
+  dosfstools,
+  e2fsprogs,
+  exfatprogs,
+  xfsprogs,
+  btrfs-progs,
+  lzop,
+  procps,
+  lsof,
+  libxml2,
+  binutils,
+  diffutils,
+  iputils,
+  curl,
+  dhcpcd,
+  eudev,
+  fakeNss,
+  dockerTools,
+
+  superminExtraArgs ? "--verbose",
+  appliancePackages ? [
+    libguestfs.guestfsd
+    bash
+    coreutils
+    gnugrep
+    util-linux
+    iputils
+    curl
+    dhcpcd
+    kmod
+    file
+    xz
+    zstd
+    ntfs3g
+    fuse3
+    fuse
+    gnutar
+    gnused
+    mdadm
+    findutils
+    iproute2
+    cdrkit
+    gptfdisk
+    mtools
+    parted
+    gawk
+    cpio
+    bzip2
+    acl
+    attr
+    lvm2
+    dosfstools
+    e2fsprogs
+    exfatprogs
+    xfsprogs
+    btrfs-progs
+    lzop
+    procps
+    lsof
+    libxml2
+    binutils
+    diffutils
+    eudev
+    fakeNss
+    dockerTools.caCertificates
+  ],
+  extraAppliancePackages ? [ ],
+}:
+let
+  stub-pacman = writeTextFile {
+    name = "stub-pacman";
+    text = ''
+      #!/bin/sh
+      exit 0
+    '';
+    executable = true;
+    destination = "/bin/pacman";
+  };
+  supermin2 = supermin.overrideAttrs (previousAttrs: {
+    buildInputs = previousAttrs.buildInputs ++ [
+      stub-pacman
+      fakeroot
+    ];
+  });
+
+  appliancePackageEnv = buildEnv {
+    name = "appliance-nixosEnv";
+    paths = appliancePackages ++ extraAppliancePackages;
+  };
+
+  applianceInit =
+    runCommand "init"
+      {
+        nativeBuildInputs = [ gnutar ];
+      }
+      ''
+        tar -xOf ${libguestfs.src} --wildcards '*/appliance/init' > $out
+        chmod +x $out
+      '';
+
+  applianceRootfsLayout = runCommand "appliance-rootfs-layout" { } ''
+    mkdir -p $out/{dev,proc,sys,tmp}
+
+    pushd $out
+      # avoid supermin quirk where it would follow FHS bin symlink chain
+      ln -s .${appliancePackageEnv}/bin ./bin
+      ln -s .${appliancePackageEnv}/bin ./sbin
+    popd
+
+    cp ${applianceInit} $out/init
+
+    # must re-create /lib symlink chain 1:1 like they are inside the FHSEnv
+    mkdir -p $out/usr/lib64/
+    ln -sr $out/usr/lib64/ $out/usr/lib
+    ln -sr $out/usr/lib $out/lib
+
+    mkdir -p $out/var/lib/
+    mkdir -p $out/var/run/
+    mkdir -p $out/run
+    mkdir -p $out/etc/udev
+
+    cp -rL ${appliancePackageEnv}/etc/. $out/etc/
+    rmdir $out/etc/udev/rules.d
+    ln -s ../../${eudev}/var/lib/udev/rules.d $out/etc/udev/rules.d
+  '';
+
+  applianceRootfsTarball = runCommand "appliance-rootfs-tarball.tar.gz" { } ''
+    ${fakeroot}/bin/fakeroot tar -czvf $out -C ${applianceRootfsLayout}/ .
+  '';
+
+  applianceSuperminInputs =
+    runCommand "appliance-supermin-inputs"
+      {
+        nativeBuildInputs = [
+          findutils
+          gnutar
+        ];
+      }
+      ''
+        mkdir -p $out
+        export closureInfo=${closureInfo { rootPaths = [ appliancePackageEnv ]; }}
+        echo "Processing closure from: $closureInfo"
+
+        echo "Generating hostfiles list..."
+        xargs -I % find % -type f < $closureInfo/store-paths > $out/hostfiles
+
+        echo "Generating symlinks list..."
+        xargs -I % find % -type l < $closureInfo/store-paths > ./symlinks.list
+        echo "Packing symlinks into tarball..."
+        tar -czf $out/symlinks.tar.gz --no-recursion -T ./symlinks.list
+      '';
+
+  applianceFHS = (
+    buildFHSEnv {
+      name = "appliance-fhs-builder";
+      targetPkgs = p: [
+        (writeTextFile {
+          name = "arch-release";
+          text = "";
+          destination = "/etc/arch-release";
+        })
+        stub-pacman
+        supermin2
+        p.fakeroot
+        p.cpio
+        p.gnutar
+      ];
+      runScript = writeScript "build_appliance.sh" ''
+        mkdir input
+        export SUPERMIN_KERNEL=${linux}/bzImage
+        export SUPERMIN_MODULES=${linux.modules}/lib/modules/${linux.version}/
+
+        ln -s ${applianceRootfsTarball} ./input/base.tar.gz
+        ln -s ${applianceSuperminInputs}/hostfiles ./input/hostfiles
+        ln -s ${applianceSuperminInputs}/symlinks.tar.gz ./input/symlinks.tar.gz
+
+        fakeroot supermin --build ${superminExtraArgs} input/ -f ext2 -o ./build/
+      '';
+    }
+  );
+in
+stdenvNoCC.mkDerivation {
+  name = "libguestfs-appliance-nixos";
+  version = libguestfs.version;
+
+  phases = [
+    "buildPhase"
+    "installPhase"
+  ];
+
+  buildPhase = ''
+    ${applianceFHS}/bin/${applianceFHS.name}
+  '';
+
+  installPhase = ''
+    mv ./build/ $out
+    echo "NixOS based appliance" > $out/README.fixed
+  '';
+
+  meta = {
+    description = "A fixed appliance for libguestfs to use, built from NixOS";
+    platforms = lib.platforms.linux;
+    hydraPlatforms = [ ];
+    maintainers = with lib.maintainers; [ lukts30 ];
+    license = lib.licenses.free;
+  };
+}

--- a/pkgs/by-name/li/libguestfs-with-appliance/package.nix
+++ b/pkgs/by-name/li/libguestfs-with-appliance/package.nix
@@ -1,11 +1,11 @@
 {
   lib,
   libguestfs,
-  libguestfs-appliance,
+  libguestfs-appliance-nixos,
 }:
 
 let
-  appliance = libguestfs-appliance;
+  appliance = libguestfs-appliance-nixos;
   # check explicit forward compatibility declaration:
   # then do not warn if older appliance if known to work fine with newer libguestfs
   libguestfsCompatible =

--- a/pkgs/by-name/li/libguestfs/package.nix
+++ b/pkgs/by-name/li/libguestfs/package.nix
@@ -169,7 +169,9 @@ stdenv.mkDerivation (finalAttrs: {
 
     ${qemu}/bin/qemu-img create -f qcow2 disk1.img 10G
 
-    $out/bin/guestfish <<'EOF'
+    # set `LIBGUESTFS_DEBUG` and `LIBGUESTFS_TRACE` to debug any
+    # potential issues caused by updates/changes to/in the appliance
+    LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1 $out/bin/guestfish <<'EOF'
     add-drive disk1.img
     run
     list-filesystems

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1070,6 +1070,7 @@ mapAliases {
   libGDSII = libgdsii; # Added 2026-02-08
   libgme = throw "'libgme' has been renamed to/replaced by 'game-music-emu'"; # Converted to throw 2025-10-27
   libgnome-keyring3 = throw "'libgnome-keyring3' has been renamed to/replaced by 'libgnome-keyring'"; # Converted to throw 2025-10-27
+  libguestfs-appliance = lib.warnOnInstantiate "'libguestfs-appliance' has been renamed to 'libguestfs-appliance-fedora'; also consider using 'libguestfs-appliance-nixos' instead" libguestfs-appliance-fedora; # Added 2025-12-06
   libheimdal = throw "'libheimdal' has been renamed to/replaced by 'heimdal'"; # Converted to throw 2025-10-27
   libHX = libhx; # Added 2026-02-08
   libICE = libice; # Added 2026-02-04


### PR DESCRIPTION
Similar to #381224 and #465581 but unlike the latter does uses the upstream projects image builder `supermin` (with a workaround).

Does not to use NixOS module system and instead presents a mostly FHS compatible environment for `guestfsd`.
In that regard it is also close in spirit to `pkgs.dockerTools.*` since the appliance will also not run systemd.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
