### PR TITLE
grafana-alloy: Add option to use LLD for linking

### DIFF
--- a/pkgs/by-name/gr/grafana-alloy/package.nix
+++ b/pkgs/by-name/gr/grafana-alloy/package.nix
@@ -13,6 +13,8 @@
   nix-update-script,
   installShellFiles,
   testers,
+  lld,
+  useLLD ? stdenv.hostPlatform.isArmv7,
 }:
 
 buildGoModule (finalAttrs: {
@@ -34,7 +36,10 @@ buildGoModule (finalAttrs: {
     yarn
     nodejs
     installShellFiles
-  ];
+  ]
+  ++ lib.optionals useLLD [ lld ];
+
+  env = lib.optionalAttrs useLLD { NIX_CFLAGS_LINK = "-fuse-ld=lld"; };
 
   ldflags =
     let


### PR DESCRIPTION
Use LLD by default on armv7. The BFD linker has issues linking this
package on that platform.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

binary is identical
```
% (cd $(nix-build -A grafana-alloy)/bin/ && sha256sum alloy >/tmp/alloy.sha256)
% git checkout HEAD^
[...]
% (cd $(nix-build -A grafana-alloy)/bin/ && sha256sum -c /tmp/alloy.sha256)
alloy: OK
%
```


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
