### PR TITLE
cudaPackages.backendStdenv: use override instead of extendDerivation

### DIFF
--- a/pkgs/development/cuda-modules/backendStdenv/default.nix
+++ b/pkgs/development/cuda-modules/backendStdenv/default.nix
@@ -30,7 +30,6 @@ let
     ;
   inherit (lib)
     assertMsg
-    extendDerivation
     filter
     findFirst
     flip
@@ -265,7 +264,8 @@ let
       stdenvAdapters.useLibsFrom stdenv maybeHostStdenv;
 in
 # TODO: Consider testing whether we in fact use the newer libstdc++
-# NOTE: The assertion message we get from `extendDerivation` is not at all helpful. Instead, we use assertMsg.
 assert assertMsg (failedAssertionsString == "")
   "${mkVersionedName "cudaPackages" cudaMajorMinorVersion}.backendStdenv has failed assertions:${failedAssertionsString}";
-extendDerivation true passthruExtra backendStdenv
+backendStdenv.override (prevArgs: {
+  extraAttrs = prevArgs.extraAttrs or { } // passthruExtra;
+})


### PR DESCRIPTION
`extendDerivation` is the wrong function to use with a `stdenv`, since they are constructed directly with `derivation` and not `mkDerivation`. Indeed, any attributes added through `extendDerivation` are lost when using `override`-based functionality (for example, using `overrideCC`).

Instead, we should add our extra attributes to `backendStdenv` through its `override`, ensuring later modifications don't cause us to lose those attributes.

## Things done


- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
