### PR TITLE
cudaPackages.cuda_nvcc: use our own nvcc.profile

### DIFF
--- a/pkgs/development/cuda-modules/packages/cuda_nvcc.nix
+++ b/pkgs/development/cuda-modules/packages/cuda_nvcc.nix
@@ -18,6 +18,10 @@ buildRedist (finalAttrs: {
   # directory structure. This happens partly because NVCC is also home to NVVM.
   outputs = [
     "out"
+    "bin"
+    "lib"
+    "dev"
+    "include"
   ];
 
   # The nvcc and cicc binaries contain hard-coded references to /usr
@@ -30,140 +34,65 @@ buildRedist (finalAttrs: {
   # Entries here will be in nativeBuildInputs when cuda_nvcc is in nativeBuildInputs
   propagatedBuildInputs = [ setupCudaHook ];
 
-  # Patch the nvcc.profile.
-  # Syntax:
-  # - `=` for assignment,
-  # - `?=` for conditional assignment,
-  # - `+=` to "prepend",
-  # - `=+` to "append".
-
+  # We create nvcc.profile explicitly to avoid the need to do complicated, in-place modifications.
   # Cf. https://web.archive.org/web/20220912081901/https://developer.download.nvidia.com/compute/DevZone/docs/html/C/doc/nvcc.pdf
-
-  # We set all variables with the lowest priority (=+), but we do force
-  # nvcc to use the fixed backend toolchain. Cf. comments in
-  # backend-stdenv.nix
-
-  # As an example, here's the nvcc.profile for CUDA 11.8-12.4 (yes, that is a leading newline):
-
-  #
-  # TOP              = $(_HERE_)/..
-  #
-  # NVVMIR_LIBRARY_DIR = $(TOP)/$(_NVVM_BRANCH_)/libdevice
-  #
-  # LD_LIBRARY_PATH += $(TOP)/lib:
-  # PATH            += $(TOP)/$(_NVVM_BRANCH_)/bin:$(_HERE_):
-  #
-  # INCLUDES        +=  "-I$(TOP)/$(_TARGET_DIR_)/include" $(_SPACE_)
-  #
-  # LIBRARIES        =+ $(_SPACE_) "-L$(TOP)/$(_TARGET_DIR_)/lib$(_TARGET_SIZE_)/stubs" "-L$(TOP)/$(_TARGET_DIR_)/lib$(_TARGET_SIZE_)"
-  #
-  # CUDAFE_FLAGS    +=
-  # PTXAS_FLAGS     +=
-
-  # And here's the nvcc.profile for CUDA 12.5:
-
-  #
-  # TOP              = $(_HERE_)/..
-  #
-  # CICC_PATH        = $(TOP)/nvvm/bin
-  # CICC_NEXT_PATH   = $(TOP)/nvvm-next/bin
-  # NVVMIR_LIBRARY_DIR = $(TOP)/nvvm/libdevice
-  #
-  # LD_LIBRARY_PATH += $(TOP)/lib:
-  # PATH            += $(CICC_PATH):$(_HERE_):
-  #
-  # INCLUDES        +=  "-I$(TOP)/$(_TARGET_DIR_)/include" $(_SPACE_)
-  #
-  # LIBRARIES        =+ $(_SPACE_) "-L$(TOP)/$(_TARGET_DIR_)/lib$(_TARGET_SIZE_)/stubs" "-L$(TOP)/$(_TARGET_DIR_)/lib$(_TARGET_SIZE_)"
-  #
-  # CUDAFE_FLAGS    +=
-  # PTXAS_FLAGS     +=
-
   postInstall =
-    let
-      # TODO: Should we also patch the LIBRARIES line's use of $(TOP)/$(_TARGET_DIR_)?
-      oldNvvmDir = lib.concatStringsSep "/" (
-        [ "$(TOP)" ]
-        ++ lib.optionals (cudaOlder "12.5") [ "$(_NVVM_BRANCH_)" ]
-        ++ lib.optionals (cudaAtLeast "12.5") [ "nvvm" ]
-      );
-      newNvvmDir = ''''${!outputBin:?}/nvvm'';
-    in
-    lib.optionalString finalAttrs.finalPackage.meta.available (
-      # From CUDA 13.0, NVVM is available as a separate library and not bundled in the NVCC redist.
-      lib.optionalString (cudaOlder "13.0") ''
-        nixLog "moving $PWD/nvvm to ''${!outputBin:?} and renaming lib64 to lib"
-        moveToOutput "nvvm" "''${!outputBin:?}"
-        mv --verbose --no-clobber "${newNvvmDir}/lib64" "${newNvvmDir}/lib"
-      ''
-      # NVVM is unpacked and made top-level; we cannot make a symlink to it because build systems (like CMake)
-      # may take the target and do relative path operations to it.
-      + lib.optionalString (cudaAtLeast "13.0") ''
-        nixLog "copying ${libnvvm} to ${newNvvmDir} and fixing permissions"
-        cp -rv "${libnvvm}" "${newNvvmDir}"
-        chmod -Rv u+w "${newNvvmDir}"
-      ''
-      # Unconditional patching to remove the use of $(_TARGET_SIZE_) since we don't use lib64 in Nixpkgs
-      + ''
-        nixLog 'removing $(_TARGET_SIZE_) from nvcc.profile'
-        substituteInPlace "''${!outputBin:?}/bin/nvcc.profile" \
-          --replace-fail \
-            '$(_TARGET_SIZE_)' \
-            ""
-      ''
-      # CUDA 13.0+ introduced
-      # SYSTEM_INCLUDES +=  "-isystem" "$(TOP)/$(_TARGET_DIR_)/include/cccl" $(_SPACE_)
-      # so we need to make sure to patch the reference to cccl.
-      + lib.optionalString (cudaAtLeast "13.0") ''
-        nixLog "patching nvcc.profile to include correct path to cccl"
-        substituteInPlace "''${!outputBin:?}/bin/nvcc.profile" \
-          --replace-fail \
-            '$(TOP)/$(_TARGET_DIR_)/include/cccl' \
-            "${lib.getOutput "include" cuda_cccl}/include"
-      ''
-      # Unconditional patching to switch to the correct include paths.
-      # NOTE: _TARGET_DIR_ appears to be used for the target architecture, which is relevant for cross-compilation.
-      + ''
-        nixLog "patching nvcc.profile to use the correct include paths"
-        substituteInPlace "''${!outputBin:?}/bin/nvcc.profile" \
-          --replace-fail \
-            '$(TOP)/$(_TARGET_DIR_)/include' \
-            "''${!outputInclude:?}/include"
-      ''
-      # Fixup the nvcc.profile to use the correct paths for NVVM.
-      # NOTE: In our replacement substitution, we use double quotes to allow for variable expansion.
-      # NOTE: We use a trailing slash only on the NVVM directory replacement to prevent partial matches.
-      + ''
-        nixLog "patching nvcc.profile to use the correct NVVM paths"
-        substituteInPlace "''${!outputBin:?}/bin/nvcc.profile" \
-          --replace-fail \
-            '${oldNvvmDir}/' \
-            "${newNvvmDir}/"
+    # From CUDA 13.0, NVVM is available as a separate library and not bundled in the NVCC redist.
+    lib.optionalString (cudaOlder "13.0") ''
+      nixLog "moving $PWD/nvvm to ''${!outputBin:?} and renaming lib64 to lib"
+      moveToOutput "nvvm" "''${!outputBin:?}"
+      mv --verbose --no-clobber "''${!outputBin:?}/nvvm/lib64" "''${!outputBin:?}/nvvm/lib"
+    ''
+    # NVVM is unpacked and made top-level; we cannot make a symlink to it because build systems (like CMake)
+    # may take the target and do relative path operations to it.
+    + lib.optionalString (cudaAtLeast "13.0") ''
+      nixLog "copying ${libnvvm} to ''${!outputBin:?}/nvvm and fixing permissions"
+      cp -rv "${libnvvm}" "''${!outputBin:?}/nvvm"
+      chmod -Rv u+w "''${!outputBin:?}/nvvm"
+    ''
+    # Add the dependency on backendStdenv.cc to the nvcc.profile.
+    # NOTE: NVCC explodes in horrifying fashion if GCC is not on PATH -- it fails even before
+    # reading nvcc.profile!
+    + ''
+      nixLog "wrapping nvcc to add backendStdenv.cc to its PATH"
 
-        nixLog "adding ${newNvvmDir} to nvcc.profile"
-        cat << EOF >> "''${!outputBin:?}/bin/nvcc.profile"
+      wrapProgramBinary \
+        "''${!outputBin:?}/bin/nvcc" \
+        --prefix PATH : ${lib.makeBinPath [ backendStdenv.cc ]}
+    ''
+    # Write the nvcc.profile
+    # TODO(@connorbaker): Can this be modified to work with multiple-output NVVM?
+    # TODO(@connorbaker): Do any of these need to be set?
+    # - TOP
+    # - LD_LIBRARY_PATH
+    # NOTE: CICC_PATH and NVVMIR_LIBRARY_DIR must be set.
+    # NOTE: CICC_PATH, NVVMIR_LIBRARY_DIR, and compiler-bindir cannot be quoted since they are interpreted literally.
+    + ''
+      nixLog "writing ''${!outputBin:?}/bin/nvcc.profile"
+      cat << EOF > "''${!outputBin:?}/bin/nvcc.profile"
+      # Add NVCC's components
+      PATH      =+ :"''${!outputBin:?}/bin"
+      INCLUDES  =+ \$(_SPACE_) "-I''${!outputInclude:?}/include"
+      LIBRARIES =+ \$(_SPACE_) "-L''${!outputLib:?}/lib"
 
-        # Expose the split-out nvvm
-        LIBRARIES =+ \$(_SPACE_) "-L${newNvvmDir}/lib"
-        INCLUDES =+ \$(_SPACE_) "-I${newNvvmDir}/include"
-        EOF
-      ''
-      # Add the dependency on backendStdenv.cc to the nvcc.profile.
-      # NOTE: NVCC explodes in horrifying fashion if GCC is not on PATH -- it fails even before
-      # reading nvcc.profile!
-      + ''
-        nixLog "setting compiler-bindir to backendStdenv.cc in nvcc.profile"
-        cat << EOF >> "''${!outputBin:?}/bin/nvcc.profile"
-        # Fix a compatible backend compiler
-        compiler-bindir = ${backendStdenv.cc}/bin
-        EOF
+      # Set the directory NVCC will search for host compilers
+      compiler-bindir = ${lib.getBin backendStdenv.cc}/bin
 
-        nixLog "wrapping nvcc to add backendStdenv.cc to its PATH"
-        wrapProgramBinary \
-          "''${!outputBin:?}/bin/nvcc" \
-          --prefix PATH : ${lib.makeBinPath [ backendStdenv.cc ]}
-      ''
-    );
+      # Add NVVM's components
+      CICC_PATH          = ''${!outputBin:?}/nvvm/bin
+      NVVMIR_LIBRARY_DIR = ''${!outputBin:?}/nvvm/libdevice
+      PATH               =+ :"''${!outputBin:?}/nvvm/bin"
+      INCLUDES           =+ \$(_SPACE_) "-I''${!outputBin:?}/nvvm/include"
+      LIBRARIES          =+ \$(_SPACE_) "-L''${!outputBin:?}/nvvm/lib"
+
+      # Add CCCL's components
+      SYSTEM_INCLUDES =+ \$(_SPACE_) "-isystem" "${lib.getInclude cuda_cccl}/cccl"
+
+      # Additional flags, etc.
+      CUDAFE_FLAGS =+
+      PTXAS_FLAGS  =+
+      EOF
+    '';
 
   brokenAssertions = [
     # TODO(@connorbaker): Build fails on x86 when using pkgsLLVM.


### PR DESCRIPTION
> [!IMPORTANT]
>
> Still need to verify builds function as expected. Also need to move the re-introduction of outputs to a separate PR.

Patching the `nvcc.profile` given by NVIDIA is error-prone and complicated (lots of escaping interpolation). Instead, we should just replace it with one we create. It's cleaner, easier to maintain, and less likely to have bugs introduced by templating.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
