### PR TITLE
[Backport release-25.05] pkgsite: 0-unstable-2025-11-06 -> 0-unstable-2025-11-28

### DIFF
--- a/pkgs/by-name/pk/pkgsite/package.nix
+++ b/pkgs/by-name/pk/pkgsite/package.nix
@@ -7,13 +7,13 @@
 
 buildGoModule {
   pname = "pkgsite";
-  version = "0-unstable-2025-11-13";
+  version = "0-unstable-2025-11-20";
 
   src = fetchFromGitHub {
     owner = "golang";
     repo = "pkgsite";
-    rev = "28eed86815232e48f5e757569fcd061f858142d4";
-    hash = "sha256-de6aDMNOE+N6OWwHD2p6jjuX2z0d6eKZeAYgatuJLgk=";
+    rev = "84333735ffe124f7bd904805fd488b93841de49f";
+    hash = "sha256-XYySnVvnNZr1tg46AoYBsmeT5y/StByWcQhnNOdoLJo=";
   };
 
   vendorHash = "sha256-Zv9kyBGLicSJlWD0/wv6ggteA+DttOb18/P5s91tJxE=";

--- a/pkgs/by-name/pk/pkgsite/package.nix
+++ b/pkgs/by-name/pk/pkgsite/package.nix
@@ -7,13 +7,13 @@
 
 buildGoModule {
   pname = "pkgsite";
-  version = "0-unstable-2025-11-20";
+  version = "0-unstable-2025-11-28";
 
   src = fetchFromGitHub {
     owner = "golang";
     repo = "pkgsite";
-    rev = "84333735ffe124f7bd904805fd488b93841de49f";
-    hash = "sha256-XYySnVvnNZr1tg46AoYBsmeT5y/StByWcQhnNOdoLJo=";
+    rev = "d74adeade195e94064b1dc38fd14b93037ad7694";
+    hash = "sha256-Rlm5XwOLjGYOtg12tlUtkd2+upY2EP7x5dI+Nx2JAF0=";
   };
 
   vendorHash = "sha256-Zv9kyBGLicSJlWD0/wv6ggteA+DttOb18/P5s91tJxE=";

--- a/pkgs/by-name/pk/pkgsite/package.nix
+++ b/pkgs/by-name/pk/pkgsite/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule {
   pname = "pkgsite";
-  version = "0-unstable-2025-11-06";
+  version = "0-unstable-2025-11-13";
 
   src = fetchFromGitHub {
     owner = "golang";
     repo = "pkgsite";
-    rev = "0d7e29046a911358f7f5a5c4028a9db875187281";
-    hash = "sha256-2dHT/p0cImvaJGxf50SSebgq3eSkbX1A0kdi93rCJCE=";
+    rev = "28eed86815232e48f5e757569fcd061f858142d4";
+    hash = "sha256-de6aDMNOE+N6OWwHD2p6jjuX2z0d6eKZeAYgatuJLgk=";
   };
 
-  vendorHash = "sha256-EbZ+38LLnp5aefiuBAOFHA3uPPUmPGLsDIEMln5Vh7c=";
+  vendorHash = "sha256-Zv9kyBGLicSJlWD0/wv6ggteA+DttOb18/P5s91tJxE=";
 
   subPackages = [ "cmd/pkgsite" ];
 


### PR DESCRIPTION
Manual backport to release-25.05.

Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md?rgh-link-date=2025-12-05T02%3A06%3A44Z#changes-acceptable-for-releases).

Even as a non-committer, if you find that it is not acceptable, leave a comment.