### PR TITLE
fcron: improve cross compilation and parameterize embedded paths

### DIFF
--- a/pkgs/by-name/fc/fcron/package.nix
+++ b/pkgs/by-name/fc/fcron/package.nix
@@ -6,8 +6,12 @@
   stdenv,
   fetchurl,
   perl,
+  buildPackages,
   busybox,
   vim,
+  sendmailProgram ?
+    if lib.meta.availableOn stdenv.hostPlatform busybox then "${busybox}/sbin/sendmail" else null,
+  editorProgram ? if lib.meta.availableOn stdenv.hostPlatform vim then "${vim}/bin/vi" else null,
 }:
 
 stdenv.mkDerivation rec {
@@ -24,14 +28,17 @@ stdenv.mkDerivation rec {
   patches = [ ./relative-fcronsighup.patch ];
 
   configureFlags = [
-    "--with-sendmail=${busybox}/sbin/sendmail"
-    "--with-editor=${vim}/bin/vi" # TODO customizable
+    "--with-sendmail=${if sendmailProgram == null then "no" else sendmailProgram}"
+    "--with-editor=${if editorProgram == null then "no" else editorProgram}"
     "--with-bootinstall=no"
     "--localstatedir=/var"
     "--sysconfdir=/etc"
     "--with-rootname=root"
     "--with-rootgroup=root"
     "--disable-checks"
+  ]
+  ++ lib.optionals (!(stdenv.buildPlatform.canExecute stdenv.hostPlatform)) [
+    "ac_cv_func_memcmp_working=yes"
   ];
 
   installTargets = [ "install-staged" ]; # install does also try to change permissions of /etc/* files
@@ -48,7 +55,7 @@ stdenv.mkDerivation rec {
   ];
 
   preConfigure = ''
-    sed -i 's@/usr/bin/env perl@${perl}/bin/perl@g' configure script/*
+    sed -i 's@/usr/bin/env perl@${lib.getExe buildPackages.perl}@g' configure script/*
     # Don't let fcron create the group fcron, nix(os) should do this
     sed -i '2s@.*@exit 0@' script/user-group
 


### PR DESCRIPTION
Allows cross building fcron for linux->freebsd.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd (cross)
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
