### PR TITLE
[Backport release-25.11] cargo-llvm-cov: fix checkPhase using a writable $HOME

### DIFF
--- a/pkgs/by-name/ca/cargo-llvm-cov/package.nix
+++ b/pkgs/by-name/ca/cargo-llvm-cov/package.nix
@@ -20,6 +20,7 @@
   rustPlatform,
   llvmPackages_19,
   gitMinimal,
+  writableTmpDirAsHomeHook,
 }:
 
 let
@@ -63,6 +64,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeCheckInputs = [
     gitMinimal
+    writableTmpDirAsHomeHook
   ];
 
   # `cargo-llvm-cov` tests rely on `git ls-files.


### PR DESCRIPTION
(cherry picked from commit d90ae263a6b62eff3fd3fb300a0bd6b88d8beb4a)

Manual backport of https://github.com/NixOS/nixpkgs/pull/464928 to release-25.11

Fixes https://github.com/NixOS/nixpkgs/issues/467882
