### PR TITLE
siesta: 5.2.2 -> 5.4.1; migrate to by-name

### DIFF
--- a/pkgs/by-name/si/siesta/package.nix
+++ b/pkgs/by-name/si/siesta/package.nix
@@ -13,11 +13,12 @@
   readline,
   ninja,
   elpa,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "siesta";
-  version = "5.2.2";
+  version = "5.4.1";
 
   src = fetchFromGitLab {
     owner = "siesta-project";
@@ -29,6 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     inherit mpi;
+    updateScript = nix-update-script { };
   };
 
   nativeBuildInputs = [
@@ -59,14 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = false; # Started making trouble with gcc-11
 
-  preBuild = ''
-    # See https://gitlab.com/siesta-project/siesta/-/commit/a10bf1628e7141ba263841889c3503c263de1582
-    # This may be fixed in the next release.
-    makeFlagsArray=(
-        FFLAGS="-fallow-argument-mismatch"
-    )
-  ''
-  + (
+  preBuild =
     if useMpi then
       ''
         makeFlagsArray+=(
@@ -80,8 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
         makeFlagsArray+=(
           COMP_LIBS="" LIBS="-lblas -llapack"
         );
-      ''
-  );
+      '';
 
   meta = {
     description = "First-principles materials simulation code using DFT";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13338,9 +13338,7 @@ with pkgs;
     hdf5 = hdf5-fortran;
   };
 
-  siesta = callPackage ../applications/science/chemistry/siesta { };
-
-  siesta-mpi = callPackage ../applications/science/chemistry/siesta { useMpi = true; };
+  siesta-mpi = callPackage ../by-name/si/siesta/package.nix { useMpi = true; };
 
   cp2k = callPackage ../by-name/cp/cp2k/package.nix {
     libxc = pkgs.libxc_7;


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
