### PR TITLE
gnuradioPackages.gr-difi: init at 0-unstable-2025-08-16

### DIFF
--- a/pkgs/development/gnuradio-modules/gr-difi/default.nix
+++ b/pkgs/development/gnuradio-modules/gr-difi/default.nix
@@ -1,0 +1,53 @@
+{
+  boost,
+  cmake,
+  fetchFromGitHub,
+  gmp,
+  gnuradio,
+  lib,
+  mkDerivation,
+  pkg-config,
+  python,
+  spdlog,
+  unstableGitUpdater,
+}:
+
+mkDerivation {
+  pname = "gr-difi";
+  version = "0-unstable-2025-08-16";
+
+  src = fetchFromGitHub {
+    owner = "DIFI-Consortium";
+    repo = "gr-difi";
+    rev = "330dd7f245f840903d034603850222a08c5a7c66";
+    hash = "sha256-zztnTaeYEWw9OAvgvy99aoj5UiJ/dOKQQWF+7Lfp59A=";
+  };
+
+  buildInputs = [
+    boost
+    gmp
+    gnuradio
+    spdlog
+  ]
+  ++ lib.optionals (gnuradio.hasFeature "python-support") [
+    python.pkgs.pybind11
+    python.pkgs.numpy
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  passthru.updateScript = unstableGitUpdater {
+    hardcodeZeroVersion = true;
+  };
+
+  meta = {
+    description = "GNU Radio Digital Intermediate Frequency Interoperability (DIFI) Out of Tree Module";
+    homepage = "https://github.com/DIFI-Consortium/gr-difi";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ lib.maintainers.jmbaur ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/gnuradio-packages.nix
+++ b/pkgs/top-level/gnuradio-packages.nix
@@ -49,5 +49,6 @@ lib.makeScope newScope (
 
     fosphor = callPackage ../development/gnuradio-modules/fosphor/default.nix { };
 
+    gr-difi = callPackage ../development/gnuradio-modules/gr-difi/default.nix { };
   }
 )


### PR DESCRIPTION
This adds the out-of-tree module for DIFI support in gnuradio.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
