### PR TITLE
ocamlPackages: exit useDune2

### DIFF
--- a/doc/languages-frameworks/ocaml.section.md
+++ b/doc/languages-frameworks/ocaml.section.md
@@ -45,10 +45,7 @@ Here is a simple package example.
 
 - It also accepts a `duneVersion` parameter (valid values are `"2"`, and
   `"3"`). The recommended practice is to set it only if you don't want the
-  default value and/or it depends on something else like package version. You
-  might see a not-supported argument `useDune2`. The behavior was `useDune2 =
-  true;` => `duneVersion = "2";` and `useDune2 = false;` => `duneVersion =
-  "1";`. It was used at the time when dune3 didn't exist.
+  default value and/or it depends on something else like package version.
 
 - It sets the optional `doCheck` attribute such that tests will be run with
   `dune runtest -p angstrom` after the build (`dune build -p angstrom`) is

--- a/pkgs/development/ocaml-modules/ocaml-syntax-shims/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-syntax-shims/default.nix
@@ -4,26 +4,22 @@
   fetchurl,
 }:
 
-buildDunePackage rec {
-  minimumOCamlVersion = "4.02.3";
-
+buildDunePackage (finalAttrs: {
   pname = "ocaml-syntax-shims";
   version = "1.0.0";
 
   src = fetchurl {
-    url = "https://github.com/ocaml-ppx/${pname}/releases/download/${version}/${pname}-${version}.tbz";
-    sha256 = "1j7848khli4p7j8i2kmnvhdnhcwhy3zgdpf5ds5ic30ax69y3cl9";
+    url = "https://github.com/ocaml-ppx/ocaml-syntax-shims/releases/download/${finalAttrs.version}/ocaml-syntax-shims-${finalAttrs.version}.tbz";
+    hash = "sha256-ibLhk+kKDBaLbsXd9v7wkDNoG9y2ThGRPJdECici6Mg=";
   };
-
-  useDune2 = true;
 
   doCheck = true;
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/ocaml-ppx/ocaml-syntax-shims";
     description = "Backport new syntax to older OCaml versions";
     mainProgram = "ocaml-syntax-shims";
-    license = licenses.mit;
-    maintainers = with maintainers; [ sternenseemann ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sternenseemann ];
   };
-}
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
