### PR TITLE
timr-tui: add module option programs.timr-tui

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23692,6 +23692,11 @@
     githubId = 56278796;
     name = "Sergio Ribera";
   };
+  serhao = {
+    github = "shobu13";
+    githubId = 21972673;
+    name = "Sin Ser'Hao";
+  };
   servalcatty = {
     email = "servalcat@pm.me";
     github = "servalcatty";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -329,6 +329,7 @@
   ./programs/throne.nix
   ./programs/thunar.nix
   ./programs/thunderbird.nix
+  ./programs/timr-tui.nix
   ./programs/tmux.nix
   ./programs/traceroute.nix
   ./programs/trippy.nix

--- a/nixos/modules/programs/timr-tui.nix
+++ b/nixos/modules/programs/timr-tui.nix
@@ -1,0 +1,47 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.timr-tui;
+
+  timr-tui-sound = pkgs.timr-tui.override (
+    prev:
+    prev
+    // {
+      enableSound = true;
+    }
+  );
+  timr-tui-sound-wrapped = pkgs.writeShellScriptBin "timr-tui" ''
+    ${lib.getExe timr-tui-sound} --sound ${cfg.soundFile} "$@"
+  '';
+
+  timr-tui = if cfg.enableSound then timr-tui-sound-wrapped else pkgs.timr-tui;
+in
+{
+  meta.maintainers = [ lib.maintainers.serhao ];
+  options.programs.timr-tui = {
+    enable = lib.mkEnableOption "timr-tui, a cli timr / pomodoro tool";
+    enableSound = lib.mkEnableOption ''
+      Enable sound notification when a timer end, this will wrap the timr command
+      with the --sound <programs.timr-tui.soundFile> flag.
+    '';
+    soundFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        Path to a file to play when a timer reach the end,
+        and the `programs.timr-tui.enableSound` option is enabled.
+        The provided file must be in .mp3 or .wav format.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      timr-tui
+    ];
+  };
+}


### PR DESCRIPTION
this module add a programs.timr-tui option to enable the program, adding it to the environment.systemPackages, an option can be enable to activate the sound feature, building the package with the needed feature flag, providing an option to set a sound file and wrapping the resulting binary to avoid repetition of the option flag for the end user

##### Reviewed points

- [x] module path fits the guidelines
- [ ] module tests, if any, succeed on ARCHITECTURE
- [ ] module tests, if any, are added to package `passthru.tests`
- [x] options have appropriate types
- [ ] options have default
- [ ] options have example
- [x] options have descriptions
- [x] No unneeded package is added to `environment.systemPackages`
- [x] `meta.maintainers` is set
- [ ] module documentation is declared in `meta.doc`

##### Possible improvements

##### Comments