### PR TITLE
nixos/radicale: allow setting the user on service.radicale

### DIFF
--- a/nixos/modules/services/networking/radicale.nix
+++ b/nixos/modules/services/networking/radicale.nix
@@ -108,6 +108,18 @@ in
       default = [ ];
       description = "Extra arguments passed to the Radicale daemon.";
     };
+
+    user = mkOption {
+      type = types.str;
+      default = "radicale";
+      description = "User account under which Radicale runs.";
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = "radicale";
+      description = "Group under which Radicale runs.";
+    };
   };
 
   config = mkIf cfg.enable {
@@ -155,12 +167,16 @@ in
 
     environment.systemPackages = [ pkg ];
 
-    users.users.radicale = {
-      isSystemUser = true;
-      group = "radicale";
+    users.users = mkIf (cfg.user == "radicale") {
+      radicale = {
+        group = cfg.group;
+        isSystemUser = true;
+      };
     };
 
-    users.groups.radicale = { };
+    users.groups = mkIf (cfg.group == "radicale") {
+      radicale = { };
+    };
 
     systemd.services.radicale = {
       description = "A Simple Calendar and Contact Server";
@@ -176,8 +192,8 @@ in
           ]
           ++ (map escapeShellArg cfg.extraArgs)
         );
-        User = "radicale";
-        Group = "radicale";
+        User = cfg.user;
+        Group = cfg.group;
         StateDirectory = "radicale/collections";
         StateDirectoryMode = "0750";
         # Hardening


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- allow changing the user for services.radicale
- dont generate /var/lib/radicale as state dir when a storage path is set

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `dfc493ab1df487a53ee8d32fbbae4766d97da514`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 2 packages blacklisted:</summary>
  <ul>
    <li>nixos-install-tools</li>
    <li>tests.nixos-functions.nixos-test</li>
  </ul>
</details>

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
