### PR TITLE
startup-disk: init at 0.1.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17140,6 +17140,12 @@
     githubId = 5378535;
     name = "Milo Gertjejansen";
   };
+  milomc123 = {
+    email = "contact@milo.zip";
+    github = "milomc123";
+    githubId = 33701036;
+    name = "Milo Mc";
+  };
   mimame = {
     email = "miguel.madrid.mencia@gmail.com";
     github = "mimame";

--- a/pkgs/by-name/st/startup-disk/package.nix
+++ b/pkgs/by-name/st/startup-disk/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitLab,
+  nix-update-script,
+  pkg-config,
+  libadwaita,
+  gtk4,
+  glib,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "startup-disk";
+  version = "0.1.5";
+
+  src = fetchFromGitLab {
+    owner = "davide125";
+    repo = "startup-disk";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-258whEX6hKqfrk2aII15tuFEuB7NQUCNLEmi3OCOWV4=";
+    domain = "gitlab.gnome.org";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    glib # glib-compile-resources
+  ];
+
+  buildInputs = [
+    libadwaita
+    gtk4
+    glib
+  ];
+
+  postPatch = ''
+    # Fix sudo crate's hardcoded /usr/bin/sudo
+    substituteInPlace $cargoDepsCopy/sudo-0.6.0/src/lib.rs \
+      --replace-fail 'Command::new("/usr/bin/sudo")' 'Command::new("sudo")'
+  '';
+
+  cargoHash = "sha256-Ec2u/F/lVdT5Oi8N116kVWtp7duZTU0d5zOhYungJ/U=";
+
+  postInstall = ''
+    install -Dm644 res/org.startup_disk.StartupDisk.desktop -t $out/share/applications/
+    install -Dm644 res/org.startup_disk.StartupDisk.svg -t $out/share/icons/hicolor/scalable/apps/
+    install -Dm644 res/org.startup_disk.StartupDisk.metainfo.xml -t $out/share/metainfo/
+    install -Dm644 res/org.startup_disk.StartupDisk.policy -t $out/share/polkit-1/actions/
+  '';
+
+  postFixup = ''
+    substituteInPlace $out/share/polkit-1/actions/org.startup_disk.StartupDisk.policy \
+      --replace-fail /usr/bin/startup-disk /run/current-system/sw/bin/startup-disk
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Interface to choose the startup volume on Apple Silicon systems";
+    homepage = "https://gitlab.gnome.org/davide125/startup-disk";
+    changelog = "https://gitlab.gnome.org/davide125/startup-disk/-/tags/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "startup-disk";
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ milomc123 ];
+  };
+})


### PR DESCRIPTION
This PR adds a package for [Startup Disk](https://gitlab.gnome.org/davide125/startup-disk), a GNOME tool for changing the selected boot volume on Apple Silicon/Asahi Linux systems.

I decided to set the `platforms` to `lib.platforms.linux` instead of just `aarch64-linux`, as that's what the package for `asahi-bless` (a cli which provides the same function as this package) does. The package still builds and runs on non-Apple Silicon systems, it is just useless.

(This is my first nixpkgs contribution, please let me know if I have made any mistakes)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
