### PR TITLE
trgui-ng: 1.4.0-unstable-2025-05-18 -> 1.5.0

### DIFF
--- a/pkgs/by-name/tr/trgui-ng/package.nix
+++ b/pkgs/by-name/tr/trgui-ng/package.nix
@@ -15,13 +15,13 @@
   webkitgtk_4_1,
 }:
 let
-  version = "1.4.0-unstable-2025-05-18";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "openscopeproject";
     repo = "TrguiNG";
-    rev = "d2cd93ecc724f196d93c701fa27afa4288d2a37c";
-    hash = "sha256-Y3ZSpXmG+wi7x7qanKpRp917alssqF78L27Yt9K9Khs=";
+    tag = "v${version}";
+    hash = "sha256-N049HA+X9DcXyhmFbnxjfbQoKlf3dA73c1IOYFrDgwc=";
   };
 
   meta = {
@@ -34,7 +34,7 @@ let
   frontend = buildNpmPackage (finalAttrs: {
     pname = "TrguiNG-frontend";
     inherit version src;
-    npmDepsHash = "sha256-sHZHAlV3zVeCmVTlIr0NeS1zxRCKfRMv1w9bW0tOg3g=";
+    npmDepsHash = "sha256-Ql1/itjEfvYigUzEZDWsGgJj7oZ1p6Bo00eLHRVHi4c=";
 
     npmBuildScript = "webpack-prod";
 
@@ -58,7 +58,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "TrguiNG";
   inherit version src;
 
-  cargoHash = "sha256-TflzT1BNAciMcxcejrlmIOIjXc1tpm/zX0kjk+dpGiM=";
+  cargoHash = "sha256-YGBLAO8lFvbowbT3yt2m/OQrpGzWghtyyZQJeYVQijA=";
 
   postPatch = ''
     cp ${dbip-country-lite}/share/dbip/dbip-country-lite.mmdb src-tauri/dbip.mmdb


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
