### PR TITLE
oscar64: 1.32.265 -> 1.32.266

### DIFF
--- a/pkgs/by-name/os/oscar64/package.nix
+++ b/pkgs/by-name/os/oscar64/package.nix
@@ -3,26 +3,17 @@
   stdenv,
   nix-update-script,
   fetchFromGitHub,
-  fetchpatch2,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "oscar64";
-  version = "1.32.265";
+  version = "1.32.266";
 
   src = fetchFromGitHub {
     owner = "drmortalwombat";
     repo = "oscar64";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-nPwebydRFHoIWp2sbfPaudKj/sPZRKamYdIuSVZ9dcc=";
+    hash = "sha256-udbVRdGIGv3jgeh1cKp7MhSDxNs56FlqEbpzgfWcieE=";
   };
-
-  patches = [
-    (fetchpatch2 {
-      name = "fix-make-install.patch";
-      url = "https://github.com/drmortalwombat/oscar64/commit/af9e06a467be07422bc87058bebdef79e0a94ea1.patch?full_index=1";
-      hash = "sha256-YsbdYi+dwLQSGOT8krJsFqJxS0EpIiQqavQpH0nl7S0=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace ./oscar64.1 \


### PR DESCRIPTION
Release: https://github.com/drmortalwombat/oscar64/releases/tag/v1.32.266
Diff: https://github.com/drmortalwombat/oscar64/compare/v1.32.265...v1.32.266

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
