### PR TITLE
wasm-bindgen-cli_0_2_105: init and fix tuliprox build

### DIFF
--- a/pkgs/by-name/tu/tuliprox/package.nix
+++ b/pkgs/by-name/tu/tuliprox/package.nix
@@ -7,7 +7,7 @@
   ffmpeg,
   which,
   rustc,
-  wasm-bindgen-cli_0_2_104,
+  wasm-bindgen-cli_0_2_105,
   trunk,
   binaryen,
   dart-sass,
@@ -30,7 +30,7 @@ rustPlatform.buildRustPackage rec {
     pkg-config
     ffmpeg
     which
-    wasm-bindgen-cli_0_2_104
+    wasm-bindgen-cli_0_2_105
     trunk
     rustc.llvmPackages.lld
     binaryen

--- a/pkgs/by-name/tu/tuliprox/package.nix
+++ b/pkgs/by-name/tu/tuliprox/package.nix
@@ -56,6 +56,9 @@ rustPlatform.buildRustPackage rec {
     popd
   '';
 
+  # Tests don't compile in 3.2.0
+  doCheck = lib.versionAtLeast version "3.2.1";
+
   checkFlags = [
     "--skip=processing::parser::xmltv::tests::normalize"
     "--skip=processing::parser::xtream::tests::test_read_json_file_into_struct"

--- a/pkgs/by-name/wa/wasm-bindgen-cli_0_2_105/package.nix
+++ b/pkgs/by-name/wa/wasm-bindgen-cli_0_2_105/package.nix
@@ -1,0 +1,19 @@
+{
+  buildWasmBindgenCli,
+  fetchCrate,
+  rustPlatform,
+}:
+
+buildWasmBindgenCli rec {
+  src = fetchCrate {
+    pname = "wasm-bindgen-cli";
+    version = "0.2.105";
+    hash = "sha256-zLPFFgnqAWq5R2KkaTGAYqVQswfBEYm9x3OPjx8DJRY=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit src;
+    inherit (src) pname version;
+    hash = "sha256-a2X9bzwnMWNt0fTf30qAiJ4noal/ET1jEtf5fBFj5OU=";
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1658,7 +1658,7 @@ mapAliases {
   warmux = throw "'warmux' has been removed as it is unmaintained and broken"; # Added 2025-11-03
   warsow = throw "'warsow' has been removed as it is unmaintained and is broken"; # Added 2025-10-09
   warsow-engine = throw "'warsow-engine' has been removed as it is unmaintained and is broken"; # Added 2025-10-09
-  wasm-bindgen-cli = wasm-bindgen-cli_0_2_104;
+  wasm-bindgen-cli = wasm-bindgen-cli_0_2_105;
   wasm-strip = throw "'wasm-strip' has been removed due to upstream deprecation. Use 'wabt' instead."; # Added 2025-11-06
   wavebox = throw "'wavebox' has been removed due to lack of maintenance in nixpkgs"; # Added 2025-06-24
   wavm = throw "wavm has been removed, as it does not build with supported LLVM versions"; # Added 2025-08-10


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

tuliprox builds fails on Hydra because the bindgen cli version is wrong : 
```
    3: couldn't find the required version (0.2.105) of the application wasm-bindgen (found: 0.2.104), unable to download in offline mode
```

I had to create the bindgen version 0.2.105 as it has not been packaged yet.

I disabled the tests for this version as I couldn't fix it with a simple patch from upstream.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
