### PR TITLE
libqb: 2.0.8 -> 2.0.9, modernize, fixes hash mismatch

### DIFF
--- a/pkgs/by-name/li/libqb/package.nix
+++ b/pkgs/by-name/li/libqb/package.nix
@@ -16,7 +16,18 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "ClusterLabs";
     repo = "libqb";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-e3lXieKy3JqvuAIzXQjq6kDMfMmokXR/v3p4VQDIuOI=";
+    # Upstream uses .gitattributes to inject information about the revision
+    # hash and the refname into `configure.ac`, see:
+    # - https://git-scm.com/docs/gitattributes#_export_subst and
+    # - https://github.com/ClusterLabs/libqb/commit/d6875f29d6d1175f621e33d312fcace9a55f9094
+    # Directly inject version and remove complicated logic
+    # https://github.com/ClusterLabs/libqb/blob/d6875f29d6d1175f621e33d312fcace9a55f9094/configure.ac#L9-L15
+    postFetch = ''
+      substituteInPlace $out/configure.ac \
+        --replace-fail "AC_INIT([libqb]," "AC_INIT([libqb], ${finalAttrs.version},"
+      sed -i '/m4_esyscmd(\[build-aux\/git-version-gen/ , /\]),/ d' $out/configure.ac
+    '';
+    hash = "sha256-LhB7Q78heCmcgtcHqL+uEv0O2s4mXyfdTzmoCVqC0x0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/libqb/package.nix
+++ b/pkgs/by-name/li/libqb/package.nix
@@ -10,22 +10,14 @@
 
 stdenv.mkDerivation rec {
   pname = "libqb";
-  version = "2.0.8";
+  version = "2.0.9";
 
   src = fetchFromGitHub {
     owner = "ClusterLabs";
     repo = "libqb";
-    rev = "v${version}";
-    sha256 = "sha256-ZjxC7W4U8T68mZy/OvWj/e4W9pJIj2lVDoEjxXYr/G8=";
+    tag = "v${version}";
+    hash = "sha256-e3lXieKy3JqvuAIzXQjq6kDMfMmokXR/v3p4VQDIuOI=";
   };
-
-  patches = [
-    # add a declaration of fdatasync, missing on darwin https://github.com/ClusterLabs/libqb/pull/496
-    (fetchpatch {
-      url = "https://github.com/ClusterLabs/libqb/commit/255ccb70ee19cc0c82dd13e4fd5838ca5427795f.patch";
-      hash = "sha256-6x4B3FM0XSRIeAly8JtMOGOdyunTcbaDzUeBZInXR4U=";
-    })
-  ];
 
   nativeBuildInputs = [
     autoreconfHook
@@ -35,7 +27,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libxml2 ];
 
   postPatch = ''
-    sed -i '/# --enable-new-dtags:/,/--enable-new-dtags is required/ d' configure.ac
+    sed -i '/# --enable-new-dtags:/,/esac/ d' configure.ac
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/li/libqb/package.nix
+++ b/pkgs/by-name/li/libqb/package.nix
@@ -8,14 +8,14 @@
   libxml2,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libqb";
   version = "2.0.9";
 
   src = fetchFromGitHub {
     owner = "ClusterLabs";
     repo = "libqb";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-e3lXieKy3JqvuAIzXQjq6kDMfMmokXR/v3p4VQDIuOI=";
   };
 
@@ -26,14 +26,16 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libxml2 ];
 
+  # Remove configure check for linker flag `--enable-new-dtags`, which fails
+  # on darwin. The flag is never used by the Makefile anyway.
   postPatch = ''
     sed -i '/# --enable-new-dtags:/,/esac/ d' configure.ac
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/clusterlabs/libqb";
     description = "Library providing high performance logging, tracing, ipc, and poll";
-    license = licenses.lgpl21Plus;
-    platforms = platforms.unix;
+    license = lib.licenses.lgpl21Plus;
+    platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
https://github.com/ClusterLabs/libqb/compare/v2.0.8...v2.0.9

This also fixes

```
error: hash mismatch in fixed-output derivation '/nix/store/c1vm58ql3v7s26h9scyv1dy7r3ydivsx-libqb-2.0.8-source.drv':
         specified: sha256-ZjxC7W4U8T68mZy/OvWj/e4W9pJIj2lVDoEjxXYr/G8=
            got:    sha256-xCwENbo9ONsFNiutebsIRqjmvtUz+qnlytvvlCC4P78=
```

for the existing version.

Encountered with `nixpkgs.config.fetchedSourceNameDefault = "versioned";`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
