### PR TITLE
python3Packages.pydantic-yaml: (re)init at 1.6.0

### DIFF
--- a/pkgs/development/python-modules/pydantic-yaml/default.nix
+++ b/pkgs/development/python-modules/pydantic-yaml/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pydantic,
+  ruamel-yaml,
+  typing-extensions,
+  setuptools-scm,
+  pytest-mock,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "pydantic-yaml";
+  version = "1.6.0";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "NowanIlfideme";
+    repo = "pydantic-yaml";
+    tag = "v${version}";
+    hash = "sha256-n5QWVHgYAg+Ad7Iv6CBSRQcl8lv4ZtcFMiC2ZHyi414=";
+  };
+
+  postPatch = ''
+    substituteInPlace src/pydantic_yaml/version.py \
+      --replace-fail "0.0.0" "${version}"
+  '';
+
+  build-system = [ setuptools-scm ];
+
+  dependencies = [
+    pydantic
+    ruamel-yaml
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [ "pydantic_yaml" ];
+
+  nativeCheckInputs = [
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Small helper library that adds some YAML capabilities to pydantic";
+    homepage = "https://github.com/NowanIlfideme/pydantic-yaml";
+    changelog = "https://github.com/NowanIlfideme/pydantic-yaml/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      adhityaravi
+      bepri
+      dstathis
+    ];
+  };
+}

--- a/pkgs/development/python-modules/pydantic-yaml/default.nix
+++ b/pkgs/development/python-modules/pydantic-yaml/default.nix
@@ -50,6 +50,7 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       adhityaravi
+      bbjubjub
       bepri
       dstathis
     ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13087,6 +13087,8 @@ self: super: with self; {
 
   pydantic-settings = callPackage ../development/python-modules/pydantic-settings { };
 
+  pydantic-yaml = callPackage ../development/python-modules/pydantic-yaml { };
+
   pydantic_1 = callPackage ../development/python-modules/pydantic/1.nix { };
 
   pydash = callPackage ../development/python-modules/pydash { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This module was removed in #443998 since it was not used in Nixpkgs. It is used in ethereum.nix however so it is indirectly useful to include it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
