### PR TITLE
glpk: fix build with gcc15

### DIFF
--- a/pkgs/by-name/gl/glpk/package.nix
+++ b/pkgs/by-name/gl/glpk/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   fetchpatch,
+  fetchDebianPatch,
   libmysqlclient,
   # Excerpt from glpk's INSTALL file:
   # This feature allows the exact simplex solver to use the GNU MP
@@ -50,6 +51,14 @@ stdenv.mkDerivation rec {
       name = "error_recovery.patch";
       url = "https://raw.githubusercontent.com/sagemath/sage/d3c1f607e32f964bf0cab877a63767c86fd00266/build/pkgs/glpk/patches/error_recovery.patch";
       sha256 = "sha256-2hNtUEoGTFt3JgUvLH3tPWnz+DZcXNhjXzS+/V89toA=";
+    })
+
+    # Fix build with gcc15
+    (fetchDebianPatch {
+      inherit pname version;
+      debianRevision = "2";
+      patch = "gcc-15.patch";
+      hash = "sha256-wuWPYqJKIKJAJaeJXW7lhvapu8Fd3zHjLAv7Ve7q8Qw=";
     })
   ];
 


### PR DESCRIPTION
- add patch from debian replacing `bool` typedef and `true`/`false` defines with `#include <stdbool.h>`:
https://sources.debian.org/data/main/g/glpk/5.0-2/debian/patches/gcc-15.patch

Upstream issue:
https://lists.gnu.org/archive/html/bug-glpk/2025-05/msg00000.html (recommends to use `CFLAGS="-ansi"` instead)

Fixes build failure with gcc15:
```
In file included from api/minisat1.c:23:
./minisat/minisat.h:37:13: error: 'bool' cannot be defined via 'typedef'
   37 | typedef int bool;
      |             ^~~~
./minisat/minisat.h:37:13: note: 'bool' is a keyword with '-std=c23' onwards
./minisat/minisat.h:37:1: warning: useless type name in empty declaration
   37 | typedef int bool;
      | ^~~~~~~
```

---

Tested build with:
```bash
nix-build --expr 'with import ./. {}; glpk.override { stdenv = gcc15Stdenv; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
