### PR TITLE
zscaler-cacert: init at 2025-02-02

### DIFF
--- a/pkgs/by-name/zs/zscaler-cacert/package.nix
+++ b/pkgs/by-name/zs/zscaler-cacert/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "zscaler-cacert";
+
+  # check it on the DHL keyserver homepage ('validity period')
+  # and using openssl:
+  # openssl x509 -startdate -noout -in ZscalerRootCertificate-2048-SHA256.crt
+
+  version = "0-unstable-2025-02-02";
+
+  src = fetchurl {
+    url = "https://keyserver.dhl.com/pki/X3/ZscalerRootCertificate-2048-SHA256.crt";
+    hash = "sha256-HrQ7am1IteSP1O3mz3weay1NQG8aj3EUt1ZjYRbOEQA=";
+  };
+
+  dontUnpack = true;
+
+  dontBuild = true;
+
+  installPhase = ''
+    install -Dm644 $src $out/etc/ssl/certs/zscaler-ca.crt
+  '';
+
+  meta = {
+    description = "ZScaler Root CA certificate";
+    homepage = "https://keyserver.dhl.com/certificates";
+    license = lib.licenses.publicDomain;
+    maintainers = with lib.maintainers; [ aiyion ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
[ZScaler ZIA](https://www.zscaler.com/products-and-solutions/zscaler-internet-access) is often used in enterprise contexts to break open SSL encrypted traffic.
Work PCs might require this certificate added to the trusted certificates for mandatory proxies to work.

Prominent german infrastructure examples appear to include DHL, ZeitOnline or Sennheiser.

The certificate referenced can be found using the proprietary admin portal or at DHL keyserver where they kindly provide it.
As noted above https://github.com/ZeitOnline/zscaler-ca-certificate would also provide it.

The two can be compared by diffing/checksumming the output of this openssl invocation to minimize whitespace errors:
```bash
openssl x509 -in ZscalerRootCertificate-2048-SHA256.crt -text
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - ~[NixOS tests] in [nixos/tests].~
  - ~[Package tests] at `passthru.tests`.~
  - ~Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.~
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - ~Package update: when the change is major or breaking.~
- NixOS Release Notes
  - ~Module addition: when adding a new NixOS module.~
  - ~Module update: when the change is significant.~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
