### PR TITLE
formats.javaProperties: fix cross-compilation

### DIFF
--- a/pkgs/pkgs-lib/formats/java-properties/default.nix
+++ b/pkgs/pkgs-lib/formats/java-properties/default.nix
@@ -65,89 +65,96 @@ in
 
       generate =
         name: value:
-        pkgs.runCommand name
+        pkgs.callPackage (
           {
-            # Requirements
-            # ============
-            #
-            #  1. Strings in Nix carry over to the same
-            #     strings in Java => need proper escapes
-            #  2. Generate files quickly
-            #      - A JVM would have to match the app's
-            #        JVM to avoid build closure bloat
-            #      - Even then, JVM startup would slow
-            #        down config generation.
-            #
-            #
-            # Implementation
-            # ==============
-            #
-            # Escaping has two steps
-            #
-            # 1. jq
-            #    Escape known separators, in order not
-            #    to break up the keys and values.
-            #    This handles typical whitespace correctly,
-            #    but may produce garbage for other control
-            #    characters.
-            #
-            # 2. iconv
-            #    Escape >ascii code points to java escapes,
-            #    as .properties files are supposed to be
-            #    encoded in ISO 8859-1. It's an old format.
-            #    UTF-8 behavior may exist in some apps and
-            #    libraries, but we can't rely on this in
-            #    general.
+            runCommand,
+            jq,
+            libiconvReal,
+          }:
+          runCommand name
+            {
+              # Requirements
+              # ============
+              #
+              #  1. Strings in Nix carry over to the same
+              #     strings in Java => need proper escapes
+              #  2. Generate files quickly
+              #      - A JVM would have to match the app's
+              #        JVM to avoid build closure bloat
+              #      - Even then, JVM startup would slow
+              #        down config generation.
+              #
+              #
+              # Implementation
+              # ==============
+              #
+              # Escaping has two steps
+              #
+              # 1. jq
+              #    Escape known separators, in order not
+              #    to break up the keys and values.
+              #    This handles typical whitespace correctly,
+              #    but may produce garbage for other control
+              #    characters.
+              #
+              # 2. iconv
+              #    Escape >ascii code points to java escapes,
+              #    as .properties files are supposed to be
+              #    encoded in ISO 8859-1. It's an old format.
+              #    UTF-8 behavior may exist in some apps and
+              #    libraries, but we can't rely on this in
+              #    general.
 
-            preferLocalBuild = true;
-            passAsFile = [ "value" ];
-            value = builtins.toJSON value;
-            nativeBuildInputs = [
-              pkgs.jq
-              pkgs.libiconvReal
-            ];
+              preferLocalBuild = true;
+              passAsFile = [ "value" ];
+              value = builtins.toJSON value;
+              nativeBuildInputs = [
+                jq
+                libiconvReal
+              ];
 
-            jqCode =
-              let
-                main = ''
-                  to_entries
-                    | .[]
-                    | "\(
-                        .key
-                        | ${commonEscapes}
-                        | gsub(" "; "\\ ")
-                        | gsub("="; "\\=")
-                      ) = \(
-                        .value
-                        | ${commonEscapes}
-                        | gsub("^ "; "\\ ")
-                        | gsub("\\n "; "\n\\ ")
-                      )"
-                '';
-                # Most escapes are equal for both keys and values.
-                commonEscapes = ''
-                  gsub("\\\\"; "\\\\")
-                  | gsub("\\n"; "\\n\\\n")
-                  | gsub("#"; "\\#")
-                  | gsub("!"; "\\!")
-                  | gsub("\\t"; "\\t")
-                  | gsub("\r"; "\\r")
-                '';
-              in
-              main;
+              jqCode =
+                let
+                  main = ''
+                    to_entries
+                      | .[]
+                      | "\(
+                          .key
+                          | ${commonEscapes}
+                          | gsub(" "; "\\ ")
+                          | gsub("="; "\\=")
+                        ) = \(
+                          .value
+                          | ${commonEscapes}
+                          | gsub("^ "; "\\ ")
+                          | gsub("\\n "; "\n\\ ")
+                        )"
+                  '';
+                  # Most escapes are equal for both keys and values.
+                  commonEscapes = ''
+                    gsub("\\\\"; "\\\\")
+                    | gsub("\\n"; "\\n\\\n")
+                    | gsub("#"; "\\#")
+                    | gsub("!"; "\\!")
+                    | gsub("\\t"; "\\t")
+                    | gsub("\r"; "\\r")
+                  '';
+                in
+                main;
 
-            inputEncoding = "UTF-8";
+              inputEncoding = "UTF-8";
 
-            inherit comment;
+              inherit comment;
 
-          }
-          ''
-            (
-              echo "$comment" | while read -r ln; do echo "# $ln"; done
-              echo
-              jq -r --arg hash '#' "$jqCode" "$valuePath" \
-                | iconv --from-code "$inputEncoding" --to-code JAVA \
-            ) > "$out"
-          '';
+            }
+            ''
+              (
+                echo "$comment" | while read -r ln; do echo "# $ln"; done
+                echo
+                jq -r --arg hash '#' "$jqCode" "$valuePath" \
+                  | iconv --from-code "$inputEncoding" --to-code JAVA \
+              ) > "$out"
+            ''
+        ) { };
     };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

When cross-compiling, the format generator is using host-platform
binaries in nativeBuildInputs, causing build failures.

Example: failure when trying to cross-compile languagetool service
```
error: Cannot build '/nix/store/wxx06pmpxqvnz86cirm3nhvkrn3z6df9-languagetool.conf.drv'.
       Reason: builder failed with exit code 126.
       Output paths:
         /nix/store/zbpj46afs17zb9frigzqgabnlxv1fyj6-languagetool.conf
       Last 2 log lines:
       > /build/.attr-0l2nkwhif96f51f4amnlf414lhl4rv9vh8iffyp431v6s28gsr90: line 4: /nix/store/ml483zs7sgh8qf36ia8syb88yd6iaj4v-jq-aarch64-unknown-linux-gnu-1.8.1-bin/bin/jq: cannot execute binary file: Exec format error
       > /build/.attr-0l2nkwhif96f51f4amnlf414lhl4rv9vh8iffyp431v6s28gsr90: line 5: /nix/store/9bji4bi01criyly5jq3khjnah899sayq-libiconv-aarch64-unknown-linux-gnu-1.18/bin/iconv: cannot execute binary file: Exec format error
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

@roberth 