### PR TITLE
elfutils: patch for run-sysroot test

### DIFF
--- a/pkgs/by-name/el/elfutils/package.nix
+++ b/pkgs/by-name/el/elfutils/package.nix
@@ -57,6 +57,8 @@ stdenv.mkDerivation rec {
       url = "https://git.alpinelinux.org/aports/plain/main/elfutils/musl-strndupa.patch?id=2e3d4976eeffb4704cf83e2cc3306293b7c7b2e9";
       sha256 = "sha256-7daehJj1t0wPtQzTv+/Rpuqqs5Ng/EYnZzrcf2o/Lb0=";
     })
+    # https://patchwork.sourceware.org/project/elfutils/patch/20251205145241.1165646-1-arnout@bzzt.net/
+    ./test-run-sysroot-reliability.patch
   ]
   ++ lib.optionals stdenv.hostPlatform.isMusl [ ./musl-error_h.patch ];
 

--- a/pkgs/by-name/el/elfutils/test-run-sysroot-reliability.patch
+++ b/pkgs/by-name/el/elfutils/test-run-sysroot-reliability.patch
@@ -1,0 +1,44 @@
+commit 898804bed022d1ef26e5c0b12550f87fc86f29ed
+Author: Arnout Engelen <arnout@bzzt.net>
+Date:   Thu Dec 4 21:42:40 2025 +0100
+
+    tests: improve reliability of run-sysroot.sh
+    
+    Previously, the 'second' test would test the `RESOLVE_IN_ROOT` feature
+    when the current libc supports it, even when the currently running
+    kernel did not yet support it.
+    
+    Signed-off-by: Arnout Engelen <arnout@bzzt.net>
+
+diff --git a/tests/run-sysroot.sh b/tests/run-sysroot.sh
+index fe302446..d2041e8a 100755
+--- a/tests/run-sysroot.sh
++++ b/tests/run-sysroot.sh
+@@ -46,10 +46,14 @@ TID 431185:
+ #8  0x0000aaaae56127f0 _start
+ EOF
+ 
+-HAVE_OPENAT2=$(grep '^#define HAVE_OPENAT2_RESOLVE_IN_ROOT' \
+-                    ${abs_builddir}/../config.h | awk '{print $3}')
++libc_has_openat2_resolve_in_root() {
++  grep '^#define HAVE_OPENAT2_RESOLVE_IN_ROOT' ${abs_builddir}/../config.h | awk '{print $3}'
++}
++kernel_has_openat2_resolve_in_root() {
++  printf "%s\n%s" "5.6.0" "$(uname -r)" | sort -V -C
++}
+ 
+-if [[ "$HAVE_OPENAT2" = 1 ]]; then
++if libc_has_openat2_resolve_in_root && kernel_has_openat2_resolve_in_root; then
+     # Change the layout of files in sysroot to test symlink escape scenario
+     rm -f "${tmpdir}/sysroot/bin"
+     mkdir "${tmpdir}/sysroot/bin"
+@@ -57,7 +61,8 @@ if [[ "$HAVE_OPENAT2" = 1 ]]; then
+     ln -s /bin/bash "${tmpdir}/sysroot/usr/bin/bash"
+ 
+     # Check that stack with --sysroot generates correct backtrace even if target
+-    # binary is actually absolute symlink pointing outside of sysroot directory
++    # binary is actually absolute symlink to be interpreted relative to the sysroot
++    # directory
+     testrun "${abs_top_builddir}"/src/stack --core "${tmpdir}/core.bash" \
+ 	    --sysroot "${tmpdir}/sysroot" >"${tmpdir}/stack.out"
+ 


### PR DESCRIPTION
Fixes #467866

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
