### PR TITLE
lychee: 0.21.0 -> 0.22.0-unstable-2025-12-05

### DIFF
--- a/pkgs/by-name/ly/lychee/package.nix
+++ b/pkgs/by-name/ly/lychee/package.nix
@@ -17,12 +17,13 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "lychee";
-  version = "0.21.0";
+  version = "0.22.0-unstable-2025-12-05";
 
   src = fetchFromGitHub {
     owner = "lycheeverse";
     repo = "lychee";
-    tag = "lychee-v${version}";
+    # tag = "lychee-v${version}"; # use again with next release
+    rev = "db0f8a842f594e0a879563caf7d183266c02ca95"; # one revision after 0.22.0
     leaveDotGit = true;
     postFetch = ''
       GIT_DATE=$(git -C $out/.git show -s --format=%cs)
@@ -32,10 +33,10 @@ rustPlatform.buildRustPackage rec {
           '("cargo:rustc-env=GIT_DATE={}", "'$GIT_DATE'")'
       rm -rf $out/.git
     '';
-    hash = "sha256-Nt7LsnQkWQS0f2/lS8WNYkI+XbKUSHQ6bNf9FNjfk7A=";
+    hash = "sha256-l8/llYq8rwt+UQMLnsva4/2m53cwqaJXD/XvgEfxXg4=";
   };
 
-  cargoHash = "sha256-1sqFjNil6KktpqrsXXgt3xtOz7eFQc2skkFHqmTMDg4=";
+  cargoHash = "sha256-03eahQ6GvOPxnvC82lfT1J/XfOg9V7gOZeOEBJx8IYY=";
 
   nativeBuildInputs = [
     pkg-config
@@ -55,8 +56,6 @@ rustPlatform.buildRustPackage rec {
     "--bins"
     "--tests"
   ];
-
-  checkType = "debug"; # compilation fails otherwise
 
   checkFlags = [
     #  Network errors for all of these tests


### PR DESCRIPTION
Note that we include one revision after `0.22.0` where octocrab was bumped to v0.48.1 so it becomes `0.22.0-unstable-2025-12-05`. This fixes a build error. See https://github.com/XAMPPRocky/octocrab/pull/828

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
