### PR TITLE
ocamlPackages.dream-html: 3.11.1 -> 3.11.2

### DIFF
--- a/pkgs/development/ocaml-modules/dream-html/default.nix
+++ b/pkgs/development/ocaml-modules/dream-html/default.nix
@@ -1,5 +1,4 @@
 {
-  lib,
   buildDunePackage,
   dream,
   pure-html,
@@ -8,7 +7,7 @@
 
 buildDunePackage {
   pname = "dream-html";
-  inherit (pure-html) src version;
+  inherit (pure-html) src version meta;
 
   buildInputs = [
     ppxlib
@@ -18,11 +17,4 @@ buildDunePackage {
     pure-html
     dream
   ];
-
-  meta = {
-    description = "Write HTML directly in your OCaml source files with editor support";
-    license = lib.licenses.gpl3;
-    maintainers = [ lib.maintainers.naora ];
-    broken = lib.versionAtLeast ppxlib.version "0.36";
-  };
 }

--- a/pkgs/development/ocaml-modules/dream-html/pure.nix
+++ b/pkgs/development/ocaml-modules/dream-html/pure.nix
@@ -5,22 +5,26 @@
   uri,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "pure-html";
-  version = "3.11.1";
+  version = "3.11.2";
 
   src = fetchFromGitHub {
     owner = "yawaramin";
     repo = "dream-html";
-    tag = "v${version}";
-    hash = "sha256-L/q3nxUONPdZtzmfCfP8nnNCwQNSpeYI0hqowioGYNg=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/I233A86T+QEb2qbSHucgzRzYEjS08eKezSXOwz2ml0=";
   };
+
+  doCheck = true;
 
   propagatedBuildInputs = [ uri ];
 
   meta = {
     description = "Write HTML directly in your OCaml source files with editor support";
+    homepage = "https://github.com/yawaramin/dream-html";
+    changelog = "https://raw.githubusercontent.com/yawaramin/dream-html/refs/tags/v${finalAttrs.version}/CHANGES.md";
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.naora ];
   };
-}
+})


### PR DESCRIPTION
Fixes compatibility with ppxlib > 0.36, since this package is currently marked broken.

When ppxlib 0.36 landed in nixpkgs, it broke dream-html, so the broken attribute was added to reflect this. Now that dream-html 3.11.2 is compatible with that version of ppxlib, everything works again.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
