### PR TITLE
add security.run0 module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -402,6 +402,7 @@
   ./security/please.nix
   ./security/polkit.nix
   ./security/rtkit.nix
+  ./security/run0.nix
   ./security/soteria.nix
   ./security/sudo-rs.nix
   ./security/sudo.nix

--- a/nixos/modules/security/run0.nix
+++ b/nixos/modules/security/run0.nix
@@ -1,0 +1,52 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.security.run0;
+
+  sudoAlias = pkgs.writeScriptBin "sudo" ''
+    if [[ "$1" == -* ]]; then
+      echo "This script is a sudo-alias to systemd's run0 and does not support any sudo parameters."
+      exit 1
+    fi
+    exec run0 "$@"
+  '';
+in
+{
+  options.security.run0 = {
+    wheelNeedsPassword = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Whether users of the `wheel` group must
+        provide a password to run commands as super user via {command}`run0`.
+      '';
+    };
+
+    enableSudoAlias = lib.mkEnableOption "make {command}`sudo` an alias to {command}`run0`.";
+  };
+
+  config = {
+    assertions = [
+      {
+        assertion =
+          cfg.enableSudoAlias -> (!config.security.sudo.enable && !config.security.sudo-rs.enable);
+        message = "`security.run0.enableSudoAlias` cannot be enabled if `security.sudo` or `security.sudo-rs` are enabled.";
+      }
+    ];
+
+    security.polkit.extraConfig = lib.mkIf (!cfg.wheelNeedsPassword) ''
+      polkit.addRule(function(action, subject) {
+        if (action.id == "org.freedesktop.systemd1.manage-units" && subject.isInGroup("wheel")) {
+          return polkit.Result.YES;
+        }
+      });
+    '';
+
+    environment.systemPackages = lib.optional cfg.enableSudoAlias sudoAlias;
+  };
+}


### PR DESCRIPTION
I just learned about `run0` as a potential substitute for `sudo` (and similar apps).
This is cool because:

- no extra software as run0 is included in systemd
- no SUID bit, so this simplifies getting rid of SUID stuff in NixOS.

This module provides options to:

- allow all `wheel` users to run `run0` without password
- alias `sudo` with `run0`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
