### PR TITLE
orca-slicer: Fix upstream version number

### DIFF
--- a/pkgs/by-name/or/orca-slicer/package.nix
+++ b/pkgs/by-name/or/orca-slicer/package.nix
@@ -135,6 +135,10 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/SoftFever/OrcaSlicer/commit/d10a06ae11089cd1f63705e87f558e9392f7a167.patch";
       hash = "sha256-t4own5AwPsLYBsGA15id5IH1ngM0NSuWdFsrxMRXmTk=";
     })
+  ]
+  ++ lib.optionals (finalAttrs.version == "2.3.1") [
+    # Fix upstream version number
+    ./patches/fix-upstream-version-number.patch
   ];
 
   doCheck = true;

--- a/pkgs/by-name/or/orca-slicer/patches/fix-upstream-version-number.patch
+++ b/pkgs/by-name/or/orca-slicer/patches/fix-upstream-version-number.patch
@@ -1,0 +1,13 @@
+diff --git a/version.inc b/version.inc
+index 0ca14c629e..09670015aa 100644
+--- a/version.inc
++++ b/version.inc
+@@ -10,7 +10,7 @@ endif()
+ if(NOT DEFINED BBL_INTERNAL_TESTING)
+ set(BBL_INTERNAL_TESTING "0")
+ endif()
+-set(SoftFever_VERSION "2.3.2-dev")
++set(SoftFever_VERSION "2.3.1")
+ string(REGEX MATCH "^([0-9]+)\\.([0-9]+)\\.([0-9]+)"
+        SoftFever_VERSION_MATCH ${SoftFever_VERSION})
+ set(ORCA_VERSION_MAJOR ${CMAKE_MATCH_1})


### PR DESCRIPTION
The orca repo have the [wrong version](https://github.com/SoftFever/OrcaSlicer/blob/737948be1f5b108b191420d4c670b511f8118604/version.inc#L13) on the tag `v2.3.1`, which is already reported [here](https://github.com/SoftFever/OrcaSlicer/issues/10955).

Since there hasn't been any progress upstream about it (and it's just a minor bug), I think it's valid to patch it on our end.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
