### PR TITLE
filestash: init at 0-unstable-2025-12-05

### DIFF
--- a/pkgs/by-name/fi/filestash/package.nix
+++ b/pkgs/by-name/fi/filestash/package.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+  pkg-config,
+  brotli,
+  libraw,
+  giflib,
+  libwebp,
+  libjpeg,
+  libpng,
+  vips,
+}:
+let
+  rev = "8935c628dabeabdeda2dd9d102e01102cceb24bf";
+  buildDate = "20251205";
+  goModuleName = "github.com/mickael-kerjean/filestash";
+in
+buildGoModule {
+  pname = "filestash";
+  version = "0-unstable-2025-12-05";
+
+  src = fetchFromGitHub {
+    inherit rev;
+
+    owner = "mickael-kerjean";
+    repo = "filestash";
+    hash = "sha256-XRzNUbIS9/rcpq5q/b7DthClTDQtf4fA5dkzaJjjTs0=";
+  };
+
+  vendorHash = "sha256-AfgTt4dSUQ8YN+ekHRwmoGJSSMF9SQqS9K7kheQeNNA=";
+
+  excludedPackages = [
+    "server/generator"
+    "server/plugin/plg_override_actiondelete" # Go source code error
+    "server/plugin/plg_override_download" # Go source code error
+  ];
+
+  ldflags = [
+    "-s -w -X ${goModuleName}/server/common.BUILD_REF=${rev} -X ${goModuleName}/server/common.BUILD_DATE=${buildDate}"
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    brotli.dev
+    libraw.dev
+    giflib
+    libwebp
+    libjpeg.dev
+    libpng.dev
+    vips.dev
+  ];
+
+  patches = [ ./pwd.patch ];
+
+  postPatch = ''
+    # Don't use static libs.
+    for f in $(find . -type f -name '*.go'); do
+      substituteInPlace "$f" --replace-quiet "-l:libwebp.a" "-lwebp"
+      substituteInPlace "$f" --replace-quiet "-l:libjpeg.a" "-ljpeg"
+      substituteInPlace "$f" --replace-quiet "-l:libpng.a" "-lpng"
+      substituteInPlace "$f" --replace-quiet "-l:libraw.a" "-lraw"
+      substituteInPlace "$f" --replace-quiet "-l:libz.a" "-lz"
+    done
+
+    # Constants set via ldflags.
+    substituteInPlace server/common/constants.go --replace-fail "//go:generate go run ../generator/constants.go" ""
+  '';
+
+  doCheck = true;
+
+  preBuild = ''
+    go generate -x ./server/...
+  '';
+
+  postInstall = ''
+    mv $out/bin/cmd $out/bin/filestash
+  '';
+
+  meta = {
+    mainProgram = "filestash";
+    description = "Web app for managing and sharing files across different storage backends";
+    homepage = "https://github.com/mickael-kerjean/filestash";
+    license = lib.licenses.agpl3Only;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ angelodlfrtr ];
+  };
+}

--- a/pkgs/by-name/fi/filestash/pwd.patch
+++ b/pkgs/by-name/fi/filestash/pwd.patch
@@ -1,0 +1,15 @@
+diff --git a/server/common/files.go b/server/common/files.go
+index 3e580118..a71bf2c2 100644
+--- a/server/common/files.go
++++ b/server/common/files.go
+@@ -15,8 +15,8 @@ func GetCurrentDir() string {
+ 	if MOCK_CURRENT_DIR != "" {
+ 		return MOCK_CURRENT_DIR
+ 	}
+-	ex, _ := os.Executable()
+-	return filepath.Dir(ex)
++	pwd, _ := os.Getwd()
++	return pwd
+ }
+ 
+ func GetAbsolutePath(base string, opts ...string) string {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add [filestash](https://github.com/mickael-kerjean/filestash) package.

This a simple web client for managing files across multiple backends : SFTP, S3, FTP, WebDAV, Git, Minio, LDAP, CalDAV, CardDAV, Mysql, Backblaze, ...

There is no fixed versioning.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
