### PR TITLE
maintainers: drop sander

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23163,12 +23163,6 @@
     github = "SandaruKasa";
     githubId = 50824690;
   };
-  sander = {
-    email = "s.vanderburg@tudelft.nl";
-    github = "svanderburg";
-    githubId = 1153271;
-    name = "Sander van der Burg";
-  };
   sandptel = {
     email = "sandppatel15@gmail.com";
     github = "sandptel";

--- a/pkgs/applications/emulators/zsnes/default.nix
+++ b/pkgs/applications/emulators/zsnes/default.nix
@@ -87,7 +87,6 @@ stdenv.mkDerivation {
   meta = {
     description = "Super Nintendo Entertainment System Emulator";
     license = lib.licenses.gpl2Plus;
-    maintainers = [ lib.maintainers.sander ];
     homepage = "https://www.zsnes.com";
     platforms = [
       "i686-linux"

--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -419,7 +419,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Only;
     homepage = "https://www.virtualbox.org/";
     maintainers = with lib.maintainers; [
-      sander
       friedrichaltheide
       blitz
     ];

--- a/pkgs/applications/virtualization/virtualbox/extpack.nix
+++ b/pkgs/applications/virtualization/virtualbox/extpack.nix
@@ -24,7 +24,6 @@ fetchurl rec {
     license = licenses.virtualbox-puel;
     homepage = "https://www.virtualbox.org/";
     maintainers = with maintainers; [
-      sander
       friedrichaltheide
     ];
     platforms = [ "x86_64-linux" ];

--- a/pkgs/applications/virtualization/virtualbox/guest-additions-iso/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions-iso/default.nix
@@ -14,7 +14,6 @@ fetchurl {
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.gpl2;
     maintainers = [
-      lib.maintainers.sander
       lib.maintainers.friedrichaltheide
     ];
     platforms = [

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -171,7 +171,6 @@ stdenv.mkDerivation {
     sourceProvenance = with lib.sourceTypes; [ fromSource ];
     license = lib.licenses.gpl3Only;
     maintainers = [
-      lib.maintainers.sander
       lib.maintainers.friedrichaltheide
     ];
     platforms = [

--- a/pkgs/by-name/ar/arj/package.nix
+++ b/pkgs/by-name/ar/arj/package.nix
@@ -61,7 +61,6 @@ gccStdenv.mkDerivation (finalAttrs: {
       provided by ARJ Software, Inc.
     '';
     license = lib.licenses.gpl2Plus;
-    maintainers = [ lib.maintainers.sander ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/da/daemon/package.nix
+++ b/pkgs/by-name/da/daemon/package.nix
@@ -31,7 +31,6 @@ stdenv.mkDerivation rec {
       Java).
     '';
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.sander ];
     platforms = platforms.unix;
     mainProgram = "daemon";
   };

--- a/pkgs/by-name/db/dbus_java/package.nix
+++ b/pkgs/by-name/db/dbus_java/package.nix
@@ -32,7 +32,6 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     platforms = platforms.linux;
-    maintainers = [ maintainers.sander ];
     license = licenses.afl21;
   };
 }

--- a/pkgs/by-name/di/DisnixWebService/package.nix
+++ b/pkgs/by-name/di/DisnixWebService/package.nix
@@ -72,7 +72,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/svanderburg/DisnixWebService";
     changelog = "https://github.com/svanderburg/DisnixWebService/blob/${finalAttrs.src.rev}/NEWS.txt";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.sander ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/di/disnixos/package.nix
+++ b/pkgs/by-name/di/disnixos/package.nix
@@ -29,7 +29,6 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Provides complementary NixOS infrastructure deployment to Disnix";
     license = lib.licenses.lgpl21Plus;
-    maintainers = [ lib.maintainers.sander ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/ec/ecwolf/package.nix
+++ b/pkgs/by-name/ec/ecwolf/package.nix
@@ -112,7 +112,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [
       jayman2000
-      sander
     ];
     platforms = platforms.all;
   };

--- a/pkgs/by-name/ed/eduke32/package.nix
+++ b/pkgs/by-name/ed/eduke32/package.nix
@@ -184,7 +184,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = with lib.licenses; [ gpl2Plus ];
     maintainers = with lib.maintainers; [
       qubitnano
-      sander
     ];
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/ei/eigen/package.nix
+++ b/pkgs/by-name/ei/eigen/package.nix
@@ -52,7 +52,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "C++ template library for linear algebra: vectors, matrices, and related algorithms";
     license = lib.licenses.lgpl3Plus;
     maintainers = with lib.maintainers; [
-      sander
       raskin
     ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/ei/eigen2/package.nix
+++ b/pkgs/by-name/ei/eigen2/package.nix
@@ -27,7 +27,6 @@ stdenv.mkDerivation rec {
     description = "C++ template library for linear algebra: vectors, matrices, and related algorithms";
     license = licenses.lgpl3Plus;
     maintainers = with maintainers; [
-      sander
       raskin
     ];
     platforms = platforms.unix;

--- a/pkgs/by-name/ei/eigen_3_4_0/package.nix
+++ b/pkgs/by-name/ei/eigen_3_4_0/package.nix
@@ -41,7 +41,6 @@ stdenv.mkDerivation rec {
     description = "C++ template library for linear algebra: vectors, matrices, and related algorithms";
     license = licenses.lgpl3Plus;
     maintainers = with maintainers; [
-      sander
       raskin
       pbsds
     ];

--- a/pkgs/by-name/ej/ejabberd/package.nix
+++ b/pkgs/by-name/ej/ejabberd/package.nix
@@ -221,7 +221,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.ejabberd.im";
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
-      sander
       chuangzhu
       toastal
     ];

--- a/pkgs/by-name/fr/freetts/package.nix
+++ b/pkgs/by-name/fr/freetts/package.nix
@@ -55,7 +55,6 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "http://freetts.sourceforge.net";
     license = lib.licenses.bsdOriginal;
-    maintainers = with lib.maintainers; [ sander ];
     sourceProvenance = with lib.sourceTypes; [
       fromSource
       binaryBytecode # jsapi.jar is bundled in a self-extracting shell-script

--- a/pkgs/by-name/fs/fsuae-launcher/package.nix
+++ b/pkgs/by-name/fs/fsuae-launcher/package.nix
@@ -56,9 +56,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Graphical front-end for the FS-UAE emulator";
     license = lib.licenses.gpl2Plus;
     mainProgram = "fs-uae-launcher";
-    maintainers = with lib.maintainers; [
-      sander
-    ];
     platforms = with lib.systems.inspect; patternLogicalAnd patterns.isx86 patterns.isLinux;
   };
 })

--- a/pkgs/by-name/ge/geoipjava/package.nix
+++ b/pkgs/by-name/ge/geoipjava/package.nix
@@ -28,7 +28,6 @@ stdenv.mkDerivation rec {
   meta = {
     description = "GeoIP Java API";
     license = lib.licenses.lgpl21Plus;
-    maintainers = [ lib.maintainers.sander ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/jb/jboss/package.nix
+++ b/pkgs/by-name/jb/jboss/package.nix
@@ -23,7 +23,6 @@ stdenv.mkDerivation rec {
     description = "Open Source J2EE application server";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.lgpl21;
-    maintainers = [ maintainers.sander ];
     platforms = platforms.unix;
     knownVulnerabilities = [
       "CVE-2015-7501: remote code execution in apache-commons-collections: InvokerTransformer during deserialisation"

--- a/pkgs/by-name/kr/krusader/package.nix
+++ b/pkgs/by-name/kr/krusader/package.nix
@@ -38,7 +38,6 @@ stdenv.mkDerivation rec {
     homepage = "http://www.krusader.org";
     description = "Norton/Total Commander clone for KDE";
     license = lib.licenses.gpl2Only;
-    maintainers = with lib.maintainers; [ sander ];
     mainProgram = "krusader";
   };
 }

--- a/pkgs/by-name/lh/lha/package.nix
+++ b/pkgs/by-name/lh/lha/package.nix
@@ -23,7 +23,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/jca02266/lha";
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [
-      sander
       momeemt
     ];
     # Some of the original LHa code has been rewritten and the current author

--- a/pkgs/by-name/lh/lhasa/package.nix
+++ b/pkgs/by-name/lh/lhasa/package.nix
@@ -22,7 +22,6 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.isc;
     homepage = "http://fragglet.github.io/lhasa";
-    maintainers = [ maintainers.sander ];
     mainProgram = "lha";
     platforms = platforms.unix;
   };

--- a/pkgs/by-name/li/libmatthew_java/package.nix
+++ b/pkgs/by-name/li/libmatthew_java/package.nix
@@ -21,7 +21,6 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     platforms = platforms.linux;
-    maintainers = [ maintainers.sander ];
     license = licenses.mit;
   };
 }

--- a/pkgs/by-name/li/libresample/package.nix
+++ b/pkgs/by-name/li/libresample/package.nix
@@ -58,7 +58,6 @@ stdenv.mkDerivation (finalAttrs: {
     sourceProvenance = [ lib.sourceTypes.fromSource ];
     platforms = lib.platforms.all;
     maintainers = [
-      lib.maintainers.sander
       lib.maintainers.emily
     ];
     mainProgram = "resample-sndfile";

--- a/pkgs/by-name/li/libssh/package.nix
+++ b/pkgs/by-name/li/libssh/package.nix
@@ -61,7 +61,6 @@ stdenv.mkDerivation rec {
     description = "SSH client library";
     homepage = "https://libssh.org";
     license = licenses.lgpl2Plus;
-    maintainers = with maintainers; [ sander ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/by-name/mc/mc/package.nix
+++ b/pkgs/by-name/mc/mc/package.nix
@@ -101,7 +101,6 @@ stdenv.mkDerivation rec {
     downloadPage = "https://ftp.osuosl.org/pub/midnightcommander/";
     homepage = "https://midnight-commander.org";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ sander ];
     platforms = platforms.linux ++ platforms.darwin;
     mainProgram = "mc";
   };

--- a/pkgs/by-name/mu/mupen64plus/package.nix
+++ b/pkgs/by-name/mu/mupen64plus/package.nix
@@ -56,7 +56,6 @@ stdenv.mkDerivation rec {
     description = "Nintendo 64 Emulator";
     license = licenses.gpl2Plus;
     homepage = "http://www.mupen64plus.org/";
-    maintainers = [ maintainers.sander ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "mupen64plus";
   };

--- a/pkgs/by-name/ne/netbeans/package.nix
+++ b/pkgs/by-name/ne/netbeans/package.nix
@@ -91,7 +91,6 @@ stdenv.mkDerivation {
       binaryNativeCode
     ];
     maintainers = with lib.maintainers; [
-      sander
       rszibele
       kashw2
     ];

--- a/pkgs/by-name/op/opencbm/package.nix
+++ b/pkgs/by-name/op/opencbm/package.nix
@@ -51,6 +51,5 @@ stdenv.mkDerivation rec {
     homepage = "https://spiro.trikaliotis.net/opencbm";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = [ maintainers.sander ];
   };
 }

--- a/pkgs/by-name/pn/pngout/package.nix
+++ b/pkgs/by-name/pn/pngout/package.nix
@@ -73,7 +73,6 @@ stdenv.mkDerivation {
     license = lib.licenses.unfreeRedistributable;
     homepage = "http://advsys.net/ken/utils.htm";
     platforms = lib.attrNames platforms;
-    maintainers = [ lib.maintainers.sander ];
     mainProgram = "pngout";
   };
 }

--- a/pkgs/by-name/ro/rott/package.nix
+++ b/pkgs/by-name/ro/rott/package.nix
@@ -75,7 +75,6 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "rott";
     homepage = "https://icculus.org/rott/";
     license = with lib.licenses; [ gpl2Plus ] ++ lib.optional withSharewareData unfreeRedistributable;
-    maintainers = with lib.maintainers; [ sander ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/vi/vice/package.nix
+++ b/pkgs/by-name/vi/vice/package.nix
@@ -87,7 +87,6 @@ stdenv.mkDerivation rec {
     description = "Emulators for a variety of 8-bit Commodore computers";
     homepage = "https://vice-emu.sourceforge.io/";
     license = lib.licenses.gpl2Plus;
-    maintainers = [ lib.maintainers.sander ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/xp/xplanet/package.nix
+++ b/pkgs/by-name/xp/xplanet/package.nix
@@ -55,7 +55,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     maintainers = with maintainers; [
       lassulus
-      sander
     ];
     platforms = platforms.all;
   };

--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -203,6 +203,5 @@ buildPythonPackage rec {
     homepage = "https://riverbankcomputing.com/";
     license = licenses.gpl3Only;
     inherit (mesa.meta) platforms;
-    maintainers = with maintainers; [ sander ];
   };
 }

--- a/pkgs/development/python-modules/pyqt/sip.nix
+++ b/pkgs/development/python-modules/pyqt/sip.nix
@@ -26,6 +26,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/Python-SIP/sip";
     license = licenses.gpl3Only;
     inherit (mesa.meta) platforms;
-    maintainers = with maintainers; [ sander ];
   };
 }

--- a/pkgs/development/python-modules/sip/4.x.nix
+++ b/pkgs/development/python-modules/sip/4.x.nix
@@ -64,7 +64,6 @@ buildPythonPackage rec {
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [
       lovek323
-      sander
     ];
     platforms = platforms.all;
   };

--- a/pkgs/servers/felix/default.nix
+++ b/pkgs/servers/felix/default.nix
@@ -22,7 +22,6 @@ stdenv.mkDerivation rec {
     homepage = "https://felix.apache.org";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.asl20;
-    maintainers = [ maintainers.sander ];
     mainProgram = "felix.jar";
   };
 }

--- a/pkgs/tools/compression/kzipmix/default.nix
+++ b/pkgs/tools/compression/kzipmix/default.nix
@@ -26,6 +26,5 @@ stdenv.mkDerivation rec {
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     homepage = "http://advsys.net/ken/utils.htm";
-    maintainers = [ maintainers.sander ];
   };
 }

--- a/pkgs/tools/compression/xz/default.nix
+++ b/pkgs/tools/compression/xz/default.nix
@@ -98,7 +98,6 @@ stdenv.mkDerivation (finalAttrs: {
       gpl2Plus
       lgpl21Plus
     ];
-    maintainers = with maintainers; [ sander ];
     platforms = platforms.all;
     pkgConfigModules = [ "liblzma" ];
   };

--- a/pkgs/tools/package-management/disnix/default.nix
+++ b/pkgs/tools/package-management/disnix/default.nix
@@ -47,7 +47,6 @@ stdenv.mkDerivation rec {
     description = "Nix-based distributed service deployment tool";
     license = lib.licenses.lgpl21Plus;
     maintainers = with lib.maintainers; [
-      sander
       tomberek
     ];
     platforms = lib.platforms.unix;

--- a/pkgs/tools/package-management/disnix/dysnomia/default.nix
+++ b/pkgs/tools/package-management/disnix/dysnomia/default.nix
@@ -103,7 +103,6 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Automated deployment of mutable components and services for Disnix";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.sander ];
     platforms = lib.platforms.unix;
   };
 }


### PR DESCRIPTION
Inactive since at least 2024. Was removed as commmiter for inactivity a while ago. No reaction to maintainer pings for quite some time.

Dropping according to maintainer guidelines: https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status

Technically, @svanderburg has 7 days to respond and mention why they'd like to stay maintainer. Practically, we could just revert if that's the case. They did not react to https://github.com/NixOS/nixpkgs-committers/pull/18 or https://github.com/NixOS/nixpkgs/pull/283978, so I think it's safe to merge right away.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
