### PR TITLE
vscode-extensions.prettier.prettier-vscode: init at 12.0.7

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -3762,6 +3762,8 @@ let
         };
       };
 
+      prettier.prettier-vscode = callPackage ./prettier.prettier-vscode { };
+
       prince781.vala = callPackage ./prince781.vala { };
 
       prisma.prisma = buildVscodeMarketplaceExtension {

--- a/pkgs/applications/editors/vscode/extensions/prettier.prettier-vscode/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/prettier.prettier-vscode/default.nix
@@ -1,0 +1,89 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  libsecret,
+  nodejs,
+  npmHooks,
+  pkg-config,
+  clang_20,
+  vscode-utils,
+  nix-update-script,
+}:
+
+let
+  vsix = stdenv.mkDerivation (finalAttrs: {
+    name = "prettier-vscode-${finalAttrs.version}.vsix";
+    pname = "prettier-vscode-vsix";
+    version = "12.0.7";
+
+    src = fetchFromGitHub {
+      owner = "prettier";
+      repo = "prettier-vscode";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-pbUvgchOEWgBm0D5wdAPMfHouFdHZPEvCChD9JJf4Xk=";
+    };
+
+    npmDeps = fetchNpmDeps {
+      name = "${finalAttrs.pname}-npm-deps";
+      inherit (finalAttrs) src;
+      hash = "sha256-VcJ3mzuspML2z3EzAUi21tavPtI62/Jo3X8swnMXwOs=";
+    };
+
+    buildInputs = lib.optionals stdenv.isLinux [
+      libsecret
+    ];
+
+    nativeBuildInputs = [
+      nodejs
+      nodejs.python
+      npmHooks.npmConfigHook
+    ]
+    ++ lib.optionals stdenv.isLinux [
+      pkg-config
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      clang_20 # clang_21 breaks @vscode/vsce's optional dependency keytar
+    ];
+
+    strictDeps = true;
+
+    env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
+
+    buildPhase = ''
+      runHook preBuild
+
+      node --run compile
+      npx @vscode/vsce package --out $out
+
+      runHook postBuild
+    '';
+  });
+in
+vscode-utils.buildVscodeExtension (finalAttrs: {
+  pname = "prettier-vscode";
+  inherit (finalAttrs.src) version;
+
+  vscodeExtPublisher = "prettier";
+  vscodeExtName = "prettier-vscode";
+  vscodeExtUniqueId = "${finalAttrs.vscodeExtPublisher}.${finalAttrs.vscodeExtName}";
+
+  src = vsix;
+
+  passthru = {
+    vsix = finalAttrs.src;
+    updateScript = nix-update-script {
+      attrPath = "vscode-extensions.prettier.prettier-vscode.vsix";
+    };
+  };
+
+  meta = {
+    changelog = "https://marketplace.visualstudio.com/items/Prettier.prettier-vscode/changelog";
+    description = "Visual Studio Code extension for Prettier";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=Prettier.prettier-vscode";
+    homepage = "https://github.com/prettier/prettier-vscode";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ xiaoxiangmoe ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
