### PR TITLE
dbus-cpp: 5.0.5 -> 5.0.6

### DIFF
--- a/pkgs/by-name/db/dbus-cpp/package.nix
+++ b/pkgs/by-name/db/dbus-cpp/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitLab,
   gitUpdater,
   testers,
-  boost186,
+  boost,
   cmake,
   ctestCheckHook,
   dbus,
@@ -63,7 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    boost186 # uses boost/asio/io_service.hpp
+    boost
     lomiri.cmake-extras
     dbus
     libxml2

--- a/pkgs/by-name/db/dbus-cpp/package.nix
+++ b/pkgs/by-name/db/dbus-cpp/package.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  fetchpatch2,
   gitUpdater,
   testers,
   boost186,
@@ -21,13 +20,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "dbus-cpp";
-  version = "5.0.5";
+  version = "5.0.6";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/lib-cpp/dbus-cpp";
     tag = finalAttrs.version;
-    hash = "sha256-+QqmZsBFmYRwaAFqRyMBxVFFrjZGBDdMaW4YD/7D2gU=";
+    hash = "sha256-ehP+QW/tTR6tLHEiWGDbiYT9oAqlS346UaVTkJC5bSE=";
   };
 
   outputs = [
@@ -35,16 +34,6 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
     "doc"
     "examples"
-  ];
-
-  patches = [
-    # Provide more information when there's an issue in AsyncExecutionLoadTest.RepeatedlyInvokingAnAsyncFunctionWorks
-    # Remove when version > 5.0.5
-    (fetchpatch2 {
-      name = "0001-dbus-cpp-tests-async_execution_load_test-Print-received-error-on-DBus-method-failure.name";
-      url = "https://gitlab.com/ubports/development/core/lib-cpp/dbus-cpp/-/commit/8390ce83153c2ae29f21afd2bf5e79e88c59e6d9.diff";
-      hash = "sha256-js2nXT7eG9dcX+yoFMNRVlamQxsbJclmKTX6/5RxxM4=";
-    })
   ];
 
   postPatch = ''
@@ -101,6 +90,9 @@ stdenv.mkDerivation (finalAttrs: {
   enableParallelChecking = false;
 
   disabledTests = [
+    # Flaky flaky flaky. Spams D-Bus with hundreds of requests, and if any is dropped, the test fails.
+    "async_execution_load_test"
+
     # Possible memory corruption in Executor.TimeoutsAreHandledCorrectly
     # https://gitlab.com/ubports/development/core/lib-cpp/dbus-cpp/-/issues/10
     "executor_test"
@@ -113,9 +105,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     tests.pkg-config = testers.hasPkgConfigModules {
       package = finalAttrs.finalPackage;
-      # Not bumped for 5.0.5: https://gitlab.com/ubports/development/core/lib-cpp/dbus-cpp/-/issues/9
-      # Try again on next bump.
-      versionCheck = finalAttrs.version != "5.0.5";
+      versionCheck = true;
     };
     updateScript = gitUpdater { };
   };

--- a/pkgs/desktops/lomiri/development/trust-store/default.nix
+++ b/pkgs/desktops/lomiri/development/trust-store/default.nix
@@ -5,8 +5,8 @@
   fetchpatch,
   gitUpdater,
   testers,
-  # dbus-cpp not compatible with Boost 1.87
-  # https://gitlab.com/ubports/development/core/lib-cpp/dbus-cpp/-/issues/8
+  # Uses boost/asio/io_service.hpp
+  # Waiting for https://gitlab.com/ubports/development/core/trust-store/-/merge_requests/19 to get finished & merged
   boost186,
   cmake,
   cmake-extras,

--- a/pkgs/desktops/lomiri/services/mediascanner2/default.nix
+++ b/pkgs/desktops/lomiri/services/mediascanner2/default.nix
@@ -5,9 +5,7 @@
   gitUpdater,
   nixosTests,
   testers,
-  # dbus-cpp not compatible with Boost 1.87
-  # https://gitlab.com/ubports/development/core/lib-cpp/dbus-cpp/-/issues/8
-  boost186,
+  boost,
   cmake,
   cmake-extras,
   dbus,
@@ -60,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    boost186
+    boost
     cmake-extras
     dbus
     dbus-cpp


### PR DESCRIPTION
https://gitlab.com/ubports/development/core/lib-cpp/dbus-cpp/-/blob/5.0.6/ChangeLog

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
