### PR TITLE
process-cpp: 3.0.2 -> 3.0.3

### DIFF
--- a/pkgs/by-name/pr/process-cpp/package.nix
+++ b/pkgs/by-name/pr/process-cpp/package.nix
@@ -2,43 +2,38 @@
   lib,
   stdenv,
   fetchFromGitLab,
-  fetchpatch2,
   testers,
   gitUpdater,
+  boost,
   cmake,
   coreutils,
-  boost,
+  doxygen,
+  graphviz,
   gtest,
   lomiri,
   properties-cpp,
   pkg-config,
+  withDocumentation ? true,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "process-cpp";
-  version = "3.0.2";
+  version = "3.0.3";
 
   src = fetchFromGitLab {
     domain = "gitlab.com";
     owner = "ubports";
     repo = "development/core/lib-cpp/process-cpp";
     rev = finalAttrs.version;
-    hash = "sha256-UCNmD5Ea2wnEwG9gkt88TaX0vfS4SCaIOPRMeNFx80Y=";
+    hash = "sha256-PmlgzCEvBPC0k/pU6xneKINOGAas+hDWIrWUEkj+rDU=";
   };
 
   outputs = [
     "out"
     "dev"
-  ];
-
-  patches = [
-    # Fix compat with CMake 4
-    # Remove when version > 3.0.2
-    (fetchpatch2 {
-      name = "0001-process-cpp-Bump-cmake_minimum_required-to-version-3.10.patch";
-      url = "https://gitlab.com/ubports/development/core/lib-cpp/process-cpp/-/commit/c374b62cb79d668505c1c8dc55edddc938a573ba.diff";
-      hash = "sha256-2H6f+EAR7p4mb0ReNl8LaosPVF/CNRm+PiYV7tkOQ/w=";
-    })
+  ]
+  ++ lib.optionals withDocumentation [
+    "doc"
   ];
 
   postPatch = ''
@@ -56,6 +51,10 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     pkg-config
+  ]
+  ++ lib.optionals withDocumentation [
+    doxygen
+    graphviz
   ];
 
   buildInputs = [
@@ -66,7 +65,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   checkInputs = [ gtest ];
 
-  cmakeFlags = [ (lib.cmakeBool "BUILD_TESTING" finalAttrs.finalPackage.doCheck) ];
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_TESTING" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeBool "PROCESS_CPP_ENABLE_DOC_GENERATION" withDocumentation)
+  ];
 
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 


### PR DESCRIPTION
https://gitlab.com/ubports/development/core/lib-cpp/process-cpp/-/blob/3.0.3/ChangeLog

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
