### PR TITLE
cc-wrapper: set gl_cv_clean_version_stddef=yes on cygwin

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -603,6 +603,10 @@ stdenvNoCC.mkDerivation {
         if targetPlatform.isCygwin then
           ''
             echo addToSearchPath "LINK_DLL_FOLDERS" "${cc_bin}/lib" >> $out
+            # Work around build failure caused by the gnulib workaround for
+            # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114870. remove after
+            # gnulib is updated in core packages (e.g. iconv, gnupatch, gnugrep)
+            echo appendToVar configureFlags gl_cv_clean_version_stddef=yes >> $out
           ''
         else
           ''

--- a/pkgs/development/libraries/libidn2/default.nix
+++ b/pkgs/development/libraries/libidn2/default.nix
@@ -44,12 +44,6 @@ stdenv.mkDerivation rec {
   buildInputs = [ libunistring ] ++ lib.optional stdenv.hostPlatform.isDarwin libiconv;
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
-  configureFlags =
-    # Work around build failure caused by the gnulib workaround for
-    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114870.
-    # remove after gnulib is updated
-    lib.optional stdenv.hostPlatform.isCygwin "gl_cv_clean_version_stddef=yes";
-
   meta = {
     homepage = "https://www.gnu.org/software/libidn/#libidn2";
     description = "Free software implementation of IDNA2008 and TR46";

--- a/pkgs/tools/text/gnugrep/default.nix
+++ b/pkgs/tools/text/gnugrep/default.nix
@@ -80,11 +80,6 @@ stdenv.mkDerivation {
     export MKDIR_P="mkdir -p"
   '';
 
-  configureFlags =
-    # Work around build failure caused by the gnulib workaround for
-    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114870. remove after GCC 15
-    lib.optional stdenv.hostPlatform.isCygwin "gl_cv_clean_version_stddef=yes";
-
   enableParallelBuilding = true;
 
   # Fix reference to sh in bootstrap-tools, and invoke grep via


### PR DESCRIPTION
This fixes errors such as:

> error: unknown type name ‘wint_t’


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
