### PR TITLE
libkate: remove extra slash from src.domain

### DIFF
--- a/pkgs/by-name/li/libkate/package.nix
+++ b/pkgs/by-name/li/libkate/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.4.3";
 
   src = fetchFromGitLab {
-    domain = "gitlab.xiph.org/";
+    domain = "gitlab.xiph.org";
     owner = "xiph";
     repo = "kate";
     tag = "kate-${finalAttrs.version}";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I'm building with `config.fetchedSourceNameDefault` set to `full`. For some reason, it's failing to pull the source. `nix log`-ing it gives:

```
trying https://gitlab.xiph.org//api/v4/projects/xiph%2Fkate/repository/archive.tar.gz?sha=refs%2Ftags%2Fkate-0.4.3
% Total % Received % Xferd Average Speed Time Time Time Current

Dload Upload Total Spent Left Speed^M 0 0 0 0 0 0 0 0 --:--:-- --:--:-- --:--:-- 0^M100 120 100 120 0 0 264 0 --:--:-- --:--:-- --:--:-- 265^M 0 0 0 0 0 0 0 0 --:--:-- --:--:-- --:--:-- 0

curl: (22) SSL certificate OpenSSL verify result: unable to get local issuer certificate (20)

Warning: Problem (retrying all errors). Will retry in 1 second. 3 retries left.^M 0 0 0 0 0 0 0 0 --:--:-- --:--:-- --:--:-- 0^M100 120 100 120 0 0 1106 0 --:--:-- --:--:-- --:--:-- 1111^M 0 0 0 0 0 0 0 0 --:--:-- --:--:-- --:--:-- 0

curl: (22) The requested URL returned error: 404

Warning: Problem (retrying all errors). Will retry in 2 seconds. 2 retries

Warning: left.^M 0 0 0 0 0 0 0 0 --:--:-- --:--:-- --:--:-- 0^M100 120 100 120 0 0 1078 0 --:--:-- --:--:-- --:--:-- 1081^M 0 0 0 0 0 0 0 0 --:--:-- --:--:-- --:--:-- 0

curl: (22) The requested URL returned error: 404

Warning: Problem (retrying all errors). Will retry in 4 seconds. 1 retry left.^M 0 0 0 0 0 0 0 0 --:--:-- --:--:-- --:--:-- 0^M100 120 100 120 0 0 1090 0 --:--:-- --:--:-- --:--:-- 1090^M 0 0 0 0 0 0 0 0 --:--:-- --:--:-- --:--:-- 0

curl: (22) The requested URL returned error: 404

error: cannot download kate-0.4.3-gitlab-source from any mirror
```

deleting the `/` fixes it for me. I'm really sure how this ever worked?

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
