### PR TITLE
nixos/various: use `sessionVariables` for graphical-related settings

### DIFF
--- a/nixos/modules/config/qt.nix
+++ b/nixos/modules/config/qt.nix
@@ -211,7 +211,7 @@ in
         }
       ];
 
-    environment.variables = {
+    environment.sessionVariables = {
       QT_QPA_PLATFORMTHEME = lib.mkIf (cfg.platformTheme != null) cfg.platformTheme;
       QT_STYLE_OVERRIDE = lib.mkIf (cfg.style != null) cfg.style;
     };

--- a/nixos/modules/i18n/input-method/fcitx5.nix
+++ b/nixos/modules/i18n/input-method/fcitx5.nix
@@ -137,17 +137,18 @@ in
         ) cfg.settings.addons)
       ];
 
-    environment.variables = {
-      XMODIFIERS = "@im=fcitx";
-      QT_PLUGIN_PATH = [ "${fcitx5Package}/${pkgs.qt6.qtbase.qtPluginPrefix}" ];
-    }
-    // lib.optionalAttrs (!cfg.waylandFrontend) {
-      GTK_IM_MODULE = "fcitx";
-      QT_IM_MODULE = "fcitx";
-    };
-
-    environment.sessionVariables = lib.mkIf cfg.ignoreUserConfig {
-      SKIP_FCITX_USER_PATH = "1";
-    };
+    environment.sessionVariables = lib.mkMerge [
+      {
+        XMODIFIERS = "@im=fcitx";
+        QT_PLUGIN_PATH = [ "${fcitx5Package}/${pkgs.qt6.qtbase.qtPluginPrefix}" ];
+      }
+      (lib.optionalAttrs (!cfg.waylandFrontend) {
+        GTK_IM_MODULE = "fcitx";
+        QT_IM_MODULE = "fcitx";
+      })
+      (lib.mkIf cfg.ignoreUserConfig {
+        SKIP_FCITX_USER_PATH = "1";
+      })
+    ];
   };
 }

--- a/nixos/modules/i18n/input-method/hime.nix
+++ b/nixos/modules/i18n/input-method/hime.nix
@@ -10,7 +10,7 @@ in
 {
   config = lib.mkIf (imcfg.enable && imcfg.type == "hime") {
     i18n.inputMethod.package = pkgs.hime;
-    environment.variables = {
+    environment.sessionVariables = {
       GTK_IM_MODULE = "hime";
       QT_IM_MODULE = "hime";
       XMODIFIERS = "@im=hime";

--- a/nixos/modules/i18n/input-method/ibus.nix
+++ b/nixos/modules/i18n/input-method/ibus.nix
@@ -84,13 +84,15 @@ in
       ibusPackage
     ];
 
-    environment.variables = {
-      XMODIFIERS = "@im=ibus";
-    }
-    // lib.optionalAttrs (!cfg.waylandFrontend) {
-      GTK_IM_MODULE = "ibus";
-      QT_IM_MODULE = "ibus";
-    };
+    environment.sessionVariables = lib.mkMerge [
+      {
+        XMODIFIERS = "@im=ibus";
+      }
+      (lib.optionalAttrs (!cfg.waylandFrontend) {
+        GTK_IM_MODULE = "ibus";
+        QT_IM_MODULE = "ibus";
+      })
+    ];
 
     xdg.portal.extraPortals = lib.mkIf config.xdg.portal.enable [
       ibusPackage

--- a/nixos/modules/i18n/input-method/kime.nix
+++ b/nixos/modules/i18n/input-method/kime.nix
@@ -63,7 +63,7 @@ in
   config = lib.mkIf (imcfg.enable && imcfg.type == "kime") {
     i18n.inputMethod.package = pkgs.kime;
 
-    environment.variables = {
+    environment.sessionVariables = {
       GTK_IM_MODULE = "kime";
       QT_IM_MODULE = "kime";
       XMODIFIERS = "@im=kime";

--- a/nixos/modules/i18n/input-method/nabi.nix
+++ b/nixos/modules/i18n/input-method/nabi.nix
@@ -11,7 +11,7 @@ in
   config = lib.mkIf (imcfg.enable && imcfg.type == "nabi") {
     i18n.inputMethod.package = pkgs.nabi;
 
-    environment.variables = {
+    environment.sessionVariables = {
       GTK_IM_MODULE = "nabi";
       QT_IM_MODULE = "nabi";
       XMODIFIERS = "@im=nabi";

--- a/nixos/modules/i18n/input-method/uim.nix
+++ b/nixos/modules/i18n/input-method/uim.nix
@@ -33,7 +33,7 @@ in
   config = lib.mkIf (imcfg.enable && imcfg.type == "uim") {
     i18n.inputMethod.package = pkgs.uim;
 
-    environment.variables = {
+    environment.sessionVariables = {
       GTK_IM_MODULE = "uim";
       QT_IM_MODULE = "uim";
       XMODIFIERS = "@im=uim";

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-calamares-gnome.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-calamares-gnome.nix
@@ -31,7 +31,7 @@
   };
 
   # Fix scaling for calamares on wayland
-  environment.variables = {
+  environment.sessionVariables = {
     QT_QPA_PLATFORM = "$([[ $XDG_SESSION_TYPE = \"wayland\" ]] && echo \"wayland\")";
   };
 

--- a/nixos/modules/programs/plotinus.nix
+++ b/nixos/modules/programs/plotinus.nix
@@ -33,9 +33,11 @@ in
   ###### implementation
 
   config = lib.mkIf cfg.enable {
-    environment.sessionVariables.XDG_DATA_DIRS = [
-      "${pkgs.plotinus}/share/gsettings-schemas/${pkgs.plotinus.name}"
-    ];
-    environment.variables.GTK3_MODULES = [ "${pkgs.plotinus}/lib/libplotinus.so" ];
+    environment.sessionVariables = {
+      XDG_DATA_DIRS = [
+        "${pkgs.plotinus}/share/gsettings-schemas/${pkgs.plotinus.name}"
+      ];
+      GTK3_MODULES = [ "${pkgs.plotinus}/lib/libplotinus.so" ];
+    };
   };
 }

--- a/nixos/modules/programs/ssh.nix
+++ b/nixos/modules/programs/ssh.nix
@@ -403,7 +403,7 @@ in
       fi
     '';
 
-    environment.variables.SSH_ASKPASS = lib.optionalString cfg.enableAskPassword cfg.askPassword;
+    environment.sessionVariables.SSH_ASKPASS = lib.optionalString cfg.enableAskPassword cfg.askPassword;
 
   };
 }

--- a/nixos/modules/programs/ydotool.nix
+++ b/nixos/modules/programs/ydotool.nix
@@ -41,7 +41,7 @@ in
           Group = config.programs.ydotool.group;
           RuntimeDirectory = runtimeDirectory;
           RuntimeDirectoryMode = "0750";
-          ExecStart = "${lib.getExe' pkgs.ydotool "ydotoold"} --socket-path=${config.environment.variables.YDOTOOL_SOCKET} --socket-perm=0660";
+          ExecStart = "${lib.getExe' pkgs.ydotool "ydotoold"} --socket-path=${config.environment.sessionVariables.YDOTOOL_SOCKET} --socket-perm=0660";
 
           # hardening
 
@@ -85,7 +85,7 @@ in
         };
       };
 
-      environment.variables = {
+      environment.sessionVariables = {
         YDOTOOL_SOCKET = "/run/${runtimeDirectory}/socket";
       };
       environment.systemPackages = with pkgs; [ ydotool ];


### PR DESCRIPTION
This'll make graphics-related variables (mostly GTK and QT stuff) get set in desktops launched from login managers[^1]

[^1]: i hope i'm not misunderstanding `sessionVariables` vs `variables`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
