### PR TITLE
{libgdstk,python3Packages.gdstk}: init at 0.9.61

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9668,6 +9668,12 @@
     githubId = 58785758;
     name = "Tim Lanzinger";
   };
+  gonsolo = {
+    email = "gonsolo@gmail.com";
+    github = "gonsolo";
+    githubId = 2041764;
+    name = "Andreas Wendleder";
+  };
   Gonzih = {
     email = "gonzih@gmail.com";
     github = "Gonzih";

--- a/pkgs/by-name/li/libgdstk/package.nix
+++ b/pkgs/by-name/li/libgdstk/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+
+  # build-time deps
+  cmake,
+  ninja,
+
+  # run-time deps
+  zlib,
+  qhull,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libgdstk";
+  version = "0.9.61";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "heitzmann";
+    repo = "gdstk";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-soU+6EbyOkHGvVq230twiRzywOskhkkXFr5akBpvgBw=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  buildInputs = [
+    zlib
+    qhull
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "C++/Python library for creation and manipulation of GDSII and OASIS files";
+    homepage = "https://github.com/heitzmann/gdstk";
+    changelog = "https://github.com/heitzmann/gdstk/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.boost;
+    maintainers = with lib.maintainers; [
+      eljamm
+      gonsolo
+    ];
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/development/python-modules/gdstk/default.nix
+++ b/pkgs/development/python-modules/gdstk/default.nix
@@ -1,0 +1,93 @@
+{
+  lib,
+  buildPythonPackage,
+  libgdstk,
+
+  # build-system
+  build,
+  scikit-build-core,
+
+  # deps
+  numpy,
+  typing-extensions,
+
+  # deps (optional)
+  matplotlib,
+  sphinx,
+  sphinx-inline-tabs,
+  sphinx-rtd-theme,
+
+  # build-time
+  cmake,
+  ninja,
+
+  # run-time
+  zlib,
+  qhull,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage {
+  pname = "gdstk";
+  inherit (libgdstk) src version;
+
+  pyproject = true;
+  strictDeps = true;
+
+  # scikit is supposed to handle the module build
+  dontUseCmakeConfigure = true;
+
+  build-system = [
+    build
+    cmake
+    ninja
+    numpy
+    scikit-build-core
+  ];
+
+  dependencies = [
+    numpy
+    typing-extensions
+  ];
+
+  optional-dependencies = {
+    docs = [
+      matplotlib
+      sphinx
+      sphinx-inline-tabs
+      sphinx-rtd-theme
+    ];
+  };
+
+  buildInputs = [
+    zlib
+    qhull
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  # remove the `gdstk` source directory, else pytest will attempt to import it
+  # instead of the actual module
+  preCheck = ''
+    rm -rf gdstk
+  '';
+
+  pythonImportsCheck = [
+    "gdstk"
+  ];
+
+  meta = {
+    inherit (libgdstk.meta)
+      description
+      homepage
+      changelog
+      license
+      maintainers
+      teams
+      ;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5881,6 +5881,8 @@ self: super: with self; {
 
   gdsfactory = callPackage ../development/python-modules/gdsfactory { };
 
+  gdstk = callPackage ../development/python-modules/gdstk { };
+
   ge25519 = callPackage ../development/python-modules/ge25519 { };
 
   geant4 = toPythonModule (


### PR DESCRIPTION
[Gdstk (GDSII Tool Kit)](https://github.com/heitzmann/gdstk) is a C++/Python library for creation and manipulation of GDSII and OASIS files.

**Note:** It's possible to package the python module and cpp library together, which felt a bit hacky, so I've oped to split them, instead.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
