### PR TITLE
nixos/man-db: Use `-q` option to decrease verbosity

### DIFF
--- a/nixos/modules/misc/man-db.nix
+++ b/nixos/modules/misc/man-db.nix
@@ -86,7 +86,7 @@ in
             }
             ''
               echo "MANDB_MAP ${cfg.manualPages}/share/man $out" > man.conf
-              mandb -C man.conf -psc >/dev/null 2>&1
+              mandb -C man.conf -pscq
             '';
       in
       ''


### PR DESCRIPTION
This reverts commit 87d614441d51da42d4d7102155e4535c64f8c1df (https://github.com/NixOS/nixpkgs/pull/105829).

I don't think silencing all output from the man-cache build is a correct solution to "people are unnerved by seeing warnings in build logs". _Many_ builds print warnings: perhaps we should rather encourage tools to avoid showing logs unless the build actually fails (e.g. https://github.com/maralorn/nix-output-monitor/issues/59).

Less abstractly, the redirect to /dev/null made it extremely frustrating for me to diagnose a genuine build failure of man-cache, and I spent a long time trying to work out if the builder was not printing an error because it ran out of disk or memory. The following error is printed by `mandb`, but the redirect hides all but the "failed with exit code 2" line.

```
man-cache> Processing manual pages under /usr/local/man...
man-cache> /nix/store/7kv7jjn3y7g2lvajn5b41qsdahvcx2ay-man-db-2.13.1/bin/mandb: warning: cannot create catdir /var/cache/man/oldlocal
man-cache> /nix/store/7kv7jjn3y7g2lvajn5b41qsdahvcx2ay-man-db-2.13.1/bin/mandb: can't create index cache /var/cache/man/oldlocal/98333: No such file or directory
error: builder for '/nix/store/y3qxp566az2x686y6c2qj531k8hhg14z-man-cache.drv' failed with exit code 2
```

Pinging author of the original PR @rnhmjoj as a courtesy.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
