### PR TITLE
nixosTests.lomiri-camera-app.v4l2-qr: Fix click on QR button

### DIFF
--- a/nixos/tests/lomiri-camera-app.nix
+++ b/nixos/tests/lomiri-camera-app.nix
@@ -244,12 +244,12 @@ in
             machine.send_key("alt-f10")
             machine.sleep(5)
             machine.wait_for_text("${feedLabel}")
-            machine.succeed("xdotool mousemove 510 670 click 1") # open up QR decode result
+            machine.succeed("xdotool mousemove 510 720 click 1") # open up QR decode result
 
             # OCR is struggling to recognise the text. Click the clipboard button, check what got copied
             machine.sleep(5)
             machine.screenshot("lomiri-barcode_decode")
-            machine.succeed("xdotool mousemove 540 590 click 1")
+            machine.succeed("xdotool mousemove 540 640 click 1")
             machine.wait_until_succeeds("env DISPLAY=:0 xclip -selection clipboard -o | grep -q '${feedQrContent}'")
       '';
     }


### PR DESCRIPTION
Button is fixed relative to the bottom of the window. IceWM task bar in the VM setup was removed in #456757, so the button & its menu moved further down.

#456757 is in 25.11, so needs a backport to stable.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
