### PR TITLE
Revert "libcosmicAppHook: use RUSTFLAGS instead of platform specific flags"

### DIFF
--- a/pkgs/by-name/li/libcosmicAppHook/libcosmic-app-hook.sh
+++ b/pkgs/by-name/li/libcosmicAppHook/libcosmic-app-hook.sh
@@ -15,11 +15,7 @@ libcosmicAppVergenHook() {
 
 libcosmicAppLinkerArgsHook() {
   # Force linking to certain libraries like libEGL, which are always dlopen()ed
-  # local flags="CARGO_TARGET_@cargoLinkerVar@_RUSTFLAGS"
-
-  # Temporarily use this simpler solution, it should work for simple cross compilation
-  # https://github.com/NixOS/nixpkgs/issues/464392
-  local flags="RUSTFLAGS"
+  local flags="CARGO_TARGET_@cargoLinkerVar@_RUSTFLAGS"
 
   export "$flags"="${!flags-} -C link-arg=-Wl,--push-state,--no-as-needed"
   # shellcheck disable=SC2043

--- a/pkgs/by-name/li/libcosmicAppHook/package.nix
+++ b/pkgs/by-name/li/libcosmicAppHook/package.nix
@@ -55,10 +55,7 @@ makeSetupHook {
       lib.makeSearchPath "share" (
         lib.optionals includeSettings [ fallbackThemes ] ++ [ targetPackages.cosmic-icons ]
       );
-    # Temporarily using RUSTFLAGS: https://github.com/NixOS/nixpkgs/issues/464392
-    # See ./libcosmic-app-hook.sh
-    # cargoLinkerVar = targetPackages.stdenv.hostPlatform.rust.cargoEnvVarTarget;
-
+    cargoLinkerVar = targetPackages.stdenv.hostPlatform.rust.cargoEnvVarTarget;
     # force linking for all libraries that may be dlopen'd by libcosmic/iced apps
     cargoLinkLibs = lib.escapeShellArgs (
       [


### PR DESCRIPTION
This reverts commit d2c62217d3748a3ff8ac8d6c9281cb05f92ae641.

This is no longer needed in staging due to the proper fix https://github.com/NixOS/nixpkgs/pull/464707 having been merged

See also https://github.com/NixOS/nixpkgs/pull/467552#issuecomment-3618522894

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
