### PR TITLE
pipewire: 1.4.9 -> 1.5.84

### DIFF
--- a/pkgs/by-name/pa/pastel/package.nix
+++ b/pkgs/by-name/pa/pastel/package.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "pastel";
-  version = "0.10.0";
+  version = "0.11.0";
 
   src = fetchFromGitHub {
     owner = "sharkdp";
     repo = "pastel";
     rev = "v${version}";
-    sha256 = "sha256-kr2aLRd143ksVx42ZDO/NILydObinn3AwPCniXVVmY0=";
+    sha256 = "sha256-ISzZZNh9X91vBbVOpYXnYpO3ztGgIhMJTZmoY2T0FRw=";
   };
 
-  cargoHash = "sha256-u+1KDcC2KGqvmOk6k7hOHE16TMvDg92eMOdNMQQszug=";
+  cargoHash = "sha256-r0QiooMrTqFaXq2Y9wVW45zjtHT7qQ6XTWPRhlLpVQ8=";
 
   meta = {
     description = "Command-line tool to generate, analyze, convert and manipulate colors";

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -77,7 +77,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pipewire";
-  version = "1.4.9";
+  version = "1.5.84";
 
   outputs = [
     "out"
@@ -93,7 +93,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "pipewire";
     repo = "pipewire";
     rev = finalAttrs.version;
-    sha256 = "sha256-380KY17l6scVchZAoSHswTvceYl427e79eU11JQallc=";
+    sha256 = "sha256-+ZIBXFwzETHNflboEBdPlHrg4lLDg0rnrcIpos4Z4a0=";
   };
 
   patches = [
@@ -204,7 +204,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonEnable "avb" stdenv.hostPlatform.isLinux)
     (lib.mesonEnable "v4l2" stdenv.hostPlatform.isLinux)
     (lib.mesonEnable "pipewire-v4l2" stdenv.hostPlatform.isLinux)
-    (lib.mesonEnable "systemd" enableSystemd)
+    (lib.mesonEnable "libsystemd" enableSystemd)
     (lib.mesonEnable "systemd-system-service" enableSystemd)
     (lib.mesonEnable "udev" (!enableSystemd && stdenv.hostPlatform.isLinux))
     (lib.mesonEnable "ffmpeg" true)
@@ -219,6 +219,9 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonEnable "bluez5-codec-lc3plus" false)
     (lib.mesonEnable "bluez5-codec-lc3" bluezSupport)
     (lib.mesonEnable "bluez5-codec-ldac" (bluezSupport && ldacbtSupport))
+    (lib.mesonEnable "bluez5-codec-ldac-dec" false) # Wasn't included previously and was causing mason errors
+    (lib.mesonEnable "bluez5-plc-spandsp" false) # Same as above
+    (lib.mesonEnable "onnxruntime" false) # Same as above
     (lib.mesonEnable "opus" true)
     (lib.mesonOption "sysconfdir" "/etc")
     (lib.mesonEnable "raop" raopSupport)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelog: https://gitlab.freedesktop.org/pipewire/pipewire/-/releases/1.5.84

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Updated finalAttrs.version from `1.4.9` -> `1.5.84` and the hashes accordingly,
- Renamed meson option `systemd` -> `libsystemd` to match upstream changes,
- Disabled meson option `bluez5-codec-ldac-dec`(not previously enabled, requires separate library; `libldac`),
- Disabled meson option `bluez5-plc-spandsp`(not previously enabled, however, `spandsp` is in nixpkgs but wasn't used before),
- Disabled meson option `onnxruntime` (not previously enabled)

- Tested with:
    - `./result/bin/pipewire --version` ("Compiled with libpipewire 1.5.84 Linked with libpipewire 1.5.84")
    - `nix-build --attr pipewire.passthru.tests` passed 23/24. 
    The failing test `spa-benchmark-aec.test` requires sample files. Debian also skips this test (1.5.81). Should it be disabled in Nix as well?

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
