### PR TITLE
lomiri.morph-browser: 1.1.2 -> 1.99.1

### DIFF
--- a/pkgs/desktops/lomiri/applications/morph-browser/default.nix
+++ b/pkgs/desktops/lomiri/applications/morph-browser/default.nix
@@ -2,13 +2,13 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  fetchpatch2,
   gitUpdater,
   nixosTests,
   cmake,
   ctestCheckHook,
   gettext,
   libapparmor,
+  libpsl,
   lomiri-action-api,
   lomiri-content-hub,
   lomiri-ui-extras,
@@ -31,27 +31,18 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "morph-browser";
-  version = "1.99.0";
+  version = "1.99.1";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/morph-browser";
     tag = finalAttrs.version;
-    hash = "sha256-fuemZhBMtx6MiQGsdAlsRkK4uJJvIOjcSSc9Z1nGeXU=";
+    hash = "sha256-RCyauz7qBNzq7Aqr22NBSAgVSBsFpXpNb+aVo73CBQU=";
   };
 
   outputs = [
     "out"
     "doc"
-  ];
-
-  patches = [
-    # Fix an issue with asset installation & loading
-    # Remove when version > 1.99.0
-    (fetchpatch2 {
-      url = "https://gitlab.com/ubports/development/core/morph-browser/-/commit/512a7dceebd4665856c4877c02d5d01fd8411574.diff";
-      hash = "sha256-yincXEYXsfOJz7cpotD4OX90kwiDgk9E7FL1MP4iNuM=";
-    })
   ];
 
   postPatch = ''
@@ -86,6 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     libapparmor
+    libpsl
     qtbase
     qtdeclarative
     qtwebengine


### PR DESCRIPTION
https://gitlab.com/ubports/development/core/morph-browser/-/blob/1.99.0/ChangeLog
https://gitlab.com/ubports/development/core/morph-browser/-/blob/1.99.1/ChangeLog

Should be the first releases that can get us off of the insecure Qt5 WebEngine. Won't do that in this PR though, as it also needs Qt6-ification of the `lomiri` scope. Will be tackled in #467662.

<img width="960" height="1050" alt="image" src="https://github.com/user-attachments/assets/e89e3d72-0622-4243-9a44-656c1d66e7f4" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
