### PR TITLE
nix-prefetch-hg: remove Bashisms

### DIFF
--- a/pkgs/build-support/fetchhg/nix-prefetch-hg
+++ b/pkgs/build-support/fetchhg/nix-prefetch-hg
@@ -1,12 +1,12 @@
-#! /usr/bin/env bash
+#!/bin/sh
 set -e
 
-url=$1
-rev=$2
-expHash=$3
+url="$1"
+rev="$2"
+expHash="$3"
 
 hashType="${NIX_HASH_ALGO:-sha256}"
-hashFormat=${hashFormat:-"--base32"}
+hashFormat="${hashFormat:-"--base32"}"
 rev="${rev:-tip}"
 
 LOG() {
@@ -18,11 +18,11 @@ die() {
   exit 1
 }
 
-if [[ -z "$url" || "$url" == "--help" ]]; then
+if [ -z "$url" ] || [ "$url" = "--help" ]; then
     die "Usage: nix-prefetch-hg URL [rev [EXPECTED-HASH]]"
 fi
 
-if [[ "${fetchSubrepos:-0}" == 1 ]]; then
+if [ "${fetchSubrepos:-0}" -eq 1 ]; then
     subrepoClause=S
 else
     subrepoClause=
@@ -30,7 +30,7 @@ fi
 
 # If the hash was given, a file with that hash may already be in the
 # store.
-if [[ -n "$expHash" ]]; then
+if [ -n "$expHash" ]; then
     finalPath=$(nix-store --print-fixed-path --recursive "$hashType" "$expHash" hg-archive)
     if ! nix-store --check-validity "$finalPath" 2> /dev/null; then
         finalPath=
@@ -41,7 +41,7 @@ fi
 
 # If we don't know the hash or a path with that hash doesn't exist,
 # download the file and add it to the store.
-if [[ -z "$finalPath" ]]; then
+if [ -z "$finalPath" ]; then
     # nix>=2.20 rejects adding symlinked paths to the store, so use realpath
     # to resolve to a physical path. https://github.com/NixOS/nix/issues/11941
     tmpPath="$(realpath "$(mktemp -d --tmpdir hg-checkout-tmp-XXXXXXXX)")"
@@ -50,7 +50,7 @@ if [[ -z "$finalPath" ]]; then
     tmpArchive="$tmpPath/hg-archive"
 
     # Perform the checkout.
-    if [[ "$url" != /* ]]; then
+    if [ "${url#/*}" = "$url" ]; then
       tmpClone="$tmpPath/hg-clone"
       hg clone -q -y -U "$url" "$tmpClone" >&2
     else
@@ -63,22 +63,20 @@ if [[ -z "$finalPath" ]]; then
 
     # Compute the hash.
     hash=$(nix-hash --type "$hashType" "$hashFormat" "$tmpArchive")
-    if [[ -z "$QUIET" ]]; then LOG "hash is $hash"; fi
+    if [ -z "$QUIET" ]; then LOG "hash is $hash"; fi
 
     # Add the downloaded file to the Nix store.
     finalPath=$(nix-store --add-fixed --recursive "$hashType" "$tmpArchive")
 
-    if [[ -n "$expHash" && "$expHash" != "$hash" ]]; then
+    if [ -n "$expHash" ] && [ "$expHash" != "$hash" ]; then
         die "ERROR: hash mismatch for URL \`$url'"
     fi
-
-
 fi
 
-if [[ -z "$QUIET" ]]; then LOG "path is $finalPath"; fi
+if [ -z "$QUIET" ]; then LOG "path is $finalPath"; fi
 
 echo "$hash"
 
-if [[ -n "$PRINT_PATH" ]]; then
+if [ -n "$PRINT_PATH" ]; then
     echo "$finalPath"
 fi


### PR DESCRIPTION
This could be POSIX shell which would reduce closure size & increase speed.

Related to #462164 where we actually could switch to `dash` over `bash`…

```sh-session
$ result/bin/nix-prefetch-hg https://hg.prosody.im/trunk 0ff11f2e87cd
hg revision is 0ff11f2e87cd
hash is 155cim431wv65a7inmdd0lhkr9gnzr5z0vl015ay5sqwqigcf07q
path is /nix/store/i0h4i7xjzh02qipqixl7j3ax91il77hb-hg-archive
155cim431wv65a7inmdd0lhkr9gnzr5z0vl015ay5sqwqigcf07q
```


<!--
^ Please summarize the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
