### PR TITLE
rust-parallel: 1.18.1 -> 1.20.0

### DIFF
--- a/pkgs/by-name/ru/rust-parallel/package.nix
+++ b/pkgs/by-name/ru/rust-parallel/package.nix
@@ -9,24 +9,25 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "rust-parallel";
-  version = "1.18.1";
+  version = "1.20.0";
 
   src = fetchFromGitHub {
     owner = "aaronriekenberg";
     repo = "rust-parallel";
     rev = "v${version}";
-    hash = "sha256-4f/JE8KWYDdLwx+bCSSbz0Cpfy/g3WIaRzqCvUix4t0=";
+    hash = "sha256-osuuEYOktSMmpKURXvn0rWUeBgFV07aTeM8oxkiCe10=";
   };
 
-  cargoHash = "sha256-wJtXYx2mncOnnUep4CMFt+1mK1vMyhYFCQM/2B9m6zY=";
+  cargoHash = "sha256-20Lr7nRhr7Vrkk31iCioxmYpXYOfQFAmPkyHe1Nfijc=";
 
   postPatch = ''
     substituteInPlace tests/dummy_shell.sh \
-      --replace "/bin/bash" "${bash}/bin/bash"
+      --replace-fail "/bin/bash" "${bash}/bin/bash"
   '';
 
   checkFlags = [
     "--skip=runs_echo_commands_dry_run"
+    "--skip=test_keep_order_with_sleep"
 
     "--skip=runs_regex_command_with_dollar_signs"
     "--skip=runs_regex_from_command_line_args_nomatch_1"


### PR DESCRIPTION
Update rust-parallel 1.18.1 -> 1.20.0.

Changelog:

1.19.0 -> 1.20.0: https://github.com/aaronriekenberg/rust-parallel/releases/tag/v1.20.0
1.18.1 -> 1.19.0: https://github.com/aaronriekenberg/rust-parallel/releases/tag/v1.19.0

skipped new test 'test_keep_order_with_sleep', uses FHS /bin/bash - patching would break reproduceable build AFAICT

nixpkgs-update failing on test trying to update:
https://nixpkgs-update-logs.nix-community.org/rust-parallel/2025-12-06.log

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
