### PR TITLE
nebula: add PKCS#11 support with passthru tests

### DIFF
--- a/pkgs/by-name/ne/nebula/package.nix
+++ b/pkgs/by-name/ne/nebula/package.nix
@@ -3,16 +3,17 @@
   buildGoModule,
   fetchFromGitHub,
   nixosTests,
+  withPkcs11 ? true,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "nebula";
   version = "1.10.0";
 
   src = fetchFromGitHub {
     owner = "slackhq";
     repo = "nebula";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-p/2A1ZTBUPvrA8eAgLxjR7NSAfiIEkDcjX0Db8dCmfQ=";
   };
 
@@ -23,9 +24,33 @@ buildGoModule rec {
     "cmd/nebula-cert"
   ];
 
-  ldflags = [ "-X main.Build=${version}" ];
+  tags = lib.optional withPkcs11 "pkcs11";
+
+  ldflags = [ "-X main.Build=${finalAttrs.version}" ];
+
+  checkFlags = [
+    "-v"
+  ]
+  ++ lib.optionals withPkcs11 [
+    "-tags"
+    "pkcs11"
+  ];
+
+  env = lib.optionalAttrs (!withPkcs11) {
+    CGO_ENABLED = 0;
+  };
 
   passthru.tests = {
+    e2e = finalAttrs.finalPackage.overrideAttrs (prev: {
+      # go test picks up all the tests if we do not limit the subpackages built
+      subPackages = [ ];
+
+      # Also run the e2e tests.
+      postCheck = ''
+        make e2ev
+      '';
+    });
+
     inherit (nixosTests.nebula)
       connectivity
       reload
@@ -50,11 +75,11 @@ buildGoModule rec {
       parts.
     '';
     homepage = "https://github.com/slackhq/nebula";
-    changelog = "https://github.com/slackhq/nebula/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/slackhq/nebula/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       Br1ght0ne
       numinit
     ];
   };
-}
+})


### PR DESCRIPTION
PKCS#11 support is disabled by default because upstream does not default to CGO_ENABLED=1. Since using CGO is the default in nixpkgs, allow disabling it for a static build. Still build a dynamic binary (with PKCS#11 support) by default for compatibility.

Run all the Nebula tests (including builtin e2e tests, which all pass) as a passthru test.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
