### PR TITLE
neocities-deploy: init at 0.1.21

### DIFF
--- a/pkgs/by-name/ne/neocities-deploy/package.nix
+++ b/pkgs/by-name/ne/neocities-deploy/package.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "neocities-deploy";
+  version = "0.1.21";
+  src = fetchFromGitHub {
+    owner = "kugland";
+    repo = "neocities-deploy";
+    rev = "v${version}";
+    hash = "sha256-ZOiHFK3CrDvCNoH5LoB7EUmjF9M6syYvqthpWm9uoCE=";
+  };
+  cargoHash = "sha256-CpUC+u+3+2EdnCpOfm+sYIiVY/ftfcHZ6zH6jqdF9P8=";
+  doCheck = false; # This package's tests are impure
+  meta = with lib; {
+    description = "A command-line tool for deploying your Neocities site";
+    homepage = "https://github.com/kugland/neocities-deploy";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ kugland ];
+    mainProgram = "neocities-deploy";
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
neocities-deploy is a command-line tool for deploying your Neocities site. It can upload files to your site, list remote files, and more.

https://github.com/kugland/neocities-deploy

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
