### PR TITLE
fex: 2511 -> 2512

### DIFF
--- a/pkgs/by-name/fe/fex/package.nix
+++ b/pkgs/by-name/fe/fex/package.nix
@@ -192,7 +192,6 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeFeature "USE_LINKER" "lld")
     (lib.cmakeFeature "OVERRIDE_VERSION" finalAttrs.version)
-    (lib.cmakeBool "BUILD_TESTING" finalAttrs.finalPackage.doCheck)
     (lib.cmakeBool "BUILD_THUNKS" true)
     (lib.cmakeBool "BUILD_FEXCONFIG" withQt)
     (lib.cmakeFeature "X86_32_TOOLCHAIN_FILE" "${toolchain32}")
@@ -202,8 +201,21 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  # Unsupported on non-4K page size kernels (e.g. Apple Silicon)
+  # Running the tests isn't supported on non-4K pagesize systems, but the build
+  # itself doesn't require 4K pagesize. So, to avoid breaking the build, enable
+  # checkPhase by default (so that the check inputs are included) and then
+  # manually disable it if we're running on a non-4K pagesize system.
   doCheck = true;
+  preConfigure = ''
+    if [ "$(getconf PAGESIZE)" != "4096" ]; then
+      echo "Disabling checkPhase due to non-4K pagesize environment"
+      unset doCheck
+      cmakeFlagsArray+=("-DBUILD_TESTING:BOOL=FALSE")
+    else
+      echo "Keeping checkPhase as-is"
+      cmakeFlagsArray+=("${lib.cmakeBool "BUILD_TESTING" finalAttrs.doCheck}")
+    fi
+  '';
 
   nativeCheckInputs = [ nasm ];
   checkInputs = [ catch2_3 ];

--- a/pkgs/by-name/fe/fex/package.nix
+++ b/pkgs/by-name/fe/fex/package.nix
@@ -95,13 +95,13 @@ let
 in
 llvmPackages.stdenv.mkDerivation (finalAttrs: {
   pname = "fex";
-  version = "2511";
+  version = "2512";
 
   src = fetchFromGitHub {
     owner = "FEX-Emu";
     repo = "FEX";
     tag = "FEX-${finalAttrs.version}";
-    hash = "sha256-CulENHssPkCXI+oyVKwf3GN5bjxUok2+AHsoOQ+Mchc=";
+    hash = "sha256-G61FdzNctTp8jarTcnBXd+MQpMxnPqd33hblvi9UXNo=";
 
     leaveDotGit = true;
     postFetch = ''


### PR DESCRIPTION
Upstream release notes:

- [Website blog post](https://fex-emu.com/FEX-2512/)
- [Full GitHub release notes](https://github.com/FEX-Emu/FEX/releases/tag/FEX-2512)

Closes #468676

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
