### PR TITLE
Add packages for seadrive-fuse, seadrive-gui

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27910,6 +27910,12 @@
     name = "Han Verstraete";
     keys = [ { fingerprint = "2145 955E 3F5E 0C95 3458  41B5 11F7 BAEA 8567 43FF"; } ];
   };
+  wenbin-liu = {
+    name = "wenbin-liu";
+    email = "wenbin_liu@outlook.com";
+    github = "wenbin-liu";
+    githubId = 25171141;
+  };
   wenjinnn = {
     name = "wenjin";
     email = "hewenjin94@outlook.com";

--- a/pkgs/by-name/se/seadrive-fuse/package.nix
+++ b/pkgs/by-name/se/seadrive-fuse/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenv,
+  nix-update-script,
+  fetchFromGitHub,
+  autoreconfHook,
+  curl,
+  libargon2,
+  libevent,
+  libsearpc,
+  libuuid,
+  pkg-config,
+  python3,
+  sqlite,
+  vala,
+  libwebsockets,
+  fuse,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "seadrive-fuse";
+  version = "3.0.18";
+
+  src = fetchFromGitHub {
+    owner = "haiwen";
+    repo = "seadrive-fuse";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-oMi297ORIKdJhuYOvazJ+oSVCwRAqvjy0pc+lyBq5oQ=";
+  };
+
+  nativeBuildInputs = [
+    libwebsockets
+    autoreconfHook
+    vala
+    fuse
+    pkg-config
+    python3
+  ];
+
+  buildInputs = [
+    libargon2
+    libuuid
+    sqlite
+    libsearpc
+    libevent
+    curl
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://github.com/haiwen/seadrive-fuse";
+    description = "SeaDrive daemon with FUSE interface";
+    changelog = "https://github.com/haiwen/seadrive-fuse/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      wenbin-liu
+    ];
+    mainProgram = "seadrive";
+  };
+})

--- a/pkgs/by-name/se/seadrive-gui/package.nix
+++ b/pkgs/by-name/se/seadrive-gui/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  stdenv,
+  fetchpatch,
+  nix-update-script,
+  fetchFromGitHub,
+  pkg-config,
+  cmake,
+  qt6,
+  libuuid,
+  seafile-shared,
+  jansson,
+  libsearpc,
+  seadrive-fuse,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "seadrive-gui";
+  version = "3.0.18";
+
+  src = fetchFromGitHub {
+    owner = "haiwen";
+    repo = "seadrive-gui";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-TAmLHoJmFZyGa0wMBBPBWYOOdBCiMBdVfrIBTCZ8Sig=";
+  };
+
+  # Fix cmake modernization warning.
+  # Avoid mixed use of plain signature and keyword signature
+  # for all seadrive-gui targets in target_link_libraries.
+  postPatch = ''
+    substituteInPlace CMakeLists.txt --replace-fail \
+      'CMAKE_MINIMUM_REQUIRED(VERSION 2.8.9)' \
+      'CMAKE_MINIMUM_REQUIRED(VERSION 3.10)'; \
+    substituteInPlace CMakeLists.txt --replace-fail \
+      'TARGET_LINK_LIBRARIES(seadrive-gui PRIVATE Qt6::DBus)' \
+      'TARGET_LINK_LIBRARIES(seadrive-gui Qt6::DBus)'
+  '';
+
+  nativeBuildInputs = [
+    libuuid
+    pkg-config
+    cmake
+    qt6.wrapQtAppsHook
+    qt6.qttools
+  ];
+
+  buildInputs = [
+    qt6.qt5compat
+    seafile-shared
+    jansson
+    libsearpc
+    seadrive-fuse
+    qt6.qtwebengine
+  ];
+
+  qtWrapperArgs = [
+    "--suffix PATH : ${lib.makeBinPath [ seadrive-fuse ]}"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://github.com/haiwen/seadrive-gui";
+    changelog = "https://github.com/haiwen/seadrive-gui/releases/tag/v${finalAttrs.version}";
+    description = "GUI part of Seafile drive";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      wenbin-liu
+    ];
+    mainProgram = "seadrive-gui";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add package [seadrive-gui](https://github.com/haiwen/seadrive-gui) and its dependency [seadrive-fuse](https://github.com/haiwen/seadrive-fuse)

Different from seafile-client(which has been collected in nixpkgs), seadrive can mount seafile storage as local virtual disk

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
