### PR TITLE
nixos/kresd, nixos/knot-resolver: fix assertion format

### DIFF
--- a/nixos/modules/services/networking/knot-resolver.nix
+++ b/nixos/modules/services/networking/knot-resolver.nix
@@ -112,8 +112,15 @@ in
     };
     users.groups.knot-resolver = { };
     networking.resolvconf.useLocalResolver = lib.mkDefault true;
-    assertions = lib.optionals (lib.versions.major cfg.package.version == 5) [
-      "services.knot-resolver only works with knot-resolver 6 or later. Please use services.kresd for knot-resolver 5."
+
+    assertions = [
+      {
+        assertion = lib.versionAtLeast cfg.package.version "6.0.0";
+        message = ''
+          services.knot-resolver only works with knot-resolver 6 or later.
+          Please use services.kresd for knot-resolver 5.
+        '';
+      }
     ];
 
     environment = {

--- a/nixos/modules/services/networking/kresd.nix
+++ b/nixos/modules/services/networking/kresd.nix
@@ -135,8 +135,14 @@ in
 
   ###### implementation
   config = lib.mkIf cfg.enable {
-    assertions = lib.optionals (lib.versions.major cfg.package.version > 5) [
-      "services.kresd only works with knot-resolver 5. Please use services.knot-resolver for knot-resolver 6 and newer."
+    assertions = [
+      {
+        assertion = lib.versionOlder cfg.package.version "6.0.0";
+        message = ''
+          services.kresd only works with knot-resolver 5.
+          Please use services.knot-resolver for knot-resolver 6 and newer.
+        '';
+      }
     ];
     environment = {
       etc."knot-resolver/kresd.conf".source = configFile; # not required


### PR DESCRIPTION
These bad assertions were added in PR #463467

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  * N/A, this doesn't cause rebuilds
- Tested, as applicable:
  - checked evaluation that trigger and avoid the assertions
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
