### PR TITLE
matchbox-server: fix package version

### DIFF
--- a/pkgs/by-name/ma/matchbox-server/package.nix
+++ b/pkgs/by-name/ma/matchbox-server/package.nix
@@ -2,16 +2,17 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "matchbox-server";
-  version = "v0.11.0";
+  version = "0.11.0";
 
   src = fetchFromGitHub {
     owner = "poseidon";
     repo = "matchbox";
-    rev = "${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-u1VY+zEx2YToz+WxVFaUDzY7HM9OeokbR/FmzcR3UJ8=";
   };
 
@@ -24,7 +25,7 @@ buildGoModule rec {
   # Go linker flags (go tool link)
   # Omit symbol tables and debug info
   ldflags = [
-    "-w -s -X github.com/poseidon/matchbox/matchbox/version.Version=${version}"
+    "-w -s -X github.com/poseidon/matchbox/matchbox/version.Version=${finalAttrs.version}"
   ];
 
   # Disable cgo to produce a static binary
@@ -33,12 +34,14 @@ buildGoModule rec {
   # Don't run Go tests
   doCheck = false;
 
-  meta = with lib; {
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
     description = "Server to network boot and provision Fedora CoreOS and Flatcar Linux clusters";
     homepage = "https://matchbox.psdn.io/";
     changelog = "https://github.com/poseidon/matchbox/blob/main/CHANGES.md";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ dghubble ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ dghubble ];
     mainProgram = "matchbox";
   };
-}
+})


### PR DESCRIPTION
should be 0 rebuild

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
