### PR TITLE
netperf: fix build with gcc15

### DIFF
--- a/pkgs/by-name/ne/netperf/package.nix
+++ b/pkgs/by-name/ne/netperf/package.nix
@@ -26,6 +26,14 @@ stdenv.mkDerivation {
       url = "https://github.com/HewlettPackard/netperf/commit/c6a2e17fe35f0e68823451fedfdf5b1dbecddbe3.patch";
       sha256 = "P/lRa6EakSalKWDTgZ7bWeGleaTLLa5UhzulxKd1xE4=";
     })
+    # Fix build with gcc15
+    # https://github.com/HewlettPackard/netperf/pull/86
+    # https://salsa.debian.org/debian/netperf/-/commit/a278c7a8eb24cb45dc500393c6e8749a3427f650
+    (fetchpatch {
+      name = "netperf-fix-build-with-gcc15.patch";
+      url = "https://salsa.debian.org/debian/netperf/-/raw/a278c7a8eb24cb45dc500393c6e8749a3427f650/debian/patches/0004-Fix-build-with-gcc-15.patch";
+      hash = "sha256-fv/cx1rkUQRqyluWQKO5q5sNWPYcyZUz2NNYwalDizQ=";
+    })
   ];
 
   buildInputs = lib.optional (with stdenv.hostPlatform; isx86 && isLinux) libsmbios;


### PR DESCRIPTION
- add patch from debian submitted in unmerged PR upstream:
https://www.github.com/HewlettPackard/netperf/pull/86

Fixes build failure with gcc15:
```
hist.h:135:6: error: conflicting types for 'HIST_purge'; have
'void(struct histogram_struct *)'
  135 | void HIST_purge(HIST h);
      |      ^~~~~~~~~~
In file included from nettest_bsd.c:175:
netlib.h:651:17: note: previous declaration of 'HIST_purge' with type
'void(void)'
  651 | extern void     HIST_purge();
      |                 ^~~~~~~~~~
nettest_bsd.c:4497:19: error: too many arguments to function
'alloc_sendfile_buf_ring'; expected 0, have 4
 4497 |       send_ring = alloc_sendfile_buf_ring(send_width,
      |                   ^~~~~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~
netlib.h:690:26: note: declared here
  690 | extern  struct ring_elt *alloc_sendfile_buf_ring();
      |                          ^~~~~~~~~~~~~~~~~~~~~~~
nettest_bsd.c: In function 'recv_tcp_stream':
nettest_bsd.c:5197:15: error: too many arguments to function
'allocate_buffer_ring'; expected 0, have 4
 5197 |   recv_ring = allocate_buffer_ring(recv_width,
      |               ^~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~
netlib.h:679:26: note: declared here
  679 | extern  struct ring_elt *allocate_buffer_ring();
      |                          ^~~~~~~~~~~~~~~~~~~~
nettest_omni.c:5050:5: error: too many arguments to function
'HIST_get_stats'; expected 0, have 5
 5050 |     HIST_get_stats(time_hist,
      |     ^~~~~~~~~~~~~~ ~~~~~~~~~
netlib.h:650:17: note: declared here
  650 | extern void     HIST_get_stats();
      |                 ^~~~~~~~~~~~~~
nettest_omni.c:5055:19: error: too many arguments to function
'HIST_get_percentile'; expected 0, have 2
 5055 |     p50_latency = HIST_get_percentile(time_hist, 0.50);
      |                   ^~~~~~~~~~~~~~~~~~~ ~~~~~~~~~
netlib.h:649:17: note: declared here
  649 | extern int      HIST_get_percentile();
      |                 ^~~~~~~~~~~~~~~~~~~
```

---

Tested build on `master` with:

```
nix-build --expr 'with import ./. {}; netperf.override { stdenv = gcc15Stdenv; }'
```
and on current `staging` where https://github.com/NixOS/nixpkgs/pull/440456 is merged.

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
