### PR TITLE
emacsPackages.manualPackages: update on 2025-12-06

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-browser/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-browser/default.nix
@@ -16,7 +16,7 @@
 melpaBuild (finalAttrs: {
 
   pname = "eaf-browser";
-  version = "0-unstable-2025-06-14";
+  version = "0-unstable-2025-06-13";
 
   src = fetchFromGitHub {
     owner = "emacs-eaf";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-map/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-map/package.nix
@@ -14,13 +14,13 @@
 melpaBuild (finalAttrs: {
 
   pname = "eaf-map";
-  version = "0-unstable-2025-07-04";
+  version = "0-unstable-2025-07-26";
 
   src = fetchFromGitHub {
     owner = "emacs-eaf";
     repo = "eaf-map";
-    rev = "667865a9422ec71e3518833e1a13806d4f03adfb";
-    hash = "sha256-UgHIzYu/K1NzTDvUn2JkEmiyDEBT9JDmlvp6xG7Nv5k=";
+    rev = "8bec6ab7c1194491ffccbeeec45451d8dc6fb405";
+    hash = "sha256-rwtC4CAOTNmR8sH6P4mKyON65yNYWMBYImQkBGZH0Qs=";
   };
 
   env.npmDeps = fetchNpmDeps {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-pyqterminal/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-pyqterminal/package.nix
@@ -10,13 +10,13 @@
 melpaBuild {
 
   pname = "eaf-pyqterminal";
-  version = "0-unstable-2025-05-05";
+  version = "0-unstable-2025-10-19";
 
   src = fetchFromGitHub {
     owner = "mumu-lhl";
     repo = "eaf-pyqterminal";
-    rev = "db947f136660adc4c3883b332f4465af82e4c9da";
-    hash = "sha256-0BH29XvBzJPgJBFSKHiKSLo/dpj5rixg7+u+LDpB5+U=";
+    rev = "37b7b2afbdd47c89d85ff6e3412e1dc6c555ab50";
+    hash = "sha256-+RVA+UM473eTPrsX3TpUrzPx8UY5gAgIkMl0CB/iBTw=";
   };
 
   files = ''

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/elpaca/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/elpaca/default.nix
@@ -8,13 +8,13 @@
 
 melpaBuild {
   pname = "elpaca";
-  version = "0-unstable-2025-02-16";
+  version = "0-unstable-2025-11-06";
 
   src = fetchFromGitHub {
     owner = "progfolio";
     repo = "elpaca";
-    rev = "07b3a653e2411f4d4b5902af1c9b3f159e07bec5";
-    hash = "sha256-+YJX2BJxH3D5u7YC/yJskZu0F4Nlat3ZROe+RCZGq9w=";
+    rev = "b5ef5f19ac1224853234c9acdac0ec9ea1c440a1";
+    hash = "sha256-EZ9emYTweRZzMKxZu9nbAaGgE2tInaL7KCKvJ5TaD0g=";
   };
 
   nativeBuildInputs = [ git ];

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/emacs-application-framework/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/emacs-application-framework/package.nix
@@ -54,13 +54,13 @@ in
 melpaBuild (finalAttrs: {
 
   pname = "eaf";
-  version = "0-unstable-2025-08-22";
+  version = "0-unstable-2025-08-29";
 
   src = fetchFromGitHub {
     owner = "emacs-eaf";
     repo = "emacs-application-framework";
-    rev = "dc5f6e7fa21a15b5e05c7722c2b8f32158aeab82";
-    hash = "sha256-wWC5Ma9p/k0GLcGpPn7NO0KqkIXmEbaQc7TJ2ImMIr4=";
+    rev = "ada92215ad864c2d142feb6ad6e1127e90bce668";
+    hash = "sha256-on+cIZW+lV+J4FwPq5HH2C6FPOHRq4+BU+e0shM1l4E=";
   };
 
   packageRequires = [

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/git-undo/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/git-undo/package.nix
@@ -7,13 +7,13 @@
 
 melpaBuild {
   pname = "git-undo";
-  version = "0-unstable-2022-08-07";
+  version = "0-unstable-2025-09-22";
 
   src = fetchFromGitHub {
     owner = "jwiegley";
     repo = "git-undo-el";
-    rev = "3d9c95fc40a362eae4b88e20ee21212d234a9ee6";
-    hash = "sha256-xwVCAdxnIRHrFNWvtlM3u6CShsUiGgl1CiBTsp2x7IM=";
+    rev = "1e94d2dad39ffa168005dee182dde5694416d9c9";
+    hash = "sha256-EppewewNPWVbQN76LVoebtKu+FOFCnWDhDeUognPmAo=";
   };
 
   passthru.updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/notdeft/notdeft-xapian-program.diff
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/notdeft/notdeft-xapian-program.diff
@@ -1,0 +1,23 @@
+diff --git a/notdeft-xapian.el b/notdeft-xapian.el
+index e71ef3e..5fad501 100644
+--- a/notdeft-xapian.el
++++ b/notdeft-xapian.el
+@@ -13,17 +13,7 @@
+ 
+ ;;; Code:
+ 
+-(defcustom notdeft-xapian-program
+-  (let ((dir (expand-file-name
+-              "xapian"
+-               (file-name-directory
+-	        (locate-library "notdeft-xapian.el")))))
+-    (when (and dir (file-directory-p dir))
+-      (cl-some (lambda (cand)
+-                 (let ((exe (expand-file-name cand dir)))
+-                   (when (file-executable-p exe)
+-                     exe)))
+-               '("notdeft-xapian" "notdeft-xapian.exe"))))
++(defcustom notdeft-xapian-program "@notdeft-xapian@"
+   "Xapian backend's executable program path.
+ Specified as an absolute path. Must be set appropriately for the
+ `notdeft-xapian' feature to be usable, on which much of NotDeft

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/notdeft/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/notdeft/package.nix
@@ -18,21 +18,23 @@
 
 melpaBuild {
   pname = "notdeft";
-  version = "0-unstable-2025-02-04";
+  version = "0-unstable-2025-06-14";
 
   src = fetchFromGitHub {
     owner = "hasu";
     repo = "notdeft";
-    rev = "de2b6a7666e9e5010184966f89a04241f221afe3";
-    hash = "sha256-B8aVRb8hyAKmHTTVCtDRcb2F0Rs5zhlqyfRe7IxH5jc=";
+    rev = "e0426807f608f550df14b7cd50b8455dee4dbfb3";
+    hash = "sha256-RB7KL04JNJ0d+wH9Q7aHCLYJHevy67XfXEyDxpjTbvg=";
   };
 
   packageRequires = lib.optional withHydra hydra ++ lib.optional withIvy ivy;
 
+  patches = [
+    ./notdeft-xapian-program.diff
+  ];
   postPatch = ''
     substituteInPlace notdeft-xapian.el \
-      --replace-fail 'defcustom notdeft-xapian-program nil' \
-                     "defcustom notdeft-xapian-program \"$out/bin/notdeft-xapian\""
+      --replace-fail "@notdeft-xapian@" "$out/bin/notdeft-xapian"
   '';
 
   files = ''

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/straight/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/straight/default.nix
@@ -8,13 +8,13 @@
 
 melpaBuild {
   pname = "straight";
-  version = "0-unstable-2025-01-30";
+  version = "0-unstable-2025-11-21";
 
   src = fetchFromGitHub {
     owner = "radian-software";
     repo = "straight.el";
-    rev = "44a866f28f3ded6bcd8bc79ddc73b8b5044de835";
-    hash = "sha256-riKagjhCn5NyTerw1WqGOn37TZNfmhPb7DS49TXw1CA=";
+    rev = "4b6289f42a4da0c1bae694ba918b43c72daf0330";
+    hash = "sha256-FlGo+Nl6n+xSwQSIrMHJa7tu+MjLG2Ldxf7poJCz4Nc=";
   };
 
   nativeBuildInputs = [ git ];

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/wat-mode/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/wat-mode/package.nix
@@ -2,7 +2,7 @@
   lib,
   melpaBuild,
   fetchFromGitHub,
-  unstableGitUpdater,
+  nix-update-script,
 }:
 
 melpaBuild {
@@ -16,7 +16,7 @@ melpaBuild {
     hash = "sha256-jV5V3TRY+D3cPSz3yFwVWn9yInhGOYIaUTPEhsOBxto=";
   };
 
-  passthru.updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
 
   meta = {
     homepage = "https://github.com/devonsparks/wat-mode";


### PR DESCRIPTION
Many of these were pretty outdated, so I updated them here.

Performed with:
```sh
nix-shell maintainers/scripts/update.nix --argstr path emacsPackages.manualPackages --argstr commit true --argstr keep-going true
```

Manual interventions:
- separate commits:
  - ~~`codeium` couldn't update due to not reusing `version` in `src.tag`~~
  - `wat-mode` just had weird problems with `unstableGitUpdater`
- amends (moved to the end):
  - original patches for ~~`codeium` and~~ `notdeft` didn't apply

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Testing
### wat-mode
kinda self-explanatory
<img width="940" height="1055" alt="изображение" src="https://github.com/user-attachments/assets/edd8cbbb-98a1-45ad-9622-ae6ced82c49c" />

### git-undo
`git-undo-browse` output (tbh, i have no idea what to do with this, but it outputs something)
<img width="1920" height="1057" alt="изображение" src="https://github.com/user-attachments/assets/6d00545a-3fe6-4c45-b60d-fd60d2a86364" />

### notdeft
```
$ tree ~/.deft
/home/acid/.deft
├── test1.org # contains `#+title: Oi there, mates`
├── test2.org
└── test5.org
```
<img width="546" height="262" alt="изображение" src="https://github.com/user-attachments/assets/e33451fd-ecf5-481e-8bec-93c945cccbc2" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage]. (why tf does CI report 0 rebuilds??)
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
