### PR TITLE
influxdb2: fix hardcoded source path

### DIFF
--- a/pkgs/servers/nosql/influxdb2/default.nix
+++ b/pkgs/servers/nosql/influxdb2/default.nix
@@ -30,7 +30,7 @@ let
     hash = "sha256-aC+GYMaxYKkY9GMaeRx22hQ3xi3kfWpaTLC9ajqOaAA=";
   };
 
-  flux = rustPlatform.buildRustPackage {
+  flux = rustPlatform.buildRustPackage (finalAttrs: {
     pname = "libflux";
     version = libflux_version;
     src = fetchFromGitHub {
@@ -50,7 +50,7 @@ let
       substituteInPlace flux-core/Cargo.toml \
         --replace-fail 'default = ["strict"]' 'default = []'
     '';
-    sourceRoot = "${src.name}/libflux";
+    sourceRoot = "${finalAttrs.src.name}/libflux";
 
     cargoHash = "sha256-A6j/lb47Ob+Po8r1yvqBXDVP0Hf7cNz8WFZqiVUJj+Y=";
     nativeBuildInputs = [ rustPlatform.bindgenHook ];
@@ -65,14 +65,14 @@ let
     passAsFile = [ "pkgcfg" ];
     postInstall = ''
       mkdir -p $out/include $out/pkgconfig
-      cp -r $NIX_BUILD_TOP/source/libflux/include/influxdata $out/include
+      cp -r $NIX_BUILD_TOP/${finalAttrs.src.name}/libflux/include/influxdata $out/include
       substitute $pkgcfgPath $out/pkgconfig/flux.pc \
         --replace-fail /out $out
     ''
     + lib.optionalString stdenv.hostPlatform.isDarwin ''
       install_name_tool -id $out/lib/libflux.dylib $out/lib/libflux.dylib
     '';
-  };
+  });
 in
 buildGoModule {
   pname = "influxdb";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Influxdb2 does not build with `fetchedSourceNameDefault = "full"`. Reproducible with

```
nix build --impure --expr 'let nixpkgs = builtins.getFlake "github:NixOS/nixpkgs/4c25e2da4d3a847e5105e6660f266cf46f108f2e"; in
    let
      pkgs = import nixpkgs {
        localSystem = "x86_64-linux";
        config = {
          fetchedSourceNameDefault = "full";
        };
      };
    in
    pkgs.influxdb2
    ' --substituters ""
```

This PR fixes the hardcoded path in the same style as #468402. 

A lingering thought is that it might be worthwhile exposing libflux as its own package so it's actually overridable.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
