### PR TITLE
nils-k1v: init at 1.26

### DIFF
--- a/pkgs/by-name/ni/nils-k1v/package.nix
+++ b/pkgs/by-name/ni/nils-k1v/package.nix
@@ -1,0 +1,60 @@
+{
+  stdenvNoCC,
+  lib,
+  fetchurl,
+  dpkg,
+  autoPatchelfHook,
+  SDL2,
+  cairo,
+  libxcb-util,
+  libxcb-cursor,
+
+  installVST3 ? true,
+  installVST2 ? true,
+}:
+stdenvNoCC.mkDerivation {
+  pname = "nils-k1v";
+  version = "1.26";
+
+  src = fetchurl {
+    url = "https://archive.org/download/nils-k1v-1.26/NilsK1v-x86_64.deb";
+    hash = "sha256-uRwUXRUK/MBaQSxF6ERKAsP/3m8W1gom6aqUFfqBV0o=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    SDL2
+    cairo
+    libxcb-util
+    libxcb-cursor
+  ];
+
+  installPhase = ''
+    dpkg -x $src .
+
+    pushd usr/local/lib/lxvst
+      ${lib.optionalString installVST3 ''
+        mkdir -p $out/lib/vst3
+        install -Dm755 libNilsK1vVST3.vst3 $out/lib/vst3/libNilsK1vVST3.so
+      ''}
+
+      ${lib.optionalString installVST2 ''
+        mkdir -p $out/lib/vst
+        install -Dm755 libNilsK1vVST2.so $out/lib/vst
+      ''}
+    popd
+  '';
+
+  meta = {
+    description = "Kawai K1 Emulation Plugin";
+    homepage = "https://www.nilsschneider.de/wp/nils-k1v";
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    platforms = [ "x86_64-linux" ];
+    license = lib.licenses.unfree;
+    maintainers = [ lib.maintainers.mrtnvgr ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (tested vst3 plugin)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
