### PR TITLE
python3Packages.approvaltests: 15.3.2 -> 16.1.0

### DIFF
--- a/pkgs/development/python-modules/approval-utilities/default.nix
+++ b/pkgs/development/python-modules/approval-utilities/default.nix
@@ -11,9 +11,10 @@ buildPythonPackage {
   inherit (approvaltests) version src;
   pyproject = true;
 
-  postPatch = approvaltests.postPatch or "" + ''
-    mv setup.approval_utilities.py setup.py
-  '';
+  postPatch = ''
+    mv setup/setup.approval_utilities.py setup.py
+  ''
+  + approvaltests.postPatch or "";
 
   build-system = [ setuptools ];
 

--- a/pkgs/development/python-modules/approvaltests/default.nix
+++ b/pkgs/development/python-modules/approvaltests/default.nix
@@ -20,21 +20,25 @@
 
 buildPythonPackage rec {
   pname = "approvaltests";
-  version = "15.3.2";
+  version = "16.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "approvals";
     repo = "ApprovalTests.Python";
     tag = "v${version}";
-    hash = "sha256-cOaL8u5q9kx+yLB0e/ALnGYYGF5v50wsIIF1UUTPe1Y=";
+    hash = "sha256-9zBpq4/jAH441eeMMV2WS767Rz+1qCX/QIfbToUHnAQ=";
   };
 
   postPatch = ''
+    test -f setup.py || mv setup/setup.py .
+    touch setup/__init__.py
+    substituteInPlace setup.py \
+      --replace-fail "from setup_utils" "from setup.setup_utils"
+
     echo 'version_number = "${version}"' > version.py
-    mv .github approvaltests approval_utilities tests setup
-    cd setup
-    rm setup.cfg
+
+    patchShebangs internal_documentation/scripts
   '';
 
   build-system = [ setuptools ];


### PR DESCRIPTION
Diff: https://github.com/approvals/ApprovalTests.Python/compare/v15.3.2...v16.1.0

Changelog: https://github.com/approvals/ApprovalTests.Python/releases/tag/v16.1.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
