### PR TITLE
go-errorlint: Update src upstream

### DIFF
--- a/pkgs/by-name/go/go-errorlint/package.nix
+++ b/pkgs/by-name/go/go-errorlint/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildGoModule,
-  fetchFromGitHub,
+  fetchFromGitea,
   nix-update-script,
 }:
 
@@ -9,7 +9,8 @@ buildGoModule rec {
   pname = "go-errorlint";
   version = "1.8.0";
 
-  src = fetchFromGitHub {
+  src = fetchFromGitea {
+    domain = "codeberg.org";
     owner = "polyfloyd";
     repo = "go-errorlint";
     rev = "v${version}";
@@ -24,12 +25,13 @@ buildGoModule rec {
   ];
 
   passthru.updateScript = nix-update-script { };
-  meta = with lib; {
+
+  meta = {
     description = "Source code linter that can be used to find code that will cause problems with Go's error wrapping scheme";
-    homepage = "https://github.com/polyfloyd/go-errorlint";
-    changelog = "https://github.com/polyfloyd/go-errorlint/blob/${src.rev}/CHANGELOG.md";
-    license = licenses.mit;
-    maintainers = with maintainers; [
+    homepage = "https://codeberg.org/polyfloyd/go-errorlint";
+    changelog = "https://codeberg.org/polyfloyd/go-errorlint/src/tag/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
       meain
       polyfloyd
     ];


### PR DESCRIPTION
Maintainer of this package here!

I migrated go-errorlint from GitHub to Codeberg. This patch alters the src and meta to reflect this.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
