### PR TITLE
python3Packages.mitmproxy-macos: fix download hash

### DIFF
--- a/pkgs/development/python-modules/mitmproxy-macos/default.nix
+++ b/pkgs/development/python-modules/mitmproxy-macos/default.nix
@@ -10,13 +10,14 @@ buildPythonPackage rec {
   inherit (mitmproxy-rs) version;
   format = "wheel";
 
+  # Note: if this isn't downloading, its because mitmproxy-rs updated without also updating this.
   src = fetchPypi {
     pname = "mitmproxy_macos";
     inherit version;
     format = "wheel";
     dist = "py3";
     python = "py3";
-    hash = "sha256-NArp10yhERk7Hhw5fIU+ekbupyldyzpLQdKgebiUpOM=";
+    hash = "sha256-baAfEY4hEN3wOEicgE53gY71IX003JYFyyZaNJ7U8UA=";
   };
 
   # repo has no python tests

--- a/pkgs/development/python-modules/mitmproxy-macos/default.nix
+++ b/pkgs/development/python-modules/mitmproxy-macos/default.nix
@@ -30,6 +30,6 @@ buildPythonPackage rec {
     description = "MacOS Rust bits in mitmproxy";
     homepage = "https://github.com/mitmproxy/mitmproxy_rs/tree/main/mitmproxy-macos";
     platforms = lib.platforms.darwin;
-    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
 }


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/315191186

The version updated silently when `python3Packages.mitmproxy-rs` did, leading to a Hydra failure. (Question: are these two packages on the same release cycle?)

Fix: Updated the hash.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
