### PR TITLE
python3Packages.rcar-flash: init at 0.1.0-unstable-2025-07-18

### DIFF
--- a/pkgs/applications/misc/rcar-flash/default.nix
+++ b/pkgs/applications/misc/rcar-flash/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  setuptools,
+  pyserial,
+  pyyaml,
+  pyftdi,
+}:
+
+buildPythonPackage {
+  pname = "rcar-flash";
+  version = "0.1.0-unstable-2025-07-18";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "xen-troops";
+    repo = "rcar_flash";
+    rev = "f1de190c153926de67aced31884da13443737b88";
+    hash = "sha256-qNRcMuxKNqzaARIXm3wz+GmwORTpxqeSTMBSp2JFJSU=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    pyserial
+    pyyaml
+    pyftdi
+  ];
+
+  # no tests implemented
+  doCheck = false;
+
+  pythonImportsCheck = [ "rcar_flash" ];
+
+  meta = {
+    homepage = "https://github.com/xen-troops/rcar_flash";
+    description = "Simple command line tool to automate writing IPLs (firmware) to Renesas RCAR-based boards";
+    mainProgram = "rcar_flash";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.zatm8 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16059,6 +16059,8 @@ self: super: with self; {
 
   rbtools = callPackage ../development/python-modules/rbtools { };
 
+  rcar-flash = callPackage ../applications/misc/rcar-flash { };
+
   rchitect = callPackage ../development/python-modules/rchitect { };
 
   rclone-python = callPackage ../development/python-modules/rclone-python { };


### PR DESCRIPTION
Added rcar_flash package for automating writing IPLs (firmware) to Renesas RCAR-based boards.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
