### PR TITLE
python3Packages.coloraide: 5.1 -> 6.1

### DIFF
--- a/pkgs/development/python-modules/coloraide/default.nix
+++ b/pkgs/development/python-modules/coloraide/default.nix
@@ -36,6 +36,7 @@ buildPythonPackage {
     license = lib.licenses.mit;
     maintainers = [
       lib.maintainers._9999years
+      lib.maintainers.djacu
     ];
   };
 }

--- a/pkgs/development/python-modules/coloraide/default.nix
+++ b/pkgs/development/python-modules/coloraide/default.nix
@@ -1,21 +1,24 @@
 {
-  lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   hatchling,
+  lib,
+  pytestCheckHook,
   typing-extensions,
 }:
 let
-  pname = "coloraide";
-  version = "5.1";
+  version = "6.1";
 in
 buildPythonPackage {
-  inherit pname version;
+  pname = "coloraide";
+  inherit version;
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-DfBmpjbb2EgZgfrEkCQNPtkGtANDx8AXErPfVC8rJ1A=";
+  src = fetchFromGitHub {
+    owner = "facelessuser";
+    repo = "coloraide";
+    tag = version;
+    hash = "sha256-hsuFouesw4B9rr17NCQVB6LyYUdNRm9Cj2Cqj+MdLkc=";
   };
 
   build-system = [
@@ -30,9 +33,13 @@ buildPythonPackage {
     "coloraide"
   ];
 
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
   meta = {
-    description = "Color library for Python";
-    homepage = "https://pypi.org/project/coloraide/";
+    description = "Library to aid in using colors";
+    homepage = "https://github.com/facelessuser/coloraide";
     license = lib.licenses.mit;
     maintainers = [
       lib.maintainers._9999years


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] ~~[NixOS tests] in [nixos/tests].~~
  - [ ] ~~[Package tests] at `passthru.tests`.~~
  - [ ] ~~Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.~~
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] ~~Tested basic functionality of all binary files, usually in `./result/bin/`.~~
- Nixpkgs Release Notes
  - [ ] ~~Package update: when the change is major or breaking.~~
- NixOS Release Notes
  - [ ] ~~Module addition: when adding a new NixOS module.~~
  - [ ] ~~Module update: when the change is significant.~~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

---

closes https://github.com/NixOS/nixpkgs/pull/461158