### PR TITLE
nextcloud-talk-desktop: correct hash, set updateScript, use patchelf in argument

### DIFF
--- a/pkgs/by-name/ne/nextcloud-talk-desktop/package.nix
+++ b/pkgs/by-name/ne/nextcloud-talk-desktop/package.nix
@@ -30,7 +30,7 @@ let
 
   hashes = {
     linux = "sha256-Nky3ws1UV0F4qjbBog53BjXkZ/ttTER/32NlB2ONJaE=";
-    darwin = "sha256-FgiUb2MNEqmbK4BphHQ7M2IeN7Vg1NQ9FR9UO4AfvNs=";
+    darwin = "sha256-N/v1842rheqrjG4pAwrSDYNWhQDgWinTiZPusD1dvaM=";
   };
 
   # Only x86_64-linux is supported with Darwin support being universal

--- a/pkgs/by-name/ne/nextcloud-talk-desktop/package.nix
+++ b/pkgs/by-name/ne/nextcloud-talk-desktop/package.nix
@@ -127,7 +127,7 @@ let
     '';
 
     postFixup = ''
-      patchelf --add-needed libGL.so.1 --add-needed libEGL.so.1 \
+      ${lib.getExe patchelf} --add-needed libGL.so.1 --add-needed libEGL.so.1 \
         "$out/opt/Nextcloud Talk-linux-x64/Nextcloud Talk"
     '';
 

--- a/pkgs/by-name/ne/nextcloud-talk-desktop/update.py
+++ b/pkgs/by-name/ne/nextcloud-talk-desktop/update.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i python3 -p python3 bash nix-update jq
+
+import subprocess
+from os.path import join, dirname
+
+# This will set the version correctly,
+# and will also set the hash for x86_64-linux.
+subprocess.run(["nix-update", "nextcloud-talk-desktop"])
+
+# Now get the hash for Darwin.
+# (It's the same for both Darwin platforms, and we don't support aarch64-linux).
+newVer = subprocess.run(
+  ["nix-instantiate", "--eval", "--raw", "-A", "nextcloud-talk-desktop.version"], capture_output=True, encoding="locale"
+).stdout
+
+darwinUrl = (
+  f"https://github.com/nextcloud-releases/talk-desktop/releases/download/v{newVer}/Nextcloud.Talk-macos-universal.dmg"
+)
+
+oldDarwinHash = subprocess.run(
+  ["nix-instantiate", "--eval", "--raw", "-A", f"nextcloud-talk-desktop.passthru.hashes.darwin"],
+  capture_output=True,
+  encoding="locale",
+).stdout
+
+newDarwinHash = subprocess.run(
+  ["bash", "-c", f"nix store prefetch-file {darwinUrl} --json | jq -r '.hash'"],
+  capture_output=True,
+  encoding="locale",
+).stdout.strip()  # Has a newline
+
+with open(join(dirname(__file__), "package.nix"), "r") as f:
+  txt = f.read()
+
+txt = txt.replace(oldDarwinHash, newDarwinHash)
+
+with open(join(dirname(__file__), "package.nix"), "w") as f:
+  f.write(txt)


### PR DESCRIPTION
Follow-up to #466426 and #466201.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
