### PR TITLE
python3Packages.iocsearcher: 2.4.8 -> 2.5.7

### DIFF
--- a/pkgs/development/python-modules/iocsearcher/default.nix
+++ b/pkgs/development/python-modules/iocsearcher/default.nix
@@ -15,24 +15,20 @@
   pdfminer-six,
   phonenumbers,
   python-magic,
-  pythonOlder,
   readabilipy,
   setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "iocsearcher";
-  version = "2.4.8";
+  version = "2.5.7";
   pyproject = true;
-
-  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "malicialab";
     repo = "iocsearcher";
-    # https://github.com/malicialab/iocsearcher/issues/6
-    rev = "be29cb4090284155b49a358e7fe2d24371b6a981";
-    hash = "sha256-LMpFK1Z1KaKUCm/X9Sh+Gp9GNKrGWp7N4UjAOVkhmSU=";
+    tag = "v${version}";
+    hash = "sha256-qykPMtdGjys6d1cdP6cM/lmtU5WR/jk9tc9g+8uc31E=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
Diff: https://github.com/malicialab/iocsearcher/compare/v2.4.8...v2.5.7

Changelog: https://github.com/malicialab/iocsearcher/releases/tag/v2.5.7

closes https://github.com/NixOS/nixpkgs/pull/462463
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
