### PR TITLE
build-fhsenv-bubblewrap: fix /usr/lib to point to /usr/lib32 on i686-…

### DIFF
--- a/pkgs/build-support/build-fhsenv-bubblewrap/buildFHSEnv.nix
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/buildFHSEnv.nix
@@ -46,6 +46,13 @@ let
 
   # "use of glibc_multi is only supported on x86_64-linux"
   isMultiBuild = multiArch && stdenv.system == "x86_64-linux";
+  # What should lib be linked to: lib32 or lib64?
+  defaultLib =
+    {
+      "i686-linux" = "lib32";
+      "x86_64-linux" = "lib64";
+    }
+    .${stdenv.system} or (throw "Please expand list of system with defaultLib for '${stdenv.system}'");
 
   # list of packages (usually programs) which match the host's architecture
   # (which includes stuff from multiPkgs)
@@ -229,7 +236,7 @@ let
         ln -s /usr/lib $out/lib
         ln -s /usr/lib32 $out/lib32
         ln -s /usr/lib64 $out/lib64
-        ln -s /usr/lib64 $out/usr/lib
+        ln -s /usr/${defaultLib} $out/usr/lib
         ln -s /usr/libexec $out/libexec
 
         # symlink 32-bit ld-linux so it's visible in /lib


### PR DESCRIPTION
…linux

Without the change buildFHSEnv on "i686-linux" tries to link /usr/lib to /usr/lib64. This causes problems for packages that assume that /usr/lib contains actual libraries (like vanilla gcc build).

On "i686-linux" most libraries go to /usr/lib32. /usr/lib64 is virtually empty (it should be completely, but let's leave it for another day).

As a result /usr/lib contains none of the expected libraries and FHS programs fails to find them.

THe change makes "lib" dependent on `system` target.

Tested the change by building `gcc` on `x86_64-linux` and `i686-linux`. Both still pass the build.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
