### PR TITLE
hp-unified-linux-driver: init at 1.00.39.12_00.15

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5736,6 +5736,13 @@
     matrix = "@Dan:matrix.org";
     name = "Daniel Theriault";
   };
+  danberdev = {
+    email = "me@danber.dev";
+    github = "danberdev";
+    githubId = 13893528;
+    name = "Daniil Berendeev";
+    keys = [ { fingerprint = "60D7 0EE0 3BD4 A415 B255  1938 6556 0668 006B 4906"; } ];
+  };
   danbst = {
     email = "abcz2.uprola@gmail.com";
     github = "danbst";

--- a/pkgs/by-name/hp/hp-unified-linux-driver/libsane-smfp-wrapper.c
+++ b/pkgs/by-name/hp/hp-unified-linux-driver/libsane-smfp-wrapper.c
@@ -1,0 +1,51 @@
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include <dirent.h>
+
+static const char libsane_smfp_cfg[] = "/opt/smfp-common/scanner/share/libsane-smfp.cfg";
+static const char libsane_smfp_cfg_to[] = "@libsane_smfp_cfg_to@";
+
+static const char smfp_conf[] = "/etc/sane.d/smfp.conf";
+static const char smfp_conf_to[] = "@smfp_conf_to@";
+
+static const char usedby[] = "/opt/smfp-common/scanner/.usedby/";
+static const char usedby_to[] = "@usedby_to@";
+
+static const char oem[] = "/opt/smfp-common/scanner/share/oem.conf";
+static const char oem_to[] = "@oem_to@";
+
+static const char sane_d[] = "/etc/sane.d";
+static const char sane_d_to[] = "@sane_d_to@";
+
+static const char opt[] = "/opt";
+static const char opt_to[] = "@opt_to@";
+
+
+const char* pick_path(const char* path)
+{
+  if (!strcmp(path, libsane_smfp_cfg)) {
+    return libsane_smfp_cfg_to;
+  } else if (!strcmp(path, smfp_conf)) {
+    return smfp_conf_to;
+  } else if (!strcmp(path, usedby)) {
+    return usedby_to;
+  } else if (!strcmp(path, oem)) {
+    return oem_to;
+  } if (!strcmp(path, sane_d)) {
+    return sane_d_to;
+  } if (!strcmp(path, opt)) {
+    return opt_to;
+  }
+  return path;
+}
+
+FILE *fopen_wrapper(const char* file_name, const char* mode)
+{
+  return fopen(pick_path(file_name), mode);
+}
+
+DIR *opendir_wrapper(const char* dirname)
+{
+  return opendir(pick_path(dirname));
+}

--- a/pkgs/by-name/hp/hp-unified-linux-driver/package.nix
+++ b/pkgs/by-name/hp/hp-unified-linux-driver/package.nix
@@ -1,0 +1,151 @@
+{
+  lib,
+  stdenv,
+  cups,
+  libusb1,
+  libxml2_13, # The uld library uses libxml2.so.2 which is provided only in the older version
+  fetchurl,
+  patchPpdFilesHook,
+  buildPackages,
+  replaceVars,
+}:
+
+let
+  version = "1.00.39.12_00.15";
+  installationPath =
+    {
+      x86_64-linux = "x86_64";
+      i686-linux = "i386";
+    }
+    .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  unpacked = stdenv.mkDerivation (finalAttrs: {
+    inherit version;
+    pname = "hp-unified-linux-driver-unpacked";
+
+    src = fetchurl {
+      url = "https://ftp.hp.com/pub/softlib/software13/printers/MFP170/uld-hp_V${version}.tar.gz";
+      hash = "sha256-zrube2El50BmNLucKpiwFHfR4R1mx8kEdGad6ZJ7yR0=";
+    };
+    dontBuild = true;
+
+    installPhase = ''
+      mkdir -p $out/opt/smfp-common/scanner/.usedby/
+      cp -r . $out
+    '';
+  });
+
+  patchedWrapper = replaceVars ./libsane-smfp-wrapper.c {
+    libsane_smfp_cfg_to = "${unpacked}/noarch/libsane-smfp.cfg";
+    smfp_conf_to = "${unpacked}/noarch/etc/smfp.conf";
+    usedby_to = "${unpacked}/opt/smfp-common/scanner/.usedby/";
+    oem_to = "${unpacked}/noarch/oem.conf";
+    sane_d_to = "${unpacked}/etc/sane.d";
+    opt_to = "${unpacked}/opt";
+  };
+
+  # Contains a fopen() wrapper
+  wrapperLibName = "libsane-smfp-wrapper.so";
+  wrapperLib = stdenv.mkDerivation (finalAttrs: {
+    pname = "libsane-smfp-wrapper-lib";
+    inherit version;
+
+    unpackPhase = ''
+      cp ${patchedWrapper} libsane-smfp-wrapper.c
+    '';
+
+    buildPhase = ''
+      $CC -fPIC -shared libsane-smfp-wrapper.c -o ${wrapperLibName}
+    '';
+
+    installPhase = ''
+      install -D ${wrapperLibName} -t $out/lib
+    '';
+  });
+
+  libPath =
+    lib.makeLibraryPath [
+      cups
+      libusb1
+      libxml2_13
+      wrapperLib
+    ]
+    + ":$out/lib:${lib.getLib stdenv.cc.cc}/lib";
+in
+stdenv.mkDerivation {
+  inherit version;
+
+  pname = "hp-unified-linux-driver";
+  src = unpacked;
+
+  nativeBuildInputs = [ patchPpdFilesHook ];
+
+  dontPatchELF = true;
+  dontStrip = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/opt/smfp-common/scanner/.usedby/
+    mkdir -p $out/share/cups
+    mkdir -p $out/etc/sane.d/dll.d
+    mkdir -p $out/lib/udev/rules.d
+
+    install -m755 ${installationPath}/{pstosecps,rastertospl,smfpnetdiscovery}  -D -t $out/lib/cups/filter/
+    install -m755 ${installationPath}/libscmssc.so -D -t $out/lib/
+    install -m755 ${installationPath}/libsane-smfp.so.1.0.1 -D -t $out/lib/sane/
+    install -m644 noarch/etc/smfp.conf -D -t $out/etc/sane.d/
+    cp -r noarch/share/ppd $out/share/
+
+    echo "smfp" >> $out/etc/sane.d/dll.d/hp-uld.conf
+
+    ln -s $out/share/ppd $out/share/cups/model
+    ln -sf $out/lib/sane/libsane-smfp.so.1.0.1 $out/lib/sane/libsane-smfp.so.1
+    ln -sf $out/lib/sane/libsane-smfp.so.1 $out/lib/sane/libsane-smfp.so
+
+    (
+      OEM_FILE=noarch/oem.conf
+      INSTALL_LOG_FILE=/dev/null
+      . noarch/scripting_utils
+      . noarch/package_utils
+      . noarch/scanner-script.pkg
+      fill_full_template noarch/etc/smfp.rules.in $out/lib/udev/rules.d/60_smfp_hp.rules
+      chmod -x $out/lib/udev/rules.d/60_smfp_hp.rules
+    )
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    patchelf --set-rpath ${libPath} --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+        $out/lib/cups/filter/{pstosecps,rastertospl,smfpnetdiscovery}
+
+    echo fopen fopen_wrapper >> name_map
+    echo opendir opendir_wrapper >> name_map
+    ${buildPackages.patchelfUnstable}/bin/patchelf \
+      --rename-dynamic-symbols name_map \
+      --add-needed ${wrapperLibName} \
+      --set-rpath ${libPath} \
+      $out/lib/sane/libsane-smfp.so.1.0.1
+
+    patchelf --set-rpath ${libPath} $out/lib/libscmssc.so
+  '';
+
+  ppdFileCommands = [
+    "pstosecps"
+    "rastertospl"
+    "smfpnetdiscovery"
+  ];
+
+  meta = {
+    description = "Drivers for HP printers that are actually Samsung printers";
+    homepage = "http://www.hp.com/";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.unfree;
+    platforms = [
+      "x86_64-linux"
+      "i686-linux"
+    ];
+    maintainers = with lib.maintainers; [ danberdev ];
+  };
+}


### PR DESCRIPTION

Hello! 

I've been migrating to NixOS and encountered a problem setting up my HP printer ([Laser MFP 135r](https://support.hp.com/in-en/product/details/hp-laser-mfp-130-printer-series/model/25532086) to be precise). I've always had problems with it, needing to install some strange hp-uld driver instead of using the hplip suite on other distributions. 

I've started to dig into it, because the package collection didn't have this driver, and it turned out, that my HP was a Samsung in disguise all this time :D. That's why it needs a special driver among some other HP models.  

I tried to write a derivation to package the driver for my machine, and it worked (but it wasn't easy, some ugly library patching, ugh). As I've managed to write the derivation and package the driver, I thought that it would be nice to offer it to the community (and maintain it, of course). 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
