### PR TITLE
[Backport release-25.11] ruffle: 0.2.0-nightly-2025-11-16 -> 0.2.0-nightly-2025-11-29 

### DIFF
--- a/pkgs/by-name/ru/ruffle/package.nix
+++ b/pkgs/by-name/ru/ruffle/package.nix
@@ -27,13 +27,13 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ruffle";
-  version = "0.2.0-nightly-2025-11-22";
+  version = "0.2.0-nightly-2025-11-29";
 
   src = fetchFromGitHub {
     owner = "ruffle-rs";
     repo = "ruffle";
     tag = lib.strings.removePrefix "0.2.0-" finalAttrs.version;
-    hash = "sha256-uKl4gw6HMP+PowuavfGjPTov7cFwnxarMqWsiNK8euY=";
+    hash = "sha256-CGeLCbmACKDKfnqbrqfOSc1MNVL14rHjFMl3ZbS7/Co=";
   };
 
   postPatch =
@@ -49,7 +49,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
                        "OpenH264Version(${major}, ${minor}, ${patch})"
     '';
 
-  cargoHash = "sha256-8OEiM6Gp9Zqi3ul6Y1x17WRzNDgIKqKn7QrHeFRRqDc=";
+  cargoHash = "sha256-B4q2OhzAc5zy0BUPlK+ABBCbW1nea4azu057h3F1KZo=";
   cargoBuildFlags = lib.optional withRuffleTools "--workspace";
 
   env =

--- a/pkgs/by-name/ru/ruffle/package.nix
+++ b/pkgs/by-name/ru/ruffle/package.nix
@@ -27,13 +27,13 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ruffle";
-  version = "0.2.0-nightly-2025-11-16";
+  version = "0.2.0-nightly-2025-11-22";
 
   src = fetchFromGitHub {
     owner = "ruffle-rs";
     repo = "ruffle";
     tag = lib.strings.removePrefix "0.2.0-" finalAttrs.version;
-    hash = "sha256-iiiC5emyAAGyaaP4dqo25osUFjAAEtUEGd4M2et26Bg=";
+    hash = "sha256-uKl4gw6HMP+PowuavfGjPTov7cFwnxarMqWsiNK8euY=";
   };
 
   postPatch =
@@ -49,7 +49,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
                        "OpenH264Version(${major}, ${minor}, ${patch})"
     '';
 
-  cargoHash = "sha256-5sGodB0RNRZ2QiJv9zHyzFjBwTbRffvPkt21trUZgZE=";
+  cargoHash = "sha256-8OEiM6Gp9Zqi3ul6Y1x17WRzNDgIKqKn7QrHeFRRqDc=";
   cargoBuildFlags = lib.optional withRuffleTools "--workspace";
 
   env =


### PR DESCRIPTION
Manual backport of #464213 and #466307 to `release-25.11`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
