### PR TITLE
skktools: fix build with gcc15

### DIFF
--- a/pkgs/by-name/sk/skktools/package.nix
+++ b/pkgs/by-name/sk/skktools/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   pkg-config,
   gdbm,
   glib,
@@ -33,6 +34,16 @@ stdenv.mkDerivation rec {
   #   rev = "e14d98e734d2fdff611385c7df65826e94d929db";
   #   sha256 = "1k9zxqybl1l5h0a8px2awc920qrdyp1qls50h3kfrj3g65d08aq2";
   # };
+
+  patches = [
+    # Fix build with gcc15
+    # https://github.com/skk-dev/skktools/pull/30
+    (fetchpatch {
+      name = "skktools-fix-function-prototype-empty-arguments-gcc15.patch";
+      url = "https://github.com/skk-dev/skktools/commit/fb6a295607dbe2b5171c2c89f8a2f0b82bee9766.patch";
+      hash = "sha256-wao2kRsDq5WN4JO/YpXhNirsdnA3vZpsY9GDCTPSJKY=";
+    })
+  ];
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [


### PR DESCRIPTION
- add patch from merged upstream PR:
https://www.github.com/skk-dev/skktools/pull/30
https://github.com/skk-dev/skktools/commit/fb6a295607dbe2b5171c2c89f8a2f0b82bee9766

Fixes build failure with gcc15:
```
./skkdic-expr.c:359:13: error: too many arguments to function
'add_content_line'; expected 0, have 3
  359 |         if (add_content_line(new, content, NULL))
      |             ^~~~~~~~~~~~~~~~ ~~~
./skkdic-expr.c:115:12: note: declared here
  115 | static int add_content_line();
      |            ^~~~~~~~~~~~~~~~
./skkdic-expr.c:576:9: error: too many arguments to function
'subtract_content_line'; expected 0, have 3
  576 |         subtract_content_line(new, content, NULL);
      |         ^~~~~~~~~~~~~~~~~~~~~ ~~~
./skkdic-expr.c:116:13: note: declared here
  116 | static void subtract_content_line();
      |             ^~~~~~~~~~~~~~~~~~~~~
```

---

Tested build on `master` with:
```bash
nix-build --expr 'with import ./. {}; skktools.override { stdenv = gcc15Stdenv; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
