### PR TITLE
python3Packages.magika: refactor

### DIFF
--- a/pkgs/development/python-modules/magika/default.nix
+++ b/pkgs/development/python-modules/magika/default.nix
@@ -9,7 +9,6 @@
   hatchling,
   python-dotenv,
   pythonOlder,
-  stdenv,
   tabulate,
   testers,
   tqdm,
@@ -48,7 +47,5 @@ buildPythonPackage rec {
     license = licenses.asl20;
     maintainers = with maintainers; [ mihaimaruseac ];
     mainProgram = "magika-python-client";
-    # Currently, disabling on AArch64 as it onnx runtime crashes on ofborg
-    broken = stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isLinux;
   };
 }

--- a/pkgs/development/python-modules/magika/default.nix
+++ b/pkgs/development/python-modules/magika/default.nix
@@ -3,31 +3,28 @@
   buildPythonPackage,
   click,
   fetchPypi,
-  magika,
   numpy,
   onnxruntime,
   hatchling,
   python-dotenv,
-  pythonOlder,
   tabulate,
-  testers,
   tqdm,
+  versionCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "magika";
   version = "1.0.1";
   pyproject = true;
-  disabled = pythonOlder "3.9";
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-MT+Mv83Jp+VcJChicyMKJzK4mCXlipPeK1dlMTk7g5g=";
   };
 
-  nativeBuildInputs = [ hatchling ];
+  build-system = [ hatchling ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     click
     numpy
     onnxruntime
@@ -36,16 +33,18 @@ buildPythonPackage rec {
     tqdm
   ];
 
+  nativeCheckInputs = [
+    versionCheckHook
+  ];
+
   pythonImportsCheck = [ "magika" ];
 
-  passthru.tests.version = testers.testVersion { package = magika; };
-
-  meta = with lib; {
+  meta = {
     description = "Detect file content types with deep learning";
     homepage = "https://github.com/google/magika";
     changelog = "https://github.com/google/magika/blob/python-v${version}/python/CHANGELOG.md";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ mihaimaruseac ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ mihaimaruseac ];
     mainProgram = "magika-python-client";
   };
 }

--- a/pkgs/development/python-modules/magika/default.nix
+++ b/pkgs/development/python-modules/magika/default.nix
@@ -9,6 +9,8 @@
   python-dotenv,
   tabulate,
   tqdm,
+  pytestCheckHook,
+  dacite,
   versionCheckHook,
 }:
 
@@ -17,10 +19,19 @@ buildPythonPackage rec {
   version = "1.0.1";
   pyproject = true;
 
+  # Use pypi tarball instead of GitHub source
+  # Pypi tarball contains a pure python implementation of magika
+  # while GitHub source requires compiling magika-cli
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-MT+Mv83Jp+VcJChicyMKJzK4mCXlipPeK1dlMTk7g5g=";
   };
+
+  postPatch = ''
+    substituteInPlace tests/test_python_magika_client.py \
+      --replace-fail 'python_root_dir / "src" / "magika" / "cli" / "magika_client.py"' \
+        "Path('$out/bin/magika-python-client')"
+  '';
 
   build-system = [ hatchling ];
 
@@ -34,7 +45,22 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
+    pytestCheckHook
+    dacite
     versionCheckHook
+  ];
+
+  disabledTests = [
+    # These tests require test data which doesn't exist in pypi tarball
+    "test_features_extraction_vs_reference"
+    "test_reference_generation"
+    "test_inference_vs_reference"
+    "test_reference_generation"
+    "test_magika_module_with_one_test_file"
+    "test_magika_module_with_explicit_model_dir"
+    "test_magika_module_with_basic"
+    "test_magika_module_with_all_models"
+    "test_magika_module_with_previously_missdetected_samples"
   ];
 
   pythonImportsCheck = [ "magika" ];


### PR DESCRIPTION


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
