### PR TITLE
js80p: init at 3.5.0

### DIFF
--- a/pkgs/by-name/js/js80p/package.nix
+++ b/pkgs/by-name/js/js80p/package.nix
@@ -1,0 +1,90 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  symlinkJoin,
+  cairo,
+  libxcb,
+  libx11,
+  cppcheck,
+  zenity,
+  nix-update-script,
+
+  instructionSet ? "avx", # sse2 or avx
+}:
+let
+  arch = stdenv.targetPlatform.uname.processor;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "js80p";
+  version = "3.5.0";
+
+  src = fetchFromGitHub {
+    owner = "attilammagyar";
+    repo = "js80p";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-RFaQJLk3Dj+ftRXfRizC62YtzlnR0PvbZFlBgCrUgiw=";
+  };
+
+  postPatch = ''
+    substituteInPlace make/linux-gpp.mk \
+      --replace-fail "/usr/bin/objcopy" "${stdenv.cc}/bin/objcopy"
+
+    substituteInPlace src/gui/xcb.cpp \
+      --replace-fail "/usr/bin/zenity" "${zenity}/bin/zenity"
+  '';
+
+  buildInputs = [
+    cairo
+    libx11
+    libxcb
+  ];
+
+  CPP_TARGET_PLATFORM = lib.getExe' stdenv.cc "c++";
+
+  SYS_LIB_PATH =
+    let
+      libraries = symlinkJoin {
+        name = "js80p-libs";
+        paths = [
+          cairo
+          libxcb
+        ];
+      };
+    in
+    "${libraries}/lib";
+
+  VERSION_STR = "v${finalAttrs.version}";
+  VERSION_INT = lib.replaceString "." "" finalAttrs.version;
+
+  CPP_DEV_PLATFORM = lib.getExe' stdenv.cc "c++";
+  CPPCHECK = lib.getExe' cppcheck "cppcheck";
+
+  NIX_CFLAGS_COMPILE = "-Wno-format-security";
+
+  installPhase = ''
+    mkdir -p $out/share/js80p
+    cp -r presets $out/share/js80p
+
+    mkdir -p $out/share/js80p/doc
+    cp README.md $out/share/js80p/doc
+
+    pushd dist
+      mkdir -p $out/lib/vst3
+      install -Dm755 js80p-dev-linux-${arch}-${instructionSet}-vst3_single_file/js80p.vst3 $out/lib/vst3/js80p.so
+
+      mkdir -p $out/lib/vst
+      cp -r js80p-dev-linux-${arch}-${instructionSet}-fst/js80p.so $out/lib/vst
+    popd
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "MIDI driven, performance oriented, versatile synthesizer";
+    homepage = "https://attilammagyar.github.io/js80p";
+    platforms = lib.platforms.linux;
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ lib.maintainers.mrtnvgr ];
+  };
+})


### PR DESCRIPTION
This PR adds a js80p to nixpkgs. Currently, I does not seems to be working (tested in REAPER and Renoise), help is appreciated :)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
