### PR TITLE
freebsd.{various}: init and incremental upgrade

### DIFF
--- a/pkgs/os-specific/bsd/freebsd/patches/14.2/passwd-install.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/14.2/passwd-install.patch
@@ -1,0 +1,24 @@
+diff --git a/usr.bin/passwd/Makefile b/usr.bin/passwd/Makefile
+index f8734053deb0..3bfc1d0e9b5a 100644
+--- a/usr.bin/passwd/Makefile
++++ b/usr.bin/passwd/Makefile
+@@ -3,7 +3,7 @@
+ PACKAGE	 = runtime
+ PROG	 = passwd
+ BINOWN	 = root
+-BINMODE	 = 4555
++BINMODE	 = 0555
+ PRECIOUSPROG=
+ LIBADD   = pam
+ .if ${MK_NIS} != "no"
+@@ -11,10 +11,4 @@ SYMLINKS = passwd ${BINDIR}/yppasswd
+ MLINKS	 = passwd.1 yppasswd.1
+ .endif
+ 
+-beforeinstall:
+-.for i in passwd yppasswd
+-	[ ! -e ${DESTDIR}${BINDIR}/$i ] || \
+-		chflags noschg ${DESTDIR}${BINDIR}/$i || true
+-.endfor
+-
+ .include <bsd.prog.mk>

--- a/pkgs/os-specific/bsd/freebsd/patches/14.2/stand-label.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/14.2/stand-label.patch
@@ -1,0 +1,390 @@
+diff --git a/stand/common/disk.c b/stand/common/disk.c
+index c1650f0fa..1baf91efa 100644
+--- a/stand/common/disk.c
++++ b/stand/common/disk.c
+@@ -468,7 +468,7 @@ disk_parsedev(struct devdesc **idev, const char *devspec, const char **path)
+ 
+ 	if (*cp != '\0' && *cp != ':')
+ 		return (EINVAL);
+-	dev = malloc(sizeof(*dev));
++	dev = calloc(sizeof(*dev), 1);
+ 	if (dev == NULL)
+ 		return (ENOMEM);
+ 	dev->dd.d_unit = unit;
+diff --git a/stand/efi/include/efi.h b/stand/efi/include/efi.h
+index b603c3a78..d430a7012 100644
+--- a/stand/efi/include/efi.h
++++ b/stand/efi/include/efi.h
+@@ -74,14 +74,16 @@ typedef uint32_t   UINTN;
+ #include "efidef.h"
+ #include "efidevp.h"
+ #include "efipciio.h"
+-#include "efiprot.h"
+ #include "eficon.h"
++#include "efiapi.h"
++#include "efipart.h"
++#include "efigpt.h"
++#include "efiprot.h"
+ #include "eficonsctl.h"
+ #include "efiser.h"
+ #include "efi_nii.h"
+ #include "efipxebc.h"
+ #include "efinet.h"
+-#include "efiapi.h"
+ #include "efifs.h"
+ #include "efierr.h"
+ #include "efigop.h"
+@@ -90,6 +92,7 @@ typedef uint32_t   UINTN;
+ #include "efitcp.h"
+ #include "efipoint.h"
+ #include "efiuga.h"
++#include "efichar.h"
+ #include <sys/types.h>
+ 
+ /*
+diff --git a/stand/efi/include/efilib.h b/stand/efi/include/efilib.h
+index e1920430a..3bbd83a50 100644
+--- a/stand/efi/include/efilib.h
++++ b/stand/efi/include/efilib.h
+@@ -40,6 +40,7 @@ extern EFI_RUNTIME_SERVICES	*RS;
+ extern struct devsw efipart_fddev;
+ extern struct devsw efipart_cddev;
+ extern struct devsw efipart_hddev;
++extern struct devsw efipart_label;
+ extern struct devsw efihttp_dev;
+ extern struct devsw efinet_dev;
+ extern struct netif_driver efinetif;
+@@ -58,6 +59,7 @@ typedef struct pdinfo
+ 	uint32_t		pd_unit;	/* unit number */
+ 	uint32_t		pd_open;	/* reference counter */
+ 	void			*pd_bcache;	/* buffer cache data */
++	char			pd_volname[36*2];
+ 	struct pdinfo		*pd_parent;	/* Linked items (eg partitions) */
+ 	struct devsw		*pd_devsw;	/* Back pointer to devsw */
+ } pdinfo_t;
+diff --git a/stand/efi/include/efiprot.h b/stand/efi/include/efiprot.h
+index be11ea83b..1463c756c 100644
+--- a/stand/efi/include/efiprot.h
++++ b/stand/efi/include/efiprot.h
+@@ -632,4 +632,41 @@ typedef struct _EFI_COMPONENT_NAME2 {
+     CHAR8 **SupportedLanguages;
+ } EFI_COMPONENT_NAME2;
+ 
++//
++// Partition Info Protocol
++//
++
++#define PARTITION_INFO_PROTOCOL \
++  { 0x8cf2f62c, 0xbc9b, 0x4821, {0x80, 0x8d, 0xec, 0x9e, 0xc4, 0x21, 0xa1, 0xa0} }
++
++INTERFACE_DECL(_EFI_PARTITION_INFO);
++
++#define EFI_PARTITION_INFO_INTERFACE_REVISION 0x0001000
++#define PARTITION_TYPE_OTHER 0x00
++#define PARTITION_TYPE_MBR 0x01
++#define PARTITION_TYPE_GPT 0x02
++
++#pragma pack(1)
++
++typedef struct _EFI_PARTITION_INFO {
++
++  UINT32         Revision;
++  UINT32         Type;
++  UINT8          System;
++  UINT8          Reserved[7];
++  union {
++   ///
++   /// MBR data
++   ///
++   MBR_PARTITION_RECORD Mbr;
++
++   ///
++   /// GPT data
++   ///
++   EFI_PARTITION_ENTRY Gpt;
++  } Info;
++} EFI_PARTITION_INFO;
++
++#pragma pack()
++
+ #endif
+diff --git a/stand/efi/libefi/efipart.c b/stand/efi/libefi/efipart.c
+index 3df603457..a7b6050ff 100644
+--- a/stand/efi/libefi/efipart.c
++++ b/stand/efi/libefi/efipart.c
+@@ -35,11 +35,10 @@
+ 
+ #include <efi.h>
+ #include <efilib.h>
+-#include <efiprot.h>
+-#include <efichar.h>
+ #include <disk.h>
+ 
+ static EFI_GUID blkio_guid = BLOCK_IO_PROTOCOL;
++static EFI_GUID partinfo_guid = PARTITION_INFO_PROTOCOL;
+ 
+ typedef bool (*pd_test_cb_t)(pdinfo_t *, pdinfo_t *);
+ static int efipart_initfd(void);
+@@ -58,6 +57,12 @@ static int efipart_printfd(int);
+ static int efipart_printcd(int);
+ static int efipart_printhd(int);
+ 
++static int efipart_get_volname(EFI_HANDLE h, char *dest, int size);
++static int label_parsedev(struct devdesc **idev, const char *devspec, const char **path);
++
++static char *nullfmt(struct devdesc *vdev);
++static int nullinit(void);
++
+ /* EISA PNP ID's for floppy controllers */
+ #define	PNP0604	0x604
+ #define	PNP0700	0x700
+@@ -104,6 +109,20 @@ struct devsw efipart_hddev = {
+ 	.dv_parsedev = disk_parsedev,
+ };
+ 
++struct devsw efipart_label = {
++	.dv_name = "label",
++	.dv_type = DEVT_LABEL,
++	.dv_init = nullinit,
++	.dv_strategy = efipart_strategy,
++	.dv_open = efipart_open,
++	.dv_close = efipart_close,
++	.dv_ioctl = efipart_ioctl,
++	.dv_print = efipart_printhd,
++	.dv_cleanup = nullsys,
++	.dv_fmtdev = nullfmt,
++	.dv_parsedev = label_parsedev,
++};
++
+ static pdinfo_list_t fdinfo = STAILQ_HEAD_INITIALIZER(fdinfo);
+ static pdinfo_list_t cdinfo = STAILQ_HEAD_INITIALIZER(cdinfo);
+ static pdinfo_list_t hdinfo = STAILQ_HEAD_INITIALIZER(hdinfo);
+@@ -406,6 +425,8 @@ efipart_inithandles(void)
+ 		pd->pd_handle = hin[i];
+ 		pd->pd_devpath = devpath;
+ 		pd->pd_blkio = blkio;
++		/* Do not fail here */
++		efipart_get_volname(hin[i], pd->pd_volname, sizeof(pd->pd_volname));
+ 		STAILQ_INSERT_TAIL(&pdinfo, pd, pd_link);
+ 	}
+ 
+@@ -419,6 +440,20 @@ efipart_inithandles(void)
+ 	return (0);
+ }
+ 
++static int
++efipart_get_volname(EFI_HANDLE h, char *dest, int size)
++{
++	EFI_PARTITION_INFO *partinfo;
++	int status;
++
++	status = OpenProtocolByHandle(h, &partinfo_guid, (void **)&partinfo);
++	if (EFI_ERROR(status)) {
++		return (efi_status_to_errno(status));
++	}
++	cpy16to8(partinfo->Info.Gpt.PartitionName, dest, size);
++	return (0);
++}
++
+ /*
+  * Get node identified by pd_test() from plist.
+  */
+@@ -1249,3 +1284,99 @@ efipart_realstrategy(void *devdata, int rw, daddr_t blk, size_t size,
+ 		free(blkbuf);
+ 	return (rc);
+ }
++
++static pdinfo_t *
++label_lookup_part(const char *label, struct devsw **dev)
++{
++	pdinfo_t *dp, *pp;
++
++	/*
++	 * Check hard disks, then cd, then floppy
++	 */
++	STAILQ_FOREACH(dp, &hdinfo, pd_link) {
++		if (!strcmp(label, dp->pd_volname)) {
++			*dev = &efipart_hddev;
++			return (dp);
++		}
++		STAILQ_FOREACH(pp, &dp->pd_part, pd_link) {
++			if (!strcmp(label, pp->pd_volname)) {
++				*dev = &efipart_hddev;
++				return (pp);
++			}
++		}
++	}
++	STAILQ_FOREACH(dp, &cdinfo, pd_link) {
++		if (!strcmp(label, dp->pd_volname)) {
++			*dev = &efipart_cddev;
++			return (dp);
++		}
++		STAILQ_FOREACH(pp, &dp->pd_part, pd_link) {
++			if (!strcmp(label, pp->pd_volname)) {
++				*dev = &efipart_cddev;
++				return (pp);
++			}
++		}
++	}
++	STAILQ_FOREACH(dp, &fdinfo, pd_link) {
++		if (!strcmp(label, dp->pd_volname)) {
++			*dev = &efipart_fddev;
++			return (dp);
++		}
++	}
++	return (NULL);
++}
++
++static int
++label_parsedev(struct devdesc **idev, const char *devspec, const char **path)
++{
++	pdinfo_t *part;
++	const char *devspeci, *devspecp;
++	char *label;
++	struct disk_devdesc *dev;
++
++	if (strncmp(devspec, "label:", strlen("label:"))) {
++		return (EINVAL);
++	}
++	devspeci = devspec + strlen("label:");
++	devspecp = strchr(devspeci, ':');
++	if (devspecp == NULL) {
++		return (EINVAL);
++	}
++	label = malloc(devspecp - devspeci + 1);
++	if (label == NULL) {
++		return (ENOMEM);
++	}
++	memcpy(label, devspeci, devspecp - devspeci);
++	label[devspecp - devspeci] = 0;
++
++	dev = calloc(sizeof(*dev), 1);
++	if (dev == NULL)
++		return (ENOMEM);
++
++	part = label_lookup_part(label, &dev->dd.d_dev);
++	if (part == NULL) {
++		return (ENOENT);
++	}
++
++	dev->dd.d_unit = part->pd_parent->pd_unit;
++	dev->d_slice = part->pd_unit;
++	dev->d_partition = D_PARTISGPT;
++	*idev = &dev->dd;
++	if (path != NULL) {
++		*path = devspecp + 1;
++	}
++
++	return (0);
++}
++
++static char *
++nullfmt(struct devdesc *vdev)
++{
++	return ("");
++}
++
++static int
++nullinit(void)
++{
++	return (0);
++}
+diff --git a/stand/efi/loader/conf.c b/stand/efi/loader/conf.c
+index 3bc74ea63..042aa15b3 100644
+--- a/stand/efi/loader/conf.c
++++ b/stand/efi/loader/conf.c
+@@ -40,6 +40,7 @@ struct devsw *devsw[] = {
+ 	&efipart_fddev,
+ 	&efipart_cddev,
+ 	&efipart_hddev,
++	&efipart_label,
+ 	&efihttp_dev, /* ordering with efinet_dev matters */
+ #if defined(LOADER_NET_SUPPORT)
+ 	&efinet_dev,
+diff --git a/stand/kboot/kboot/hostdisk.c b/stand/kboot/kboot/hostdisk.c
+index a9117d4c1..fc98bf534 100644
+--- a/stand/kboot/kboot/hostdisk.c
++++ b/stand/kboot/kboot/hostdisk.c
+@@ -465,7 +465,7 @@ hostdisk_parsedev(struct devdesc **idev, const char *devspec, const char **path)
+ 		return (EINVAL);
+ 	}
+ 	free(fn);
+-	dev = malloc(sizeof(*dev));
++	dev = calloc(sizeof(*dev), 1);
+ 	if (dev == NULL)
+ 		return (ENOMEM);
+ 	dev->d_unit = 0;
+diff --git a/stand/libofw/devicename.c b/stand/libofw/devicename.c
+index 5e3a789c1..dd7eb2cf8 100644
+--- a/stand/libofw/devicename.c
++++ b/stand/libofw/devicename.c
+@@ -98,7 +98,7 @@ ofw_common_parsedev(struct devdesc **dev, const char *devspec, const char **path
+ 
+ 	if (ofw_path_to_handle(devspec, ofwtype, &rem_path) == -1)
+ 		return (ENOENT);
+-	idev = malloc(sizeof(struct ofw_devdesc));
++	idev = calloc(sizeof(struct ofw_devdesc), 1);
+ 	if (idev == NULL) {
+ 		printf("ofw_parsedev: malloc failed\n");
+ 		return ENOMEM;
+diff --git a/stand/libsa/dev.c b/stand/libsa/dev.c
+index 1edc843d5..841615588 100644
+--- a/stand/libsa/dev.c
++++ b/stand/libsa/dev.c
+@@ -72,7 +72,7 @@ default_parsedev(struct devdesc **dev, const char *devspec,
+ 	int unit, err;
+ 	char *cp;
+ 
+-	idev = malloc(sizeof(struct devdesc));
++	idev = calloc(sizeof(struct devdesc), 1);
+ 	if (idev == NULL)
+ 		return (ENOMEM);
+ 
+@@ -139,7 +139,8 @@ devparse(struct devdesc **dev, const char *devspec, const char **path)
+ 	if (err != 0)
+ 		return (err);
+ 
+-	idev->d_dev = dv;
++	if (idev->d_dev == NULL)
++		idev->d_dev = dv;
+ 	if (dev != NULL)
+ 		*dev = idev;
+ 	else
+diff --git a/stand/libsa/stand.h b/stand/libsa/stand.h
+index 260defa3a..8fb5c818d 100644
+--- a/stand/libsa/stand.h
++++ b/stand/libsa/stand.h
+@@ -148,6 +148,7 @@ struct devsw {
+ #define DEVT_CD		3
+ #define DEVT_ZFS	4
+ #define DEVT_FD		5
++#define DEVT_LABEL	6
+     int		(*dv_init)(void);	/* early probe call */
+     int		(*dv_strategy)(void *devdata, int rw, daddr_t blk,
+ 			size_t size, char *buf, size_t *rsize);
+diff --git a/stand/libsa/zfs/zfs.c b/stand/libsa/zfs/zfs.c
+index 70a102f64..2f7c1caaa 100644
+--- a/stand/libsa/zfs/zfs.c
++++ b/stand/libsa/zfs/zfs.c
+@@ -1643,7 +1643,7 @@ zfs_parsedev(struct devdesc **idev, const char *devspec, const char **path)
+ 	spa = spa_find_by_name(poolname);
+ 	if (!spa)
+ 		return (ENXIO);
+-	dev = malloc(sizeof(*dev));
++	dev = calloc(sizeof(*dev), 1);
+ 	if (dev == NULL)
+ 		return (ENOMEM);
+ 	dev->pool_guid = spa->spa_guid;
+diff --git a/stand/uboot/devicename.c b/stand/uboot/devicename.c
+index 4ee9c7fd7..23670d759 100644
+--- a/stand/uboot/devicename.c
++++ b/stand/uboot/devicename.c
+@@ -102,7 +102,7 @@ uboot_parsedev(struct uboot_devdesc **dev, const char *devspec,
+ 	}
+ 	if (dv == NULL)
+ 		return(ENOENT);
+-	idev = malloc(sizeof(struct uboot_devdesc));
++	idev = calloc(sizeof(struct uboot_devdesc), 1);
+ 	err = 0;
+ 	np = (devspec + strlen(dv->dv_name));
+ 

--- a/pkgs/os-specific/bsd/freebsd/patches/14.2/su-install.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/14.2/su-install.patch
@@ -1,0 +1,13 @@
+diff --git a/usr.bin/su/Makefile b/usr.bin/su/Makefile
+index f6d95defa195..b43d7592ef89 100644
+--- a/usr.bin/su/Makefile
++++ b/usr.bin/su/Makefile
+@@ -10,7 +10,7 @@ LIBADD+=	bsm
+ .endif
+ 
+ BINOWN=	root
+-BINMODE=4555
++BINMODE=0555
+ PRECIOUSPROG=
+ 
+ .include <bsd.prog.mk>

--- a/pkgs/os-specific/bsd/freebsd/patches/14.2/sysctl-funcname-backport.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/14.2/sysctl-funcname-backport.patch
@@ -1,0 +1,27 @@
+commit faa845aab6113190ba8c75a171b2cca8673a6214
+Author: Zhenlei Huang <zlei@FreeBSD.org>
+Date:   Sun Jan 26 01:59:33 2025 +0800
+
+    kern_sysctl: Fix printing function name in the re-use sysctl leaf warning
+    
+    The helper function sysctl_warn_reuse() is intended to print the name of
+    the caller rather than that of itself.
+    
+    PR:     221853
+    Fixes:  4ae2ade11426 Enhance debugibility of sysctl leaf re-use warnings
+    MFC after:      3 days
+    Differential Revision:  https://reviews.freebsd.org/D48645
+
+diff --git a/sys/kern/kern_sysctl.c b/sys/kern/kern_sysctl.c
+index 9d824fbd3cbd..da09aaed5558 100644
+--- a/sys/kern/kern_sysctl.c
++++ b/sys/kern/kern_sysctl.c
+@@ -411,7 +411,7 @@ sysctl_warn_reuse(const char *func, struct sysctl_oid *leaf)
+ 	(void)sbuf_new(&sb, buf, sizeof(buf), SBUF_FIXEDLEN | SBUF_INCLUDENUL);
+ 	sbuf_set_drain(&sb, sbuf_printf_drain, NULL);
+ 
+-	sbuf_printf(&sb, "%s: can't re-use a leaf (", __func__);
++	sbuf_printf(&sb, "%s: can't re-use a leaf (", func);
+ 
+ 	rc = sysctl_search_oid(nodes, leaf);
+ 	if (rc > 0) {

--- a/pkgs/os-specific/bsd/freebsd/patches/15.0/stand-label.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/15.0/stand-label.patch
@@ -1,0 +1,390 @@
+diff --git a/stand/common/disk.c b/stand/common/disk.c
+index c1650f0fa..1baf91efa 100644
+--- a/stand/common/disk.c
++++ b/stand/common/disk.c
+@@ -468,7 +468,7 @@ disk_parsedev(struct devdesc **idev, const char *devspec, const char **path)
+ 
+ 	if (*cp != '\0' && *cp != ':')
+ 		return (EINVAL);
+-	dev = malloc(sizeof(*dev));
++	dev = calloc(sizeof(*dev), 1);
+ 	if (dev == NULL)
+ 		return (ENOMEM);
+ 	dev->dd.d_unit = unit;
+diff --git a/stand/efi/include/efi.h b/stand/efi/include/efi.h
+index b603c3a78..d430a7012 100644
+--- a/stand/efi/include/efi.h
++++ b/stand/efi/include/efi.h
+@@ -74,14 +74,16 @@ typedef uint32_t   UINTN;
+ #include "efidef.h"
+ #include "efidevp.h"
+ #include "efipciio.h"
+-#include "efiprot.h"
+ #include "eficon.h"
++#include "efiapi.h"
++#include "efipart.h"
++#include "efigpt.h"
++#include "efiprot.h"
+ #include "eficonsctl.h"
+ #include "efiser.h"
+ #include "efi_nii.h"
+ #include "efipxebc.h"
+ #include "efinet.h"
+-#include "efiapi.h"
+ #include "efifs.h"
+ #include "efierr.h"
+ #include "efigop.h"
+@@ -91,6 +93,7 @@ typedef uint32_t   UINTN;
+ #include "efipoint.h"
+ #include "efiuga.h"
+ #include <sys/types.h>
++#include "efichar.h"
+ 
+ /*
+  * Global variables
+diff --git a/stand/efi/include/efilib.h b/stand/efi/include/efilib.h
+index e1920430a..3bbd83a50 100644
+--- a/stand/efi/include/efilib.h
++++ b/stand/efi/include/efilib.h
+@@ -40,6 +40,7 @@ extern EFI_RUNTIME_SERVICES	*RS;
+ extern struct devsw efipart_fddev;
+ extern struct devsw efipart_cddev;
+ extern struct devsw efipart_hddev;
++extern struct devsw efipart_label;
+ extern struct devsw efihttp_dev;
+ extern struct devsw efinet_dev;
+ extern struct netif_driver efinetif;
+@@ -58,6 +59,7 @@ typedef struct pdinfo
+ 	uint32_t		pd_unit;	/* unit number */
+ 	uint32_t		pd_open;	/* reference counter */
+ 	void			*pd_bcache;	/* buffer cache data */
++	char			pd_volname[36*2];
+ 	struct pdinfo		*pd_parent;	/* Linked items (eg partitions) */
+ 	struct devsw		*pd_devsw;	/* Back pointer to devsw */
+ } pdinfo_t;
+diff --git a/stand/efi/include/efiprot.h b/stand/efi/include/efiprot.h
+index be11ea83b..1463c756c 100644
+--- a/stand/efi/include/efiprot.h
++++ b/stand/efi/include/efiprot.h
+@@ -632,4 +632,41 @@ typedef struct _EFI_COMPONENT_NAME2 {
+     CHAR8 **SupportedLanguages;
+ } EFI_COMPONENT_NAME2;
+ 
++//
++// Partition Info Protocol
++//
++
++#define PARTITION_INFO_PROTOCOL \
++  { 0x8cf2f62c, 0xbc9b, 0x4821, {0x80, 0x8d, 0xec, 0x9e, 0xc4, 0x21, 0xa1, 0xa0} }
++
++INTERFACE_DECL(_EFI_PARTITION_INFO);
++
++#define EFI_PARTITION_INFO_INTERFACE_REVISION 0x0001000
++#define PARTITION_TYPE_OTHER 0x00
++#define PARTITION_TYPE_MBR 0x01
++#define PARTITION_TYPE_GPT 0x02
++
++#pragma pack(1)
++
++typedef struct _EFI_PARTITION_INFO {
++
++  UINT32         Revision;
++  UINT32         Type;
++  UINT8          System;
++  UINT8          Reserved[7];
++  union {
++   ///
++   /// MBR data
++   ///
++   MBR_PARTITION_RECORD Mbr;
++
++   ///
++   /// GPT data
++   ///
++   EFI_PARTITION_ENTRY Gpt;
++  } Info;
++} EFI_PARTITION_INFO;
++
++#pragma pack()
++
+ #endif
+diff --git a/stand/efi/libefi/efipart.c b/stand/efi/libefi/efipart.c
+index 3df603457..a7b6050ff 100644
+--- a/stand/efi/libefi/efipart.c
++++ b/stand/efi/libefi/efipart.c
+@@ -35,11 +35,10 @@
+ 
+ #include <efi.h>
+ #include <efilib.h>
+-#include <efiprot.h>
+-#include <efichar.h>
+ #include <disk.h>
+ 
+ static EFI_GUID blkio_guid = BLOCK_IO_PROTOCOL;
++static EFI_GUID partinfo_guid = PARTITION_INFO_PROTOCOL;
+ 
+ typedef bool (*pd_test_cb_t)(pdinfo_t *, pdinfo_t *);
+ static int efipart_initfd(void);
+@@ -58,6 +57,12 @@ static int efipart_printfd(int);
+ static int efipart_printcd(int);
+ static int efipart_printhd(int);
+ 
++static int efipart_get_volname(EFI_HANDLE h, char *dest, int size);
++static int label_parsedev(struct devdesc **idev, const char *devspec, const char **path);
++
++static char *nullfmt(struct devdesc *vdev);
++static int nullinit(void);
++
+ /* EISA PNP ID's for floppy controllers */
+ #define	PNP0604	0x604
+ #define	PNP0700	0x700
+@@ -104,6 +109,20 @@ struct devsw efipart_hddev = {
+ 	.dv_parsedev = disk_parsedev,
+ };
+ 
++struct devsw efipart_label = {
++	.dv_name = "label",
++	.dv_type = DEVT_LABEL,
++	.dv_init = nullinit,
++	.dv_strategy = efipart_strategy,
++	.dv_open = efipart_open,
++	.dv_close = efipart_close,
++	.dv_ioctl = efipart_ioctl,
++	.dv_print = efipart_printhd,
++	.dv_cleanup = nullsys,
++	.dv_fmtdev = nullfmt,
++	.dv_parsedev = label_parsedev,
++};
++
+ static pdinfo_list_t fdinfo = STAILQ_HEAD_INITIALIZER(fdinfo);
+ static pdinfo_list_t cdinfo = STAILQ_HEAD_INITIALIZER(cdinfo);
+ static pdinfo_list_t hdinfo = STAILQ_HEAD_INITIALIZER(hdinfo);
+@@ -406,6 +425,8 @@ efipart_inithandles(void)
+ 		pd->pd_handle = hin[i];
+ 		pd->pd_devpath = devpath;
+ 		pd->pd_blkio = blkio;
++		/* Do not fail here */
++		efipart_get_volname(hin[i], pd->pd_volname, sizeof(pd->pd_volname));
+ 		STAILQ_INSERT_TAIL(&pdinfo, pd, pd_link);
+ 	}
+ 
+@@ -419,6 +440,20 @@ efipart_inithandles(void)
+ 	return (0);
+ }
+ 
++static int
++efipart_get_volname(EFI_HANDLE h, char *dest, int size)
++{
++	EFI_PARTITION_INFO *partinfo;
++	int status;
++
++	status = OpenProtocolByHandle(h, &partinfo_guid, (void **)&partinfo);
++	if (EFI_ERROR(status)) {
++		return (efi_status_to_errno(status));
++	}
++	cpy16to8(partinfo->Info.Gpt.PartitionName, dest, size);
++	return (0);
++}
++
+ /*
+  * Get node identified by pd_test() from plist.
+  */
+@@ -1249,3 +1284,99 @@ efipart_realstrategy(void *devdata, int rw, daddr_t blk, size_t size,
+ 		free(blkbuf);
+ 	return (rc);
+ }
++
++static pdinfo_t *
++label_lookup_part(const char *label, struct devsw **dev)
++{
++	pdinfo_t *dp, *pp;
++
++	/*
++	 * Check hard disks, then cd, then floppy
++	 */
++	STAILQ_FOREACH(dp, &hdinfo, pd_link) {
++		if (!strcmp(label, dp->pd_volname)) {
++			*dev = &efipart_hddev;
++			return (dp);
++		}
++		STAILQ_FOREACH(pp, &dp->pd_part, pd_link) {
++			if (!strcmp(label, pp->pd_volname)) {
++				*dev = &efipart_hddev;
++				return (pp);
++			}
++		}
++	}
++	STAILQ_FOREACH(dp, &cdinfo, pd_link) {
++		if (!strcmp(label, dp->pd_volname)) {
++			*dev = &efipart_cddev;
++			return (dp);
++		}
++		STAILQ_FOREACH(pp, &dp->pd_part, pd_link) {
++			if (!strcmp(label, pp->pd_volname)) {
++				*dev = &efipart_cddev;
++				return (pp);
++			}
++		}
++	}
++	STAILQ_FOREACH(dp, &fdinfo, pd_link) {
++		if (!strcmp(label, dp->pd_volname)) {
++			*dev = &efipart_fddev;
++			return (dp);
++		}
++	}
++	return (NULL);
++}
++
++static int
++label_parsedev(struct devdesc **idev, const char *devspec, const char **path)
++{
++	pdinfo_t *part;
++	const char *devspeci, *devspecp;
++	char *label;
++	struct disk_devdesc *dev;
++
++	if (strncmp(devspec, "label:", strlen("label:"))) {
++		return (EINVAL);
++	}
++	devspeci = devspec + strlen("label:");
++	devspecp = strchr(devspeci, ':');
++	if (devspecp == NULL) {
++		return (EINVAL);
++	}
++	label = malloc(devspecp - devspeci + 1);
++	if (label == NULL) {
++		return (ENOMEM);
++	}
++	memcpy(label, devspeci, devspecp - devspeci);
++	label[devspecp - devspeci] = 0;
++
++	dev = calloc(sizeof(*dev), 1);
++	if (dev == NULL)
++		return (ENOMEM);
++
++	part = label_lookup_part(label, &dev->dd.d_dev);
++	if (part == NULL) {
++		return (ENOENT);
++	}
++
++	dev->dd.d_unit = part->pd_parent->pd_unit;
++	dev->d_slice = part->pd_unit;
++	dev->d_partition = D_PARTISGPT;
++	*idev = &dev->dd;
++	if (path != NULL) {
++		*path = devspecp + 1;
++	}
++
++	return (0);
++}
++
++static char *
++nullfmt(struct devdesc *vdev)
++{
++	return ("");
++}
++
++static int
++nullinit(void)
++{
++	return (0);
++}
+diff --git a/stand/efi/loader/conf.c b/stand/efi/loader/conf.c
+index 3bc74ea63..042aa15b3 100644
+--- a/stand/efi/loader/conf.c
++++ b/stand/efi/loader/conf.c
+@@ -40,6 +40,7 @@ struct devsw *devsw[] = {
+ 	&efipart_fddev,
+ 	&efipart_cddev,
+ 	&efipart_hddev,
++	&efipart_label,
+ 	&efihttp_dev, /* ordering with efinet_dev matters */
+ #if defined(LOADER_NET_SUPPORT)
+ 	&efinet_dev,
+diff --git a/stand/kboot/kboot/hostdisk.c b/stand/kboot/kboot/hostdisk.c
+index a9117d4c1..fc98bf534 100644
+--- a/stand/kboot/kboot/hostdisk.c
++++ b/stand/kboot/kboot/hostdisk.c
+@@ -465,7 +465,7 @@ hostdisk_parsedev(struct devdesc **idev, const char *devspec, const char **path)
+ 		return (EINVAL);
+ 	}
+ 	free(fn);
+-	dev = malloc(sizeof(*dev));
++	dev = calloc(sizeof(*dev), 1);
+ 	if (dev == NULL)
+ 		return (ENOMEM);
+ 	dev->d_unit = 0;
+diff --git a/stand/libofw/devicename.c b/stand/libofw/devicename.c
+index 5e3a789c1..dd7eb2cf8 100644
+--- a/stand/libofw/devicename.c
++++ b/stand/libofw/devicename.c
+@@ -98,7 +98,7 @@ ofw_common_parsedev(struct devdesc **dev, const char *devspec, const char **path
+ 
+ 	if (ofw_path_to_handle(devspec, ofwtype, &rem_path) == -1)
+ 		return (ENOENT);
+-	idev = malloc(sizeof(struct ofw_devdesc));
++	idev = calloc(sizeof(struct ofw_devdesc), 1);
+ 	if (idev == NULL) {
+ 		printf("ofw_parsedev: malloc failed\n");
+ 		return ENOMEM;
+diff --git a/stand/libsa/dev.c b/stand/libsa/dev.c
+index 1edc843d5..841615588 100644
+--- a/stand/libsa/dev.c
++++ b/stand/libsa/dev.c
+@@ -72,7 +72,7 @@ default_parsedev(struct devdesc **dev, const char *devspec,
+ 	int unit, err;
+ 	char *cp;
+ 
+-	idev = malloc(sizeof(struct devdesc));
++	idev = calloc(sizeof(struct devdesc), 1);
+ 	if (idev == NULL)
+ 		return (ENOMEM);
+ 
+@@ -139,7 +139,8 @@ devparse(struct devdesc **dev, const char *devspec, const char **path)
+ 	if (err != 0)
+ 		return (err);
+ 
+-	idev->d_dev = dv;
++	if (idev->d_dev == NULL)
++		idev->d_dev = dv;
+ 	if (dev != NULL)
+ 		*dev = idev;
+ 	else
+diff --git a/stand/libsa/stand.h b/stand/libsa/stand.h
+index 260defa3a..8fb5c818d 100644
+--- a/stand/libsa/stand.h
++++ b/stand/libsa/stand.h
+@@ -148,6 +148,7 @@ struct devsw {
+ #define DEVT_CD		3
+ #define DEVT_ZFS	4
+ #define DEVT_FD		5
++#define DEVT_LABEL	6
+     int		(*dv_init)(void);	/* early probe call */
+     int		(*dv_strategy)(void *devdata, int rw, daddr_t blk,
+ 			size_t size, char *buf, size_t *rsize);
+diff --git a/stand/libsa/zfs/zfs.c b/stand/libsa/zfs/zfs.c
+index 70a102f64..2f7c1caaa 100644
+--- a/stand/libsa/zfs/zfs.c
++++ b/stand/libsa/zfs/zfs.c
+@@ -1643,7 +1643,7 @@ zfs_parsedev(struct devdesc **idev, const char *devspec, const char **path)
+ 	spa = spa_find_by_name(poolname);
+ 	if (!spa)
+ 		return (ENXIO);
+-	dev = malloc(sizeof(*dev));
++	dev = calloc(sizeof(*dev), 1);
+ 	if (dev == NULL)
+ 		return (ENOMEM);
+ 	dev->pool_guid = spa->spa_guid;
+diff --git a/stand/uboot/devicename.c b/stand/uboot/devicename.c
+index 4ee9c7fd7..23670d759 100644
+--- a/stand/uboot/devicename.c
++++ b/stand/uboot/devicename.c
+@@ -102,7 +102,7 @@ uboot_parsedev(struct uboot_devdesc **dev, const char *devspec,
+ 	}
+ 	if (dv == NULL)
+ 		return(ENOENT);
+-	idev = malloc(sizeof(struct uboot_devdesc));
++	idev = calloc(sizeof(struct uboot_devdesc), 1);
+ 	err = 0;
+ 	np = (devspec + strlen(dv->dv_name));
+ 

--- a/pkgs/os-specific/bsd/freebsd/pkgs/arp.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/arp.nix
@@ -1,0 +1,12 @@
+{
+  lib,
+  mkDerivation,
+  libxo,
+}:
+mkDerivation {
+  path = "usr.sbin/arp";
+  buildInputs = [ libxo ];
+
+  meta.platforms = lib.platforms.freebsd;
+  meta.mainProgram = "arp";
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/ctfconvert.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/ctfconvert.nix
@@ -3,6 +3,7 @@
   mkDerivation,
   compatIfNeeded,
   libdwarf,
+  libelf,
   zlib,
   libspl,
 }:
@@ -29,6 +30,7 @@ mkDerivation {
     libdwarf
     zlib
     libspl
+    libelf
   ];
 
   meta.license = lib.licenses.cddl;

--- a/pkgs/os-specific/bsd/freebsd/pkgs/ctfmerge.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/ctfmerge.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  mkDerivation,
+  compatIfNeeded,
+  libelf,
+  zlib,
+  libspl,
+}:
+
+mkDerivation {
+  path = "cddl/usr.bin/ctfmerge";
+  extraPaths = [
+    "cddl/compat/opensolaris"
+    "cddl/contrib/opensolaris"
+    "sys/cddl/compat/opensolaris"
+    "sys/cddl/contrib/opensolaris"
+    "sys/contrib/openzfs"
+  ];
+  OPENSOLARIS_USR_DISTDIR = "$(SRCTOP)/cddl/contrib/opensolaris";
+  OPENSOLARIS_SYS_DISTDIR = "$(SRCTOP)/sys/cddl/contrib/opensolaris";
+
+  makeFlags = [
+    "STRIP=-s"
+    "MK_WERROR=no"
+    "MK_TESTS=no"
+  ];
+
+  buildInputs = compatIfNeeded ++ [
+    zlib
+    libspl
+    libelf
+  ];
+
+  meta.license = lib.licenses.cddl;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/devd.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/devd.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  mkDerivation,
+  libutil,
+  flex,
+  byacc,
+}:
+mkDerivation {
+  path = "sbin/devd";
+
+  outputs = [
+    "out"
+    "etc"
+    "man"
+    "debug"
+  ];
+
+  buildInputs = [
+    libutil
+  ];
+
+  extraNativeBuildInputs = [
+    flex
+    byacc
+  ];
+
+  clangFixup = false;
+
+  MK_TESTS = "no";
+  MK_AUTOFS = "yes";
+  MK_BLUETOOTH = "yes";
+  MK_HYPERV = "yes";
+  MK_USB = "yes";
+  MK_ZFS = "yes";
+
+  postPatch = ''
+    substituteInPlace $BSDSRCDIR/sbin/devd/Makefile --replace-fail /etc $etc/etc
+  '';
+
+  NIX_CFLAGS_COMPILE = [
+    "-Wno-c++20-extensions"
+    "-Wno-nullability-completeness"
+  ];
+
+  postInstall = ''
+    make $makeFlags installconfig
+  '';
+
+  meta.platforms = lib.platforms.freebsd;
+  meta.mainProgram = "devd";
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod-firmware.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod-firmware.nix
@@ -12,7 +12,7 @@ mkDerivation rec {
   pname =
     "drm-kmod-firmware" + lib.optionalString withAmd "-amd" + lib.optionalString withIntel "-intel";
 
-  version = "20230625_4";  # there is a _8 but freebsd-ports is pinned to _4
+  version = "20230625_4"; # there is a _8 but freebsd-ports is pinned to _4
 
   src = fetchFromGitHub {
     owner = "freebsd";

--- a/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod-firmware.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod-firmware.nix
@@ -21,6 +21,11 @@ mkDerivation rec {
     hash = "sha256-RS8uXZMYoHfjDSC0OUJUU81eR8rLlEgFhuh+Y7+kXtA=";
   };
 
+  outputs = [
+    "out"
+    "debug"
+  ];
+
   extraNativeBuildInputs = [ buildFreebsd.xargs-j ];
 
   hardeningDisable = [
@@ -40,8 +45,15 @@ mkDerivation rec {
 
   env = sys.passthru.env;
   SYSDIR = "${sys.src}/sys";
+  KERN_DEBUGDIR = "${builtins.placeholder "debug"}/lib/debug";
+  KERN_DEBUGDIR_KODIR = "${KERN_DEBUGDIR}/kernel";
+  KERN_DEBUGDIR_KMODDIR = "${KERN_DEBUGDIR}/kernel";
 
   KMODDIR = "${placeholder "out"}/kernel";
+
+  makeFlags = [
+    "DEBUG_FLAGS=-g"
+  ];
 
   meta = {
     description = "GPU firmware for FreeBSD drm-kmod";

--- a/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod-firmware.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod-firmware.nix
@@ -8,16 +8,17 @@
   withIntel ? true,
 }:
 mkDerivation rec {
+  path = "...";
   pname =
     "drm-kmod-firmware" + lib.optionalString withAmd "-amd" + lib.optionalString withIntel "-intel";
 
-  version = "20230625_8";
+  version = "20230625_4";  # there is a _8 but freebsd-ports is pinned to _4
 
   src = fetchFromGitHub {
     owner = "freebsd";
     repo = "drm-kmod-firmware";
     rev = version;
-    hash = "sha256-Ly9B0zf+YODel/X1sZYVVUVWh38faNLhkcXcjEnQwII=";
+    hash = "sha256-RS8uXZMYoHfjDSC0OUJUU81eR8rLlEgFhuh+Y7+kXtA=";
   };
 
   extraNativeBuildInputs = [ buildFreebsd.xargs-j ];

--- a/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod/package.nix
@@ -11,9 +11,9 @@ let
   reldate = lib.toIntBase10 versionData.reldate;
   branch =
     if reldate >= 1500008 then
-      "6.1-lts"
+      "6.6-lts"
     else if reldate >= 1400097 then
-      "5.15-lts"
+      "6.1-lts"
     else if reldate >= 1302000 then
       "5.10-lts"
     else
@@ -25,6 +25,7 @@ mkDerivation {
   # this derivation is tricky; it is not an in-tree FreeBSD build but it is meant to be built
   # at the same time as the in-tree FreeBSD code, so it expects the same environment. Therefore,
   # it is appropriate to use the freebsd mkDerivation.
+  path = "...";
   pname = "drm-kmod";
   version = branch;
 
@@ -52,6 +53,10 @@ mkDerivation {
   SYSDIR = "${sys.src}/sys";
 
   KMODDIR = "${placeholder "out"}/kernel";
+
+  preBuild = ''
+    mkdir -p linuxkpi/dummy/include
+  '';
 
   meta = {
     description = "Linux drm driver, ported to FreeBSD";

--- a/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod/package.nix
@@ -21,7 +21,7 @@ let
 
   fetchOptions = (lib.importJSON ./versions.json).${branch};
 in
-mkDerivation {
+mkDerivation rec {
   # this derivation is tricky; it is not an in-tree FreeBSD build but it is meant to be built
   # at the same time as the in-tree FreeBSD code, so it expects the same environment. Therefore,
   # it is appropriate to use the freebsd mkDerivation.
@@ -30,6 +30,11 @@ mkDerivation {
   version = branch;
 
   src = fetchFromGitHub fetchOptions;
+
+  outputs = [
+    "out"
+    "debug"
+  ];
 
   extraNativeBuildInputs = [ xargs-j ];
 
@@ -53,10 +58,17 @@ mkDerivation {
   SYSDIR = "${sys.src}/sys";
 
   KMODDIR = "${placeholder "out"}/kernel";
+  KERN_DEBUGDIR = "${placeholder "debug"}/lib/debug";
+  KERN_DEBUGDIR_KODIR = "${KERN_DEBUGDIR}/kernel";
+  KERN_DEBUGDIR_KMODDIR = "${KERN_DEBUGDIR}/kernel";
 
   preBuild = ''
     mkdir -p linuxkpi/dummy/include
   '';
+
+  makeFlags = [
+    "DEBUG_FLAGS=-g"
+  ];
 
   meta = {
     description = "Linux drm driver, ported to FreeBSD";

--- a/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod/update.py
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod/update.py
@@ -5,7 +5,7 @@ import subprocess
 import json
 import os.path
 
-BRANCHES = ["5.10-lts", "5.15-lts", "6.1-lts"]
+BRANCHES = ["5.10-lts", "5.15-lts", "6.1-lts", "6.6-lts"]
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 versions = dict()

--- a/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod/versions.json
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod/versions.json
@@ -1,20 +1,26 @@
 {
   "5.10-lts": {
-    "hash": "sha256-6v8FhaEch9fJfo0/1UXeo0bcZh5n4Y2TyAsyHmCBJgw=",
+    "hash": "sha256-cmjdoqgCs4Rm7z0VzlDB5eJGdEWKl9uqZ+vcHqc6gbU=",
     "owner": "freebsd",
     "repo": "drm-kmod",
-    "rev": "e7950546196d44af502dd6abf162d1453f6f0dd0"
+    "rev": "17498c322eeae74eea80d4c2589540a059bb59e5"
   },
   "5.15-lts": {
-    "hash": "sha256-i768QfnYo2hqxnoCEnfYqOurDSRwkAsC4qsP7TUalxc=",
+    "hash": "sha256-R/OHaqjzY4CkUeW/zNj34UzUr8nRk0iALShHQa7efZU=",
     "owner": "freebsd",
     "repo": "drm-kmod",
-    "rev": "d7dc64fb8e63208afaca01e6d48284aa2305df35"
+    "rev": "9efcad4186ed869300e41b759598c3cb057b0753"
   },
   "6.1-lts": {
-    "hash": "sha256-+CsqQ0beJgoO3SSWzwLcAO8JP15oaDW9HR+bxwPaan4=",
+    "hash": "sha256-CWLUA8SGhQ8FZ/8y1iKhLdK7qx0r4IHLnNG2+oQkHBw=",
     "owner": "freebsd",
     "repo": "drm-kmod",
-    "rev": "f2d6d4b58446fa45de575bae76d6435439b3ca8b"
+    "rev": "f52b90d97d3bcefe4b2f09cad1ae668ffff99c53"
+  },
+  "6.6-lts": {
+    "hash": "sha256-XY+Q2AqS3t2rPL/aaFzjaOUgAn5IL0bXUPjkzp+qz1Y=",
+    "owner": "freebsd",
+    "repo": "drm-kmod",
+    "rev": "b0b44e1905934a37d8d4870791b36b3e8ff1face"
   }
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/growfs.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/growfs.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  mkDerivation,
+  libufs,
+  libutil,
+}:
+mkDerivation {
+  path = "sbin/growfs";
+  extraPaths = [
+    "sbin/mount"
+  ];
+
+  buildInputs = [
+    libufs
+    libutil
+  ];
+
+  outputs = [
+    "out"
+    "man"
+    "debug"
+  ];
+
+  MK_TESTS = "no";
+
+  meta.mainProgram = "growfs";
+  meta.platforms = lib.platforms.freebsd;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/kbdmap.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/kbdmap.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  mkDerivation,
+  libbsddialog,
+}:
+mkDerivation {
+  path = "usr.sbin/kbdmap";
+
+  outputs = [
+    "out"
+    "man"
+    "debug"
+  ];
+
+  buildInputs = [
+    libbsddialog
+  ];
+
+  meta.mainProgram = "kbdmap";
+  meta.platforms = lib.platforms.freebsd;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libctf.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libctf.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  mkDerivation,
+  libspl,
+  zlib,
+}:
+mkDerivation {
+  path = "cddl/lib/libctf";
+  extraPaths = [
+    "cddl/contrib/opensolaris/common/ctf"
+    "cddl/contrib/opensolaris/lib/libctf/common"
+
+    "sys/contrib/openzfs/include"
+    "sys/contrib/openzfs/lib/libspl/include"
+
+    "sys/cddl/compat/opensolaris"
+    "cddl/compat/opensolaris/include"
+
+    "sys/contrib/openzfs/include/os/freebsd/spl/sys/ccompile.h"
+    "cddl/contrib/opensolaris/head"
+    "cddl/contrib/opensolaris/common/ctf"
+    "cddl/contrib/opensolaris/lib/libctf/common"
+    "sys/cddl/contrib/opensolaris/uts/common"
+  ];
+
+  outputs = [
+    "out"
+    "man"
+  ];
+
+  buildInputs = [
+    zlib
+    libspl
+  ];
+
+  preBuild = ''
+    export OPENSOLARIS_USR_DISTDIR=$BSDSRCDIR/cddl/contrib/opensolaris
+    export OPENSOLARIS_SYS_DISTDIR=$BSDSRCDIR/sys/cddl/contrib/opensolaris
+  '';
+
+  MK_WERROR = "no";
+
+  alwaysKeepStatic = true;
+
+  meta.platforms = lib.platforms.freebsd;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libdevinfo.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libdevinfo.nix
@@ -1,0 +1,15 @@
+{
+  lib,
+  mkDerivation,
+}:
+mkDerivation {
+  path = "lib/libdevinfo";
+
+  outputs = [
+    "out"
+    "man"
+    "debug"
+  ];
+
+  meta.platforms = lib.platforms.freebsd;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libdwarf.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libdwarf.nix
@@ -16,6 +16,9 @@ mkDerivation {
     "sys/sys/elf_common.h"
   ];
   extraNativeBuildInputs = [ m4 ];
-  buildInputs = compatIfNeeded ++ [ zlib libelf ];
+  buildInputs = compatIfNeeded ++ [
+    zlib
+    libelf
+  ];
   MK_TESTS = "no";
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libdwarf.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libdwarf.nix
@@ -3,6 +3,7 @@
   m4,
   compatIfNeeded,
   zlib,
+  libelf,
 }:
 
 mkDerivation {
@@ -15,6 +16,6 @@ mkDerivation {
     "sys/sys/elf_common.h"
   ];
   extraNativeBuildInputs = [ m4 ];
-  buildInputs = compatIfNeeded ++ [ zlib ];
+  buildInputs = compatIfNeeded ++ [ zlib libelf ];
   MK_TESTS = "no";
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libncurses-form.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libncurses-form.nix
@@ -1,0 +1,18 @@
+{
+  mkDerivation,
+  libncurses-tinfo,
+  libncurses,
+}:
+mkDerivation {
+  pname = "ncurses-form";
+  path = "lib/ncurses/form";
+  extraPaths = [
+    "lib/ncurses"
+    "contrib/ncurses"
+    "lib/Makefile.inc"
+  ];
+  buildInputs = [
+    libncurses-tinfo
+    libncurses
+  ];
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libnetgraph.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libnetgraph.nix
@@ -1,0 +1,15 @@
+{
+  lib,
+  mkDerivation,
+}:
+mkDerivation {
+  path = "lib/libnetgraph";
+
+  outputs = [
+    "out"
+    "man"
+    "debug"
+  ];
+
+  meta.platforms = lib.platforms.freebsd;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libpam.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libpam.nix
@@ -2,6 +2,8 @@
   mkDerivation,
   openssl,
   libradius,
+  libutil,
+  pwd_mkdb,
 }:
 mkDerivation {
   path = "lib/libpam/libpam";
@@ -15,6 +17,9 @@ mkDerivation {
   buildInputs = [
     libradius
     openssl
+    (libutil.override {
+      withPwdMkdb = pwd_mkdb;
+    })
   ];
 
   MK_NIS = "no"; # TODO

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libproc.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libproc.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  mkDerivation,
+  libctf,
+  librtld-db,
+  zlib,
+}:
+mkDerivation {
+  path = "lib/libproc";
+  extraPaths = [
+    "sys/contrib/openzfs/include"
+    "sys/contrib/openzfs/lib/libspl/include"
+    "sys/contrib/openzfs/lib/libspl/include"
+    "sys/contrib/openzfs/include/os/freebsd/spl/sys/ccompile.h"
+    "cddl/contrib/opensolaris/lib/libctf/common"
+    "sys/cddl/contrib/opensolaris/uts/common"
+    "sys/cddl/compat/opensolaris"
+  ];
+
+  buildInputs = [
+    libctf
+    librtld-db
+    zlib
+  ];
+
+  outputs = [
+    "out"
+    "debug"
+  ];
+
+  MK_TESTS = "no";
+
+  meta.platforms = lib.platforms.freebsd;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/librtld-db.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/librtld-db.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  mkDerivation,
+  libelf,
+  libprocstat,
+}:
+mkDerivation {
+  path = "lib/librtld_db";
+  extraPaths = [
+    "lib/libproc/libproc.h"
+  ];
+
+  outputs = [
+    "out"
+    "man"
+    "debug"
+  ];
+
+  buildInputs = [
+    libelf
+    libprocstat
+  ];
+
+  meta.platforms = lib.platforms.freebsd;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libusb.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libusb.nix
@@ -1,0 +1,19 @@
+{
+  lib,
+  mkDerivation,
+}:
+mkDerivation {
+  path = "lib/libusb";
+
+  outputs = [
+    "out"
+    "man"
+    "debug"
+  ];
+
+  postInstall = ''
+    mv $out/data/pkgconfig $out/lib/pkgconfig
+  '';
+
+  meta.platforms = lib.platforms.freebsd;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libusbhid.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libusbhid.nix
@@ -1,0 +1,15 @@
+{
+  lib,
+  mkDerivation,
+}:
+mkDerivation {
+  path = "lib/libusbhid";
+
+  outputs = [
+    "out"
+    "man"
+    "debug"
+  ];
+
+  meta.platforms = lib.platforms.freebsd;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libutil.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libutil.nix
@@ -29,9 +29,13 @@ mkDerivation {
   ];
 
   # XXX mass rebuild moment
-  postPatch = if withPwdMkdb == null then null else ''
-    substituteInPlace lib/libutil/pw_util.c --replace-fail _PATH_PWD_MKDB '"${lib.getExe withPwdMkdb}"'
-  '';
+  postPatch =
+    if withPwdMkdb == null then
+      null
+    else
+      ''
+        substituteInPlace lib/libutil/pw_util.c --replace-fail _PATH_PWD_MKDB '"${lib.getExe withPwdMkdb}"'
+      '';
 
   preBuild = ''
     export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -B${csu}/lib"

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libutil.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libutil.nix
@@ -1,9 +1,11 @@
 {
+  lib,
   mkDerivation,
   include,
   libgcc,
   libcMinimal,
   csu,
+  withPwdMkdb ? null,
 }:
 mkDerivation {
   path = "lib/libutil";
@@ -25,6 +27,11 @@ mkDerivation {
     libgcc
     libcMinimal
   ];
+
+  # XXX mass rebuild moment
+  postPatch = if withPwdMkdb == null then null else ''
+    substituteInPlace lib/libutil/pw_util.c --replace-fail _PATH_PWD_MKDB '"${lib.getExe withPwdMkdb}"'
+  '';
 
   preBuild = ''
     export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -B${csu}/lib"

--- a/pkgs/os-specific/bsd/freebsd/pkgs/netstat.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/netstat.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  mkDerivation,
+  libxo,
+  libutil,
+  libmemstat,
+  libjail,
+  libnetgraph,
+}:
+mkDerivation {
+  path = "usr.bin/netstat";
+
+  buildInputs = [
+    libxo
+    libutil
+    libmemstat
+    libjail
+    libnetgraph
+  ];
+
+  meta.platforms = lib.platforms.freebsd;
+  meta.mainProgram = "netstat";
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/nvidia-driver/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/nvidia-driver/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  mkDerivation,
+  fetchurl,
+  sys,
+  drm-kmod,
+  xargs-j,
+}:
+mkDerivation rec {
+  path = "...";
+  pname = "nvidia-driver";
+  version = "570.124.04";
+  src = fetchurl {
+    url = "https://us.download.nvidia.com/XFree86/FreeBSD-x86_64/${version}/NVIDIA-FreeBSD-x86_64-${version}.tar.xz";
+    hash = "sha256-3FNJPZWg23H/YiUdIfO4KOUZ7BrJ2/xw8LD6MMSEICY=";
+  };
+
+  outputs = [
+    "out"
+    "debug"
+  ];
+
+  extraNativeBuildInputs = [
+    xargs-j
+  ];
+
+  preConfigure = ''
+    cd src
+  '';
+
+  makeFlags = [
+    "BSDSRCTOP=${sys.src}"
+    "SYSDIR=${sys.src}/sys"
+    "DRMKMODDIR=${drm-kmod.src}"
+    "KMODDIR=${builtins.placeholder "out"}/kernel"
+    "NO_XREF=1"
+    "DEBUG_FLAGS=-g"
+  ];
+
+  hardeningDisable = [
+    "pic" # generates relocations the linker can't handle
+  ];
+
+  env.NIX_CFLAGS_COMPILE_AFTER = "-O0";   # XXX REMOVE
+
+  meta.platforms = [ "x86_64-freebsd" ];
+  meta.license = lib.licenses.unfree;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/nvidia-driver/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/nvidia-driver/package.nix
@@ -41,7 +41,7 @@ mkDerivation rec {
     "pic" # generates relocations the linker can't handle
   ];
 
-  env.NIX_CFLAGS_COMPILE_AFTER = "-O0";   # XXX REMOVE
+  env.NIX_CFLAGS_COMPILE_AFTER = "-O0"; # XXX REMOVE
 
   meta.platforms = [ "x86_64-freebsd" ];
   meta.license = lib.licenses.unfree;

--- a/pkgs/os-specific/bsd/freebsd/pkgs/nvidia-drm-kmod-firmware/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/nvidia-drm-kmod-firmware/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  mkDerivation,
+  sys,
+  xargs-j,
+  kldxref,
+  nvidia-drm-kmod,
+}:
+mkDerivation {
+  path = "...";
+  pname = "nvidia-drm-kmod-firmware";
+  inherit (nvidia-drm-kmod) version src;
+
+  extraNativeBuildInputs = [
+    xargs-j
+    kldxref
+  ];
+
+  makeFlags = [
+    "SYSDIR=${sys.src}/sys"
+    "KMODDIR=${builtins.placeholder "out"}/kernel"
+    "NO_XREF=1"
+  ];
+
+  hardeningDisable = [
+    "pic" # generates relocations the linker can't handle
+  ];
+
+  preConfigure = ''
+    cd firmware
+  '';
+
+  meta.platforms = [ "x86_64-freebsd" ];
+  meta.license = lib.licenses.unfreeRedistributableFirmware;
+  meta.sourceProvenance = [ lib.sourceTypes.binaryFirmware ];
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/nvidia-drm-kmod/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/nvidia-drm-kmod/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  stdenv,
+  mkDerivation,
+  fetchurl,
+  fetchpatch,
+  sys,
+  drm-kmod,
+  xargs-j,
+  nvidia-driver,
+}:
+mkDerivation rec {
+  path = "...";
+  pname = "nvidia-drm-kmod";
+  inherit (nvidia-driver) version src;
+
+  outputs = [
+    "out"
+    "debug"
+  ];
+
+  patches = lib.optionals (lib.versionOlder version "565") [
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/freebsd/freebsd-ports/d07cdab9108a8cf6ab66aa1ff834339f8695f457/graphics/nvidia-drm-61-kmod/files/extra-patch-nvidia-drm-conftest.h";
+      extraPrefix = "a/src/nvidia-drm";
+      hash = "sha256-EgzEx1VxQyoNpnY0MnNVa08A0ENSyU/rdRM2hOwUE2g=";
+    })
+  ] ++ lib.optionals (lib.versionOlder version "555") [
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/freebsd/freebsd-ports/d07cdab9108a8cf6ab66aa1ff834339f8695f457/graphics/nvidia-drm-61-kmod/files/extra-patch-nvidia-drm-freebsd-lkpi.c";
+      extraPrefix = "a/src/nvidia-drm";
+      hash = "sha256-aFOs811J5e9Nu8Kwd6dImiSefEOlKlnRp3kg7DTIccg=";
+    })
+  ];
+
+  postPatch = lib.optionalString (lib.versionAtLeast version "570") ''
+    sed -E -i -e 's:\&nv_drm_fbdev_module_param\,  1\,:\&nv_drm_fbdev_module_param\,  0\,:' src/nvidia-drm/nvidia-drm-freebsd-lkpi.c
+    sed -E -i -e 's:bool nv_drm_fbdev_module_param = true;:bool nv_drm_fbdev_module_param = false;:' src/nvidia-drm/nvidia-drm-os-interface.c
+  '' + ''
+    sed -E -i -e '/DRMKMODDIR.*\/linuxkpi\/dummy\/include/d' src/nvidia-drm/Makefile
+
+    mkdir -p $TMP/bin
+    ln -s ${stdenv.cc}/bin/${stdenv.cc.targetPrefix}nm $TMP/bin/nm
+    export PATH=$PATH:$TMP/bin
+  '';
+
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";  # conftests rely on this
+  env.CONFTEST_BSD_KMODPATHS = "${sys}/kernel ${drm-kmod}/kernel";
+
+  extraNativeBuildInputs = [
+    xargs-j
+  ];
+
+  preConfigure = ''
+    cd src/nvidia-drm
+  '';
+
+  makeFlags = [
+    "BSDSRCTOP=${sys.src}"
+    "SYSDIR=${sys.src}/sys"
+    "DRMKMODDIR=${drm-kmod.src}"
+    "NO_XREF=1"
+    "DEBUG_FLAGS=-g"
+  ];
+
+  KMODDIR = "${builtins.placeholder "out"}/kernel";
+  KERN_DEBUGDIR = "${builtins.placeholder "debug"}/lib/debug";
+  KERN_DEBUGDIR_KODIR = "${KERN_DEBUGDIR}/kernel";
+  KERN_DEBUGDIR_KMODDIR = "${KERN_DEBUGDIR}/kernel";
+
+  hardeningDisable = [
+    "pic" # generates relocations the linker can't handle
+  ];
+
+  meta.platforms = [ "x86_64-freebsd" ];
+  meta.license = lib.licenses.unfree;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/nvidia-drm-kmod/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/nvidia-drm-kmod/package.nix
@@ -19,32 +19,36 @@ mkDerivation rec {
     "debug"
   ];
 
-  patches = lib.optionals (lib.versionOlder version "565") [
-    (fetchpatch {
-      url = "https://raw.githubusercontent.com/freebsd/freebsd-ports/d07cdab9108a8cf6ab66aa1ff834339f8695f457/graphics/nvidia-drm-61-kmod/files/extra-patch-nvidia-drm-conftest.h";
-      extraPrefix = "a/src/nvidia-drm";
-      hash = "sha256-EgzEx1VxQyoNpnY0MnNVa08A0ENSyU/rdRM2hOwUE2g=";
-    })
-  ] ++ lib.optionals (lib.versionOlder version "555") [
-    (fetchpatch {
-      url = "https://raw.githubusercontent.com/freebsd/freebsd-ports/d07cdab9108a8cf6ab66aa1ff834339f8695f457/graphics/nvidia-drm-61-kmod/files/extra-patch-nvidia-drm-freebsd-lkpi.c";
-      extraPrefix = "a/src/nvidia-drm";
-      hash = "sha256-aFOs811J5e9Nu8Kwd6dImiSefEOlKlnRp3kg7DTIccg=";
-    })
-  ];
+  patches =
+    lib.optionals (lib.versionOlder version "565") [
+      (fetchpatch {
+        url = "https://raw.githubusercontent.com/freebsd/freebsd-ports/d07cdab9108a8cf6ab66aa1ff834339f8695f457/graphics/nvidia-drm-61-kmod/files/extra-patch-nvidia-drm-conftest.h";
+        extraPrefix = "a/src/nvidia-drm";
+        hash = "sha256-EgzEx1VxQyoNpnY0MnNVa08A0ENSyU/rdRM2hOwUE2g=";
+      })
+    ]
+    ++ lib.optionals (lib.versionOlder version "555") [
+      (fetchpatch {
+        url = "https://raw.githubusercontent.com/freebsd/freebsd-ports/d07cdab9108a8cf6ab66aa1ff834339f8695f457/graphics/nvidia-drm-61-kmod/files/extra-patch-nvidia-drm-freebsd-lkpi.c";
+        extraPrefix = "a/src/nvidia-drm";
+        hash = "sha256-aFOs811J5e9Nu8Kwd6dImiSefEOlKlnRp3kg7DTIccg=";
+      })
+    ];
 
-  postPatch = lib.optionalString (lib.versionAtLeast version "570") ''
-    sed -E -i -e 's:\&nv_drm_fbdev_module_param\,  1\,:\&nv_drm_fbdev_module_param\,  0\,:' src/nvidia-drm/nvidia-drm-freebsd-lkpi.c
-    sed -E -i -e 's:bool nv_drm_fbdev_module_param = true;:bool nv_drm_fbdev_module_param = false;:' src/nvidia-drm/nvidia-drm-os-interface.c
-  '' + ''
-    sed -E -i -e '/DRMKMODDIR.*\/linuxkpi\/dummy\/include/d' src/nvidia-drm/Makefile
+  postPatch =
+    lib.optionalString (lib.versionAtLeast version "570") ''
+      sed -E -i -e 's:\&nv_drm_fbdev_module_param\,  1\,:\&nv_drm_fbdev_module_param\,  0\,:' src/nvidia-drm/nvidia-drm-freebsd-lkpi.c
+      sed -E -i -e 's:bool nv_drm_fbdev_module_param = true;:bool nv_drm_fbdev_module_param = false;:' src/nvidia-drm/nvidia-drm-os-interface.c
+    ''
+    + ''
+      sed -E -i -e '/DRMKMODDIR.*\/linuxkpi\/dummy\/include/d' src/nvidia-drm/Makefile
 
-    mkdir -p $TMP/bin
-    ln -s ${stdenv.cc}/bin/${stdenv.cc.targetPrefix}nm $TMP/bin/nm
-    export PATH=$PATH:$TMP/bin
-  '';
+      mkdir -p $TMP/bin
+      ln -s ${stdenv.cc}/bin/${stdenv.cc.targetPrefix}nm $TMP/bin/nm
+      export PATH=$PATH:$TMP/bin
+    '';
 
-  env.NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";  # conftests rely on this
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration"; # conftests rely on this
   env.CONFTEST_BSD_KMODPATHS = "${sys}/kernel ${drm-kmod}/kernel";
 
   extraNativeBuildInputs = [

--- a/pkgs/os-specific/bsd/freebsd/pkgs/nvidia-libs.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/nvidia-libs.nix
@@ -1,0 +1,56 @@
+{
+  mkDerivation,
+  nvidia-driver,
+  autoPatchelfHook,
+  xorg,
+  freetype,
+  gtk2,
+  gtk3,
+  cairo,
+  pango,
+  fontconfig,
+  glib,
+  libintl,
+  libdrm,
+  libgbm,
+}:
+mkDerivation {
+  path = "...";
+  pname = "nvidia-libs";
+  inherit (nvidia-driver) src version;
+
+  extraNativeBuildInputs = [
+    autoPatchelfHook
+  ];
+  buildInputs = [
+    libdrm
+    libgbm
+    gtk2
+    gtk3
+    cairo
+    pango
+    fontconfig
+    glib
+    libintl
+    freetype
+    xorg.libXext
+    xorg.libX11
+  ];
+
+  env.LOCALBASE = "${builtins.placeholder "out"}";
+  env.VKICD_PATH = "${builtins.placeholder "out"}/share/vulkan/icd.d";
+  env.VKLAYERS_PATH = "${builtins.placeholder "out"}/share/vulkan/implicit_layer.d";
+  env.EGL_GLVND_JSON_PATH = "${builtins.placeholder "out"}/share/glvnd/egl_vendor.d";
+  env.EGL_EXTERNAL_PLATFORM_JSON_PATH = "${builtins.placeholder "out"}/share/egl/egl_external_platform.d";
+
+  postPatch = ''
+    substituteInPlace lib/libGLX_nvidia/Makefile \
+      --replace-fail /usr/share/nvidia $out/share/nvidia \
+      --replace-fail " '''" ""
+  '';
+
+  dontBuild = true;
+  installPhase = ''
+    make -C lib install
+  '';
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/nvidia-nvml.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/nvidia-nvml.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  mkDerivation,
+  nvidia-driver,
+  nvidia-libs,
+  autoPatchelfHook,
+}:
+mkDerivation {
+  path = "...";
+  pname = "nvidia-nvml";
+  inherit (nvidia-driver) src version;
+
+  extraNativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  runtimeDependencies = [ nvidia-libs ];
+  buildInputs = [ nvidia-libs ];
+
+  env.LOCALBASE = "${builtins.placeholder "out"}";
+
+  dontBuild = true;
+  installPhase = ''
+    mkdir -p $out/bin
+    make -C nvml install
+  '';
+
+  meta.platforms = [ "x86_64-freebsd" ];
+  meta.license = lib.licenses.unfree;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/nvidia-x11.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/nvidia-x11.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  mkDerivation,
+  nvidia-driver,
+  nvidia-libs,
+  autoPatchelfHook,
+}:
+mkDerivation {
+  path = "...";
+  pname = "nvidia-x11";
+  inherit (nvidia-driver) src version;
+
+  extraNativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    nvidia-libs
+  ];
+
+  env.LOCALBASE = "${builtins.placeholder "out"}";
+
+  dontBuild = true;
+  installPhase = ''
+    mkdir -p $out/bin
+    make -C x11 install
+  '';
+
+  meta.platforms = [ "x86_64-freebsd" ];
+  meta.license = lib.licenses.unfree;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/passwd.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/passwd.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  mkDerivation,
+  libpam,
+}:
+mkDerivation {
+  path = "usr.bin/passwd";
+
+  buildInputs = [
+    libpam
+  ];
+
+  outputs = [
+    "out"
+    "man"
+    "debug"
+  ];
+
+  postPatch = ''
+    sed -E -i -e '/BINOWN|BINMODE|PRECIOUSPROG/d' $BSDSRCDIR/usr.bin/passwd/Makefile
+  '';
+
+  meta.platforms = lib.platforms.freebsd;
+  meta.mainProgram = "passwd";
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/pciconf.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/pciconf.nix
@@ -1,0 +1,16 @@
+{
+  lib,
+  mkDerivation,
+}:
+mkDerivation {
+  path = "usr.sbin/pciconf";
+
+  outputs = [
+    "out"
+    "man"
+    "debug"
+  ];
+
+  meta.platorms = lib.platforms.freebsd;
+  meta.mainProgram = "pciconf";
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/pwd_mkdb.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/pwd_mkdb.nix
@@ -3,4 +3,6 @@ mkDerivation {
   path = "usr.sbin/pwd_mkdb";
 
   extraPaths = [ "lib/libc/gen" ];
+
+  meta.mainProgram = "pwd_mkdb";
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/su.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/su.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  mkDerivation,
+  libpam,
+  libbsm,
+}:
+mkDerivation {
+  path = "usr.bin/su";
+
+  outputs = [
+    "out"
+    "man"
+    "debug"
+  ];
+
+  buildInputs = [
+    libpam
+    libbsm
+  ];
+
+  postPatch = ''
+    sed -E -i -e '/BINOWN|BINMODE|PRECIOUSPROG/d' $BSDSRCDIR/usr.bin/su/Makefile
+  '';
+
+  meta.mainProgram = "su";
+  meta.platforms = lib.platforms.freebsd;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/sys/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/sys/package.nix
@@ -24,6 +24,8 @@
   bintrans,
   xargs-j,
   kldxref,
+  ctfconvert,
+  ctfmerge,
 }:
 let
   baseConfigFile =
@@ -53,26 +55,19 @@ let
       for f in sys/conf/*.mk; do
         substituteInPlace "$f" --replace-quiet 'KERN_DEBUGDIR}''${' 'KERN_DEBUGDIR_'
       done
-
-      sed -i sys/${hostArchBsd}/conf/${baseConfig} \
-        -e 's/WITH_CTF=1/WITH_CTF=0/' \
-        -e '/KDTRACE/d'
-    ''
-    + lib.optionalString (baseConfigFile != null) ''
-      cat ${baseConfigFile} >>sys/${hostArchBsd}/conf/${baseConfig}
-    '';
+      ''
+      + lib.optionalString (baseConfigFile != null) ''
+        cat ${baseConfigFile} >>sys/${hostArchBsd}/conf/${baseConfig}
+      '';
   };
 
   # Kernel modules need this for kern.opts.mk
-  env = {
-    MK_CTF = "no";
-  }
-  // (lib.flip lib.mapAttrs' extraFlags (
+  env = lib.flip lib.mapAttrs' extraFlags (
     name: value: {
       name = "MK_${lib.toUpper name}";
       value = lib.boolToYesNo value;
     }
-  ));
+  );
 in
 mkDerivation rec {
   pname = "sys";
@@ -96,6 +91,8 @@ mkDerivation rec {
     bintrans
     xargs-j
     kldxref
+    ctfconvert
+    ctfmerge
   ];
 
   # --dynamic-linker /red/herring is used when building the kernel.

--- a/pkgs/os-specific/bsd/freebsd/pkgs/sys/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/sys/package.nix
@@ -55,10 +55,10 @@ let
       for f in sys/conf/*.mk; do
         substituteInPlace "$f" --replace-quiet 'KERN_DEBUGDIR}''${' 'KERN_DEBUGDIR_'
       done
-      ''
-      + lib.optionalString (baseConfigFile != null) ''
-        cat ${baseConfigFile} >>sys/${hostArchBsd}/conf/${baseConfig}
-      '';
+    ''
+    + lib.optionalString (baseConfigFile != null) ''
+      cat ${baseConfigFile} >>sys/${hostArchBsd}/conf/${baseConfig}
+    '';
   };
 
   # Kernel modules need this for kern.opts.mk

--- a/pkgs/os-specific/bsd/freebsd/pkgs/tip.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/tip.nix
@@ -1,0 +1,19 @@
+{
+  lib,
+  mkDerivation,
+}:
+mkDerivation {
+  path = "usr.bin/tip";
+  extraPaths = [
+    "usr.bin/Makefile.inc"
+  ];
+
+  outputs = [
+    "out"
+    "man"
+    "debug"
+  ];
+
+  meta.platforms = lib.platforms.freebsd;
+  meta.mainProgram = "tip";
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/usbconfig.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/usbconfig.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  mkDerivation,
+  libusb,
+}:
+mkDerivation {
+  path = "usr.sbin/usbconfig";
+
+  outputs = [
+    "out"
+    "man"
+    "debug"
+  ];
+
+  buildInputs = [
+    libusb
+  ];
+
+  meta.mainProgram = "usbconfig";
+  meta.platforms = lib.platforms.freebsd;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/v4l-compat.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/v4l-compat.nix
@@ -1,0 +1,60 @@
+{ lib, stdenv, fetchurl }:
+let
+  types_h = fetchurl {
+    url = "https://raw.githubusercontent.com/freebsd/freebsd-ports/3da53417998c611f340d75e45962da2fa912add5/multimedia/libv4l/files/types.h";
+    hash = "sha256-vbw82kxDC02vFhqdK3klh52pk/ecL+HwmmgQYYMEV9w=";
+  };
+  videodev_h = fetchurl {
+    url = "https://raw.githubusercontent.com/freebsd/freebsd-ports/3da53417998c611f340d75e45962da2fa912add5/multimedia/libv4l/files/videodev.h";
+    hash = "sha256-tcSZeBkaRo+K6i/tUYjhgQdEAuMhstvWsyVydIevAU4=";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "v4l-compat";
+  version = "5.8";
+
+  src = fetchurl {
+    url = "mirror://kernel/linux/kernel/v${lib.versions.major version}.x/linux-${version}.tar.xz";
+    hash = "sha256-5/dRhqoGQhFK+PGdmVWZNzAMonrK90UbNtT5sPhc8fU=";
+  };
+  allFiles = [
+    "linux/cec.h"
+    "linux/cec-funcs.h"
+    "linux/const.h"
+    "linux/dvb/audio.h"
+    "linux/dvb/ca.h"
+    "linux/dvb/dmx.h"
+    "linux/dvb/frontend.h"
+    "linux/dvb/net.h"
+    "linux/dvb/osd.h"
+    "linux/dvb/version.h"
+    "linux/dvb/video.h"
+    "linux/ivtv.h"
+    "linux/lirc.h"
+    "linux/media.h"
+    "linux/media-bus-format.h"
+    "linux/v4l2-common.h"
+    "linux/v4l2-controls.h"
+    "linux/v4l2-mediabus.h"
+    "linux/v4l2-subdev.h"
+    "linux/videodev2.h"
+  ];
+
+  buildPhase = ":";
+
+  installPhase = ''
+    for f in $allFiles; do
+      mkdir -p $(dirname $out/include/$f)
+      cp include/uapi/$f $out/include/$f
+    done
+    cp ${types_h} $out/include/linux/types.h
+    cp ${videodev_h} $out/include/linux/videodev.h
+  '';
+
+  meta = {
+    description = "Video4Linux header files for FreeBSD";
+    maintainers = [ lib.maintainers.rhelmot ];
+    platforms = lib.platforms.freebsd;
+    license = lib.licenses.gpl2Only;
+  };
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/v4l-compat.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/v4l-compat.nix
@@ -1,4 +1,8 @@
-{ lib, stdenv, fetchurl }:
+{
+  lib,
+  stdenv,
+  fetchurl,
+}:
 let
   types_h = fetchurl {
     url = "https://raw.githubusercontent.com/freebsd/freebsd-ports/3da53417998c611f340d75e45962da2fa912add5/multimedia/libv4l/files/types.h";

--- a/pkgs/os-specific/bsd/freebsd/pkgs/vidcontrol.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/vidcontrol.nix
@@ -1,0 +1,10 @@
+{
+  lib,
+  mkDerivation,
+}:
+mkDerivation {
+  path = "usr.sbin/vidcontrol";
+
+  meta.mainProgram = "vidcontrol";
+  meta.platorms = lib.platforms.freebsd;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/xf86-video-scfb.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/xf86-video-scfb.nix
@@ -1,4 +1,9 @@
-{ stdenv, fetchFromGitHub, xorg, pkg-config }:
+{
+  stdenv,
+  fetchFromGitHub,
+  xorg,
+  pkg-config,
+}:
 stdenv.mkDerivation rec {
   pname = "xf86-video-scfb";
   version = "0.0.7";

--- a/pkgs/os-specific/bsd/freebsd/pkgs/xf86-video-scfb.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/xf86-video-scfb.nix
@@ -1,0 +1,18 @@
+{ stdenv, fetchFromGitHub, xorg, pkg-config }:
+stdenv.mkDerivation rec {
+  pname = "xf86-video-scfb";
+  version = "0.0.7";
+  src = fetchFromGitHub {
+    owner = "rayddteam";
+    repo = pname;
+    rev = version;
+    hash = "sha256-hYBGnk/lpVOrl05tN6kXxEft6QktU5432wgZ8a+WdZc=";
+  };
+
+  postPatch = ''
+    sed -E -i -e "/xf86DisableRandR/d" src/scfb_driver.c
+  '';
+
+  buildInputs = [ xorg.xorgserver ];
+  nativeBuildInputs = [ pkg-config ];
+}


### PR DESCRIPTION
- Init various packages
- drm-kmod: upgrade and split debug output
- sys: enable ctf and dtrace (also backport a patch for 14.2)
- stand-efi: allow booting from partition label (in submission at https://reviews.freebsd.org/D49355)
- libutil: un-hardcode a path
- format entire tree. there were somehow some packages which weren't formatted?

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd (cross)
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
