### PR TITLE
coreboot-toolchain: add overridable "archives" attribute

### DIFF
--- a/pkgs/development/tools/misc/coreboot-toolchain/default.nix
+++ b/pkgs/development/tools/misc/coreboot-toolchain/default.nix
@@ -41,6 +41,8 @@ let
           allowedRequisites = [ ];
         };
 
+        archives = ./stable.nix;
+
         nativeBuildInputs = [
           bison
           curl
@@ -63,7 +65,7 @@ let
           mkdir -p util/crossgcc/tarballs
 
           ${lib.concatMapStringsSep "\n" (file: "ln -s ${file.archive} util/crossgcc/tarballs/${file.name}") (
-            callPackage ./stable.nix { }
+            callPackage finalAttrs.archives { }
           )}
 
           patchShebangs util/genbuild_h/genbuild_h.sh


### PR DESCRIPTION
For various reasons, the coreboot toolchain is extremely picky about having *exactly* the expected versions of its various dependencies available to it. Because this is the case it is not really functional to leverage the toolchain derivation definition from nixpkgs in an out-of-tree configuration that may wish to build a different version of coreboot (e.g. an older/newer version, or a minor fork as many vendors tend to create). This is because that out-of-tree build would have to override not just the `src` and `version` for coreboot (which, can easily be done), but also the dependency definitions in stable.nix (which is not easy to do). By introducing an indirection through an explicit `archives` attribute, it becomes  possible to override stable.nix with an alternate version.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
