### PR TITLE
nixosTests.pulseaudio-tcp: init

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1303,6 +1303,7 @@ in
   public-inbox = runTest ./public-inbox.nix;
   pufferpanel = runTest ./pufferpanel.nix;
   pulseaudio = discoverTests (import ./pulseaudio.nix);
+  pulseaudio-tcp = runTest ./pulseaudio-tcp.nix;
   pykms = runTest ./pykms.nix;
   pyload = runTest ./pyload.nix;
   qbittorrent = runTest ./qbittorrent.nix;

--- a/nixos/tests/pulseaudio-tcp.nix
+++ b/nixos/tests/pulseaudio-tcp.nix
@@ -1,0 +1,87 @@
+{ pkgs, lib, ... }:
+
+{
+  name = "pulseaudio-tcp";
+
+  meta.maintainers =
+    pkgs.pulseaudio.meta.maintainers
+    ++ (with lib.maintainers; [
+      aleksana
+      doronbehar
+    ]);
+
+  nodes = {
+    server = {
+      virtualisation.vlans = [ 1 ];
+
+      networking.useNetworkd = true;
+
+      systemd.network.networks."01-eth1" = {
+        name = "eth1";
+        networkConfig.Address = "10.0.0.1/24";
+      };
+
+      services.pulseaudio = {
+        enable = true;
+        tcp = {
+          enable = true;
+          port = 4713;
+          openFirewall = true;
+          anonymousClients.allowedIpRanges = [ "10.0.0.2" ];
+        };
+        systemWide = true;
+        extraConfig = ''
+          load-module module-pipe-sink file=/tmp/audio_check sink_name=virtual_server_sink
+          set-default-sink virtual_server_sink
+        '';
+      };
+
+      systemd.services.pulseaudio.wantedBy = [ "multi-user.target" ];
+    };
+    client = {
+      virtualisation.vlans = [ 1 ];
+
+      networking.useNetworkd = true;
+
+      systemd.network.networks."01-eth1" = {
+        name = "eth1";
+        networkConfig.Address = "10.0.0.2/24";
+      };
+
+      services.pulseaudio = {
+        enable = true;
+        extraClientConf = ''
+          default-server = tcp:10.0.0.1:4713
+        '';
+      };
+    };
+  };
+
+  testScript = # python
+    ''
+      start_all()
+      server.wait_for_unit("pulseaudio.service")
+
+      # port is open
+      server.wait_for_open_port(4713)
+      client.wait_for_open_port(4713, "10.0.0.1")
+
+      # client can see server
+      client.succeed('pactl info | grep "Server String" | grep -q "tcp"')
+      client.succeed('pactl list sinks short | grep -q "virtual_server_sink"')
+
+      # server sink pipe is in place
+      server.succeed('[ -e "/tmp/audio_check" ]')
+
+      # try to read something from it, it should not work as we haven't played anything
+      server.fail('timeout 1s head -c 1 /tmp/audio_check')
+
+      # client start to play something
+      client.execute("pacat -p --latency-msec=100 --channels=1 /dev/zero >/dev/null 2>&1 &")
+
+      server.sleep(1)
+
+      # server sink has received data now, in a normal setup it should be able to play
+      server.succeed('timeout 1s head -c 100 /tmp/audio_check')
+    '';
+}

--- a/pkgs/servers/pulseaudio/default.nix
+++ b/pkgs/servers/pulseaudio/default.nix
@@ -276,7 +276,7 @@ stdenv.mkDerivation rec {
     '';
 
   passthru.tests = {
-    inherit (nixosTests) pulseaudio;
+    inherit (nixosTests) pulseaudio pulseaudio-tcp;
   };
 
   meta = {


### PR DESCRIPTION
Follow-up of #466504

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
