### PR TITLE
splitcode: 0.31.5 -> 0.31.6

### DIFF
--- a/pkgs/by-name/sp/splitcode/package.nix
+++ b/pkgs/by-name/sp/splitcode/package.nix
@@ -9,13 +9,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "splitcode";
-  version = "0.31.5";
+  version = "0.31.6";
 
   src = fetchFromGitHub {
     owner = "pachterlab";
     repo = "splitcode";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-x2N+IQHB6gbEKTEofsWy7SwVf1lvRxh5f93avtAs8fM=";
+    hash = "sha256-80XrLr6gk398a/JVSpb8j0i2pMEDKn0EnTiSw7cWS2c=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -24,12 +24,6 @@ stdenv.mkDerivation (finalAttrs: {
     libcxx
     zlib
   ];
-
-  postPatch = ''
-    # https://github.com/pachterlab/splitcode/pull/46
-    substituteInPlace CMakeLists.txt \
-      --replace-fail 2.8.12 3.10
-  '';
 
   doCheck = true;
   checkPhase = ''
@@ -44,7 +38,8 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Tool for flexible, efficient parsing, interpreting, and editing of technical sequences in sequencing reads";
     homepage = "https://github.com/pachterlab/splitcode";
     license = lib.licenses.bsd2;
-    platforms = lib.platforms.all;
+    # also compiles on macos, but since it seems to return invalid results.
+    platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ zimward ];
     mainProgram = "splitcode";
     badPlatforms = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
