### PR TITLE
helium-browser: init at 0.7.1.1

### DIFF
--- a/pkgs/applications/networking/browsers/helium-browser/default.nix
+++ b/pkgs/applications/networking/browsers/helium-browser/default.nix
@@ -1,0 +1,80 @@
+nix
+{ lib
+, stdenv
+, appimageTools
+, fetchurl
+, makeWrapper
+, gtk3
+, libGL
+, libxkbcommon
+, xorg
+, nss
+, nspr
+, atk
+, at-spi2-atk
+, cups
+, dbus
+, libdrm
+, libxshmfence
+, mesa
+, pango
+, cairo
+, gdk-pixbuf
+, glib
+, alsa-lib
+, expat
+, fontconfig
+, freetype
+}:
+
+appimageTools.wrapType2 {
+  pname = "helium-browser";
+  version = "0.7.1.1";
+
+  src = fetchurl {
+    url = "https://github.com/imputnet/helium-linux/releases/download/0.7.1.1/helium-0.7.1.1-x86_64.AppImage";
+    hash = "sha256-spUogmjv+RNjtuDs5tY7vXFgKR62qUb85Gj/bERCza4=";
+  };
+
+  extraPkgs = pkgs: with pkgs; [
+    gtk3
+    libGL
+    libxkbcommon
+    xorg.libX11
+    xorg.libXcomposite
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXrandr
+    xorg.libXrender
+    xorg.libxcb
+    xorg.libXcursor
+    xorg.libXi
+    xorg.libXScrnSaver
+    nss
+    nspr
+    atk
+    at-spi2-atk
+    cups
+    dbus
+    libdrm
+    libxshmfence
+    mesa
+    pango
+    cairo
+    gdk-pixbuf
+    glib
+    alsa-lib
+    expat
+    fontconfig
+    freetype
+  ];
+
+  meta = with lib; {
+    description = "Internet without interruptions - A privacy-focused browser";
+    homepage = "https://github.com/imputnet/helium-linux";
+    license = licenses.gpl3Only;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ sharifmdathar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10952,6 +10952,8 @@ with pkgs;
     pname = "floorp-bin";
   };
 
+  helium-browser = callPackage ../applications/networking/browsers/helium-browser { };
+
   formiko =
     with python3Packages;
     callPackage ../applications/editors/formiko {


### PR DESCRIPTION
<!--

^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.

For new packages please briefly describe the package or provide a link to its homepage.

-->

## Summary

Adds Helium Browser, a privacy-focused web browser built on Chromium. Helium Browser is designed to provide "Internet without interruptions" with a focus on user privacy and minimal distractions.

**Homepage:** https://github.com/imputnet/helium-linux  
**Source:** AppImage release from https://github.com/imputnet/helium-linux/releases

## Changes

- Added `helium-browser` package at `pkgs/applications/networking/browsers/helium-browser/default.nix`
- Added package to `pkgs/top-level/all-packages.nix`
- Added maintainer entry for `sharifmdathar` to `maintainers/maintainer-list.nix`

## Package Details

- **Version:** 0.7.1.1
- **License:** GPL-3.0 (confirmed from repository LICENSE file)
- **Platform:** x86_64-linux
- **Packaging method:** AppImage wrapped with `appimageTools.wrapType2`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:

  - [x] x86_64-linux

  - [ ] aarch64-linux

  - [ ] x86_64-darwin

  - [ ] aarch64-darwin

- Tested, as applicable:

  - [ ] [NixOS tests] in [nixos/tests].

  - [ ] [Package tests] at `passthru.tests`.

  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.

- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].

- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - Verified: `./result/bin/helium-browser --version` returns `Helium 0.7.1.1 (Chromium 143.0.7499.40)`

- Nixpkgs Release Notes

  - [ ] Package update: when the change is major or breaking.

- NixOS Release Notes

  - [ ] Module addition: when adding a new NixOS module.

  - [ ] Module update: when the change is significant.

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests

[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests

[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md

[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests

[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md

[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests

[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md

[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/

[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc