### PR TITLE
symengine: add llvm as dependency

### DIFF
--- a/pkgs/by-name/sy/symengine/package.nix
+++ b/pkgs/by-name/sy/symengine/package.nix
@@ -8,6 +8,7 @@
   flint,
   mpfr,
   libmpc,
+  libllvm,
   withShared ? !stdenv.hostPlatform.isStatic,
 }:
 
@@ -46,6 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     flint
     mpfr
     libmpc
+    libllvm
   ];
 
   cmakeFlags = [
@@ -53,6 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "INTEGER_CLASS" "flint")
     (lib.cmakeBool "WITH_SYMENGINE_THREAD_SAFE" true)
     (lib.cmakeBool "WITH_MPC" true)
+    (lib.cmakeBool "WITH_LLVM" true)
     (lib.cmakeBool "BUILD_FOR_DISTRIBUTION" true)
     (lib.cmakeBool "BUILD_TESTS" finalAttrs.finalPackage.doCheck)
     (lib.cmakeBool "BUILD_SHARED_LIBS" withShared)


### PR DESCRIPTION
Added LLVM as a dependency to SymEngine, this will enable projects to work that use its JIT compilation system to numerically evaluate symbolic expressions. See: https://github.com/symengine/symengine/blob/master/symengine/llvm_double.cpp
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
