### PR TITLE
nixosTests/cosmic: test more GUI packages

### DIFF
--- a/nixos/modules/services/desktop-managers/cosmic.nix
+++ b/nixos/modules/services/desktop-managers/cosmic.nix
@@ -86,6 +86,7 @@ in
           cosmic-icons
           cosmic-player
           cosmic-randr
+          cosmic-reader
           cosmic-screenshot
           cosmic-term
           cosmic-wallpapers

--- a/nixos/tests/cosmic.nix
+++ b/nixos/tests/cosmic.nix
@@ -42,6 +42,8 @@
       # infrastructure.
       jq
       lswt
+
+      cosmic-reader
     ];
 
     # So far, all COSMIC tests launch a few GUI applications. In doing
@@ -64,6 +66,18 @@
       DISPLAY = lib.strings.optionalString enableXWayland (
         if enableAutologin then "DISPLAY=:0" else "DISPLAY=:1"
       );
+      emptyPDF = config.node.pkgs.stdenvNoCC.mkDerivation {
+        name = "empty-pdf";
+        dontUnpack = true;
+        nativeBuildInputs = [ config.node.pkgs.imagemagick ];
+        buildPhase = ''
+          magick xc:none -page Letter empty.pdf
+        '';
+        installPhase = ''
+          mkdir $out
+          mv empty.pdf $out/empty.pdf
+        '';
+      };
     in
     ''
       #testName: ${testName}
@@ -107,6 +121,7 @@
           gui_apps_to_launch['cosmic-edit'] = 'com.system76.CosmicEdit'
           gui_apps_to_launch['cosmic-files'] = 'com.system76.CosmicFiles'
           gui_apps_to_launch['cosmic-player'] = 'com.system76.CosmicPlayer'
+          gui_apps_to_launch['cosmic-reader'] = 'com.system76.CosmicReader'
           gui_apps_to_launch['cosmic-settings'] = 'com.system76.CosmicSettings'
           gui_apps_to_launch['cosmic-store'] = 'com.system76.CosmicStore'
           gui_apps_to_launch['cosmic-term'] = 'com.system76.CosmicTerm'
@@ -114,10 +129,16 @@
           for gui_app, app_id in gui_apps_to_launch.items():
               # Don't fail the test if binary is absent
               if machine.execute(f"su - ${user.name} -c 'command -v {gui_app}'", timeout=5)[0] == 0:
-                  machine.succeed(f"su - ${user.name} -c 'WAYLAND_DISPLAY=wayland-1 XDG_RUNTIME_DIR=/run/user/${toString user.uid} ${DISPLAY} {gui_app} >&2 &'", timeout=5)
+                  match gui_app:
+                      case 'cosmic-reader':
+                          opt_arg = '${emptyPDF}/empty.pdf'
+                      case _:
+                          opt_arg = ""
+
+                  machine.succeed(f"su - ${user.name} -c 'WAYLAND_DISPLAY=wayland-1 XDG_RUNTIME_DIR=/run/user/${toString user.uid} ${DISPLAY} {gui_app} {opt_arg} >&2 &'", timeout=5)
                   # Nix builds the following non-commented expression to the following:
                   #                              `su - alice -c 'WAYLAND_DISPLAY=wayland-1 XDG_RUNTIME_DIR=/run/user/1000 lswt --json | jq ".toplevels" | grep "^    \\"app-id\\": \\"{app_id}\\"$"' `
-                  machine.wait_until_succeeds(f''''su - ${user.name} -c 'WAYLAND_DISPLAY=wayland-1 XDG_RUNTIME_DIR=/run/user/${toString user.uid} lswt --json | jq ".toplevels" | grep "^    \\"app-id\\": \\"{app_id}\\"$"' '''', timeout=30)
+                  machine.wait_until_succeeds(f''''su - ${user.name} -c 'WAYLAND_DISPLAY=wayland-1 XDG_RUNTIME_DIR=/run/user/${toString user.uid} lswt --json | jq ".toplevels" | grep "^    \\"app-id\\": \\"{app_id}\\"$"' '''', timeout=60)
                   machine.succeed(f"pkill {gui_app}", timeout=5)
 
       machine.succeed("echo 'test completed succeessfully' > /${testName}", timeout=5)

--- a/nixos/tests/cosmic.nix
+++ b/nixos/tests/cosmic.nix
@@ -42,8 +42,6 @@
       # infrastructure.
       jq
       lswt
-
-      cosmic-reader
     ];
 
     # So far, all COSMIC tests launch a few GUI applications. In doing


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
