### PR TITLE
test driver: normalize callpackage call

### DIFF
--- a/nixos/lib/test-driver/default.nix
+++ b/nixos/lib/test-driver/default.nix
@@ -1,41 +1,50 @@
 {
   lib,
-  python3Packages,
-  enableOCR ? false,
-  qemu_pkg ? qemu_test,
+
+  buildPythonApplication,
+  colorama,
   coreutils,
   imagemagick_light,
-  netpbm,
-  qemu_test,
-  socat,
+  ipython,
+  junit-xml,
+  mypy,
+  ptpython,
+  python,
   ruff,
+  remote-pdb,
+
+  netpbm,
+  nixosTests,
+  qemu_pkg ? qemu_test,
+  qemu_test,
+  setuptools,
+  socat,
   tesseract4,
   vde2,
+
+  enableOCR ? false,
   extraPythonPackages ? (_: [ ]),
-  nixosTests,
 }:
 
-python3Packages.buildPythonApplication {
+buildPythonApplication {
   pname = "nixos-test-driver";
   version = "1.1";
   pyproject = true;
 
   src = ./src;
 
-  build-system = with python3Packages; [
+  build-system = [
     setuptools
   ];
 
-  dependencies =
-    with python3Packages;
-    [
-      colorama
-      junit-xml
-      ptpython
-      ipython
-      remote-pdb
-    ]
-    ++ extraPythonPackages python3Packages;
+  dependencies = [
+    colorama
+    ipython
+    junit-xml
+    ptpython
+    remote-pdb
+  ]
+  ++ extraPythonPackages python.pkgs;
 
   propagatedBuildInputs = [
     coreutils
@@ -55,7 +64,7 @@ python3Packages.buildPythonApplication {
 
   doCheck = true;
 
-  nativeCheckInputs = with python3Packages; [
+  nativeCheckInputs = [
     mypy
     ruff
   ];

--- a/nixos/lib/testing/driver.nix
+++ b/nixos/lib/testing/driver.nix
@@ -9,7 +9,7 @@ let
 
   # Reifies and correctly wraps the python test driver for
   # the respective qemu version and with or without ocr support
-  testDriver = hostPkgs.callPackage ../test-driver {
+  testDriver = hostPkgs.python3Packages.callPackage ../test-driver {
     inherit (config) enableOCR extraPythonPackages;
     qemu_pkg = config.qemu.package;
     imagemagick_light = hostPkgs.imagemagick_light.override { inherit (hostPkgs) libtiff; };


### PR DESCRIPTION
This PR puts the test driver package function into package normal form to facilitate easier override of the python version of everything.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
