### PR TITLE
stremio-linux-shell: init at 1.0.0-beta.13

### DIFF
--- a/pkgs/by-name/st/stremio-linux-shell/allow-local-network-access.patch
+++ b/pkgs/by-name/st/stremio-linux-shell/allow-local-network-access.patch
@@ -1,0 +1,15 @@
+diff --git a/src/webview/app/mod.rs b/src/webview/app/mod.rs
+index 2c6125e..26ab73f 100644
+--- a/src/webview/app/mod.rs
++++ b/src/webview/app/mod.rs
+@@ -23,6 +23,10 @@ cef_impl!(
+                 CMD_SWITCHES.iter().for_each(|switch| {
+                     line.append_switch(Some(&CefString::from(switch.to_owned())));
+                 });
++                line.append_switch_with_value(
++                    Some(&CefString::from("disable-features")),
++                    Some(&CefString::from("LocalNetworkAccessChecks")),
++                );
+             }
+         }
+ 

--- a/pkgs/by-name/st/stremio-linux-shell/better-server-path.patch
+++ b/pkgs/by-name/st/stremio-linux-shell/better-server-path.patch
@@ -1,0 +1,13 @@
+diff --git a/src/config.rs b/src/config.rs
+index 4eda395..679699f 100644
+--- a/src/config.rs
++++ b/src/config.rs
+@@ -70,7 +70,7 @@ pub struct ServerConfig {
+ 
+ impl ServerConfig {
+     pub fn new(current_dir: &Path) -> Self {
+-        let file = current_dir.join(SERVER_FILE);
++        let file = Path::new("@serverjs@").to_path_buf();
+ 
+         Self { file }
+     }

--- a/pkgs/by-name/st/stremio-linux-shell/fix-getshaderinfolog-call.patch
+++ b/pkgs/by-name/st/stremio-linux-shell/fix-getshaderinfolog-call.patch
@@ -1,0 +1,21 @@
+diff --git a/src/shared/renderer/utils.rs b/src/shared/renderer/utils.rs
+index be4a65d..1b944ad 100644
+--- a/src/shared/renderer/utils.rs
++++ b/src/shared/renderer/utils.rs
+@@ -1,6 +1,6 @@
+ use std::{mem, ptr};
+ 
+-use gl::types::{GLenum, GLfloat, GLint, GLsizei, GLsizeiptr, GLuint};
++use gl::types::{GLchar, GLenum, GLfloat, GLint, GLsizei, GLsizeiptr, GLuint};
+ 
+ use super::constants::BYTES_PER_PIXEL;
+ 
+@@ -139,7 +139,7 @@ pub fn compile_shader(kind: GLenum, src: &str) -> GLuint {
+             gl::GetShaderiv(shader, gl::INFO_LOG_LENGTH, &mut len);
+ 
+             let mut buffer = vec![0u8; len as usize];
+-            gl::GetShaderInfoLog(shader, len, ptr::null_mut(), buffer.as_mut_ptr() as *mut i8);
++            gl::GetShaderInfoLog(shader, len, ptr::null_mut(), buffer.as_mut_ptr() as *mut GLchar);
+ 
+             panic!(
+                 "Shader compile error: {}",

--- a/pkgs/by-name/st/stremio-linux-shell/package.nix
+++ b/pkgs/by-name/st/stremio-linux-shell/package.nix
@@ -1,0 +1,142 @@
+{
+  lib,
+  symlinkJoin,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+  gitUpdater,
+
+  # buildInputs
+  atk,
+  cef-binary,
+  gtk3,
+  libayatana-appindicator,
+  libxkbcommon,
+  mpv,
+  openssl,
+
+  # nativeBuildInputs
+  makeBinaryWrapper,
+  pkg-config,
+  wrapGAppsHook4,
+
+  # Wrapper
+  addDriverRunpath,
+  libGL,
+  nodejs,
+}:
+
+let
+  # Stremio expects CEF files in a specific layout
+  cef = symlinkJoin {
+    name = "stremio-linux-shell-cef";
+    paths = [
+      "${cef-binary}/Resources"
+      "${cef-binary}/Release"
+    ];
+  };
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "stremio-linux-shell";
+  version = "1.0.0-beta.13";
+
+  src = fetchFromGitHub {
+    owner = "Stremio";
+    repo = "stremio-linux-shell";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-1f9IBNo5gxpSqTSIf8QuQOlf+sfRhohOmQTLRbX/OU8=";
+  };
+
+  cargoHash = "sha256-wx5oF4uF9UMtKzfGxZKsy6mVjYaRD40dLuvaRtz8yE4=";
+
+  patches = [
+    # Chromium 142 stopped allowing local network access by default, which
+    # breaks the app's ability to communicate with the Stremio server.
+    ./allow-local-network-access.patch
+
+    # GLchar is u8 on aarch64
+    # Upstream PR: https://github.com/Stremio/stremio-linux-shell/pull/40
+    ./fix-getshaderinfolog-call.patch
+
+    # Patch server.js path so that we don't have to install it in $out/bin
+    ./better-server-path.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace src/config.rs \
+      --replace-fail "@serverjs@" "${placeholder "out"}/share/stremio/server.js"
+
+    substituteInPlace $cargoDepsCopy/libappindicator-sys-*/src/lib.rs \
+      --replace-fail "libayatana-appindicator3.so.1" "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
+    substituteInPlace $cargoDepsCopy/xkbcommon-dl-*/src/lib.rs \
+      --replace-fail "libxkbcommon.so.0" "${libxkbcommon}/lib/libxkbcommon.so.0"
+    substituteInPlace $cargoDepsCopy/xkbcommon-dl-*/src/x11.rs \
+      --replace-fail "libxkbcommon-x11.so.0" "${libxkbcommon}/lib/libxkbcommon-x11.so.0"
+  '';
+
+  # Don't download CEF during build
+  buildFeatures = [ "offline-build" ];
+
+  buildInputs = [
+    atk
+    cef
+    gtk3
+    libayatana-appindicator
+    libxkbcommon
+    mpv
+    openssl
+  ];
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  env.CEF_PATH = "${cef}";
+
+  postInstall = ''
+    mkdir -p $out/share/applications
+    cp data/com.stremio.Stremio.desktop $out/share/applications/com.stremio.Stremio.desktop
+
+    mkdir -p $out/share/icons/hicolor/scalable/apps
+    cp data/icons/com.stremio.Stremio.svg $out/share/icons/hicolor/scalable/apps/com.stremio.Stremio.svg
+
+    mkdir -p $out/share/stremio
+    cp data/server.js $out/share/stremio/server.js
+
+    mv $out/bin/stremio-linux-shell $out/bin/stremio
+  '';
+
+  # Node.js is required to run `server.js`
+  # Add to `gappsWrapperArgs` to avoid two layers of wrapping.
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix LD_LIBRARY_PATH : "${addDriverRunpath.driverLink}/lib" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libGL ]}" \
+      --prefix PATH : "${lib.makeBinPath [ nodejs ]}"
+    )
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  passthru = {
+    inherit cef;
+    updateScript = gitUpdater { rev-prefix = "v"; };
+  };
+
+  meta = {
+    description = "Modern media center that gives you the freedom to watch everything you want";
+    homepage = "https://www.stremio.com/";
+    license = with lib.licenses; [
+      gpl3Only
+      # server.js is unfree
+      unfree
+    ];
+    maintainers = with lib.maintainers; [ thunze ];
+    platforms = lib.platforms.linux;
+    mainProgram = "stremio";
+  };
+})


### PR DESCRIPTION
This PR adds [stremio-linux-shell](https://github.com/Stremio/stremio-linux-shell), the new client for Stremio on Linux.

Given that `qt5.qtwebengine` [will be dropped](https://github.com/NixOS/nixpkgs/pull/480196) in the near future due to being vulnerable, I think now is a good time to drop the old `stremio` package that still depends on `qt5.qtwebengine` (I'll do that in a separate PR) and init `stremio-linux-shell` as a replacement (at least on Linux). Looking at upstream, it unfortunately doesn't look like there's a suitable replacement for darwin yet.

Historically, stremio-linux-shell has seen a few different rewrites, each using different underlying technologies, so at first we held off on packaging it in nixpkgs. However, since I originally opened this PR, `main` and the tagged releases have been pretty stable.

I based this derivation on [@fxzzi's derivation](https://gitlab.com/fazzi/nixohess/-/blob/63fc6bfe27b99cfc00a4c898dfd6843ed82b6f53/parts/pkgs/packages/stremio-linux-shell-rewrite/package.nix) for an earlier version of stremio-linux-shell.

Closes #437992, #489227

---

For reference, here's the part of the old PR description that used to track the different rewrites of stremio-linux-shell:

<details>
<summary>Old description</summary>

> [!NOTE]
>
> Please don't merge this yet. It seems like upstream hasn't yet decided which technologies they want to use for the Linux client. See below for an overview of the rewrites we've seen so far.
>
> I'll keep this PR a draft until upstream stabilizes and until we've decided how and when to move forward with it. This PR should merely serve as a preliminary implementation for now.
>
> We might also wanna consider updating `stremio` instead of adding a new package.
>
> For context, please read: https://github.com/NixOS/nixpkgs/issues/437992

This PR adds [stremio-linux-shell](https://github.com/Stremio/stremio-linux-shell), the new client for Stremio on Linux.

It currently packages rewrite number **2** on the below list of rewrites that are out there, following tag [`v1.0.0-beta.13`](https://github.com/Stremio/stremio-linux-shell/releases/tag/v1.0.0-beta.13). I'll try to keep this list updated as upstream continues to work on the app.

1. [gtk4](https://github.com/gtk-rs/gtk4-rs) + [webkitgtk](https://gitlab.gnome.org/World/Rust/webkit6-rs) + [libmpv](https://github.com/mpv-player/mpv/blob/master/DOCS/man/libmpv.rst)
    - Upstream branch: https://github.com/Stremio/stremio-linux-shell/tree/refactor/rewrite
    - Last tracked rev: https://github.com/Stremio/stremio-linux-shell/commit/71f2594396ce4f851572b779e595ce1bd4063267
    - Derivation: See [fazzi/nixohess on GitLab](https://gitlab.com/fazzi/nixohess/-/blob/63fc6bfe27b99cfc00a4c898dfd6843ed82b6f53/parts/pkgs/packages/stremio-linux-shell-rewrite/package.nix) by @fxzzi
2. [winit](https://github.com/rust-windowing/winit) + [glutin](https://github.com/rust-windowing/glutin) with [libmpv](https://github.com/mpv-player/mpv/blob/master/DOCS/man/libmpv.rst) and [CEF](https://github.com/chromiumembedded/cef) **← Currently packaged in this PR**
    - Upstream branch: https://github.com/Stremio/stremio-linux-shell/tree/main
    - Last tracked rev: https://github.com/Stremio/stremio-linux-shell/commit/57bbfdb6d8773bf4976871b2016ab1ce33fdd9f2 (tag `v1.0.0-beta.13`)
    - Derivation: See this PR
3. [gtk4](https://docs.gtk.org/gtk4/) + [libadwaita](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.8/) + [CEF](https://github.com/chromiumembedded/cef) + [libmpv](https://github.com/mpv-player/mpv/blob/master/DOCS/man/libmpv.rst)
    - Upstream branch: https://github.com/Stremio/stremio-linux-shell/tree/refactor/gtk4
    - Last tracked rev: https://github.com/Stremio/stremio-linux-shell/commit/a0d8793ab585a4b54ea46ccdd253f47faa711563
    - Derivation: None yet, will update this PR once tagged or merged into `main`

</details>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
