### PR TITLE
perlPackages.BitVector: fix build with gcc15

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -2571,6 +2571,15 @@ with self;
       url = "mirror://cpan/authors/id/S/ST/STBEY/Bit-Vector-7.4.tar.gz";
       hash = "sha256-PG2qZx/s+8Nfkqk4W1Y9ZfUN/Gvci0gF+e9GwNA1qSY=";
     };
+    patches = [
+      # Fix build with gcc15
+      # https://rt.cpan.org/Public/Bug/Display.html?id=165142
+      (fetchpatch {
+        name = "perl-bitvector-fix-bool-detection.patch";
+        url = "https://src.fedoraproject.org/rpms/perl-Bit-Vector/raw/fe339c95e0da8a130c5bba5a975d37230178b59d/f/0001-Fix-bool-detection.patch";
+        hash = "sha256-zC4/RMKhdFNEwNIorzuU76p8P/Lwgv1pF6Oi4MX4M1o=";
+      })
+    ];
     propagatedBuildInputs = [ CarpClan ];
     meta = {
       description = "Efficient bit vector, set of integers and 'big int' math library";


### PR DESCRIPTION
- add patch from fedora:
https://src.fedoraproject.org/rpms/perl-Bit-Vector/raw/fe339c95e0da8a130c5bba5a975d37230178b59d/f/0001-Fix-bool-detection.patch

Upstream issue with similar (but bigger) patch submitted:
https://rt.cpan.org/Public/Bug/Display.html?id=165142
gentoo uses it:
https://gitweb.gentoo.org/repo/gentoo.git/plain/dev-perl/Bit-Vector/files/Bit-Vector-7.400.0-c23.patch?id=10708b8f345e68000e07c38e58c8ecd9d7bbcf45

Fixes build failure with gcc15:
```
In file included from BitVector.c:12:
ToolBox.h:98:20: error: cannot use keyword 'false' as enumeration constant
   98 |             enum { false, true };
      |                    ^~~~~
ToolBox.h:98:20: note: 'false' is a keyword with '-std=c23' onwards
```

---

Tested build with:
```bash
nix-build --expr 'with import ./. {}; (perlPackages.overrideScope (final: prev: { stdenv = gcc15Stdenv; })).BitVector'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
