### PR TITLE
python3Packages.compressai: 1.2.6 -> 1.2.8

### DIFF
--- a/pkgs/development/python-modules/compressai/default.nix
+++ b/pkgs/development/python-modules/compressai/default.nix
@@ -10,14 +10,17 @@
 
   # dependencies
   einops,
-  numpy,
   matplotlib,
+  numpy,
   pandas,
   pytorch-msssim,
   scipy,
+  tomli,
   torch,
   torch-geometric,
   torchvision,
+  tqdm,
+  typing-extensions,
 
   # optional-dependencies
   ipywidgets,
@@ -30,14 +33,14 @@
 
 buildPythonPackage rec {
   pname = "compressai";
-  version = "1.2.6";
+  version = "1.2.8";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "InterDigitalInc";
     repo = "CompressAI";
     tag = "v${version}";
-    hash = "sha256-xvzhhLn0iBzq3h1nro8/83QWEQe9K4zRa3RSZk+hy3Y=";
+    hash = "sha256-Fgobh7Q1rKomcqAT4kJl2RsM1W13ErO8sFB2urCqrCk=";
     fetchSubmodules = true;
   };
 
@@ -46,16 +49,22 @@ buildPythonPackage rec {
     setuptools
   ];
 
+  pythonRelaxDeps = [
+    "numpy"
+  ];
   dependencies = [
     einops
-    numpy
     matplotlib
+    numpy
     pandas
     pytorch-msssim
     scipy
+    tomli
     torch
     torch-geometric
     torchvision
+    tqdm
+    typing-extensions
   ];
 
   optional-dependencies = {
@@ -70,11 +79,9 @@ buildPythonPackage rec {
     "compressai._CXX"
   ];
 
+  # We have to delete the source because otherwise it is used intead the installed package.
   preCheck = ''
-    # We have to delete the source because otherwise it is used intead the installed package.
     rm -rf compressai
-
-    export HOME=$(mktemp -d)
   '';
 
   nativeCheckInputs = [
@@ -91,6 +98,7 @@ buildPythonPackage rec {
     "test_pretrained"
 
     # Flaky (AssertionError: assert 0.08889999999999998 < 0.064445)
+    "test_compiling"
     "test_find_close"
   ];
 


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/InterDigitalInc/CompressAI/compare/v1.2.6...v1.2.8

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc