### PR TITLE
xrootd: 5.8.4 -> 5.9.1

### DIFF
--- a/pkgs/by-name/xr/xrootd/package.nix
+++ b/pkgs/by-name/xr/xrootd/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   callPackage,
   fetchFromGitHub,
-  fetchpatch2,
   davix,
   cmake,
   gtest,
@@ -31,24 +30,15 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xrootd";
-  version = "5.8.4";
+  version = "5.9.1";
 
   src = fetchFromGitHub {
     owner = "xrootd";
     repo = "xrootd";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-r0wXAlm+K6TE6189QyZL/k3q5IKlouSBKWzWXz1Tws4=";
+    hash = "sha256-XClMtQfCGWpLtILGQyYCsKMcOlhLHC5i7UabzXH/imc=";
   };
-
-  patches = [
-    # Downgrade -Wnull-dereference from error to warning
-    # Should be removed in the release after next
-    (fetchpatch2 {
-      url = "https://github.com/xrootd/xrootd/commit/135b33b9631891219889fcaad449a4efb5e77d95.patch";
-      hash = "sha256-t6Cy2XWp3B+sbMBxLhsh3WjQlXg4Tb7fF+rGGgYollU=";
-    })
-  ];
 
   postPatch = ''
     patchShebangs genversion.sh


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/xrootd/xrootd/compare/v5.8.4...v5.9.1
Changelog: https://github.com/xrootd/xrootd/releases/tag/v5.9.1

cc @ShamrockLee

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc