### PR TITLE
python3Packages.torchcodec: 0.8.1 -> 0.9.0

### DIFF
--- a/pkgs/development/python-modules/torchcodec/default.nix
+++ b/pkgs/development/python-modules/torchcodec/default.nix
@@ -26,14 +26,14 @@
 
 buildPythonPackage rec {
   pname = "torchcodec";
-  version = "0.8.1";
+  version = "0.9.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "meta-pytorch";
     repo = "torchcodec";
     tag = "v${version}";
-    hash = "sha256-trYS4sRPSNmQLHZZS174zxbu74LT+39N23zOJdWwN6Q=";
+    hash = "sha256-QG7LX9G1HV2l75jsgsbM4ts6bg0wvsNhjml19b7yYEQ=";
   };
 
   postPatch = ''
@@ -44,17 +44,10 @@ buildPythonPackage rec {
         '"ffprobe"' \
         '"${lib.getExe' ffmpeg "ffprobe"}"'
 
-    substituteInPlace \
-      test/test_ops.py \
-      test/test_encoders.py \
+    substituteInPlace test/test_encoders.py \
       --replace-fail \
         '"ffmpeg"' \
         '"${lib.getExe ffmpeg}"'
-
-    substituteInPlace test/test_transform_ops.py \
-      --replace-fail \
-        'ffmpeg_cli = "ffmpeg"' \
-        'ffmpeg_cli = "${lib.getExe ffmpeg}"'
   '';
 
   nativeBuildInputs = [
@@ -92,7 +85,7 @@ buildPythonPackage rec {
 
   env = {
     # Upstream (Meta) is cautious with linking against GPL ffmpeg
-    # We explicitly want to link against our packages ffmpeg
+    # We explicitly want to link against our packaged ffmpeg
     I_CONFIRM_THIS_IS_NOT_A_LICENSE_VIOLATION = true;
 
     ENABLE_CUDA = cudaSupport;
@@ -151,8 +144,10 @@ buildPythonPackage rec {
       "test_against_to_file"
       "test_against_to_file"
       "test_contiguit"
+      "test_crf_valid_value"
       "test_encode_to_tensor_long_outpu"
       "test_round_trip"
+      "test_video_encoder_against_ffmpeg_cli"
       "test_video_encoder_round_trip"
 
       # RuntimeError: Requested next frame while there are no more frames left to decode


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/meta-pytorch/torchcodec/compare/v0.8.1...v0.9.0
Changelog: https://github.com/meta-pytorch/torchcodec/releases/tag/v0.9.0

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc