### PR TITLE
nixos/firewall-nftables: fix multicast ping

### DIFF
--- a/nixos/modules/services/networking/firewall-nftables.nix
+++ b/nixos/modules/services/networking/firewall-nftables.nix
@@ -117,6 +117,10 @@ in
           ifaceSet != ""
         ) ''iifname { ${ifaceSet} } accept comment "trusted interfaces"''}
 
+        # Multicast ICMPv6 echo replies get marked as invalid by conntrack.
+        # Accept them before conntrack to avoid dropped replies.
+        icmpv6 type echo-reply accept
+
         # Some ICMPv6 types like NDP is untracked
         ct state vmap {
           invalid : drop,


### PR DESCRIPTION
We can currently observe that pinging the multicast IPv6 address ff02::1 does not work as expected. This is because conntrack is marking the ICMPv6 replies as invalid and thus is dropping them.

This can behaviour can be seen with these commands:
1. Get handle of the rule above the conntrack rule: ``` nft -a list ruleset inet ```
2. Insert a rule to log all packets marked as invalid by conntrack: ``` nft insert rule inet nixos-fw \ input position <handle> ct state invalid \ log prefix \"ct invalid: \" ```
3. Starting pinging ff02::1 and observe dmesg

This change adds a rule to allow all ICMPv6 echo replies (type 129) before the conntrack rule starts taking action.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
