### PR TITLE
swift: fix build with gcc15

### DIFF
--- a/pkgs/development/compilers/swift/compiler/default.nix
+++ b/pkgs/development/compilers/swift/compiler/default.nix
@@ -418,6 +418,25 @@ stdenv.mkDerivation {
     patchShebangs .
 
     ${lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
+      patch -p1 -d llvm-project/llvm -i ${
+        # Fix build with gcc15
+        fetchpatch {
+          name = "llvm-SmallVector-add-cstdint.patch";
+          url = "https://github.com/llvm/llvm-project/commit/7e44305041d96b064c197216b931ae3917a34ac1.patch";
+          stripLen = 1;
+          hash = "sha256-1htuzsaPHbYgravGc1vrR8sqpQ/NSQ8PUZeAU8ucCFk=";
+        }
+      }
+      patch -p1 -d llvm-project/llvm -i ${./patches/llvm-X86MCTargetDesc-add-cstdint.patch}
+      patch -p1 -d swift -i ${
+        fetchpatch {
+          name = "swift-SmallVector-add-cstdint.patch";
+          url = "https://github.com/swiftlang/swift/commit/a5c727125e952839c373fe47e9f9e359db3d4d38.patch";
+          hash = "sha256-DC+Z0JAO6BQXylbpJq7viKYOAhW8X5oxaqhEQ6CxAXk=";
+          includes = [ "stdlib/include/llvm/ADT/SmallVector.h" ];
+        }
+      }
+
       patch -p1 -d swift-corelibs-libdispatch -i ${
         # Fix the build with modern Clang.
         fetchpatch {

--- a/pkgs/development/compilers/swift/compiler/patches/llvm-X86MCTargetDesc-add-cstdint.patch
+++ b/pkgs/development/compilers/swift/compiler/patches/llvm-X86MCTargetDesc-add-cstdint.patch
@@ -1,0 +1,17 @@
+Rebase of:
+https://github.com/llvm/llvm-project/commit/7abf44069aec61eee147ca67a6333fc34583b524
+
+---
+ lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h b/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h
+index e166b68668d9b..0e0e13e896aea 100644
+--- a/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h
++++ b/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h
+@@ -14,6 +14,7 @@
+ #define LLVM_LIB_TARGET_X86_MCTARGETDESC_X86MCTARGETDESC_H
+ 
++#include <cstdint>
+ #include <memory>
+ #include <string>


### PR DESCRIPTION
- add patches from merged upstream commits:
https://github.com/llvm/llvm-project/commit/7e44305041d96b064c197216b931ae3917a34ac1
https://github.com/llvm/llvm-project/commit/7abf44069aec61eee147ca67a6333fc34583b524 (does not apply with `fetchpatch`)
https://github.com/swiftlang/swift/commit/a5c727125e952839c373fe47e9f9e359db3d4d38

Fixes build failure with gcc15:
```
/build/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:109:62:
error: use of undeclared identifier 'uint64_t'
  109 |     std::conditional_t<sizeof(T) < 4 && sizeof(void *) >= 8, uint64_t,
      |                                                              ^~~~~~~~
...
/build/src/llvm-project/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h:86:50:
error: unknown type name 'uint64_t'
   86 |                               int MemoryOperand, uint64_t TSFlags);
      |                                                  ^
...
/build/src/swift/stdlib/include/llvm/ADT/SmallVector.h:93:69:
error: use of undeclared identifier 'uint64_t'
    typename std::conditional<sizeof(T) < 4 && sizeof(void *) >= 8, uint64_t,                                                                    ^
```

---

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

---

Currently does not build on linux because of #462451
Patches included in PR fix header errors that come up before, but it stops on same errors as on `master`:
```text
/build/src/llvm-project/llvm/include/llvm/Support/type_traits.h:35:13: error: missing '#include <type_traits>'; 'is_class' must be defined before it is used
      !std::is_class<UnderlyingT>::value && // Filter conversion operators.
            ^
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
