### PR TITLE
Crypto kernel modules cleanup

### DIFF
--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -648,6 +648,7 @@ in
         "af_alg"
         "algif_skcipher"
         "cryptd"
+        "input_leds" # for capslock LED on most keyboards in case decryption requires password
       ];
       description = ''
         A list of cryptographic kernel modules needed to decrypt the root device(s).
@@ -1136,7 +1137,6 @@ in
     boot.initrd.availableKernelModules = [
       "dm_mod"
       "dm_crypt"
-      "input_leds"
     ]
     ++ luks.cryptoModules
     # workaround until https://marc.info/?l=linux-crypto-vger&m=148783562211457&w=4 is merged

--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -647,6 +647,7 @@ in
         "sha512"
         "af_alg"
         "algif_skcipher"
+        "cryptd"
       ];
       description = ''
         A list of cryptographic kernel modules needed to decrypt the root device(s).
@@ -1135,7 +1136,6 @@ in
     boot.initrd.availableKernelModules = [
       "dm_mod"
       "dm_crypt"
-      "cryptd"
       "input_leds"
     ]
     ++ luks.cryptoModules


### PR DESCRIPTION
I am building a minified kernel for an arm64 machine without autoModules = true and which has LUKS enabled. LUKS would like to make cryptd available to loaded in the initrd and [does so by adding](https://github.com/NixOS/nixpkgs/blob/63b93d777c5c593eb25aa5331810823bd373d3d3/nixos/modules/system/boot/luksroot.nix#L1135-L1140) it to boot.initrd.availableKernelModules. The default configuration for arm64 does not enable CONFIG_CRYPTD and the module is not built. Move cryptd to boot.initrd.luks.cryptoModules so that I can override this for my kernel configuration. Also, move input_leds, which is similarly not strictly required for LUKS.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
