### PR TITLE
[25.05] wireshark: 4.4.7 -> 4.4.12

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -56,7 +56,7 @@ assert withQt -> qt6 != null;
 
 stdenv.mkDerivation rec {
   pname = "wireshark-${if withQt then "qt" else "cli"}";
-  version = "4.4.7";
+  version = "4.4.12";
 
   outputs = [
     "out"
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
     repo = "wireshark";
     owner = "wireshark";
     rev = "v${version}";
-    hash = "sha256-9h25vfjw8QIrRZ6APTsvhW4D5O6fkhkiy/1bj7hGwwY=";
+    hash = "sha256-La7bRS++RN/Glj6lUKUww47bmmQpzULimpxmDilnEpM=";
   };
 
   patches = [


### PR DESCRIPTION
Fixes CVE-2025-13674, CVE-2025-13499, CVE-2025-13945, CVE-2025-13946, CVE-2025-9817 and CVE-2025-11626.

https://www.wireshark.org/security/wnpa-sec-2025-05.html
https://www.wireshark.org/security/wnpa-sec-2025-06.html
https://www.wireshark.org/security/wnpa-sec-2025-07.html
https://www.wireshark.org/security/wnpa-sec-2025-08.html
https://www.wireshark.org/security/wnpa-sec-2025-03.html
https://www.wireshark.org/security/wnpa-sec-2025-04.html

https://www.wireshark.org/docs/relnotes/wireshark-4.4.8
https://www.wireshark.org/docs/relnotes/wireshark-4.4.9
https://www.wireshark.org/docs/relnotes/wireshark-4.4.10
https://www.wireshark.org/docs/relnotes/wireshark-4.4.11
https://www.wireshark.org/docs/relnotes/wireshark-4.4.12

Not-cherry-picked-because: unstable is using 4.6.x branch.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 468806`
Commit: `994493dd51d9d5babd837114b058d75a4911e485`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 24 packages built:</summary>
  <ul>
    <li>compactor</li>
    <li>dbmonster</li>
    <li>hfinger</li>
    <li>hfinger.dist</li>
    <li>ostinato</li>
    <li>python312Packages.dissect-cobaltstrike</li>
    <li>python312Packages.dissect-cobaltstrike.dist</li>
    <li>python312Packages.manuf</li>
    <li>python312Packages.manuf.dist</li>
    <li>python312Packages.pyshark</li>
    <li>python312Packages.pyshark.dist</li>
    <li>python313Packages.dissect-cobaltstrike</li>
    <li>python313Packages.dissect-cobaltstrike.dist</li>
    <li>python313Packages.manuf</li>
    <li>python313Packages.manuf.dist</li>
    <li>python313Packages.pyshark</li>
    <li>python313Packages.pyshark.dist</li>
    <li>termshark</li>
    <li>tshark (wireshark-cli)</li>
    <li>tshark.dev (wireshark-cli.dev)</li>
    <li>wifite2</li>
    <li>wifite2.dist</li>
    <li>wireshark (wireshark-qt)</li>
    <li>wireshark.dev (wireshark-qt.dev)</li>
  </ul>
</details>


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
