### PR TITLE
amd-blis: backport fix for GCC 15 build error

### DIFF
--- a/pkgs/by-name/am/amd-blis/package.nix
+++ b/pkgs/by-name/am/amd-blis/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   perl,
   python3,
 
@@ -36,6 +37,18 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     # Set the date stamp to $SOURCE_DATE_EPOCH
     ./build-date.patch
+    # backporting a fix for a GCC15 build error
+    # ./frame/include/bli_x86_asm_macros.h:102:21: error: 'asm' operand has impossible constraints or there are not enough registers
+    (fetchpatch {
+      name = "amd-blis-gcc-15-fix-1.patch";
+      url = "https://github.com/amd/blis/commit/14e46ad83bac5fd82569a43c7cbd3e791a1eacc8.patch";
+      hash = "sha256-3vk9NSnhT64J6PUabeP58Gn7p1zheGbPxSRjVEX7WNg=";
+    })
+    (fetchpatch {
+      name = "amd-blis-gcc-15-fix-2.patch";
+      url = "https://github.com/amd/blis/commit/30c42202d78fd5ee5e54d50ad57348e5e541a7d5.patch";
+      hash = "sha256-FCMWQzfzQxCQqngULoXfh35BFGaNTu732iu3HctNcFM=";
+    })
   ];
 
   inherit blas64;


### PR DESCRIPTION
amd-blis build started failing with `error: 'asm' operand has impossible constraints or there are not enough register` after the GCC 15 update

Upstream issue: https://github.com/amd/blis/issues/34

No full nixpkgs-review run, ROCm package set is widely broken due to an unrelated GCC 15 bump issue with `__glibcxx_assert_fail()` (see #468809)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
