### PR TITLE
nixos/prometheus/mqtt-exporter: correct MQTT_IGNORED_TOPICS variable name

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters/mqtt.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/mqtt.nix
@@ -115,7 +115,7 @@ in
       KEEP_FULL_TOPIC = toConfigBoolean cfg.keepFullTopic;
       LOG_LEVEL = cfg.logLevel;
       LOG_MQTT_MESSAGE = toConfigBoolean cfg.logMqttMessage;
-      MQTT_IGNORED_TOPIC = toConfigList cfg.mqttIgnoredTopics;
+      MQTT_IGNORED_TOPICS = toConfigList cfg.mqttIgnoredTopics;
       MQTT_ADDRESS = cfg.mqttAddress;
       MQTT_PORT = toString cfg.mqttPort;
       MQTT_TOPIC = cfg.mqttTopic;


### PR DESCRIPTION
As stated in the [documentation](https://github.com/kpetremann/mqtt-exporter/blob/ea10c381224b6f51a2526e5b9f3a9dd946eb22c4/README.md#configuration) the environment variable is `MQTT_IGNORED_TOPICS` plural, but the NixOS configuration generates an environment variable `MQTT_IGNORED_TOPIC` singular.

The workaround is to use `environmentFile`.

```nix
services.prometheus = {
  exporters.mqtt = {
    enable = true;
    # Broken as of this PR, use `environmentFile` workaround below.
    mqttIgnoredTopics = ["zigbee2mqtt/bridge/*" "zigbee2mqtt/config/*" "zigbee2mqtt/clusters/*"];
    environmentFile = pkgs.writeText  "mqtt-exporter-environment-file" ''
        MQTT_IGNORED_TOPICS=zigbee2mqtt/bridge/*,zigbee2mqtt/config/*,zigbee2mqtt/clusters/*
    '';
  };
};

```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
