### PR TITLE
floresta: init at 0.9.0

### DIFF
--- a/pkgs/by-name/fl/floresta/package.nix
+++ b/pkgs/by-name/fl/floresta/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  cmake,
+  pkg-config,
+  boost,
+  openssl,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "floresta";
+  version = "0.9.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "getfloresta";
+    repo = "Floresta";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-8GXCHvk6xxT93c073W15L0+xpri8lQvIcIdDcPead8I=";
+  };
+
+  cargoHash = "sha256-6xsCBw1rO36crFsAaJz42zHpbWju3umr1ppbflJ4uG8=";
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    boost
+    openssl
+  ];
+
+  cargoBuildFlags = [
+    "--package"
+    "florestad"
+    "--package"
+    "floresta-cli"
+  ];
+  cargoInstallFlags = finalAttrs.cargoBuildFlags;
+
+  # Tests rely on external services (bitcoind).
+  doCheck = false;
+
+  strictDeps = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Fully-validating Utreexo-based lightweight Bitcoin node with Electrum server";
+    homepage = "https://github.com/getfloresta/Floresta";
+    changelog = "https://github.com/getfloresta/Floresta/releases/tag/v${finalAttrs.version}";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    mainProgram = "florestad";
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ starius ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Floresta is a lightweight, fully-validating Bitcoin node built on the Utreexo accumulator. It is written in Rust and ships two binaries: `florestad` (daemon with integrated Electrum server) and `floresta-cli` (client). Users can run a pruned validating node with tiny disk requirements, serve Electrum for wallets, or interact via JSON-RPC and the CLI; validation relies on Utreexo proofs instead of storing the full UTXO set.

Tests are disabled in nixpkgs because they require external daemons (bitcoind/utreexod).

Upstream has its own Nix packaging. They also provide libfloresta. I excluded it here, since it lacks header files and it is unclear how to use the library from other languages. Floresta author mentioned FFI support in [the yearly update article](https://blog.dlsouza.lol/2024/08/01/florestad.html), but I couldn't find it, maybe it is still planned.

Upstream repository: https://github.com/getfloresta/Floresta

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
