### PR TITLE
forgejo-runner: unbreak on darwin

### DIFF
--- a/pkgs/by-name/fo/forgejo-runner/package.nix
+++ b/pkgs/by-name/fo/forgejo-runner/package.nix
@@ -105,6 +105,7 @@ buildGoModule rec {
       emilylange
       christoph-heiss
       tebriel
+      nrabulinski
     ];
     mainProgram = "forgejo-runner";
   };

--- a/pkgs/by-name/fo/forgejo-runner/package.nix
+++ b/pkgs/by-name/fo/forgejo-runner/package.nix
@@ -38,6 +38,10 @@ let
     # These tests rely on outbound IP address
     "TestHandler"
     "TestHandler_gcCache"
+  ]
+  ++ lib.optionals stdenv.isDarwin [
+    # Uses docker-specific options, unsupported on Darwin
+    "TestMergeJobOptions"
   ];
 in
 buildGoModule rec {
@@ -92,8 +96,6 @@ buildGoModule rec {
   };
 
   meta = with lib; {
-    # Cannot process container options: '--pid=host --device=/dev/sda': 'unknown server OS: darwin'
-    broken = stdenv.hostPlatform.isDarwin;
     description = "Runner for Forgejo based on act";
     homepage = "https://code.forgejo.org/forgejo/runner";
     changelog = "https://code.forgejo.org/forgejo/runner/releases/tag/${src.rev}";


### PR DESCRIPTION
## Things done

Unbroken ~~`forgejo` and~~ `forgejo-runner` on Darwin. Neither are actually broken, runner just needed a docker test disabled, and forgejo I'm not sure why it was marked broken in the first place.

For testing `forgejo` I ran the binary and went through the initial setup.
For testing the runner, I added it as a runner to my personal forgejo instance and triggered a job on it.

~~Both worked perfectly, so I can't see why they should be marked broken.~~

Only `forgejo-runner` is not broken due to lack of bandwidth for darwin maintainership. Potentially `forgejo` could eventually get unbroken too, but that day is not today.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
