### PR TITLE
python3Packages.gehomesdk: 2025.5.0 -> 2025.11.5

### DIFF
--- a/pkgs/development/python-modules/gehomesdk/default.nix
+++ b/pkgs/development/python-modules/gehomesdk/default.nix
@@ -8,7 +8,6 @@
   fetchPypi,
   humanize,
   pytestCheckHook,
-  pythonOlder,
   requests,
   setuptools,
   websockets,
@@ -18,8 +17,6 @@ buildPythonPackage rec {
   pname = "gehomesdk";
   version = "2025.11.5";
   pyproject = true;
-
-  disabled = pythonOlder "3.9";
 
   src = fetchPypi {
     inherit pname version;
@@ -47,7 +44,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Python SDK for GE smart appliances";
     homepage = "https://github.com/simbaja/gehome";
-    changelog = "https://github.com/simbaja/gehome/blob/master/CHANGELOG.md";
+    changelog = "https://github.com/simbaja/gehome/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
     mainProgram = "gehome-appliance-data";

--- a/pkgs/development/python-modules/gehomesdk/default.nix
+++ b/pkgs/development/python-modules/gehomesdk/default.nix
@@ -1,45 +1,46 @@
 {
   lib,
   aiohttp,
+  beautifulsoup4,
   bidict,
   buildPythonPackage,
+  cryptography,
   fetchPypi,
   humanize,
-  lxml,
+  pytestCheckHook,
   pythonOlder,
   requests,
   setuptools,
-  slixmpp,
   websockets,
 }:
 
 buildPythonPackage rec {
   pname = "gehomesdk";
-  version = "2025.5.0";
+  version = "2025.11.5";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-YMw0W9EWz3KY1+aZMdtE4TRvFd9yqTHkfw0X3+ZDCfQ=";
+    hash = "sha256-HS33yTE+3n0DKRD4+cr8zAE+xcW1ca7q8inQ7qwKJMA=";
   };
 
   build-system = [ setuptools ];
 
   dependencies = [
     aiohttp
+    beautifulsoup4
     bidict
     humanize
-    lxml
     requests
-    slixmpp
     websockets
   ];
 
-  # Tests are not shipped and source is not tagged
-  # https://github.com/simbaja/gehome/issues/32
-  doCheck = false;
+  nativeCheckInputs = [
+    pytestCheckHook
+    cryptography
+  ];
 
   pythonImportsCheck = [ "gehomesdk" ];
 


### PR DESCRIPTION
Changelog: https://github.com/simbaja/gehome/blob/master/CHANGELOG.md#2025115

The dependency list changed, and it also has some basic tests now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
