### PR TITLE
gittype: init at 0.10.0

### DIFF
--- a/pkgs/by-name/gi/gittype/package.nix
+++ b/pkgs/by-name/gi/gittype/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  rustPlatform,
+  stdenvNoCC,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  libgit2,
+  libssh2,
+  gitMinimal,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "gittype";
+  version = "0.10.0";
+
+  src = fetchFromGitHub {
+    owner = "unhappychoice";
+    repo = "gittype";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-pzJWXVCGUn85OCHMRlMY5ufrGyJyuhhkYLUk4e01Ri0=";
+  };
+
+  cargoHash = "sha256-E1LKaiTClHmrF7zhGEj1rfELKryIiyVKIf/8Rozm1RQ=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    openssl
+    libgit2
+    libssh2
+  ];
+
+  env = {
+    OPENSSL_NO_VENDOR = 1;
+    LIBGIT2_NO_VENDOR = 1;
+    LIBSSH2_SYS_USE_PKG_CONFIG = 1;
+  };
+
+  nativeCheckInputs = [ gitMinimal ];
+
+  checkFlags = [
+    "--skip=unit::domain::services::challenge_generator::challenge_generator_tests::"
+  ]
+  ++ lib.optionals stdenvNoCC.hostPlatform.isDarwin [
+    "--skip=unit::domain::services::scoring::tracker::stage::test_pause_resume"
+    "--skip=unit::domain::services::scoring::calculator::stage::test_calculate_with_pauses"
+    "--skip=unit::domain::services::scoring::calculator::stage::test_pause_resume"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  __structuredAttrs = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "CLI code-typing game that turns your source code into typing challenges";
+    homepage = "https://github.com/unhappychoice/gittype";
+    changelog = "https://github.com/unhappychoice/gittype/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ chillcicada ];
+    mainProgram = "gittype";
+    # corrupted size vs. prev_size
+    # error: test failed, to rerun pass `--test mod`
+    broken = stdenvNoCC.hostPlatform.isAarch64 && stdenvNoCC.hostPlatform.isLinux;
+  };
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
