### PR TITLE
perlPackages.YAMLSyck: fix build with gcc15

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -39082,6 +39082,8 @@ with self;
       url = "mirror://cpan/authors/id/T/TO/TODDR/YAML-Syck-1.34.tar.gz";
       hash = "sha256-zJFWzK69p5jr/i8xthnoBld/hg7RcEJi8X/608bjQVk=";
     };
+    # Fix build with gcc15
+    env.NIX_CFLAGS_COMPILE = "-std=gnu17";
     meta = {
       description = "Fast, lightweight YAML loader and dumper";
       homepage = "https://github.com/toddr/YAML-Syck";


### PR DESCRIPTION
- add "-std=gnu17" to `env.NIX_CFLAGS_COMPILE`

Upstream issue:
https://www.github.com/cpan-authors/YAML-Syck/issues/61

There is a PR with proposed patch:
https://www.github.com/cpan-authors/YAML-Syck/pull/64
alpine uses it:
https://gitlab.alpinelinux.org/alpine/aports/-/commit/7dab2a77194967a52df82378c817f686d32056a7

Other distros settled on "-std=gnu17":
https://gitlab.archlinux.org/archlinux/packaging/packages/perl-yaml-syck/-/commit/9355df2bddfdda80963a629d750d0dbc1c1d8aa8
https://src.fedoraproject.org/rpms/perl-YAML-Syck/c/5fb93f7185d99ad738c985a944191ceb89368a82

Fixes build failure with gcc15:
```
emitter.c:161:9: error: too many arguments to function 'st_foreach';
expected 0, have 3
  161 |         st_foreach( e->anchors, syck_st_free_anchors, 0 );
      |         ^~~~~~~~~~  ~~~~~~~~~~
In file included from syck.h:36,
                 from emitter.c:15:
syck_st.h:35:6: note: declared here
   35 | void st_foreach(), st_add_direct(), st_free_table(), st_cleanup_safe();
      |      ^~~~~~~~~~
emitter.c:162:9: error: too many arguments to function 'st_free_table';
expected 0, have 1
  162 |         st_free_table( e->anchors );
      |         ^~~~~~~~~~~~~  ~~~~~~~~~~
syck_st.h:35:37: note: declared here
   35 | void st_foreach(), st_add_direct(), st_free_table(), st_cleanup_safe();
      |                                     ^~~~~~~~~~~~~
emitter.c:400:9: error: too many arguments to function 'st_lookup';
expected 0, have 3
  400 |         st_lookup( e->markers, n, (st_data_t *)&oid ) &&
      |         ^~~~~~~~~  ~~~~~~~~~~
syck_st.h:34:18: note: declared here
   34 | int st_insert(), st_lookup();
      |                  ^~~~~~~~~
```

---

Tested build with:
```bash
nix-build --expr 'with import ./. {}; (perlPackages.overrideScope (final: prev: { stdenv = gcc15Stdenv; })).YAMLSyck'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
