### PR TITLE
rocmPackages.clang: fix errors with gcc15

### DIFF
--- a/pkgs/development/rocm-modules/6/llvm/default.nix
+++ b/pkgs/development/rocm-modules/6/llvm/default.nix
@@ -359,6 +359,14 @@ overrideLlvmPackagesRocm (s: {
             url = "https://github.com/llvm/llvm-project/commit/816fde1cbb700ebcc8b3df81fb93d675c04c12cd.patch";
             relative = "clang";
           })
+          (fetchpatch {
+            # [PATCH] Reapply "[CUDA][HIP] Add a __device__ version of std::__glibcxx_assert_fail()"
+            # Fix errors with gcc15
+            # https://github.com/ROCm/composable_kernel/issues/2887
+            hash = "sha256-liowyS6FTsDhH8mJYXsanK7GEIlXFhd68GRDf/7Y6gg=";
+            url = "https://github.com/llvm/llvm-project/commit/8ec0552a7f1f50986dda6d13eae310d121d7e3ba.patch";
+            relative = "clang";
+          })
         ]
         ++ old.patches
         ++ [


### PR DESCRIPTION
rocmPackages.clang: fix errors with gcc15
- add patch from merged upstream llvm PR:
https://www.github.com/llvm/llvm-project/pull/136133 (previous attempt)
https://www.github.com/llvm/llvm-project/pull/144886

Upstream issue:
https://www.github.com/ROCm/composable_kernel/issues/2887

Fixes build failure of `hipblaslt` with gcc15:
```
In file included from /build/source/projects/hipblaslt/clients/common/src/hipblaslt_init_device.cpp:27:
In file included from /build/source/projects/hipblaslt/clients/common/include/hipblaslt_datatype2string.hpp:29:
In file included from /build/source/projects/hipblaslt/library/src/amd_detail/include/auxiliary.hpp:29:
In file included from /build/source/projects/hipblaslt/library/include/hipblaslt/hipblaslt.h:58:
In file included from /nix/store/klmhyss10wmwknlcz7j3h2i4cqrcmnqg-clr-6.4.3/include/hip/hip_bfloat16.h:37:
In file included from /nix/store/klmhyss10wmwknlcz7j3h2i4cqrcmnqg-clr-6.4.3/include/hip/amd_detail/amd_hip_bfloat16.h:53:
In file included from /nix/store/klmhyss10wmwknlcz7j3h2i4cqrcmnqg-clr-6.4.3/include/hip/hip_runtime.h:62:
In file included from /nix/store/klmhyss10wmwknlcz7j3h2i4cqrcmnqg-clr-6.4.3/include/hip/amd_detail/amd_hip_runtime.h:114:
In file included from /nix/store/klmhyss10wmwknlcz7j3h2i4cqrcmnqg-clr-6.4.3/include/hip/hip_runtime_api.h:578:
In file included from /nix/store/klmhyss10wmwknlcz7j3h2i4cqrcmnqg-clr-6.4.3/include/hip/texture_types.h:47:
In file included from /nix/store/klmhyss10wmwknlcz7j3h2i4cqrcmnqg-clr-6.4.3/include/hip/channel_descriptor.h:32:
In file included from /nix/store/klmhyss10wmwknlcz7j3h2i4cqrcmnqg-clr-6.4.3/include/hip/amd_detail/amd_channel_descriptor.h:29:
In file included from /nix/store/klmhyss10wmwknlcz7j3h2i4cqrcmnqg-clr-6.4.3/include/hip/amd_detail/amd_hip_vector_types.h:49:
/nix/store/042ckvfbpa2v36v12jd34jnwr274ph5r-gcc-prefix/include/c++/array:219:2:
error: reference to __host__ function '__glibcxx_assert_fail' in __host__ __device__ function
  219 |         __glibcxx_requires_subscript(__n);
      |         ^
/nix/store/042ckvfbpa2v36v12jd34jnwr274ph5r-gcc-prefix/include/c++/debug/assertions.h:39:3:
note: expanded from macro '__glibcxx_requires_subscript'
   39 |   __glibcxx_assert(_N < this->size())
      |   ^
/nix/store/042ckvfbpa2v36v12jd34jnwr274ph5r-gcc-prefix/include/c++/x86_64-unknown-linux-gnu/bits/c++config.h:658:12:
note: expanded from macro '__glibcxx_assert'
  658 |       std::__glibcxx_assert_fail();                                     \
      |            ^
/build/source/projects/hipblaslt/clients/common/src/hipblaslt_init_device.cpp:135:20: note: called by 'operator()'
  135 |             return rand_nans[pseudo_random_device(idx) % rand_nans.size()];
      |                    ^
/build/source/projects/hipblaslt/clients/common/src/hipblaslt_init_device.cpp:39:27:
note: called by 'fill_kernel<float, (lambda at /build/source/projects/hipblaslt/clients/common/src/hipblaslt_init_device.cpp:134:55)>'
   39 |         A[idx + offset] = f(idx + offset);
      |                           ^
/nix/store/042ckvfbpa2v36v12jd34jnwr274ph5r-gcc-prefix/include/c++/x86_64-unknown-linux-gnu/bits/c++config.h:652:3:
note: '__glibcxx_assert_fail' declared here
  652 |   __glibcxx_assert_fail()
      |   ^
```

---

Tested builds of:
`rocmPackages.clang`
`rocmPackages.hipblaslt`
on current `staging` where https://github.com/NixOS/nixpkgs/pull/440456 is merged.
And on `master` with https://github.com/NixOS/nixpkgs/pull/440456 (and fixes for other packages) on top.

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

Fixes #468809

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
