### PR TITLE
nix-store-veritysetup: cover case if systemd is overriden

### DIFF
--- a/nixos/modules/system/boot/nix-store-veritysetup.nix
+++ b/nixos/modules/system/boot/nix-store-veritysetup.nix
@@ -7,6 +7,12 @@
 
 let
   cfg = config.boot.initrd.nix-store-veritysetup;
+
+  # nix-store-veritysetup-generator must be build against exactly same systemd that initrd use,
+  # otherwise storePath statement below wouldn't work properly
+  package = pkgs.nix-store-veritysetup-generator.override {
+    systemd = config.boot.initrd.systemd.package;
+  };
 in
 {
   meta.maintainers = with lib.maintainers; [ nikstur ];
@@ -25,8 +31,7 @@ in
 
     boot.initrd.systemd = {
       contents = {
-        "/etc/systemd/system-generators/nix-store-veritysetup-generator".source =
-          "${lib.getExe pkgs.nix-store-veritysetup-generator}";
+        "/etc/systemd/system-generators/nix-store-veritysetup-generator".source = "${lib.getExe package}";
       };
 
       storePaths = [


### PR DESCRIPTION
In case, if systemd is overriden by `config.systemd.package` or `
config.boot.initrd.systemd.package` -- nix-store-veritysetup fails, because unable to find systemd-escape
(path to old systemd hardcoded, but `storePath` in module point to different systemd)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
