### PR TITLE
home-assistant-custom-components.ingress: init at 1.2.9

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/ingress/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/ingress/package.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "lovelylain";
+  domain = "ingress";
+  version = "1.2.9";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = "hass_ingress";
+    tag = version;
+    hash = "sha256-jjig0Dl/vdeuN7e25CH5L/Xvc60RM3BiAt3jUw/C9q4=";
+  };
+
+  meta = {
+    changelog = "https://github.com/lovelylain/hass_ingress/releases/tag/${src.tag}";
+    description = "Add additional ingress panels to your Home Assistant frontend";
+    homepage = "https://github.com/lovelylain/hass_ingress";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ David-Kopczynski ];
+  };
+}


### PR DESCRIPTION
I added [hass_ingress](https://github.com/lovelylain/hass_ingress) as a custom component to `home-assistant`. This component allows to configure custom authenticated panels without the need to change any reverse proxy setups when trying to forward local services (e.g. `esphome`).

ps. testing is not possible with the result bin and thus has been achievend with something like:
```nix
let
  custom =
    import (fetchTarball "https://github.com/David-Kopczynski/nixpkgs/archive/hass-ingress.tar.gz")
      { };
in
{
  # some working HA setup with ESPHome...

  services.home-assistant.customComponents = with custom.pkgs.home-assistant-custom-components; [
    ingress
  ];
  services.home-assistant.config.ingress = {
    "esphome" = {
      title = "ESPHome";
      icon = "mdi:memory";
      url = "http://${config.services.esphome.address}:${toString config.services.esphome.port}/";
    };
  };
}
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
