### PR TITLE
mitex: init at 0.2.6

### DIFF
--- a/pkgs/by-name/mi/mitex/package.nix
+++ b/pkgs/by-name/mi/mitex/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  typst,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "mitex";
+  version = "0.2.6";
+
+  src = fetchFromGitHub {
+    owner = "mitex-rs";
+    repo = "mitex";
+    tag = finalAttrs.version;
+    hash = "sha256-ec/vocq+gU3zbFU2zNTLuHWmte9t8riYlgpS8BzxJBE=";
+  };
+
+  cargoHash = "sha256-AKQrIehctDlG06R21Ia14IC7Yj2/mq/VKPOyIdDBS2g=";
+
+  nativeBuildInputs = [ typst ];
+
+  buildAndTestSubdir = "crates/mitex-cli";
+
+  cargoBuildFlags = [ "--features generate-spec" ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--use-github-releases" ]; };
+
+  meta = {
+    description = "LaTeX support for Typst, CLI for MiTeX";
+    homepage = "https://mitex-rs.github.io/mitex/";
+    downloadPage = "https://github.com/mitex-rs/mitex";
+    changelog = "https://github.com/mitex-rs/mitex/releases/tag/${finalAttrs.src.tag}";
+    maintainers = with lib.maintainers; [ chillcicada ];
+    license = lib.licenses.asl20;
+    mainProgram = "mitex";
+  };
+})


### PR DESCRIPTION
init [mitex](https://github.com/mitex-rs/mitex) (actually mitex-cli) at 0.2.6.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
