### PR TITLE
blocks: init at 0-unstable-2024-08-08

### DIFF
--- a/pkgs/by-name/bl/blocks/package.nix
+++ b/pkgs/by-name/bl/blocks/package.nix
@@ -1,0 +1,109 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  juce,
+  cmake,
+  pkg-config,
+  libx11,
+  libxrandr,
+  libxinerama,
+  libxext,
+  libxcursor,
+  libxtst,
+  freetype,
+  fontconfig,
+  curl,
+  alsa-lib,
+  expat,
+  nix-update-script,
+
+  buildVST3 ? true,
+  buildStandalone ? true,
+}:
+let
+  formats = lib.concatStringsSep " " [
+    (lib.optionalString buildVST3 "VST3")
+    (lib.optionalString buildStandalone "Standalone")
+  ];
+in
+stdenv.mkDerivation {
+  pname = "blocks";
+  version = "0-unstable-2024-08-08";
+
+  src = fetchFromGitHub {
+    owner = "dan-german";
+    repo = "blocks";
+    rev = "fae783735daa8cb1a0b8158508ccede4292639ae";
+    hash = "sha256-TxG4Gnpen+klAJUqbq+40Xzkxk/Osl41Vmc3u1WhIGs=";
+  };
+
+  preConfigure = ''
+    # JUCE submodule from upstream is too old
+    rm -r JUCE
+    ln -s ${juce.src} JUCE
+  '';
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "FORMATS AU VST3 Standalone" "FORMATS ${formats}" \
+      --replace-fail "juce::juce_recommended_lto_flags)" ") # Not forcing LTO"
+  '';
+
+  # https://github.com/dan-german/blocks/issues/39
+  cmakeBuildType = "Debug";
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    libx11
+    libxrandr
+    libxinerama
+    libxext
+    libxcursor
+    libxtst
+    freetype
+    fontconfig
+    curl
+    alsa-lib
+    expat
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    pushd blocks_artefacts/Debug
+      ${lib.optionalString buildStandalone ''
+        install -Dm755 Standalone/blocks -t $out/bin
+      ''}
+
+      ${lib.optionalString buildVST3 ''
+        mkdir -p $out/lib/vst3
+        cp -r VST3/blocks.vst3 $out/lib/vst3
+      ''}
+    popd
+
+    runHook postInstall
+  '';
+
+  # Needed for standalone
+  NIX_LDFLAGS = [
+    "-lX11"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Modular synthesizer audio plugin";
+    homepage = "https://www.soonth.com";
+    platforms = lib.platforms.linux;
+    license = with lib.licenses; [ gpl3Plus ];
+    maintainers = [ lib.maintainers.mrtnvgr ];
+  }
+  // lib.optionalAttrs buildStandalone {
+    mainProgram = "blocks";
+  };
+}


### PR DESCRIPTION
Adds blocks audio plugin.

⚠️ It has memory leaks, does not compile in `Release` mode, so I'll mark this as a draft.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
