### PR TITLE
vimPlugins.nomad: init at 2025.11.2

### DIFF
--- a/pkgs/applications/editors/vim/plugins/non-generated/nomad/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/nomad/default.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  nix-update-script,
+  pkg-config,
+  stdenv,
+  dbus,
+}:
+rustPlatform.buildRustPackage (self: {
+  pname = "nomad";
+  version = "2025.11.2";
+  src = fetchFromGitHub {
+    owner = "nomad";
+    repo = "nomad";
+    tag = self.version;
+    hash = "sha256-fF70G5fTrOHKxZ/EB6+Q0pyOEjfvAd30BL70xr3DKeM=";
+  };
+
+  cargoHash = "sha256-tNFCT5Puddj2K2HCQd/ENdmZ6mSruWczA3RvbTrEeQg=";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = lib.lists.optionals stdenv.isLinux [
+    dbus
+  ];
+
+  # cargo xtask builds & installs the Neovim plugin
+  buildPhase = ''
+    runHook preBuild
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    cargo xtask neovim build --release --out-dir=$out
+    runHook postInstall
+  '';
+
+  # arboard_impl::tests::clipboard_set_get_cycle fails
+  doCheck = false;
+
+  env = {
+    RUSTC_BOOTSTRAP = 1; # We need rust unstable features
+
+    # nomad's `version` build script tries to determine the version using git if these are not set.
+    RELEASE_TAG = self.version;
+    COMMIT_HASH = self.src.rev;
+    COMMIT_UNIX_TIMESTAMP = "0";
+  };
+
+  passthru = {
+    vimPlugin = true;
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Real-time collaborative editing in Neovim";
+    homepage = "https://github.com/nomad/nomad";
+    changelog = "https://github.com/nomad/nomad/blob/${self.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      mrcjkb
+    ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/nomad/nomad

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
