### PR TITLE
python3Packages.urllib3: 2.5.0 -> 2.6.0

### DIFF
--- a/pkgs/development/python-modules/quart-trio/default.nix
+++ b/pkgs/development/python-modules/quart-trio/default.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+
+  # build-system
+  pdm-backend,
+
+  # dependencies
+  exceptiongroup,
+  hypercorn,
+  quart,
+  trio,
+
+  # tests
+  pytest-cov-stub,
+  pytest-trio,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "quart-trio";
+  version = "0.12.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "pgjones";
+    repo = "quart-trio";
+    tag = version;
+    hash = "sha256-n41XATex20iw3ZYxud/5cTdx+F6tTQQJmP91TIw2xJo=";
+  };
+
+  build-system = [
+    pdm-backend
+  ];
+
+  dependencies = [
+    hypercorn
+    quart
+    trio
+  ]
+  ++ hypercorn.optional-dependencies.trio
+  ++ lib.optionals (pythonOlder "3.11") [
+    exceptiongroup
+  ];
+
+  pythonImportsCheck = [
+    "quart_trio"
+  ];
+
+  nativeCheckInputs = [
+    pytest-cov-stub
+    pytest-trio
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Quart-Trio is an extension for Quart to support the Trio event loop";
+    homepage = "https://github.com/pgjones/quart-trio";
+    changelog = "https://github.com/pgjones/quart-trio/blob/${src.tag}/CHANGELOG.rst";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/urllib3/default.nix
+++ b/pkgs/development/python-modules/urllib3/default.nix
@@ -16,9 +16,15 @@
   pysocks,
 
   # tests
+  httpx,
+  pyopenssl,
   pytestCheckHook,
+  pytest-socket,
   pytest-timeout,
+  quart,
+  quart-trio,
   tornado,
+  trio,
   trustme,
 }:
 
@@ -51,12 +57,22 @@ let
     };
 
     nativeCheckInputs = [
+      httpx
+      pyopenssl
+      pytest-socket
       pytest-timeout
       pytestCheckHook
+      quart
+      quart-trio
       tornado
+      trio
       trustme
     ]
     ++ lib.concatAttrValues optional-dependencies;
+
+    disabledTestMarks = [
+      "requires_network"
+    ];
 
     # Tests in urllib3 are mostly timeout-based instead of event-based and
     # are therefore inherently flaky. On your own machine, the tests will

--- a/pkgs/development/python-modules/urllib3/default.nix
+++ b/pkgs/development/python-modules/urllib3/default.nix
@@ -9,10 +9,11 @@
   hatch-vcs,
 
   # optional-dependencies
+  backports-zstd,
   brotli,
   brotlicffi,
+  h2,
   pysocks,
-  zstandard,
 
   # tests
   pytestCheckHook,
@@ -24,12 +25,12 @@
 let
   self = buildPythonPackage rec {
     pname = "urllib3";
-    version = "2.5.0";
+    version = "2.6.0";
     pyproject = true;
 
     src = fetchPypi {
       inherit pname version;
-      hash = "sha256-P8R3M8fkGdS8P2s9wrT4kLt0OQajDVa6Slv6S7/5J2A=";
+      hash = "sha256-y5vO9aSzRdXaXRRdw+MINPWOgBiCjLxyTTC0y31NSfE=";
     };
 
     build-system = [
@@ -39,13 +40,14 @@ let
 
     postPatch = ''
       substituteInPlace pyproject.toml \
-        --replace-fail ', "setuptools-scm>=8,<9"' ""
+        --replace-fail ', "setuptools-scm>=8,<10"' ""
     '';
 
     optional-dependencies = {
       brotli = if isPyPy then [ brotlicffi ] else [ brotli ];
+      h2 = [ h2 ];
       socks = [ pysocks ];
-      zstd = [ zstandard ];
+      zstd = [ backports-zstd ];
     };
 
     nativeCheckInputs = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15929,6 +15929,8 @@ self: super: with self; {
 
   quart-schema = callPackage ../development/python-modules/quart-schema { };
 
+  quart-trio = callPackage ../development/python-modules/quart-trio { };
+
   quaternion = callPackage ../development/python-modules/quaternion { };
 
   qudida = callPackage ../development/python-modules/qudida { };


### PR DESCRIPTION
https://github.com/urllib3/urllib3/blob/2.6.0/CHANGES.rst
https://github.com/urllib3/urllib3/security/advisories/GHSA-gm62-xv2j-4w53
https://github.com/urllib3/urllib3/security/advisories/GHSA-2xpw-w6gg-jr37

Port to stable should be using patches, since 2.6.0 contains API breakage.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`. (down to ~30 failing)
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
