### PR TITLE
nixVersions.nix_2_31: Add tarball fetcher URL check patch

### DIFF
--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -178,13 +178,18 @@ lib.makeExtensible (
             hash = "sha256-NLGXPLjENLeKVOg3OZgHXZ+1x6sPIKq9FHH8pxbCrDI=";
           };
         }).appendPatches
-          [
-            (fetchpatch2 {
-              name = "nix-2.31-14240-sri-error-message.patch";
-              url = "https://github.com/NixOS/nix/commit/56751b1cd2c4700c71c545f2246adf602c97fdf5.patch";
-              hash = "sha256-CerSBAI+H2RqPp9jsCP0QIM2rZYx3yBZHVVUAztgc18=";
-            })
-          ];
+          (
+            [
+              (fetchpatch2 {
+                name = "nix-2.31-14240-sri-error-message.patch";
+                url = "https://github.com/NixOS/nix/commit/56751b1cd2c4700c71c545f2246adf602c97fdf5.patch";
+                hash = "sha256-CerSBAI+H2RqPp9jsCP0QIM2rZYx3yBZHVVUAztgc18=";
+              })
+            ]
+            # Condition on !isLinux to avoid rebuilding NixOS tests
+            # https://github.com/NixOS/nix/pull/14734
+            ++ lib.optional (!stdenv.hostPlatform.isLinux) ./patches/nix-2.31-tarball-decode-url.patch
+          );
 
       nix_2_31 = addTests "nix_2_31" self.nixComponents_2_31.nix-everything;
 

--- a/pkgs/tools/package-management/nix/patches/nix-2.31-tarball-decode-url.patch
+++ b/pkgs/tools/package-management/nix/patches/nix-2.31-tarball-decode-url.patch
@@ -1,0 +1,41 @@
+From 25abfbd465de48679a01397b4bafb0402f0d22a9 Mon Sep 17 00:00:00 2001
+From: dramforever <dramforever@live.com>
+Date: Tue, 9 Dec 2025 00:28:30 +0800
+Subject: [PATCH] libfetchers/tarball: Decode URL before checking existence
+
+If the URL has special characters, it would need to be decoded to get a
+file path.
+
+Fixes test failure with appendPatches and sandbox = false, where the
+version number and hence build directory name has a plus sign in the
+name.
+---
+ src/libfetchers/tarball.cc | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/src/libfetchers/tarball.cc b/src/libfetchers/tarball.cc
+index 309bbaf5a..99f6688d0 100644
+--- a/src/libfetchers/tarball.cc
++++ b/src/libfetchers/tarball.cc
+@@ -6,6 +6,7 @@
+ #include "nix/util/archive.hh"
+ #include "nix/util/tarfile.hh"
+ #include "nix/util/types.hh"
++#include "nix/util/url.hh"
+ #include "nix/fetchers/store-path-accessor.hh"
+ #include "nix/store/store-api.hh"
+ #include "nix/fetchers/git-utils.hh"
+@@ -114,8 +115,8 @@ static DownloadTarballResult downloadTarball_(
+     // Namely lets catch when the url is a local file path, but
+     // it is not in fact a tarball.
+     if (url.rfind("file://", 0) == 0) {
+-        // Remove "file://" prefix to get the local file path
+-        std::string localPath = url.substr(7);
++        // Remove "file://" prefix and decode to get the local file path
++        std::string localPath = percentDecode(url.substr(7));
+         if (!std::filesystem::exists(localPath)) {
+             throw Error("tarball '%s' does not exist.", localPath);
+         }
+-- 
+2.51.2
+


### PR DESCRIPTION
Apparently appendPatches surfaced a latent bug with the tarball fetcher where paths with special characters (here, a plus sign in the version number) are not handled correctly. Add a patch for *that*.

Condition on !isLinux temporarily to avoid rebuilding NixOS tests.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
