### PR TITLE
argc: add progrm_jarvis to maintainers

### DIFF
--- a/pkgs/by-name/ar/argc/package.nix
+++ b/pkgs/by-name/ar/argc/package.nix
@@ -8,6 +8,7 @@
   fetchFromGitHub,
   installShellFiles,
   versionCheckHook,
+  nix-update-script,
 }:
 
 let
@@ -51,6 +52,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   versionCheckProgramArg = "--argc-version";
 
   passthru = {
+    update-script = nix-update-script { };
     tests = {
       cross =
         (

--- a/pkgs/by-name/ar/argc/package.nix
+++ b/pkgs/by-name/ar/argc/package.nix
@@ -7,19 +7,20 @@
   glibcLocales,
   fetchFromGitHub,
   installShellFiles,
+  versionCheckHook,
 }:
 
 let
   canExecuteHost = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 in
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "argc";
   version = "1.23.0";
 
   src = fetchFromGitHub {
     owner = "sigoden";
     repo = "argc";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-in2ymxiSZbs3wZwo/aKfu11x8SLx4OHOoa/tVxr3FyM=";
   };
 
@@ -45,6 +46,10 @@ rustPlatform.buildRustPackage rec {
     LOCALE_ARCHIVE = "${glibcLocales}/lib/locale/locale-archive";
   };
 
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--argc-version";
+
   passthru = {
     tests = {
       cross =
@@ -63,7 +68,7 @@ rustPlatform.buildRustPackage rec {
     description = "Command-line options, arguments and sub-commands parser for bash";
     mainProgram = "argc";
     homepage = "https://github.com/sigoden/argc";
-    changelog = "https://github.com/sigoden/argc/releases/tag/v${version}";
+    changelog = "https://github.com/sigoden/argc/releases/tag/v${finalAttrs.version}";
     license = with lib.licenses; [
       mit
       # or
@@ -71,4 +76,4 @@ rustPlatform.buildRustPackage rec {
     ];
     maintainers = [ lib.maintainers.progrm_jarvis ];
   };
-}
+})

--- a/pkgs/by-name/ar/argc/package.nix
+++ b/pkgs/by-name/ar/argc/package.nix
@@ -69,6 +69,6 @@ rustPlatform.buildRustPackage rec {
       # or
       asl20
     ];
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.progrm_jarvis ];
   };
 }


### PR DESCRIPTION
For package `argc`:

- add myself to maintainers (see #458096);
- migrate to `finalAttrs` paradigm;
- add `nix-update-script`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
