### PR TITLE
statix: add progrm_jarvis to maintainers

### DIFF
--- a/pkgs/by-name/st/statix/package.nix
+++ b/pkgs/by-name/st/statix/package.nix
@@ -5,6 +5,7 @@
   withJson ? true,
   stdenv,
   versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -31,6 +32,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = "--version";
+
+  passthru.update-script = nix-update-script { };
 
   meta = {
     description = "Lints and suggestions for the nix programming language";

--- a/pkgs/by-name/st/statix/package.nix
+++ b/pkgs/by-name/st/statix/package.nix
@@ -4,9 +4,10 @@
   fetchFromGitHub,
   withJson ? true,
   stdenv,
+  versionCheckHook,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "statix";
   # also update version of the vim plugin in
   # pkgs/applications/editors/vim/plugins/overrides.nix
@@ -16,7 +17,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "oppiliappan";
     repo = "statix";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "sha256-bMs3XMiGP6sXCqdjna4xoV6CANOIWuISSzCaL5LYY4c=";
   };
 
@@ -27,14 +28,18 @@ rustPlatform.buildRustPackage rec {
   # tests are failing on darwin
   doCheck = !stdenv.hostPlatform.isDarwin;
 
-  meta = with lib; {
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  meta = {
     description = "Lints and suggestions for the nix programming language";
     homepage = "https://github.com/oppiliappan/statix";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     mainProgram = "statix";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       nerdypepper
       progrm_jarvis
     ];
   };
-}
+})

--- a/pkgs/by-name/st/statix/package.nix
+++ b/pkgs/by-name/st/statix/package.nix
@@ -34,6 +34,7 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "statix";
     maintainers = with maintainers; [
       nerdypepper
+      progrm_jarvis
     ];
   };
 }


### PR DESCRIPTION
For package `statix`:

- add myself to maintainers (see #458096);
- migrate to `finalAttrs` paradigm;
- add `nix-update-script`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
