### PR TITLE
edname: init at 1.0.1

### DIFF
--- a/pkgs/by-name/ed/edname/package.nix
+++ b/pkgs/by-name/ed/edname/package.nix
@@ -1,0 +1,41 @@
+{
+  stdenv,
+  coreutils,
+  lib,
+  fetchFromGitea,
+  makeWrapper,
+}:
+stdenv.mkDerivation {
+
+  pname = "edname";
+  version = "1.0.1";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  src = fetchFromGitea {
+    domain = "git.tudbut.de";
+    owner = "TudbuT";
+    repo = "edname";
+    rev = "v1.0.1";
+    hash = "sha256-Bj7c18O+Z64KlpTNG3FvR17YM2GsTOUyFuapUyhgZ6M=";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp edname.sh "$out/bin/edname"
+    wrapProgram "$out/bin/edname" \
+      --prefix PATH : "${
+        lib.makeBinPath [
+          coreutils
+        ]
+      }"
+  '';
+
+  meta = with lib; {
+    description = "Mass renamer using $EDITOR";
+    license = licenses.mit;
+    maintainers = [ maintainers.tudbut ];
+    homepage = "https://git.tudbut.de/TudbuT/edname";
+    mainProgram = "edname";
+  };
+}


### PR DESCRIPTION
Add the edname package: a mass renamer using an ordinary editor, taken from $EDITOR.

https://git.tudbut.de/TudbuT/edname#readme

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
