### PR TITLE
nixos/tests/nebula: short-circuit connectivity checks

### DIFF
--- a/nixos/tests/nebula/connectivity.nix
+++ b/nixos/tests/nebula/connectivity.nix
@@ -257,7 +257,7 @@ in
 
       restartAndCheckNebula = name: ip: ''
         ${name}.systemctl("restart nebula@smoke.service")
-        ${name}.succeed("ping -c5 ${ip}")
+        ${name}.wait_until_succeeds("ping -c1 -W1 ${ip}", timeout=10)
       '';
 
       # Create a keypair on the client node, then use the public key to sign a cert on the lighthouse.
@@ -317,7 +317,13 @@ in
       lighthouse.shutdown()
       lighthouse.start()
       lighthouse.wait_for_unit("nebula@smoke.service")
-      lighthouse.succeed("ping -c5 10.0.100.1")
+      lighthouse.wait_until_succeeds("ping -c1 -W1 10.0.100.1", timeout=10)
+
+      # Start all the machines to be set up
+      allowAny.start()
+      allowFromLighthouse.start()
+      allowToLighthouse.start()
+      disabled.start()
 
       # Create keys for allowAny's nebula service and test that it comes up.
       ${setUpPrivateKey "allowAny"}
@@ -338,87 +344,87 @@ in
       ${setUpPrivateKey "disabled"}
       ${signKeysFor "disabled" "10.0.100.5/24"}
       disabled.fail("systemctl status nebula@smoke.service")
-      disabled.fail("ping -c5 10.0.100.5")
+      disabled.fail("ping -c3 -W1 10.0.100.5")
 
       # The lighthouse can ping allowAny and allowFromLighthouse but not disabled
-      lighthouse.succeed("ping -c3 10.0.100.2")
-      lighthouse.succeed("ping -c3 10.0.100.3")
-      lighthouse.fail("ping -c3 10.0.100.5")
+      lighthouse.wait_until_succeeds("ping -c1 -W1 10.0.100.2", timeout=10)
+      lighthouse.wait_until_succeeds("ping -c1 -W1 10.0.100.3", timeout=10)
+      lighthouse.fail("ping -c3 -W1 10.0.100.5")
 
       # allowAny can ping the lighthouse, but not allowFromLighthouse because of its inbound firewall
-      allowAny.succeed("ping -c3 10.0.100.1")
-      allowAny.fail("ping -c3 10.0.100.3")
+      allowAny.wait_until_succeeds("ping -c1 -W1 10.0.100.1", timeout=10)
+      allowAny.fail("ping -c3 -W1 10.0.100.3")
       # allowAny can also resolve DNS on lighthouse
       allowAny.succeed("dig @10.0.100.1 allowToLighthouse | grep -E 'allowToLighthouse\.\s+[0-9]+\s+IN\s+A\s+10\.0\.100\.4'")
 
       # allowFromLighthouse can ping the lighthouse and allowAny
-      allowFromLighthouse.succeed("ping -c3 10.0.100.1")
-      allowFromLighthouse.succeed("ping -c3 10.0.100.2")
+      allowFromLighthouse.wait_until_succeeds("ping -c1 -W1 10.0.100.1", timeout=10)
+      allowFromLighthouse.wait_until_succeeds("ping -c1 -W1 10.0.100.2", timeout=10)
 
       # block allowFromLighthouse <-> allowAny, and allowFromLighthouse -> allowAny should still work.
       ${blockTrafficBetween "allowFromLighthouse" "allowAny"}
-      allowFromLighthouse.succeed("ping -c10 10.0.100.2")
+      allowFromLighthouse.wait_until_succeeds("ping -c1 -W1 10.0.100.2", timeout=10)
       ${allowTrafficBetween "allowFromLighthouse" "allowAny"}
-      allowFromLighthouse.succeed("ping -c10 10.0.100.2")
+      allowFromLighthouse.wait_until_succeeds("ping -c1 -W1 10.0.100.2", timeout=10)
 
       # allowToLighthouse can ping the lighthouse but not allowAny or allowFromLighthouse
-      allowToLighthouse.succeed("ping -c3 10.0.100.1")
-      allowToLighthouse.fail("ping -c3 10.0.100.2")
-      allowToLighthouse.fail("ping -c3 10.0.100.3")
+      allowToLighthouse.wait_until_succeeds("ping -c1 -W1 10.0.100.1", timeout=10)
+      allowToLighthouse.fail("ping -c3 -W1 10.0.100.2")
+      allowToLighthouse.fail("ping -c3 -W1 10.0.100.3")
 
       # allowAny can ping allowFromLighthouse now that allowFromLighthouse pinged it first
-      allowAny.succeed("ping -c3 10.0.100.3")
+      allowAny.wait_until_succeeds("ping -c1 -W1 10.0.100.3", timeout=10)
 
       # block allowAny <-> allowFromLighthouse, and allowAny -> allowFromLighthouse should still work.
       ${blockTrafficBetween "allowAny" "allowFromLighthouse"}
-      allowFromLighthouse.succeed("ping -c10 10.0.100.2")
-      allowAny.succeed("ping -c10 10.0.100.3")
+      allowFromLighthouse.wait_until_succeeds("ping -c1 -W1 10.0.100.2", timeout=10)
+      allowAny.wait_until_succeeds("ping -c1 -W1 10.0.100.3", timeout=10)
       ${allowTrafficBetween "allowAny" "allowFromLighthouse"}
-      allowFromLighthouse.succeed("ping -c10 10.0.100.2")
-      allowAny.succeed("ping -c10 10.0.100.3")
+      allowFromLighthouse.wait_until_succeeds("ping -c1 -W1 10.0.100.2", timeout=10)
+      allowAny.wait_until_succeeds("ping -c1 -W1 10.0.100.3", timeout=10)
 
       # allowToLighthouse can ping allowAny if allowAny pings it first
-      allowAny.succeed("ping -c3 10.0.100.4")
-      allowToLighthouse.succeed("ping -c3 10.0.100.2")
+      allowAny.wait_until_succeeds("ping -c1 -W1 10.0.100.4", timeout=10)
+      allowToLighthouse.wait_until_succeeds("ping -c1 -W1 10.0.100.2", timeout=10)
 
       # block allowToLighthouse <-> allowAny, and allowAny <-> allowToLighthouse should still work.
       ${blockTrafficBetween "allowAny" "allowToLighthouse"}
-      allowAny.succeed("ping -c10 10.0.100.4")
-      allowToLighthouse.succeed("ping -c10 10.0.100.2")
+      allowAny.wait_until_succeeds("ping -c1 -W1 10.0.100.4", timeout=10)
+      allowToLighthouse.wait_until_succeeds("ping -c1 -W1 10.0.100.2", timeout=10)
       ${allowTrafficBetween "allowAny" "allowToLighthouse"}
-      allowAny.succeed("ping -c10 10.0.100.4")
-      allowToLighthouse.succeed("ping -c10 10.0.100.2")
+      allowAny.wait_until_succeeds("ping -c1 -W1 10.0.100.4", timeout=10)
+      allowToLighthouse.wait_until_succeeds("ping -c1 -W1 10.0.100.2", timeout=10)
 
       # block lighthouse <-> allowFromLighthouse and allowAny <-> allowFromLighthouse; allowFromLighthouse won't get to allowAny
       ${blockTrafficBetween "allowFromLighthouse" "lighthouse"}
       ${blockTrafficBetween "allowFromLighthouse" "allowAny"}
-      allowFromLighthouse.fail("ping -c3 10.0.100.2")
+      allowFromLighthouse.fail("ping -c3 -W1 10.0.100.2")
       ${allowTrafficBetween "allowFromLighthouse" "lighthouse"}
       ${allowTrafficBetween "allowFromLighthouse" "allowAny"}
-      allowFromLighthouse.succeed("ping -c3 10.0.100.2")
+      allowFromLighthouse.wait_until_succeeds("ping -c1 -W1 10.0.100.2", timeout=10)
 
       # block lighthouse <-> allowAny, allowAny <-> allowFromLighthouse, and allowAny <-> allowToLighthouse; it won't get to allowFromLighthouse or allowToLighthouse
       ${blockTrafficBetween "allowAny" "lighthouse"}
       ${blockTrafficBetween "allowAny" "allowFromLighthouse"}
       ${blockTrafficBetween "allowAny" "allowToLighthouse"}
-      allowFromLighthouse.fail("ping -c3 10.0.100.2")
-      allowAny.fail("ping -c3 10.0.100.3")
-      allowAny.fail("ping -c3 10.0.100.4")
+      allowFromLighthouse.fail("ping -c3 -W1 10.0.100.2")
+      allowAny.fail("ping -c3 -W1 10.0.100.3")
+      allowAny.fail("ping -c3 -W1 10.0.100.4")
       ${allowTrafficBetween "allowAny" "lighthouse"}
       ${allowTrafficBetween "allowAny" "allowFromLighthouse"}
       ${allowTrafficBetween "allowAny" "allowToLighthouse"}
-      allowFromLighthouse.succeed("ping -c3 10.0.100.2")
-      allowAny.succeed("ping -c3 10.0.100.3")
-      allowAny.succeed("ping -c3 10.0.100.4")
+      allowFromLighthouse.wait_until_succeeds("ping -c1 -W1 10.0.100.2", timeout=10)
+      allowAny.wait_until_succeeds("ping -c1 -W1 10.0.100.3", timeout=10)
+      allowAny.wait_until_succeeds("ping -c1 -W1 10.0.100.4", timeout=10)
 
       # block lighthouse <-> allowToLighthouse and allowToLighthouse <-> allowAny; it won't get to allowAny
       ${blockTrafficBetween "allowToLighthouse" "lighthouse"}
       ${blockTrafficBetween "allowToLighthouse" "allowAny"}
-      allowAny.fail("ping -c3 10.0.100.4")
-      allowToLighthouse.fail("ping -c3 10.0.100.2")
+      allowAny.fail("ping -c3 -W1 10.0.100.4")
+      allowToLighthouse.fail("ping -c3 -W1 10.0.100.2")
       ${allowTrafficBetween "allowToLighthouse" "lighthouse"}
       ${allowTrafficBetween "allowToLighthouse" "allowAny"}
-      allowAny.succeed("ping -c3 10.0.100.4")
-      allowToLighthouse.succeed("ping -c3 10.0.100.2")
+      allowAny.wait_until_succeeds("ping -c1 -W1 10.0.100.4", timeout=10)
+      allowToLighthouse.wait_until_succeeds("ping -c1 -W1 10.0.100.2", timeout=10)
     '';
 }

--- a/nixos/tests/nebula/reload.nix
+++ b/nixos/tests/nebula/reload.nix
@@ -72,7 +72,7 @@ in
 
       # Restart nebula to pick up the keys.
       lighthouse.systemctl("restart nebula@smoke.service")
-      lighthouse.succeed("ping -c5 10.0.100.1")
+      lighthouse.wait_until_succeeds("ping -c1 -W1 10.0.100.1", timeout=10)
 
       # Verify that nebula's ssh interface is up.
       lighthouse.succeed("${pkgs.nmap}/bin/nmap 127.0.0.1 | grep 2222/tcp")


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

A few changes to make the nixos/nebula tests run faster:

- Instead of asserting the success of `ping -c3` or `ping -c10`, which takes multiple seconds, use `wait_for_succeeds` with `-c1` to attempt one ping at a time until it works. In most cases, the first ping succeeds and the whole assertion takes a fraction of a second.
- Apply a 1 second timeout to failure assertions. These node VMs are on the same machine: if it doesn't work within a second, it probably isn't going to work.
- Start the non-lighthouse nodes all at once. VM startup takes several seconds and happens lazily, so this was happening serially. Launching all four nodes at once makes it much faster to complete the setup part of the test. Note that this means that some of the nodes are stuck with nebula in a crash loop until their keys are provisioned, but it doesn't affect the test, it just adds some noise to the logs. We could use systemd restart limits to keep them disabled until the unit is restarted if we wanted to suppress that.

Executing the test locally, this brings the runtime down from ~340s to ~100s.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
