### PR TITLE
nixos/lix: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -256,6 +256,7 @@
   ./programs/less.nix
   ./programs/liboping.nix
   ./programs/light.nix
+  ./programs/lix.nix
   ./programs/localsend.nix
   ./programs/mdevctl.nix
   ./programs/mepo.nix

--- a/nixos/modules/programs/lix.nix
+++ b/nixos/modules/programs/lix.nix
@@ -1,0 +1,115 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+
+  cfg = config.nix;
+
+  nixPackage = cfg.package.out;
+
+  makeNixBuildUser = nr: {
+    name = "nixbld${toString nr}";
+    value = {
+      description = "Lix build user ${toString nr}";
+      uid = builtins.add config.ids.uids.nixbld nr;
+      isSystemUser = true;
+      group = "nixbld";
+      extraGroups = [ "nixbld" ];
+    };
+  };
+
+  nixbldUsers = lib.listToAttrs (map makeNixBuildUser (lib.range 1 cfg.nrBuildUsers));
+
+in
+
+{
+  config = lib.mkIf (cfg.enable && nixPackage.pname == "lix") {
+    environment.systemPackages = [
+      nixPackage
+      pkgs.nix-info
+    ]
+    ++ lib.optional (config.programs.bash.completion.enable) pkgs.nix-bash-completions;
+
+    systemd.packages = [ nixPackage ];
+
+    systemd.tmpfiles.packages = [ nixPackage ];
+
+    systemd.sockets.nix-daemon.wantedBy = [ "sockets.target" ];
+
+    systemd.services.nix-daemon = {
+      path = [
+        nixPackage
+        config.programs.ssh.package
+      ];
+
+      environment =
+        cfg.envVars
+        // {
+          CURL_CA_BUNDLE = config.security.pki.caBundle;
+        }
+        // config.networking.proxy.envVars;
+
+      serviceConfig = {
+        CPUSchedulingPolicy = cfg.daemonCPUSchedPolicy;
+        IOSchedulingClass = cfg.daemonIOSchedClass;
+        IOSchedulingPriority = cfg.daemonIOSchedPriority;
+      };
+
+      restartTriggers = [ config.environment.etc."nix/nix.conf".source ];
+
+      # `stopIfChanged = false` changes to switch behavior
+      # from   stop -> update units -> start
+      #   to   update units -> restart
+      #
+      # The `stopIfChanged` setting therefore controls a trade-off between a
+      # more predictable lifecycle, which runs the correct "version" of
+      # the `ExecStop` line, and on the other hand the availability of
+      # sockets during the switch, as the effectiveness of the stop operation
+      # depends on the socket being stopped as well.
+      #
+      # As `nix-daemon.service` does not make use of `ExecStop`, we prefer
+      # to keep the socket up and available. This is important for machines
+      # that run Nix-based services, such as automated build, test, and deploy
+      # services, that expect the daemon socket to be available at all times.
+      #
+      # Notably, the Nix client does not retry on failure to connect to the
+      # daemon socket, and the in-process RemoteStore instance will disable
+      # itself. This makes retries infeasible even for services that are
+      # aware of the issue. Failure to connect can affect not only new client
+      # processes, but also new RemoteStore instances in existing processes,
+      # as well as existing RemoteStore instances that have not saturated
+      # their connection pool.
+      #
+      # Also note that `stopIfChanged = true` does not kill existing
+      # connection handling daemons, as one might wish to happen before a
+      # breaking Nix upgrade (which is rare). The daemon forks that handle
+      # the individual connections split off into their own sessions, causing
+      # them not to be stopped by systemd.
+      # If a Nix upgrade does require all existing daemon processes to stop,
+      # nix-daemon must do so on its own accord, and only when the new version
+      # starts and detects that Nix's persistent state needs an upgrade.
+      stopIfChanged = false;
+
+    };
+
+    # Set up the environment variables for running Nix.
+    environment.sessionVariables = cfg.envVars;
+
+    nix.nrBuildUsers = lib.mkDefault (
+      if cfg.settings.auto-allocate-uids or false then
+        0
+      else
+        lib.max 32 (if cfg.settings.max-jobs == "auto" then 0 else cfg.settings.max-jobs)
+    );
+
+    users.users = nixbldUsers;
+
+    services.displayManager.hiddenUsers = lib.attrNames nixbldUsers;
+
+    # Legacy configuration conversion.
+    nix.settings.sandbox-fallback = false;
+  };
+}

--- a/nixos/modules/programs/lix.nix
+++ b/nixos/modules/programs/lix.nix
@@ -10,6 +10,26 @@ let
 
   nixPackage = cfg.package.out;
 
+  commonNixDaemonConfig = {
+    path = [
+      nixPackage
+      config.programs.ssh.package
+    ];
+
+    environment =
+      cfg.envVars
+      // {
+        CURL_CA_BUNDLE = config.security.pki.caBundle;
+      }
+      // config.networking.proxy.envVars;
+
+    serviceConfig = {
+      CPUSchedulingPolicy = cfg.daemonCPUSchedPolicy;
+      IOSchedulingClass = cfg.daemonIOSchedClass;
+      IOSchedulingPriority = cfg.daemonIOSchedPriority;
+    };
+  };
+
   makeNixBuildUser = nr: {
     name = "nixbld${toString nr}";
     value = {
@@ -39,61 +59,54 @@ in
 
     systemd.sockets.nix-daemon.wantedBy = [ "sockets.target" ];
 
-    systemd.services.nix-daemon = {
-      path = [
-        nixPackage
-        config.programs.ssh.package
-      ];
+    systemd.services."nix-daemon@" = lib.mkMerge [
+      commonNixDaemonConfig
+      {
+        # Do not kill connections serving established connections on upgrade.
+        restartIfChanged = false;
+      }
+    ];
 
-      environment =
-        cfg.envVars
-        // {
-          CURL_CA_BUNDLE = config.security.pki.caBundle;
-        }
-        // config.networking.proxy.envVars;
+    systemd.services.nix-daemon = lib.mkMerge [
+      commonNixDaemonConfig
+      {
+        restartTriggers = [ config.environment.etc."nix/nix.conf".source ];
 
-      serviceConfig = {
-        CPUSchedulingPolicy = cfg.daemonCPUSchedPolicy;
-        IOSchedulingClass = cfg.daemonIOSchedClass;
-        IOSchedulingPriority = cfg.daemonIOSchedPriority;
-      };
+        # `stopIfChanged = false` changes to switch behavior
+        # from   stop -> update units -> start
+        #   to   update units -> restart
+        #
+        # The `stopIfChanged` setting therefore controls a trade-off between a
+        # more predictable lifecycle, which runs the correct "version" of
+        # the `ExecStop` line, and on the other hand the availability of
+        # sockets during the switch, as the effectiveness of the stop operation
+        # depends on the socket being stopped as well.
+        #
+        # As `nix-daemon.service` does not make use of `ExecStop`, we prefer
+        # to keep the socket up and available. This is important for machines
+        # that run Nix-based services, such as automated build, test, and deploy
+        # services, that expect the daemon socket to be available at all times.
+        #
+        # Notably, the Nix client does not retry on failure to connect to the
+        # daemon socket, and the in-process RemoteStore instance will disable
+        # itself. This makes retries infeasible even for services that are
+        # aware of the issue. Failure to connect can affect not only new client
+        # processes, but also new RemoteStore instances in existing processes,
+        # as well as existing RemoteStore instances that have not saturated
+        # their connection pool.
+        #
+        # Also note that `stopIfChanged = true` does not kill existing
+        # connection handling daemons, as one might wish to happen before a
+        # breaking Nix upgrade (which is rare). The daemon forks that handle
+        # the individual connections split off into their own sessions, causing
+        # them not to be stopped by systemd.
+        # If a Nix upgrade does require all existing daemon processes to stop,
+        # nix-daemon must do so on its own accord, and only when the new version
+        # starts and detects that Nix's persistent state needs an upgrade.
+        stopIfChanged = false;
 
-      restartTriggers = [ config.environment.etc."nix/nix.conf".source ];
-
-      # `stopIfChanged = false` changes to switch behavior
-      # from   stop -> update units -> start
-      #   to   update units -> restart
-      #
-      # The `stopIfChanged` setting therefore controls a trade-off between a
-      # more predictable lifecycle, which runs the correct "version" of
-      # the `ExecStop` line, and on the other hand the availability of
-      # sockets during the switch, as the effectiveness of the stop operation
-      # depends on the socket being stopped as well.
-      #
-      # As `nix-daemon.service` does not make use of `ExecStop`, we prefer
-      # to keep the socket up and available. This is important for machines
-      # that run Nix-based services, such as automated build, test, and deploy
-      # services, that expect the daemon socket to be available at all times.
-      #
-      # Notably, the Nix client does not retry on failure to connect to the
-      # daemon socket, and the in-process RemoteStore instance will disable
-      # itself. This makes retries infeasible even for services that are
-      # aware of the issue. Failure to connect can affect not only new client
-      # processes, but also new RemoteStore instances in existing processes,
-      # as well as existing RemoteStore instances that have not saturated
-      # their connection pool.
-      #
-      # Also note that `stopIfChanged = true` does not kill existing
-      # connection handling daemons, as one might wish to happen before a
-      # breaking Nix upgrade (which is rare). The daemon forks that handle
-      # the individual connections split off into their own sessions, causing
-      # them not to be stopped by systemd.
-      # If a Nix upgrade does require all existing daemon processes to stop,
-      # nix-daemon must do so on its own accord, and only when the new version
-      # starts and detects that Nix's persistent state needs an upgrade.
-      stopIfChanged = false;
-
-    };
+      }
+    ];
 
     # Set up the environment variables for running Nix.
     environment.sessionVariables = cfg.envVars;

--- a/nixos/modules/services/system/nix-daemon.nix
+++ b/nixos/modules/services/system/nix-daemon.nix
@@ -183,7 +183,7 @@ in
 
   ###### implementation
 
-  config = lib.mkIf cfg.enable {
+  config = lib.mkIf (cfg.enable && nixPackage.pname != "lix") {
     environment.systemPackages = [
       nixPackage
       pkgs.nix-info


### PR DESCRIPTION
Over time, it is expected that the setups for Lix and Nix will diverge in some ways. To prevent cluttering the modules too much, we will introduce a separate Lix module. It begins its existence as a fork of the nix-daemon module, right now without major changes, although this will change soon. It is also slightly weird due to not having any option definitions on its own and instead dispatching on the pname of `nix.package`, which is done for backwards compatibility (particularly on 25.11), and will also change soon by the gradual introduction of a separate `programs.lix` option subtree.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
