### PR TITLE
python3Packages.pydub: ffmpeg-full -> ffmpeg

### DIFF
--- a/pkgs/development/python-modules/pydub/default.nix
+++ b/pkgs/development/python-modules/pydub/default.nix
@@ -4,7 +4,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   fetchpatch,
-  ffmpeg-full,
+  ffmpeg,
   pytestCheckHook,
   pythonOlder,
   setuptools,
@@ -34,9 +34,9 @@ buildPythonPackage rec {
     })
     # Fix paths to ffmpeg, ffplay and ffprobe
     (replaceVars ./ffmpeg-fix-path.patch {
-      ffmpeg = lib.getExe ffmpeg-full;
-      ffplay = lib.getExe' ffmpeg-full "ffplay";
-      ffprobe = lib.getExe' ffmpeg-full "ffprobe";
+      ffmpeg = lib.getExe ffmpeg;
+      ffplay = lib.getExe' ffmpeg "ffplay";
+      ffprobe = lib.getExe' ffmpeg "ffprobe";
     })
   ];
 


### PR DESCRIPTION
`ffmpeg-full.aarch64-darwin` has a build failure on Hydra ([build 315167080](https://hydra.nixos.org/build/315167080)), so it's not in the binary cache. This forces local builds of pydub and all its reverse dependencies on aarch64-darwin.

Regular `ffmpeg` builds successfully on Hydra and provides all required binaries (`ffmpeg`, `ffplay`, `ffprobe`).

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests
  - [ ] Package tests at `passthru.tests`
  - [ ] Tests in lib/tests or pkgs/test
- [x] Ran `nixpkgs-review` on this PR
- [x] Tested basic functionality of all binary files
  - pydub test suite: 111/113 passed (2 failures are unrelated upstream `assertEquals` deprecation)
- [x] Fits CONTRIBUTING.md and other READMEs