### PR TITLE
freelens-bin: darwin build now uses _7zz instead of undmg for APFS DMG support

### DIFF
--- a/pkgs/by-name/fr/freelens-bin/darwin.nix
+++ b/pkgs/by-name/fr/freelens-bin/darwin.nix
@@ -5,7 +5,8 @@
   src,
   passthru,
   meta,
-  undmg,
+  _7zz,
+  autoSignDarwinBinariesHook,
 }:
 
 stdenvNoCC.mkDerivation {
@@ -19,16 +20,18 @@ stdenvNoCC.mkDerivation {
 
   sourceRoot = ".";
 
-  nativeBuildInputs = [ undmg ];
+  # APFS format is unsupported by undmg
+  nativeBuildInputs = [
+    _7zz
+    autoSignDarwinBinariesHook
+  ];
 
   installPhase = ''
     runHook preInstall
 
     mkdir -p "$out/Applications"
-    cp -R "Freelens.app" "$out/Applications/Freelens.app"
+    cp -R Freelens*/Freelens.app "$out/Applications/Freelens.app"
 
     runHook postInstall
   '';
-
-  dontFixup = true;
 }

--- a/pkgs/by-name/fr/freelens-bin/package.nix
+++ b/pkgs/by-name/fr/freelens-bin/package.nix
@@ -5,7 +5,8 @@
   lib,
   appimageTools,
   makeWrapper,
-  undmg,
+  _7zz,
+  darwin,
   writeShellScript,
   nix-update,
   jq,
@@ -81,8 +82,9 @@ if stdenv.hostPlatform.isDarwin then
       src
       passthru
       meta
-      undmg
+      _7zz
       ;
+    autoSignDarwinBinariesHook = darwin.autoSignDarwinBinariesHook;
   }
 else
   import ./linux.nix {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fixes the darwin build failure for freelens-bin by replacing `undmg` with `_7zz` to handle APFS-formatted DMG files (since the former does not support it, see https://github.com/matthewbauer/undmg/issues/12).
Changes:
- Replaced `undmg` with `_7zz` in darwin.nix and package.nix
- Fixed app name from `Lens.app` to `Freelens.app` to match actual extracted bundle
- Added `autoSignDarwinBinariesHook` and removed `dontFixup = true` to allow the signing hook to run

Similar to #388547 _et al._

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
