### PR TITLE
ankiAddons.recolor: 3.1 -> 3.3

### DIFF
--- a/pkgs/by-name/an/anki/addons/recolor/default.nix
+++ b/pkgs/by-name/an/anki/addons/recolor/default.nix
@@ -6,21 +6,56 @@
 }:
 anki-utils.buildAnkiAddon (finalAttrs: {
   pname = "recolor";
-  version = "3.1";
+  version = "3.3";
   src = fetchFromGitHub {
     owner = "AnKing-VIP";
     repo = "AnkiRecolor";
     tag = finalAttrs.version;
     sparseCheckout = [ "src/addon" ];
-    hash = "sha256-28DJq2l9DP8O6OsbNQCZ0pm4S6CQ3Yz0Vfvlj+iQw8Y=";
+    hash = "sha256-Rfie1m4wfwZvmxxFngt1tky1j5dIZKX7c64A1pSbE3c=";
   };
   sourceRoot = "${finalAttrs.src.name}/src/addon";
+
+  patches = [
+    # With this patch, Nix users only need to update their ReColor config when a
+    # migration happens rather than on every update.
+    # Upstream always wants the last used addon version in the config file in case an
+    # update corrupts the config. That isn't a concern here, since the config is
+    # readonly with Nix.
+    ./only-update-config-version-when-migration-happens.patch
+  ];
+
   passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "ReColor your Anki desktop to whatever aesthetic you like";
+    longDescription = ''
+      This add-on must be configured with a theme to use. You can find some pre-made
+      themes at <https://github.com/AnKing-VIP/AnkiRecolor/wiki/Themes>.
+
+      Example:
+
+      ```nix
+      pkgs.ankiAddons.recolor.withConfig {
+        config = {
+          colors = {
+            ACCENT_CARD = [
+              "Card mode"
+              "#cba6f7"
+              "#cba6f7"
+              "--accent-card"
+            ];
+            # ...
+          };
+          version = {
+            major = 3;
+            minor = 1;
+          };
+        };
+      }
+      ```
+    '';
     homepage = "https://github.com/AnKing-VIP/AnkiRecolor";
-    # No license file, but it can be assumed to be AGPL3 based on
-    # https://ankiweb.net/account/terms.
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [ junestepp ];
   };

--- a/pkgs/by-name/an/anki/addons/recolor/only-update-config-version-when-migration-happens.patch
+++ b/pkgs/by-name/an/anki/addons/recolor/only-update-config-version-when-migration-happens.patch
@@ -1,0 +1,30 @@
+From b291ccbc93fec594346ed9590618c4b740f447fe Mon Sep 17 00:00:00 2001
+From: June Stepp <git@junestepp.me>
+Date: Thu, 9 Oct 2025 16:43:16 -0500
+Subject: [PATCH] Only update config version when migration happens
+
+---
+ migrate.py | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/migrate.py b/migrate.py
+index c84e0c1..7138748 100644
+--- a/migrate.py
++++ b/migrate.py
+@@ -18,11 +18,12 @@ def maybe_migrate_config(conf: ConfigManager) -> None:
+         v2_to_v3(conf)
+     elif version < "3.0":
+         v2_to_v3(conf)
++    else:
++        return
+ 
+-    if version != version_string:
+-        conf["version.major"] = int(version_string.split(".")[0])
+-        conf["version.minor"] = int(version_string.split(".")[1])
+-        conf.save()
++    conf["version.major"] = int(version_string.split(".")[0])
++    conf["version.minor"] = int(version_string.split(".")[1])
++    conf.save()
+ 
+ # some versions of v2 may be incorrectly in -1.-1
+ def detect_v2(conf: ConfigManager) -> bool:


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
