### PR TITLE
ankiAddons.image-occlusion-enhanced: init at version 1.4.0 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5922,6 +5922,11 @@
     githubId = 28738918;
     name = "Pratyush Das";
   };
+  dastarruer = {
+    name = "dastarruer";
+    github = "dastarruer";
+    githubId = 173855353;
+  };
   datafoo = {
     github = "datafoo";
     githubId = 34766150;

--- a/pkgs/by-name/an/anki/addons/default.nix
+++ b/pkgs/by-name/an/anki/addons/default.nix
@@ -8,6 +8,8 @@
 
   anki-quizlet-importer-extended = callPackage ./anki-quizlet-importer-extended { };
 
+  image-occlusion-enhanced = callPackage ./image-occlusion-enhanced { };
+
   local-audio-yomichan = callPackage ./local-audio-yomichan { };
 
   passfail2 = callPackage ./passfail2 { };

--- a/pkgs/by-name/an/anki/addons/image-occlusion-enhanced/default.nix
+++ b/pkgs/by-name/an/anki/addons/image-occlusion-enhanced/default.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  anki-utils,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+anki-utils.buildAnkiAddon (finalAttrs: {
+  pname = "image-occlusion-enhanced";
+  version = "1.4.0";
+  src = fetchFromGitHub {
+    owner = "glutanimate";
+    repo = "image-occlusion-enhanced";
+    sparseCheckout = [ "src/image_occlusion_enhanced" ];
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-YR1hicBDb08J+1Qc+SDiJDXLo5FzLqCQGeVe7brbPME=";
+  };
+  sourceRoot = "${finalAttrs.src.name}/src/image_occlusion_enhanced";
+  passthru.updateScript = nix-update-script { };
+  meta = {
+    description = ''
+      Adds extra features for creating image-based cloze-deletions
+    '';
+    homepage = "https://github.com/glutanimate/image-occlusion-enhanced";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ dastarruer ];
+  };
+})


### PR DESCRIPTION
@JuneStepp @ethancedwards8 This is the same pull request as https://github.com/NixOS/nixpkgs/pull/468582. I gave up trying to sync my fork with the official repo and decided to start again for the sake of my sanity.

I've also fixed the issue from this comment: https://github.com/NixOS/nixpkgs/pull/468582#issuecomment-3628308573 which means that it successfully builds now.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add the image-occlusion-enhanced Anki addon, which allows the user to easily create image occlusion cards (where part of an image is covered up, and the user has to figure out what it is).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. -> I've been using this in my dotfiles for a while now. Not sure if that counts. 
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests -> I've read this already, but not sure what I need to do for this specific package
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
