### PR TITLE
nixos/hddtemp: fix start script to work with strictShellChecks enabled

### DIFF
--- a/nixos/modules/hardware/sensor/hddtemp.nix
+++ b/nixos/modules/hardware/sensor/hddtemp.nix
@@ -14,11 +14,11 @@ let
 
     file=/var/lib/hddtemp/hddtemp.db
 
-    raw_drives=""
-    ${lib.concatStringsSep "\n" (map (drives: "raw_drives+=\"${drives} \"") cfg.drives)}
-    drives=""
-    for i in $raw_drives; do
-      drives+=" $(realpath $i)"
+    declare -a raw_drives
+    raw_drives=( ${lib.concatStringsSep " " (map (drives: "\"${drives}\"") cfg.drives)} )
+    declare -a drives
+    for i in "''${raw_drives[@]}"; do
+      drives+=( "$(realpath "$i")" )
     done
 
     cp ${pkgs.hddtemp}/share/hddtemp/hddtemp.db $file
@@ -28,12 +28,15 @@ let
       --daemon \
       --unit=${cfg.unit} \
       --file=$file \
-      $drives
+      "''${drives[@]}"
   '';
 
 in
 {
-  meta.maintainers = with lib.maintainers; [ peterhoeg ];
+  meta.maintainers = with lib.maintainers; [
+    peterhoeg
+    usovalx
+  ];
 
   ###### interface
 

--- a/nixos/modules/hardware/sensor/hddtemp.nix
+++ b/nixos/modules/hardware/sensor/hddtemp.nix
@@ -14,11 +14,11 @@ let
 
     file=/var/lib/hddtemp/hddtemp.db
 
-    raw_drives=""
-    ${lib.concatStringsSep "\n" (map (drives: "raw_drives+=\"${drives} \"") cfg.drives)}
-    drives=""
-    for i in $raw_drives; do
-      drives+=" $(realpath $i)"
+    declare -a raw_drives
+    raw_drives=( ${lib.escapeShellArgs cfg.drives} )
+    declare -a drives
+    for i in "''${raw_drives[@]}"; do
+      drives+=( "$(realpath "$i")" )
     done
 
     cp ${pkgs.hddtemp}/share/hddtemp/hddtemp.db $file
@@ -28,12 +28,15 @@ let
       --daemon \
       --unit=${cfg.unit} \
       --file=$file \
-      $drives
+      "''${drives[@]}"
   '';
 
 in
 {
-  meta.maintainers = with lib.maintainers; [ peterhoeg ];
+  meta.maintainers = with lib.maintainers; [
+    peterhoeg
+    usovalx
+  ];
 
   ###### interface
 
@@ -82,6 +85,7 @@ in
       description = "HDD/SSD temperature";
       documentation = [ "man:hddtemp(8)" ];
       wantedBy = [ "multi-user.target" ];
+      enableStrictShellChecks = true;
       inherit script;
       serviceConfig = {
         Type = "forking";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -719,6 +719,7 @@ in
     imports = [ ./hbase.nix ];
     _module.args.getPackage = pkgs: pkgs.hbase_2_5;
   };
+  hddtemp = runTest ./hddtemp.nix;
   headscale = runTest ./headscale.nix;
   healthchecks = runTest ./web-apps/healthchecks.nix;
   hedgedoc = runTest ./hedgedoc.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -784,6 +784,7 @@ in
     imports = [ ./hbase.nix ];
     _module.args.getPackage = pkgs: pkgs.hbase_2_5;
   };
+  hddtemp = runTest ./hddtemp.nix;
   headplane = runTest ./headplane.nix;
   headscale = runTest ./headscale.nix;
   healthchecks = runTest ./web-apps/healthchecks.nix;

--- a/nixos/tests/hddtemp.nix
+++ b/nixos/tests/hddtemp.nix
@@ -1,0 +1,31 @@
+{ pkgs, ... }:
+{
+  name = "hddtemp";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [
+      peterhoeg
+      usovalx
+    ];
+  };
+
+  nodes.machine =
+    { config, pkgs, ... }:
+    {
+      systemd.enableStrictShellChecks = true;
+
+      hardware.sensor.hddtemp = {
+        enable = true;
+        drives = [
+          "/dev/sda"
+          "/dev/sdb"
+        ];
+        extraArgs = [ "--listen=127.0.0.1" ];
+      };
+    };
+
+  # system build-only test, nothing to actually run
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("hddtemp.service")
+  '';
+}

--- a/nixos/tests/hddtemp.nix
+++ b/nixos/tests/hddtemp.nix
@@ -1,0 +1,35 @@
+{ pkgs, ... }: {
+  name = "hddtemp";
+  meta = {
+    inherit (pkgs.hddtemp.meta) maintainers;
+  };
+
+  nodes.machine =
+    { config, pkgs, ... }:
+    {
+      virtualisation.qemu.options = [
+        "-drive file=${pkgs.emptyFile},format=raw,if=ide,media=disk,snapshot=on"
+      ];
+
+      environment.systemPackages = [ pkgs.netcat ];
+
+      hardware.sensor.hddtemp = {
+        enable = true;
+        drives = [
+          "/dev/sda"
+        ];
+        extraArgs = [ "--listen=127.0.0.1" ];
+        dbEntries = [
+          # custom SMART decoding rule for QEMU disk
+          ''"QEMU HARDDISK"   190 C "QEMU hard disk"''
+        ];
+      };
+    };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("hddtemp.service")
+    output = machine.succeed("nc -w1 localhost 7634")
+    assert output == "|/dev/sda|QEMU HARDDISK|31|C|", output
+  '';
+}

--- a/pkgs/by-name/hd/hddtemp/package.nix
+++ b/pkgs/by-name/hd/hddtemp/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  nixosTests,
 }:
 let
   db = fetchurl {
@@ -40,6 +41,8 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   enableParallelBuilding = true;
+
+  passthru.tests.nixos = nixosTests.hddtemp;
 
   meta = {
     description = "Tool for displaying hard disk temperature";

--- a/pkgs/by-name/hd/hddtemp/package.nix
+++ b/pkgs/by-name/hd/hddtemp/package.nix
@@ -42,6 +42,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   passthru.tests.nixos = nixosTests.hddtemp;
 
   meta = {


### PR DESCRIPTION
Rewrite generated systemd start script so that it won't trigger shellcheck errors.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
