### PR TITLE
home-assistant-custom-components.thewatchman: init at 0.7.0-beta.1

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/thewatchman/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/thewatchman/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  prettytable,
+  pytest-cov-stub,
+  pytest-homeassistant-custom-component,
+  pytestCheckHook,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "dummylabs";
+  domain = "watchman";
+  version = "0.7.0-beta.1";
+
+  src = fetchFromGitHub {
+    owner = "dummylabs";
+    repo = "thewatchman";
+    tag = "v${version}";
+    hash = "sha256-U2AYxQ37XQocHcnY2Uv9Lhu0LmEZhhcGdO29i565tBM=";
+  };
+
+  postPatch = ''
+    substituteInPlace custom_components/watchman/manifest.json \
+      --replace-fail "prettytable==3.12.0" "prettytable"
+
+    substituteInPlace tests/{__init__,test_{action,regex,report}}.py \
+      --replace-fail "/workspaces/thewatchman/" ""
+  '';
+
+  dontBuild = true;
+
+  dependencies = [
+    prettytable
+  ];
+
+  nativeCheckInputs = [
+    pytest-cov-stub
+    pytest-homeassistant-custom-component
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Keep track of missing entities and services in your config files";
+    homepage = "https://github.com/dummylabs/thewatchman";
+    maintainers = with maintainers; [ SuperSandro2000 ];
+    license = licenses.mit;
+  };
+}


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
