### PR TITLE
obs-studio-plugins.droidcam-obs: switch to ffmpeg 8

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/droidcam-obs/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/droidcam-obs/default.nix
@@ -2,8 +2,9 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   obs-studio,
-  ffmpeg_7,
+  ffmpeg,
   libjpeg,
   libimobiledevice,
   libusbmuxd,
@@ -21,6 +22,15 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-hxG/v15Q4D+6LU4BNV6ErSa1WvPk4kMPl07pIqiMcc4=";
   };
 
+  patches = [
+    # Fix build with ffmpeg 8 / libavcodec 62
+    # TODO: Drop this once v2.4.3+ is released
+    (fetchpatch {
+      url = "https://github.com/dev47apps/droidcam-obs-plugin/commit/73ec2a01e234e6b2287866c25b4242dca6d9d2f6.patch";
+      hash = "sha256-AI2Z9i3+KfvmpyVX9WwX3jcA1hyUZiFO7kWRsb+8/10=";
+    })
+  ];
+
   preBuild = ''
     mkdir ./build
   '';
@@ -31,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
     libusbmuxd
     libplist
     obs-studio
-    ffmpeg_7
+    ffmpeg
   ];
 
   nativeBuildInputs = [
@@ -47,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
     "IMOBILEDEV_DIR=${lib.getDev libimobiledevice}"
     "IMOBILEDEV_DIR=${lib.getLib libimobiledevice}"
     "LIBOBS_INCLUDES=${obs-studio}/include/obs"
-    "FFMPEG_INCLUDES=${lib.getLib ffmpeg_7}"
+    "FFMPEG_INCLUDES=${lib.getLib ffmpeg}"
     "LIBUSBMUXD=libusbmuxd-2.0"
     "LIBIMOBILEDEV=libimobiledevice-1.0"
   ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Closes #468755

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
