### PR TITLE
zita-resampler: update license

### DIFF
--- a/pkgs/by-name/zi/zita-resampler/package.nix
+++ b/pkgs/by-name/zi/zita-resampler/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Resample library by Fons Adriaensen";
-    homepage = "http://kokkinizita.linuxaudio.org/linuxaudio/downloads/index.html";
+    homepage = "https://kokkinizita.linuxaudio.org/linuxaudio/index.html";
     license = lib.licenses.gpl3Only;
     maintainers = [ lib.maintainers.magnetophon ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/zi/zita-resampler/package.nix
+++ b/pkgs/by-name/zi/zita-resampler/package.nix
@@ -1,16 +1,16 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchzip,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "zita-resampler";
   version = "1.11.2";
 
-  src = fetchurl {
+  src = fetchzip {
     url = "https://kokkinizita.linuxaudio.org/linuxaudio/downloads/zita-resampler-${finalAttrs.version}.tar.xz";
-    hash = "sha256-qlxU5pYGmvJvPx/tSpYxE8wSN83f1XrlhCq8sazVSSw=";
+    hash = "sha256-0lgpTOxf8y32GgYtcVbLDUDzyKvbsSZx3LKaDcdID6A=";
   };
 
   makeFlags = [

--- a/pkgs/by-name/zi/zita-resampler/package.nix
+++ b/pkgs/by-name/zi/zita-resampler/package.nix
@@ -13,15 +13,14 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-0lgpTOxf8y32GgYtcVbLDUDzyKvbsSZx3LKaDcdID6A=";
   };
 
+  sourceRoot = "${finalAttrs.src.name}/source";
+
   makeFlags = [
     "PREFIX=$(out)"
     "SUFFIX="
   ];
 
-  postPatch = ''
-    cd source
-  ''
-  + lib.optionalString (!stdenv.hostPlatform.isx86_64) ''
+  postPatch = lib.optionalString (!stdenv.hostPlatform.isx86_64) ''
     substituteInPlace Makefile \
       --replace-fail '-DENABLE_SSE2' ""
   '';

--- a/pkgs/by-name/zi/zita-resampler/package.nix
+++ b/pkgs/by-name/zi/zita-resampler/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Resample library by Fons Adriaensen";
     homepage = "http://kokkinizita.linuxaudio.org/linuxaudio/downloads/index.html";
-    license = lib.licenses.gpl2;
+    license = lib.licenses.gpl3Only;
     maintainers = [ lib.maintainers.magnetophon ];
     platforms = lib.platforms.linux;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Updated the license to GPLv3, reflecting the license stated on the website and the COPYING file provided with the software.
- Used fetchzip so that the hash is based on the decompressed archive.
- Made additional minor stylistic changes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
