### PR TITLE
tmuxinator: 3.3.5 -> 3.3.7

### DIFF
--- a/pkgs/by-name/tm/tmuxinator/package.nix
+++ b/pkgs/by-name/tm/tmuxinator/package.nix
@@ -13,8 +13,8 @@ buildRubyGem rec {
   inherit ruby;
   name = "${gemName}-${version}";
   gemName = "tmuxinator";
-  version = "3.3.5";
-  source.sha256 = "sha256-lkP0gCjMCcc8MpOA7aLrQut7jkpaZt9v9GWqh4C/JyE=";
+  version = "3.3.7";
+  source.sha256 = "sha256-z0E/zS6o8MXW4Gi6KqtusRtPpUBa5XhGMAsNJGZxL7I=";
 
   erubi = buildRubyGem rec {
     inherit ruby;


### PR DESCRIPTION
nixpkgs' `tmux` was upgraded to an unsupported version for tmuxinator (3.6). This PR upgrades tmuxinator to a version that supports the latest. 

The gemspec was not updated in these versions, leading me to believe the dependency versions can stay locked to their current versions. Testing basic functionality seems to confirm this.

## Release Notes

### 3.3.7
- Misc
  - Update CI tmux versions to include 3.6a
  - Include tmux 3.6a in supported versions list

### 3.3.6
- Features
  - Add help to the list of commands output by tmuxinator commands
  - Add --help/-h flag support to subcommands (start, stop, new, debug, copy, delete, list) for easier access to command-specific help
- Misc
  - Update CI ruby versions to latest, remove Ruby 3.1
  - Update CI tmux versions to include 3.6
  - Include tmux 3.6 in supported versions list

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
