### PR TITLE
ocamlPackages.{promtheus,-app}: 1.2 -> 1.3

### DIFF
--- a/pkgs/development/ocaml-modules/prometheus/app.nix
+++ b/pkgs/development/ocaml-modules/prometheus/app.nix
@@ -1,0 +1,47 @@
+{
+  buildDunePackage,
+  prometheus,
+  asetmap,
+  astring,
+  cohttp-lwt,
+  cohttp-lwt-unix,
+  cmdliner,
+  fmt,
+  logs,
+  lwt,
+  re,
+  alcotest,
+  alcotest-lwt,
+}:
+
+buildDunePackage {
+  pname = "prometheus-app";
+  inherit (prometheus)
+    version
+    src
+    ;
+
+  propagatedBuildInputs = [
+    asetmap
+    astring
+    cmdliner
+    cohttp-lwt
+    cohttp-lwt-unix
+    fmt
+    logs
+    lwt
+    prometheus
+    re
+  ];
+
+  doCheck = true;
+
+  checkInputs = [
+    alcotest
+    alcotest-lwt
+  ];
+
+  meta = prometheus.meta // {
+    description = "A web-server reporting prometheus metrics.";
+  };
+}

--- a/pkgs/development/ocaml-modules/prometheus/default.nix
+++ b/pkgs/development/ocaml-modules/prometheus/default.nix
@@ -6,7 +6,6 @@
   asetmap,
   re,
   lwt,
-  alcotest,
 }:
 
 buildDunePackage (finalAttrs: {

--- a/pkgs/development/ocaml-modules/prometheus/default.nix
+++ b/pkgs/development/ocaml-modules/prometheus/default.nix
@@ -4,35 +4,32 @@
   buildDunePackage,
   astring,
   asetmap,
-  fmt,
   re,
   lwt,
   alcotest,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "prometheus";
-  version = "1.2";
+  version = "1.3";
 
   src = fetchurl {
-    url = "https://github.com/mirage/prometheus/releases/download/v${version}/prometheus-${version}.tbz";
-    sha256 = "sha256-g2Q6ApprbecdFANO7i6U/v8dCHVcSkHVg9wVMKtVW8s=";
+    url = "https://github.com/mirage/prometheus/releases/download/v${finalAttrs.version}/prometheus-${finalAttrs.version}.tbz";
+    hash = "sha256-4C0UzwaCgqtk5SGIY89rg0dxdrKm63lhdcOaQAa20L8=";
   };
-
-  duneVersion = "3";
 
   propagatedBuildInputs = [
     astring
     asetmap
-    fmt
     re
     lwt
-    alcotest
   ];
 
   meta = {
+    homepage = "https://github.com/mirage/prometheus";
     description = "Client library for Prometheus monitoring";
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.ulrikstrid ];
+    changelog = "https://raw.githubusercontent.com/mirage/prometheus/v${finalAttrs.version}/CHANGES.md";
   };
-}
+})

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1767,6 +1767,8 @@ let
 
         prometheus = callPackage ../development/ocaml-modules/prometheus { };
 
+        prometheus-app = callPackage ../development/ocaml-modules/prometheus/app.nix { };
+
         progress = callPackage ../development/ocaml-modules/progress { };
 
         promise_jsoo = callPackage ../development/ocaml-modules/promise_jsoo { };


### PR DESCRIPTION
The tests in the original prometheus package have not been run so far.
Because the tests depend on prometheus-app and preometheus-app depends on prometheus, tests were disabled in prometheus and activated in prometheus-app.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
