### PR TITLE
ioping: 1.2 -> 1.3

### DIFF
--- a/pkgs/by-name/io/ioping/package.nix
+++ b/pkgs/by-name/io/ioping/package.nix
@@ -2,27 +2,18 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
 }:
 
 stdenv.mkDerivation rec {
   pname = "ioping";
-  version = "1.2";
+  version = "1.3";
 
   src = fetchFromGitHub {
     owner = "koct9i";
     repo = "ioping";
     rev = "v${version}";
-    sha256 = "10bv36bqga8sdifxzywzzpjil7vmy62psirz7jbvlsq1bw71aiid";
+    hash = "sha256-9lJEjns8ttjgI52ZXeWgL77GMd7o7IvefBJ5UH9y9ks=";
   };
-
-  patches = [
-    # add netdata support: https://github.com/koct9i/ioping/pull/41
-    (fetchpatch {
-      url = "https://github.com/koct9i/ioping/commit/e7b818457ddb952cbcc13ae732ba0328f6eb73b3.patch";
-      sha256 = "122ivp4rqsnjszjfn33z8li6glcjhy7689bgipi8cgs5q55j99gf";
-    })
-  ];
 
   makeFlags = [ "PREFIX=$(out)" ];
 


### PR DESCRIPTION
## Summary

- Update ioping from 1.2 to 1.3
- Remove netdata patch (PR #41 was closed by upstream, never merged) that no longer applies

## Testing

- [x] Built on x86_64-linux
- [x] `ioping -v` shows version 1.3
- [x] `ioping -c 3 /tmp` works correctly

## Release notes

https://github.com/koct9i/ioping/releases/tag/v1.3