### PR TITLE
python3Packages.endesive: init at 2.19.2

### DIFF
--- a/pkgs/development/python-modules/endesive/default.nix
+++ b/pkgs/development/python-modules/endesive/default.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  asn1crypto,
+  cryptography,
+  certifi,
+  pytz,
+  lxml,
+  pillow,
+  pykcs11,
+  requests,
+  paramiko,
+}:
+
+buildPythonPackage rec {
+  pname = "endesive";
+  version = "2.19.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "m32";
+    repo = "endesive";
+    rev = "v${version}";
+    hash = "sha256-two1W4mmHL5HV8k+skpa6X/KcaLx78Y6WSlazW75sRo=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    asn1crypto
+    cryptography
+    certifi
+    pytz
+  ];
+
+  passthru.optional-dependencies = {
+    full = [
+      lxml
+      pillow
+      pykcs11
+      requests
+      paramiko
+    ];
+  };
+
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "endesive"
+  ];
+
+  meta = {
+    description = "Library for digital signing and verification of digital signatures in mail, PDF and XML documents";
+    homepage = "https://github.com/m32/endesive";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ruiiiijiiiiang ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4859,6 +4859,8 @@ self: super: with self; {
 
   encodec = callPackage ../development/python-modules/encodec { };
 
+  endesive = callPackage ../development/python-modules/endesive { };
+
   energyflip-client = callPackage ../development/python-modules/energyflip-client { };
 
   energyflow = callPackage ../development/python-modules/energyflow { };


### PR DESCRIPTION
## Summary
Init `endesive` at 2.19.2.

Endesive is a python library for digital signing and verification of digital signatures in mail, PDF, and XML documents.



- Built on platform:
  - [X] ~~x86_64-linux~~ N/A
  - [X] ~~aarch64-linux~~ N/A
  - [X] ~~x86_64-darwin~~ N/A
  - [X] ~~aarch64-darwin~~ N/A
- Tested, as applicable:
  - [X] ~~[NixOS tests] in [nixos/tests].~~ N/A
  - [X] ~~[Package tests] at `passthru.tests`.~~ N/A
  - [X] ~~Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.~~ N/A
  - [x] Built successfully on my local machine (`nix-build -A python3Packages.endesive`)
  - [x] Verified import in python shell (`nix-shell -p python3Packages.endesive --run "python -c 'import endesive; print(endesive.__version__)'"`)
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] ~~Tested basic functionality of all binary files, usually in `./result/bin/`.~~ N/A
- Nixpkgs Release Notes
  - [X] ~~Package update: when the change is major or breaking.~~ N/A
- NixOS Release Notes
  - [X] ~~Module addition: when adding a new NixOS module.~~ N/A
  - [X] ~~Module update: when the change is significant.~~ N/A
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


## Metadata
- **Pypi:** https://pypi.org/project/endesive/
- **Source:** https://github.com/m32/endesive
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
