### PR TITLE
freerpd: SLD2 -> SDL3, Option for UWAC, 3.18.0 -> 3.19.1, add updateScript, Assign maintainer

### DIFF
--- a/pkgs/by-name/fr/freerdp/package.nix
+++ b/pkgs/by-name/fr/freerdp/package.nix
@@ -58,6 +58,7 @@
   withUnfree ? false,
   withWaylandSupport ? false,
   withSDL2 ? false,
+  makeWrapper,
 
   # tries to compile and run generate_argument_docbook.c
   withManPages ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
@@ -104,6 +105,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     wayland-scanner
     writableTmpDirAsHomeHook
+    makeWrapper
   ];
 
   buildInputs = [
@@ -205,6 +207,11 @@ stdenv.mkDerivation (finalAttrs: {
       "-Wno-error=incompatible-function-pointer-types"
     ]
   );
+
+  postFixup = lib.optionalString (withWaylandSupport && withSDL2) ''
+    wrapProgram $out/bin/sdl2-freerdp \
+      --set SDL_VIDEODRIVER wayland
+  '';
 
   passthru.tests = {
     inherit remmina;

--- a/pkgs/by-name/fr/freerdp/package.nix
+++ b/pkgs/by-name/fr/freerdp/package.nix
@@ -56,6 +56,7 @@
   buildServer ? true,
   nocaps ? false,
   withUnfree ? false,
+  withWaylandSupport ? false,
   withSDL2 ? false,
 
   # tries to compile and run generate_argument_docbook.c
@@ -166,26 +167,32 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "CMAKE_INSTALL_LIBDIR" "lib")
     (lib.cmakeFeature "DOCBOOKXSL_DIR" "${docbook-xsl-nons}/xml/xsl/docbook")
   ]
-  ++ lib.mapAttrsToList lib.cmakeBool {
-    BUILD_TESTING = false; # false is recommended by upstream
-    WITH_CAIRO = cairo != null;
-    WITH_CUPS = cups != null;
-    WITH_FAAC = withUnfree && faac != null;
-    WITH_FAAD2 = faad2 != null;
-    WITH_FUSE = stdenv.hostPlatform.isLinux && fuse3 != null;
-    WITH_JPEG = libjpeg_turbo != null;
-    WITH_KRB5 = libkrb5 != null;
-    WITH_OPENH264 = openh264 != null;
-    WITH_OPUS = libopus != null;
-    WITH_OSS = false;
-    WITH_MANPAGES = withManPages;
-    WITH_PCSC = pcsclite != null;
-    WITH_PULSE = libpulseaudio != null;
-    WITH_SERVER = buildServer;
-    WITH_WEBVIEW = false; # avoid introducing webkit2gtk-4.0
-    WITH_VAAPI = false; # false is recommended by upstream
-    WITH_X11 = true;
-  }
+  ++ lib.mapAttrsToList lib.cmakeBool (
+    {
+      BUILD_TESTING = false; # false is recommended by upstream
+      WITH_CAIRO = cairo != null;
+      WITH_CUPS = cups != null;
+      WITH_FAAC = withUnfree && faac != null;
+      WITH_FAAD2 = faad2 != null;
+      WITH_FUSE = stdenv.hostPlatform.isLinux && fuse3 != null;
+      WITH_JPEG = libjpeg_turbo != null;
+      WITH_KRB5 = libkrb5 != null;
+      WITH_OPENH264 = openh264 != null;
+      WITH_OPUS = libopus != null;
+      WITH_OSS = false;
+      WITH_MANPAGES = withManPages;
+      WITH_PCSC = pcsclite != null;
+      WITH_PULSE = libpulseaudio != null;
+      WITH_SERVER = buildServer;
+      WITH_WEBVIEW = false; # avoid introducing webkit2gtk-4.0
+      WITH_VAAPI = false; # false is recommended by upstream
+    }
+    // lib.filterAttrs (name: value: value) {
+      # Only select one
+      WITH_X11 = !withWaylandSupport;
+      WITH_WAYLAND = withWaylandSupport;
+    }
+  )
   ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
     (lib.cmakeBool "SDL_USE_COMPILED_RESOURCES" false)
   ];

--- a/pkgs/by-name/fr/freerdp/package.nix
+++ b/pkgs/by-name/fr/freerdp/package.nix
@@ -226,7 +226,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://www.freerdp.com/";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ peterhoeg ];
+    maintainers = with lib.maintainers; [ deimelias ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/fr/freerdp/package.nix
+++ b/pkgs/by-name/fr/freerdp/package.nix
@@ -65,11 +65,12 @@
 
   gnome-remote-desktop,
   remmina,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "freerdp";
-  version = "3.18.0";
+  version = "3.19.1";
 
   src = fetchFromGitHub {
     owner = "FreeRDP";
@@ -213,9 +214,11 @@ stdenv.mkDerivation (finalAttrs: {
       --set SDL_VIDEODRIVER wayland
   '';
 
-  passthru.tests = {
-    inherit remmina;
-    inherit gnome-remote-desktop;
+  passthru = {
+    tests = {
+      inherit gnome-remote-desktop remmina;
+    };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/by-name/fr/freerdp/package.nix
+++ b/pkgs/by-name/fr/freerdp/package.nix
@@ -46,6 +46,9 @@
   SDL2,
   SDL2_ttf,
   SDL2_image,
+  sdl3,
+  sdl3-ttf,
+  sdl3-image,
   systemd,
   libjpeg_turbo,
   libkrb5,
@@ -53,6 +56,7 @@
   buildServer ? true,
   nocaps ? false,
   withUnfree ? false,
+  withSDL2 ? false,
 
   # tries to compile and run generate_argument_docbook.c
   withManPages ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
@@ -134,9 +138,9 @@ stdenv.mkDerivation (finalAttrs: {
     pcre2
     pcsclite
     pkcs11helper
-    SDL2
-    SDL2_ttf
-    SDL2_image
+    sdl3
+    sdl3-ttf
+    sdl3-image
     uriparser
     zlib
   ]
@@ -146,6 +150,11 @@ stdenv.mkDerivation (finalAttrs: {
     systemd
     wayland
     wayland-scanner
+  ]
+  ++ lib.optionals withSDL2 [
+    SDL2
+    SDL2_ttf
+    SDL2_image
   ]
   ++ lib.optionals withUnfree [
     faac

--- a/pkgs/by-name/fr/freerdp/package.nix
+++ b/pkgs/by-name/fr/freerdp/package.nix
@@ -70,13 +70,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "freerdp";
-  version = "3.19.1";
+  version = "3.20.0";
 
   src = fetchFromGitHub {
     owner = "FreeRDP";
     repo = "FreeRDP";
     rev = finalAttrs.version;
-    hash = "sha256-+/nZulRjZ/Sc2x9WkKVxyrRX/8F/qDc+2B4QGTPWAmw=";
+    hash = "sha256-/v6M3r0qELpKvDmM8p3SnOmstyqfYNzyS7gw6HBOSd0=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Update SDL version, since version 2 has been deprecated since February. Adding options to include SDL2 version and UWAC (Using Wayland As Client), which improves stability for Wayland compositors (Tested on Hyprland). Also, I included myself as a maintainer. After that, I include the update script and manually update to the latest release.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
