### PR TITLE
scalapack: fix build with gcc15

### DIFF
--- a/pkgs/by-name/sc/scalapack/package.nix
+++ b/pkgs/by-name/sc/scalapack/package.nix
@@ -46,6 +46,14 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/Reference-ScaLAPACK/scalapack/commit/c3d6b22b0032fd2b8772d99c2239c18473e197a7.patch";
       hash = "sha256-935KtaqPO2cghbD9Z8YMxGGOQJo1D1LqTje6/IL4bGI=";
     })
+
+    # Fix build with gcc15
+    # https://github.com/Reference-ScaLAPACK/scalapack/pull/139
+    (fetchpatch {
+      name = "scalapack-fix-function-declaration-arguments.patch";
+      url = "https://github.com/Reference-ScaLAPACK/scalapack/commit/0cd017afa3eefd0597cfe71b7bcfd6356a258da2.patch";
+      hash = "sha256-uUdazKplDt8K5yuVaHX5pLFqDMh0F7eBBGEHfxOiM0Y=";
+    })
   ];
 
   # Required to activate ILP64.


### PR DESCRIPTION
- add patch from merged upstream PR:
https://www.github.com/Reference-ScaLAPACK/scalapack/pull/139
https://github.com/Reference-ScaLAPACK/scalapack/commit/0cd017afa3eefd0597cfe71b7bcfd6356a258da2

Upstream issue:
https://www.github.com/Reference-ScaLAPACK/scalapack/issues/129

Fixes build failure with gcc15:
```
/build/source/TOOLS/reshape.c: In function 'Creshape':
/build/source/TOOLS/reshape.c:32:4: error: too many arguments to
function 'Cblacs_gridinfo'; expected 0, have 5
   32 |    Cblacs_gridinfo( context_in, &nprow_in, &npcol_in, &myrow_in, &mycol_in );
      |    ^~~~~~~~~~~~~~~  ~~~~~~~~~~
/build/source/TOOLS/reshape.c:15:9: note: declared here
   15 |    void Cblacs_gridinfo();
      |         ^~~~~~~~~~~~~~~
/build/source/TOOLS/reshape.c:63:14: error: too many arguments to
function 'Cblacs_pnum'; expected 0, have 3
   63 |       pnum = Cblacs_pnum( context_in, myrow_old, mycol_old );
      |              ^~~~~~~~~~~  ~~~~~~~~~~
/build/source/TOOLS/reshape.c:16:8: note: declared here
   16 |    Int Cblacs_pnum();
      |        ^~~~~~~~~~~
/build/source/TOOLS/reshape.c:65:7: error: too many arguments to
function 'proc_inc'; expected 0, have 5
   65 |       proc_inc( &myrow_old, &mycol_old, nprow_in, npcol_in, major_in );
      |       ^~~~~~~~  ~~~~~~~~~~
/build/source/TOOLS/reshape.c:14:9: note: declared here
   14 |    void proc_inc();
      |         ^~~~~~~~
/build/source/TOOLS/reshape.c:66:7: error: too many arguments to
function 'proc_inc'; expected 0, have 5
   66 |       proc_inc( &myrow_new, &mycol_new, nprow_new, npcol_new, major_out );
      |       ^~~~~~~~  ~~~~~~~~~~
/build/source/TOOLS/reshape.c:14:9: note: declared here
   14 |    void proc_inc();
      |         ^~~~~~~~
/build/source/TOOLS/reshape.c:70:4: error: too many arguments to
function 'Cblacs_get'; expected 0, have 3
   70 |    Cblacs_get( context_in, 10, context_out );
      |    ^~~~~~~~~~  ~~~~~~~~~~
/build/source/TOOLS/reshape.c:17:9: note: declared here
   17 |    void Cblacs_get();
      |         ^~~~~~~~~~
/build/source/TOOLS/reshape.c:73:4: error: too many arguments to
function 'Cblacs_gridmap'; expected 0, have 5
   73 |    Cblacs_gridmap( context_out, grid_new, nprow_new, nprow_new, npcol_new );
      |    ^~~~~~~~~~~~~~  ~~~~~~~~~~~
/build/source/TOOLS/reshape.c:18:9: note: declared here
   18 |    void Cblacs_gridmap();
      |         ^~~~~~~~~~~~~~
...
```

---

Tested build with:
```bash
nix-build --expr 'with import ./. {}; scalapack.override { gfortran = gfortran15; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
