### PR TITLE
terragrunt-atlantis-config: init at 1.21.1

### DIFF
--- a/pkgs/by-name/te/terragrunt-atlantis-config/package.nix
+++ b/pkgs/by-name/te/terragrunt-atlantis-config/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+buildGoModule (finalAttrs: {
+  pname = "terragrunt-atlantis-config";
+  version = "1.21.1";
+
+  src = fetchFromGitHub {
+    owner = "transcend-io";
+    repo = "terragrunt-atlantis-config";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-lh5c5+Lj2jb9BrM3piG9ERUjluiN0f/sPYp4OyKzYBw=";
+  };
+
+  vendorHash = "sha256-brTFOsO2tgWlli1z0W0DGh7114iSlTMHlSZWoFmGdAs=";
+
+  env.CGO_ENABLED = 0;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+  doInstallCheck = true;
+
+  doCheck = false; # requires network access
+
+  ldflags = [
+    "-X main.VERSION=${finalAttrs.version}"
+  ];
+
+  meta = {
+    homepage = "https://github.com/transcend-io/terragrunt-atlantis-config";
+    changelog = "https://github.com/transcend-io/terragrunt-atlantis-config/releases/tag/v${finalAttrs.version}";
+    description = "Generate Atlantis Config for Terragrunt projects";
+    mainProgram = "terragrunt-atlantis-config";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      yethal
+    ];
+  };
+})


### PR DESCRIPTION
Initializing terragrunt-atlantis-config at v1.21.1 for all platforms
homepage: https://github.com/transcend-io/terragrunt-atlantis-config
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
