### PR TITLE
various: devendor publicsuffix-list

### DIFF
--- a/pkgs/by-name/li/libnspsl/package.nix
+++ b/pkgs/by-name/li/libnspsl/package.nix
@@ -4,6 +4,7 @@
   fetchurl,
   pkg-config,
   netsurf-buildsystem,
+  publicsuffix-list,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -14,6 +15,11 @@ stdenv.mkDerivation (finalAttrs: {
     url = "http://download.netsurf-browser.org/libs/releases/libnspsl-${finalAttrs.version}-src.tar.gz";
     hash = "sha256-NoTOwy9VXa7UMZk+C/bL2TdPbJCERiN+CJ8LYdaUrIA=";
   };
+
+  postPatch = ''
+    rm public_suffix_list.dat
+    ln -s ${publicsuffix-list}/share/publicsuffix/public_suffix_list.dat public_suffix_list.dat
+  '';
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/development/python-modules/publicsuffix/default.nix
+++ b/pkgs/development/python-modules/publicsuffix/default.nix
@@ -4,6 +4,7 @@
   fetchPypi,
   setuptools,
   pythonOlder,
+  publicsuffix-list,
 }:
 
 buildPythonPackage rec {
@@ -22,6 +23,9 @@ buildPythonPackage rec {
   postPatch = ''
     sed -i -e "/def test_fetch/i\\
     \\t@unittest.skip('requires internet')" -e "/def additional_tests():/,+1d" tests.py
+
+    rm publicsuffix/public_suffix_list.dat
+    ln -s ${publicsuffix-list}/share/publicsuffix/public_suffix_list.dat publicsuffix/public_suffix_list.dat
   '';
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/publicsuffix2/default.nix
+++ b/pkgs/development/python-modules/publicsuffix2/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,
+  publicsuffix-list,
 }:
 let
   tagVersion = "2.2019-12-21";
@@ -27,6 +28,9 @@ buildPythonPackage {
     # only used to update the interal publicsuffix list
     substituteInPlace setup.py \
       --replace "'requests >= 2.7.0'," ""
+
+    rm src/publicsuffix2/public_suffix_list.dat
+    ln -s ${publicsuffix-list}/share/publicsuffix/public_suffix_list.dat src/publicsuffix2/public_suffix_list.dat
   '';
 
   pythonImportsCheck = [ "publicsuffix2" ];

--- a/pkgs/development/python-modules/publicsuffixlist/default.nix
+++ b/pkgs/development/python-modules/publicsuffixlist/default.nix
@@ -6,6 +6,7 @@
   pytestCheckHook,
   requests,
   setuptools,
+  publicsuffix-list,
 }:
 
 buildPythonPackage rec {
@@ -17,6 +18,11 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-RYvLtdaQV+XXbIuLYdXKocmYEE71eIuV2KJlVhaW+nY=";
   };
+
+  postPatch = ''
+    rm publicsuffixlist/public_suffix_list.dat
+    ln -s ${publicsuffix-list}/share/publicsuffix/public_suffix_list.dat publicsuffixlist/public_suffix_list.dat
+  '';
 
   build-system = [ setuptools ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
