### PR TITLE
nixos/karakeep: add nixosTest

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -714,6 +714,7 @@ in
   kanboard = runTest ./web-apps/kanboard.nix;
   kanidm = runTest ./kanidm.nix;
   kanidm-provisioning = runTest ./kanidm-provisioning.nix;
+  karakeep = runTest ./web-apps/karakeep.nix;
   karma = runTest ./karma.nix;
   kavita = runTest ./kavita.nix;
   kbd-setfont-decompress = runTest ./kbd-setfont-decompress.nix;

--- a/nixos/tests/web-apps/karakeep.nix
+++ b/nixos/tests/web-apps/karakeep.nix
@@ -1,0 +1,33 @@
+{ lib, ... }:
+let
+  port = 3001;
+  host = "karakeep_server";
+in
+{
+  name = "karakeep";
+  meta.maintainers = with lib.maintainers; [ tetov ];
+
+  nodes.${host} = {
+    networking.firewall.allowedTCPPorts = [ port ];
+
+    services.karakeep = {
+      enable = true;
+      extraEnvironment = {
+        HOST = host;
+        PORT = toString port;
+        DISABLE_NEW_RELEASE_CHECK = "true";
+      };
+      meilisearch.enable = true;
+    };
+  };
+
+  testScript = ''
+    import json
+
+    ${host}.wait_for_unit("karakeep-web")
+
+    resp = json.loads(${host}.wait_until_succeeds("curl -sS -f http://${host}:${toString port}/api/health", timeout=300))
+
+    assert resp["status"] == "ok"
+  '';
+}

--- a/pkgs/by-name/ka/karakeep/package.nix
+++ b/pkgs/by-name/ka/karakeep/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   nix-update-script,
+  nixosTests,
   testers,
   nodejs,
   node-gyp,
@@ -128,6 +129,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests = {
+      inherit (nixosTests) karakeep;
       version = testers.testVersion {
         package = finalAttrs.finalPackage;
         # remove hardcoded version if upstream syncs general version with cli


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
