### PR TITLE
qt6.qtbase: use cmake lookup paths by default for finding other Qt bits

### DIFF
--- a/pkgs/development/libraries/qt-6/modules/qtbase/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtbase/default.nix
@@ -215,6 +215,9 @@ stdenv.mkDerivation rec {
     # allow translations to be found outside of install prefix, as is the case in our split builds
     ./allow-translations-outside-prefix.patch
 
+    # make internal find_package calls between Qt components work with split builds
+    ./use-cmake-path.patch
+
     # always link to libraries by name in qmake-generated build scripts
     ./qmake-always-use-libname.patch
     # always explicitly list includedir in qmake-generated pkg-config files

--- a/pkgs/development/libraries/qt-6/modules/qtbase/use-cmake-path.patch
+++ b/pkgs/development/libraries/qt-6/modules/qtbase/use-cmake-path.patch
@@ -1,0 +1,60 @@
+diff --git a/cmake/QtConfig.cmake.in b/cmake/QtConfig.cmake.in
+index 93f47570706..b00d398d671 100644
+--- a/cmake/QtConfig.cmake.in
++++ b/cmake/QtConfig.cmake.in
+@@ -190,7 +190,6 @@ foreach(module ${__qt_umbrella_find_components})
+                 ${_qt_additional_packages_prefix_paths}
+                 ${__qt_find_package_host_qt_path}
+                 ${_qt_additional_host_packages_prefix_paths}
+-            ${__qt_use_no_default_path_for_qt_packages}
+         )
+     endif()
+ 
+diff --git a/cmake/QtFindWrapHelper.cmake b/cmake/QtFindWrapHelper.cmake
+index c43824b8234..7ef65eb0f36 100644
+--- a/cmake/QtFindWrapHelper.cmake
++++ b/cmake/QtFindWrapHelper.cmake
+@@ -79,7 +79,6 @@ macro(qt_find_package_system_or_bundled _unique_prefix)
+                     "${CMAKE_CURRENT_LIST_DIR}/.."
+                     ${_qt_cmake_dir}
+                     ${_qt_additional_packages_prefix_paths}
+-                ${${_unique_prefix}_qt_use_no_default_path_for_qt_packages}
+             )
+         else()
+             # For the non-bundled case we will look for FindWrapSystemFoo.cmake module files,
+diff --git a/cmake/QtModuleConfig.cmake.in b/cmake/QtModuleConfig.cmake.in
+index e3af0299c57..2bbc06ddec3 100644
+--- a/cmake/QtModuleConfig.cmake.in
++++ b/cmake/QtModuleConfig.cmake.in
+@@ -59,7 +59,6 @@ if (@INSTALL_CMAKE_NAMESPACE@@target@_FOUND
+             "${CMAKE_CURRENT_LIST_DIR}/.."
+             "${_qt_cmake_dir}"
+             ${_qt_additional_packages_prefix_paths}
+-        ${__qt_use_no_default_path_for_qt_packages}
+     )
+ 
+     if(NOT @INSTALL_CMAKE_NAMESPACE@@target_private@_FOUND)
+diff --git a/cmake/QtModuleDependencies.cmake.in b/cmake/QtModuleDependencies.cmake.in
+index 78ada0a7425..74659943a83 100644
+--- a/cmake/QtModuleDependencies.cmake.in
++++ b/cmake/QtModuleDependencies.cmake.in
+@@ -23,7 +23,6 @@ if(NOT @INSTALL_CMAKE_NAMESPACE@_FOUND)
+             "${CMAKE_CURRENT_LIST_DIR}/.."
+             "${_qt_cmake_dir}"
+             ${_qt_additional_packages_prefix_paths}
+-        ${__qt_use_no_default_path_for_qt_packages}
+     )
+ endif()
+ 
+diff --git a/cmake/QtPublicDependencyHelpers.cmake b/cmake/QtPublicDependencyHelpers.cmake
+index b4a0342ad87..a7de8750485 100644
+--- a/cmake/QtPublicDependencyHelpers.cmake
++++ b/cmake/QtPublicDependencyHelpers.cmake
+@@ -144,7 +144,6 @@ macro(_qt_internal_find_qt_dependencies target target_dep_list find_dependency_p
+                     ${QT_BUILD_CMAKE_PREFIX_PATH}
+                     ${${find_dependency_path_list}}
+                     ${_qt_additional_packages_prefix_paths}
+-                ${__qt_use_no_default_path_for_qt_packages}
+             )
+             if(NOT ${__qt_${target}_pkg}_FOUND)
+                 list(APPEND __qt_${target}_missing_deps "${__qt_${target}_pkg}")


### PR DESCRIPTION
Fixes things that just do `find_package(Qt6Quick)` without `find_package(Qt6 COMPONENTS ...)` or `find_package(Qt6Core)` first.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
