### PR TITLE
betteralign: init at 0.8.3

### DIFF
--- a/pkgs/by-name/be/betteralign/package.nix
+++ b/pkgs/by-name/be/betteralign/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "betteralign";
+  version = "0.8.3";
+
+  src = fetchFromGitHub {
+    owner = "dkorunic";
+    repo = "betteralign";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-1YAuIdSLibCmiWNRMjVJJHv64Rx8jzO5AyJg+I05Vu0=";
+
+    # Trick for getting accurate commit, source date and timestamp for ldflags
+    # Required by upstream https://github.com/dkorunic/betteralign/blob/346baa9c9dd024bfe55302c9d7d0ca46b2734c1c/.goreleaser.yml
+    leaveDotGit = true;
+    postFetch = ''
+      cd "$out"
+      git rev-parse HEAD > $out/COMMIT
+      git log -1 --pretty=%cd --date=format:'%Y-%m-%dT%H:%M:%SZ' > $out/SOURCE_DATE
+      git log -1 --pretty=%cd --date=format:'%s' > $out/SOURCE_TIMESTAMP
+      find "$out" -name .git -print0 | xargs -0 rm -rf
+    '';
+  };
+
+  vendorHash = "sha256-9jhlshLzS+fNri8eax8SrX1X0KqzQ4clgSyVgXqcx04=";
+
+  env.CGO_ENABLED = 0;
+
+  ldflags = [
+    "-s -w"
+    "-X main.Version=${finalAttrs.version}"
+  ];
+
+  preBuild = ''
+    ldflags+=" -X main.Commit=$(cat COMMIT)"
+    ldflags+=" -X main.Date=$(cat SOURCE_DATE)"
+    ldflags+=" -X main.Timestamp=$(cat SOURCE_TIMESTAMP)"
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "-V";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Make your Go programs use less memory (maybe)";
+    longDescription = ''
+      betteralign is a tool to detect structs that would use less
+      memory if their fields were sorted and optionally sort such fields.
+    '';
+    homepage = "https://github.com/dkorunic/betteralign";
+    changelog = "https://github.com/dkorunic/betteralign/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.bsd3;
+    mainProgram = "betteralign";
+    maintainers = with lib.maintainers; [ cterence ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[betteralign](https://github.com/dkorunic/betteralign): betteralign is a tool to detect structs that would use less memory if their fields were sorted and optionally sort such fields (Golang).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
