### PR TITLE
python3Packages.aiosql: 13.4 -> 14.1

### DIFF
--- a/pkgs/development/python-modules/aiosql/default.nix
+++ b/pkgs/development/python-modules/aiosql/default.nix
@@ -20,8 +20,8 @@ buildPythonPackage rec {
   pyproject = true;
 
   outputs = [
-    "doc"
     "out"
+    "doc"
   ];
 
   src = fetchFromGitHub {

--- a/pkgs/development/python-modules/aiosql/default.nix
+++ b/pkgs/development/python-modules/aiosql/default.nix
@@ -3,7 +3,9 @@
   buildPythonPackage,
   fetchFromGitHub,
   pg8000,
+  psycopg,
   pytest-asyncio,
+  pytest-postgresql,
   pytestCheckHook,
   pythonOlder,
   setuptools,
@@ -38,10 +40,11 @@ buildPythonPackage rec {
     sphinxHook
   ];
 
-  propagatedBuildInputs = [ pg8000 ];
-
   nativeCheckInputs = [
+    pg8000
+    psycopg
     pytest-asyncio
+    pytest-postgresql
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/aiosql/default.nix
+++ b/pkgs/development/python-modules/aiosql/default.nix
@@ -14,10 +14,8 @@
 
 buildPythonPackage rec {
   pname = "aiosql";
-  version = "13.4";
+  version = "14.1";
   pyproject = true;
-
-  disabled = pythonOlder "3.8";
 
   outputs = [
     "doc"
@@ -28,7 +26,7 @@ buildPythonPackage rec {
     owner = "nackjicholson";
     repo = "aiosql";
     tag = version;
-    hash = "sha256-a3pRzcDMXdaDs0ub6k5bPRwnk+RCbxZ7ceIt8/fMSPg=";
+    hash = "sha256-BNsjVVyYRfp3sNdzQwHy9nQveP2AHfXGK10DLybat9I=";
   };
 
   sphinxRoot = "docs/source";


### PR DESCRIPTION
- Updated to the latest upstream release. Upstream diff: <https://github.com/nackjicholson/aiosql/compare/13.4...14.1>.
- Drop the Python version check. We don’t have anything older than Python 3.10 anyway (and aiosql does support 3.10).
- Enabled PostgreSQL tests with two backends, `pg8000` and `psycopg`. Also moved `pg8000` from `propagatedBuildInputs` to `nativeCheckInputs`. It is just one of many supported backends, so it’s an optional dependency.
- Made `out` the first derivation. This way, `"PYTHONPATH=${python3.pkgs.aiosql}/${python3.sitePackages}"` will produce the correct result. Previously it produced `/nix/store/ajap8ygf2i5ri25ynagnalv9917yr571-python3.13-aiosql-14.1-doc/lib/python3.13/site-packages`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test