### PR TITLE
python313Packages.parso: 0.8.4 -> 0.8.5

### DIFF
--- a/pkgs/development/python-modules/parso/default.nix
+++ b/pkgs/development/python-modules/parso/default.nix
@@ -2,28 +2,20 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pythonAtLeast,
-  pythonOlder,
   pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "parso";
-  version = "0.8.4";
+  version = "0.8.5";
   format = "setuptools";
-  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-6zp7WCQPuZCZo0VXHe7MD5VA6l9N0v4UwqmdaygauS0=";
+    hash = "sha256-A01zVKmgGL3ONS9IsqikUPBenW7oXbhHZOm2vZba/lo=";
   };
 
   nativeCheckInputs = [ pytestCheckHook ];
-
-  disabledTests = lib.optionals (pythonAtLeast "3.10") [
-    # python changed exception message format in 3.10, 3.10 not yet supported
-    "test_python_exception_matches"
-  ];
 
   meta = with lib; {
     description = "Python Parser";

--- a/pkgs/development/python-modules/parso/default.nix
+++ b/pkgs/development/python-modules/parso/default.nix
@@ -22,6 +22,8 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  pythonImportsCheck = [ "parso" ];
+
   meta = {
     description = "Python Parser";
     homepage = "https://parso.readthedocs.io/en/latest/";

--- a/pkgs/development/python-modules/parso/default.nix
+++ b/pkgs/development/python-modules/parso/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   meta = {
     description = "Python Parser";
     homepage = "https://parso.readthedocs.io/en/latest/";
-    changelog = "https://github.com/davidhalter/parso/blob/master/CHANGELOG.rst";
+    changelog = "https://github.com/davidhalter/parso/blob/${src.tag}/CHANGELOG.rst";
     license = lib.licenses.mit;
   };
 }

--- a/pkgs/development/python-modules/parso/default.nix
+++ b/pkgs/development/python-modules/parso/default.nix
@@ -2,13 +2,14 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
   pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "parso";
   version = "0.8.5";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "davidhalter";
@@ -17,12 +18,14 @@ buildPythonPackage rec {
     hash = "sha256-faSXCrOkybLr0bboF/8rPV/Humq8s158A3UOpdlYi0I=";
   };
 
+  build-system = [ setuptools ];
+
   nativeCheckInputs = [ pytestCheckHook ];
 
-  meta = with lib; {
+  meta = {
     description = "Python Parser";
     homepage = "https://parso.readthedocs.io/en/latest/";
     changelog = "https://github.com/davidhalter/parso/blob/master/CHANGELOG.rst";
-    license = licenses.mit;
+    license = lib.licenses.mit;
   };
 }

--- a/pkgs/development/python-modules/parso/default.nix
+++ b/pkgs/development/python-modules/parso/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   pytestCheckHook,
 }:
 
@@ -10,9 +10,11 @@ buildPythonPackage rec {
   version = "0.8.5";
   format = "setuptools";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-A01zVKmgGL3ONS9IsqikUPBenW7oXbhHZOm2vZba/lo=";
+  src = fetchFromGitHub {
+    owner = "davidhalter";
+    repo = "parso";
+    tag = "v${version}";
+    hash = "sha256-faSXCrOkybLr0bboF/8rPV/Humq8s158A3UOpdlYi0I=";
   };
 
   nativeCheckInputs = [ pytestCheckHook ];


### PR DESCRIPTION
Changelog: https://github.com/davidhalter/parso/blob/v0.8.5/CHANGELOG.rst
Diff: https://github.com/davidhalter/parso/compare/v0.8.4...v0.8.5

This fixes the build of `python314Packages.parso`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
