### PR TITLE
nixos/jellyfin: Add more lockdown options

### DIFF
--- a/nixos/modules/services/misc/jellyfin.nix
+++ b/nixos/modules/services/misc/jellyfin.nix
@@ -129,6 +129,7 @@ in
           ];
 
           # Security options:
+          CapabilityBoundingSet = [ "" ];
           NoNewPrivileges = true;
           SystemCallArchitectures = "native";
           # AF_NETLINK needed because Jellyfin monitors the network connection
@@ -141,11 +142,15 @@ in
           RestrictNamespaces = !config.boot.isContainer;
           RestrictRealtime = true;
           RestrictSUIDSGID = true;
+          ProcSubset = "pid";
           ProtectControlGroups = !config.boot.isContainer;
+          ProtectClock = true;
           ProtectHostname = true;
           ProtectKernelLogs = !config.boot.isContainer;
           ProtectKernelModules = !config.boot.isContainer;
           ProtectKernelTunables = !config.boot.isContainer;
+          ProtectProc = "invisible";
+          ProtectSystem = true;
           LockPersonality = true;
           PrivateTmp = !config.boot.isContainer;
           # needed for hardware acceleration
@@ -154,21 +159,8 @@ in
           RemoveIPC = true;
 
           SystemCallFilter = [
-            "~@clock"
-            "~@aio"
-            "~@chown"
-            "~@cpu-emulation"
-            "~@debug"
-            "~@keyring"
-            "~@memlock"
-            "~@module"
-            "~@mount"
-            "~@obsolete"
+            "@system-service"
             "~@privileged"
-            "~@raw-io"
-            "~@reboot"
-            "~@setuid"
-            "~@swap"
           ];
           SystemCallErrorNumber = "EPERM";
         };

--- a/nixos/tests/jellyfin.nix
+++ b/nixos/tests/jellyfin.nix
@@ -154,5 +154,7 @@
 
           if duration.strip() != "5.000000":
               raise Exception("Downloaded video has wrong duration")
+
+      machine.log(machine.succeed("systemd-analyze security jellyfin.service | grep -v '✓'"))
     '';
 }


### PR DESCRIPTION
Also tested on my own Jellyfin server for a couple of days.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
