### PR TITLE
uptime-kuma: 1.23.16 -> 2.0.2

### DIFF
--- a/pkgs/by-name/up/uptime-kuma/fix-database-permissions.patch
+++ b/pkgs/by-name/up/uptime-kuma/fix-database-permissions.patch
@@ -1,12 +1,12 @@
-diff --git a/server/server.js b/server/server.js
-index 0c9a45e6..cec31c7c 100644
---- a/server/server.js
-+++ b/server/server.js
-@@ -1583,6 +1583,7 @@ async function initDatabase(testMode = false) {
-     if (! fs.existsSync(Database.path)) {
-         log.info("server", "Copying Database");
-         fs.copyFileSync(Database.templatePath, Database.path);
-+        fs.chmodSync(Database.path, 0o640);
-     }
-
-     log.info("server", "Connecting to the Database");
+diff --git a/server/database.js b/server/database.js
+index a65a7fdc..0dbd490e 100644
+--- a/server/database.js
++++ b/server/database.js
+@@ -251,6 +251,7 @@ class Database {
+             if (! fs.existsSync(Database.sqlitePath)) {
+                 log.info("server", "Copying Database");
+                 fs.copyFileSync(Database.templatePath, Database.sqlitePath);
++                fs.chmodSync(Database.sqlitePath, 0o640);
+             }
+ 
+             const Dialect = require("knex/lib/dialects/sqlite3/index.js");

--- a/pkgs/by-name/up/uptime-kuma/package.nix
+++ b/pkgs/by-name/up/uptime-kuma/package.nix
@@ -10,23 +10,23 @@
 
 buildNpmPackage rec {
   pname = "uptime-kuma";
-  version = "1.23.16";
+  version = "2.0.2";
 
   src = fetchFromGitHub {
     owner = "louislam";
     repo = "uptime-kuma";
     rev = version;
-    hash = "sha256-+bhKnyZnGd+tNlsxvP96I9LXOca8FmOPhIFHp7ijmyA=";
+    hash = "sha256-zW5sl1g96PvDK3S6XhJ6F369/NSnvU9uSQORCQugfvs=";
   };
 
-  npmDepsHash = "sha256-5i1NxwHqOahkioyM4wSu2X5KeMu7CdC4BqoUooAshn4=";
+  npmDepsHash = "sha256-EmSZJUbtD4FW7Rzdpue6/bV8oZt7RUL11tFBXGJQthg=";
 
   patches = [
     # Fixes the permissions of the database being not set correctly
     # See https://github.com/louislam/uptime-kuma/pull/2119
     ./fix-database-permissions.patch
   ];
-
+  
   nativeBuildInputs = [ python3 ];
 
   CYPRESS_INSTALL_BINARY = 0; # Stops Cypress from trying to download binaries


### PR DESCRIPTION
Updated Uptime Kuma version to 2.0.2
Created a new patch for the SQLite DB to Fix the Permissions.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
