### PR TITLE
python3Packages.nanobind: 2.9.2 -> 2.10.1

### DIFF
--- a/pkgs/by-name/pr/proxsuite/fix-cmake-python-version.patch
+++ b/pkgs/by-name/pr/proxsuite/fix-cmake-python-version.patch
@@ -1,0 +1,14 @@
+diff --git a/bindings/python/CMakeLists.txt b/bindings/python/CMakeLists.txt
+index 07678691f..1d85e5eb2 100644
+--- a/bindings/python/CMakeLists.txt
++++ b/bindings/python/CMakeLists.txt
+@@ -31,6 +31,9 @@ execute_process(
+   OUTPUT_STRIP_TRAILING_WHITESPACE
+   OUTPUT_VARIABLE nanobind_ROOT
+ )
++if(NOT Python_VERSION AND Python3_VERSION)
++  set(Python_VERSION ${Python3_VERSION})
++endif()
+ find_package(nanobind CONFIG)
+ cmake_policy(POP)
+ if(NOT nanobind_FOUND)

--- a/pkgs/by-name/pr/proxsuite/package.nix
+++ b/pkgs/by-name/pr/proxsuite/package.nix
@@ -36,6 +36,11 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-1+a5tFOlEwzhGZtll35EMFceD0iUOOQCbwJd9NcFDlk=";
   };
 
+  patches = [
+    # Set Python_VERSION to Python3_VERSION if not already set
+    ./fix-cmake-python-version.patch
+  ];
+
   # ref. https://github.com/Simple-Robotics/proxsuite/pull/408 merged upstream
   postPatch = ''
     substituteInPlace CMakeLists.txt --replace-fail \

--- a/pkgs/development/python-modules/nanobind/default.nix
+++ b/pkgs/development/python-modules/nanobind/default.nix
@@ -26,7 +26,7 @@
 }:
 buildPythonPackage rec {
   pname = "nanobind";
-  version = "2.9.2";
+  version = "2.10.1";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     repo = "nanobind";
     tag = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-cC+sf2FUm1jdGMRdDoaQK8rjUVkWjn/53c1HQ5gsUWs=";
+    hash = "sha256-LNr3d0ytnkcJOps6DzdZtyiihFwNgv34s5RJsRBD844=";
   };
 
   build-system = [


### PR DESCRIPTION
Regular package version bump.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
