### PR TITLE
akkoma: 3.15.2 → 3.17.0

### DIFF
--- a/pkgs/by-name/ak/akkoma-admin-fe/package.nix
+++ b/pkgs/by-name/ak/akkoma-admin-fe/package.nix
@@ -2,77 +2,51 @@
   lib,
   stdenv,
   fetchFromGitea,
-  fetchYarnDeps,
-  writableTmpDirAsHomeHook,
-  fixup-yarn-lock,
-  yarn,
+  yarn-berry_3,
   nodejs,
-  git,
   python3,
   pkg-config,
   libsass,
-  nix-update-script,
   xcbuild,
+  nix-update-script,
 }:
 
+let
+  yarn-berry = yarn-berry_3;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "admin-fe";
-  version = "2.3.0-2-unstable-2024-04-27";
+  version = "2.3.0-2-unstable-2025-12-07";
 
   src = fetchFromGitea {
     domain = "akkoma.dev";
     owner = "AkkomaGang";
     repo = "admin-fe";
-    rev = "7e16abcbaab10efa6c2c4589660cf99f820a718d";
-    hash = "sha256-W/2Ay2dNeVQk88lgkyTzKwCNw0kLkfI6+Azlbp0oMm4=";
+    rev = "a0e3b95a75367d1b5e329963a3d54f67cf59dfca";
+    hash = "sha256-eEAM1itUvpR57B0BseeeRuV+ZjcYiJvbdln8vleRNcc=";
+
+    # upstream repository archive fetching is broken
+    forceFetchGit = true;
   };
 
-  offlineCache = fetchYarnDeps {
+  offlineCache = yarn-berry.fetchYarnBerryDeps {
     yarnLock = finalAttrs.src + "/yarn.lock";
-    hash = "sha256-acF+YuWXlMZMipD5+XJS+K9vVFRz3wB2fZqc3Hd0Bjc=";
+    hash = "sha256-YZlvIr27bHBgsQcBiayqEX07kjX6iH2Kh5wt+PQFq04=";
   };
 
   nativeBuildInputs = [
-    fixup-yarn-lock
-    writableTmpDirAsHomeHook
-    yarn
+    yarn-berry.yarnBerryConfigHook
+    yarn-berry
     nodejs
     pkg-config
     python3
-    git
     libsass
   ]
   ++ lib.optional stdenv.hostPlatform.isDarwin xcbuild;
 
-  configurePhase = ''
-    runHook preConfigure
-
-    yarn config --offline set yarn-offline-mirror ${lib.escapeShellArg finalAttrs.offlineCache}
-    fixup-yarn-lock yarn.lock
-    substituteInPlace yarn.lock \
-      --replace-fail '"git://github.com/adobe-webplatform/eve.git#eef80ed"' '"https://github.com/adobe-webplatform/eve.git#eef80ed"'
-
-    yarn install --offline --frozen-lockfile --ignore-platform --ignore-scripts --no-progress --non-interactive
-    patchShebangs node_modules/cross-env
-
-    mkdir -p "$HOME/.node-gyp/${nodejs.version}"
-    echo 9 >"$HOME/.node-gyp/${nodejs.version}/installVersion"
-    ln -sfv "${nodejs}/include" "$HOME/.node-gyp/${nodejs.version}"
-    export npm_config_nodedir=${nodejs}
-
-    runHook postConfigure
-  '';
-
   buildPhase = ''
     runHook preBuild
-
-    pushd node_modules/node-sass
-    LIBSASS_EXT=auto yarn run build --offline
-    popd
-
-    export NODE_OPTIONS="--openssl-legacy-provider"
     yarn run build:prod --offline
-
     runHook postBuild
   '';
 

--- a/pkgs/by-name/ak/akkoma-fe/package.nix
+++ b/pkgs/by-name/ak/akkoma-fe/package.nix
@@ -4,8 +4,8 @@
   fetchFromGitea,
   fetchYarnDeps,
   writableTmpDirAsHomeHook,
-  fixup-yarn-lock,
-  yarn,
+  yarnConfigHook,
+  yarnBuildHook,
   nodejs,
   jpegoptim,
   oxipng,
@@ -28,15 +28,15 @@ stdenv.mkDerivation (finalAttrs: {
     forceFetchGit = true;
   };
 
-  offlineCache = fetchYarnDeps {
+  yarnOfflineCache = fetchYarnDeps {
     yarnLock = finalAttrs.src + "/yarn.lock";
     hash = "sha256-QB523QZX8oBMHWBSFF7MpaWWXc+MgEUaw/2gsCPZ9a4=";
   };
 
   nativeBuildInputs = [
     writableTmpDirAsHomeHook
-    fixup-yarn-lock
-    yarn
+    yarnConfigHook
+    yarnBuildHook
     nodejs
     jpegoptim
     oxipng
@@ -49,27 +49,6 @@ stdenv.mkDerivation (finalAttrs: {
       builtins.substring 0 7 finalAttrs.src.rev
     }";' \
       build/webpack.prod.conf.js
-  '';
-
-  configurePhase = ''
-    runHook preConfigure
-
-    yarn config --offline set yarn-offline-mirror ${lib.escapeShellArg finalAttrs.offlineCache}
-    fixup-yarn-lock yarn.lock
-
-    yarn install --offline --frozen-lockfile --ignore-platform --ignore-scripts --no-progress --non-interactive
-
-    runHook postConfigure
-  '';
-
-  buildPhase = ''
-    runHook preBuild
-
-    export NODE_ENV="production"
-    export NODE_OPTIONS="--openssl-legacy-provider"
-    yarn run build --offline
-
-    runHook postBuild
   '';
 
   installPhase = ''

--- a/pkgs/by-name/ak/akkoma-fe/package.nix
+++ b/pkgs/by-name/ak/akkoma-fe/package.nix
@@ -15,14 +15,17 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "akkoma-fe";
-  version = "3.15.0";
+  version = "3.12.0";
 
   src = fetchFromGitea {
     domain = "akkoma.dev";
     owner = "AkkomaGang";
     repo = "akkoma-fe";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-VKYeJwAc4pMpF1dWBnx5D39ffNk7eGpJI2es+GAxdow=";
+    hash = "sha256-DK+KLAcT/10qhwmB+GoHN/7nOKJEJ32zSao8/fjgW7E=";
+
+    # upstream repository archive fetching is broken
+    forceFetchGit = true;
   };
 
   offlineCache = fetchYarnDeps {

--- a/pkgs/by-name/ak/akkoma/package.nix
+++ b/pkgs/by-name/ak/akkoma/package.nix
@@ -10,14 +10,17 @@
 
 beamPackages.mixRelease rec {
   pname = "akkoma";
-  version = "3.15.2";
+  version = "3.17.0";
 
   src = fetchFromGitea {
     domain = "akkoma.dev";
     owner = "AkkomaGang";
     repo = "akkoma";
     tag = "v${version}";
-    hash = "sha256-GW86OyO/XPIrCS+cPKQ8LG8PdhhfA2rNH1FXFiuL6vM=";
+    hash = "sha256-RXKqeaS+cvOGQNMU/g2lbAk/V1JbkU2XXqITqv1U/wU=";
+
+    # upstream repository archive fetching is broken
+    forceFetchGit = true;
   };
 
   nativeBuildInputs = [ cmake ];
@@ -36,7 +39,7 @@ beamPackages.mixRelease rec {
   mixFodDeps = beamPackages.fetchMixDeps {
     pname = "mix-deps-${pname}";
     inherit src version;
-    hash = "sha256-ygRj0s9J2/nBXR5s9CE7eMRBxsRhKlV/IZrkwPpco14=";
+    hash = "sha256-DqSeMjom9UjgGjjfJomWCr7jQhXEkqVrDCvW3+pDtcQ=";
 
     postInstall = ''
       substituteInPlace "$out/http_signatures/mix.exs" \


### PR DESCRIPTION
New upstream releases for akkoma and its frontends.

Fetching archives from the upstream Gitea instance at https://akkoma.dev/ consistently results in HTTP 500 errors for the initial fetch attempts for every new release and then appears to resolve itself after a few days. Upstream has been reluctant to investigate as nixpkgs appears to be the only user, and this behaviour makes package updates tedious. Therefore pass `forceFetchGit = true` to `fetchFromGitea`.

Reliance on `yarnConfigHook` leads to compilation of `node-sass` during `configurePhase` for `akkoma-admin-fe`. I’d prefer to keep the package simple, but if anybody objects I can re‐implement the workaround for `yarn-berry`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
