### PR TITLE
nixos/brave: system-wide brave module/options

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -181,6 +181,7 @@
   ./programs/bazecor.nix
   ./programs/bcc.nix
   ./programs/benchexec.nix
+  ./programs/brave.nix
   ./programs/browserpass.nix
   ./programs/calls.nix
   ./programs/captive-browser.nix

--- a/nixos/modules/programs/brave.nix
+++ b/nixos/modules/programs/brave.nix
@@ -9,10 +9,6 @@ let
   cfg = config.programs.brave;
 
   defaultProfile = lib.filterAttrs (_: v: v != null) {
-    HomepageLocation = cfg.homepageLocation;
-    DefaultSearchProviderEnabled = cfg.defaultSearchProviderEnabled;
-    DefaultSearchProviderSearchURL = cfg.defaultSearchProviderSearchURL;
-    DefaultSearchProviderSuggestURL = cfg.defaultSearchProviderSuggestURL;
     ExtensionInstallForcelist = cfg.extensions;
   };
 
@@ -49,30 +45,6 @@ in
       '';
     };
 
-    homepageLocation = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
-      default = null;
-      description = "Brave default homepage.";
-    };
-
-    defaultSearchProviderEnabled = lib.mkOption {
-      type = lib.types.nullOr lib.types.bool;
-      default = null;
-      description = "Enable/disable default search provider.";
-    };
-
-    defaultSearchProviderSearchURL = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
-      default = null;
-      description = "Search URL Brave should use as the default search provider.";
-    };
-
-    defaultSearchProviderSuggestURL = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
-      default = null;
-      description = "Suggestion URL for Brave's default search provider.";
-    };
-
     policies = lib.mkOption {
       type = lib.types.attrs;
       default = { };
@@ -82,9 +54,9 @@ in
         https://support.brave.app/hc/en-us/articles/360039248271-Group-Policy
       '';
       example = {
-        "SyncDisabled" = true;
-        "MetricsReportingEnabled" = false;
-        "BraveRewardsDisabled" = false;
+        SyncDisabled = true;
+        MetricsReportingEnabled = false;
+        BraveRewardsDisabled = false;
       };
     };
   };

--- a/nixos/modules/programs/brave.nix
+++ b/nixos/modules/programs/brave.nix
@@ -1,0 +1,98 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.brave;
+
+  defaultProfile = lib.filterAttrs (_: v: v != null) {
+    HomepageLocation = cfg.homepageLocation;
+    DefaultSearchProviderEnabled = cfg.defaultSearchProviderEnabled;
+    DefaultSearchProviderSearchURL = cfg.defaultSearchProviderSearchURL;
+    DefaultSearchProviderSuggestURL = cfg.defaultSearchProviderSuggestURL;
+    ExtensionInstallForcelist = cfg.extensions;
+  };
+
+  braveEtcConfig = {
+    # Managed (enterprise) policy files
+    "brave/policies/managed/default.json" = lib.mkIf (defaultProfile != { }) {
+      text = builtins.toJSON defaultProfile;
+    };
+
+    "brave/policies/managed/extra.json" = lib.mkIf (cfg.policies != { }) {
+      text = builtins.toJSON cfg.policies;
+    };
+  };
+
+in
+{
+  options.programs.brave = {
+    enable = lib.mkEnableOption "the Brave web browser";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.brave;
+      description = "The Brave browser package to install.";
+      defaultText = lib.literalExpression "pkgs.brave";
+    };
+
+    extensions = lib.mkOption {
+      type = with lib.types; nullOr (listOf str);
+      default = null;
+      description = ''
+        List of Brave (Chromium-style) extensions to force-install.
+        These work the same way as Chromium extensions: a Chrome Web Store ID,
+        optionally followed by `;url-to-update-manifest.xml`.
+      '';
+    };
+
+    homepageLocation = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "Brave default homepage.";
+    };
+
+    defaultSearchProviderEnabled = lib.mkOption {
+      type = lib.types.nullOr lib.types.bool;
+      default = null;
+      description = "Enable/disable default search provider.";
+    };
+
+    defaultSearchProviderSearchURL = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "Search URL Brave should use as the default search provider.";
+    };
+
+    defaultSearchProviderSuggestURL = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "Suggestion URL for Brave's default search provider.";
+    };
+
+    policies = lib.mkOption {
+      type = lib.types.attrs;
+      default = { };
+      description = ''
+        Additional Brave Enterprise policy settings.
+        These follow the same format as Chromium policies:
+        https://support.brave.app/hc/en-us/articles/360039248271-Group-Policy
+      '';
+      example = {
+        "SyncDisabled" = true;
+        "MetricsReportingEnabled" = false;
+        "BraveRewardsDisabled" = false;
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment = {
+      etc = braveEtcConfig;
+      systemPackages = [ cfg.package ];
+    };
+  };
+}

--- a/nixos/modules/programs/brave.nix
+++ b/nixos/modules/programs/brave.nix
@@ -1,0 +1,67 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.brave;
+
+  defaultProfile = lib.filterAttrs (_: v: v != null) {
+    ExtensionInstallForcelist = cfg.extensions;
+  };
+
+  braveEtcConfig = {
+    # Managed (enterprise) policy files
+    "brave/policies/managed/default.json" = lib.mkIf (defaultProfile != { }) {
+      text = builtins.toJSON defaultProfile;
+    };
+
+    "brave/policies/managed/extra.json" = lib.mkIf (cfg.policies != { }) {
+      text = builtins.toJSON cfg.policies;
+    };
+  };
+
+in
+{
+  options.programs.brave = {
+    enable = lib.mkEnableOption "the Brave web browser";
+
+    package = lib.mkPackageOption pkgs "brave" {
+      default = [ "brave" ];
+    };
+
+    extensions = lib.mkOption {
+      type = with lib.types; nullOr (listOf str);
+      default = null;
+      description = ''
+        List of Brave (Chromium-style) extensions to force-install.
+        These work the same way as Chromium extensions: a Chrome Web Store ID,
+        optionally followed by `;url-to-update-manifest.xml`.
+      '';
+    };
+
+    policies = lib.mkOption {
+      type = lib.types.attrs;
+      default = { };
+      description = ''
+        Additional Brave Enterprise policy settings.
+        These follow the same format as Chromium policies:
+        <https://support.brave.app/hc/en-us/articles/360039248271-Group-Policy>
+      '';
+      example = {
+        SyncDisabled = true;
+        MetricsReportingEnabled = false;
+        BraveRewardsDisabled = false;
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment = {
+      etc = braveEtcConfig;
+      systemPackages = [ cfg.package ];
+    };
+  };
+}


### PR DESCRIPTION
This PR implements brave browser's module and its respective options. It also allows the user to configure the browser system-wide if the user desires to do so.

Example to test this PR: https://gist.github.com/2hexed/a9aadd6b16b9d55a34d07acd5e7e417a


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
