### PR TITLE
pyrefly: 0.44.2 -> 0.46.0

### DIFF
--- a/pkgs/by-name/py/pyrefly/fix-shebang.patch
+++ b/pkgs/by-name/py/pyrefly/fix-shebang.patch
@@ -1,0 +1,13 @@
+diff --git a/pyrefly/lib/test/lsp/lsp_interaction/configuration.rs b/pyrefly/lib/test/lsp/lsp_interaction/configuration.rs
+index edc2db09f..ce33a2774 100644
+--- a/pyrefly/lib/test/lsp/lsp_interaction/configuration.rs
++++ b/pyrefly/lib/test/lsp/lsp_interaction/configuration.rs
+@@ -56,7 +56,7 @@ fn setup_dummy_interpreter(custom_interpreter_path: &Path) -> PathBuf {
+     // Create a mock Python interpreter script that returns the environment info
+     // This simulates what a real Python interpreter would return when queried with the env script
+     let python_script = format!(
+-        r#"#!/usr/bin/env bash
++        r#"#!@bash@
+ if [[ "$1" == "-c" && "$2" == *"import json, sys"* ]]; then
+     cat << 'EOF'
+ {{"python_platform": "linux", "python_version": "3.12.0", "site_package_path": ["{site_packages}"]}}

--- a/pkgs/by-name/py/pyrefly/package.nix
+++ b/pkgs/by-name/py/pyrefly/package.nix
@@ -1,5 +1,7 @@
 {
   lib,
+  bash,
+  replaceVars,
   rustPlatform,
   fetchFromGitHub,
   versionCheckHook,
@@ -8,17 +10,17 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "pyrefly";
-  version = "0.44.2";
+  version = "0.46.0";
 
   src = fetchFromGitHub {
     owner = "facebook";
     repo = "pyrefly";
     tag = finalAttrs.version;
-    hash = "sha256-d0aZQkCt2Yypj2CSav585M6TuoUEwPXpz1oKLjFo6NI=";
+    hash = "sha256-Owsma92bEwjyYFOb2AOzdLmAYIY398NrR9ztZ0bYhMc=";
   };
 
   buildAndTestSubdir = "pyrefly";
-  cargoHash = "sha256-gXKLzD5JbG62pc0pW5sRQJvBwr1ftu/ZOOXsQ7ZdWIU=";
+  cargoHash = "sha256-U3VlzjnsPmFlgaXdogqWOyJAv63vpPDULfcmcB5IHXc=";
 
   buildInputs = [ rust-jemalloc-sys ];
 
@@ -26,17 +28,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
   versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
+  patches = [
+    (replaceVars ./fix-shebang.patch { bash = lib.getExe bash; })
+  ];
+
   # redirect tests writing to /tmp
   preCheck = ''
     export TMPDIR=$(mktemp -d)
   '';
-
-  checkFlags = [
-    # FIX: tracking on https://github.com/facebook/pyrefly/issues/1667
-    "--skip=test::lsp::lsp_interaction::configuration::test_pythonpath_change"
-    "--skip=test::lsp::lsp_interaction::configuration::test_workspace_pythonpath_ignored_when_set_in_config_file"
-    "--skip=test::lsp::lsp_interaction::notebook_sync::test_notebook_publish_diagnostics"
-  ];
 
   # requires unstable rust features
   env.RUSTC_BOOTSTRAP = 1;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
