### PR TITLE
python313Packages.voxelmorph: init at 0.3-unstable-2025-12-08

### DIFF
--- a/pkgs/development/python-modules/neurite/default.nix
+++ b/pkgs/development/python-modules/neurite/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+  setuptools,
+  einops,
+  matplotlib,
+  nibabel,
+  numpy,
+  pystrum,
+  scipy,
+  torch,
+  tqdm,
+  pytestCheckHook,
+}:
+
+buildPythonPackage {
+  pname = "neurite";
+  version = "0.3-unstable-2025-12-09";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "adalca";
+    repo = "neurite";
+    rev = "bd8f4153382f043b11887840ceff8ae0db3a83e6";
+    hash = "sha256-KFNuT1RYXgIQWz56eyK55yDA8JqucSviJChUO9/JSLY=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    einops
+    matplotlib
+    nibabel
+    numpy
+    pystrum
+    scipy
+    torch
+    tqdm
+  ];
+
+  pythonImportsCheck = [ "neurite" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  meta = {
+    description = "Neural networks toolbox focused on medical image analysis";
+    homepage = "https://github.com/adalca/neurite";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/pystrum/default.nix
+++ b/pkgs/development/python-modules/pystrum/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+  setuptools,
+  pytestCheckHook,
+  matplotlib,
+  numpy,
+  scipy,
+  six,
+}:
+
+buildPythonPackage {
+  pname = "pystrum";
+  version = "0.4-unstable-2025-01-16";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "adalca";
+    repo = "pystrum";
+    rev = "d83bd99ce25e3c79789f6891c174c39ec7f5209b";
+    hash = "sha256-wzdfxQVSr4A2saSW25wjXzs99I3lTxbxboqrj9A/jJQ=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    numpy
+    matplotlib
+    scipy
+    six
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+  doCheck = false; # no tests in repo
+
+  pythonImportsCheck = [ "pystrum" ];
+
+  meta = {
+    description = "Imaging focused utility library";
+    homepage = "https://github.com/adalca/pystrum";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/voxelmorph/default.nix
+++ b/pkgs/development/python-modules/voxelmorph/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+  setuptools,
+  neurite,
+  scikit-image,
+  torch,
+  pytestCheckHook,
+}:
+
+buildPythonPackage {
+  pname = "voxelmorph";
+  version = "0.3-unstable-2025-12-08";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "voxelmorph";
+    repo = "voxelmorph";
+    rev = "b5cf28f89e2e45bbe2b6071668ac77e95c998b81";
+    hash = "sha256-UnLwprsJxkdeeZsgs2UEdCZB6+hJc/GEo+ZPZ8HDISs=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    neurite
+    scikit-image
+    torch
+  ];
+
+  pythonImportsCheck = [ "voxelmorph" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  meta = {
+    description = "Unsupervised learning for image registration";
+    homepage = "https://github.com/voxelmorph/voxelmorph";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20215,6 +20215,8 @@ self: super: with self; {
 
   vowpalwabbit = callPackage ../development/python-modules/vowpalwabbit { };
 
+  voxelmorph = callPackage ../development/python-modules/voxelmorph { };
+
   vpk = callPackage ../development/python-modules/vpk { };
 
   vprof = callPackage ../development/python-modules/vprof { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14654,6 +14654,8 @@ self: super: with self; {
 
   pystray = callPackage ../development/python-modules/pystray { };
 
+  pystrum = callPackage ../development/python-modules/pystrum { };
+
   pysubs2 = callPackage ../development/python-modules/pysubs2 { };
 
   pysuezv2 = callPackage ../development/python-modules/pysuezv2 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10688,6 +10688,8 @@ self: super: with self; {
 
   neurio = callPackage ../development/python-modules/neurio { };
 
+  neurite = callPackage ../development/python-modules/neurite { };
+
   neurokit2 = callPackage ../development/python-modules/neurokit2 { };
 
   neuron-full = pkgs.neuron-full.override { python3 = python; };


### PR DESCRIPTION
python313Packages.neurite: init at 0.3-unstable-2025-12-09
python313Packages.pystrum: init at 0.4-unstable-2025-01-16

Init [python313Packages.voxelmorph](https://github.com/voxelmorph/voxelmorph), a Python framework for medical image registration via unsupervised learning, and its dependencies.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
