### PR TITLE
python3Packages.granian: 2.5.6 -> 2.6.0

### DIFF
--- a/pkgs/development/python-modules/granian/default.nix
+++ b/pkgs/development/python-modules/granian/default.nix
@@ -19,14 +19,14 @@
 
 buildPythonPackage rec {
   pname = "granian";
-  version = "2.5.6";
+  version = "2.6.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "emmett-framework";
     repo = "granian";
     tag = "v${version}";
-    hash = "sha256-XSDBSl7QWqIN5u48z4H5yPHR+ltRmmmrP0JSmvcCcsA=";
+    hash = "sha256-Jj75ycr9Y0aCTP5YGzd6um/7emWKqqegUDB7HpTfTcM=";
   };
 
   # Granian forces a custom allocator for all the things it runs,
@@ -39,7 +39,7 @@ buildPythonPackage rec {
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-zQAHJcBWNx5IT/t2wtm7UeOfVNnvfowcp137TePnwiM=";
+    hash = "sha256-Q7BWwvkK5rRuhVobxW4qXLo6tnusOaQYN8mBoNVoulw=";
   };
 
   nativeBuildInputs = with rustPlatform; [
@@ -78,6 +78,12 @@ buildPythonPackage rec {
   __darwinAllowLocalNetworking = true;
 
   enabledTestPaths = [ "tests/" ];
+
+  disabledTests = [
+    # SSLCertVerificationError: certificate verify failed: certificate has expired
+    "test_asgi_ws_scope"
+    "test_rsgi_ws_scope"
+  ];
 
   pythonImportsCheck = [ "granian" ];
 

--- a/pkgs/development/python-modules/granian/no-alloc.patch
+++ b/pkgs/development/python-modules/granian/no-alloc.patch
@@ -1,26 +1,26 @@
 diff --git a/Cargo.toml b/Cargo.toml
-index cbf1cdb..e819e14 100644
+index c7d1647..d5710bd 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -41,7 +41,6 @@ hyper = { version = "=1.6", features = ["http1", "http2", "server"] }
+@@ -41,7 +41,6 @@ hyper = { version = "=1.8", features = ["http1", "http2", "server"] }
  hyper-util = { version = "=0.1", features = ["server-auto", "tokio"] }
  itertools = "0.14"
  log = "0.4"
--mimalloc = { version = "0.1.43", default-features = false, features = ["local_dynamic_tls"], optional = true }
+-mimalloc = { version = "0.1.43", default-features = false, features = ["local_dynamic_tls", "v3"], optional = true }
  mime_guess = "=2.0"
  pem = "=3.0"
  percent-encoding = "=2.3"
-@@ -52,7 +51,6 @@ pyo3-log = "=0.12"
+@@ -52,7 +51,6 @@ pyo3-log = { version = "=0.13", git = "https://github.com/gi0baro/pyo3-log.git",
  rustls-pemfile = "2.2"
  socket2 = { version = "=0.6", features = ["all"] }
- sysinfo = "=0.36"
+ sysinfo = "=0.37"
 -tikv-jemallocator = { version = "0.6.0", default-features = false, features = ["disable_initial_exec_tls"], optional = true }
- tls-listener = { version = "=0.11", features = ["rustls-ring"] }
+ tls-listener = { version = "=0.11", git = "https://github.com/gi0baro/tls-listener.git", branch = "0.11.x", features = ["rustls-ring", "rustls-tls12"] }
  tokio = { version = "1.45", features = ["full"] }
  tokio-stream = "0.1"
 @@ -62,10 +60,6 @@ tokio-util = { version = "0.7", features = ["codec", "rt"] }
  [build-dependencies]
- pyo3-build-config = "=0.25"
+ pyo3-build-config = "=0.27"
  
 -[features]
 -jemalloc = ["dep:tikv-jemallocator"]


### PR DESCRIPTION
Diff: https://github.com/emmett-framework/granian/compare/v2.5.6...v2.6.0

Changelog: https://github.com/emmett-framework/granian/releases/tag/v2.6.0

closes https://github.com/NixOS/nixpkgs/pull/461624
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
