### PR TITLE
diod: 1.0.24 -> 1.1.0

### DIFF
--- a/nixos/modules/services/network-filesystems/diod.nix
+++ b/nixos/modules/services/network-filesystems/diod.nix
@@ -9,20 +9,6 @@ let
 
   diodBool = b: if b then "1" else "0";
 
-  diodConfig = pkgs.writeText "diod.conf" ''
-    allsquash = ${diodBool cfg.allsquash}
-    auth_required = ${diodBool cfg.authRequired}
-    exportall = ${diodBool cfg.exportall}
-    exportopts = "${lib.concatStringsSep "," cfg.exportopts}"
-    exports = { ${lib.concatStringsSep ", " (map (s: ''"${s}"'') cfg.exports)} }
-    listen = { ${lib.concatStringsSep ", " (map (s: ''"${s}"'') cfg.listen)} }
-    logdest = "${cfg.logdest}"
-    nwthreads = ${toString cfg.nwthreads}
-    squashuser = "${cfg.squashuser}"
-    statfs_passthru = ${diodBool cfg.statfsPassthru}
-    userdb = ${diodBool cfg.userdb}
-    ${cfg.extraConfig}
-  '';
 in
 {
   options = {
@@ -150,13 +136,22 @@ in
   config = lib.mkIf config.services.diod.enable {
     environment.systemPackages = [ pkgs.diod ];
 
-    systemd.services.diod = {
-      description = "diod 9P file server";
-      wantedBy = [ "multi-user.target" ];
-      after = [ "network.target" ];
-      serviceConfig = {
-        ExecStart = "${pkgs.diod}/sbin/diod -f -c ${diodConfig}";
-      };
-    };
+    environment.etc."diod.conf".text = ''
+      allsquash = ${diodBool cfg.allsquash}
+      auth_required = ${diodBool cfg.authRequired}
+      exportall = ${diodBool cfg.exportall}
+      exportopts = "${lib.concatStringsSep "," cfg.exportopts}"
+      exports = { ${lib.concatStringsSep ", " (map (s: ''"${s}"'') cfg.exports)} }
+      listen = { ${lib.concatStringsSep ", " (map (s: ''"${s}"'') cfg.listen)} }
+      logdest = "${cfg.logdest}"
+      nwthreads = ${toString cfg.nwthreads}
+      squashuser = "${cfg.squashuser}"
+      statfs_passthru = ${diodBool cfg.statfsPassthru}
+      userdb = ${diodBool cfg.userdb}
+      ${cfg.extraConfig}
+    '';
+
+    systemd.packages = [ pkgs.diod ];
+    systemd.services.diod.wantedBy = [ "multi-user.target" ];
   };
 }

--- a/pkgs/servers/diod/default.nix
+++ b/pkgs/servers/diod/default.nix
@@ -1,7 +1,9 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
+  autoreconfHook,
+  pkg-config,
   munge,
   lua,
   libcap,
@@ -11,17 +13,23 @@
 
 stdenv.mkDerivation rec {
   pname = "diod";
-  version = "1.0.24";
+  version = "1.1.0";
 
-  src = fetchurl {
-    url = "https://github.com/chaos/diod/releases/download/${version}/${pname}-${version}.tar.gz";
-    sha256 = "17wckwfsqj61yixz53nwkc35z66arb1x3napahpi64m7q68jn7gl";
+  src = fetchFromGitHub {
+    owner = "chaos";
+    repo = "diod";
+    tag = "v${version}";
+    hash = "sha256-Fz+qvgw5ipyAcZlWBGkmSHuGrZ95i5OorLN3dkdsYKU=";
   };
 
   postPatch = ''
-    substituteInPlace diod/xattr.c --replace attr/xattr.h sys/xattr.h
-    sed -i -e '/sys\/types\.h>/a #include <sys/sysmacros.h>' diod/ops.c
+    sed -i configure.ac -e '/git describe/c ${version})'
   '';
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
 
   buildInputs = [
     munge
@@ -29,6 +37,11 @@ stdenv.mkDerivation rec {
     libcap
     perl
     ncurses
+  ];
+
+  configureFlags = [
+    "--with-systemdsystemunitdir=$(out)/lib/systemd/system/"
+    "--sysconfdir=/etc"
   ];
 
   meta = {


### PR DESCRIPTION
### Things done

Version bump, closes #469371 

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

cc: @IncredibleLaser