### PR TITLE
just: 1.43.1 -> 1.44.1

### DIFF
--- a/pkgs/by-name/ju/just/package.nix
+++ b/pkgs/by-name/ju/just/package.nix
@@ -17,7 +17,7 @@
   withDocumentation ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
 }:
 let
-  version = "1.43.1";
+  version = "1.44.1";
 in
 rustPlatform.buildRustPackage {
   inherit version;
@@ -34,10 +34,10 @@ rustPlatform.buildRustPackage {
     owner = "casey";
     repo = "just";
     tag = version;
-    hash = "sha256-ma1P8mcSnU/G/B/pN2tDEVokP+fGShGFodS2TG4wyQY=";
+    hash = "sha256-bjsk2Qsh15VW3KYcBDnOfklkqEHmEioTZ3+40DkVz0M=";
   };
 
-  cargoHash = "sha256-nT5GTAvj2+ytbOpRNNVardchK1aXPCiJGSUp5ZoBCVA=";
+  cargoHash = "sha256-7U81uZhVK/+g7sFgdrHkagX6KL8p+sOpRDf22gqQ0xw=";
 
   nativeBuildInputs =
     lib.optionals (installShellCompletions || installManPages) [ installShellFiles ]
@@ -91,8 +91,8 @@ rustPlatform.buildRustPackage {
       # No linkcheck in sandbox
       echo 'optional = true' >> book/en/book.toml
       mdbook build book/en
-      mkdir -p $doc/share/doc/$name
-      mv ./book/en/build/html $doc/share/doc/$name
+      mkdir -p $doc/share/doc/$name/html
+      mv ./book/en/build/* $doc/share/doc/$name/html/
     ''
     + lib.optionalString installManPages ''
       $out/bin/just --man > ./just.1


### PR DESCRIPTION
## Description

Updates `just` command runner from version 1.43.1 to 1.44.1.

Also fixes the mdbook documentation build output path which changed in recent versions - the build directory no longer has an `html` subdirectory.

## Changes

- Version bump: 1.43.1 → 1.44.1
- Updated source hash and cargoHash
- Fixed documentation install path in postInstall

## Testing

- [x] Built package locally (`nix-build -A just`)
- [x] Verified binary works (`./result/bin/just --version` → 1.44.1)
- [x] Ran `nixpkgs-review wip` (building dependent packages)

## Links

- Upstream release: https://github.com/casey/just/releases/tag/1.44.1
- Changelog: https://github.com/casey/just/blob/1.44.1/CHANGELOG.md