### PR TITLE
python3Packages.libdebug: init at 0.9.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17836,6 +17836,12 @@
     githubId = 15896005;
     name = "Vladyslav Burzakovskyy";
   };
+  mrsmoer = {
+    email = "mrsmoer@protonmail.com";
+    github = "MrSmoer";
+    githubId = 66489839;
+    name = "MrSmör";
+  };
   MrSom3body = {
     email = "nix@sndh.dev";
     matrix = "@mrsom3body:matrix.org";

--- a/pkgs/development/python-modules/libdebug/default.nix
+++ b/pkgs/development/python-modules/libdebug/default.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  buildPythonPackage,
+  cmake,
+  elfutils,
+  fetchFromGitHub,
+  libdwarf,
+  libiberty,
+  nanobind,
+  ninja,
+  pkg-config,
+  prompt-toolkit,
+  psutil,
+  pyelftools,
+  requests,
+  scikit-build-core,
+  typing-extensions,
+  writableTmpDirAsHomeHook,
+  zlib,
+  zstd,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "libdebug";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "libdebug";
+    repo = "libdebug";
+    tag = finalAttrs.version;
+
+    hash = "sha256-J0ETzqAGufsZyW+XDhJCKwX1rrmDBwlAicvBb1AAiIQ=";
+  };
+
+  dontUseCmakeConfigure = true;
+  pyproject = true;
+  build-system = [ scikit-build-core ];
+
+  buildInputs = [
+    libdwarf
+    elfutils
+    zstd
+    libiberty
+    zlib
+  ];
+
+  dependencies = [
+    psutil
+    pyelftools
+    requests
+    prompt-toolkit
+    nanobind
+    typing-extensions
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    ninja
+  ];
+
+  nativeCheckInputs = [ writableTmpDirAsHomeHook ];
+
+  pythonImportsCheck = [ "libdebug" ];
+  meta = {
+    homepage = "https://github.com/libdebug/libdebug";
+    description = "Programmatic debugging of userland Linux binaries";
+    maintainers = with lib.maintainers; [ mrsmoer ];
+    license = lib.licenses.mit;
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8477,6 +8477,8 @@ self: super: with self; {
 
   libcst = callPackage ../development/python-modules/libcst { };
 
+  libdebug = callPackage ../development/python-modules/libdebug { inherit (pkgs) zstd; };
+
   libdnf = lib.pipe pkgs.libdnf [
     toPythonModule
     (


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Libdebug is "A Python library to debug binary executables, your own way."

It is easlily scriptable, common in the CTF-community and also very handy for crude binary-patching.
The README has a great overview:
[https://github.com/libdebug/libdebug](https://github.com/libdebug/libdebug)

I had to replace the pythonImportsCheckPhase, which is really not optimal, because during import it tries to create a history-log in `$HOME/libdebug/.cache` directory, which fails at `/homeless-shelter`. 
I could probably provide a patch to disable this feature during building (which doesn't sound like the way patches should work); I am not really sure about that.

This is my first time opening a PR in nixpkgs, so I added myself to the maintainers-list.nix.
I am not full sure on what exactly to do with the todo list down there, so any help with that would be appreciated.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
