### PR TITLE
glycin: make /usr optional

### DIFF
--- a/pkgs/by-name/fr/fractal/package.nix
+++ b/pkgs/by-name/fr/fractal/package.nix
@@ -29,6 +29,7 @@
   libseccomp,
   glycin-loaders,
   libwebp,
+  libglycin,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -60,6 +61,14 @@ stdenv.mkDerivation (finalAttrs: {
       "target_dir / '${stdenv.hostPlatform.rust.cargoShortTarget}' / rust_target / meson.project_name()"
   '';
 
+  preConfigure = ''
+    # Dirty approach to add patches after cargoSetupPostUnpackHook
+    # We should eventually use a cargo vendor patch hook instead
+    pushd ../$(stripHash $cargoDeps)/glycin-3.*
+      patch -p3 < ${libglycin.passthru.glycin3PathsPatch}
+      patch -p3 < ${libglycin.passthru.glycin3OptionalUsrPatch}
+    popd
+  '';
   nativeBuildInputs = [
     glib
     grass-sass
@@ -102,7 +111,6 @@ stdenv.mkDerivation (finalAttrs: {
   preFixup = ''
     gappsWrapperArgs+=(
       --prefix XDG_DATA_DIRS : "${glycin-loaders}/share"
-      --prefix PATH : "${lib.makeBinPath [ bubblewrap ]}"
     )
   '';
 

--- a/pkgs/by-name/li/libglycin/glycin-3-optional-usr.patch
+++ b/pkgs/by-name/li/libglycin/glycin-3-optional-usr.patch
@@ -1,0 +1,13 @@
+diff --git a/vendor/glycin/src/sandbox.rs b/vendor/glycin/src/sandbox.rs
+index d840674..475d4be 100644
+--- a/vendor/glycin/src/sandbox.rs
++++ b/vendor/glycin/src/sandbox.rs
+@@ -292,7 +292,7 @@ impl Sandbox {
+             "--chdir",
+             "/",
+             // Make /usr available as read only
+-            "--ro-bind",
++            "--ro-bind-try",
+             "/usr",
+             "/usr",
+             // Make tmpfs dev available

--- a/pkgs/by-name/li/libglycin/package.nix
+++ b/pkgs/by-name/li/libglycin/package.nix
@@ -79,6 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     patch -p2 < ${finalAttrs.passthru.glycin3PathsPatch}
+    patch -p2 < ${finalAttrs.passthru.glycin3OptionalUsrPatch}
 
     patchShebangs \
       build-aux/crates-version.py
@@ -120,6 +121,8 @@ stdenv.mkDerivation (finalAttrs: {
     glycin3PathsPatch = replaceVars ./fix-glycin-3-paths.patch {
       bwrap = "${bubblewrap}/bin/bwrap";
     };
+
+    glycin3OptionalUsrPatch = ./glycin-3-optional-usr.patch;
   };
 
   meta = {

--- a/pkgs/by-name/lo/loupe/package.nix
+++ b/pkgs/by-name/lo/loupe/package.nix
@@ -69,6 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
     # We should eventually use a cargo vendor patch hook instead
     pushd ../$(stripHash $cargoDeps)/glycin-3.*
       patch -p3 < ${libglycin.passthru.glycin3PathsPatch}
+      patch -p3 < ${libglycin.passthru.glycin3OptionalUsrPatch}
     popd
   '';
 

--- a/pkgs/by-name/sn/snapshot/package.nix
+++ b/pkgs/by-name/sn/snapshot/package.nix
@@ -37,6 +37,8 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     # Fix paths in glycin library
     libglycin.passthru.glycin3PathsPatch
+    # Make /usr optional in glycin library
+    libglycin.passthru.glycin3OptionalUsrPatch
   ];
 
   cargoVendorDir = "vendor";


### PR DESCRIPTION
[I tried to get this through upstream, but it was rejected.](https://gitlab.gnome.org/GNOME/glycin/-/merge_requests/348)

I'm on a mission to get rid of /bin/sh and /usr/bin/env, and the addition of glycin to the GNOME ecosystem is the latest hiccup I've encountered. The sandboxing code wants to bind-mount /usr into the sandbox and straight up crashes when /usr doesn't exist. This PR includes a minimally invasive patch to fix my particular use case by ignoring the absence of /usr.

I've exposed the patch via `passthru` as was previously done for a different patch, and applied the patch in all the places where the other patch was applied. I've also changed Fractal to also make use of the paths patch instead of prefixing `PATH` via the wrapper, because I think it's cleaner to call the binary by its absolute path.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
