### PR TITLE
aardvark-dns: 1.16.0 -> 1.17.0

### DIFF
--- a/pkgs/by-name/aa/aardvark-dns/package.nix
+++ b/pkgs/by-name/aa/aardvark-dns/package.nix
@@ -7,16 +7,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "aardvark-dns";
-  version = "1.16.0";
+  version = "1.17.0";
 
   src = fetchFromGitHub {
     owner = "containers";
     repo = "aardvark-dns";
     tag = "v${version}";
-    hash = "sha256-mC+PP5sXt2O0CgxxyzS2WjtQe0RjuKNCamrjRY7qBP8=";
+    hash = "sha256-NJ1ViJpN6fBO9U1RkCkqyr6JXiHa5zX1BQAGGqKWVYY=";
   };
 
-  cargoHash = "sha256-e/VxQgpTOS4snM78BewvloWap9cU+Vzlahlr00BWmVY=";
+  cargoHash = "sha256-rQQ+Y7uWsjGSp6CeIs794/mGPceJ31OTxAmRonP1WL0=";
 
   passthru.tests = { inherit (nixosTests) podman; };
 


### PR DESCRIPTION
## Description
Updates `aardvark-dns` from 1.16.0 to 1.17.0.

## Testing
- [x] Built locally (package is Linux-only, testing on CI)
- [ ] Ran nixpkgs-review wip (encountered unrelated evaluation error)

## Links
- Release: https://github.com/containers/aardvark-dns/releases/tag/v1.17.0