### PR TITLE
goldentests: init at 1.4.1

### DIFF
--- a/pkgs/by-name/go/goldentests/package.nix
+++ b/pkgs/by-name/go/goldentests/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  python3,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "goldentests";
+  version = "1.4.1";
+
+  src = fetchFromGitHub {
+    owner = "jfecher";
+    repo = "golden-tests";
+    rev = "2d15f0bad8c808f09d7a632e17a1653ae94d5c04";
+    hash = "sha256-JLejQaYttwdA95rUv3+mRYu+oIMv9ov0gD2HT0vJ3gQ=";
+  };
+
+  cargoHash = "sha256-DxqtCvFnP/+13x5ZHq0np3AasbtyYPMkdvn9+amDDTo=";
+
+  buildFeatures = [ "binary" ];
+
+  nativeBuildInputs = [
+    python3 # used in tests
+  ];
+
+  meta = {
+    description = "A golden file testing CLI";
+    mainProgram = "goldentests";
+    homepage = "https://github.com/jfecher/golden-tests";
+    changelog = "https://github.com/jfecher/golden-tests/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ rpqt ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
[Golden Tests](https://github.com/jfecher/golden-tests) is a CLI (and library) for testing compilers/interpreters by checking their output against the expected stdout/stderr defined in the source files. The CLI has additionnal features compared to the library (e.g. updating the tests).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
