### PR TITLE
gamma-launcher: 2.5 -> 2.6

### DIFF
--- a/pkgs/by-name/ga/gamma-launcher/package.nix
+++ b/pkgs/by-name/ga/gamma-launcher/package.nix
@@ -1,19 +1,29 @@
 {
   lib,
   python3Packages,
+  _7zz,
   fetchFromGitHub,
   versionCheckHook,
+  runCommand,
 }:
+
+let
+  # gamma-launcher looks for the "7z", not "7zz"
+  _7z = runCommand "7z" { } ''
+    mkdir -p $out/bin
+    ln -s ${_7zz}/bin/7zz $out/bin/7z
+  '';
+in
 python3Packages.buildPythonApplication rec {
   pname = "gamma-launcher";
-  version = "2.5";
+  version = "2.6";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Mord3rca";
     repo = "gamma-launcher";
     tag = "v${version}";
-    hash = "sha256-qzjfgDFimEL6vtsJBubY6fHsokilDB248WwHJt3F7fI=";
+    hash = "sha256-QegptRWMUKpkzsHBdT6KlyyWpmrIuvcyCRvWT9Te3DQ=";
   };
 
   build-system = [ python3Packages.setuptools ];
@@ -33,13 +43,25 @@ python3Packages.buildPythonApplication rec {
   nativeCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
 
+  postFixup = ''
+    wrapProgram $out/bin/gamma-launcher \
+    --prefix PATH : "${
+      lib.makeBinPath [
+        _7z
+      ]
+    }"
+  '';
+
   meta = {
     description = "Python cli to download S.T.A.L.K.E.R. GAMMA";
     changelog = "https://github.com/Mord3rca/gamma-launcher/releases/tag/v${version}";
     homepage = "https://github.com/Mord3rca/gamma-launcher";
     mainProgram = "gamma-launcher";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ DrymarchonShaun ];
+    maintainers = with lib.maintainers; [
+      DrymarchonShaun
+      bbigras
+    ];
     platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I added myself as a maintainer.

I also added `p7zip` otherwise I had:
```
  File "/nix/store/3lll9y925zz9393sa59h653xik66srjb-python3-3.13.9/lib/python3.13/subprocess.py", line 1972, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: '7z'
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
