### PR TITLE
Revert "maintainers: drop edwtjo"

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7447,6 +7447,12 @@
     githubId = 494483;
     name = "Michael Francis";
   };
+  edwtjo = {
+    email = "ed@cflags.cc";
+    github = "edwtjo";
+    githubId = 54799;
+    name = "Edward Tjörnhammar";
+  };
   eeedean = {
     github = "eeedean";
     githubId = 8173116;

--- a/pkgs/applications/misc/sweethome3d/default.nix
+++ b/pkgs/applications/misc/sweethome3d/default.nix
@@ -24,6 +24,7 @@ let
     description = "Design and visualize your future home";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
+      edwtjo
       DimitarNestorov
     ];
     platforms = [

--- a/pkgs/applications/misc/sweethome3d/editors.nix
+++ b/pkgs/applications/misc/sweethome3d/editors.nix
@@ -93,6 +93,7 @@ let
         homepage = "http://www.sweethome3d.com/index.jsp";
         inherit description;
         inherit license;
+        maintainers = [ lib.maintainers.edwtjo ];
         platforms = lib.platforms.linux;
         mainProgram = exec;
       };

--- a/pkgs/applications/office/cb2bib/default.nix
+++ b/pkgs/applications/office/cb2bib/default.nix
@@ -39,6 +39,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Rapidly extract unformatted, or unstandardized bibliographic references from email alerts, journal Web pages and PDF files";
     homepage = "http://www.molspaces.com/d_cb2bib-overview.php";
+    maintainers = with lib.maintainers; [ edwtjo ];
     license = lib.licenses.gpl3;
   };
 

--- a/pkgs/applications/science/machine-learning/shogun/default.nix
+++ b/pkgs/applications/science/machine-learning/shogun/default.nix
@@ -264,6 +264,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "http://shogun-toolbox.org/";
     license = if withSvmLight then lib.licenses.unfree else lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
+      edwtjo
       smancill
     ];
   };

--- a/pkgs/by-name/bu/bully/package.nix
+++ b/pkgs/by-name/bu/bully/package.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation rec {
     description = "Retrieve WPA/WPA2 passphrase from a WPS enabled access point";
     homepage = "https://github.com/kimocoder/bully";
     license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ edwtjo ];
     platforms = lib.platforms.linux;
     mainProgram = "bully";
   };

--- a/pkgs/by-name/ca/catch2/package.nix
+++ b/pkgs/by-name/ca/catch2/package.nix
@@ -24,7 +24,9 @@ stdenv.mkDerivation rec {
     description = "Multi-paradigm automated test framework for C++ and Objective-C (and, maybe, C)";
     homepage = "http://catch-lib.net";
     license = lib.licenses.boost;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [
+      edwtjo
+    ];
     platforms = with lib.platforms; unix ++ windows;
   };
 }

--- a/pkgs/by-name/co/colpack/package.nix
+++ b/pkgs/by-name/co/colpack/package.nix
@@ -43,5 +43,6 @@ stdenv.mkDerivation rec {
     homepage = "https://cscapes.cs.purdue.edu/coloringpage/software.htm#functionalities";
     license = lib.licenses.lgpl3Plus;
     platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ edwtjo ];
   };
 }

--- a/pkgs/by-name/ez/ezquake/package.nix
+++ b/pkgs/by-name/ez/ezquake/package.nix
@@ -68,5 +68,6 @@ stdenv.mkDerivation rec {
     mainProgram = "ezquake";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ edwtjo ];
   };
 }

--- a/pkgs/by-name/gr/greg/package.nix
+++ b/pkgs/by-name/gr/greg/package.nix
@@ -28,5 +28,6 @@ python3Packages.buildPythonApplication rec {
     description = "Command-line podcast aggregator";
     mainProgram = "greg";
     license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ edwtjo ];
   };
 }

--- a/pkgs/by-name/ht/html-tidy/package.nix
+++ b/pkgs/by-name/ht/html-tidy/package.nix
@@ -54,6 +54,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.libpng; # very close to it - the 3 clauses are identical
     homepage = "http://html-tidy.org";
     platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ edwtjo ];
     mainProgram = "tidy";
   };
 }

--- a/pkgs/by-name/i2/i2pd/package.nix
+++ b/pkgs/by-name/i2/i2pd/package.nix
@@ -53,6 +53,7 @@ stdenv.mkDerivation rec {
     homepage = "https://i2pd.website";
     description = "Minimal I2P router written in C++";
     license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ edwtjo ];
     platforms = lib.platforms.unix;
     mainProgram = "i2pd";
   };

--- a/pkgs/by-name/la/languagetool/package.nix
+++ b/pkgs/by-name/la/languagetool/package.nix
@@ -41,6 +41,7 @@ stdenv.mkDerivation rec {
     homepage = "https://languagetool.org";
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.lgpl21Plus;
+    maintainers = with lib.maintainers; [ edwtjo ];
     platforms = jre.meta.platforms;
     description = "Proofreading program for English, French German, Polish, and more";
   };

--- a/pkgs/by-name/li/libcrossguid/package.nix
+++ b/pkgs/by-name/li/libcrossguid/package.nix
@@ -32,6 +32,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Lightweight cross platform C++ GUID/UUID library";
     license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ edwtjo ];
     homepage = "https://github.com/graeme-hill/crossguid";
     platforms = with lib.platforms; linux;
   };

--- a/pkgs/by-name/md/mdevctl/package.nix
+++ b/pkgs/by-name/md/mdevctl/package.nix
@@ -46,6 +46,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/mdevctl/mdevctl";
     description = "Mediated device management utility for linux";
     license = lib.licenses.lgpl21Only;
+    maintainers = with lib.maintainers; [ edwtjo ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/ny/nylon/package.nix
+++ b/pkgs/by-name/ny/nylon/package.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation rec {
     homepage = "http://monkey.org/~marius/nylon";
     description = "Proxy server, supporting SOCKS 4 and 5, as well as a mirror mode";
     license = lib.licenses.bsdOriginal;
+    maintainers = with lib.maintainers; [ edwtjo ];
     platforms = lib.platforms.linux;
     mainProgram = "nylon";
   };

--- a/pkgs/by-name/pr/properties-cpp/package.nix
+++ b/pkgs/by-name/pr/properties-cpp/package.nix
@@ -51,6 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://gitlab.com/ubports/development/core/lib-cpp/properties-cpp";
     description = "Very simple convenience library for handling properties and signals in C++11";
     license = lib.licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [ edwtjo ];
     platforms = lib.platforms.linux;
     pkgConfigModules = [
       "properties-cpp"

--- a/pkgs/by-name/qp/qperf/package.nix
+++ b/pkgs/by-name/qp/qperf/package.nix
@@ -53,5 +53,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/linux-rdma/qperf";
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ edwtjo ];
   };
 }

--- a/pkgs/by-name/sr/srm/package.nix
+++ b/pkgs/by-name/sr/srm/package.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation {
     '';
     homepage = "https://srm.sourceforge.net";
     license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ edwtjo ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/st/storcli2/package.nix
+++ b/pkgs/by-name/st/storcli2/package.nix
@@ -62,6 +62,7 @@ stdenvNoCC.mkDerivation (
       description = "Storage Command Line Tool";
       sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
       license = lib.licenses.unfree;
+      maintainers = with lib.maintainers; [ edwtjo ];
       mainProgram = "storcli2";
       platforms = [
         "x86_64-linux"

--- a/pkgs/by-name/ts/tsocks/package.nix
+++ b/pkgs/by-name/ts/tsocks/package.nix
@@ -39,6 +39,7 @@ stdenv.mkDerivation rec {
     mainProgram = "tsocks";
     homepage = "https://tsocks.sourceforge.net/";
     license = lib.licenses.gpl2;
+    maintainers = with lib.maintainers; [ edwtjo ];
     platforms = lib.platforms.unix;
     broken = stdenv.hostPlatform.isDarwin;
   };

--- a/pkgs/by-name/x1/x11basic/package.nix
+++ b/pkgs/by-name/x1/x11basic/package.nix
@@ -62,6 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://x11-basic.codeberg.page";
     description = "Basic interpreter and compiler with graphics capabilities";
     license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ edwtjo ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/development/python-modules/cvxopt/default.nix
+++ b/pkgs/development/python-modules/cvxopt/default.nix
@@ -83,6 +83,7 @@ buildPythonPackage rec {
       standard library and on the strengths of Python as a high-level
       programming language.
     '';
+    maintainers = with lib.maintainers; [ edwtjo ];
     license = lib.licenses.gpl3Plus;
   };
 }

--- a/pkgs/development/python-modules/sharedmem/default.nix
+++ b/pkgs/development/python-modules/sharedmem/default.nix
@@ -21,6 +21,7 @@ buildPythonPackage rec {
   meta = {
     homepage = "http://rainwoodman.github.io/sharedmem/";
     description = "Easier parallel programming on shared memory computers";
+    maintainers = with lib.maintainers; [ edwtjo ];
     license = lib.licenses.gpl3;
   };
 }

--- a/pkgs/os-specific/linux/nvidia-x11/fabricmanager.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/fabricmanager.nix
@@ -59,5 +59,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.unfreeRedistributable;
     platforms = nvidia_x11.meta.platforms;
     mainProgram = "nv-fabricmanager";
+    maintainers = with lib.maintainers; [ edwtjo ];
   };
 }

--- a/pkgs/os-specific/linux/nvidia-x11/generic.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/generic.nix
@@ -340,6 +340,7 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optionals (sha256_aarch64 != null) [ "aarch64-linux" ];
     maintainers = with lib.maintainers; [
       kiskae
+      edwtjo
     ];
     priority = 4; # resolves collision with xorg-server's "lib/xorg/modules/extensions/libglx.so"
     inherit broken;


### PR DESCRIPTION
Reintroduces myself as maintainer while reducing the package set, mainly removing myself from high traffic packages which already has a functioning team or multiple maintainers (notably jetbrains, jdk packages, retroarch and kodi).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
