### PR TITLE
arrow-cpp: enable azure filesystem support, enable gcs on darwin

### DIFF
--- a/pkgs/by-name/ar/arrow-cpp/package.nix
+++ b/pkgs/by-name/ar/arrow-cpp/package.nix
@@ -17,6 +17,7 @@
       "transfer"
     ];
   },
+  azure-sdk-for-cpp,
   boost,
   brotli,
   bzip2,
@@ -59,6 +60,7 @@
   enableS3 ? true,
   # google-cloud-cpp fails to build on RiscV
   enableGcs ? !stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isRiscV64,
+  enableAzure ? true,
 }:
 
 let
@@ -170,6 +172,11 @@ stdenv.mkDerivation (finalAttrs: {
     google-cloud-cpp
     grpc
     nlohmann_json
+  ]
+  ++ lib.optionals enableAzure [
+    azure-sdk-for-cpp.identity
+    azure-sdk-for-cpp.storage-blobs
+    azure-sdk-for-cpp.storage-files-datalake
   ];
 
   # apache-orc looks for things in caps
@@ -224,6 +231,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "ARROW_FLIGHT_TESTING" enableFlight)
     (lib.cmakeBool "ARROW_S3" enableS3)
     (lib.cmakeBool "ARROW_GCS" enableGcs)
+    (lib.cmakeBool "ARROW_AZURE" enableAzure)
     (lib.cmakeBool "ARROW_ORC" true)
     # Parquet options:
     (lib.cmakeBool "ARROW_PARQUET" true)

--- a/pkgs/by-name/ar/arrow-cpp/package.nix
+++ b/pkgs/by-name/ar/arrow-cpp/package.nix
@@ -59,7 +59,7 @@
     !stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isAarch64 && !stdenv.hostPlatform.isRiscV64,
   enableS3 ? true,
   # google-cloud-cpp fails to build on RiscV
-  enableGcs ? !stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isRiscV64,
+  enableGcs ? !stdenv.hostPlatform.isRiscV64,
   enableAzure ? true,
 }:
 


### PR DESCRIPTION
Can finally be done after https://github.com/NixOS/nixpkgs/pull/348202.
`google-cloud-cpp` builds fine on darwin nowadays, so we don't need to disable GCS support for that platform any more.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
