### PR TITLE
rust-script: add acuteaangle to maintainers, add missing dependency, refactor

### DIFF
--- a/pkgs/by-name/ru/rust-script/package.nix
+++ b/pkgs/by-name/ru/rust-script/package.nix
@@ -3,6 +3,7 @@
   rustPlatform,
   fetchFromGitHub,
   pkgs,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -24,6 +25,8 @@ rustPlatform.buildRustPackage rec {
     wrapProgramBinary $out/bin/rust-script \
       --prefix PATH : ${lib.makeBinPath [ pkgs.cargo ]}
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   # tests require network access
   doCheck = false;

--- a/pkgs/by-name/ru/rust-script/package.nix
+++ b/pkgs/by-name/ru/rust-script/package.nix
@@ -7,14 +7,14 @@
   versionCheckHook,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rust-script";
   version = "0.36.0";
 
   src = fetchFromGitHub {
     owner = "fornwall";
     repo = "rust-script";
-    rev = version;
+    rev = finalAttrs.version;
     sha256 = "sha256-Bb8ULD2MmZiSW/Tx5vAAHv95OMJ0EdWgR+NFhBkTlDU=";
   };
 
@@ -40,7 +40,7 @@ rustPlatform.buildRustPackage rec {
     description = "Run Rust files and expressions as scripts without any setup or compilation step";
     mainProgram = "rust-script";
     homepage = "https://rust-script.org";
-    changelog = "https://github.com/fornwall/rust-script/releases/tag/${version}";
+    changelog = "https://github.com/fornwall/rust-script/releases/tag/${finalAttrs.version}";
     license = with lib.licenses; [
       mit # or
       asl20
@@ -49,4 +49,4 @@ rustPlatform.buildRustPackage rec {
       acuteaangle
     ];
   };
-}
+})

--- a/pkgs/by-name/ru/rust-script/package.nix
+++ b/pkgs/by-name/ru/rust-script/package.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "fornwall";
     repo = "rust-script";
     rev = finalAttrs.version;
-    sha256 = "sha256-Bb8ULD2MmZiSW/Tx5vAAHv95OMJ0EdWgR+NFhBkTlDU=";
+    hash = "sha256-Bb8ULD2MmZiSW/Tx5vAAHv95OMJ0EdWgR+NFhBkTlDU=";
   };
 
   cargoHash = "sha256-kxnylNZ8FsaR2S1o/p7qtlaXsBLDNv2PsFye0rcf/+A=";
@@ -34,13 +34,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
   doInstallCheck = true;
 
   # tests require network access
+  # Upstream issue: https://github.com/fornwall/rust-script/issues/38
   doCheck = false;
 
   meta = {
-    description = "Run Rust files and expressions as scripts without any setup or compilation step";
+    description = "Tool to run Rust files and expressions as scripts without any setup or compilation step";
     mainProgram = "rust-script";
     homepage = "https://rust-script.org";
-    changelog = "https://github.com/fornwall/rust-script/releases/tag/${finalAttrs.version}";
+    changelog = "https://github.com/fornwall/rust-script/blob/${finalAttrs.version}/CHANGELOG.md";
+    downloadPage = "https://github.com/fornwall/rust-script/releases/tag/${finalAttrs.version}";
     license = with lib.licenses; [
       mit # or
       asl20

--- a/pkgs/by-name/ru/rust-script/package.nix
+++ b/pkgs/by-name/ru/rust-script/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   pkgs,
   nix-update-script,
+  versionCheckHook,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -27,6 +28,10 @@ rustPlatform.buildRustPackage rec {
   '';
 
   passthru.updateScript = nix-update-script { };
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
 
   # tests require network access
   doCheck = false;

--- a/pkgs/by-name/ru/rust-script/package.nix
+++ b/pkgs/by-name/ru/rust-script/package.nix
@@ -29,6 +29,8 @@ rustPlatform.buildRustPackage rec {
       mit # or
       asl20
     ];
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [
+      acuteaangle
+    ];
   };
 }

--- a/pkgs/by-name/ru/rust-script/package.nix
+++ b/pkgs/by-name/ru/rust-script/package.nix
@@ -2,6 +2,7 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  pkgs,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -16,6 +17,13 @@ rustPlatform.buildRustPackage rec {
   };
 
   cargoHash = "sha256-kxnylNZ8FsaR2S1o/p7qtlaXsBLDNv2PsFye0rcf/+A=";
+
+  nativeBuildInputs = [ pkgs.makeBinaryWrapper ];
+
+  postInstall = ''
+    wrapProgramBinary $out/bin/rust-script \
+      --prefix PATH : ${lib.makeBinPath [ pkgs.cargo ]}
+  '';
 
   # tests require network access
   doCheck = false;


### PR DESCRIPTION
Fixes: https://github.com/fornwall/rust-script/issues/151
Related-to: https://github.com/fornwall/rust-script/issues/55

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  I tested with both `--expr '1+2'` and invoking a simple ‘Hello World’ file
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
