### PR TITLE
hyprlax: init v2.2.0

### DIFF
--- a/pkgs/by-name/hy/hyprlax/package.nix
+++ b/pkgs/by-name/hy/hyprlax/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  wayland,
+  wayland-protocols,
+  wayland-scanner,
+  libGL,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "hyprlax";
+  version = "2.2.0";
+
+  src = fetchFromGitHub {
+    owner = "sandwichfarm";
+    repo = "hyprlax";
+    tag = "v${version}";
+    hash = "sha256-RIeMsQt6MxSTI7TunIxk7wd08sYmr3EvjAQifr+M4e8=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    wayland
+    wayland-protocols
+    libGL
+  ];
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  meta = {
+    description = "Dynamic parallax wallpaper engine with multi-compositor support for Linux";
+    longDescription = ''
+      hyprlax is a GPU-accelerated Wayland wallpaper daemon with parallax effects.
+
+      Features:
+      - Buttery smooth GPU-accelerated animations with configurable FPS
+      - Multi-layer parallax with depth-of-field blur effects
+      - Multi-compositor support (Hyprland, Sway, River, Niri, generic Wayland)
+      - Customizable per-layer easing functions, delays, and animation parameters
+      - Dynamic layer management via IPC (add, remove, modify layers at runtime)
+      - Lightweight native client using compositor-specific protocols
+      - Seamless animation interrupts and chaining
+    '';
+    homepage = "https://github.com/sandwichfarm/hyprlax";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers._6543 ];
+    mainProgram = "hyprlax";
+  };
+}


### PR DESCRIPTION
package https://github.com/sandwichfarm/hyprlax

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
