### PR TITLE
lib.attrsets.recursiveUpdate: check if merge is necessary

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -1682,23 +1682,37 @@ rec {
 
     :::
   */
+
   recursiveUpdateUntil =
     pred: lhs: rhs:
     let
       f =
-        attrPath:
-        zipAttrsWith (
-          n: values:
-          let
-            here = attrPath ++ [ n ];
-          in
-          if length values == 1 || pred here (elemAt values 1) (head values) then
-            head values
-          else
-            f here values
-        );
+        attrPath: lhs: rhs:
+        if (intersectAttrs lhs rhs) == { } then
+          lhs // rhs
+        else
+          zipAttrsWith
+            (
+              name: values:
+              let
+                here = attrPath ++ [ name ];
+                lhs = elemAt values 1;
+                rhs = head values;
+              in
+              if length values == 1 || pred here lhs rhs then
+                # Either there's no conflict and only head is valid (aka rhs),
+                # or we can't recurse anymore and should pick rhs. Laziness
+                # means even if lhs is invalid, we'll never evaluate it
+                rhs
+              else
+                f here lhs rhs
+            )
+            [
+              rhs
+              lhs
+            ];
     in
-    f [ ] [ rhs lhs ];
+    f [ ] lhs rhs;
 
   /**
     A recursive variant of the update operator `//`.  The recursion


### PR DESCRIPTION
Getting a minor speedup with this. Here's my test case:

```nix
{ lib ? import ./lib }:

lib.recursiveUpdate { foo = 1; } { bar = "2"; }
```

Before:
```js
{
  "cpuTime": 0.011427000164985657,
  "envs": {
    "bytes": 2176,
    "elements": 251,
    "number": 21
  },
  "gc": {
    "heapSize": 402915328,
    "totalBytes": 49328
  },
  "list": {
    "bytes": 40,
    "concats": 0,
    "elements": 5
  },
  "nrAvoided": 15,
  "nrFunctionCalls": 11,
  "nrLookups": 4,
  "nrOpUpdateValuesCopied": 462,
  "nrOpUpdates": 1,
  "nrPrimOpCalls": 4,
  "nrThunks": 580,
  "sets": {
    "bytes": 17984,
    "elements": 1119,
    "number": 10
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 8,
    "Env": 8,
    "Value": 8
  },
  "symbols": {
    "bytes": 7688,
    "number": 734
  },
  "values": {
    "bytes": 0,
    "number": 0
  }
}
```
And after:
```js
{
  "cpuTime": 0.01259700022637844,
  "envs": {
    "bytes": 2096,
    "elements": 246,
    "number": 16
  },
  "gc": {
    "heapSize": 402915328,
    "totalBytes": 45232
  },
  "list": {
    "bytes": 8,
    "concats": 0,
    "elements": 1
  },
  "nrAvoided": 13,
  "nrFunctionCalls": 7,
  "nrLookups": 4,
  "nrOpUpdateValuesCopied": 464,
  "nrOpUpdates": 2,
  "nrPrimOpCalls": 4,
  "nrThunks": 576,
  "sets": {
    "bytes": 18008,
    "elements": 1120,
    "number": 11
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 8,
    "Env": 8,
    "Value": 8
  },
  "symbols": {
    "bytes": 7688,
    "number": 734
  },
  "values": {
    "bytes": 0,
    "number": 0
  }
}
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
