### PR TITLE
szurubooru: wrap szuru-admin with the required ffmpeg version

### DIFF
--- a/pkgs/servers/web-apps/szurubooru/server.nix
+++ b/pkgs/servers/web-apps/szurubooru/server.nix
@@ -5,6 +5,7 @@
   nixosTests,
   fetchPypi,
   python3,
+  ffmpeg_4-full,
 }:
 
 let
@@ -66,6 +67,10 @@ python.pkgs.buildPythonApplication {
     pyyaml
     sqlalchemy
     yt-dlp
+  ];
+
+  makeWrapperArgs = [
+    "--prefix PATH : ${lib.makeBinPath [ ffmpeg_4-full ]}"
   ];
 
   postInstall = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`szuru-admin --regenerate-thumbnails` requires ffmpeg 4 (c.f. https://github.com/rr-/szurubooru/issues/718). This is currently added to PATH in the systemd service:

https://github.com/NixOS/nixpkgs/blob/0b7b06b46b2e6a4ab77b618f7a08bbe4b598718e/nixos/modules/services/web-apps/szurubooru.nix#L290-L299

However, if you try to run `szuru-admin` via `nix shell nixpkgs#szurubooru.server`, you will probably not have the right ffmpeg on your PATH since the default version is currently 8.

This PR wraps `szuru-admin` by prefixing its PATH with ffmpeg 4. Since Python applications are already wrapped once, this is done with `makeWrapperArgs` to hook into the wrapper already being created.

I tested this with a local installation, building the fixed version, and running

```
env --chdir=/var/lib/szurubooru sudo -u szurubooru $(realpath $PWD/result/bin/szuru-admin) --regenerate-thumbnails
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
