### PR TITLE
foundationdb: fix build, 7.3.42 -> 7.3.68

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13958,6 +13958,12 @@
     githubId = 913109;
     name = "Emil Fresk";
   };
+  kornholi = {
+    email = "kornholijo@gmail.com";
+    github = "kornholi";
+    githubId = 659440;
+    name = "Kornelijus";
+  };
   koschi13 = {
     email = "maximilian.konter@protonmail.com";
     github = "koschi13";

--- a/pkgs/by-name/fo/foundationdb/package.nix
+++ b/pkgs/by-name/fo/foundationdb/package.nix
@@ -107,6 +107,12 @@ stdenv.mkDerivation rec {
 
     "-DBUILD_DOCUMENTATION=FALSE"
 
+    # Disable the default static linking to libc++, libstdc++ and libgcc.
+    #
+    # This leads to various, non-obvious problems as our dependencies bring in
+    # their own copies of these libraries.
+    "-DSTATIC_LINK_LIBCXX=FALSE"
+
     # LTO brings up overall build time, but results in much smaller
     # binaries for all users and the cache.
     "-DUSE_LTO=ON"

--- a/pkgs/by-name/fo/foundationdb/package.nix
+++ b/pkgs/by-name/fo/foundationdb/package.nix
@@ -15,6 +15,7 @@
   toml11,
   jemalloc,
   doctest,
+  zlib,
 }:
 let
   boost = boost186;
@@ -29,13 +30,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "foundationdb";
-  version = "7.3.42";
+  version = "7.3.68";
 
   src = fetchFromGitHub {
     owner = "apple";
     repo = "foundationdb";
     tag = version;
-    hash = "sha256-jQcm+HLai5da2pZZ7iLdN6fpQZxf5+/kkfv9OSXQ57c=";
+    hash = "sha256-OaV7YyBggeX3vrnI2EYwlWdIGRHOAeP5OZN0Rmd/dnw=";
   };
 
   patches = [
@@ -80,6 +81,7 @@ stdenv.mkDerivation rec {
     msgpack-cxx
     openssl
     toml11
+    zlib
   ];
 
   checkInputs = [ doctest ];

--- a/pkgs/by-name/fo/foundationdb/package.nix
+++ b/pkgs/by-name/fo/foundationdb/package.nix
@@ -171,6 +171,7 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [
       thoughtpolice
       lostnet
+      kornholi
     ];
   };
 }


### PR DESCRIPTION
Our FoundationDB has been broken for almost two years due to statically linking against libc++/libstdc++/libgcc, showing up as weird segfaults at startup (luckily). Disable that. 

Also update to the latest release validated in production, 7.3.68.

Tested that `fdbcli` starts up and can connect to a cluster on both x86_64 and aarch64.

Fixes #319537.
Fixes #378888.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
