### PR TITLE
lief: make Python and Rust bindings optional

### DIFF
--- a/pkgs/by-name/li/lief/package.nix
+++ b/pkgs/by-name/li/lief/package.nix
@@ -8,6 +8,8 @@
   nix-update-script,
   testers,
   validatePkgConfig,
+  withPython ? true,
+  withRust ? true,
 }:
 
 let
@@ -31,6 +33,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   outputs = [
     "out"
+  ]
+  ++ lib.optionals withPython [
     "py"
   ];
 
@@ -42,29 +46,32 @@ stdenv.mkDerivation (finalAttrs: {
 
   # Not in propagatedBuildInputs because only the $py output needs it; $out is
   # just the library itself (e.g. C/C++ headers).
-  buildInputs = with python3.pkgs; [
-    python
-    build
-    pathspec
-    pip
-    pydantic
-    scikit-build-core
-  ];
+  buildInputs =
+    with python3.pkgs;
+    lib.optionals withPython [
+      python
+      build
+      pathspec
+      pip
+      pydantic
+      scikit-build-core
+    ];
 
   cmakeFlags = [
-    (lib.cmakeBool "LIEF_PYTHON_API" true)
+    (lib.cmakeBool "LIEF_PYTHON_API" withPython)
+    (lib.cmakeBool "LIEF_RUST_API" withRust)
     (lib.cmakeBool "LIEF_EXAMPLES" false)
     (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
     (lib.cmakeFeature "Python_EXECUTABLE" pyEnv.interpreter)
   ];
 
-  postBuild = ''
+  postBuild = lib.optionalString withPython ''
     pushd ../api/python
     ${pyEnv.interpreter} -m build --no-isolation --wheel --skip-dependency-check --config-setting=--parallel=$NIX_BUILD_CORES
     popd
   '';
 
-  postInstall = ''
+  postInstall = lib.optionalString withPython ''
     pushd ../api/python
     ${pyEnv.interpreter} -m pip install --prefix $py dist/*.whl
     popd


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added options `withPython` and `withRust`, both initialized to `true`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
