### PR TITLE
cachix: move dontCheck to configuration-darwin.nix

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -3904,25 +3904,21 @@ with haskellLib;
       src = src + "/cachix-api";
     } super.cachix-api;
 
-    cachix = lib.pipe super.cachix (
-      [
-        (overrideSrc {
-          inherit version;
-          src = src + "/cachix";
-        })
-        (addBuildDepends [
-          self.pqueue
-        ])
-        (
-          drv:
-          drv.override {
-            nix = self.hercules-ci-cnix-store.nixPackage;
-            hnix-store-core = self.hnix-store-core_0_8_0_0;
-          }
-        )
-      ]
-      # https://github.com/NixOS/nixpkgs/issues/461651
-      ++ lib.optional pkgs.stdenv.isDarwin dontCheck
-    );
+    cachix = lib.pipe super.cachix [
+      (overrideSrc {
+        inherit version;
+        src = src + "/cachix";
+      })
+      (addBuildDepends [
+        self.pqueue
+      ])
+      (
+        drv:
+        drv.override {
+          nix = self.hercules-ci-cnix-store.nixPackage;
+          hnix-store-core = self.hnix-store-core_0_8_0_0;
+        }
+      )
+    ];
   }
 )

--- a/pkgs/development/haskell-modules/configuration-darwin.nix
+++ b/pkgs/development/haskell-modules/configuration-darwin.nix
@@ -335,6 +335,9 @@ self: super:
       + (old.preBuild or "");
     }) super.hercules-ci-agent;
 
+    # https://github.com/NixOS/nixpkgs/issues/461651
+    cachix = dontCheck super.cachix;
+
     # Require /usr/bin/security which breaks sandbox
     http-reverse-proxy = dontCheck super.http-reverse-proxy;
     servant-auth-server = dontCheck super.servant-auth-server;


### PR DESCRIPTION
Follow up on https://github.com/NixOS/nixpkgs/pull/461839#discussion_r2529703822

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
