### PR TITLE
android-ota-payload-extractor: init at 1.1

### DIFF
--- a/pkgs/by-name/an/android-ota-payload-extractor/package.nix
+++ b/pkgs/by-name/an/android-ota-payload-extractor/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finallAttrs: {
+  pname = "android-ota-payload-extractor";
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    owner = "tobyxdd";
+    repo = "android-ota-payload-extractor";
+    tag = "v${finallAttrs.version}";
+    hash = "sha256-Ln9HSM3mmba5XrzPCmgdn+erGK1v/POz586K/D4krnY=";
+  };
+
+  vendorHash = "sha256-JsinGljnb+kC0QgaF4Vbi6Mh3Lwwwk/SbC+p5WLt08A=";
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  meta = {
+    description = "A fast & natively cross-platform Android OTA payload extractor written in Go";
+    homepage = "https://github.com/tobyxdd/android-ota-payload-extractor";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ matthewcroughan ];
+    mainProgram = "android-ota-payload-extractor";
+  };
+})

--- a/pkgs/by-name/an/android-ota-payload-extractor/package.nix
+++ b/pkgs/by-name/an/android-ota-payload-extractor/package.nix
@@ -27,6 +27,7 @@ buildGoModule (finallAttrs: {
     homepage = "https://github.com/tobyxdd/android-ota-payload-extractor";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ matthewcroughan ];
+    teams = with lib.teams; [ android ];
     mainProgram = "android-ota-payload-extractor";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
