### PR TITLE
linphonePackages.bc-mbedtls: fix build with gcc15

### DIFF
--- a/pkgs/applications/networking/instant-messengers/linphone/bc-mbedtls/default.nix
+++ b/pkgs/applications/networking/instant-messengers/linphone/bc-mbedtls/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitLab,
+  fetchpatch,
 
   cmake,
   ninja,
@@ -26,6 +27,17 @@ stdenv.mkDerivation {
     sha256 = "sha256-jQpRn2F21sPKKAiaqsUvaKyuR80AnedG/hAyiNamKjc=";
     fetchSubmodules = true;
   };
+
+  patches = [
+    # Fix build with gcc15
+    # https://www.github.com/Mbed-TLS/mbedtls/pull/10215
+    (fetchpatch {
+      name = "linphone-mbedtls-fix-unterminated-string-initialization.patch";
+      url = "https://github.com/Mbed-TLS/mbedtls/commit/d593c54b3cbfc3c806476a725e7d82763da0da9e.patch";
+      hash = "sha256-hh2cGzL75fEqlFNhEyL2fI9qsBW2Eq43DdWFD9qLsKE=";
+      excludes = [ "ChangeLog.d/unterminated-string-initialization.txt" ];
+    })
+  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
- add patches from merged upstream PR included in versions 3.6.4+:
https://www.github.com/Mbed-TLS/mbedtls/pull/10215
https://github.com/Mbed-TLS/mbedtls/commit/d593c54b3cbfc3c806476a725e7d82763da0da9e

Fixes build failure with gcc15:
```
/build/source/library/ssl_tls13_keys.h:14:40:
error: initializer-string for array of 'unsigned char' truncates NUL
terminator but destination lacks 'nonstring' attribute
(9 chars into 8 available) [-Werror=unterminated-string-initialization]
   14 |     MBEDTLS_SSL_TLS1_3_LABEL(finished, "finished") \
      |                                        ^~~~~~~~~~
/build/source/library/ssl_tls13_keys.c:38:13:
note: in definition of macro 'MBEDTLS_SSL_TLS1_3_LABEL'
   38 |     .name = string,
      |             ^~~~~~
/build/source/library/ssl_tls13_keys.c:44:5:
note: in expansion of macro 'MBEDTLS_SSL_TLS1_3_LABEL_LIST'
   44 |     MBEDTLS_SSL_TLS1_3_LABEL_LIST
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

---

Tested build with:
```bash
nix-build --expr 'with import ./. {}; linphonePackages.bc-mbedtls.override { stdenv = gcc15Stdenv; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
