### PR TITLE
reqable: 2.33.12 -> 3.0.30; fix settings schema; adopted

### DIFF
--- a/pkgs/by-name/re/reqable/package.nix
+++ b/pkgs/by-name/re/reqable/package.nix
@@ -28,11 +28,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "reqable";
-  version = "2.33.12";
+  version = "3.0.30";
 
   src = fetchurl {
     url = "https://github.com/reqable/reqable-app/releases/download/${finalAttrs.version}/reqable-app-linux-x86_64.deb";
-    hash = "sha256-LCHeJUzTRjl/lh3PWygZV0Rd3AxJEGlTkVrI/5l+Go4=";
+    hash = "sha256-tqeTcM0+RClOgWY72NJAFJAe62zbqAtdsIe//nZ3Kjs=";
   };
 
   nativeBuildInputs = [
@@ -75,7 +75,8 @@ stdenv.mkDerivation (finalAttrs: {
   preFixup = ''
     mkdir $out/bin
     makeWrapper $out/share/reqable/reqable $out/bin/reqable \
-      --prefix LD_LIBRARY_PATH : $out/share/reqable/lib
+      --prefix LD_LIBRARY_PATH : $out/share/reqable/lib \
+      --set GIO_MODULE_DIR "${glib.out}/lib/gio/modules"
   '';
 
   passthru.updateScript = nix-update-script { };
@@ -83,10 +84,12 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Generation API debugging and testing one-stop solution";
     homepage = "https://reqable.com";
+    downloadPage = "https://github.com/reqable/reqable-app/releases";
+    changelog = "https://github.com/reqable/reqable-app/releases/tag/${finalAttrs.version}";
     mainProgram = "reqable";
     license = lib.licenses.unfree;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ chillcicada ];
     platforms = [ "x86_64-linux" ];
   };
 })


### PR DESCRIPTION
update reqable to 3.0.30, fix setting schema for gtk, add me as a maintainer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
