### PR TITLE
ykush: init at 1.2.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14154,6 +14154,13 @@
     githubId = 9920871;
     name = "Monotoko";
   };
+  ktemkin = {
+    email = "kate@ktemk.in";
+    github = "ktemkin";
+    githubId = 1298105;
+    name = "Kate Temkin";
+    matrix = "@ktemkin:katesiria.org";
+  };
   ktf = {
     email = "giulio.eulisse@cern.ch";
     github = "ktf";

--- a/pkgs/by-name/yk/ykush/99-ykush.rules
+++ b/pkgs/by-name/yk/ykush/99-ykush.rules
@@ -1,0 +1,14 @@
+# Yepkit YKUSH3.
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="f11b", MODE="0666"
+
+# Yepkit YKUSH2.
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="efed", MODE="0666"
+
+# Yepkit YKUSHXs
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="f0cd", MODE="0666"
+
+# Yepkit YKUSH(1).
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="f2f7", MODE="0666"
+
+# Yepkit YKUSH-legacy.
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="0042", MODE="0666"

--- a/pkgs/by-name/yk/ykush/package.nix
+++ b/pkgs/by-name/yk/ykush/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  libusb1,
+  runCommand,
+  versionCheckHook,
+}:
+stdenv.mkDerivation (final: {
+  pname = "ykushcmd";
+  version = "1.2.5";
+
+  buildInputs = [ libusb1 ];
+
+  src = fetchFromGitHub {
+    owner = "yepkit";
+    repo = "ykush";
+    tag = "${final.version}";
+    hash = "sha256-FbqlXh8A5hzpthBE3jZ1LLOMs4WcEGke3sOZi9vmZF8=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D bin/ykushcmd $out/bin/ykushcmd
+    install -Dm444 ${./99-ykush.rules} $out/lib/udev/rules.d/99_ykush.rules
+
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.tests = {
+    # We can't run any actual tests without hardware, but we can at least check the binary.
+    run-only = runCommand "${final.pname}-test" ''
+      ${final}/bin/ykushcmd -h | grep YKUSHCMD
+    '';
+  };
+
+  meta = {
+    description = "Control utility for YepKit USB hubs";
+    longDescription = ''
+      controls the features of YepKit USB hubs, allowing one to arbitrarily
+      turn ports on and off and otherwise control the hub.
+    '';
+    homepage = "https://github.com/Yepkit/ykush";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      aiyion
+      ktemkin
+    ];
+    mainProgram = "ykushcmd";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
> YKUsh (yepkit USB hub) is a tool for managing YepKit hubs, which allow one to do things like very rapidly control power to individual ports, modify USB connection state, and etc.

I addressed all mentioned issues in the original PR and swapped the unreleased 1.3.0-beta for the latest release 1.2.5.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - ~Package update: when the change is major or breaking.~
- NixOS Release Notes
  - ~Module addition: when adding a new NixOS module.~
  - ~Module update: when the change is significant.~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
