### PR TITLE
fix inputDerivation in case of __structuredAttrs

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -860,10 +860,21 @@ let
       # for a fixed-output derivation, the corresponding inputDerivation should
       # *not* be fixed-output. To achieve this we simply delete the attributes that
       # would make it fixed-output.
-      deleteFixedOutputRelatedAttrs = lib.flip removeAttrs [
+      fixedOutputRelatedAttrs = [
         "outputHashAlgo"
         "outputHash"
         "outputHashMode"
+      ];
+
+      # inputDerivation produces the inputs; not the outputs, so any
+      # restrictions on what used to be the outputs don't serve a purpose
+      # anymore.
+      outputCheckAttrs = [
+        "allowedReferences"
+        "allowedRequisites"
+        "disallowedReferences"
+        "disallowedRequisites"
+        "outputChecks"
       ];
 
     in
@@ -876,7 +887,7 @@ let
         # needed to enter a nix-shell with
         #   nix-build shell.nix -A inputDerivation
         inputDerivation = derivation (
-          deleteFixedOutputRelatedAttrs derivationArg
+          removeAttrs derivationArg (fixedOutputRelatedAttrs ++ outputCheckAttrs)
           // {
             # Add a name in case the original drv didn't have one
             name = "inputDerivation" + lib.optionalString (derivationArg ? name) "-${derivationArg.name}";
@@ -911,25 +922,6 @@ let
               ''
             ];
           }
-          // (
-            let
-              sharedOutputChecks = {
-                # inputDerivation produces the inputs; not the outputs, so any
-                # restrictions on what used to be the outputs don't serve a purpose
-                # anymore.
-                allowedReferences = null;
-                allowedRequisites = null;
-                disallowedReferences = [ ];
-                disallowedRequisites = [ ];
-              };
-            in
-            if __structuredAttrs then
-              {
-                outputChecks.out = sharedOutputChecks;
-              }
-            else
-              sharedOutputChecks
-          )
         );
 
         inherit passthru overrideAttrs;

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -879,7 +879,7 @@ let
           deleteFixedOutputRelatedAttrs derivationArg
           // {
             # Add a name in case the original drv didn't have one
-            name = derivationArg.name or "inputDerivation";
+            name = "inputDerivation" + lib.optionalString (derivationArg ? name) "-${derivationArg.name}";
             # This always only has one output
             outputs = [ "out" ];
 

--- a/pkgs/test/stdenv/default.nix
+++ b/pkgs/test/stdenv/default.nix
@@ -216,6 +216,22 @@ let
         touch $out
       '';
     };
+
+  testInputDerivationDep = stdenv.mkDerivation {
+    name = "test-input-derivation-dependency";
+    buildCommand = "touch $out";
+  };
+  testInputDerivation =
+    attrs:
+    (stdenv.mkDerivation (
+      attrs
+      // {
+        buildInputs = [ testInputDerivationDep ];
+      }
+    )).inputDerivation
+    // {
+      meta = { };
+    };
 in
 
 {
@@ -355,6 +371,55 @@ in
         grep ${inputDerivation.dep2} graph
         touch $out
       '';
+
+  test-inputDerivation-structured = testInputDerivation {
+    name = "test-inDrv-structured";
+    __structuredAttrs = true;
+  };
+
+  test-inputDerivation-allowedReferences = testInputDerivation {
+    name = "test-inDrv-allowedReferences";
+    allowedReferences = [ ];
+  };
+
+  test-inputDerivation-disallowedReferences = testInputDerivation {
+    name = "test-inDrv-disallowedReferences";
+    disallowedReferences = [ "${testInputDerivationDep}" ];
+  };
+
+  test-inputDerivation-allowedRequisites = testInputDerivation {
+    name = "test-inDrv-allowedRequisites";
+    allowedRequisites = [ ];
+  };
+
+  test-inputDerivation-disallowedRequisites = testInputDerivation {
+    name = "test-inDrv-disallowedRequisites";
+    disallowedRequisites = [ "${testInputDerivationDep}" ];
+  };
+
+  test-inputDerivation-structured-allowedReferences = testInputDerivation {
+    name = "test-inDrv-structured-allowedReferences";
+    __structuredAttrs = true;
+    outputChecks.out.allowedReferences = [ ];
+  };
+
+  test-inputDerivation-structured-disallowedReferences = testInputDerivation {
+    name = "test-inDrv-structured-disallowedReferences";
+    __structuredAttrs = true;
+    outputChecks.out.disallowedReferences = [ "${testInputDerivationDep}" ];
+  };
+
+  test-inputDerivation-structured-allowedRequisites = testInputDerivation {
+    name = "test-inDrv-structured-allowedRequisites";
+    __structuredAttrs = true;
+    outputChecks.out.allowedRequisites = [ ];
+  };
+
+  test-inputDerivation-structured-disallowedRequisites = testInputDerivation {
+    name = "test-inDrv-structured-disallowedRequisites";
+    __structuredAttrs = true;
+    outputChecks.out.disallowedRequisites = [ "${testInputDerivationDep}" ];
+  };
 
   test-prepend-append-to-var = testPrependAndAppendToVar {
     name = "test-prepend-append-to-var";


### PR DESCRIPTION
`package.inputDerivation` is broken when `package` sets `__structuredAttrs = true;`. You can test this with

```
$ nix-build --expr 'with import <nixpkgs> {}; (pkgs.hello.overrideAttrs { __structuredAttrs = true; }).inputDerivation'
this derivation will be built:
  /nix/store/5cg7cp1ym7zs9lzxvnqryj2s058m5gld-hello-2.12.1.drv
these 2 paths will be fetched (0.99 MiB download, 0.99 MiB unpacked):
  /nix/store/pa10z4ngm0g83kx9mssrqzz30s84vq7k-hello-2.12.1.tar.gz
  /nix/store/b8w73v17699k1zdnd31lvzzcp5f0rmni-version-check-hook
copying path '/nix/store/pa10z4ngm0g83kx9mssrqzz30s84vq7k-hello-2.12.1.tar.gz' from 'https://cache.nixos.org'...
copying path '/nix/store/b8w73v17699k1zdnd31lvzzcp5f0rmni-version-check-hook' from 'https://cache.nixos.org'...
building '/nix/store/5cg7cp1ym7zs9lzxvnqryj2s058m5gld-hello-2.12.1.drv'...
error: output '/nix/store/30kpdjhl0iy97z3lama80q93b6jgxh5y-hello-2.12.1' is not allowed to refer to the following paths:
         /nix/store/30kpdjhl0iy97z3lama80q93b6jgxh5y-hello-2.12.1
         /nix/store/b8w73v17699k1zdnd31lvzzcp5f0rmni-version-check-hook
         /nix/store/l9k32vj2aczxw62134j1x0dsh569jz2l-bash-5.2p37
         /nix/store/lfwfj17y9fpjb73nsj2m35rmkh587a0x-stdenv-linux
         /nix/store/pa10z4ngm0g83kx9mssrqzz30s84vq7k-hello-2.12.1.tar.gz
         /nix/store/shkw4qm9qcw5sc5n1k5jznc83ny02r39-default-builder.sh
         /nix/store/vj1c3wf9c11a0qs6p3ymfvrnsdgsdcbq-source-stdenv.sh
```

There is an attempt to account for this in the implementation of `inputDerivation`, but it's broken. The issue is that it assumes setting `allowedRefrences` and `allowedRequisites` to `null` will be like not setting them at all, which is false.

It does seem to work as top-level attributes (~~though I'm honestly not sure why this works, and I couldn't get it to work in my own derivations~~[^why-works]), but in `outputChecks.out.allowedReferences`, it definitely doesn't work.

In any case, Rather than setting `allowedReferences`, `disallowedReferences`, `allowedRequisites` and `disallowedRequisites` to values that we hope **mimic** the default behaviour, we can remove those attributes to get the default behaviour.

[^why-works]: It works currently because `__ignoreNulls = true;` is added. However, this only seems to work for top-level attributes, not `outputChecks.out.foo`. I still think getting rid of the attributes entirely is the right way forward.


Related issues:
- https://github.com/NixOS/nix/pull/14688
- https://github.com/NixOS/nix/pull/14750


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
