### PR TITLE
fsnav: init at 0.1

### DIFF
--- a/pkgs/by-name/fs/fsnav/package.nix
+++ b/pkgs/by-name/fs/fsnav/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  freetype,
+  libpng,
+  libjpeg,
+  libGL,
+  libGLU,
+  freeglut,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "fsnav";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "jtsiomb";
+    repo = "fsnav";
+    tag = "v${version}";
+    hash = "sha256-Bt1QRqtJkVFR1uMzmB3OUyqyzUyJdQyQdbMOfMyWJOc=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    freetype
+    libpng
+    libjpeg
+    libGL
+    libGLU
+    freeglut
+  ];
+
+  preBuild = ''
+    makeFlagsArray+=(
+      "PREFIX=$out"
+      "CC=$CC"
+      "CXX=$CXX"
+    )
+  '';
+
+  preInstall = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/fsnav
+  '';
+
+  meta = {
+    description = "3D filesystem navigator inspired by SGI FSN";
+    homepage = "https://github.com/jtsiomb/fsnav";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ aaravrav ];
+    mainProgram = "fsnav";
+    platforms = with lib.platforms; linux;
+    broken = !stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+  };
+
+}


### PR DESCRIPTION
Package this app

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
