### PR TITLE
[25.11] .git-blame-ignore-revs: add meta = with cleanup

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -307,3 +307,6 @@ c283f32d296564fd649ef3ed268c1f1f7b199c49 # !autorebase nix-shell --run treefmt
 
 # aliases: keep-sorted
 48ce0739044bd6eba83c3a43bd4ad1046399cdad # !autorebase nix-shell --run treefmt
+
+# treewide: clean up 'meta = with' pattern
+cca3b04b44a5c57502fe2440cc3d2114779cc40c


### PR DESCRIPTION
Happened in #469667.