### PR TITLE
gccNGPackages: Replace some mailing list fetches with commits

### DIFF
--- a/pkgs/development/compilers/gcc/ng/15/libatomic/gthr-include.patch
+++ b/pkgs/development/compilers/gcc/ng/15/libatomic/gthr-include.patch
@@ -1,0 +1,16 @@
+This change was upstreamed in e5d853bbe9b05d6a00d98ad236f01937303e40c4
+in GCC, but this file was slightly different in GCC 15, so we're
+patching it manually.
+
+diff --git a/libatomic/aclocal.m4 b/libatomic/aclocal.m4
+index 80e24219d7d..581fedcfe13 100644
+--- a/libatomic/aclocal.m4
++++ b/libatomic/aclocal.m4
+@@ -1189,6 +1189,7 @@ AC_SUBST([am__untar])
+
+ m4_include([../config/acx.m4])
+ m4_include([../config/depstand.m4])
++m4_include([../config/gthr.m4])
+ m4_include([../config/lead-dot.m4])
+ m4_include([../config/lthostflags.m4])
+ m4_include([../config/multi.m4])

--- a/pkgs/development/compilers/gcc/ng/common/libatomic/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/libatomic/default.nix
@@ -41,13 +41,14 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     (fetchpatch {
       name = "custom-threading-model.patch";
-      url = "https://inbox.sourceware.org/gcc-patches/20250716204545.1063669-1-git@JohnEricson.me/raw";
-      hash = "sha256-kxNntY2r4i/+XHQSpf9bYV2Jg+FD/pD5TiMn5hd4ckk=";
+      url = "https://github.com/gcc-mirror/gcc/commit/e5d853bbe9b05d6a00d98ad236f01937303e40c4.diff";
+      hash = "sha256-U1Eh6ByhmseHQigfHIyO4MlAQB3fECmpPEP/M00DOg0=";
       includes = [
         "config/*"
-        "libatomic/*"
+        "libatomic/configure.ac"
       ];
     })
+    (getVersionFile "libatomic/gthr-include.patch")
   ];
 
   postUnpack = ''

--- a/pkgs/development/compilers/gcc/ng/common/libgcc/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/libgcc/default.nix
@@ -45,18 +45,28 @@ stdenv.mkDerivation (finalAttrs: {
     })
     (fetchpatch {
       name = "custom-threading-model.patch";
-      url = "https://inbox.sourceware.org/gcc-patches/20250716204545.1063669-1-git@JohnEricson.me/raw";
-      hash = "sha256-NgiC4cFeFInXXg27me1XpSeImPaL0WHs50Tf1YHz4ps=";
+      url = "https://github.com/gcc-mirror/gcc/commit/e5d853bbe9b05d6a00d98ad236f01937303e40c4.diff";
+      hash = "sha256-92LIttIXdh12/lRhivb2JTPpqUmGBRn+uKmR5pzuveo=";
+      includes = [
+        "config/*"
+        "libgcc/configure.ac"
+      ];
     })
     (fetchpatch {
-      name = "libgcc.mvars-less-0.patch";
-      url = "https://inbox.sourceware.org/gcc-patches/20250716234028.1153560-1-John.Ericson@Obsidian.Systems/raw";
-      hash = "sha256-NEcieDCsy+7IRU3qQKVD3i57OuwGZKB/rmNF8X2I1n0=";
+      name = "no-pie-cflags.patch";
+      url = "https://github.com/gcc-mirror/gcc/commit/77144dd3b6736e0166156bb509590d924375a4f1.diff";
+      hash = "sha256-QlxlTkWAK1dB7JiU5wz2iOW24gj3bFaeBpwb90oWwns=";
+      includes = [
+        "gcc/Makefile.in"
+        "gcc/configure.ac"
+        "libgcc/Makefile.in"
+        "libgcc/configure.ac"
+      ];
     })
     (fetchpatch {
-      name = "libgcc.mvars-less-1.patch";
-      url = "https://inbox.sourceware.org/gcc-patches/20250716234028.1153560-2-John.Ericson@Obsidian.Systems/raw";
-      hash = "sha256-nfRC4f6m3kHDro4+6E4y1ZPs+prxBQmn0H2rzIjaMWM=";
+      name = "no-target-system-root.patch";
+      url = "https://github.com/gcc-mirror/gcc/commit/9947930b7ae923010c5061fd8fa6b1ec4f22f161.diff";
+      hash = "sha256-BZmpHpJuuyDmQMwpQhSgCZO0Rg7kXt8rTiJAT+e0sUw=";
     })
     (fetchpatch {
       name = "regular-libdir-includedir.patch";

--- a/pkgs/development/compilers/gcc/ng/common/libstdcxx/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/libstdcxx/default.nix
@@ -54,11 +54,11 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     (fetchpatch {
       name = "custom-threading-model.patch";
-      url = "https://inbox.sourceware.org/gcc-patches/20250716204545.1063669-1-git@JohnEricson.me/raw";
-      hash = "sha256-jPP0+MoPLtCwWcW6doO6KHCppwAYK40qNVyriLXcGOg=";
+      url = "https://github.com/gcc-mirror/gcc/commit/e5d853bbe9b05d6a00d98ad236f01937303e40c4.diff";
+      hash = "sha256-f0XAim3uzHnUx5lm/xO00IqBHu4YUEHF2WY+c0yCF6Y=";
       includes = [
         "config/*"
-        "libstdc++-v3/*"
+        "libstdc++-v3/acinclude.m4"
       ];
     })
     (getVersionFile "libstdcxx/force-regular-dirs.patch")


### PR DESCRIPTION
A few patches of mine were just merged (yay!). Let's upgrade the `fetchpatch` invocations from the original mailing list submission to the accepted commit, accordingly.

I narrowed down the the files to patch because patching autoconf-generated files will break, and is not needed because we are regenerating those files anyways.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
