### PR TITLE
git-xet: init at 0.2.0

### DIFF
--- a/pkgs/by-name/gi/git-xet/package.nix
+++ b/pkgs/by-name/gi/git-xet/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+  pkg-config,
+  openssl,
+  zlib,
+  git,
+  git-lfs,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "git-xet";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "huggingface";
+    repo = "xet-core";
+    tag = "git-xet-v${finalAttrs.version}";
+    hash = "sha256-XnCp9Dt4isFsT124ZVA/ID5y9l4bCSBQRrqrIPpv5Ow=";
+  };
+
+  cargoHash = "sha256-0xUik5zHO4T2PjFXrA0XHuy2892piE5Kiw2pcpa7xdY=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+    zlib
+  ];
+
+  # Build only the git_xet package
+  buildAndTestSubdir = "git_xet";
+
+  nativeCheckInputs = [
+    git
+    git-lfs
+  ];
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Git LFS plugin that uploads and downloads using the Xet protocol";
+    homepage = "https://github.com/huggingface/xet-core/blob/main/git_xet/README.md";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    mainProgram = "git-xet";
+    maintainers = with lib.maintainers; [
+      cybardev
+    ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Git-Xet is a Git LFS custom transfer agent that implements upload and download of files using the Xet protocol.

More information: https://github.com/huggingface/xet-core/blob/main/git_xet/README.md

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
