### PR TITLE
teams.ci: remove wolfgangwalther

### DIFF
--- a/maintainers/github-teams.json
+++ b/maintainers/github-teams.json
@@ -726,13 +726,11 @@
     "id": 13362067,
     "maintainers": {
       "philiptaron": 43863,
-      "wolfgangwalther": 9132420
-    },
-    "members": {
       "MattSturgeon": 5046562,
       "Mic92": 96200,
       "zowoq": 59103226
     },
+    "members": {},
     "name": "Nixpkgs CI"
   },
   "nixpkgs-core": {


### PR DESCRIPTION
I didn't achieve everything I had hoped for, but certainly GHA CI is in a better state than half a year ago.

It makes no sense to have Philip as a single point of failure, so I just added all members as maintainers - we are all committers anyway, there is no point in making a difference here.

Thanks for all the support, @NixOS/nixpkgs-ci. :heart:

*this is already implemented, so merging immediately to reflect that*