### PR TITLE
lldap: make package more overridable

### DIFF
--- a/pkgs/by-name/ll/lldap/package.nix
+++ b/pkgs/by-name/ll/lldap/package.nix
@@ -14,110 +14,115 @@
   curl,
   staticAssetsHash ? "sha256-xVbHD9s3ofbtHCDvjYwmsWXDEJ9z9vRxQDRR6pW6rt8=",
 }:
-rustPlatform.buildRustPackage (
-  finalAttrs: {
-    pname = "lldap";
-    version = "0.6.2";
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "lldap";
+  version = "0.6.2";
 
-    src = fetchFromGitHub {
-      owner = "lldap";
-      repo = "lldap";
-      rev = "v${finalAttrs.version}";
-      hash = "sha256-UBQWOrHika8X24tYdFfY8ETPh9zvI7/HV5j4aK8Uq+Y=";
-    };
+  src = fetchFromGitHub {
+    owner = "lldap";
+    repo = "lldap";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-UBQWOrHika8X24tYdFfY8ETPh9zvI7/HV5j4aK8Uq+Y=";
+  };
 
-    cargoHash = "sha256-SO7+HiiXNB/KF3fjzSMeiTPjRQq/unEfsnplx4kZv9c=";
-    ## workaround for overrideAttrs on buildRustPackage
-    ## see https://discourse.nixos.org/t/is-it-possible-to-override-cargosha256-in-buildrustpackage/4393/3
-    cargoDeps = rustPlatform.fetchCargoVendor {
-      name = "${finalAttrs.pname}-cargo-deps";
-      inherit (finalAttrs) src patches;
-      hash = finalAttrs.cargoHash;
-    };
+  cargoHash = "sha256-SO7+HiiXNB/KF3fjzSMeiTPjRQq/unEfsnplx4kZv9c=";
+  ## workaround for overrideAttrs on buildRustPackage
+  ## see https://discourse.nixos.org/t/is-it-possible-to-override-cargosha256-in-buildrustpackage/4393/3
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    name = "${finalAttrs.pname}-cargo-deps";
+    inherit (finalAttrs) src patches;
+    hash = finalAttrs.cargoHash;
+  };
 
-    cargoBuildFlags = [
-      "-p"
-      "lldap"
-      "-p"
-      "lldap_migration_tool"
-      "-p"
-      "lldap_set_password"
-    ];
+  cargoBuildFlags = [
+    "-p"
+    "lldap"
+    "-p"
+    "lldap_migration_tool"
+    "-p"
+    "lldap_set_password"
+  ];
 
-    nativeBuildInputs = [ makeWrapper ];
-    postInstall = ''
-      wrapProgram $out/bin/lldap \
-        --set LLDAP_ASSETS_PATH ${finalAttrs.finalPackage.frontend}
-    '';
+  nativeBuildInputs = [ makeWrapper ];
+  postInstall = ''
+    wrapProgram $out/bin/lldap \
+      --set LLDAP_ASSETS_PATH ${finalAttrs.finalPackage.frontend}
+  '';
 
-    passthru = {
+  passthru = {
 
-      frontend = rustPlatform.buildRustPackage {
-        inherit (finalAttrs) version src cargoDeps patches;
-        pname = finalAttrs.pname + "-frontend";
-        nativeBuildInputs = [
-          wasm-pack
-          wasm-bindgen-cli_0_2_100
-          binaryen
-          which
-          rustc
-          rustc.llvmPackages.lld
-        ];
-        buildPhase = ''
-          runHook preBuild
-          HOME=`pwd` ./app/build.sh
-          runHook postBuild
-        '';
-        installPhase = ''
-          runHook preInstall
-          mkdir -p $out
-          cp -R app/{pkg,static} $out/
-          cp app/index_local.html $out/index.html
-          cp -R ${finalAttrs.finalPackage.staticAssets}/* $out/static
-          rm $out/static/libraries.txt $out/static/fonts/fonts.txt
-          runHook postInstall
-        '';
-        doCheck = false;
-      };
-
-      staticAssets = runCommand "${finalAttrs.pname}-static-assets" {
-        outputHash = staticAssetsHash;
-        outputHashAlgo = "sha256";
-        outputHashMode = "recursive";
-        inherit (finalAttrs) src;
-        nativeBuildInputs = [
-          curl
-        ];
-        env.SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
-      } ''
-        mkdir $out
-        mkdir $out/fonts
-        for file in $(cat $src/app/static/libraries.txt); do
-          curl $file --location --remote-name --output-dir $out
-        done
-        for file in $(cat $src/app/static/fonts/fonts.txt); do
-          curl $file --location --remote-name --output-dir $out/fonts
-        done
-      '';
-
-      tests = {
-        inherit (nixosTests) lldap;
-      };
-
-    };
-
-    meta = {
-      description = "Lightweight authentication server that provides an opinionated, simplified LDAP interface for authentication";
-      homepage = "https://github.com/lldap/lldap";
-      changelog = "https://github.com/lldap/lldap/blob/v${finalAttrs.version}/CHANGELOG.md";
-      license = lib.licenses.gpl3Only;
-      platforms = lib.platforms.linux;
-      maintainers = with lib.maintainers; [
-        bendlas
-        ibizaman
+    frontend = rustPlatform.buildRustPackage {
+      inherit (finalAttrs)
+        version
+        src
+        cargoDeps
+        patches
+        ;
+      pname = finalAttrs.pname + "-frontend";
+      nativeBuildInputs = [
+        wasm-pack
+        wasm-bindgen-cli_0_2_100
+        binaryen
+        which
+        rustc
+        rustc.llvmPackages.lld
       ];
-      mainProgram = "lldap";
+      buildPhase = ''
+        runHook preBuild
+        HOME=`pwd` ./app/build.sh
+        runHook postBuild
+      '';
+      installPhase = ''
+        runHook preInstall
+        mkdir -p $out
+        cp -R app/{pkg,static} $out/
+        cp app/index_local.html $out/index.html
+        cp -R ${finalAttrs.finalPackage.staticAssets}/* $out/static
+        rm $out/static/libraries.txt $out/static/fonts/fonts.txt
+        runHook postInstall
+      '';
+      doCheck = false;
     };
-  }
 
-)
+    staticAssets =
+      runCommand "${finalAttrs.pname}-static-assets"
+        {
+          outputHash = staticAssetsHash;
+          outputHashAlgo = "sha256";
+          outputHashMode = "recursive";
+          inherit (finalAttrs) src;
+          nativeBuildInputs = [
+            curl
+          ];
+          env.SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+        }
+        ''
+          mkdir $out
+          mkdir $out/fonts
+          for file in $(cat $src/app/static/libraries.txt); do
+            curl $file --location --remote-name --output-dir $out
+          done
+          for file in $(cat $src/app/static/fonts/fonts.txt); do
+            curl $file --location --remote-name --output-dir $out/fonts
+          done
+        '';
+
+    tests = {
+      inherit (nixosTests) lldap;
+    };
+
+  };
+
+  meta = {
+    description = "Lightweight authentication server that provides an opinionated, simplified LDAP interface for authentication";
+    homepage = "https://github.com/lldap/lldap";
+    changelog = "https://github.com/lldap/lldap/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      bendlas
+      ibizaman
+    ];
+    mainProgram = "lldap";
+  };
+})

--- a/pkgs/by-name/ll/lldap/package.nix
+++ b/pkgs/by-name/ll/lldap/package.nix
@@ -2,7 +2,6 @@
   binaryen,
   fetchFromGitHub,
   lib,
-  lldap,
   makeWrapper,
   nixosTests,
   rustPlatform,
@@ -15,95 +14,27 @@
   curl,
   staticAssetsHash ? "sha256-xVbHD9s3ofbtHCDvjYwmsWXDEJ9z9vRxQDRR6pW6rt8=",
 }:
-
-let
-  version = "0.6.2";
-
-  commonDerivationAttrs = {
+rustPlatform.buildRustPackage (
+  finalAttrs: {
     pname = "lldap";
-    inherit version;
+    version = "0.6.2";
 
     src = fetchFromGitHub {
       owner = "lldap";
       repo = "lldap";
-      rev = "v${version}";
+      rev = "v${finalAttrs.version}";
       hash = "sha256-UBQWOrHika8X24tYdFfY8ETPh9zvI7/HV5j4aK8Uq+Y=";
     };
 
     cargoHash = "sha256-SO7+HiiXNB/KF3fjzSMeiTPjRQq/unEfsnplx4kZv9c=";
-  };
+    ## workaround for overrideAttrs on buildRustPackage
+    ## see https://discourse.nixos.org/t/is-it-possible-to-override-cargosha256-in-buildrustpackage/4393/3
+    cargoDeps = rustPlatform.fetchCargoVendor {
+      name = "${finalAttrs.pname}-cargo-deps";
+      inherit (finalAttrs) src patches;
+      hash = finalAttrs.cargoHash;
+    };
 
-  staticAssets =
-    src:
-    runCommand "${commonDerivationAttrs.pname}-static-assets"
-      {
-        outputHash = staticAssetsHash;
-        outputHashAlgo = "sha256";
-        outputHashMode = "recursive";
-
-        inherit src;
-
-        nativeBuildInputs = [
-          curl
-        ];
-
-        env.SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
-      }
-      ''
-        mkdir $out
-        mkdir $out/fonts
-        for file in $(cat ${src}/app/static/libraries.txt); do
-          curl $file --location --remote-name --output-dir $out
-        done
-        for file in $(cat ${src}/app/static/fonts/fonts.txt); do
-          curl $file --location --remote-name --output-dir $out/fonts
-        done
-      '';
-
-  frontend = rustPlatform.buildRustPackage (
-    finalAttrs:
-    commonDerivationAttrs
-    // {
-      pname = commonDerivationAttrs.pname + "-frontend";
-
-      nativeBuildInputs = [
-        wasm-pack
-        wasm-bindgen-cli_0_2_100
-        binaryen
-        which
-        rustc
-        rustc.llvmPackages.lld
-      ];
-
-      buildPhase = ''
-        runHook preBuild
-
-        HOME=`pwd` ./app/build.sh
-
-        runHook postBuild
-      '';
-
-      installPhase = ''
-        runHook preInstall
-
-        mkdir -p $out
-        cp -R app/{pkg,static} $out/
-        cp app/index_local.html $out/index.html
-        cp -R ${staticAssets finalAttrs.src}/* $out/static
-        rm $out/static/libraries.txt $out/static/fonts/fonts.txt
-
-        runHook postInstall
-      '';
-
-      doCheck = false;
-    }
-  );
-
-in
-rustPlatform.buildRustPackage (
-  finalAttrs:
-  commonDerivationAttrs
-  // {
     cargoBuildFlags = [
       "-p"
       "lldap"
@@ -120,16 +51,65 @@ rustPlatform.buildRustPackage (
     '';
 
     passthru = {
-      inherit frontend;
+
+      frontend = rustPlatform.buildRustPackage {
+        inherit (finalAttrs) version src cargoDeps patches;
+        pname = finalAttrs.pname + "-frontend";
+        nativeBuildInputs = [
+          wasm-pack
+          wasm-bindgen-cli_0_2_100
+          binaryen
+          which
+          rustc
+          rustc.llvmPackages.lld
+        ];
+        buildPhase = ''
+          runHook preBuild
+          HOME=`pwd` ./app/build.sh
+          runHook postBuild
+        '';
+        installPhase = ''
+          runHook preInstall
+          mkdir -p $out
+          cp -R app/{pkg,static} $out/
+          cp app/index_local.html $out/index.html
+          cp -R ${finalAttrs.finalPackage.staticAssets}/* $out/static
+          rm $out/static/libraries.txt $out/static/fonts/fonts.txt
+          runHook postInstall
+        '';
+        doCheck = false;
+      };
+
+      staticAssets = runCommand "${finalAttrs.pname}-static-assets" {
+        outputHash = staticAssetsHash;
+        outputHashAlgo = "sha256";
+        outputHashMode = "recursive";
+        inherit (finalAttrs) src;
+        nativeBuildInputs = [
+          curl
+        ];
+        env.SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+      } ''
+        mkdir $out
+        mkdir $out/fonts
+        for file in $(cat $src/app/static/libraries.txt); do
+          curl $file --location --remote-name --output-dir $out
+        done
+        for file in $(cat $src/app/static/fonts/fonts.txt); do
+          curl $file --location --remote-name --output-dir $out/fonts
+        done
+      '';
+
       tests = {
         inherit (nixosTests) lldap;
       };
+
     };
 
     meta = {
       description = "Lightweight authentication server that provides an opinionated, simplified LDAP interface for authentication";
       homepage = "https://github.com/lldap/lldap";
-      changelog = "https://github.com/lldap/lldap/blob/v${lldap.version}/CHANGELOG.md";
+      changelog = "https://github.com/lldap/lldap/blob/v${finalAttrs.version}/CHANGELOG.md";
       license = lib.licenses.gpl3Only;
       platforms = lib.platforms.linux;
       maintainers = with lib.maintainers; [


### PR DESCRIPTION
## Things done

Prepare lldap package for overrideAttrs:
- reference everything from finalAttrs instead of from local let
- construct frontend also from finalAttrs

I needed this for testing a PR. Can override src, patches and cargoHash now ..

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
