### PR TITLE
nixos/home-assistant: do not set server_host by default

### DIFF
--- a/nixos/modules/services/home-automation/home-assistant.nix
+++ b/nixos/modules/services/home-automation/home-assistant.nix
@@ -406,14 +406,15 @@ in
             http = {
               # https://www.home-assistant.io/integrations/http/
               server_host = mkOption {
-                type = types.either types.str (types.listOf types.str);
-                default = [
-                  "0.0.0.0"
-                  "::"
+                type = types.nullOr (types.either types.str (types.listOf types.str));
+                default = null;
+                example = [
+                  "::1"
+                  "127.0.0.1"
                 ];
-                example = "::1";
                 description = ''
-                  Only listen to incoming requests on specific IP/host. The default listed assumes support for IPv4 and IPv6.
+                  Only listen to incoming requests on specific IP/host.
+                  The option is unset by default, meaning that Home Assistant listens on all available addresses.
                 '';
               };
 


### PR DESCRIPTION
The option `services.home-assistant.config.http.server_host' has been
deprecated by home-assistant in version 2025.12  and will be removed with
version 2026.06. 
See commit:
https://github.com/home-assistant/core/commit/07c4c58ce45cd54e067ab01e7fcc6e163cdee0c7

This commit removes the default value from the config and introduces a
warning if set manually. It also addss an assert that prevents settings
the option starting with HA version 2026.06

This option can not be marked as removed with lib.mkRemovedOptionModule
as `services.home-assistant.config` has the type yaml and is not a submodule

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
