### PR TITLE
nixos-rebuild-ng: improve IPv6 support

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
@@ -140,3 +140,23 @@ def test_remote_from_name(monkeypatch: MonkeyPatch) -> None:
             opts=["-f", "foo", "-b", "bar", "-t"],
             sudo_password="password",
         )
+
+
+def test_ssh_host() -> None:
+    remotes = {
+        "user@[fe80::1%25eth0]": "user@fe80::1%eth0",
+        "[fe80::c98b%25enp4s0]": "fe80::c98b%enp4s0",
+        "user@[2001::5fce:a:198]": "user@2001::5fce:a:198",
+        "[2001::dead:beef]": "2001::dead:beef",
+        "root@192.168.178.1": "root@192.168.178.1",
+        "192.168.178.1": "192.168.178.1",
+        "user@localhost": "user@localhost",
+        "localhost": "localhost",
+        "user@example.org": "user@example.org",
+        "example.org": "example.org",
+    }
+
+    for host_input, expected in remotes.items():
+        remote = m.Remote.from_arg(host_input, None, False)
+        assert remote is not None
+        assert remote.ssh_host() == expected


### PR DESCRIPTION
These changes fix support for using an IPv6 address for the target host. This approach is similar to the one found in nix [1]. Previously, nixos-rebuild-ng would pass a host string to `ssh` that cannot be parsed.

Since the host string is being treated like a URL, we encode the scope ID symbol (%) as %25. This is required for compatibility with other nix commands (e.g. nix-copy-closure).

Example:
```
nixos-rebuild \
  --target-host "root@[fe80::9272:6aff:fe15:faf3%25enp4s0]" \
  --flake path:/etc/nixos#xiatian -L \
  switch
```

[1] https://github.com/NixOS/nix/blob/8b955d8/src/libstore/store-reference.cc#L143-L166


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
