### PR TITLE
libqb: fix hash

### DIFF
--- a/pkgs/by-name/li/libqb/package.nix
+++ b/pkgs/by-name/li/libqb/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     owner = "ClusterLabs";
     repo = "libqb";
     rev = "v${version}";
-    sha256 = "sha256-ZjxC7W4U8T68mZy/OvWj/e4W9pJIj2lVDoEjxXYr/G8=";
+    sha256 = "sha256-xCwENbo9ONsFNiutebsIRqjmvtUz+qnlytvvlCC4P78=";
   };
 
   patches = [


### PR DESCRIPTION
Upstream recreated the tag for some reason.

```diff
diff -rub ./configure.ac /nix/store/wqa0ij7bv2lav7zwk6x6w9fn5a2qkx54-source/configure.ac
--- ./configure.ac	2023-07-21 20:30:39.000000000 +0900
+++ /nix/store/wqa0ij7bv2lav7zwk6x6w9fn5a2qkx54-source/configure.ac	1970-01-01 09:00:01.000000000 +0900
@@ -6,7 +6,7 @@
 dnl inject zero as a "patch" component of the version if missing in tag;
 dnl care to bump "X.Y.Z-yank" template below upon each release very desirable
 AC_INIT([libqb],
-	m4_esyscmd([build-aux/git-version-gen $(echo '002171bbc??tag: v2.0.8'\
+	m4_esyscmd([build-aux/git-version-gen $(echo '002171bbc??HEAD -> main, tag: v2.0.8'\
 	            | sed -ne 's/^[$]Format:[^$]*[$]$/.tarball-version/p;tend'\
 	                  -e 's/.*tag: v\([^, ][^, ]*\).*/\1-yank/;tv'\
 	                  -e 's/^\([[:xdigit:]][[:xdigit:]]*\).*/1.9.0-yank\1/'\
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
