### PR TITLE
build-fhsenv-bubblewrap: use `hostPlatform.is64bit` for `$out/usr/lib`

### DIFF
--- a/pkgs/build-support/build-fhsenv-bubblewrap/buildFHSEnv.nix
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/buildFHSEnv.nix
@@ -46,14 +46,14 @@ let
 
   # "use of glibc_multi is only supported on x86_64-linux"
   isMultiBuild = multiArch && stdenv.system == "x86_64-linux";
-  # What should lib be linked to: lib32 or lib64?
+  # What should $out/usr/lib be linked to: lib32 or lib64?
   defaultLib =
-    {
-      "i686-linux" = "lib32";
-      "x86_64-linux" = "lib64";
-      "aarch64-linux" = "lib64";
-    }
-    .${stdenv.system} or (throw "Please expand list of system with defaultLib for '${stdenv.system}'");
+    if stdenv.hostPlatform.is64bit then
+      "lib64"
+    else if stdenv.hostPlatform.is32bit then
+      "lib32"
+    else
+      throw "buildFHSEnvBubblewrap: defaultLib cannot handle system ${stdenv.hostPlatform.system} (expected 64bit or 32bit)";
 
   # list of packages (usually programs) which match the host's architecture
   # (which includes stuff from multiPkgs)


### PR DESCRIPTION
Follow-up to https://github.com/NixOS/nixpkgs/pull/468536 and https://github.com/NixOS/nixpkgs/pull/469697, cc @trofi.

Use `«platform».libDir` instead of mapping system → directory in an explicitly curated table.

> [!Note]
> This will use "lib" on 32-bit systems, instead of `lib32`. Based on https://github.com/NixOS/nixpkgs/pull/468536#discussion_r2600249868 I believe this is the intended bahaviour?

For aarch64 systems `hostPlatform.libDir` would be "lib", unlike most 64-bit systems. This is handled explicitly by returning "lib64" when `isAarch64`.

One potential disadvantage of `hostPlatform.libDir` is that it is based on a whitelist of architectures instead of the simpler `is64Bit`. If a less strict approach is desired, or you want the `$out/usr/lib` symlink to target `lib32` instead of `lib`, I'm happy to switch to a more explicit implementation like:
```nix
if stdenv.hostPlatform.is64bit then "lib64" else "lib"
```
or
```nix
if stdenv.hostPlatform.is64bit then
  "lib64"
else if stdenv.hostPlatform.is32bit then
  "lib32"
else
  throw "unsupported host platform: ${stdenv.hostPlatform.system}"
```

Or similar, as discussed in https://github.com/NixOS/nixpkgs/pull/468536#issuecomment-3639060961. Just let me know what is preferred and why.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
