### PR TITLE
oxfmt: init at 0.18.0

### DIFF
--- a/pkgs/by-name/ox/oxfmt/package.nix
+++ b/pkgs/by-name/ox/oxfmt/package.nix
@@ -1,0 +1,107 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  cargo,
+  cmake,
+  makeBinaryWrapper,
+  nodejs-slim,
+  pnpmConfigHook,
+  pnpm_10,
+  rustPlatform,
+  rustc,
+  versionCheckHook,
+}:
+
+# Build with pnpm instead of buildRustPackage because Prettier integration
+# requires the JavaScript runtime and npm dependencies.
+# A pure Rust build would lack the Prettier plugin functionality.
+stdenv.mkDerivation (finalAttrs: {
+  pname = "oxfmt";
+  version = "0.18.0";
+
+  src = fetchFromGitHub {
+    owner = "oxc-project";
+    repo = "oxc";
+    tag = "oxfmt_v${finalAttrs.version}";
+    hash = "sha256-AatmbW8UE8UbV533I2nhijHNlqIsgvtlE7X98uT7aTA=";
+  };
+
+  # Remove patchedDependencies from both workspace and lockfile
+  # to avoid LOCKFILE_CONFIG_MISMATCH error
+  postPatch = ''
+    substituteInPlace pnpm-workspace.yaml pnpm-lock.yaml \
+      --replace-fail "patchedDependencies:" "_patchedDependencies:"
+  '';
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-4G52/8WZgNFM/vcHXBbtWabBZwWo3ZBVadFjOI2SmUk=";
+  };
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    pnpm = pnpm_10;
+    fetcherVersion = 2;
+    hash = "sha256-Do2sFEK/8Axj9B9M/W9zqMboPrAo5Zm/zdrMXZvmFg0=";
+    prePnpmInstall = finalAttrs.postPatch;
+  };
+
+  nativeBuildInputs = [
+    cargo
+    cmake
+    makeBinaryWrapper
+    nodejs-slim
+    pnpmConfigHook
+    pnpm_10
+    rustPlatform.cargoSetupHook
+    rustc
+  ];
+
+  # cmake is only needed for libmimalloc-sys2 crate, not for top-level build
+  dontUseCmakeConfigure = true;
+
+  env.OXC_VERSION = finalAttrs.version;
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm --filter oxfmt-app run build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    local outPath=$out/lib/oxfmt
+    mkdir -p $outPath $out/bin
+
+    # Reinstall production dependencies only
+    find -name 'node_modules' -type d -exec rm -rf {} \; || true
+    pnpm --filter oxfmt-app install --offline --prod --ignore-scripts
+
+    cp -r apps/oxfmt/dist $outPath/
+    cp -rL apps/oxfmt/node_modules $outPath/
+    cp npm/oxfmt/configuration_schema.json $outPath/
+
+    makeWrapper ${lib.getExe nodejs-slim} $out/bin/oxfmt \
+      --add-flags $outPath/dist/cli.js
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  meta = {
+    description = "JavaScript formatter with Prettier integration";
+    homepage = "https://github.com/oxc-project/oxc";
+    changelog = "https://github.com/oxc-project/oxc/blob/${finalAttrs.src.tag}/apps/oxfmt/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ natsukium ];
+    mainProgram = "oxfmt";
+    inherit (nodejs-slim.meta) platforms;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Oxfmt (/oh-eks-for-mat/) is a Prettier-compatible code formatter.
https://oxc.rs/docs/guide/usage/formatter.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
