### PR TITLE
<pkg>.overridePythonAttrs: take both `checkPhase` and `installCheckPhase` and pass `installCheckPhase`

### DIFF
--- a/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
@@ -96,5 +96,5 @@ EOF
 
 if [ -z "${dontUsePytestCheck-}" ] && [ -z "${installCheckPhase-}" ]; then
     echo "Using pytestCheckPhase"
-    appendToVar preDistPhases pytestCheckPhase
+    installCheckPhase=pytestCheckPhase
 fi

--- a/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
@@ -22,7 +22,7 @@ function _pytestIncludeExcludeExpr() {
 
 function pytestCheckPhase() {
     echo "Executing pytestCheckPhase"
-    runHook preCheck
+    runHook preInstallCheck
 
     # Compose arguments
     local -a flagsArray=(-m pytest)
@@ -90,7 +90,7 @@ EOF
     echoCmd 'pytest flags' "${flagsArray[@]}"
     @pythonCheckInterpreter@ "${flagsArray[@]}"
 
-    runHook postCheck
+    runHook postInstallCheck
     echo "Finished executing pytestCheckPhase"
 }
 

--- a/pkgs/development/interpreters/python/hooks/unittest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/unittest-check-hook.sh
@@ -22,5 +22,5 @@ unittestCheckPhase() {
 
 if [[ -z "${dontUseUnittestCheck-}" ]] && [[ -z "${installCheckPhase-}" ]]; then
     echo "Using unittestCheckPhase"
-    appendToVar preDistPhases unittestCheckPhase
+    installCheckPhase=unittestCheckPhase
 fi

--- a/pkgs/development/interpreters/python/hooks/unittest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/unittest-check-hook.sh
@@ -5,7 +5,7 @@ echo "Sourcing unittest-check-hook"
 
 unittestCheckPhase() {
     echo "Executing unittestCheckPhase"
-    runHook preCheck
+    runHook preInstallCheck
 
     local -a flagsArray=()
 
@@ -16,7 +16,7 @@ unittestCheckPhase() {
     echoCmd 'unittest flags' "${flagsArray[@]}"
     @pythonCheckInterpreter@ -m unittest discover "${flagsArray[@]}"
 
-    runHook postCheck
+    runHook postInstallCheck
     echo "Finished executing unittestCheckPhase"
 }
 

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -107,7 +107,6 @@ let
     "checkInputs"
     "nativeCheckInputs"
     "doCheck"
-    "doInstallCheck"
     "pyproject"
     "format"
     "stdenv"
@@ -125,10 +124,10 @@ in
   # Run-time dependencies for the package
   buildInputs ? [ ],
 
-  # Dependencies needed for running the checkPhase.
-  # These are added to buildInputs when doCheck = true.
-  checkInputs ? [ ],
-  nativeCheckInputs ? [ ],
+  # Dependencies needed for running the installCheckPhase.
+  # These are added to buildInputs when doInstallCheck = true.
+  installCheckInputs ? [ ],
+  nativeInstallCheckInputs ? [ ],
 
   # propagate build dependencies so in case we have A -> B -> C,
   # C can import package A propagated by B
@@ -194,7 +193,7 @@ in
 
   meta ? { },
 
-  doCheck ? true,
+  doInstallCheck ? true,
 
   ...
 }@attrs:
@@ -360,7 +359,7 @@ let
         )
       ]
       ++ optionals (stdenv.buildPlatform == stdenv.hostPlatform) [
-        # This is a test, however, it should be ran independent of the checkPhase and checkInputs
+        # This is a test, however, it should be ran independent of the installCheckPhase and installCheckInputs
         pythonImportsCheckHook
       ]
       ++ optionals (python.pythonAtLeast "3.3") [
@@ -390,11 +389,11 @@ let
 
       LANG = "${if python.stdenv.hostPlatform.isDarwin then "en_US" else "C"}.UTF-8";
 
-      # Python packages don't have a checkPhase, only an installCheckPhase
+      # Python packages don't have a installCheckPhase, only an installCheckPhase
       doCheck = false;
-      doInstallCheck = attrs.doCheck or true;
-      nativeInstallCheckInputs = nativeCheckInputs ++ attrs.nativeInstallCheckInputs or [ ];
-      installCheckInputs = checkInputs ++ attrs.installCheckInputs or [ ];
+      inherit doInstallCheck;
+      inherit nativeInstallCheckInputs;
+      inherit installCheckInputs;
 
       inherit dontWrapPythonPrograms;
 
@@ -432,21 +431,13 @@ let
       }
       // meta;
     }
-    // optionalAttrs (attrs ? checkPhase) {
-      # If given use the specified checkPhase, otherwise use the setup hook.
-      # Longer-term we should get rid of `checkPhase` and use `installCheckPhase`.
-      installCheckPhase =
-        lib.replaceStrings
-          [ "runHook preCheck\n" "runHook postCheck\n" ]
-          [ "runHook preInstallCheck\n" "runHook postInstallCheck\n" ]
-          attrs.checkPhase;
-    }
-    // optionalAttrs (attrs ? preCheck) {
-      preInstallCheck = attrs.preInstallCheck or attrs.preCheck;
-    }
-    // optionalAttrs (attrs ? postCheck) {
-      postInstallCheck = attrs.postInstallCheck or attrs.postCheck;
-    }
+    # If given use the specified installCheckPhase, otherwise use the setup hook.
+    # Longer-term we should get rid of `checkPhase` and use `installCheckPhase`.
+    // getOptionalAttrs [
+      "installCheckPhase"
+      "preInstallCheck"
+      "postInstallCheck"
+    ] attrs
     //
       lib.mapAttrs
         (

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -102,6 +102,8 @@ let
   cleanAttrs = flip removeAttrs [
     "disabled"
     "checkPhase"
+    "preCheck"
+    "postCheck"
     "checkInputs"
     "nativeCheckInputs"
     "doCheck"
@@ -433,7 +435,17 @@ let
     // optionalAttrs (attrs ? checkPhase) {
       # If given use the specified checkPhase, otherwise use the setup hook.
       # Longer-term we should get rid of `checkPhase` and use `installCheckPhase`.
-      installCheckPhase = attrs.checkPhase;
+      installCheckPhase =
+        lib.replaceStrings
+          [ "runHook preCheck\n" "runHook postCheck\n" ]
+          [ "runHook preInstallCheck\n" "runHook postInstallCheck\n" ]
+          attrs.checkPhase;
+    }
+    // optionalAttrs (attrs ? preCheck) {
+      preInstallCheck = attrs.preInstallCheck or attrs.preCheck;
+    }
+    // optionalAttrs (attrs ? postCheck) {
+      postInstallCheck = attrs.postInstallCheck or attrs.postCheck;
     }
     //
       lib.mapAttrs


### PR DESCRIPTION
This change makes `buildPythonPackage` and `overridePythonAttrs` take both `checkPhase`-related attributes and `installCheckPhase`-related attributes, and pass only the `installCheckPhase`-related ones to `stdenv.mkDerivation`, keeping the `<pkg>.overrideAttrs` interface clean and ordered.

This PR depends on:
-  #379637

After merging the depending PR, this PR should cause few or no rebuilds.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
