### PR TITLE
haskell.packages.ghc984.haskell-language-server: fix build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -217,6 +217,7 @@ in
         apply-refact = addBuildDepend self.data-default-class super.apply-refact;
         floskell = doJailbreak super.floskell;
         fourmolu = dontCheck (doJailbreak self.fourmolu_0_15_0_0);
+        ghcide = super.ghcide;
         haskell-language-server = addBuildDepends [
           self.retrie
           self.floskell
@@ -224,6 +225,7 @@ in
         ] super.haskell-language-server;
         hls-plugin-api = super.hls-plugin-api;
         hlint = self.hlint_3_8;
+        lsp-types = super.lsp-types;
         ormolu = self.ormolu_0_7_4_0;
         retrie = doJailbreak (unmarkBroken super.retrie);
         stylish-haskell = self.stylish-haskell_0_14_6_0;
@@ -232,9 +234,11 @@ in
     apply-refact
     floskell
     fourmolu
+    ghcide
     haskell-language-server
     hls-plugin-api
     hlint
+    lsp-types
     ormolu
     retrie
     stylish-haskell

--- a/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
@@ -121,6 +121,7 @@ in
         apply-refact = addBuildDepend self.data-default-class super.apply-refact;
         floskell = doJailbreak super.floskell;
         fourmolu = dontCheck (doJailbreak self.fourmolu_0_15_0_0);
+        ghcide = super.ghcide;
         haskell-language-server = addBuildDepends [
           self.retrie
           self.floskell
@@ -128,6 +129,7 @@ in
         ] super.haskell-language-server;
         hls-plugin-api = super.hls-plugin-api;
         hlint = self.hlint_3_8;
+        lsp-types = super.lsp-types;
         ormolu = self.ormolu_0_7_4_0;
         retrie = doJailbreak (unmarkBroken super.retrie);
         stylish-haskell = self.stylish-haskell_0_14_6_0;
@@ -136,9 +138,11 @@ in
     apply-refact
     floskell
     fourmolu
+    ghcide
     haskell-language-server
     hls-plugin-api
     hlint
+    lsp-types
     ormolu
     retrie
     stylish-haskell


### PR DESCRIPTION
ghcide and lsp-types need the same overlay to have a single consistent regex-tdfa in the closure.

Doing the same for GHC 9.6.7 for consistency, even though the build passed there, so far.

## Things done

Can't really test this locally, because the build succeeded for me without this fix, too. It only fails in hydra...

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
