### PR TITLE
devpi-server: 6.15.0 -> 6.17.0

### DIFF
--- a/pkgs/development/tools/devpi-server/default.nix
+++ b/pkgs/development/tools/devpi-server/default.nix
@@ -32,7 +32,7 @@
   nixosTests,
 }:
 
-buildPythonApplication rec {
+buildPythonApplication (finalAttrs: {
   pname = "devpi-server";
   version = "6.17.0";
   pyproject = true;
@@ -42,11 +42,11 @@ buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "devpi";
     repo = "devpi";
-    rev = "server-${version}";
+    tag = "server-${finalAttrs.version}";
     hash = "sha256-YavMvPJQXKyyq+ql5BNUlfRXPsTV2ASzaUCMgyvwT0Y=";
   };
 
-  sourceRoot = "${src.name}/server";
+  sourceRoot = "${finalAttrs.src.name}/server";
 
   postPatch = ''
     substituteInPlace tox.ini \
@@ -131,11 +131,11 @@ buildPythonApplication rec {
   meta = {
     homepage = "http://doc.devpi.net";
     description = "Github-style pypi index server and packaging meta tool";
-    changelog = "https://github.com/devpi/devpi/blob/${src.rev}/server/CHANGELOG";
+    changelog = "https://github.com/devpi/devpi/blob/${finalAttrs.src.tag}/server/CHANGELOG";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       confus
       makefu
     ];
   };
-}
+})

--- a/pkgs/development/tools/devpi-server/default.nix
+++ b/pkgs/development/tools/devpi-server/default.nix
@@ -133,6 +133,9 @@ buildPythonApplication rec {
     description = "Github-style pypi index server and packaging meta tool";
     changelog = "https://github.com/devpi/devpi/blob/${src.rev}/server/CHANGELOG";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ makefu ];
+    maintainers = with lib.maintainers; [
+      confus
+      makefu
+    ];
   };
 }

--- a/pkgs/development/tools/devpi-server/default.nix
+++ b/pkgs/development/tools/devpi-server/default.nix
@@ -37,8 +37,6 @@ buildPythonApplication (finalAttrs: {
   version = "6.17.0";
   pyproject = true;
 
-  disabled = pythonOlder "3.7";
-
   src = fetchFromGitHub {
     owner = "devpi";
     repo = "devpi";
@@ -48,17 +46,12 @@ buildPythonApplication (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/server";
 
-  postPatch = ''
-    substituteInPlace tox.ini \
-      --replace "--flake8" ""
-  '';
-
-  nativeBuildInputs = [
+  buildSystem = [
     setuptools
     setuptools-changelog-shortener
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     aiohttp
     appdirs
     defusedxml
@@ -107,7 +100,7 @@ buildPythonApplication (finalAttrs: {
     "test_devpi_server/test_streaming_replica_nginx.py"
   ];
   disabledTests = [
-    "test_fetch_later_deleted"
+    "test_fetch_later_deleted" # incompatible with newer pytest
   ];
 
   __darwinAllowLocalNetworking = true;

--- a/pkgs/development/tools/devpi-server/default.nix
+++ b/pkgs/development/tools/devpi-server/default.nix
@@ -23,6 +23,7 @@
   pytestCheckHook,
   repoze-lru,
   setuptools,
+  setuptools-changelog-shortener,
   strictyaml,
   waitress,
   webtest,
@@ -33,7 +34,7 @@
 
 buildPythonApplication rec {
   pname = "devpi-server";
-  version = "6.15.0";
+  version = "6.17.0";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -42,7 +43,7 @@ buildPythonApplication rec {
     owner = "devpi";
     repo = "devpi";
     rev = "server-${version}";
-    hash = "sha256-tKR1xZju5bDbFu8t3SunTM8FlaXodSm/OjJ3Jfl7Dzk=";
+    hash = "sha256-YavMvPJQXKyyq+ql5BNUlfRXPsTV2ASzaUCMgyvwT0Y=";
   };
 
   sourceRoot = "${src.name}/server";
@@ -54,6 +55,7 @@ buildPythonApplication rec {
 
   nativeBuildInputs = [
     setuptools
+    setuptools-changelog-shortener
   ];
 
   propagatedBuildInputs = [
@@ -105,12 +107,7 @@ buildPythonApplication rec {
     "test_devpi_server/test_streaming_replica_nginx.py"
   ];
   disabledTests = [
-    "root_passwd_hash_option"
-    "TestMirrorIndexThings"
-    "test_auth_mirror_url_no_hash"
-    "test_auth_mirror_url_with_hash"
-    "test_auth_mirror_url_hidden_in_logs"
-    "test_simplelinks_timeout"
+    "test_fetch_later_deleted"
   ];
 
   __darwinAllowLocalNetworking = true;
@@ -126,7 +123,7 @@ buildPythonApplication rec {
     };
   };
 
-  # devpi uses a monorepo for server,common,client and web
+  # devpi uses a monorepo for server, common, client and web
   passthru.updateScript = gitUpdater {
     rev-prefix = "server-";
   };


### PR DESCRIPTION
bump devpi-server from 6.15.0 to 6.17.0

changelog: https://github.com/devpi/devpi/blob/main/server/CHANGELOG
changeset: https://github.com/devpi/devpi/compare/server-6.15.0...server-6.17.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
