### PR TITLE
nginx: backport update mime-types from freenginx

### DIFF
--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -224,6 +224,21 @@ stdenv.mkDerivation {
         ./nix-etag-1.15.4.patch
         ./nix-skip-check-logs-path.patch
       ]
+      # Backport update mime-types from freenginx.
+      ++ [
+        (fetchpatch {
+          url = "https://github.com/freenginx/nginx/commit/b2f1ac35fe1d458f06008624fdc50ef99844a7bb.patch";
+          sha256 = "sha256-V2pqB6j43te8Q7wOU9GHHRs4Gm22duSiELrwxfD4fgY=";
+        })
+        (fetchpatch {
+          url = "https://github.com/freenginx/nginx/commit/4e12815b7590520417203543ccb7f116444711c9.patch";
+          sha256 = "sha256-ZV7beyblllvhEyuvxlscbEZqisBpO6XyFmJwYMpneYU=";
+        })
+        (fetchpatch {
+          url = "https://github.com/freenginx/nginx/commit/83ed572828ef4a82b2941c536411332242b71060.patch";
+          sha256 = "sha256-zlWUMU4OMyMPUKmWMv5Vg4Ey0G/aTjRbVdvU/Z2a+cE=";
+        })
+      ]
       # Upstream may be against cross-compilation patches.
       # https://trac.nginx.org/nginx/ticket/2240 https://trac.nginx.org/nginx/ticket/1928#comment:6
       # That dev quit the project in 2024 so the stance could be different now.

--- a/pkgs/servers/http/nginx/mainline.nix
+++ b/pkgs/servers/http/nginx/mainline.nix
@@ -1,6 +1,22 @@
-{ callPackage, ... }@args:
+{ callPackage, fetchpatch, ... }@args:
 
 callPackage ./generic.nix args {
   version = "1.29.7";
   hash = "sha256-Zz+PuMCWHET72UENYWGDFFNgm0QGPT8pSCU/wrVpITk=";
+
+  # Backport update mime-types from freenginx.
+  extraPatches = [
+    (fetchpatch {
+      url = "https://github.com/freenginx/nginx/commit/77ee09313a4281d891f9fa0bf325de36e9a8c933.patch";
+      sha256 = "sha256-1SB+SwtHx1zU31S3EVUs73b57LIRxD5jr5FHqAgluqM=";
+    })
+    (fetchpatch {
+      url = "https://github.com/freenginx/nginx/commit/6e44afc355ae5262506bdbf9d692d5cc7cb20994.patch";
+      sha256 = "sha256-pKlXcXPGjmvtPH2P2ewkakjNrQ4w/x3Y2GHjgg4OdIg=";
+    })
+    (fetchpatch {
+      url = "https://github.com/freenginx/nginx/commit/c85785e4116e6b175946682fc6d17d32312c20ee.patch";
+      sha256 = "sha256-gKXMUHCBiahpfNTgBUoxm5haCweAIHZHHCGL72QkoGA=";
+    })
+  ];
 }

--- a/pkgs/servers/http/nginx/stable.nix
+++ b/pkgs/servers/http/nginx/stable.nix
@@ -1,6 +1,22 @@
-{ callPackage, ... }@args:
+{ callPackage, fetchpatch, ... }@args:
 
 callPackage ./generic.nix args {
   version = "1.28.3";
   hash = "sha256-LJapRr+wiCohdE7UKXcKISOuGCjHxIZlCSmT3e6RqRg=";
+
+  # Backport update mime-types from freenginx.
+  extraPatches = [
+    (fetchpatch {
+      url = "https://github.com/freenginx/nginx/commit/77ee09313a4281d891f9fa0bf325de36e9a8c933.patch";
+      sha256 = "sha256-1SB+SwtHx1zU31S3EVUs73b57LIRxD5jr5FHqAgluqM=";
+    })
+    (fetchpatch {
+      url = "https://github.com/freenginx/nginx/commit/6e44afc355ae5262506bdbf9d692d5cc7cb20994.patch";
+      sha256 = "sha256-pKlXcXPGjmvtPH2P2ewkakjNrQ4w/x3Y2GHjgg4OdIg=";
+    })
+    (fetchpatch {
+      url = "https://github.com/freenginx/nginx/commit/c85785e4116e6b175946682fc6d17d32312c20ee.patch";
+      sha256 = "sha256-gKXMUHCBiahpfNTgBUoxm5haCweAIHZHHCGL72QkoGA=";
+    })
+  ];
 }

--- a/pkgs/servers/http/openresty/default.nix
+++ b/pkgs/servers/http/openresty/default.nix
@@ -3,6 +3,7 @@
   runCommand,
   lib,
   fetchurl,
+  fetchpatch,
   perl,
   libpq,
   nixosTests,
@@ -40,6 +41,28 @@ callPackage ../nginx/generic.nix args rec {
   ];
 
   buildInputs = [ libpq ];
+
+  # Backport update mime-types from freenginx.
+  extraPatches = [
+    (fetchpatch {
+      url = "https://github.com/freenginx/nginx/commit/77ee09313a4281d891f9fa0bf325de36e9a8c933.patch";
+      sha256 = "sha256-tSfHRKYqf1HTvzOE483UzkqqWv7aX/z9Xn5AR21+zFo=";
+      extraPrefix = "bundle/nginx-${nginxVersion}/";
+      stripLen = 1;
+    })
+    (fetchpatch {
+      url = "https://github.com/freenginx/nginx/commit/6e44afc355ae5262506bdbf9d692d5cc7cb20994.patch";
+      sha256 = "sha256-rzfEG6AqMHHtWFTtasQ6sG3equPx9yeR/B5sR42hp54=";
+      extraPrefix = "bundle/nginx-${nginxVersion}/";
+      stripLen = 1;
+    })
+    (fetchpatch {
+      url = "https://github.com/freenginx/nginx/commit/c85785e4116e6b175946682fc6d17d32312c20ee.patch";
+      sha256 = "sha256-xtHe5MQiVsNCgs5O/byFEbFaQo0/F6W3muy9+Ak3Qr4=";
+      extraPrefix = "bundle/nginx-${nginxVersion}/";
+      stripLen = 1;
+    })
+  ];
 
   postPatch = ''
     substituteInPlace bundle/nginx-${nginxVersion}/src/http/ngx_http_core_module.c \

--- a/pkgs/servers/http/tengine/default.nix
+++ b/pkgs/servers/http/tengine/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   openssl,
   zlib,
   pcre,
@@ -53,6 +54,33 @@ stdenv.mkDerivation rec {
     ../nginx/nix-etag-1.15.4.patch
     ./check-resolv-conf.patch
     ../nginx/nix-skip-check-logs-path.patch
+  ]
+  # Backport update mime-types from freenginx.
+  ++ [
+    (fetchpatch {
+      url = "https://github.com/freenginx/nginx/commit/77ee09313a4281d891f9fa0bf325de36e9a8c933.patch";
+      sha256 = "sha256-1SB+SwtHx1zU31S3EVUs73b57LIRxD5jr5FHqAgluqM=";
+    })
+    (fetchpatch {
+      url = "https://github.com/freenginx/nginx/commit/6e44afc355ae5262506bdbf9d692d5cc7cb20994.patch";
+      sha256 = "sha256-pKlXcXPGjmvtPH2P2ewkakjNrQ4w/x3Y2GHjgg4OdIg=";
+    })
+    (fetchpatch {
+      url = "https://github.com/freenginx/nginx/commit/c85785e4116e6b175946682fc6d17d32312c20ee.patch";
+      sha256 = "sha256-gKXMUHCBiahpfNTgBUoxm5haCweAIHZHHCGL72QkoGA=";
+    })
+    (fetchpatch {
+      url = "https://github.com/freenginx/nginx/commit/b2f1ac35fe1d458f06008624fdc50ef99844a7bb.patch";
+      sha256 = "sha256-V2pqB6j43te8Q7wOU9GHHRs4Gm22duSiELrwxfD4fgY=";
+    })
+    (fetchpatch {
+      url = "https://github.com/freenginx/nginx/commit/4e12815b7590520417203543ccb7f116444711c9.patch";
+      sha256 = "sha256-ZV7beyblllvhEyuvxlscbEZqisBpO6XyFmJwYMpneYU=";
+    })
+    (fetchpatch {
+      url = "https://github.com/freenginx/nginx/commit/83ed572828ef4a82b2941c536411332242b71060.patch";
+      sha256 = "sha256-zlWUMU4OMyMPUKmWMv5Vg4Ey0G/aTjRbVdvU/Z2a+cE=";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
Backport update mime-types from freenginx.

Now in nginx the mime.types parameter is in a frozen state and is unlikely to accept new types.

By default, NixOS uses the `mime.types` file from the `mailcap` package, which uses the `text/javascript` type for `.js` files, but the nginx source code hardcodes the `application/javascript` type. This PR fixes a type conflict.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
