### PR TITLE
rstudio: fix hardcoded /usr/bin/which paths

### DIFF
--- a/pkgs/by-name/rs/rstudio/package.nix
+++ b/pkgs/by-name/rs/rstudio/package.nix
@@ -10,7 +10,7 @@
   fetchzip,
   replaceVars,
   runCommand,
-
+  which,
   ant,
   cacert,
   cmake,
@@ -217,6 +217,14 @@ stdenv.mkDerivation rec {
   ];
 
   postPatch = ''
+    # fix hardcoded paths to /usr/bin/which
+    substituteInPlace \
+    src/node/desktop/src/main/detect-r.ts \
+    src/node/desktop/src/main/gwt-callback.ts \
+    src/cpp/session/modules/clang/CodeCompletion.cpp \
+    src/cpp/core/system/PosixSystemTests.cpp \
+    --replace-fail "/usr/bin/which" "${lib.getExe which}"
+
     # fix .desktop Exec field
     substituteInPlace src/node/desktop/resources/freedesktop/rstudio.desktop.in \
       --replace-fail "\''${CMAKE_INSTALL_PREFIX}/rstudio" "rstudio"


### PR DESCRIPTION
rstudio: fix hardcoded /usr/bin/which paths

Replaced impure hardcoded paths with `substituteInPlace` to fix build on NixOS.
Necessary because `/usr/bin/which` does not exist on NixOS and results in a  runtime crash. Discussed at https://discourse.nixos.org/t/rstudio-bug-segmentation-fault/73012/10

Found the following files using grep and patched them:
* src/node/desktop/src/main/detect-r.ts
* src/node/desktop/src/main/gwt-callback.ts
* src/cpp/session/modules/clang/CodeCompletion.cpp
* src/cpp/core/system/PosixSystemTests.cpp

cc  @ciil @tomasajt

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
