### PR TITLE
Revert "desync: enable tests"

### DIFF
--- a/pkgs/by-name/de/desync/package.nix
+++ b/pkgs/by-name/de/desync/package.nix
@@ -21,21 +21,8 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  # required for TestHTTPHandlerReadWrite and other tests
-  __darwinAllowLocalNetworking = true;
-
-  checkFlags =
-    let
-      skippedTests = [
-        "TestMountIndex" # FUSE does not work in sandbox
-      ]
-      ++ lib.optionals stdenv.hostPlatform.isDarwin [
-        # sendfile is not permitted in Darwin sandbox
-        "TestS3StoreGetChunk/fail"
-        "TestS3StoreGetChunk/recover"
-      ];
-    in
-    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
+  # nix builder doesn't have access to test data; tests fail for reasons unrelated to binary being bad.
+  doCheck = false;
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd desync \


### PR DESCRIPTION
This reverts commit 600c38c8b2d55a17ba771a255f570d0ba57c91d9.

Revert https://github.com/NixOS/nixpkgs/pull/469469

Doesn't pass on ofborg: https://logs.ofborg.org/?key=nixos/nixpkgs.469469&attempt_id=6759bfbc-90d6-42a1-917f-b9f5916fc2da

Doesn't pass on hydra: https://hydra.nixos.org/build/316133658

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
