### PR TITLE
wifitui: init at 0.8.0

### DIFF
--- a/pkgs/by-name/wi/wifitui/package.nix
+++ b/pkgs/by-name/wi/wifitui/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule (finalAttrs: {
+  pname = "wifitui";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "shazow";
+    repo = "wifitui";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JFs+7MDc0/hIDrefSRLWXurwJvvpR7LHJmCvmO1lpHA=";
+  };
+
+  vendorHash = "sha256-SEQPc13cefzT8SyuD3UmNtTDgcrXUGTX54SBrnOHJJw=";
+
+  ldflags = [
+    "-X main.Version=${finalAttrs.version}"
+  ];
+
+  meta = {
+    description = "Fast featureful friendly wifi terminal UI";
+    mainProgram = "wifitui";
+    homepage = "https://github.com/shazow/wifitui";
+    changelog = "https://github.com/shazow/wifitui/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      shazow
+    ];
+    # wifitui has partial/experimental darwin support but mainly linux focused;
+    # if someone needs this then would appreciate a darwin co-maintainer,
+    # see: https://github.com/shazow/wifitui/issues/49
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
wifitui is a fast, featureful, and friendly replacement for nmtui.

wifitui is already packaged on AUR and slackware's package managers, a few people requested it for nixpkgs (https://github.com/shazow/wifitui/issues/87). 

I am the author and also a NixOS user. :)

This PR supersedes https://github.com/NixOS/nixpkgs/pull/452665

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
