### PR TITLE
windsurf: 1.12.39 -> 1.12.41

### DIFF
--- a/pkgs/by-name/wi/windsurf/info.json
+++ b/pkgs/by-name/wi/windsurf/info.json
@@ -1,20 +1,20 @@
 {
   "aarch64-darwin": {
-    "version": "1.12.39",
-    "vscodeVersion": "1.105.0",
-    "url": "https://windsurf-stable.codeiumdata.com/darwin-arm64/stable/10ebfa84f4e8b018ef2459063f0293b8e9ac01da/Windsurf-darwin-arm64-1.12.39.zip",
-    "sha256": "1f1af7d5dcaf1314f86a8082dcc28406bca86b92a29048ef296107cdea72a74e"
+    "version": "1.12.41",
+    "vscodeVersion": "1.106.0",
+    "url": "https://windsurf-stable.codeiumdata.com/darwin-arm64/stable/67a0e4728145d7f5a320e1ee4e42e2aeca3fb9e9/Windsurf-darwin-arm64-1.12.41.zip",
+    "sha256": "5d3660150dfd7a7fe68b8698773579ca578bd802605a86de195a24e52b810a58"
   },
   "x86_64-darwin": {
-    "version": "1.12.39",
-    "vscodeVersion": "1.105.0",
-    "url": "https://windsurf-stable.codeiumdata.com/darwin-x64/stable/10ebfa84f4e8b018ef2459063f0293b8e9ac01da/Windsurf-darwin-x64-1.12.39.zip",
-    "sha256": "f422f2148be8e1d824abcd5ed18c86838d5edbb7f91244dcc51e142e9b5ac743"
+    "version": "1.12.41",
+    "vscodeVersion": "1.106.0",
+    "url": "https://windsurf-stable.codeiumdata.com/darwin-x64/stable/67a0e4728145d7f5a320e1ee4e42e2aeca3fb9e9/Windsurf-darwin-x64-1.12.41.zip",
+    "sha256": "0fd523b4c08fc643de57f0a9ec62f28bc95bb1f75e5aceb6d1648d4990b5bfa1"
   },
   "x86_64-linux": {
-    "version": "1.12.39",
-    "vscodeVersion": "1.105.0",
-    "url": "https://windsurf-stable.codeiumdata.com/linux-x64/stable/10ebfa84f4e8b018ef2459063f0293b8e9ac01da/Windsurf-linux-x64-1.12.39.tar.gz",
-    "sha256": "ce36ec8697ca7c9768678b99b9b8b364d33a044afed242931fea14f544581c68"
+    "version": "1.12.41",
+    "vscodeVersion": "1.106.0",
+    "url": "https://windsurf-stable.codeiumdata.com/linux-x64/stable/67a0e4728145d7f5a320e1ee4e42e2aeca3fb9e9/Windsurf-linux-x64-1.12.41.tar.gz",
+    "sha256": "b59737b9c4e540bcb754bf7fb45f46198777dbb997617b8359d5ed53266b4997"
   }
 }


### PR DESCRIPTION
Features & Tools
Cascade Hooks on User Prompts
Users can now configure Cascade Hooks on user prompts for logging all user prompts and blocking policy-violating prompts.

MCP Servers
Added support for GitLab remote MCP.
Added OAuth support for GitHub remote MCP.
Fixed an issue where every MCP would reauth on opening Windsurf.
Added support for [MCP prompts](https://modelcontextprotocol.io/docs/concepts/prompts)
Added toggles to enable/disable MCPs in the Cascade header
Diff Zones
Fixes issues with diff zones not rendering correctly or jumping to the end of a file when editing
Tab (Supercomplete)
Improves reliability of Tab autocomplete
Makes Tab more responsive and faster in the appropriate circumstances

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
