### PR TITLE
pnpm.fetchDeps: output a tarball from fetcherVersion 3

### DIFF
--- a/doc/languages-frameworks/javascript.section.md
+++ b/doc/languages-frameworks/javascript.section.md
@@ -354,7 +354,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm.fetchDeps {
     inherit (finalAttrs) pname version src;
-    fetcherVersion = 2;
+    fetcherVersion = 3;
     hash = "...";
   };
 })
@@ -501,6 +501,7 @@ Changes can include workarounds or bug fixes to existing PNPM issues.
 
 - 1: Initial version, nothing special
 - 2: [Ensure consistent permissions](https://github.com/NixOS/nixpkgs/pull/422975)
+- 3: [Build a reproducible tarball](https://github.com/NixOS/nixpkgs/pull/469950)
 
 ### Yarn {#javascript-yarn}
 

--- a/pkgs/by-name/ba/bash-language-server/package.nix
+++ b/pkgs/by-name/ba/bash-language-server/package.nix
@@ -28,8 +28,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       src
       pnpmWorkspaces
       ;
-    fetcherVersion = 1;
-    hash = "sha256-NvyqPv5OKgZi3hW98Da8LhsYatmrzrPX8kLOfLr+BrI=";
+    fetcherVersion = 3;
+    hash = "sha256-6i+1V3ZkjiJ/IXDun3JfwmfDOiemxCmAXMzS/rGT6ZU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/tools/pnpm/fetch-deps/pnpm-config-hook.sh
+++ b/pkgs/development/tools/pnpm/fetch-deps/pnpm-config-hook.sh
@@ -12,10 +12,7 @@ pnpmConfigHook() {
       exit 1
     fi
 
-    fetcherVersion=1
-    if [[ -e "${pnpmDeps}/.fetcher-version" ]]; then
-      fetcherVersion=$(cat "${pnpmDeps}/.fetcher-version")
-    fi
+    fetcherVersion=$(cat "${pnpmDeps}/.fetcher-version" || echo 1)
 
     echo "Using fetcherVersion: $fetcherVersion"
 
@@ -26,7 +23,12 @@ pnpmConfigHook() {
     export npm_config_arch="@npmArch@"
     export npm_config_platform="@npmPlatform@"
 
-    cp -Tr "$pnpmDeps" "$STORE_PATH"
+    if [[ $fetcherVersion -ge 3 ]]; then
+      tar --zstd -xf "$pnpmDeps/pnpm-store.tar.zst" -C "$STORE_PATH"
+    else
+      cp -Tr "$pnpmDeps" "$STORE_PATH"
+    fi
+
     chmod -R +w "$STORE_PATH"
 
 


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/376299#discussion_r1929997815.

This reduced `bash-language-server.pnpmDeps` from 118M to 21M.

If we want to do a treewide version update, it should be in a separate PR.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
