### PR TITLE
[Backport release-25.11] micromamba: simplify by copying executable from mamba-cpp

### DIFF
--- a/pkgs/by-name/mi/micromamba/package.nix
+++ b/pkgs/by-name/mi/micromamba/package.nix
@@ -2,9 +2,11 @@
   lib,
   stdenv,
   mamba-cpp,
+  testers,
+  runCommand,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "micromamba";
   version = mamba-cpp.version;
 
@@ -14,12 +16,50 @@ stdenv.mkDerivation {
 
   installPhase = ''
     mkdir -p $out/bin
-    ln -s ${mamba-cpp}/bin/mamba $out/bin/micromamba
+
+    # We copy the binary instead of symlinking.
+    # Mamba determines its identity (mamba vs micromamba) by reading /proc/self/exe.
+    # If we symlink, it resolves to 'mamba', causing shell init scripts to fail.
+    # Ref: <https://github.com/NixOS/nixpkgs/pull/460788#issuecomment-3585230714>
+    cp ${mamba-cpp}/bin/mamba $out/bin/micromamba
   '';
+
+  passthru.tests = {
+    # 1. Standard version check
+    version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+      command = "micromamba --version";
+    };
+
+    # 2. Regression test for the shell initialization issue
+    # This ensures that after sourcing the shell hook, `micromamba activate` works.
+    # If the binary were a symlink resolving to 'mamba', the hook would define a
+    # `mamba()` function instead of `micromamba()`, causing `micromamba activate` to fail.
+    shell-init =
+      runCommand "test-micromamba-shell-hook"
+        {
+          nativeBuildInputs = [ finalAttrs.finalPackage ];
+        }
+        ''
+          # The shell hook includes 'complete' commands for bash completion,
+          # which fail in non-interactive bash. We temporarily ignore errors
+          # during eval since we only care about the function definition.
+          set +e
+          eval "$(micromamba shell hook --shell bash)" 2>/dev/null
+          set -e
+
+          # Test that the micromamba function works (not mamba).
+          # If shell initialization fails above, then we expect to see an
+          # error beginning with something like:
+          #     'mamba' is running as a subprocess and can't modify the parent shell.
+          micromamba activate
+
+          touch $out
+        '';
+  };
 
   meta = mamba-cpp.meta // {
     maintainers = with lib.maintainers; [ mausch ];
     mainProgram = "micromamba";
   };
-
-}
+})

--- a/pkgs/by-name/mi/micromamba/package.nix
+++ b/pkgs/by-name/mi/micromamba/package.nix
@@ -1,80 +1,25 @@
 {
   lib,
   stdenv,
-  fetchFromGitHub,
-  fetchpatch,
-  bzip2,
-  cli11,
-  cmake,
-  curl,
-  ghc_filesystem,
-  libarchive,
-  libsolv,
-  yaml-cpp,
-  nlohmann_json,
-  python3,
-  reproc,
-  spdlog,
-  tl-expected,
+  mamba-cpp,
 }:
 
-let
-  libsolv' = libsolv.overrideAttrs (oldAttrs: {
-    cmakeFlags = oldAttrs.cmakeFlags ++ [
-      "-DENABLE_CONDA=true"
-    ];
-
-    patches = [
-      # Apply the same patch as in the "official" boa-forge build:
-      # https://github.com/mamba-org/boa-forge/tree/master/libsolv
-      (fetchpatch {
-        url = "https://raw.githubusercontent.com/mamba-org/boa-forge/20530f80e2e15012078d058803b6e2c75ed54224/libsolv/conda_variant_priorization.patch";
-        sha256 = "1iic0yx7h8s662hi2jqx68w5kpyrab4fr017vxd4wyxb6wyk35dd";
-      })
-    ];
-  });
-in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "micromamba";
-  version = "1.5.8";
+  version = mamba-cpp.version;
 
-  src = fetchFromGitHub {
-    owner = "mamba-org";
-    repo = "mamba";
-    rev = "micromamba-" + version;
-    hash = "sha256-sxZDlMFoMLq2EAzwBVO++xvU1C30JoIoZXEX/sqkXS0=";
-  };
+  dontUnpack = true;
+  dontBuild = true;
+  dontConfigure = true;
 
-  nativeBuildInputs = [ cmake ];
+  installPhase = ''
+    mkdir -p $out/bin
+    ln -s ${mamba-cpp}/bin/mamba $out/bin/micromamba
+  '';
 
-  buildInputs = [
-    bzip2
-    cli11
-    nlohmann_json
-    curl
-    libarchive
-    yaml-cpp
-    libsolv'
-    reproc
-    spdlog
-    ghc_filesystem
-    python3
-    tl-expected
-  ];
-
-  cmakeFlags = [
-    "-DBUILD_LIBMAMBA=ON"
-    "-DBUILD_SHARED=ON"
-    "-DBUILD_MICROMAMBA=ON"
-    # "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
-  ];
-
-  meta = {
-    description = "Reimplementation of the conda package manager";
-    homepage = "https://github.com/mamba-org/mamba";
-    license = lib.licenses.bsd3;
-    platforms = lib.platforms.all;
+  meta = mamba-cpp.meta // {
     maintainers = with lib.maintainers; [ mausch ];
     mainProgram = "micromamba";
   };
+
 }


### PR DESCRIPTION
Manual backport of #465610 to fix merge conflicts in the auto backport #469562 (which this PR supersedes)

**Reason for backporting**: micromamba fails to build on 25.11, whereas on unstable, this is fixed by copying the executable from mamba-cpp.

Note that this backport bumps micromamba from 1.5.x to 2.3.x, but that's arguably better than having it be broken.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
