### PR TITLE
nixos/repart-verity-store: expose data corruption on xhci

### DIFF
--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -99,6 +99,8 @@ let
       device =
         if cfg.qemu.diskInterface == "scsi" then
           "-device lsi53c895a -device scsi-hd,${deviceOpts}"
+        else if cfg.qemu.diskInterface == "xhci" then
+          "-device nec-usb-xhci,id=xhci -device usb-storage,bus=xhci.0,${deviceOpts}"
         else
           "-device virtio-blk-pci,${deviceOpts}";
     in
@@ -863,6 +865,7 @@ in
           "virtio"
           "scsi"
           "ide"
+          "xhci"
         ];
         default = "virtio";
         example = "scsi";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -242,6 +242,7 @@ in
   apparmor = runTest ./apparmor;
   appliance-repart-image = runTest ./appliance-repart-image.nix;
   appliance-repart-image-verity-store = runTest ./appliance-repart-image-verity-store.nix;
+  appliance-repart-image-verity-store-usb = runTest ./appliance-repart-image-verity-store-usb.nix;
   aria2 = runTest ./aria2.nix;
   armagetronad = runTest ./armagetronad.nix;
   artalk = runTest ./artalk.nix;

--- a/nixos/tests/appliance-repart-image-verity-store-usb.nix
+++ b/nixos/tests/appliance-repart-image-verity-store-usb.nix
@@ -1,0 +1,134 @@
+# similar to the appliance-repart-image test but with a dm-verity
+# protected nix store and tmpfs as rootfs
+{ lib, ... }:
+
+{
+  name = "appliance-repart-image-verity-store-usb";
+
+  meta.maintainers = with lib.maintainers; [
+    nikstur
+    willibutz
+  ];
+
+  nodes.machine =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      inherit (config.image.repart.verityStore) partitionIds;
+    in
+    {
+      imports = [ ../modules/image/repart.nix ];
+
+      virtualisation.fileSystems = lib.mkVMOverride {
+        "/" = {
+          fsType = "tmpfs";
+          options = [ "mode=0755" ];
+        };
+
+        # bind-mount the store
+        "/nix/store" = {
+          device = "/usr/nix/store";
+          options = [ "bind" ];
+        };
+      };
+
+      image.repart = {
+        verityStore = {
+          enable = true;
+          # by default the module works with systemd-boot, for simplicity this test directly boots the UKI
+          ukiPath = "/EFI/BOOT/BOOT${lib.toUpper config.nixpkgs.hostPlatform.efiArch}.EFI";
+        };
+
+        name = "appliance-verity-store-image";
+
+        partitions = {
+          ${partitionIds.esp} = {
+            # the UKI is injected into this partition by the verityStore module
+            repartConfig = {
+              Type = "esp";
+              Format = "vfat";
+              SizeMinBytes = if config.nixpkgs.hostPlatform.isx86_64 then "64M" else "96M";
+            };
+          };
+          ${partitionIds.store-verity}.repartConfig = {
+            Minimize = "best";
+          };
+          ${partitionIds.store}.repartConfig = {
+            Minimize = "best";
+          };
+        };
+      };
+
+      virtualisation = {
+        directBoot.enable = false;
+        mountHostNixStore = false;
+        useEFIBoot = true;
+
+        qemu.diskInterface = "xhci";
+      };
+
+      boot = {
+        loader.grub.enable = false;
+        initrd = {
+          systemd.enable = true;
+          availableKernelModules = [
+            "ahci"
+            "uas"
+          ];
+        };
+        kernelParams = [
+          "systemd.verity_root_options=panic-on-corruption"
+        ];
+      };
+
+      system.image = {
+        id = "nixos-appliance";
+        version = "1";
+      };
+
+      # don't create /usr/bin/env
+      # this would require some extra work on read-only /usr
+      # and it is not a strict necessity
+      system.activationScripts.usrbinenv = lib.mkForce "";
+    };
+
+  testScript =
+    { nodes, ... }: # python
+    ''
+      import os
+      import subprocess
+      import tempfile
+
+      tmp_disk_image = tempfile.NamedTemporaryFile()
+
+      subprocess.run([
+        "${nodes.machine.virtualisation.qemu.package}/bin/qemu-img",
+        "create",
+        "-f",
+        "qcow2",
+        "-b",
+        "${nodes.machine.system.build.finalImage}/${nodes.machine.image.repart.imageFile}",
+        "-F",
+        "raw",
+        tmp_disk_image.name,
+      ])
+
+      os.environ['NIX_DISK_IMAGE'] = tmp_disk_image.name
+
+      machine.wait_for_unit("default.target")
+
+      with subtest("Running with volatile root"):
+        machine.succeed("findmnt --kernel --type tmpfs /")
+
+      with subtest("/nix/store is backed by dm-verity protected fs"):
+        verity_info = machine.succeed("dmsetup info --target verity usr")
+        assert "ACTIVE" in verity_info,f"unexpected verity info: {verity_info}"
+
+        backing_device = machine.succeed("df --output=source /nix/store | tail -n1").strip()
+        assert "/dev/mapper/usr" == backing_device,"unexpected backing device: {backing_device}"
+    '';
+}


### PR DESCRIPTION
Opening as a pull request, but this is mostly a bug report.

When booting a dm-verity backed image on a USB drive, the kernel will report data corruption:
```
vm-test-run-appliance-repart-image-verity-store-usb> machine # [    3.989316] systemd[1]: Starting NixOS Activation...
vm-test-run-appliance-repart-image-verity-store-usb> machine # [    4.159470] device-mapper: verity: 8:3: metadata block 111718 is corrupted
vm-test-run-appliance-repart-image-verity-store-usb> machine # [    4.163204] device-mapper: verity: 8:3: metadata block 111719 is corrupted
vm-test-run-appliance-repart-image-verity-store-usb> machine # [    4.164262] device-mapper: verity: 8:3: metadata block 111719 is corrupted
vm-test-run-appliance-repart-image-verity-store-usb> machine # [    4.165916] device-mapper: verity: 8:3: metadata block 111719 is corrupted
vm-test-run-appliance-repart-image-verity-store-usb> machine # [    4.047041] systemd[1]: initrd-nixos-activation.service: Main process exited, code=dumped, status=7/BUS
```

It might not necessarily reproduce every time, it usually takes 2-3 attempt to reproduce.

This only appears to be the case on XHCI (XHCI=usb3, could not reproduce on EHCI (usb2)).

I can't observe any corruption when using `veritysetup verify`. I tend to believe this is a kernel bug, but I'm open to suggestions.