### PR TITLE
Fix CVS on Darwin

### DIFF
--- a/pkgs/by-name/cv/cvs/package.nix
+++ b/pkgs/by-name/cv/cvs/package.nix
@@ -24,10 +24,6 @@ stdenv.mkDerivation {
 
   patches = [
     ./getcwd-chroot.patch
-    (fetchpatch {
-      url = "https://raw.githubusercontent.com/Homebrew/formula-patches/24118ec737c7/cvs/vasnprintf-high-sierra-fix.diff";
-      sha256 = "1ql6aaia7xkfq3vqhlw5bd2z2ywka82zk01njs1b2szn699liymg";
-    })
     # Debian Patchset,
     # contains patches for CVE-2017-12836 and CVE-2012-0804 among other things
     (fetchurl {


### PR DESCRIPTION
Currently, invocations of CVS (and by extension `fetchcvs`) usually die immediately on Darwin with

    cvs [checkout aborted]: received abort signal

The root cause is a Homebrew patch that is incompatible with the Debian patchset.  Currently nixpkgs pulls in both.  This commit fixes the problem by removing the Homebrew patch.

This is the Homebrew patch:

    --- a/lib/vasnprintf.c  2017-01-01 00:00:00.000000000 -0000
    +++ b/lib/vasnprintf.c  2017-01-01 00:00:00.000000000 -0000
    @@ -558,11 +558,13 @@
              }
            *p = dp->conversion;
     #if USE_SNPRINTF
    +# if ! (defined __APPLE__ && defined __MACH__)
            p[1] = '%';
            p[2] = 'n';
            p[3] = '\0';
    -#else
    +# else
            p[1] = '\0';
    +# endif
     #endif

            /* Construct the arguments for calling snprintf or sprintf.  */

A close inspection reveals that the patch misbehaves when `USE_SNPRINTF == 0`:

 - Without the patch, the line `p[1] = '\0';` would run.
 - With the patch, the entire block is skipped, and no 0 byte is written anywhere!

The patch normally works because on Darwin `USE_SNPRINTF == 1`.  But the Debian patchset hard-codes `USE_SNPRINTF == 0`:

    +#if 0
    +/* disabled for security reasons, to avoid having %n in writable memory */
     # define USE_SNPRINTF (HAVE_DECL__SNPRINTF || HAVE_SNPRINTF)
    +#else
    +# define USE_SNPRINTF 0
    +#endif

All this is to say that we don't need both patches.  The Debian patchset alone suffices.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
