### PR TITLE
busybox: 1.36.1 -> 1.37.0

### DIFF
--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -57,14 +57,14 @@ in
 
 stdenv.mkDerivation rec {
   pname = "busybox";
-  version = "1.36.1";
+  version = "1.37.0";
 
   # Note to whoever is updating busybox: please verify that:
   # nix-build pkgs/stdenv/linux/make-bootstrap-tools.nix -A test
   # still builds after the update.
   src = fetchurl {
     url = "https://busybox.net/downloads/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-uMwkyVdNgJ5yecO+NJeVxdXOtv3xnKcJ+AzeUOR94xQ=";
+    sha256 = "sha256-MxHf8y50ZJn03w1d8E1+s5Y4LX4Qi7klDntRm4NwQ6Q=";
   };
 
   hardeningDisable = [
@@ -77,53 +77,9 @@ stdenv.mkDerivation rec {
     # necessary when it's run from the Nix store as <hash>-busybox during
     # stdenv bootstrap.
     ./busybox-in-store.patch
-    # libbb: sockaddr2str: ensure only printable characters are returned for the hostname part
-    (fetchurl {
-      name = "CVE-2022-28391.patch";
-      url = "https://git.alpinelinux.org/aports/plain/main/busybox/0001-libbb-sockaddr2str-ensure-only-printable-characters-.patch?id=ed92963eb55bbc8d938097b9ccb3e221a94653f4";
-      sha256 = "sha256-yviw1GV+t9tbHbY7YNxEqPi7xEreiXVqbeRyf8c6Awo=";
-    })
-    # nslookup: sanitize all printed strings with printable_string
-    (fetchurl {
-      name = "CVE-2022-28391.patch";
-      url = "https://git.alpinelinux.org/aports/plain/main/busybox/0002-nslookup-sanitize-all-printed-strings-with-printable.patch?id=ed92963eb55bbc8d938097b9ccb3e221a94653f4";
-      sha256 = "sha256-vl1wPbsHtXY9naajjnTicQ7Uj3N+EQ8pRNnrdsiow+w=";
-    })
-    # shell: avoid segfault on ${0::0/0~09J}
-    # See also: https://bugs.busybox.net/show_bug.cgi?id=15216
-    (fetchpatch {
-      name = "CVE-2022-48174.patch";
-      url = "https://git.busybox.net/busybox/patch/?id=d417193cf37ca1005830d7e16f5fa7e1d8a44209";
-      hash = "sha256-mpDEwYncpU6X6tmtj9xM2KCrB/v2ys5bYxmPPrhm6es=";
-    })
-    # Make sure we don't read past the end of the string in next_token()
-    # when backslash is the last character in an (invalid) regexp.
-    # See also: https://bugs.busybox.net/show_bug.cgi?id=15874
-    # This patch is also used by Alpine, see https://git.alpinelinux.org/aports/tree/main/busybox/0037-awk.c-fix-CVE-2023-42366-bug-15874.patch
-    (fetchpatch {
-      name = "CVE-2023-42366.patch";
-      url = "https://bugs.busybox.net/attachment.cgi?id=9697";
-      hash = "sha256-2eYfLZLjStea9apKXogff6sCAdG9yHx0ZsgUBaGfQIA=";
-    })
-    # awk: fix use after free (CVE-2023-42363)
-    # See also: https://bugs.busybox.net/show_bug.cgi?id=15865
-    (fetchpatch {
-      name = "CVE-2023-42363.patch";
-      url = "https://git.launchpad.net/ubuntu/+source/busybox/plain/debian/patches/CVE-2023-42363.patch?id=c9d8a323b337d58e302717d41796aa0242963d5a";
-      hash = "sha256-1W9Q8+yFkYQKzNTrvndie8QuaEbyAFL1ZASG2fPF+Z4=";
-    })
-    # awk: fix ternary operator and precedence of =
-    # See also: https://bugs.busybox.net/show_bug.cgi?id=15871 https://bugs.busybox.net/show_bug.cgi?id=15868
-    (fetchpatch {
-      name = "CVE-2023-42364_CVE-2023-42365.patch";
-      url = "https://git.alpinelinux.org/aports/plain/main/busybox/CVE-2023-42364-CVE-2023-42365.patch?id=8a4bf5971168bf48201c05afda7bee0fbb188e13";
-      hash = "sha256-nQPgT9eA1asCo38Z9X7LR9My0+Vz5YBPba3ARV3fWcc=";
-    })
-    # tar: fix TOCTOU symlink race condition
-    (fetchurl {
-      url = "https://git.alpinelinux.org/aports/plain/main/busybox/0001-tar-fix-TOCTOU-symlink-race-condition.patch?id=9e42dea5fba84a8afad1f1910b7d3884128a567e";
-      hash = "sha256-GmXQhwB1/IPVjXXpGi5RjRvuGJgIMIb7lQKB63m306g=";
-    })
+    # Fix aarch64 build failure: sha1_process_block64_shaNI is x86-specific
+    # https://lists.busybox.net/pipermail/busybox/2024-September/090943.html
+    ./fix-aarch64-sha1.patch
   ]
   ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) ./clang-cross.patch;
 

--- a/pkgs/os-specific/linux/busybox/fix-aarch64-sha1.patch
+++ b/pkgs/os-specific/linux/busybox/fix-aarch64-sha1.patch
@@ -1,0 +1,24 @@
+From upstream commit fixing aarch64 build failure
+
+The sha1_process_block64_shaNI function is x86-specific and needs
+architecture guards to prevent undeclared function errors on ARM64
+and other non-x86 platforms.
+
+This fixes the compile error: 'sha1_process_block64_shaNI' undeclared
+(first use in this function)
+
+Reference: https://lists.busybox.net/pipermail/busybox/2024-September/090943.html
+Upstream patch: https://www.mail-archive.com/busybox@busybox.net/msg29511.html
+
+--- a/libbb/hash_md5_sha.c
++++ b/libbb/hash_md5_sha.c
+@@ -1313,7 +1313,9 @@ unsigned FAST_FUNC sha1_end(sha1_ctx_t *ctx, void *resbuf)
+ 	hash_size = 8;
+ 	if (ctx->process_block == sha1_process_block64
+ #if ENABLE_SHA1_HWACCEL
++# if defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
+ 	 || ctx->process_block == sha1_process_block64_shaNI
++# endif
+ #endif
+ 	) {
+ 		hash_size = 5;


### PR DESCRIPTION
## Description

Update busybox from 1.36.1 to 1.37.0.

This removes the backported CVE patches that are now included upstream in 1.37.0:
- CVE-2022-28391 (sockaddr2str/nslookup printable character sanitization)
- CVE-2022-48174 (shell segfault on malformed input)
- CVE-2023-42363, CVE-2023-42364, CVE-2023-42365, CVE-2023-42366 (awk use-after-free and parsing fixes)
- tar TOCTOU symlink race condition

Adds `fix-aarch64-sha1.patch` to fix aarch64-linux build failure where `sha1_process_block64_shaNI` is x86-specific and needs architecture guards. See [upstream discussion](https://lists.busybox.net/pipermail/busybox/2024-September/090943.html).

Release notes: https://busybox.net/news.html

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
- Tested, as applicable:
  - [x] NixOS tests
  - [x] Package tests at `passthru.tests`
- [x] Ran `nixpkgs-review` on this PR
- [x] Tested basic functionality of binary (`busybox --help`)
- [x] Tested bootstrap tools build (`nix-build pkgs/stdenv/linux/make-bootstrap-tools.nix -A test`)