### PR TITLE
binwalk2,python3Packages.binwalk-full: init at 2.4.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10428,6 +10428,12 @@
     githubId = 15121114;
     name = "Tom Herbers";
   };
+  hero = {
+    email = "hero+nixpkgs@herogamers.dev";
+    github = "herogamers";
+    githubId = 15278940;
+    name = "Marcus Sand";
+  };
   herschenglime = {
     github = "Herschenglime";
     githubId = 69494718;

--- a/pkgs/by-name/bi/binwalk2/package.nix
+++ b/pkgs/by-name/bi/binwalk2/package.nix
@@ -1,0 +1,6 @@
+{
+  python3Packages,
+}:
+
+with python3Packages;
+toPythonApplication binwalk

--- a/pkgs/development/python-modules/binwalk/default.nix
+++ b/pkgs/development/python-modules/binwalk/default.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  stdenv,
+  zlib,
+  xz,
+  gzip,
+  bzip2,
+  gnutar,
+  p7zip,
+  cabextract,
+  cramfsprogs,
+  cramfsswap,
+  sasquatch,
+  setuptools,
+  squashfsTools,
+  matplotlib,
+  pycrypto,
+  pyqtgraph,
+  pyqt5,
+  pytestCheckHook,
+  yaffshiv,
+  visualizationSupport ? false,
+}:
+
+buildPythonPackage rec {
+  pname = "binwalk${lib.optionalString visualizationSupport "-full"}";
+  version = "2.4.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "OSPG";
+    repo = "binwalk";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-kabibUMh5HyAJCXOyZo3QSNIVz8fER4Xivuv9E3CfEE=";
+  };
+
+  build-system = [ setuptools ];
+
+  propagatedBuildInputs = [
+    zlib
+    xz
+    gzip
+    bzip2
+    gnutar
+    p7zip
+    cabextract
+    squashfsTools
+    xz
+    pycrypto
+    yaffshiv
+  ]
+  ++ lib.optionals visualizationSupport [
+    matplotlib
+    pyqtgraph
+    pyqt5
+  ]
+  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
+    cramfsprogs
+    cramfsswap
+    sasquatch
+  ];
+
+  # setup.py only installs version.py during install, not test
+  postPatch = ''
+    echo '__version__ = "${version}"' > src/binwalk/core/version.py
+  '';
+
+  # binwalk wants to access ~/.config/binwalk/magic
+  preCheck = ''
+    HOME=$(mktemp -d)
+  '';
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "binwalk" ];
+
+  # add an alias for binwalk2 for using at the same time as binwalk v3
+  postInstall = ''
+    ln -s "$out/bin/binwalk" "$out/bin/binwalk2"
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/OSPG/binwalk";
+    description = "Tool for searching a given binary image for embedded files";
+    mainProgram = "binwalk";
+    maintainers = [ maintainers.hero ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1966,6 +1966,10 @@ self: super: with self; {
 
   binsync = callPackage ../development/python-modules/binsync { };
 
+  binwalk = callPackage ../development/python-modules/binwalk { };
+
+  binwalk-full = self.binwalk.override { visualizationSupport = true; };
+
   biocframe = callPackage ../development/python-modules/biocframe { };
 
   biocutils = callPackage ../development/python-modules/biocutils { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Binwalk v2 was removed in #357991 in favor of the Rust rewrite (binwalk v3), this PR reverts the removal and re-introduces binwalk v2, with an added symlink of the binary to `binwalk2` so both v3 and v2 (theoretically) can be used at the same time.

Although the binwalk v2 fork by OSPG is already EOL, many (including myself) are still using binwalk v2 instead of the Rust rewrite (v3), mostly due to binwalk v2 being able to recognize files that binwalk v3 still fails to recognize (especially in CTFs).

Until binwalk v3 no longer has these issues, binwalk v2 is still useful in the cases where binwalk v3 fails.
There is an Issue open on ReFirmLabs' repository regarding the issue: https://github.com/ReFirmLabs/binwalk/issues/829

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
