### PR TITLE
mailutils: fix build with gcc15

### DIFF
--- a/pkgs/by-name/ma/mailutils/package.nix
+++ b/pkgs/by-name/ma/mailutils/package.nix
@@ -90,6 +90,13 @@ stdenv.mkDerivation (finalAttrs: {
     # https://github.com/NixOS/nixpkgs/issues/223967
     # https://lists.gnu.org/archive/html/bug-mailutils/2023-04/msg00000.html
     ./don-t-use-descrypt-password-in-the-test-suite.patch
+    # Fix build with gcc15
+    # https://lists.gnu.org/archive/html/bug-mailutils/2025-06/msg00000.html
+    (fetchpatch {
+      name = "mailutils-fix-sighandler-incompatible-pointer-types-gcc15.patch";
+      url = "https://gitlab.archlinux.org/archlinux/packaging/packages/mailutils/-/raw/87c3614083260f52dd1222e872a1836f0ff9abe1/fix-build.patch";
+      hash = "sha256-RN62l5mYqtViEjXpAlQKWhFez1TPynRMj/1nvZkq5Gs=";
+    })
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
- add patch from archlinux fixing `incompatible-pointer-types` error:
https://gitlab.archlinux.org/archlinux/packaging/packages/mailutils/-/raw/87c3614083260f52dd1222e872a1836f0ff9abe1/fix-build.patch

Upstream issues:
https://lists.gnu.org/archive/html/bug-mailutils/2025-06/msg00000.html
https://lists.gnu.org/archive/html/bug-mailutils/2025-09/msg00000.html

Fixes build failure with gcc15:
```
progmailer.c: In function 'mu_progmailer_create':
progmailer.c:63:18: error: assignment to 'void (*)(void)' from
incompatible pointer type 'void (*)(int)' [-Wincompatible-pointer-types]
   63 |   pm->sighandler = SIG_ERR;
      |                  ^
progmailer.c: In function 'mu_progmailer_open':
progmailer.c:116:23: error: assignment to 'void (*)(void)' from
incompatible pointer type '__sighandler_t' {aka 'void (*)(int)'} [-Wincompatible-pointer-types]
  116 |   if ((pm->sighandler = signal (SIGCHLD, SIG_DFL)) == SIG_ERR)
      |                       ^
In file included from progmailer.c:27:
/nix/store/i1qha7him4faq593wwl1zmhg2pc6lz98-glibc-2.40-66-dev/include/signal.h:72:16:
note: '__sighandler_t' declared here
   72 | typedef void (*__sighandler_t) (int);
      |                ^~~~~~~~~~~~~~
progmailer.c:116:52: warning: comparison of distinct pointer types
lacks a cast [-Wcompare-distinct-pointer-types]
  116 |   if ((pm->sighandler = signal (SIGCHLD, SIG_DFL)) == SIG_ERR)
      |                                                    ^~
progmailer.c: In function 'mu_progmailer_close':
progmailer.c:295:22: warning: comparison of distinct pointer types
lacks a cast [-Wcompare-distinct-pointer-types]
  295 |   if (pm->sighandler != SIG_ERR
      |                      ^~
progmailer.c:296:29: error: passing argument 2 of 'signal' from
incompatible pointer type [-Wincompatible-pointer-types]
  296 |       && signal (SIGCHLD, pm->sighandler) == SIG_ERR)
      |                           ~~^~~~~~~~~~~~
      |                             |
      |                             void (*)(void)
/nix/store/i1qha7him4faq593wwl1zmhg2pc6lz98-glibc-2.40-66-dev/include/signal.h:88:57:
note: expected '__sighandler_t' {aka 'void (*)(int)'} but argument is of type 'void (*)(void)'
   88 | extern __sighandler_t signal (int __sig, __sighandler_t __handler)
      |                                          ~~~~~~~~~~~~~~~^~~~~~~~~
/nix/store/i1qha7him4faq593wwl1zmhg2pc6lz98-glibc-2.40-66-dev/include/signal.h:72:16:
note: '__sighandler_t' declared here  
   72 | typedef void (*__sighandler_t) (int);
      |                ^~~~~~~~~~~~~~
progmailer.c:302:18: error: assignment to 'void (*)(void)' from
incompatible pointer type 'void (*)(int)' [-Wincompatible-pointer-types]
  302 |   pm->sighandler = SIG_ERR;
      |                  ^
```

---

Tested build with:
```bash
nix-build --expr 'with import ./. {}; mailutils.override { stdenv = gcc15Stdenv; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

---

Tried to update to newest version (`3.21` - Dec 11, 2025) instead, but it still happens. Looking at upstream git tree it is not fixed there yet.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
