### PR TITLE
cargo: Add Fish shell completions, generate others from source when possible

### DIFF
--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   pkgsHostHost,
+  pkgsBuildBuild,
   file,
   curl,
   pkg-config,
@@ -74,11 +75,23 @@ rustPlatform.buildRustPackage.override
 
       installManPage src/tools/cargo/src/etc/man/*
 
-      installShellCompletion --bash --name cargo \
-        src/tools/cargo/src/etc/cargo.bashcomp.sh
-
-      installShellCompletion --zsh src/tools/cargo/src/etc/_cargo
-    '';
+    ''
+    + (
+      if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+        ''
+          installShellCompletion --cmd cargo \
+            --bash <(CARGO_COMPLETE=bash cargo) \
+            --fish <(CARGO_COMPLETE=fish cargo) \
+            --zsh <(CARGO_COMPLETE=zsh cargo)
+        ''
+      else
+        ''
+          installShellCompletion --cmd cargo \
+            --bash src/tools/cargo/src/etc/cargo.bashcomp.sh \
+            --fish ${pkgsBuildBuild.cargo}/share/fish/vendor_completions.d/*.fish \
+            --zsh src/tools/cargo/src/etc/_cargo
+        ''
+    );
 
     checkPhase = ''
       # Disable cross compilation tests


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

1. Generate fish completions as they are not vendored in the Cargo repo
2. Generate shell completions from source when possible.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
