### PR TITLE
bazel_7: fix build on Darwin (bring `utimensat` in scope)

### DIFF
--- a/pkgs/by-name/ba/bazel_7/package.nix
+++ b/pkgs/by-name/ba/bazel_7/package.nix
@@ -431,6 +431,11 @@ stdenv.mkDerivation rec {
           sedVerbose $wrapper \
             -e "s,/usr/bin/xcrun install_name_tool,${cctools}/bin/install_name_tool,g"
         done
+
+        # set --macos_sdk_version to make utimensat visible:
+        sedVerbose compile.sh \
+          -e "/bazel_build /a\  --macos_sdk_version=${stdenv.hostPlatform.darwinMinVersion} \\\\" \
+
       '';
 
       genericPatches = ''


### PR DESCRIPTION
Set `--macos_sdk_version` as in [`package.nix` for bazel_8]:

```
sedVerbose compile.sh \
  -e "/bazel_build /a\  --macos_sdk_version=${stdenv.hostPlatform.darwinMinVersion} \\\\" \

```

To `darwinPatches` in order to fix:

```
ERROR: /nix/var/nix/builds/nix-85698-1094223598/bazel_src/src/main/native/BUILD:72:10: Compiling src/main/native/unix_jni.cc failed: (Exit 1): cc_wrapper.sh failed: error executing CppCompile command (from target //src/main/native:libunix_jni.so)
  (cd /nix/var/nix/builds/nix-85698-1094223598/bazel_POvonAvR/out/execroot/_main && \
  exec env - \
    PATH=/nix/store/xcjk9ill54kjk8mzgq6yydnx9015lidg-python3-3.13.9/bin:/nix/store/8010ag4a7cn1rhra7agjzwsap8jfj1wg-unzip-6.0/bin:/nix/store/nqf7x67vacqf73jrdw76hg8fjb29n0dn-which-2.23/bin:/nix/store/iv78g496sjrz537sw8y5dq826mk0442l-zip-3.0/bin:/nix/store/z99r3kjs85i4hqp2cblr2pxim5gkhkzw-cctools-1010.6/bin:/nix/store/qk20nysrc2170f1mal5k6r0axqn6jmfj-clang-wrapper-21.1.2/bin:/nix/store/w5wjc54p5cgl4cr1mfkd3lisnaiszaq7-clang-21.1.2/bin:/nix/store/1swaqmkr1329q50ky497sps80p16fn95-coreutils-9.8/bin:/nix/store/1sjw5a4m3904rss6fv1ix9gj7m4j67la-cctools-binutils-darwin-wrapper-1010.6/bin:/nix/store/yi44mca7gaps25sin6qwvp26pqfa3kp7-cctools-binutils-darwin-1010.6/bin:/nix/store/qqgnrrsacp13sil10wkfbaq0fjkjp4ly-xcbuild-0.1.1-unstable-2019-11-20-xcrun/bin:/nix/store/zng56j969rl5xnkz5v5c7j9fsxpm7sm1-zulu-ca-jdk-21.0.8/bin:/nix/store/6kh7pqnkls1wyhrvh37nlchnc308dy2h-bash/bin:/nix/store/19zw2r9dl44wk3j5ncwsk743zr9fc584-bash-interactive-5.3p3/bin:/nix/store/qkxnh5r8ihcmqagg6ixmffv8splnyxsf-diffutils-3.12/bin:/nix/store/x27cqyk5gazfxk4s982y3sv1ss7d2z56-file-5.45/bin:/nix/store/bc9nvjzr9bc3bras5gawzm8gdqapsd35-findutils-4.10.0/bin:/nix/store/wk6hmvlw0d7xi36c1sy5lljakzwj0r3x-gawk-5.3.2/bin:/nix/store/1r5p3mwlq9m50yvcdaf64xdv7v5gq581-gnugrep-3.12/bin:/nix/store/mr0a0xdlg1v5q5p24x6vx8dpaxxjrykp-patch-2.8/bin:/nix/store/ipgh18959gxm39fhy7b9db4cn6vl0p0j-gnused-4.9/bin:/nix/store/7lyx6px91wm2yybqxf4q8xyh4bqy1g9g-gnutar-1.35/bin:/nix/store/cv7wmmrbf07h4laz3r4laj1qga57i7bq-gzip-1.14/bin:/nix/store/9kffgbvhza212ishsam4p8wklh92ih9v-libiconv-109.100.2/bin:/nix/store/1swaqmkr1329q50ky497sps80p16fn95-coreutils-9.8/bin:/nix/store/bc9nvjzr9bc3bras5gawzm8gdqapsd35-findutils-4.10.0/bin:/nix/store/qkxnh5r8ihcmqagg6ixmffv8splnyxsf-diffutils-3.12/bin:/nix/store/ipgh18959gxm39fhy7b9db4cn6vl0p0j-gnused-4.9/bin:/nix/store/1r5p3mwlq9m50yvcdaf64xdv7v5gq581-gnugrep-3.12/bin:/nix/store/wk6hmvlw0d7xi36c1sy5lljakzwj0r3x-gawk-5.3.2/bin:/nix/store/7lyx6px91wm2yybqxf4q8xyh4bqy1g9g-gnutar-1.35/bin:/nix/store/cv7wmmrbf07h4laz3r4laj1qga57i7bq-gzip-1.14/bin:/nix/store/nrrvblhsinfighjdvgxsb8nignvd2zdd-bzip2-1.0.8-bin/bin:/nix/store/himpsafkr92afwx35m02cfqqkayjp7ab-gnumake-4.4.1/bin:/nix/store/p0k9r5h8qs7220xdbdihhfgzwjcly70x-bash-5.3p3/bin:/nix/store/bffz5h9mi6z7n83rllpyz3f09gd3msmc-patch-2.8/bin:/nix/store/3cqxjnil2vb4nz4i0kwmrncgpx06v1ar-xz-5.8.1-bin/bin:/nix/store/x27cqyk5gazfxk4s982y3sv1ss7d2z56-file-5.45/bin \
    PWD=/proc/self/cwd \
  external/bazel_tools~cc_configure_extension~local_config_cc/cc_wrapper.sh -U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -Wunused-but-set-parameter -Wno-free-nonheap-object -fcolor-diagnostics -fno-omit-frame-pointer -g0 -O2 '-D_FORTIFY_SOURCE=1' -DNDEBUG -ffunction-sections -fdata-sections '-std=c++14' -MD -MF bazel-out/darwin_arm64-opt/bin/src/main/native/_objs/libunix_jni.so/unix_jni.d '-frandom-seed=bazel-out/darwin_arm64-opt/bin/src/main/native/_objs/libunix_jni.so/unix_jni.o' -DBLAZE_OPENSOURCE -iquote . -iquote bazel-out/darwin_arm64-opt/bin -iquote external/blake3~ -iquote bazel-out/darwin_arm64-opt/bin/external/blake3~ -isystem src/main/native -isystem bazel-out/darwin_arm64-opt/bin/src/main/native -isystem external/blake3~ -isystem bazel-out/darwin_arm64-opt/bin/external/blake3~ '-mmacosx-version-min=10.11' -fPIC '-DBLAZE_JAVA_CPU=k8' -no-canonical-prefixes -Wno-builtin-macro-redefined '-D__DATE__="redacted"' '-D__TIMESTAMP__="redacted"' '-D__TIME__="redacted"' -c src/main/native/unix_jni.cc -o bazel-out/darwin_arm64-opt/bin/src/main/native/_objs/libunix_jni.so/unix_jni.o)
src/main/native/unix_jni.cc:512:7: error: 'utimensat' is only available on macOS 10.13 or newer [-Werror,-Wunguarded-availability-new]
  512 |   if (::utimensat(AT_FDCWD, path_chars, times, 0) == -1) {
      |       ^~~~~~~~~~~
/nix/store/npzkc6q10x37mb969v8c19klfsghb70l-apple-sdk-14.4/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/stat.h:402:9: note: 'utimensat' has been marked as being introduced in macOS 10.13 here, but the deployment target is macOS 10.11.0
  402 | int     utimensat(int __fd, const char *__path, const struct timespec __times[2],
      |         ^
src/main/native/unix_jni.cc:512:7: note: enclose 'utimensat' in a __builtin_available check to silence this warning
  512 |   if (::utimensat(AT_FDCWD, path_chars, times, 0) == -1) {
      |       ^~~~~~~~~~~
  513 |     PostException(env, errno, path_chars);
  514 |   }
      |
1 error generated.
INFO: Elapsed time: 15.349s, Critical Path: 6.22s
INFO: 1067 processes: 839 internal, 184 local, 44 worker.
ERROR: Build did NOT complete successfully

ERROR: Could not build Bazel
```

[`package.nix` for bazel_8]: https://github.com/nixos/nixpkgs/blob/9c81a0c598a5bb583c0ea46c4e45be1921a3a8f1/pkgs/by-name/ba/bazel_8/package.nix#L105


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
