### PR TITLE
parallel-full: add option to disable unsafe message

### DIFF
--- a/pkgs/by-name/pa/parallel-full/package.nix
+++ b/pkgs/by-name/pa/parallel-full/package.nix
@@ -12,6 +12,7 @@
     TextCSV
   ],
   willCite ? false,
+  unsafe ? false,
 }:
 
 symlinkJoin {
@@ -32,6 +33,7 @@ symlinkJoin {
     rm $out/bin/parallel
     makeWrapper ${parallel}/bin/parallel $out/bin/parallel \
       --set PERL5LIB "${perlPackages.makeFullPerlPath extraPerlPackages}" \
-      ${lib.optionalString willCite "--add-flags --will-cite"}
+      ${lib.optionalString willCite "--add-flags --will-cite"} \
+      ${lib.optionalString unsafe "--add-flags --unsafe"}
   '';
 }


### PR DESCRIPTION
## Motivation
Without the --unsafe flag, parallel produce the following warning message with undesirable $PWD character:
```
parallel: Warning: $PWD can only contain [-\p{L}\p{N}\p{M}_+,.%@:/=() ].
parallel: Warning: Use '--unsafe' to ignore this.
parallel: Warning: $OLDPWD can only contain [-\p{L}\p{N}\p{M}_+,.%@:/=() ].
parallel: Warning: Use '--unsafe' to ignore this.
```
Which is quite annoying for CJK users because:
```
\p{L} - Matches any Unicode letter
\p{N} - Matches any Unicode number
\p{M} - Matches any Unicode mark (like diacritics)
```

Ref. links:
https://savannah.gnu.org/bugs/?66750
https://lists.gnu.org/archive/html/parallel/2025-02/msg00003.html
https://lists.gnu.org/archive/html/parallel/2025-02/msg00006.html



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
