### PR TITLE
vimPlugins.nvim-lspconfig: patch the default command for flow

### DIFF
--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -2592,6 +2592,17 @@ assertNoAdditions {
     dependencies = [ self.plenary-nvim ];
   };
 
+  nvim-lspconfig = super.nvim-lspconfig.overrideAttrs {
+    # On nixpkgs, the flow package provides the `flow` executable.
+    # This patch thus changes the default for `cmd` to a more sensible value.
+    postPatch = ''
+      substituteInPlace lsp/flow.lua \
+        --replace-fail \
+          "cmd = { 'npx', '--no-install', 'flow', 'lsp' }," \
+          "cmd = { 'flow', 'lsp' },"
+    '';
+  };
+
   nvim-lsputils = super.nvim-lsputils.overrideAttrs {
     dependencies = [ self.popfix ];
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

[flow](https://flow.org/) is [packaged on nixpkgs](https://github.com/NixOS/nixpkgs/blob/addf7cf5f383a3101ecfba091b98d0a1263dc9b8/pkgs/development/tools/analysis/flow/default.nix) and directly provides the `flow` executable.
Hence, it makes more change to use this for the default `cmd` value in `nvim-lspconfig`.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
