### PR TITLE
solana-cli: 2.3.13 -> 3.0.12

### DIFF
--- a/pkgs/by-name/so/solana-cli/package.nix
+++ b/pkgs/by-name/so/solana-cli/package.nix
@@ -13,113 +13,115 @@
   clang,
   libclang,
   rocksdb,
-  # Taken from https://github.com/solana-labs/solana/blob/master/scripts/cargo-install-all.sh#L84
-  solanaPkgs ? [
-    "cargo-build-sbf"
-    "cargo-test-sbf"
-    "solana"
-    "solana-bench-tps"
-    "solana-faucet"
-    "solana-gossip"
-    "agave-install"
-    "solana-keygen"
-    "agave-ledger-tool"
-    "solana-log-analyzer"
-    "solana-net-shaper"
-    "agave-validator"
-    "solana-test-validator"
-  ]
-  ++ [
-    # XXX: Ensure `solana-genesis` is built LAST!
-    # See https://github.com/solana-labs/solana/issues/5826
-    "solana-genesis"
-  ],
-}:
-let
-  version = "2.3.13";
-  hash = "sha256-RSucqvbshaaby4fALhAQJtZztwsRdA+X7yRnoBxQvsg=";
+  # Taken from https://github.com/anza-xyz/agave/blob/master/scripts/cargo-install-all.sh#L84
+  solanaPkgs ?
+    [
+      "cargo-build-sbf"
+      "cargo-test-sbf"
+      "solana"
+      "solana-bench-tps"
+      "solana-faucet"
+      "solana-gossip"
+      "agave-install"
+      "solana-keygen"
+      "agave-ledger-tool"
+      "solana-dos"
+      "solana-net-shaper"
+      "agave-validator"
+      "solana-test-validator"
+      "agave-watchtower"
+    ]
+    ++ [
+      # XXX: Ensure `solana-genesis` is built LAST!
+      # See https://github.com/solana-labs/solana/issues/5826
+      "solana-genesis"
+    ],
+}: let
+  version = "3.0.12";
+  hash = "sha256-Zubu7cTSJrJFSuguCo3msdas/QshFpo1+T6DVQyqrhY=";
 in
-rustPlatform.buildRustPackage rec {
-  pname = "solana-cli";
-  inherit version;
+  rustPlatform.buildRustPackage rec {
+    pname = "solana-cli";
+    inherit version;
 
-  src = fetchFromGitHub {
-    owner = "anza-xyz";
-    repo = "agave";
-    tag = "v${version}";
-    inherit hash;
-  };
+    src = fetchFromGitHub {
+      owner = "anza-xyz";
+      repo = "agave";
+      tag = "v${version}";
+      inherit hash;
+    };
 
-  cargoHash = "sha256-yTS++bUu+4wmbXXZkU4eDq4sGNzls1euptJoY6OYZOM=";
+    cargoHash = "sha256-qnZbFkyzE2hdy/ynZQZmCs5kCeTUMci9f/pVKID/mRQ=";
 
-  strictDeps = true;
-  cargoBuildFlags = map (n: "--bin=${n}") solanaPkgs;
-  RUSTFLAGS = "-Amismatched_lifetime_syntaxes -Adead_code";
-  LIBCLANG_PATH = "${libclang.lib}/lib";
+    strictDeps = true;
+    cargoBuildFlags = map (n: "--bin=${n}") solanaPkgs;
+    RUSTFLAGS = "-Amismatched_lifetime_syntaxes -Adead_code -Aunused_parens";
+    LIBCLANG_PATH = "${libclang.lib}/lib";
 
-  # Even tho the tests work, a shit ton of them try to connect to a local RPC
-  # or access internet in other ways, eventually failing due to Nix sandbox.
-  # Maybe we could restrict the check to the tests that don't require an RPC,
-  # but judging by the quantity of tests, that seems like a lengthty work and
-  # I'm not in the mood ((ΦωΦ))
-  doCheck = false;
+    # Even tho the tests work, a shit ton of them try to connect to a local RPC
+    # or access internet in other ways, eventually failing due to Nix sandbox.
+    # Maybe we could restrict the check to the tests that don't require an RPC,
+    # but judging by the quantity of tests, that seems like a lengthty work and
+    # I'm not in the mood ((ΦωΦ))
+    doCheck = false;
 
-  nativeBuildInputs = [
-    installShellFiles
-    protobuf
-    pkg-config
-  ];
-  buildInputs = [
-    openssl
-    clang
-    libclang
-    rustPlatform.bindgenHook
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [ udev ];
-
-  doInstallCheck = true;
-
-  nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgram = "${placeholder "out"}/bin/solana";
-  versionCheckProgramArg = "--version";
-
-  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
-    installShellCompletion --cmd solana \
-      --bash <($out/bin/solana completion --shell bash) \
-      --fish <($out/bin/solana completion --shell fish)
-
-    mkdir -p $out/bin/platform-tools-sdk
-    cp -r ./platform-tools-sdk/sbf $out/bin/platform-tools-sdk
-
-    mkdir -p $out/bin/deps
-    find . -name libsolana_program.dylib -exec cp {} $out/bin/deps \;
-    find . -name libsolana_program.rlib -exec cp {} $out/bin/deps \;
-  '';
-
-  # Used by build.rs in the rocksdb-sys crate. If we don't set these, it would
-  # try to build RocksDB from source.
-  ROCKSDB_LIB_DIR = "${rocksdb}/lib";
-
-  # Require this on darwin otherwise the compiler starts rambling about missing
-  # cmath functions
-  CPPFLAGS = lib.optionals stdenv.hostPlatform.isDarwin "-isystem ${lib.getInclude stdenv.cc.libcxx}/include/c++/v1";
-  LDFLAGS = lib.optionals stdenv.hostPlatform.isDarwin "-L${lib.getLib stdenv.cc.libcxx}/lib";
-
-  # If set, always finds OpenSSL in the system, even if the vendored feature is enabled.
-  OPENSSL_NO_VENDOR = 1;
-
-  meta = {
-    description = "Web-Scale Blockchain for fast, secure, scalable, decentralized apps and marketplaces";
-    homepage = "https://solana.com";
-    license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [
-      netfox
-      happysalada
-      aikooo7
-      JacoMalan1
+    nativeBuildInputs = [
+      installShellFiles
+      protobuf
+      pkg-config
     ];
-    platforms = lib.platforms.unix;
-  };
+    buildInputs =
+      [
+        openssl
+        clang
+        libclang
+        rustPlatform.bindgenHook
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isLinux [udev];
 
-  passthru.updateScript = nix-update-script { };
-}
+    doInstallCheck = true;
+
+    nativeInstallCheckInputs = [versionCheckHook];
+    versionCheckProgram = "${placeholder "out"}/bin/solana";
+    versionCheckProgramArg = "--version";
+
+    postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      installShellCompletion --cmd solana \
+        --bash <($out/bin/solana completion --shell bash) \
+        --fish <($out/bin/solana completion --shell fish)
+
+      mkdir -p $out/bin/platform-tools-sdk
+      cp -r ./platform-tools-sdk/sbf $out/bin/platform-tools-sdk
+
+      mkdir -p $out/bin/deps
+      find . -name libsolana_program.dylib -exec cp {} $out/bin/deps \;
+      find . -name libsolana_program.rlib -exec cp {} $out/bin/deps \;
+    '';
+
+    # Used by build.rs in the rocksdb-sys crate. If we don't set these, it would
+    # try to build RocksDB from source.
+    ROCKSDB_LIB_DIR = "${rocksdb}/lib";
+
+    # Require this on darwin otherwise the compiler starts rambling about missing
+    # cmath functions
+    CPPFLAGS = lib.optionals stdenv.hostPlatform.isDarwin "-isystem ${lib.getInclude stdenv.cc.libcxx}/include/c++/v1";
+    LDFLAGS = lib.optionals stdenv.hostPlatform.isDarwin "-L${lib.getLib stdenv.cc.libcxx}/lib";
+
+    # If set, always finds OpenSSL in the system, even if the vendored feature is enabled.
+    OPENSSL_NO_VENDOR = 1;
+
+    meta = with lib; {
+      description = "Web-Scale Blockchain for fast, secure, scalable, decentralized apps and marketplaces";
+      homepage = "https://solana.com";
+      license = licenses.asl20;
+      maintainers = with maintainers; [
+        netfox
+        happysalada
+        aikooo7
+        JacoMalan1
+      ];
+      platforms = platforms.unix;
+    };
+
+    passthru.updateScript = nix-update-script {};
+  }

--- a/pkgs/by-name/so/solana-cli/package.nix
+++ b/pkgs/by-name/so/solana-cli/package.nix
@@ -14,114 +14,113 @@
   libclang,
   rocksdb,
   # Taken from https://github.com/anza-xyz/agave/blob/master/scripts/cargo-install-all.sh#L84
-  solanaPkgs ?
-    [
-      "cargo-build-sbf"
-      "cargo-test-sbf"
-      "solana"
-      "solana-bench-tps"
-      "solana-faucet"
-      "solana-gossip"
-      "agave-install"
-      "solana-keygen"
-      "agave-ledger-tool"
-      "solana-dos"
-      "solana-net-shaper"
-      "agave-validator"
-      "solana-test-validator"
-      "agave-watchtower"
-    ]
-    ++ [
-      # XXX: Ensure `solana-genesis` is built LAST!
-      # See https://github.com/solana-labs/solana/issues/5826
-      "solana-genesis"
-    ],
-}: let
+  solanaPkgs ? [
+    "cargo-build-sbf"
+    "cargo-test-sbf"
+    "solana"
+    "solana-bench-tps"
+    "solana-faucet"
+    "solana-gossip"
+    "agave-install"
+    "solana-keygen"
+    "agave-ledger-tool"
+    "solana-dos"
+    "solana-net-shaper"
+    "agave-validator"
+    "solana-test-validator"
+    "agave-watchtower"
+  ]
+  ++ [
+    # XXX: Ensure `solana-genesis` is built LAST!
+    # See https://github.com/solana-labs/solana/issues/5826
+    "solana-genesis"
+  ],
+}:
+let
   version = "3.0.12";
   hash = "sha256-Zubu7cTSJrJFSuguCo3msdas/QshFpo1+T6DVQyqrhY=";
 in
-  rustPlatform.buildRustPackage rec {
-    pname = "solana-cli";
-    inherit version;
+rustPlatform.buildRustPackage rec {
+  pname = "solana-cli";
+  inherit version;
 
-    src = fetchFromGitHub {
-      owner = "anza-xyz";
-      repo = "agave";
-      tag = "v${version}";
-      inherit hash;
-    };
+  src = fetchFromGitHub {
+    owner = "anza-xyz";
+    repo = "agave";
+    tag = "v${version}";
+    inherit hash;
+  };
 
-    cargoHash = "sha256-qnZbFkyzE2hdy/ynZQZmCs5kCeTUMci9f/pVKID/mRQ=";
+  cargoHash = "sha256-qnZbFkyzE2hdy/ynZQZmCs5kCeTUMci9f/pVKID/mRQ=";
 
-    strictDeps = true;
-    cargoBuildFlags = map (n: "--bin=${n}") solanaPkgs;
-    RUSTFLAGS = "-Amismatched_lifetime_syntaxes -Adead_code -Aunused_parens";
-    LIBCLANG_PATH = "${libclang.lib}/lib";
+  strictDeps = true;
+  cargoBuildFlags = map (n: "--bin=${n}") solanaPkgs;
+  RUSTFLAGS = "-Amismatched_lifetime_syntaxes -Adead_code -Aunused_parens";
+  LIBCLANG_PATH = "${libclang.lib}/lib";
 
-    # Even tho the tests work, a shit ton of them try to connect to a local RPC
-    # or access internet in other ways, eventually failing due to Nix sandbox.
-    # Maybe we could restrict the check to the tests that don't require an RPC,
-    # but judging by the quantity of tests, that seems like a lengthty work and
-    # I'm not in the mood ((ΦωΦ))
-    doCheck = false;
+  # Even tho the tests work, a shit ton of them try to connect to a local RPC
+  # or access internet in other ways, eventually failing due to Nix sandbox.
+  # Maybe we could restrict the check to the tests that don't require an RPC,
+  # but judging by the quantity of tests, that seems like a lengthty work and
+  # I'm not in the mood ((ΦωΦ))
+  doCheck = false;
 
-    nativeBuildInputs = [
-      installShellFiles
-      protobuf
-      pkg-config
+  nativeBuildInputs = [
+    installShellFiles
+    protobuf
+    pkg-config
+  ];
+  buildInputs = [
+    openssl
+    clang
+    libclang
+    rustPlatform.bindgenHook
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ udev ];
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/solana";
+  versionCheckProgramArg = "--version";
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd solana \
+      --bash <($out/bin/solana completion --shell bash) \
+      --fish <($out/bin/solana completion --shell fish)
+
+    mkdir -p $out/bin/platform-tools-sdk
+    cp -r ./platform-tools-sdk/sbf $out/bin/platform-tools-sdk
+
+    mkdir -p $out/bin/deps
+    find . -name libsolana_program.dylib -exec cp {} $out/bin/deps \;
+    find . -name libsolana_program.rlib -exec cp {} $out/bin/deps \;
+  '';
+
+  # Used by build.rs in the rocksdb-sys crate. If we don't set these, it would
+  # try to build RocksDB from source.
+  ROCKSDB_LIB_DIR = "${rocksdb}/lib";
+
+  # Require this on darwin otherwise the compiler starts rambling about missing
+  # cmath functions
+  CPPFLAGS = lib.optionals stdenv.hostPlatform.isDarwin "-isystem ${lib.getInclude stdenv.cc.libcxx}/include/c++/v1";
+  LDFLAGS = lib.optionals stdenv.hostPlatform.isDarwin "-L${lib.getLib stdenv.cc.libcxx}/lib";
+
+  # If set, always finds OpenSSL in the system, even if the vendored feature is enabled.
+  OPENSSL_NO_VENDOR = 1;
+
+  meta = with lib; {
+    description = "Web-Scale Blockchain for fast, secure, scalable, decentralized apps and marketplaces";
+    homepage = "https://solana.com";
+    license = licenses.asl20;
+    maintainers = with maintainers; [
+      netfox
+      happysalada
+      aikooo7
+      JacoMalan1
     ];
-    buildInputs =
-      [
-        openssl
-        clang
-        libclang
-        rustPlatform.bindgenHook
-      ]
-      ++ lib.optionals stdenv.hostPlatform.isLinux [udev];
+    platforms = platforms.unix;
+  };
 
-    doInstallCheck = true;
-
-    nativeInstallCheckInputs = [versionCheckHook];
-    versionCheckProgram = "${placeholder "out"}/bin/solana";
-    versionCheckProgramArg = "--version";
-
-    postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
-      installShellCompletion --cmd solana \
-        --bash <($out/bin/solana completion --shell bash) \
-        --fish <($out/bin/solana completion --shell fish)
-
-      mkdir -p $out/bin/platform-tools-sdk
-      cp -r ./platform-tools-sdk/sbf $out/bin/platform-tools-sdk
-
-      mkdir -p $out/bin/deps
-      find . -name libsolana_program.dylib -exec cp {} $out/bin/deps \;
-      find . -name libsolana_program.rlib -exec cp {} $out/bin/deps \;
-    '';
-
-    # Used by build.rs in the rocksdb-sys crate. If we don't set these, it would
-    # try to build RocksDB from source.
-    ROCKSDB_LIB_DIR = "${rocksdb}/lib";
-
-    # Require this on darwin otherwise the compiler starts rambling about missing
-    # cmath functions
-    CPPFLAGS = lib.optionals stdenv.hostPlatform.isDarwin "-isystem ${lib.getInclude stdenv.cc.libcxx}/include/c++/v1";
-    LDFLAGS = lib.optionals stdenv.hostPlatform.isDarwin "-L${lib.getLib stdenv.cc.libcxx}/lib";
-
-    # If set, always finds OpenSSL in the system, even if the vendored feature is enabled.
-    OPENSSL_NO_VENDOR = 1;
-
-    meta = with lib; {
-      description = "Web-Scale Blockchain for fast, secure, scalable, decentralized apps and marketplaces";
-      homepage = "https://solana.com";
-      license = licenses.asl20;
-      maintainers = with maintainers; [
-        netfox
-        happysalada
-        aikooo7
-        JacoMalan1
-      ];
-      platforms = platforms.unix;
-    };
-
-    passthru.updateScript = nix-update-script {};
-  }
+  passthru.updateScript = nix-update-script { };
+}


### PR DESCRIPTION
@netfox @happysalada @aikooo7 @JacoMalan1

Update solana-cli from 2.3.13 to 3.0.12, which includes:
     - Version bump and updated hashes
     - Added new `agave-watchtower` binary
     - Renamed `solana-log-analyzer` to `solana-dos`
     - Fixed RUSTFLAGS to allow unused parentheses warnings
     - Updated repository URLs in comments

This brings the package to the latest stable release of Agave (formerly Solana Labs' Solana).


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc