### PR TITLE
anchor: 0.31.1 -> 0.32.1

### DIFF
--- a/pkgs/by-name/an/anchor/package.nix
+++ b/pkgs/by-name/an/anchor/package.nix
@@ -2,29 +2,33 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  pkg-config,
+  openssl,
+  systemd,
 }:
-
 rustPlatform.buildRustPackage rec {
   pname = "anchor";
-  version = "0.31.1";
-
+  version = "0.32.1";
   src = fetchFromGitHub {
     owner = "coral-xyz";
     repo = "anchor";
     tag = "v${version}";
-    hash = "sha256-pvD0v4y7DilqCrhT8iQnAj5kBxGQVqNvObJUBzFLqzA=";
+    hash = "sha256-7YOPbMuhdssROoSG6wvwKaCFRF2ZgRLG7kwHZoY+gys=";
     fetchSubmodules = true;
   };
-
-  cargoHash = "sha256-fjhLA+utQdgR75wg+/N4VwASW6+YBHglRPj14sPHmGA=";
-
+  cargoHash = "sha256-XrVvhJ1lFLBA+DwWgTV34jufrcjszpbCgXpF+TUoEvo=";
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    openssl
+    systemd
+  ];
+  OPENSSL_NO_VENDOR = "1";
   checkFlags = [
     # the following test cases try to access network, skip them
     "--skip=tests::test_check_and_get_full_commit_when_full_commit"
     "--skip=tests::test_check_and_get_full_commit_when_partial_commit"
     "--skip=tests::test_get_anchor_version_from_commit"
   ];
-
   meta = {
     description = "Solana Sealevel Framework";
     homepage = "https://github.com/coral-xyz/anchor";


### PR DESCRIPTION
@Denommus

- Bumped anchor version from 0.31.1 to 0.32.1.
- Updated source hash and cargoHash for the new version.
 - Added new inputs: `pkg-config`, `openssl`, and `systemd`.
 - Added `nativeBuildInputs = [ pkg-config ];` for build-time tools.
 - Added `buildInputs = [ openssl systemd ];` for runtime/link-time dependencies.
 - Added `OPENSSL_NO_VENDOR = "1";` to use system OpenSSL instead of building from source.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
