### PR TITLE
elegant-sddm: replace with Qt6 compatible repo

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -16,6 +16,8 @@
 - `kanata` now requires `karabiner-dk` version 6.0+ or later.
   The package has been updated to use the new `karabiner-dk` package and the `darwinDriver` output stays at the version defined in the package.
 
+- `elegant-sddm` has been updated to be Qt6 compatible. Themes for SDDM are slightly different so read the [wiki](https://wiki.nixos.org/wiki/SDDM_Themes) for more.
+
 - `iroh` has been removed and split up into `iroh-dns-server` and `iroh-relay`.
 
 - All Log4Shell vulnerability scanners were removed, as they were all unmaintained upstream and are no longer relevant given that the vulnerability has been fixed upstream for several years.

--- a/pkgs/by-name/el/elegant-sddm/package.nix
+++ b/pkgs/by-name/el/elegant-sddm/package.nix
@@ -3,18 +3,10 @@
   formats,
   stdenvNoCC,
   fetchFromGitHub,
-  libsForQt5,
-  /*
-    An example of how you can override the background with a NixOS wallpaper
-    *
-    *  environment.systemPackages = [
-    *    (pkgs.elegant-sddm.override {
-    *      themeConfig.General = {
-             background = "${pkgs.nixos-artwork.wallpapers.simple-dark-gray-bottom.gnomeFilePath}";
-    *      };
-    *    })
-    *  ];
-  */
+  kdePackages,
+
+  # Override themeConfig.General.background for custom backgrounds
+  # https://wiki.nixos.org/wiki/SDDM_Themes
   themeConfig ? null,
 }:
 
@@ -24,18 +16,18 @@ in
 
 stdenvNoCC.mkDerivation {
   pname = "elegant-sddm";
-  version = "unstable-2024-02-08";
+  version = "0-unstable-2024-03-30";
 
   src = fetchFromGitHub {
-    owner = "surajmandalcell";
-    repo = "Elegant-sddm";
-    rev = "3102e880f46a1b72c929d13cd0a3fb64f973952a";
-    hash = "sha256-yn0fTYsdZZSOcaYlPCn8BUIWeFIKcTI1oioTWqjYunQ=";
+    owner = "rainD4X";
+    repo = "Elegant-sddm-qt6";
+    rev = "66952cbe32460938c0b6e8c6cf3343047af098f0";
+    hash = "sha256-l4gv1PEVWpLmzNt1c+dHTHtM5WlEsXdDgW3q8U3FMUQ=";
   };
 
   dontWrapQtApps = true;
   propagatedBuildInputs = [
-    libsForQt5.qtgraphicaleffects
+    kdePackages.qt5compat
   ];
 
   installPhase = ''
@@ -51,15 +43,9 @@ stdenvNoCC.mkDerivation {
     runHook postInstall
   '';
 
-  postFixup = ''
-    mkdir -p $out/nix-support
-
-    echo ${libsForQt5.qtgraphicaleffects} >> $out/nix-support/propagated-user-env-packages
-  '';
-
   meta = {
-    description = "Sleek and stylish SDDM theme crafted in QML";
-    homepage = "https://github.com/surajmandalcell/Elegant-sddm";
+    description = "Sleek and stylish SDDM theme crafted in QML for Qt6";
+    homepage = "https://github.com/rainD4X/Elegant-sddm-qt6";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ GaetanLepage ];
   };

--- a/pkgs/by-name/el/elegant-sddm/package.nix
+++ b/pkgs/by-name/el/elegant-sddm/package.nix
@@ -47,6 +47,9 @@ stdenvNoCC.mkDerivation {
     description = "Sleek and stylish SDDM theme crafted in QML for Qt6";
     homepage = "https://github.com/rainD4X/Elegant-sddm-qt6";
     license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [ GaetanLepage ];
+    maintainers = with lib.maintainers; [
+      GaetanLepage
+      redlonghead
+    ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

SDDM theme "Elegant" but with support for qt6

With the dropping of qt5 with sddm in [#444954](https://github.com/NixOS/nixpkgs/pull/444954) the package `elegant-sddm` will not work and another [repo](https://github.com/rainD4X/Elegant-sddm-qt6) does fix it for qt6. I just was not sure if we should replace the old package since in theory it's not usable now or just create a new package.

@GaetanLepage thoughts on replacing vs. just a new package?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [X] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
