### PR TITLE
ocamlPackages.yojson: 2.2.2 → 3.0.0

### DIFF
--- a/pkgs/by-name/be/beluga/package.nix
+++ b/pkgs/by-name/be/beluga/package.nix
@@ -15,8 +15,6 @@ ocamlPackages.buildDunePackage rec {
     hash = "sha256-bMaLjHq/3ZrST5E9lBSIX0T2cAhDin+lv1XwgUF4/7w=";
   };
 
-  duneVersion = "3";
-
   buildInputs = with ocamlPackages; [
     gen
     sedlex
@@ -26,7 +24,7 @@ ocamlPackages.buildDunePackage rec {
     omd
     uri
     ounit2
-    yojson
+    yojson_2
   ];
 
   doCheck = true;

--- a/pkgs/by-name/sa/satyrographos/package.nix
+++ b/pkgs/by-name/sa/satyrographos/package.nix
@@ -17,8 +17,6 @@ in
 ocamlPackages.buildDunePackage {
   inherit pname version src;
 
-  duneVersion = "3";
-
   nativeBuildInputs = with ocamlPackages; [
     menhir
   ];
@@ -29,14 +27,13 @@ ocamlPackages.buildDunePackage {
     opam-format
     opam-state
     ppx_deriving
-    ppx_deriving_yojson
+    (ppx_deriving_yojson.override { yojson = yojson_2; })
     ppx_import
     ppx_jane
     shexp
     uri
     uri-sexp
     yaml-sexp
-    yojson
   ];
 
   meta = {

--- a/pkgs/development/ada-modules/gnatprove/default.nix
+++ b/pkgs/development/ada-modules/gnatprove/default.nix
@@ -129,7 +129,7 @@ stdenv.mkDerivation {
     num
     re
     sexplib
-    yojson
+    yojson_2
   ])
   ++ (lib.optionals (gnat_version == "14") [
     gpr2_24_2_next

--- a/pkgs/development/coq-modules/vscoq-language-server/default.nix
+++ b/pkgs/development/coq-modules/vscoq-language-server/default.nix
@@ -62,7 +62,6 @@ ocamlPackages.buildDunePackage {
   ++ (with ocamlPackages; [
     findlib
     lablgtk3-sourceview3
-    yojson
     zarith
     ppx_inline_test
     ppx_assert
@@ -70,7 +69,9 @@ ocamlPackages.buildDunePackage {
     ppx_deriving
     ppx_import
     sexplib
-    ppx_yojson_conv
+    (ppx_yojson_conv.override {
+      ppx_yojson_conv_lib = ppx_yojson_conv_lib.override { yojson = yojson_2; };
+    })
     lsp
     sel
     ppx_optcomp

--- a/pkgs/development/ocaml-modules/atd/default.nix
+++ b/pkgs/development/ocaml-modules/atd/default.nix
@@ -14,8 +14,6 @@ buildDunePackage {
   pname = "atd";
   inherit (atdgen-codec-runtime) version src;
 
-  minimalOCamlVersion = "4.08";
-
   nativeBuildInputs = [ menhir ];
   buildInputs = [ cmdliner ];
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/atdgen/codec-runtime.nix
+++ b/pkgs/development/ocaml-modules/atdgen/codec-runtime.nix
@@ -4,13 +4,13 @@
   fetchurl,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "atdgen-codec-runtime";
-  version = "2.16.0";
+  version = "3.0.1";
 
   src = fetchurl {
-    url = "https://github.com/ahrefs/atd/releases/download/${version}/atd-${version}.tbz";
-    hash = "sha256-Wea0RWICQcvWkBqEKzNmg6+w6xJbOtv+4ovZTNVODe8=";
+    url = "https://github.com/ahrefs/atd/releases/download/${finalAttrs.version}/atd-${finalAttrs.version}.tbz";
+    hash = "sha256-A66uRWWjLYu2ishRSvXvx4ALFhnClzlBynE4sSs0SIQ=";
   };
 
   meta = {
@@ -19,4 +19,4 @@ buildDunePackage rec {
     maintainers = [ lib.maintainers.vbgl ];
     license = lib.licenses.mit;
   };
-}
+})

--- a/pkgs/development/ocaml-modules/github/unix.nix
+++ b/pkgs/development/ocaml-modules/github/unix.nix
@@ -1,5 +1,6 @@
 {
   buildDunePackage,
+  fetchpatch,
   github,
   cohttp,
   cohttp-lwt-unix,
@@ -11,6 +12,14 @@
 buildDunePackage {
   pname = "github-unix";
   inherit (github) version src;
+
+  patches = [
+    # Compatibility with yojson 3.0
+    (fetchpatch {
+      url = "https://github.com/mirage/ocaml-github/commit/487d7d413363921a8ffbb941610c2f71c811add8.patch";
+      hash = "sha256-ThCsWRQKmlRg7rk8tlorsO87v8RWnBvocHDvgg/WWMA=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace unix/dune --replace 'github bytes' 'github'

--- a/pkgs/development/ocaml-modules/linol/default.nix
+++ b/pkgs/development/ocaml-modules/linol/default.nix
@@ -6,7 +6,6 @@
   ppx_yojson_conv_lib,
   trace,
   uutf,
-  yojson,
 }:
 
 buildDunePackage (finalAttrs: {
@@ -27,7 +26,6 @@ buildDunePackage (finalAttrs: {
     ppx_yojson_conv_lib
     trace
     uutf
-    yojson
   ];
 
   meta = {

--- a/pkgs/development/ocaml-modules/linol/eio.nix
+++ b/pkgs/development/ocaml-modules/linol/eio.nix
@@ -2,7 +2,6 @@
   buildDunePackage,
   eio,
   linol,
-  yojson,
 }:
 
 buildDunePackage {
@@ -12,7 +11,6 @@ buildDunePackage {
   propagatedBuildInputs = [
     eio
     linol
-    yojson
   ];
 
   meta = linol.meta // {

--- a/pkgs/development/ocaml-modules/linol/lwt.nix
+++ b/pkgs/development/ocaml-modules/linol/lwt.nix
@@ -2,7 +2,6 @@
   buildDunePackage,
   linol,
   lwt,
-  yojson,
 }:
 
 buildDunePackage {
@@ -12,7 +11,6 @@ buildDunePackage {
   propagatedBuildInputs = [
     linol
     lwt
-    yojson
   ];
 
   meta = linol.meta // {

--- a/pkgs/development/ocaml-modules/morbig/default.nix
+++ b/pkgs/development/ocaml-modules/morbig/default.nix
@@ -7,7 +7,6 @@
   menhirLib,
   ppx_deriving_yojson,
   visitors,
-  yojson,
 }:
 
 lib.throwIf (lib.versionAtLeast ocaml.version "5.4")
@@ -33,7 +32,6 @@ lib.throwIf (lib.versionAtLeast ocaml.version "5.4")
       menhirLib
       ppx_deriving_yojson
       visitors
-      yojson
     ];
 
     meta = {

--- a/pkgs/development/ocaml-modules/ocaml-lsp/lsp.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/lsp.nix
@@ -4,6 +4,7 @@
   cppo,
   stdlib-shims,
   ppx_yojson_conv_lib,
+  yojson_2,
   ocaml-syntax-shims,
   jsonrpc,
   omd,
@@ -62,7 +63,6 @@ buildDunePackage rec {
       [
         pp
         re
-        ppx_yojson_conv_lib
         octavius
         dune-build-info
         dune-rpc
@@ -77,7 +77,6 @@ buildDunePackage rec {
       [
         pp
         re
-        ppx_yojson_conv_lib
         octavius
         dune-build-info
         dune-rpc
@@ -109,10 +108,16 @@ buildDunePackage rec {
   nativeBuildInputs = lib.optional (lib.versionOlder version "1.7.0") cppo;
 
   propagatedBuildInputs =
-    if lib.versionAtLeast version "1.14.0" then
+    if lib.versionAtLeast version "1.23.1" then
       [
         jsonrpc
         ppx_yojson_conv_lib
+        uutf
+      ]
+    else if lib.versionAtLeast version "1.14.0" then
+      [
+        jsonrpc
+        (ppx_yojson_conv_lib.override { yojson = yojson_2; })
         uutf
       ]
     else if lib.versionAtLeast version "1.10.0" then
@@ -120,8 +125,17 @@ buildDunePackage rec {
         dyn
         jsonrpc
         ordering
-        ppx_yojson_conv_lib
+        (ppx_yojson_conv_lib.override { yojson = yojson_2; })
         stdune
+        uutf
+      ]
+    else if lib.versionAtLeast version "1.9.0" then
+      [
+        csexp
+        jsonrpc
+        (pp.override { version = "1.2.0"; })
+        (ppx_yojson_conv_lib.override { yojson = yojson_2; })
+        result
         uutf
       ]
     else if lib.versionAtLeast version "1.7.0" then

--- a/pkgs/development/ocaml-modules/ocf/default.nix
+++ b/pkgs/development/ocaml-modules/ocf/default.nix
@@ -5,17 +5,16 @@
   yojson,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "ocf";
   version = "0.9.0";
-  duneVersion = "3";
-  minimalOCamlVersion = "4.03";
+  patches = ./yojson.patch;
   src = fetchFromGitLab {
     domain = "framagit.org";
     owner = "zoggy";
     repo = "ocf";
-    rev = version;
-    sha256 = "sha256-tTNpvncLO/WfcMbjqRfqzcdPv2Bd877fOU5AZlkkcXA=";
+    tag = finalAttrs.version;
+    hash = "sha256-tTNpvncLO/WfcMbjqRfqzcdPv2Bd877fOU5AZlkkcXA=";
   };
 
   propagatedBuildInputs = [ yojson ];
@@ -26,4 +25,4 @@ buildDunePackage rec {
     license = lib.licenses.lgpl3;
     maintainers = with lib.maintainers; [ regnat ];
   };
-}
+})

--- a/pkgs/development/ocaml-modules/ocf/yojson.patch
+++ b/pkgs/development/ocaml-modules/ocf/yojson.patch
@@ -1,0 +1,60 @@
+From caf5430f30830a2222bd7d0e6c5cea7b632e4a6a Mon Sep 17 00:00:00 2001
+From: Zoggy <zoggy@bat8.org>
+Date: Wed, 22 Oct 2025 11:41:52 +0200
+Subject: [PATCH] support Yojson >= 3.0: do not use `Tuple any more, use `List
+ instead
+
+---
+ Changes    |  3 +++
+ lib/ocf.ml | 14 +++++---------
+ 2 files changed, 8 insertions(+), 9 deletions(-)
+
+diff --git a/lib/ocf.ml b/lib/ocf.ml
+index 3169d13..3ac98a4 100644
+--- a/lib/ocf.ml
++++ b/lib/ocf.ml
+@@ -130,8 +130,7 @@ module Wrapper =
+     let list w =
+       let to_j ?with_doc l = `List (List.map (w.to_json ?with_doc) l) in
+       let from_j ?def = function
+-      | `List l
+-      | `Tuple l -> List.map (w.from_json ?def: None) l
++      | `List l -> List.map (w.from_json ?def: None) l
+       | `Null -> []
+       | json -> invalid_value json
+       in
+@@ -150,27 +149,24 @@ module Wrapper =
+
+     let pair w1 w2 =
+       let to_j ?with_doc (v1, v2) =
+-        `Tuple [w1.to_json ?with_doc v1 ; w2.to_json ?with_doc v2]
++        `List [w1.to_json ?with_doc v1 ; w2.to_json ?with_doc v2]
+       in
+       let from_j ?def = function
+-        `List [v1 ; v2]
+-      | `Tuple [v1 ; v2] -> (w1.from_json v1, w2.from_json v2)
++      | `List [v1 ; v2] -> (w1.from_json v1, w2.from_json v2)
+       | json -> invalid_value json
+       in
+       make to_j from_j
+
+     let triple w1 w2 w3 =
+       let to_j ?with_doc (v1, v2, v3) =
+-        `Tuple [
++        `List [
+           w1.to_json ?with_doc v1 ;
+           w2.to_json ?with_doc v2 ;
+           w3.to_json ?with_doc v3 ;
+         ]
+       in
+       let from_j ?def = function
+-        `List [v1 ; v2 ; v3]
+-      | `Tuple [v1 ; v2 ; v3] ->
+-          (w1.from_json v1, w2.from_json v2, w3.from_json v3)
++        `List [v1 ; v2 ; v3] -> (w1.from_json v1, w2.from_json v2, w3.from_json v3)
+       | json -> invalid_value json
+       in
+       make to_j from_j
+--
+GitLab
+

--- a/pkgs/development/ocaml-modules/ppx_deriving_yojson/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving_yojson/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildDunePackage,
   fetchFromGitHub,
+  fetchpatch,
   ocaml,
   ppxlib,
   ounit,
@@ -38,7 +39,10 @@ buildDunePackage rec {
   pname = "ppx_deriving_yojson";
   inherit (param) version;
 
-  minimalOCamlVersion = "4.07";
+  patches = fetchpatch {
+    url = "https://github.com/ocaml-ppx/ppx_deriving_yojson/commit/1bbbe2c4c5822c4297b0b812c59a155cf96c5089.patch";
+    hash = "sha256-jYW2/Ix6T94vfI2mGnIkYSG1rjsWEsnOPA1mufP3sd4=";
+  };
 
   src = fetchFromGitHub {
     owner = "ocaml-ppx";
@@ -54,7 +58,7 @@ buildDunePackage rec {
   ]
   ++ param.propagatedBuildInputs or [ ];
 
-  doCheck = lib.versionAtLeast ocaml.version "4.08";
+  doCheck = true;
   inherit (param) checkInputs;
 
   meta = {

--- a/pkgs/development/ocaml-modules/yojson/default.nix
+++ b/pkgs/development/ocaml-modules/yojson/default.nix
@@ -5,22 +5,27 @@
   seq,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "yojson";
-  version = "2.2.2";
+  version = "3.0.0";
 
   src = fetchurl {
-    url = "https://github.com/ocaml-community/yojson/releases/download/${version}/yojson-${version}.tbz";
-    hash = "sha256-mr+tjJp51HI60vZEjmacHmjb/IfMVKG3wGSwyQkSxZU=";
+    url = "https://github.com/ocaml-community/yojson/releases/download/${finalAttrs.version}/yojson-${finalAttrs.version}.tbz";
+    hash =
+      {
+        "3.0.0" = "sha256-mUFNp2CbkqAkdO9LSezaFe3Iy7pSKTQbEk5+RpXDlhA=";
+        "2.2.2" = "sha256-mr+tjJp51HI60vZEjmacHmjb/IfMVKG3wGSwyQkSxZU=";
+      }
+      ."${finalAttrs.version}";
   };
 
-  propagatedBuildInputs = [ seq ];
+  propagatedBuildInputs = lib.optional (!lib.versionAtLeast finalAttrs.version "3.0.0") seq;
 
   meta = {
     description = "Optimized parsing and printing library for the JSON format";
-    homepage = "https://github.com/ocaml-community/${pname}";
+    homepage = "https://github.com/ocaml-community/yojson";
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.vbgl ];
     mainProgram = "ydump";
   };
-}
+})

--- a/pkgs/development/rocq-modules/vsrocq-language-server/default.nix
+++ b/pkgs/development/rocq-modules/vsrocq-language-server/default.nix
@@ -48,7 +48,6 @@ ocamlPackages.buildDunePackage {
   ++ (with ocamlPackages; [
     findlib
     lablgtk3-sourceview3
-    yojson
     zarith
     ppx_inline_test
     ppx_assert
@@ -56,7 +55,9 @@ ocamlPackages.buildDunePackage {
     ppx_deriving
     ppx_import
     sexplib
-    ppx_yojson_conv
+    (ppx_yojson_conv.override {
+      ppx_yojson_conv_lib = ppx_yojson_conv_lib.override { yojson = yojson_2; };
+    })
     lsp
     sel
     ppx_optcomp

--- a/pkgs/development/tools/ocaml/merlin/4.x.nix
+++ b/pkgs/development/tools/ocaml/merlin/4.x.nix
@@ -13,6 +13,7 @@
   menhir,
   menhirLib,
   menhirSdk,
+  seq,
   # Each releases of Merlin support a limited range of versions of OCaml.
   version ?
     {
@@ -85,7 +86,8 @@ buildDunePackage {
     (if lib.versionAtLeast version "4.7-414" then merlin-lib else csexp)
     menhirSdk
     menhirLib
-  ];
+  ]
+  ++ lib.optional (!lib.versionAtLeast version "4.7-414") seq;
 
   doCheck = false;
   checkPhase = ''

--- a/pkgs/development/tools/ocaml/merlin/default.nix
+++ b/pkgs/development/tools/ocaml/merlin/default.nix
@@ -9,6 +9,7 @@
   yojson,
   csexp,
   result,
+  seq,
   menhirSdk,
 }:
 
@@ -43,6 +44,7 @@ buildDunePackage rec {
     yojson
     csexp
     result
+    seq
     menhirSdk
   ];
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -422,7 +422,12 @@ let
 
         dolmen_loop = callPackage ../development/ocaml-modules/dolmen/loop.nix { };
 
-        dolmen_lsp = callPackage ../development/ocaml-modules/dolmen/lsp.nix { };
+        dolmen_lsp = callPackage ../development/ocaml-modules/dolmen/lsp.nix {
+          lsp = lsp.override {
+            jsonrpc = jsonrpc.override { yojson = yojson_2; };
+            ppx_yojson_conv_lib = ppx_yojson_conv_lib.override { yojson = yojson_2; };
+          };
+        };
 
         dolmen_model = callPackage ../development/ocaml-modules/dolmen/model.nix { };
 
@@ -1062,7 +1067,11 @@ let
 
         linksem = callPackage ../development/ocaml-modules/linksem { };
 
-        linol = callPackage ../development/ocaml-modules/linol { };
+        linol = callPackage ../development/ocaml-modules/linol {
+          ppx_yojson_conv_lib = ppx_yojson_conv_lib.override {
+            yojson = yojson_2;
+          };
+        };
 
         linol-eio = callPackage ../development/ocaml-modules/linol/eio.nix { };
 
@@ -1310,7 +1319,11 @@ let
           inherit (pkgs.llvmPackages_19) clang libclang libllvm;
         };
 
-        morbig = callPackage ../development/ocaml-modules/morbig { };
+        morbig = callPackage ../development/ocaml-modules/morbig {
+          ppx_deriving_yojson = ppx_deriving_yojson.override {
+            yojson = yojson_2;
+          };
+        };
 
         mparser = callPackage ../development/ocaml-modules/mparser { };
 
@@ -2189,6 +2202,11 @@ let
         yaml-sexp = callPackage ../development/ocaml-modules/yaml/yaml-sexp.nix { };
 
         yojson = callPackage ../development/ocaml-modules/yojson { };
+
+        yojson_2 = yojson.overrideAttrs (_: {
+          version = "2.2.2";
+          __intentionallyOverridingVersion = true;
+        });
 
         yuscii = callPackage ../development/ocaml-modules/yuscii { };
 


### PR DESCRIPTION
ocamlPackages.atdgen-codec-runtime: 2.16.0 → 3.0.1

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
