### PR TITLE
treewide: prefer standard name for old and final Attrs

### DIFF
--- a/doc/languages-frameworks/lua.section.md
+++ b/doc/languages-frameworks/lua.section.md
@@ -103,7 +103,7 @@ final: prev: {
   lua = prev.lua.override {
     packageOverrides = luaself: luaprev: {
 
-      luarocks-nix = luaprev.luarocks-nix.overrideAttrs (oa: {
+      luarocks-nix = luaprev.luarocks-nix.overrideAttrs (old: {
         pname = "luarocks-nix";
         src = /home/my_luarocks/repository;
       });

--- a/nixos/tests/lomiri-music-app.nix
+++ b/nixos/tests/lomiri-music-app.nix
@@ -57,9 +57,9 @@ in
             lomiri-thumbnailer
             # To check if playback actually works, or is broken due to missing codecs, we need to make the app's icons more OCR-able
             (lib.meta.hiPrio (
-              suru-icon-theme.overrideAttrs (oa: {
+              suru-icon-theme.overrideAttrs (old: {
                 # Colour the background in special colours, which we can OCR for
-                postPatch = (oa.postPatch or "") + ''
+                postPatch = (old.postPatch or "") + ''
                   substituteInPlace suru/actions/scalable/media-playback-pause.svg \
                     --replace-fail 'fill:none' 'fill:${ocrPauseColor}'
 

--- a/pkgs/applications/editors/neovim/build-neovim-plugin.nix
+++ b/pkgs/applications/editors/neovim/build-neovim-plugin.nix
@@ -24,10 +24,10 @@ let
     else
       luaAttr;
 
-  luaDrv = originalLuaDrv.overrideAttrs (oa: {
-    version = attrs.version or oa.version;
+  luaDrv = originalLuaDrv.overrideAttrs (old: {
+    version = attrs.version or old.version;
     __intentionallyOverridingVersion = true;
-    rockspecVersion = oa.rockspecVersion;
+    rockspecVersion = old.rockspecVersion;
 
     extraConfig = ''
       -- to create a flat hierarchy
@@ -37,13 +37,13 @@ let
 
   finalDrv = toVimPlugin (
     luaDrv.overrideAttrs (
-      oa:
+      old:
       attrs
       // {
-        nativeBuildInputs = oa.nativeBuildInputs or [ ] ++ [
+        nativeBuildInputs = old.nativeBuildInputs or [ ] ++ [
           lua.pkgs.luarocksMoveDataFolder
         ];
-        version = "${originalLuaDrv.version}-unstable-${oa.version}";
+        version = "${originalLuaDrv.version}-unstable-${old.version}";
         __intentionallyOverridingVersion = true;
       }
     )

--- a/pkgs/applications/editors/neovim/tests/default.nix
+++ b/pkgs/applications/editors/neovim/tests/default.nix
@@ -203,7 +203,7 @@ pkgs.lib.recurseIntoAttrs rec {
     ${nvim_with_plug}/bin/nvim -V3log.txt -i NONE -c 'color base16-tomorrow-night'  +quit! -e
   '';
 
-  nvim_with_autoconfigure = pkgs.neovim.overrideAttrs (oa: {
+  nvim_with_autoconfigure = pkgs.neovim.overrideAttrs {
     plugins = [
       vimPlugins.unicode-vim
       vimPlugins.fzf-hoogle-vim
@@ -211,7 +211,7 @@ pkgs.lib.recurseIntoAttrs rec {
     autoconfigure = true;
     # legacy wrapper sets it to false
     wrapRc = true;
-  });
+  };
 
   nvim_with_runtimeDeps = pkgs.neovim.overrideAttrs {
     plugins = [

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -1292,7 +1292,7 @@ assertNoAdditions {
     '';
   };
 
-  fzf-hoogle-vim = super.fzf-hoogle-vim.overrideAttrs (oa: {
+  fzf-hoogle-vim = super.fzf-hoogle-vim.overrideAttrs (old: {
     # add this to your lua config to prevent the plugin from trying to write in the
     # nix store:
     # vim.g.hoogle_fzf_cache_file = vim.fn.stdpath('cache')..'/hoogle_cache.json'
@@ -1301,7 +1301,7 @@ assertNoAdditions {
       gawk
     ];
     dependencies = [ self.fzf-vim ];
-    passthru = oa.passthru // {
+    passthru = old.passthru // {
 
       initLua = "vim.g.hoogle_fzf_cache_file = vim.fn.stdpath('cache')..'/hoogle_cache.json";
     };
@@ -3140,8 +3140,8 @@ assertNoAdditions {
     dependencies = [ self.plenary-nvim ];
   };
 
-  rocks-nvim = super.rocks-nvim.overrideAttrs (oa: {
-    passthru = oa.passthru // {
+  rocks-nvim = super.rocks-nvim.overrideAttrs (old: {
+    passthru = old.passthru // {
       initLua = ''
         vim.g.rocks_nvim = {
           luarocks_binary = "${neovim-unwrapped.lua.pkgs.luarocks_bootstrap}/bin/luarocks"
@@ -3291,7 +3291,7 @@ assertNoAdditions {
   };
 
   sqlite-lua = super.sqlite-lua.overrideAttrs (
-    oa:
+    old:
     let
       libsqlite = "${sqlite.out}/lib/libsqlite3${stdenv.hostPlatform.extensions.sharedLibrary}";
     in
@@ -3301,7 +3301,7 @@ assertNoAdditions {
           --replace-fail "path = vim.g.sqlite_clib_path" "path = vim.g.sqlite_clib_path or '${lib.escapeShellArg libsqlite}'"
       '';
 
-      passthru = oa.passthru // {
+      passthru = old.passthru // {
         initLua = ''vim.g.sqlite_clib_path = "${libsqlite}"'';
       };
 
@@ -3692,7 +3692,7 @@ assertNoAdditions {
         sha256 = "16b0jzvvzarnlxdvs2izd5ia0ipbd87md143dc6lv6xpdqcs75s9";
       };
     in
-    super.unicode-vim.overrideAttrs (oa: {
+    super.unicode-vim.overrideAttrs (old: {
       # redirect to /dev/null else changes terminal color
       buildPhase = ''
         cp "${unicode-data}" autoload/unicode/UnicodeData.txt
@@ -3700,8 +3700,7 @@ assertNoAdditions {
         ${vim}/bin/vim --cmd ":set rtp^=$PWD" -c 'ru plugin/unicode.vim' -c 'UnicodeCache' -c ':echohl Normal' -c ':q' > /dev/null
       '';
 
-      passthru = oa.passthru // {
-
+      passthru = old.passthru // {
         initLua = ''vim.g.Unicode_data_directory="${self.unicode-vim}/autoload/unicode"'';
       };
     });

--- a/pkgs/by-name/fl/flexoptix-app/package.nix
+++ b/pkgs/by-name/fl/flexoptix-app/package.nix
@@ -20,9 +20,9 @@ let
     hash = "sha256-/1ZtJT+1IMyYqw3N0bVJ/T3vbmex169lzx+SlY5WsnA=";
   };
 
-  appimageContents = (appimageTools.extract { inherit pname version src; }).overrideAttrs (oA: {
+  appimageContents = (appimageTools.extract { inherit pname version src; }).overrideAttrs (old: {
     buildCommand = ''
-      ${oA.buildCommand}
+      ${old.buildCommand}
 
       # Remove left-over node-gyp executable symlinks
       # https://github.com/nodejs/node-gyp/issues/2713

--- a/pkgs/by-name/ne/neovim-unwrapped/package.nix
+++ b/pkgs/by-name/ne/neovim-unwrapped/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation (
         let
           luaLibDir = "$out/lib/lua/${lib.versions.majorMinor luapkgs.lua.luaversion}";
         in
-        (luapkgs.lpeg.overrideAttrs (oa: {
+        (luapkgs.lpeg.overrideAttrs (old: {
           preConfigure = ''
             # neovim wants clang .dylib
             substituteInPlace Makefile \
@@ -53,7 +53,7 @@ stdenv.mkDerivation (
             rm -f ${luaLibDir}/lpeg.so
           '';
           nativeBuildInputs =
-            oa.nativeBuildInputs ++ (lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames);
+            old.nativeBuildInputs ++ (lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames);
         }))
       else
         luapkgs.lpeg;

--- a/pkgs/by-name/on/onlykey-agent/package.nix
+++ b/pkgs/by-name/on/onlykey-agent/package.nix
@@ -22,14 +22,14 @@ let
   # onlykey requires a patched version of libagent
   lib-agent =
     with python3Packages;
-    libagent.overridePythonAttrs (oa: rec {
+    libagent.overridePythonAttrs (old: rec {
       version = "1.0.6";
       src = fetchPypi {
         inherit version;
         pname = "lib-agent";
         sha256 = "sha256-IrJizIHDIPHo4tVduUat7u31zHo3Nt8gcMOyUUqkNu0=";
       };
-      propagatedBuildInputs = oa.propagatedBuildInputs or [ ] ++ [
+      propagatedBuildInputs = old.propagatedBuildInputs or [ ] ++ [
         bech32
         cryptography
         cython
@@ -43,7 +43,7 @@ let
       doCheck = false;
       pythonImportsCheck = [ "libagent" ];
 
-      meta = oa.meta // {
+      meta = old.meta // {
         description = "Using OnlyKey as hardware SSH and GPG agent";
         homepage = "https://github.com/trustcrypto/onlykey-agent/tree/ledger";
         maintainers = with lib.maintainers; [ kalbasit ];

--- a/pkgs/by-name/re/remarshal_0_17/package.nix
+++ b/pkgs/by-name/re/remarshal_0_17/package.nix
@@ -24,9 +24,9 @@ let
       ];
     });
   };
-  python = python3Packages.python.override (oa: {
+  python = python3Packages.python.override (old: {
     self = python3Packages.python;
-    packageOverrides = lib.composeExtensions (oa.packageOverrides or (_: _: { })) packageOverrides;
+    packageOverrides = lib.composeExtensions (old.packageOverrides or (_: _: { })) packageOverrides;
   });
   pythonPackages = python.pkgs;
 in

--- a/pkgs/by-name/sw/sway/package.nix
+++ b/pkgs/by-name/sw/sway/package.nix
@@ -28,7 +28,7 @@ let
   inherit (lib.meta) getExe;
   inherit (lib.strings) concatMapStrings optionalString;
 
-  sway = sway-unwrapped.overrideAttrs (oa: {
+  sway = sway-unwrapped.overrideAttrs (old: {
     inherit isNixOS enableXWayland;
   });
   baseWrapper = writeShellScriptBin sway.meta.mainProgram ''

--- a/pkgs/by-name/tr/tracee/integration-tests.nix
+++ b/pkgs/by-name/tr/tracee/integration-tests.nix
@@ -3,9 +3,9 @@
   tracee,
   makeWrapper,
 }:
-tracee.overrideAttrs (oa: {
-  pname = oa.pname + "-integration";
-  postPatch = oa.postPatch or "" + ''
+tracee.overrideAttrs (old: {
+  pname = old.pname + "-integration";
+  postPatch = old.postPatch or "" + ''
     # fix the test to look at nixos paths for running programs
       # --replace-fail '"integration.tes"' '"tracee-integrat"' \
     substituteInPlace tests/integration/event_filters_test.go \
@@ -22,7 +22,7 @@ tracee.overrideAttrs (oa: {
     substituteInPlace tests/testutils/tracee.go \
       --replace-fail "../../dist/tracee" "${lib.getExe tracee}"
   '';
-  nativeBuildInputs = oa.nativeBuildInputs or [ ] ++ [ makeWrapper ];
+  nativeBuildInputs = old.nativeBuildInputs or [ ] ++ [ makeWrapper ];
   buildPhase = ''
     runHook preBuild
     # copy existing built object to dist
@@ -45,7 +45,7 @@ tracee.overrideAttrs (oa: {
   doInstallCheck = false;
 
   outputs = [ "out" ];
-  meta = oa.meta // {
+  meta = old.meta // {
     outputsToInstall = [ "out" ];
   };
 })

--- a/pkgs/by-name/ya/yarn-berry/fetcher/default.nix
+++ b/pkgs/by-name/ya/yarn-berry/fetcher/default.nix
@@ -27,8 +27,8 @@ let
           # Known good version: 1.3.1
           zlib = zlib;
         }).overrideAttrs
-          (oA: {
-            patches = (oA.patches or [ ]) ++ [
+          (old: {
+            patches = (old.patches or [ ]) ++ [
               (final.yarn-berry-fetcher.src + "/libzip-revert-to-old-versionneeded-behavior.patch")
             ];
           });
@@ -50,8 +50,8 @@ let
             withZlibCompat = true;
           };
         }).overrideAttrs
-          (oA: {
-            patches = (oA.patches or [ ]) ++ [
+          (old: {
+            patches = (old.patches or [ ]) ++ [
               (final.yarn-berry-fetcher.src + "/libzip-revert-to-old-versionneeded-behavior.patch")
             ];
           });

--- a/pkgs/desktops/lomiri/applications/teleports/default.nix
+++ b/pkgs/desktops/lomiri/applications/teleports/default.nix
@@ -28,26 +28,24 @@
 }:
 
 let
-  tdlib-1811 = tdlib.overrideAttrs (
-    oa: fa: {
-      version = "1.8.11";
-      src = fetchFromGitHub {
-        owner = "tdlib";
-        repo = "td";
-        rev = "3179d35694a28267a0b6273fc9b5bdce3b6b1235";
-        hash = "sha256-XvqqDXaFclWK/XpIxOqAXQ9gcc/dTljl841CN0KrlyA=";
-      };
+  tdlib-1811 = tdlib.overrideAttrs {
+    version = "1.8.11";
+    src = fetchFromGitHub {
+      owner = "tdlib";
+      repo = "td";
+      rev = "3179d35694a28267a0b6273fc9b5bdce3b6b1235";
+      hash = "sha256-XvqqDXaFclWK/XpIxOqAXQ9gcc/dTljl841CN0KrlyA=";
+    };
 
-      # CMake 4 compat
-      postPatch = ''
-        substituteInPlace CMakeLists.txt \
-          --replace-fail 'cmake_minimum_required(VERSION 3.0.2 FATAL_ERROR)' 'cmake_minimum_required(VERSION 3.10 FATAL_ERROR)'
+    # CMake 4 compat
+    postPatch = ''
+      substituteInPlace CMakeLists.txt \
+        --replace-fail 'cmake_minimum_required(VERSION 3.0.2 FATAL_ERROR)' 'cmake_minimum_required(VERSION 3.10 FATAL_ERROR)'
 
-        substituteInPlace td/generate/tl-parser/CMakeLists.txt \
-          --replace-fail 'cmake_minimum_required(VERSION 3.0 FATAL_ERROR)' 'cmake_minimum_required(VERSION 3.10 FATAL_ERROR)'
-      '';
-    }
-  );
+      substituteInPlace td/generate/tl-parser/CMakeLists.txt \
+        --replace-fail 'cmake_minimum_required(VERSION 3.0 FATAL_ERROR)' 'cmake_minimum_required(VERSION 3.10 FATAL_ERROR)'
+    '';
+  };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "teleports";

--- a/pkgs/development/coq-modules/smtcoq/default.nix
+++ b/pkgs/development/coq-modules/smtcoq/default.nix
@@ -12,13 +12,13 @@
 # Broken since https://github.com/NixOS/nixpkgs/pull/354627, temporarily disactivated
 # let
 #   # version of veriT that works with SMTCoq
-#   veriT' = veriT.overrideAttrs (oA: {
+#   veriT' = veriT.overrideAttrs {
 #     src = fetchurl {
 #       url = "https://www.lri.fr/~keller/Documents-recherche/Smtcoq/veriT9f48a98.tar.gz";
 #       sha256 = "sha256-Pe46PxQVHWwWwx5Ei4Bl95A0otCiXZuUZ2nXuZPYnhY=";
 #     };
 #     meta.broken = false;
-#   });
+#   };
 # in
 
 mkCoqDerivation {

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -1894,7 +1894,7 @@ builtins.intersectAttrs super {
     addBuildDepend
       # Overrides for tailwindcss copied from:
       # https://github.com/EmaApps/emanote/blob/master/nix/tailwind.nix
-      (pkgs.tailwindcss.overrideAttrs (oa: {
+      (pkgs.tailwindcss.overrideAttrs (old: {
         plugins = [
           pkgs.nodePackages."@tailwindcss/aspect-ratio"
           pkgs.nodePackages."@tailwindcss/forms"
@@ -1902,8 +1902,8 @@ builtins.intersectAttrs super {
           pkgs.nodePackages."@tailwindcss/typography"
         ];
         # Added a shim for the `tailwindcss` CLI entry point
-        nativeBuildInputs = (oa.nativeBuildInputs or [ ]) ++ [ pkgs.buildPackages.makeBinaryWrapper ];
-        postInstall = (oa.postInstall or "") + ''
+        nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ pkgs.buildPackages.makeBinaryWrapper ];
+        postInstall = (old.postInstall or "") + ''
           nodePath=""
           for p in "$out" "${pkgs.nodePackages.postcss}" $plugins; do
             nodePath="$nodePath''${nodePath:+:}$p/lib/node_modules"

--- a/pkgs/development/interpreters/lua-5/tests/default.nix
+++ b/pkgs/development/interpreters/lua-5/tests/default.nix
@@ -22,7 +22,7 @@ let
         + "touch $out"
       );
 
-  wrappedHello = hello.overrideAttrs (oa: {
+  wrappedHello = hello.overrideAttrs {
     propagatedBuildInputs = [
       wrapLua
       lua.pkgs.cjson
@@ -30,7 +30,7 @@ let
     postFixup = ''
       wrapLuaPrograms
     '';
-  });
+  };
 
   luaWithModule = lua.withPackages (ps: [
     ps.lua-cjson

--- a/pkgs/development/libraries/intel-oneapi/base.nix
+++ b/pkgs/development/libraries/intel-oneapi/base.nix
@@ -56,7 +56,7 @@
   libffi,
   stdenv,
 }:
-intel-oneapi.mkIntelOneApi (fa: {
+intel-oneapi.mkIntelOneApi (finalAttrs: {
   pname = "intel-oneapi-base-toolkit";
 
   src = fetchurl {
@@ -176,7 +176,7 @@ intel-oneapi.mkIntelOneApi (fa: {
   ];
 
   passthru.updateScript = intel-oneapi.mkUpdateScript {
-    inherit (fa) pname;
+    inherit (finalAttrs) pname;
     file = "base.nix";
     downloadPage = "https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit-download.html?packages=oneapi-toolkit&oneapi-toolkit-os=linux&oneapi-lin=offline";
   };

--- a/pkgs/development/libraries/intel-oneapi/default.nix
+++ b/pkgs/development/libraries/intel-oneapi/default.nix
@@ -32,7 +32,7 @@
     ];
 
     extendDrvArgs =
-      fa:
+      finalAttrs:
       {
         pname,
         versionYear,
@@ -50,7 +50,7 @@
         shortName = name: builtins.elemAt (lib.splitString "." name) 3;
       in
       {
-        version = "${fa.versionYear}.${fa.versionMajor}.${fa.versionMinor}.${fa.versionRel}";
+        version = "${finalAttrs.versionYear}.${finalAttrs.versionMajor}.${finalAttrs.versionMinor}.${finalAttrs.versionRel}";
 
         nativeBuildInputs = [
           # Installer wants tput

--- a/pkgs/development/libraries/intel-oneapi/hpc.nix
+++ b/pkgs/development/libraries/intel-oneapi/hpc.nix
@@ -26,7 +26,7 @@
   level-zero,
   libffi,
 }:
-intel-oneapi.mkIntelOneApi (fa: {
+intel-oneapi.mkIntelOneApi (finalAttrs: {
   pname = "intel-oneapi-hpc-toolkit";
 
   src = fetchurl {
@@ -62,7 +62,7 @@ intel-oneapi.mkIntelOneApi (fa: {
   ];
 
   passthru.updateScript = intel-oneapi.mkUpdateScript {
-    inherit (fa) pname;
+    inherit (finalAttrs) pname;
     file = "hpc.nix";
     downloadPage = "https://www.intel.com/content/www/us/en/developer/tools/oneapi/hpc-toolkit-download.html?packages=hpc-toolkit&hpc-toolkit-os=linux&hpc-toolkit-lin=offline";
   };

--- a/pkgs/development/lisp-modules/packages.nix
+++ b/pkgs/development/lisp-modules/packages.nix
@@ -461,8 +461,8 @@ let
         ];
       };
 
-      nsb-cga = super.nsb-cga.overrideLispAttrs (oa: {
-        lispLibs = oa.lispLibs ++ [ self.sb-cga ];
+      nsb-cga = super.nsb-cga.overrideLispAttrs (old: {
+        lispLibs = old.lispLibs ++ [ self.sb-cga ];
       });
 
       qlot-cli = build-asdf-system rec {
@@ -525,7 +525,7 @@ let
         meta.mainProgram = "qlot";
       };
 
-      fset = super.fset.overrideLispAttrs (oa: {
+      fset = super.fset.overrideLispAttrs (old: {
         systems = [
           "fset"
           "fset/test"
@@ -539,7 +539,7 @@ let
 
       thih-coalton = self.coalton;
       quil-coalton = self.coalton;
-      coalton = super.coalton.overrideLispAttrs (oa: {
+      coalton = super.coalton.overrideLispAttrs (old: {
         systems = [
           "coalton"
           "thih-coalton"
@@ -548,7 +548,7 @@ let
           "quil-coalton/tests"
           "coalton/tests"
         ];
-        lispLibs = oa.lispLibs ++ [ self.fiasco ];
+        lispLibs = old.lispLibs ++ [ self.fiasco ];
         nativeLibs = [ pkgs.mpfr ];
         meta = {
           description = "Statically typed functional programming language that supercharges Common Lisp";

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -85,8 +85,8 @@ in
     '';
   };
 
-  busted = prev.busted.overrideAttrs (oa: {
-    nativeBuildInputs = oa.nativeBuildInputs ++ [
+  busted = prev.busted.overrideAttrs (old: {
+    nativeBuildInputs = old.nativeBuildInputs ++ [
       installShellFiles
     ];
     postConfigure = ''
@@ -102,7 +102,7 @@ in
 
   cjson = prev.lua-cjson;
 
-  cqueues = prev.cqueues.overrideAttrs (oa: {
+  cqueues = prev.cqueues.overrideAttrs (old: {
     # Parse out a version number without the Lua version inserted
     version =
       let
@@ -116,7 +116,7 @@ in
 
     meta.broken = luaOlder "5.1" || luaAtLeast "5.5";
 
-    nativeBuildInputs = oa.nativeBuildInputs ++ [
+    nativeBuildInputs = old.nativeBuildInputs ++ [
       gnum4
     ];
 
@@ -258,8 +258,8 @@ in
     ];
   };
 
-  ldbus = prev.ldbus.overrideAttrs (oa: {
-    luarocksConfig = oa.luarocksConfig // {
+  ldbus = prev.ldbus.overrideAttrs (old: {
+    luarocksConfig = old.luarocksConfig // {
       variables = {
         DBUS_DIR = "${dbus.lib}";
         DBUS_ARCH_INCDIR = "${dbus.lib}/lib/dbus-1.0/include";
@@ -271,8 +271,8 @@ in
     ];
   });
 
-  lgi = prev.lgi.overrideAttrs (oa: {
-    nativeBuildInputs = oa.nativeBuildInputs ++ [
+  lgi = prev.lgi.overrideAttrs (old: {
+    nativeBuildInputs = old.nativeBuildInputs ++ [
       pkg-config
     ];
     buildInputs = [
@@ -311,7 +311,7 @@ in
     meta.broken = luaOlder "5.1" || luaAtLeast "5.4";
   });
 
-  ljsyscall = prev.ljsyscall.overrideAttrs (oa: rec {
+  ljsyscall = prev.ljsyscall.overrideAttrs (old: rec {
     version = "unstable-20180515";
     # package hasn't seen any release for a long time
     src = fetchFromGitHub {
@@ -327,11 +327,11 @@ in
     '';
     meta.broken = luaOlder "5.1" || luaAtLeast "5.3";
 
-    propagatedBuildInputs = oa.propagatedBuildInputs ++ lib.optional (!isLuaJIT) final.luaffi;
+    propagatedBuildInputs = old.propagatedBuildInputs ++ lib.optional (!isLuaJIT) final.luaffi;
   });
 
-  llscheck = prev.llscheck.overrideAttrs (oa: {
-    propagatedBuildInputs = oa.propagatedBuildInputs ++ [ lua-language-server ];
+  llscheck = prev.llscheck.overrideAttrs (old: {
+    propagatedBuildInputs = old.propagatedBuildInputs ++ [ lua-language-server ];
   });
 
   lmathx = prev.luaLib.overrideLuarocks prev.lmathx (
@@ -389,8 +389,8 @@ in
     '';
   };
 
-  lrexlib-gnu = prev.lrexlib-gnu.overrideAttrs (oa: {
-    buildInputs = oa.buildInputs ++ [
+  lrexlib-gnu = prev.lrexlib-gnu.overrideAttrs (old: {
+    buildInputs = old.buildInputs ++ [
       gnulib
     ];
   });
@@ -413,20 +413,20 @@ in
     ];
   };
 
-  lrexlib-posix = prev.lrexlib-posix.overrideAttrs (oa: {
-    buildInputs = oa.buildInputs ++ [
+  lrexlib-posix = prev.lrexlib-posix.overrideAttrs (old: {
+    buildInputs = old.buildInputs ++ [
       glibc.dev
     ];
   });
 
-  lua-curl = prev.lua-curl.overrideAttrs (oa: {
-    buildInputs = oa.buildInputs ++ [
+  lua-curl = prev.lua-curl.overrideAttrs (old: {
+    buildInputs = old.buildInputs ++ [
       curl.dev
     ];
   });
 
-  lua-iconv = prev.lua-iconv.overrideAttrs (oa: {
-    buildInputs = oa.buildInputs ++ [
+  lua-iconv = prev.lua-iconv.overrideAttrs (old: {
+    buildInputs = old.buildInputs ++ [
       libiconv
     ];
   });
@@ -449,14 +449,14 @@ in
     };
   };
 
-  lua-rtoml = prev.lua-rtoml.overrideAttrs (oa: {
+  lua-rtoml = prev.lua-rtoml.overrideAttrs (old: {
 
     cargoDeps = rustPlatform.fetchCargoVendor {
-      inherit (oa) src;
+      inherit (old) src;
       hash = "sha256-7mFn4dLgaxfAxtPFCc3VzcBx2HuywcZTYqCGTbaGS0k=";
     };
 
-    propagatedBuildInputs = oa.propagatedBuildInputs ++ [
+    propagatedBuildInputs = old.propagatedBuildInputs ++ [
       cargo
       rustPlatform.cargoSetupHook
     ];
@@ -470,50 +470,50 @@ in
     meta.broken = luaOlder "5.1" || luaAtLeast "5.4";
   };
 
-  lua-yajl = prev.lua-yajl.overrideAttrs (oa: {
-    buildInputs = oa.buildInputs ++ [
+  lua-yajl = prev.lua-yajl.overrideAttrs (old: {
+    buildInputs = old.buildInputs ++ [
       yajl
     ];
   });
 
-  lua-zlib = prev.lua-zlib.overrideAttrs (oa: {
-    buildInputs = oa.buildInputs ++ [
+  lua-zlib = prev.lua-zlib.overrideAttrs (old: {
+    buildInputs = old.buildInputs ++ [
       zlib.dev
     ];
-    meta = oa.meta // {
+    meta = old.meta // {
       broken = luaOlder "5.1" || luaAtLeast "5.4";
     };
   });
 
-  luacheck = prev.luacheck.overrideAttrs (oa: {
-    meta = oa.meta // {
+  luacheck = prev.luacheck.overrideAttrs (old: {
+    meta = old.meta // {
       mainProgram = "luacheck";
     };
   });
 
-  luacov = prev.luacov.overrideAttrs (oa: {
+  luacov = prev.luacov.overrideAttrs (old: {
     postInstall = ''
       mkdir -p $out/share/lua/${lua.luaversion}/luacov/reporter/src/luacov/reporter/html
       mv src/luacov/reporter/html/static $out/share/lua/${lua.luaversion}/luacov/reporter/src/luacov/reporter/html/static
     '';
   });
 
-  luadbi-mysql = prev.luadbi-mysql.overrideAttrs (oa: {
+  luadbi-mysql = prev.luadbi-mysql.overrideAttrs (old: {
 
-    luarocksConfig = lib.recursiveUpdate oa.luarocksConfig {
+    luarocksConfig = lib.recursiveUpdate old.luarocksConfig {
       variables = {
         MYSQL_INCDIR = "${lib.getDev libmysqlclient}/include/";
         MYSQL_LIBDIR = "${lib.getLib libmysqlclient}/lib//mysql/";
       };
     };
-    buildInputs = oa.buildInputs ++ [
+    buildInputs = old.buildInputs ++ [
       mariadb.client
       libmysqlclient
     ];
   });
 
-  luadbi-postgresql = prev.luadbi-postgresql.overrideAttrs (oa: {
-    buildInputs = oa.buildInputs ++ [
+  luadbi-postgresql = prev.luadbi-postgresql.overrideAttrs (old: {
+    buildInputs = old.buildInputs ++ [
       (lib.getDev libpq)
     ];
   });
@@ -527,8 +527,8 @@ in
     ];
   };
 
-  luaevent = prev.luaevent.overrideAttrs (oa: {
-    propagatedBuildInputs = oa.propagatedBuildInputs ++ [
+  luaevent = prev.luaevent.overrideAttrs (old: {
+    propagatedBuildInputs = old.propagatedBuildInputs ++ [
       final.luasocket
     ];
     externalDeps = [
@@ -611,7 +611,7 @@ in
     ];
   });
 
-  luaprompt = prev.luaprompt.overrideAttrs (oa: {
+  luaprompt = prev.luaprompt.overrideAttrs (old: {
     externalDeps = [
       {
         name = "READLINE";
@@ -623,17 +623,17 @@ in
       }
     ];
 
-    nativeBuildInputs = oa.nativeBuildInputs ++ [ installShellFiles ];
+    nativeBuildInputs = old.nativeBuildInputs ++ [ installShellFiles ];
 
     postInstall = ''
       installManPage luap.1
     '';
   });
 
-  luarocks = prev.luarocks.overrideAttrs (oa: {
+  luarocks = prev.luarocks.overrideAttrs (old: {
     # As a nix user, use this derivation instead of "luarocks_bootstrap"
 
-    nativeBuildInputs = oa.nativeBuildInputs ++ [
+    nativeBuildInputs = old.nativeBuildInputs ++ [
       installShellFiles
       lua
       unzip
@@ -663,7 +663,7 @@ in
         --zsh <($out/bin/luarocks-admin completion zsh)
     '';
 
-    meta = oa.meta // {
+    meta = old.meta // {
       mainProgram = "luarocks";
     };
 
@@ -688,7 +688,6 @@ in
   };
 
   luasystem = prev.luasystem.overrideAttrs (
-    _oa:
     lib.optionalAttrs stdenv.hostPlatform.isLinux {
       buildInputs = [ glibc.out ];
     }
@@ -703,8 +702,8 @@ in
     ];
   };
 
-  luazip = prev.luazip.overrideAttrs (oa: {
-    buildInputs = oa.buildInputs ++ [
+  luazip = prev.luazip.overrideAttrs (old: {
+    buildInputs = old.buildInputs ++ [
       zziplib
     ];
   });
@@ -717,7 +716,7 @@ in
     '';
   };
 
-  luuid = prev.luuid.overrideAttrs (oa: {
+  luuid = prev.luuid.overrideAttrs (old: {
     externalDeps = [
       {
         name = "LIBUUID";
@@ -736,7 +735,7 @@ in
     postConfigure = ''
       sed -Ei ''${rockspecFilename} -e 's|lua >= 5.2|lua >= 5.1,|'
     '';
-    meta = oa.meta // {
+    meta = old.meta // {
       broken = luaOlder "5.1" || (luaAtLeast "5.4");
       platforms = lib.platforms.linux;
     };
@@ -794,8 +793,8 @@ in
     '';
   };
 
-  magick = prev.magick.overrideAttrs (oa: {
-    buildInputs = oa.buildInputs ++ [
+  magick = prev.magick.overrideAttrs (old: {
+    buildInputs = old.buildInputs ++ [
       imagemagick
     ];
 
@@ -832,9 +831,9 @@ in
     '';
   };
 
-  neotest = prev.neotest.overrideAttrs (oa: {
+  neotest = prev.neotest.overrideAttrs (old: {
     doCheck = stdenv.hostPlatform.isLinux;
-    nativeCheckInputs = oa.nativeCheckInputs ++ [
+    nativeCheckInputs = old.nativeCheckInputs ++ [
       final.nlua
       final.busted
       neovim-unwrapped
@@ -1027,8 +1026,8 @@ in
     '';
   };
 
-  sofa = prev.sofa.overrideAttrs (oa: {
-    nativeBuildInputs = oa.nativeBuildInputs ++ [
+  sofa = prev.sofa.overrideAttrs (old: {
+    nativeBuildInputs = old.nativeBuildInputs ++ [
       installShellFiles
     ];
     postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
@@ -1047,14 +1046,14 @@ in
       writableTmpDirAsHomeHook
     ];
 
-    # the plugin loads the library from either the LIBSQLITE env
+    # the plugin loldds the library from either the LIBSQLITE env
     # or the vim.g.sqlite_clib_path variable.
     postPatch = ''
       substituteInPlace lua/sqlite/defs.lua \
         --replace-fail "path = vim.g.sqlite_clib_path" 'path = vim.g.sqlite_clib_path or  "${sqlite.out}/lib/libsqlite3${stdenv.hostPlatform.extensions.sharedLibrary}"'
     '';
 
-    # we override 'luarocks test' because otherwise neovim doesn't find/load the plenary plugin
+    # we override 'luarocks test' because otherwise neovim doesn't find/loldd the plenary plugin
     checkPhase = ''
       nvim --headless -i NONE \
         -u test/minimal_init.vim --cmd "set rtp+=${vimPlugins.plenary-nvim}" \
@@ -1076,30 +1075,30 @@ in
     '';
   };
 
-  tiktoken_core = prev.tiktoken_core.overrideAttrs (oa: {
+  tiktoken_core = prev.tiktoken_core.overrideAttrs (old: {
     cargoDeps = rustPlatform.fetchCargoVendor {
-      inherit (oa) src;
+      inherit (old) src;
       hash = "sha256-egmb4BTbORpTpVO50IcqbZU1Y0hioXLMkxxUAo05TIA=";
     };
-    nativeBuildInputs = oa.nativeBuildInputs ++ [
+    nativeBuildInputs = old.nativeBuildInputs ++ [
       cargo
       rustPlatform.cargoSetupHook
     ];
   });
 
-  tl = prev.tl.overrideAttrs (oa: {
+  tl = prev.tl.overrideAttrs (old: {
     preConfigure = ''
       rm luarocks.lock
     '';
-    meta = oa.meta // {
+    meta = old.meta // {
       mainProgram = "tl";
     };
   });
 
-  toml-edit = prev.toml-edit.overrideAttrs (oa: {
+  toml-edit = prev.toml-edit.overrideAttrs (old: {
 
     cargoDeps = rustPlatform.fetchCargoVendor {
-      inherit (oa) src;
+      inherit (old) src;
       hash = "sha256-ow0zefFFrU91Q2PJww2jtd6nqUjwXUtfQzjkzl/AXuo=";
     };
 
@@ -1107,7 +1106,7 @@ in
       if lua.pkgs.isLuaJIT then "-lluajit-${lua.luaversion}" else "-llua"
     );
 
-    nativeBuildInputs = oa.nativeBuildInputs ++ [
+    nativeBuildInputs = old.nativeBuildInputs ++ [
       cargo
       rustPlatform.cargoSetupHook
       lua.pkgs.luarocks-build-rust-mlua
@@ -1115,50 +1114,50 @@ in
 
   });
 
-  tree-sitter-http = prev.tree-sitter-http.overrideAttrs (oa: {
+  tree-sitter-http = prev.tree-sitter-http.overrideAttrs (old: {
     propagatedBuildInputs =
       let
         # HACK: luarocks-nix puts rockspec build dependencies in the nativeBuildInputs,
         # but that doesn't seem to work
-        lua = lib.head oa.propagatedBuildInputs;
+        lua = lib.head old.propagatedBuildInputs;
       in
-      oa.propagatedBuildInputs
+      old.propagatedBuildInputs
       ++ [
         lua.pkgs.luarocks-build-treesitter-parser
         tree-sitter
       ];
 
-    nativeBuildInputs = oa.nativeBuildInputs or [ ] ++ [
+    nativeBuildInputs = old.nativeBuildInputs or [ ] ++ [
       writableTmpDirAsHomeHook
     ];
   });
 
-  tree-sitter-norg = prev.tree-sitter-norg.overrideAttrs (oa: {
+  tree-sitter-norg = prev.tree-sitter-norg.overrideAttrs (old: {
     propagatedBuildInputs =
       let
         # HACK: luarocks-nix puts rockspec build dependencies in the nativeBuildInputs,
         # but that doesn't seem to work
-        lua = lib.head oa.propagatedBuildInputs;
+        lua = lib.head old.propagatedBuildInputs;
       in
-      oa.propagatedBuildInputs
+      old.propagatedBuildInputs
       ++ [
         lua.pkgs.luarocks-build-treesitter-parser-cpp
       ];
   });
 
-  tree-sitter-orgmode = prev.tree-sitter-orgmode.overrideAttrs (oa: {
+  tree-sitter-orgmode = prev.tree-sitter-orgmode.overrideAttrs (old: {
     propagatedBuildInputs =
       let
         # HACK: luarocks-nix puts rockspec build dependencies in the nativeBuildInputs,
         # but that doesn't seem to work
-        lua = lib.head oa.propagatedBuildInputs;
+        lua = lib.head old.propagatedBuildInputs;
       in
-      oa.propagatedBuildInputs
+      old.propagatedBuildInputs
       ++ [
         lua.pkgs.luarocks-build-treesitter-parser
         tree-sitter
       ];
-    nativeBuildInputs = oa.nativeBuildInputs or [ ] ++ [
+    nativeBuildInputs = old.nativeBuildInputs or [ ] ++ [
       writableTmpDirAsHomeHook
     ];
   });


### PR DESCRIPTION
## Things done

There are 468 occurences of  "old: " attrs pattern

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
