### PR TITLE
qt6.qtdeclarative: cherry-pick r-b fixes

### DIFF
--- a/pkgs/development/libraries/qt-6/modules/qtdeclarative/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtdeclarative/default.nix
@@ -43,6 +43,18 @@ qtModule {
       url = "https://github.com/qt/qtdeclarative/commit/9c6b2b78e9076f1c2676aa0c41573db9ca480654.diff";
       hash = "sha256-KMFurA9Q84qwuyBraU3ZdoFWs8uO3uoUcinfcfh/ps8=";
     })
+
+    # https://qt-project.atlassian.net/browse/QTBUG-137440
+    (fetchpatch {
+      name = "rb-dialogs-link-labsfolderlistmodel-into-quickdialogs2quickimpl.patch";
+      url = "https://github.com/qt/qtdeclarative/commit/4047fa8c6017d8e214e6ec3ddbed622fd34058e4.patch";
+      hash = "sha256-0a7a1AI8N35rqLY4M3aSruXXPBqz9hX2yT65r/xzfhc=";
+    })
+    (fetchpatch {
+      name = "rb-quickcontrols-fix-controls-styles-linkage.patch";
+      url = "https://github.com/qt/qtdeclarative/commit/aa805ed54d55479360e0e95964dcc09a858aeb28.patch";
+      hash = "sha256-EDdsXRokHPQ5jflaVucOZP3WSopMjrAM39WZD1Hk/5I=";
+    })
   ];
 
   cmakeFlags = [


### PR DESCRIPTION
Already merged upstream, but 6.10.2 is some way off still.

Should fix #384761

## Things done


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
