### PR TITLE
[25.11] python3Packages.ipython: 9.5.0 -> 9.7.0

### DIFF
--- a/pkgs/development/python-modules/ipython/default.nix
+++ b/pkgs/development/python-modules/ipython/default.nix
@@ -36,12 +36,12 @@
 
 buildPythonPackage rec {
   pname = "ipython";
-  version = "9.5.0";
+  version = "9.7.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-EpxEuUH+bZuC02/Hp8GBJ92x1vAvePhn9ALi463eMRM=";
+    hash = "sha256-X23ojJBaVmxqnWxACo/tVKY44fdUPReq4lURMyFrHk4=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
This pull request is a backport of #466975 to the `staging-25.11` branch. At the moment, [the “Changes acceptable for releases” section of `CONTRIBUTING.md` says:](https://github.com/NixOS/nixpkgs/blob/d981d41ffe5b541eae3782029b93e2af5d229cc2/CONTRIBUTING.md#changes-acceptable-for-releases)

> The release branches should generally only receive backwards-compatible changes, both for the Nix expressions and derivations.
> Here are some examples of changes that are okay to backport:
> - ✔️ New packages, modules and functions
> - ✔️ Security fixes
> - ✔️ Package version updates
>   - ✔️ Patch versions with fixes
>   - ✔️ Minor versions with new functionality, but no breaking changes

Looking through the patch notes for [version 9.6.0](https://ipython.readthedocs.io/en/stable/whatsnew/version9.html#ipython-9-6) and [version 9.7.0](https://ipython.readthedocs.io/en/stable/whatsnew/version9.html#ipython-9-7) of IPython, it looks like this is a minor package update with some new functionality, some fixes and no breaking changes. Therefore, I think that this backport is acceptable for release.

I tested the version of `python3Packages.ipython` from this pull request out on NixOS 25.05, and it seemed to work fine.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
