### PR TITLE
nixos/tests/util-linux: add tests

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1853,6 +1853,7 @@ in
   userborn-subids-immutable-etc = runTest ./userborn-subids-immutable-etc.nix;
   userborn-subids-mutable-etc = runTest ./userborn-subids-mutable-etc.nix;
   ustreamer = runTest ./ustreamer.nix;
+  util-linux = runTest ./util-linux.nix;
   utils = pkgs.callPackage ./utils { inherit runTest; };
   utmp = runTest ./utmp.nix;
   uwsgi = runTest ./uwsgi.nix;

--- a/nixos/tests/util-linux.nix
+++ b/nixos/tests/util-linux.nix
@@ -1,0 +1,106 @@
+{ pkgs, lib, ... }:
+
+{
+  name = "util-linux";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [
+      balsoft
+      joaosreis
+    ];
+  };
+
+  nodes.machine =
+    { ... }:
+    let
+      util-linux-with-check = pkgs.util-linux.tests.withCheck.overrideAttrs (old: {
+        nativeCheckInputs = old.nativeCheckInputs ++ [
+          pkgs.util-linux
+          pkgs.which
+          pkgs.systemd
+        ];
+
+        preCheck = ''
+          exclude=(
+            # su is not built
+            su/shell
+            # unreliable tests
+            blkid/cache
+            fdisk/gpt-resize
+            fsck/ismounted
+            libmount/loop-overlay
+            lsclocks/lsclocks
+            lsns/ioctl_ns
+            lsns/netns-from-sock
+            script/options
+            waitpid/pidfd-ino
+            waitpid/waitpid
+          )
+        '';
+
+        checkPhase = ''
+          runHook preCheck
+
+          make -j$NIX_BUILD_CORES check-programs
+
+          ./tests/run.sh --parallel --show-diff --use-system-commands --exclude="''${exclude[*]}"
+
+          runHook postCheck
+        '';
+
+        # Save some resources by not installing
+        dontInstall = true;
+        dontFixup = true;
+        dontBuild = true;
+      });
+    in
+    {
+      networking.useDHCP = false;
+
+      networking.interfaces = lib.mkForce { };
+
+      environment.systemPackages = [
+        (pkgs.writeShellScriptBin "util-linux-test" ''
+          source ${util-linux-with-check.inputDerivation}
+          ${lib.getExe' pkgs.coreutils "mkdir"} -p "$NIX_BUILD_TOP"
+          cd "$PWD"
+          # Run the derivation build
+          exec "$_derivation_original_builder" $_derivation_original_args
+        '')
+      ];
+
+      virtualisation.memorySize = 4096;
+      # virtualisation.cores >= 2 needed for chrt tests
+      virtualisation.cores = 2;
+
+      users = {
+        enforceIdUniqueness = false;
+
+        users = {
+          user1 = {
+            uid = 1;
+            group = "user1";
+          };
+          user2 = {
+            uid = 2;
+            group = "user2";
+          };
+        };
+
+        groups = {
+          user1.gid = 1;
+          user2.gid = 2;
+        };
+      };
+    };
+
+  testScript = ''
+    start_all()
+
+    machine.wait_for_unit("multi-user.target")
+
+    # needed for mount/special tests
+    machine.succeed("mkdir /sbin")
+
+    machine.succeed("systemd-cat -t TEST -p notice util-linux-test")
+  '';
+}

--- a/pkgs/by-name/ut/util-linux/package.nix
+++ b/pkgs/by-name/ut/util-linux/package.nix
@@ -33,6 +33,9 @@
   withLastlog ? !stdenv.hostPlatform.isDarwin && lib.meta.availableOn stdenv.hostPlatform pam,
   gitUpdater,
   nixosTests,
+  # For tests
+  bash,
+  e2fsprogs,
 }:
 
 # lastlog requires PAM, or else it's broken.
@@ -218,6 +221,58 @@ stdenv.mkDerivation (finalAttrs: {
 
     tests = {
       inherit (nixosTests) pam-lastlog;
+
+      withCheck = finalAttrs.finalPackage.overrideAttrs (old: {
+        nativeCheckInputs = [
+          e2fsprogs
+        ];
+
+        doCheck = true;
+
+        postPatch = old.postPatch or "" + ''
+          patchShebangs tests
+
+          # enosys: replace /bin/false with the one from coreutils
+          sed -i "s@/bin/false@${lib.getExe' coreutils "false"}@" tests/helpers/test_enosys.c
+
+          # silence errors from trying to write to closed pipe
+          sed -i "s@| head -1@2>/dev/null | head -1@" tests/ts/findmnt/df-options
+
+          # coresched: replace /bin/bash with the Nix store path to bash
+          sed -i "s@ /bin/bash\b@ ${lib.getExe' bash "bash"}@" tests/ts/coresched/coresched
+
+          # patch shebang in tests/ts/mount/special
+          sed -i "s|#!/bin/bash|#!${bash}/bin/bash|" tests/ts/mount/special
+        '';
+
+        preCheck = ''
+          # skip tests that are incompatible/unreliable with the sandbox environment
+          exclude=(
+            fadvise/drop
+            fincore/count
+            fallocate/fallocate
+            lsfd/column-ainodeclass
+            lsfd/column-type
+            lsfd/mkfds-netlink-protocol
+            lsfd/mkfds-tcp6
+            lsfd/mkfds-tcp
+            lsfd/mkfds-unix-dgram
+            lsfd/mkfds-unix-stream-requiring-sockdiag
+            lsfd/mkfds-socketpair
+            lsfd/option-inet
+            lsfd/mkfds-udp
+            lsfd/mkfds-udp6
+            lsfd/mkfds-udp-lite
+            lsfd/mkfds-udp6-lite
+            lsfd/option-inet-udplite
+            lsblk/lsblk
+          )
+
+          checkFlagsArray+=(
+            "TESTS_COMPONENTS=--exclude=\"''${exclude[*]}\""
+          )
+        '';
+      });
     };
   }
   // lib.optionalAttrs (!isMinimal) {

--- a/pkgs/by-name/ut/util-linux/package.nix
+++ b/pkgs/by-name/ut/util-linux/package.nix
@@ -220,7 +220,7 @@ stdenv.mkDerivation (finalAttrs: {
     hasCol = stdenv.hostPlatform.libc == "glibc";
 
     tests = {
-      inherit (nixosTests) pam-lastlog;
+      inherit (nixosTests) pam-lastlog util-linux;
 
       withCheck = finalAttrs.finalPackage.overrideAttrs (old: {
         nativeCheckInputs = [


### PR DESCRIPTION
Adds a NixOS test that runs the upstream test-suite for util-linux.

It skips some tests for now.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
