### PR TITLE
ucx: fix FOD hash

### DIFF
--- a/pkgs/by-name/uc/ucx/package.nix
+++ b/pkgs/by-name/uc/ucx/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "openucx";
     repo = "ucx";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-goANgYuMO1yColKOrqoBOj+yh68OSW7O8Ppng/pd4b0=";
+    hash = "sha256-54yLejOFdCa2KYstZuo+hZ5lSQR8WTZMa7lS0prc5NY=";
   };
 
   outputs = [


### PR DESCRIPTION
- fix FOD hash for `src` with tag `v1.19.1`

Upstream seems to have moved `v1.19.1` tag:
https://github.com/openucx/ucx/commits/v1.19.1/
and "rereleased"
https://github.com/openucx/ucx/releases/tag/v1.19.1
because of:
https://www.github.com/openucx/ucx/pull/11039
after update PR was merged in nixpkgs.

Now `v1.19.1` tag points to commit: 
https://github.com/openucx/ucx/commit/7009d7a19b1c2464224a3fe117a4155fb29298f5
instead of commit it pointed to before:
https://github.com/openucx/ucx/commit/a702467fd479dde8699f1f3d329733f51d0a9ab9
(confirmed by changing `rev`, it produces previous hash)

Fixes build failure:
```
error: hash mismatch in fixed-output derivation '/nix/store/wyy75b1nangzbxsfv80rflv34dvr4irv-source.drv':
         specified: sha256-goANgYuMO1yColKOrqoBOj+yh68OSW7O8Ppng/pd4b0=
            got:    sha256-54yLejOFdCa2KYstZuo+hZ5lSQR8WTZMa7lS0prc5NY=
```

---

Update PR with previous hash:
https://github.com/NixOS/nixpkgs/pull/465698

Confirmed FOD hash with:
```text
nix-build -A ucx.src --check
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
