### PR TITLE
python3Packages.mistralai: init at 1.9.11

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15898,6 +15898,12 @@
     githubId = 346094;
     name = "Michael Alyn Miller";
   };
+  mana-byte = {
+    email = "manaikilaut@gmail.com";
+    github = "mana-byte";
+    githubId = 93316844;
+    name = "Manaiki Laut";
+  };
   mandos = {
     email = "marek.maksimczyk@mandos.net.pl";
     github = "mandos";

--- a/pkgs/development/python-modules/mistralai/default.nix
+++ b/pkgs/development/python-modules/mistralai/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   python3Packages,
-  fetchPypi,
+  fetchFromGitHub,
 }:
 
 python3Packages.buildPythonPackage rec {
@@ -9,9 +9,11 @@ python3Packages.buildPythonPackage rec {
   version = "1.9.11";
   format = "pyproject";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-PfnkA8MadW7HnnjfJe5zzqPrFfhmk3c+FrFq2vWcm4o=";
+  src = fetchFromGitHub {
+    owner = "mistralai";
+    repo = "client-python";
+    rev = "v${version}";
+    hash = "sha256-34+HK4kTY1fcNWqiEJ/j5CA3xynO9DO3TCblndAJmmg=";
   };
 
   build-system = [ python3Packages.poetry-core ];
@@ -38,11 +40,17 @@ python3Packages.buildPythonPackage rec {
     ];
   };
 
+  # Fix README file for PyPI
+  patchPhase = ''
+    substituteInPlace pyproject.toml \
+      --replace 'readme = "README-PYPI.md"' 'readme = "README.md"'
+  '';
+
   pythonImportsCheck = [ "mistralai" ];
 
   meta = {
     description = "Python Client SDK for the Mistral AI API";
-    homepage = "https://pypi.org/project/mistralai/";
+    homepage = "https://github.com/mistralai/client-python";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ mana-byte ];
   };

--- a/pkgs/development/python-modules/mistralai/default.nix
+++ b/pkgs/development/python-modules/mistralai/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  python3Packages,
+  fetchPypi,
+}:
+
+python3Packages.buildPythonPackage rec {
+  pname = "mistralai";
+  version = "1.9.11";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-PfnkA8MadW7HnnjfJe5zzqPrFfhmk3c+FrFq2vWcm4o=";
+  };
+
+  build-system = [ python3Packages.poetry-core ];
+
+  dependencies = with python3Packages; [
+    eval-type-backport
+    httpx
+    invoke
+    pydantic
+    python-dateutil
+    pyyaml
+    typing-inspection
+  ];
+
+  optional-dependencies = with python3Packages; {
+    agents = [
+      authlib
+      griffe
+      mcp
+    ];
+    gcp = [
+      google-auth
+      requests
+    ];
+  };
+
+  pythonImportsCheck = [ "mistralai" ];
+
+  meta = {
+    description = "Python Client SDK for the Mistral AI API";
+    homepage = "https://pypi.org/project/mistralai/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ mana-byte ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Added MistralAI python SDK.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
