### PR TITLE
ocamlPackages.markdown: init at 0.2.1

### DIFF
--- a/pkgs/development/ocaml-modules/markdown/default.nix
+++ b/pkgs/development/ocaml-modules/markdown/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildDunePackage,
+  fetchurl,
+  batteries,
+  tyxml,
+  ounit2,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "markdown";
+  version = "0.2.1";
+
+  src = fetchurl {
+    url = "https://github.com/gildor478/ocaml-markdown/releases/download/v${finalAttrs.version}/markdown-v${finalAttrs.version}.tbz";
+    hash = "sha256-nFdbdK0UIpqwiYGaNIoaj0UwI7/PHCDrxfxHNDYj3l4=";
+  };
+
+  propagatedBuildInputs = [
+    batteries
+    tyxml
+  ];
+
+  doCheck = true;
+
+  checkInputs = [ ounit2 ];
+
+  meta = {
+    homepage = "https://github.com/gildor478/ocaml-markdown";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
+    description = "Markdown parser and printer";
+  };
+
+})

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1136,6 +1136,8 @@ let
           inherit (pkgs) mariadb;
         };
 
+        markdown = callPackage ../development/ocaml-modules/markdown { };
+
         markup = callPackage ../development/ocaml-modules/markup { };
 
         mccs = callPackage ../development/ocaml-modules/mccs { };


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
