### PR TITLE
Cinnamon updates 2025-12-12

### DIFF
--- a/pkgs/applications/backup/timeshift/unwrapped.nix
+++ b/pkgs/applications/backup/timeshift/unwrapped.nix
@@ -18,7 +18,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "timeshift";
-  version = "25.07.7";
+  version = "25.12.0";
   outputs = [
     "out"
     "man"
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "linuxmint";
     repo = "timeshift";
     tag = finalAttrs.version;
-    hash = "sha256-X3TwUkOeGzcgFM/4Fyfs8eQuGK2wHe3t13WSpIizX8s=";
+    hash = "sha256-JAp1kZ8DBjhB6Xk4ZeL2ozJoTPPcu5gn7Fh+vbm+Zjg=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/ci/cinnamon-session/package.nix
+++ b/pkgs/by-name/ci/cinnamon-session/package.nix
@@ -33,13 +33,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "cinnamon-session";
-  version = "6.6.0";
+  version = "6.6.1";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "cinnamon-session";
     tag = version;
-    hash = "sha256-16bBehc8NuPd9vr/J7Y5MoVsqOBQWzh63pzQZ96O0vs=";
+    hash = "sha256-zPfyPBKN9Qqs2UndW0vYzBqmeFla3ytvdcv/X2dv1zs=";
   };
 
   buildInputs = [

--- a/pkgs/by-name/ci/cinnamon-settings-daemon/package.nix
+++ b/pkgs/by-name/ci/cinnamon-settings-daemon/package.nix
@@ -30,13 +30,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-settings-daemon";
-  version = "6.6.0";
+  version = "6.6.1";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "cinnamon-settings-daemon";
     tag = version;
-    hash = "sha256-Ho7L4BqLJ0Vz9+ZijZ8ZhQr1NJmGVf8JWtUpplx1JF0=";
+    hash = "sha256-WK7MU63M3B0C4Dsik6j4cDyBTZlkF6pofZi2aJcH9eI=";
   };
 
   patches = [

--- a/pkgs/by-name/fo/folder-color-switcher/package.nix
+++ b/pkgs/by-name/fo/folder-color-switcher/package.nix
@@ -8,14 +8,14 @@
 
 stdenvNoCC.mkDerivation {
   pname = "folder-color-switcher";
-  version = "1.6.8";
+  version = "1.6.9";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "folder-color-switcher";
     # They don't really do tags, this is just a named commit.
-    rev = "d135f29d688d89a0e7b48acec9e08738c7976ee1";
-    hash = "sha256-3EFnQxTYcJLGjfAzZNS7pgVDUwuU3juOAwUyaKOHemI=";
+    rev = "fefe156e336d2a0bbfe1ca61cf4e6873c74ae405";
+    hash = "sha256-KL3ipzZiHEj+jwAmbIOCeSBOwm3bMpJf4PVhGS+Xx24=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/lightdm-slick-greeter/package.nix
+++ b/pkgs/by-name/li/lightdm-slick-greeter/package.nix
@@ -23,13 +23,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lightdm-slick-greeter";
-  version = "2.2.3";
+  version = "2.2.4";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "slick-greeter";
     rev = version;
-    hash = "sha256-htyFH1Q8RFyvkW75NMpjajNJDzv/87k/Dr8+R5beT2w=";
+    hash = "sha256-Kq5FcippvMyxxA56uH41UdOCrP2wSuw0Tyv1OFxKD5Q=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/mi/mint-l-theme/package.nix
+++ b/pkgs/by-name/mi/mint-l-theme/package.nix
@@ -3,25 +3,23 @@
   lib,
   fetchFromGitHub,
   python3,
-  sassc,
-  sass,
+  python3Packages,
 }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "mint-l-theme";
-  version = "2.0.2";
+  version = "2.0.3";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "mint-l-theme";
     rev = version;
-    hash = "sha256-QPTU/wCOytleuiQAodGzZ1MGWD2Sk7eoeXWpi6nS5As=";
+    hash = "sha256-RdcojX+8SQDJ9LPb81iMzdoCZBpoypf/+aQcgotnVGE=";
   };
 
   nativeBuildInputs = [
     python3
-    sassc
-    sass
+    python3Packages.libsass
   ];
 
   postPatch = ''

--- a/pkgs/by-name/mi/mint-themes/package.nix
+++ b/pkgs/by-name/mi/mint-themes/package.nix
@@ -8,13 +8,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "mint-themes";
-  version = "2.3.2";
+  version = "2.3.4";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "mint-themes";
     rev = version;
-    hash = "sha256-99bE20XheHzEa2IIlXqdTHs044FRqI3O1xOLkhEC/gY=";
+    hash = "sha256-A4k9iy0d9pGPSYa4m3tAv2GKhFuJPrQODbv+LcP/YXU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/mi/mint-y-icons/package.nix
+++ b/pkgs/by-name/mi/mint-y-icons/package.nix
@@ -10,13 +10,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "mint-y-icons";
-  version = "1.8.9";
+  version = "1.9.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "mint-y-icons";
     rev = version;
-    hash = "sha256-eUMBn+2qnU6mgDPM6i2ebwEq3mSV3Uo6bXveVew3j9U=";
+    hash = "sha256-1ymx9qcv7YyIK1+mwKaXn8afh1o6I6jMIZtdvId8dEg=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/by-name/ne/nemo/package.nix
+++ b/pkgs/by-name/ne/nemo/package.nix
@@ -36,13 +36,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "nemo";
-  version = "6.6.0";
+  version = "6.6.1";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "nemo";
     rev = version;
-    hash = "sha256-4YbWkS4J0iDkp+wnwyJg5TD/fhHsbutyh7q+yFLV9Mk=";
+    hash = "sha256-oJvGuPm6FOknSe+5TDLNf0eoE3xC+i78SkYdJUBY4PU=";
   };
 
   patches = [

--- a/pkgs/by-name/xa/xapp-symbolic-icons/package.nix
+++ b/pkgs/by-name/xa/xapp-symbolic-icons/package.nix
@@ -9,13 +9,13 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "xapp-symbolic-icons";
-  version = "1.0.5";
+  version = "1.0.6";
 
   src = fetchFromGitHub {
     owner = "xapp-project";
     repo = "xapp-symbolic-icons";
     tag = finalAttrs.version;
-    hash = "sha256-lzxNtalNNKTamoToHWXkqWUoPqQZiWvgETVqLF1ov8Q=";
+    hash = "sha256-vKQLqpKII790bl+oXvKP08sOBCsgpKwHIR2N/bq3pcM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xe/xed-editor/package.nix
+++ b/pkgs/by-name/xe/xed-editor/package.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  fetchpatch,
   libxml2,
   libpeas,
   glib,
@@ -13,6 +12,7 @@
   xapp-symbolic-icons,
   pkg-config,
   python3,
+  python3Packages,
   meson,
   ninja,
   versionCheckHook,
@@ -23,25 +23,19 @@
 
 stdenv.mkDerivation rec {
   pname = "xed-editor";
-  version = "3.8.5";
+  version = "3.8.6";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "xed";
     rev = version;
-    hash = "sha256-iPD9SawHA0bwnZvC+IyMq9cFE1YOYLISehUJjTXiqGw=";
+    hash = "sha256-CeKgJg9pyQdnpatdlgqviLnzNv9JCVDm+bFv56trrT8=";
   };
 
   patches = [
     # We patch gobject-introspection and meson to store absolute paths to libraries in typelibs
     # but that requires the install_dir is an absolute path.
     ./correct-gir-lib-path.patch
-
-    # Switch to girepository-2.0
-    (fetchpatch {
-      url = "https://src.fedoraproject.org/rpms/xed/raw/6c1a775158f166a3bc5759a6c7bd57bab8f2771a/f/libpeas_libgirepository2.patch";
-      hash = "sha256-wGbmS33YHMiSfd3S0fQRhL6tT536kto69MSgPkY2QIs=";
-    })
   ];
 
   nativeBuildInputs = [
@@ -62,6 +56,7 @@ stdenv.mkDerivation rec {
     gtksourceview4
     libpeas
     gspell
+    python3Packages.pygobject3
     xapp
   ];
 

--- a/pkgs/by-name/xv/xviewer/package.nix
+++ b/pkgs/by-name/xv/xviewer/package.nix
@@ -29,13 +29,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xviewer";
-  version = "3.4.13";
+  version = "3.4.14";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "xviewer";
     rev = version;
-    hash = "sha256-g7ifQ+2FeZzpWfKgtFrWj0YDOB0++s6KGffHhvqGNQE=";
+    hash = "sha256-2UWe9c9JkNhJyukDp+NTG/bvbMuwSyLBkk2wWvPbxRk=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--

xed-editor: 3.8.5 -> 3.8.6
timeshift: 25.07.7 -> 25.12.0
lightdm-slick-greeter: 2.2.3 -> 2.2.4
xviewer: 3.4.13 -> 3.4.14
nemo: 6.6.0 -> 6.6.1
mint-y-icons: 1.8.9 -> 1.9.0
mint-themes: 2.3.2 -> 2.3.4
mint-l-theme: 2.0.2 -> 2.0.3
folder-color-switcher: 1.6.8 -> 1.6.9
cinnamon-settings-daemon: 6.6.0 -> 6.6.1
cinnamon-session: 6.6.0 -> 6.6.1
xapp-symbolic-icons: 1.0.5 -> 1.0.6

-->

https://github.com/bobby285271/what-changed/blob/a754507a4e870ba447cc1a809688a5ba4ca845d6/003-cinnamon.md

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

