### PR TITLE
treewide: libressl.nc -> netcat

### DIFF
--- a/nixos/modules/virtualisation/libvirtd.nix
+++ b/nixos/modules/virtualisation/libvirtd.nix
@@ -421,7 +421,7 @@ in
       # this file is expected in /etc/qemu and not sysconfdir (/var/lib)
       etc."qemu/bridge.conf".text = lib.concatMapStringsSep "\n" (e: "allow ${e}") cfg.allowedBridges;
       systemPackages = with pkgs; [
-        libressl.nc
+        netcat
         config.networking.firewall.package
         cfg.package
         cfg.qemu.package

--- a/nixos/tests/ceph-multi-node.nix
+++ b/nixos/tests/ceph-multi-node.nix
@@ -53,7 +53,7 @@ let
         sudo
         ceph
         xfsprogs
-        libressl.nc
+        netcat
       ];
 
       boot.kernelModules = [ "xfs" ];

--- a/nixos/tests/fail2ban.nix
+++ b/nixos/tests/fail2ban.nix
@@ -14,7 +14,7 @@
   nodes.client = _: {
     environment.systemPackages = [
       pkgs.sshpass
-      pkgs.libressl.nc
+      pkgs.netcat
     ];
 
   };

--- a/nixos/tests/jool.nix
+++ b/nixos/tests/jool.nix
@@ -24,7 +24,7 @@ let
           printf 'HTTP/1.0 200 OK\n'
           printf 'Content-Length: ${toString (1 + builtins.stringLength msg)}\n'
           printf '\n${msg}\n\n'
-        } | ${pkgs.libressl.nc}/bin/nc -${toString ip}nvl 80
+        } | ${pkgs.netcat}/bin/nc -${toString ip}nvl 80
         done
       '';
     };

--- a/nixos/tests/samba-wsdd.nix
+++ b/nixos/tests/samba-wsdd.nix
@@ -40,7 +40,7 @@
     server_wsdd.wait_for_unit("samba-wsdd")
 
     client_wsdd.wait_until_succeeds(
-        "echo list | ${pkgs.libressl.nc}/bin/nc -N -U /run/wsdd/wsdd.sock | grep -i SERVER-WSDD"
+        "echo list | ${pkgs.netcat}/bin/nc -N -U /run/wsdd/wsdd.sock | grep -i SERVER-WSDD"
     )
   '';
 }

--- a/pkgs/by-name/hy/hydra/package.nix
+++ b/pkgs/by-name/hy/hydra/package.nix
@@ -38,7 +38,7 @@
   mdbook,
   foreman,
   python3,
-  libressl,
+  netcat,
   cacert,
   glibcLocales,
   meson,
@@ -208,7 +208,7 @@ stdenv.mkDerivation (finalAttrs: {
     foreman
     glibcLocales
     python3
-    libressl.nc
+    netcat
     nix-eval-jobs
     openldap
     postgresql


### PR DESCRIPTION
Quote from NixOS 25.11 release notes:

> `meta.mainProgram` is now used to determine the `NIX_MAIN_PROGRAM` environment variable. This means that changing it can now lead to a package rebuild.

And `netcat` is:

```
 netcat = libressl.nc.overrideAttrs (old: { 
   meta = old.meta // { 
     description = "Utility which reads and writes data across network connections — LibreSSL implementation"; 
     mainProgram = "nc"; 
   }; 
 });
```

`netcat` and `libressl.nc` are 2 different derivations now, use just one
 of them in nixpkgs for consistency.

This also fixes lots of warnings if `virtualisation.libvirtd.enable = true`:

```
pkgs.buildEnv warning: colliding subpath (ignored): `/nix/store/1mcayh9rmxmjcbmm6swkkyr59rjl66vc-libressl-4.2.1-nc/bin/nc' and `/nix/store/x1vmfpisbd494yykmvjkhvh3dplsnjhg-libressl-4.2.1-nc/bin/nc'
... more 565 warnings
```

See also https://github.com/NixOS/nixpkgs/issues/279582 https://github.com/NixOS/nixpkgs/pull/281464

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
