### PR TITLE
tribler: fix missing ui png

### DIFF
--- a/pkgs/by-name/tr/tribler/package.nix
+++ b/pkgs/by-name/tr/tribler/package.nix
@@ -115,7 +115,7 @@ python3.pkgs.buildPythonApplication {
   '';
 
   postInstall = ''
-    ln -s ${tribler-webui} $out/lib/python*/site-packages/tribler/ui
+    ln -s ${tribler-webui} $out/${python312.sitePackages}/tribler/ui
   '';
 
   preFixup = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
After upgrading to 25.11, which brought in tribler-8.2.3-unstable-2025-10-14, i found that the `tribler` command failed to launch with errors complaining about a missing .png file. ie:

```
ERROR:tribler.core.session:Uncaught exception: Traceback (most recent call last):
  File "/nix/store/bga0pmx41favd48qv4l70rh5hywwysw3-tribler/bin/..tribler-wrapped-wrapped", line 9, in <module>
    sys.exit(main_sync())
             ^^^^^^^^^^^
  File "/nix/store/bga0pmx41favd48qv4l70rh5hywwysw3-tribler/lib/python3.12/site-packages/tribler/run.py", line 329, in main_sync
    asyncio.run(main())
  File "/nix/store/fdibxyh7xcmqrc172y78awzhxs292gq1-python3-3.12.12/lib/python3.12/asyncio/runners.py", line 195, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/nix/store/fdibxyh7xcmqrc172y78awzhxs292gq1-python3-3.12.12/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/fdibxyh7xcmqrc172y78awzhxs292gq1-python3-3.12.12/lib/python3.12/asyncio/base_events.py", line 691, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/nix/store/bga0pmx41favd48qv4l70rh5hywwysw3-tribler/lib/python3.12/site-packages/tribler/run.py", line 313, in main
    icon = None if headless else spawn_tray_icon(session, config)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/bga0pmx41favd48qv4l70rh5hywwysw3-tribler/lib/python3.12/site-packages/tribler/run.py", line 262, in spawn_tray_icon
    image = Image.open(image_path.resolve())
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/341slf4ary2700z1b20186qyaqp46q2h-python3.12-pillow-12.0.0/lib/python3.12/site-packages/PIL/Image.py", line 3493, in open
    fp = builtins.open(filename, "rb")
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/nix/store/bga0pmx41favd48qv4l70rh5hywwysw3-tribler/lib/python3.12/site-packages/tribler/ui/public/tribler.png'
NoneType: None

```

I think that is supposed to be provided by the new `tribler-webui` when it is built, but the step in the postInstall phase was aiming at `python*` and the resulting package did not end up with the `..tribler/ui` folder, just a `...tribler` folder.

Changing the line to `ln -s ${tribler-webui} $out/lib/python3.12/site-packages/tribler/ui` gets the actual `ui` folder in the resulting package and the web-ui will properly launch.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
