### PR TITLE
knot-resolver*_6: fixup darwin

### DIFF
--- a/pkgs/by-name/kn/knot-resolver-manager_6/package.nix
+++ b/pkgs/by-name/kn/knot-resolver-manager_6/package.nix
@@ -25,6 +25,12 @@ python3Packages.buildPythonPackage {
     substitute '${knot-resolver.unwrapped.config_py}'/knot_resolver/constants.py ./python/knot_resolver/constants.py \
       --replace-fail '${knot-resolver.unwrapped.out}/etc' '/etc' \
       --replace-fail '${knot-resolver.unwrapped.out}/sbin' '${knot-resolver}/bin'
+  ''
+  # On non-Linux let's simplify construction of the knot-resolver command line,
+  # as it would break because of nixpkgs-specific wrapping of python packages.
+  + ''
+    substituteInPlace python/knot_resolver/controller/supervisord/config_file.py \
+      --replace-fail 'args = [sys.executable] + sys.argv' 'args = sys.argv'
   '';
 
   build-system = with python3Packages; [
@@ -42,6 +48,7 @@ python3Packages.buildPythonPackage {
     typing-extensions
   ];
 
+  doCheck = python3Packages.stdenv.isLinux; # maybe in future
   nativeCheckInputs = with python3Packages; [
     augeas
     dnspython

--- a/pkgs/by-name/kn/knot-resolver_6/package.nix
+++ b/pkgs/by-name/kn/knot-resolver_6/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
   # native deps.
   runCommand,
   pkg-config,
@@ -46,6 +47,15 @@ let
       "out"
       "dev"
       "config_py"
+    ];
+
+    patches = [
+      (fetchpatch {
+        name = "test-cache-aarch64-darwin.patch";
+        url = "https://gitlab.nic.cz/knot/knot-resolver/-/commit/d155d0dbe408a3327b39f70e122aea6fb2b86684.diff";
+        excludes = [ "NEWS" ];
+        hash = "sha256-3w33v8UfhGdA50BlkfHpQLFxg+5ELk0lp7RzgvkSzK8=";
+      })
     ];
 
     # Path fixups for the NixOS service.


### PR DESCRIPTION
Now it starts and resolves on an aarch64-darwin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
