### PR TITLE
nix-prefetch: fix compatibility with extendMkDerivation-based fetchers

### DIFF
--- a/pkgs/by-name/ni/nix-prefetch/fix-extendMkDerivation-overlay.patch
+++ b/pkgs/by-name/ni/nix-prefetch/fix-extendMkDerivation-overlay.patch
@@ -1,0 +1,23 @@
+--- a/lib/overlay.nix	2025-12-12 14:17:10.585262065 -0500
++++ b/lib/overlay.nix	2025-12-12 14:17:31.567341843 -0500
+@@ -35,9 +35,17 @@
+     ];
+   };
+ 
+-  curlFetcher = fetcher: setFunctionArgs (args: fetcher (args // {
+-    curlOpts = (args.curlOpts or "") + " --no-insecure --cacert ${cacert}/etc/ssl/certs/ca-bundle.crt ";
+-  })) (functionArgs fetcher);
++  # Handle both attrset and function arguments for extendMkDerivation compatibility
++  curlFetcher = fetcher: setFunctionArgs (args:
++    let
++      modifyArgs = a: a // {
++        curlOpts = (a.curlOpts or "") + " --no-insecure --cacert ${cacert}/etc/ssl/certs/ca-bundle.crt ";
++      };
++    in
++      if isFunction args
++      then fetcher (final: modifyArgs (args final))
++      else fetcher (modifyArgs args)
++  ) (functionArgs fetcher);
+ 
+   unsafeFetcher = name: reason: throw "The fetcher ${name} is deemed unsafe: ${reason}.";
+ 

--- a/pkgs/by-name/ni/nix-prefetch/fix-extendMkDerivation-prelude.patch
+++ b/pkgs/by-name/ni/nix-prefetch/fix-extendMkDerivation-prelude.patch
@@ -1,0 +1,37 @@
+--- a/lib/prelude.nix
++++ b/lib/prelude.nix
+@@ -108,9 +108,24 @@
+ 
+   primitiveFetchers = listFetchers builtinsOverlay true ++ [ "fetchurlBoot" ];
+ 
++  # Helper to merge args, handling both attrsets and functions (for extendMkDerivation)
++  mergeArgsWithRequired = requiredArgs: args:
++    if isFunction args
++    then final: requiredArgs // args final
++    else requiredArgs // args;
++
++  # Helper to safely intersect args with oldArgs, handling function args
++  safeIntersectArgs = args: oldArgs:
++    if isFunction args
++    then {}  # When args is a function, we can't know the keys at evaluation time
++    else builtins.intersectAttrs args oldArgs;
++
+   markFetcher = { type, name, fetcher }:
+     let
+-      customFetcher = args: markFetcherDrv { inherit type name fetcher args; drv = fetcher (requiredFetcherArgs // args); };
++      customFetcher = args: markFetcherDrv {
++        inherit type name fetcher args;
++        drv = fetcher (mergeArgsWithRequired requiredFetcherArgs args);
++      };
+ 
+       # The required fetcher arguments are assumed to be of type string,
+       # because requiring a complex value, e.g. a derivation attrset, is very unlikely,
+@@ -132,7 +147,7 @@
+               if !(elem origPassthru.__fetcher.name primitiveFetchers) then functionArgs origPassthru.__fetcher
+               else throw "Fetcher ${name} is build on top of the primitive fetcher ${origPassthru.__fetcher.name}, which is not supported."
+             else {};
+-          newArgs = oldArgs // functionArgs fetcher // mapAttrs (_: _: true) (builtins.intersectAttrs args oldArgs);
++          newArgs = oldArgs // functionArgs fetcher // mapAttrs (_: _: true) (safeIntersectArgs args oldArgs);
+         in {
+           passthru = origPassthru // {
+             __fetcher = setFunctionArgs fetcher newArgs // { inherit type name args; drv = drvOverriden; };

--- a/pkgs/by-name/ni/nix-prefetch/package.nix
+++ b/pkgs/by-name/ni/nix-prefetch/package.nix
@@ -47,6 +47,11 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/msteen/nix-prefetch/commit/508237f48f7e2d8496ce54f38abbe57f44d0cbca.patch";
       hash = "sha256-9SYPcRFZaVyNjMUVdXbef5eGvLp/kr379eU9lG5GgE0=";
     })
+    # Fix compatibility with extendMkDerivation-based fetchers (fetchzip, fetchgit, etc.)
+    # The curlFetcher and markFetcher functions assumed fetcher arguments are always
+    # attribute sets, but extendMkDerivation can pass functions for the finalAttrs pattern.
+    ./fix-extendMkDerivation-overlay.patch
+    ./fix-extendMkDerivation-prelude.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
I was running into the issue, when running `./pkgs/development/python-modules/playwright/update.sh` to update playwright. It seemed nix-prefetch didn't like being called on fetchers that used extendMkDerivation, resulting in a "expected a set but found a function" error. Nix-prefetch always assumes that fetcher arguments will always be attribute sets, but in reality we are passing functions to them.

For transparency's sake, I used Claude Opus 4.5 to actually root cause this issue because I didn't have a grasp on the issue I was encountering.

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
