### PR TITLE
keycloak.plugins.keycloak-remember-me-authenticator: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1793,6 +1793,13 @@
     githubId = 6091755;
     name = "Anirrudh Krishnan";
   };
+  anish = {
+    email = "i@anish.land";
+    github = "ap-1";
+    githubId = 67872951;
+    name = "Anish Pallati";
+    keys = [ { fingerprint = "2A0A 16F5 E026 BE3B A47F B7A6 841A FB68 9A5B ACCB"; } ];
+  };
   ankhers = {
     email = "me@ankhers.dev";
     github = "ankhers";

--- a/pkgs/by-name/ke/keycloak/all-plugins.nix
+++ b/pkgs/by-name/ke/keycloak/all-plugins.nix
@@ -7,6 +7,7 @@
   keycloak-magic-link = callPackage ./keycloak-magic-link { };
   keycloak-metrics-spi = callPackage ./keycloak-metrics-spi { };
   keycloak-restrict-client-auth = callPackage ./keycloak-restrict-client-auth { };
+  keycloak-remember-me-authenticator = callPackage ./keycloak-remember-me-authenticator { };
 
   # These could theoretically be used by something other than Keycloak, but
   # there are no other quarkus apps in nixpkgs (as of 2023-08-21)

--- a/pkgs/by-name/ke/keycloak/keycloak-remember-me-authenticator/default.nix
+++ b/pkgs/by-name/ke/keycloak/keycloak-remember-me-authenticator/default.nix
@@ -1,0 +1,32 @@
+{
+  maven,
+  lib,
+  fetchFromGitHub,
+}:
+
+maven.buildMavenPackage rec {
+  pname = "keycloak-remember-me-authenticator";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "Herdo";
+    repo = "keycloak-remember-me-authenticator";
+    rev = "v${version}";
+    hash = "sha256-zIFWbv02wbf3D6Weyc8N4YM+fFFxnve0ti5yS52KN3c=";
+  };
+
+  mvnHash = "sha256-9wvBTA9RYPJz9zeimo4tmEjoHfKVGtPPAdNTe5BKdOs=";
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm444 -t "$out" target/keycloak-remember-me-authenticator-${version}.jar
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/Herdo/keycloak-remember-me-authenticator";
+    description = "Custom authenticator for remembering the user logging in, even if no \"Remember me\" flag is set";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ anish ];
+  };
+}

--- a/pkgs/by-name/ke/keycloak/package.nix
+++ b/pkgs/by-name/ke/keycloak/package.nix
@@ -101,6 +101,7 @@ stdenv.mkDerivation (finalAttrs: {
       talyz
       nickcao
       leona
+      anish
     ];
   };
 })


### PR DESCRIPTION
Adds the [keycloak-remember-me-authenticator](https://github.com/Herdo/keycloak-remember-me-authenticator) plugin for Keycloak.

This plugin enables "Remember Me" functionality for users logging in via identity providers which don't natively support the Remember Me flag.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
