### PR TITLE
rassumfrassum: init at 0.3.3

### DIFF
--- a/pkgs/by-name/ra/rassumfrassum/package.nix
+++ b/pkgs/by-name/ra/rassumfrassum/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  basedpyright,
+  # codebook,
+  ruff,
+  ty,
+}:
+
+let
+  version = "0.3.3";
+in
+python3Packages.buildPythonApplication {
+  pname = "rassumfrassum";
+  inherit version;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "joaotavora";
+    repo = "rassumfrassum";
+    tag = "v${version}";
+    hash = "sha256-3Hcews5f7o45GUmFdpLwkAHf0bthC1tUikkxau952Ec=";
+  };
+
+  postPatch = ''
+    patchShebangs rass test/
+  '';
+
+  build-system = [ python3Packages.setuptools ];
+
+  # The test suite is timing-sensitive at present and running it on
+  # Hydra does not add much value in any case, given that this package
+  # depends on nothing but core Python, and that nothing depends on
+  # this package...
+  doCheck = false;
+
+  # ...but let's have the plumbing in place for if/when it becomes
+  # possible to run tests on Hydra reliably.
+  nativeCheckInputs = [
+    # codebook (does not work in sandbox)
+    basedpyright
+    ruff
+    ty
+  ];
+
+  checkPhase = ''
+    test/run-all.sh
+  '';
+
+  meta = {
+    description = "Connect an LSP client to multiple LSP servers";
+    homepage = "https://github.com/joaotavora/rassumfrassum";
+    changelog = "https://github.com/joaotavora/rassumfrassum/releases/tag/v${version}";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ lib.maintainers.cmm ];
+  };
+}


### PR DESCRIPTION
https://github.com/joaotavora/rassumfrassum

Another LSP server multiplexer.  What makes this one special is that it is written by the author of Eglot, and at least one commonly-desired LSP configuration (namely Eglot <-> {[Based]Pyright, Ruff}) seems to Actually Work with this.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [v] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [v] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [v] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
