### PR TITLE
nixos/actual: Fix access denied errors by exposing user, group and dataDir options

### DIFF
--- a/nixos/modules/services/web-apps/actual.nix
+++ b/nixos/modules/services/web-apps/actual.nix
@@ -31,6 +31,26 @@ in
       description = "Whether to open the firewall for the specified port.";
     };
 
+    user = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        User account under which Actual runs.
+
+        If null is specified (default), a temporary user will be created by systemd. Otherwise won't be automatically created by the service.
+      '';
+    };
+
+    group = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        Group account under which Actual runs.
+
+        If null is specified (default), a temporary user will be created by systemd. Otherwise won't be automatically created by the service.
+      '';
+    };
+
     settings = mkOption {
       default = { };
       description = ''
@@ -101,9 +121,6 @@ in
 
       serviceConfig = {
         ExecStart = getExe cfg.package;
-        DynamicUser = true;
-        User = "actual";
-        Group = "actual";
         StateDirectory = "actual";
         RuntimeDirectory = "actual";
         WorkingDirectory = cfg.settings.dataDir;
@@ -146,7 +163,21 @@ in
           "@pkey"
         ];
         UMask = "0077";
-      };
+      }
+      // (
+        if cfg.user != null then
+          {
+            DynamicUser = false;
+            Group = cfg.group;
+            User = cfg.user;
+          }
+        else
+          {
+            DynamicUser = true;
+            User = "actual";
+            Group = "actual";
+          }
+      );
     };
   };
 

--- a/nixos/modules/services/web-apps/actual.nix
+++ b/nixos/modules/services/web-apps/actual.nix
@@ -17,7 +17,6 @@ let
     ;
 
   cfg = config.services.actual;
-  dataDir = "/var/lib/actual";
 
   formatType = pkgs.formats.json { };
 in
@@ -53,12 +52,34 @@ in
             description = "The port to listen on";
             default = 3000;
           };
-        };
 
-        config = {
-          serverFiles = mkDefault "${dataDir}/server-files";
-          userFiles = mkDefault "${dataDir}/user-files";
-          dataDir = mkDefault dataDir;
+          dataDir = lib.mkOption {
+            type = lib.types.str;
+            default = "/var/lib/actual";
+            description = ''
+              Directory under which Actual runs and saves its data.
+
+              Changing this after you already have a working instance may make Actual fail to start, even if you move all files in the data dir. If migration is needed, refer to [this comment](https://github.com/actualbudget/actual/issues/3957#issuecomment-2567076794) for a fix.
+            '';
+          };
+
+          serverFiles = lib.mkOption {
+            type = lib.types.str;
+            default = "${cfg.settings.dataDir}/server-files";
+            defaultText = "\${cfg.settings.dataDir}/server-files";
+            description = ''
+              The server will put an account.sqlite file in this directory, which will contain the (hashed) server password, a list of all the budget files the server knows about, and the active session token (along with anything else the server may want to store in the future).
+            '';
+          };
+
+          userFiles = lib.mkOption {
+            type = lib.types.str;
+            default = "${cfg.settings.dataDir}/user-files";
+            defaultText = "\${cfg.settings.dataDir}/user-files";
+            description = ''
+              The server will put all the budget files in this directory as binary blobs.
+            '';
+          };
         };
       };
     };
@@ -85,7 +106,7 @@ in
         Group = "actual";
         StateDirectory = "actual";
         RuntimeDirectory = "actual";
-        WorkingDirectory = dataDir;
+        WorkingDirectory = cfg.settings.dataDir;
         LimitNOFILE = "1048576";
         PrivateTmp = true;
         PrivateDevices = true;
@@ -107,6 +128,11 @@ in
         ProtectProc = "invisible";
         ProcSubset = "pid";
         ProtectSystem = "strict";
+        ReadWritePaths = [
+          cfg.settings.dataDir
+          cfg.settings.serverFiles
+          cfg.settings.userFiles
+        ];
         RestrictAddressFamilies = [
           "AF_INET"
           "AF_INET6"

--- a/nixos/tests/actual.nix
+++ b/nixos/tests/actual.nix
@@ -9,8 +9,47 @@
       services.actual.enable = true;
     };
 
+  nodes.machine2 =
+    { ... }:
+    {
+      services.actual = {
+        enable = true;
+        user = "actual";
+        group = "actual";
+        settings = {
+          port = 7000;
+          dataDir = "/var/lib/actual-test";
+        };
+      };
+
+      users.users.actual = {
+        group = "actual";
+        home = "/var/lib/actual-test";
+        isSystemUser = true;
+      };
+
+      users.groups.actual = { };
+
+      systemd.tmpfiles.settings = {
+        "10-actualdir" = {
+          "/var/lib/actual-test" = {
+            d = {
+              group = "actual";
+              mode = "0755";
+              user = "actual";
+            };
+          };
+        };
+      };
+    };
+
   testScript = ''
+    start_all()
+
     machine.wait_for_open_port(3000)
     machine.succeed("curl -fvvv -Ls http://localhost:3000/ | grep 'Actual'")
+
+    machine2.wait_for_open_port(7000)
+    machine2.succeed("curl -fvvv -Ls http://localhost:7000/ | grep 'Actual'")
   '';
 }


### PR DESCRIPTION
This PR fixes the settings.dataDir option, which previously had no effect.

If you want to save your data files in a separate disk, or even if just your https key files are in a filesystem not chmoded to 777, the ability to set the systemd user and group for the service is required. Therefore, this PR also adds that.

This should not break any existing installations, since the default values remain the same, but more testing is always welcome.

CC maintainers: @oddlama @patrickdag

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
