### PR TITLE
ghstack: fix package build failure after Poetry to uv migration

### DIFF
--- a/pkgs/by-name/gh/ghstack/package.nix
+++ b/pkgs/by-name/gh/ghstack/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
 }:
 
-python3.pkgs.buildPythonApplication {
+python3.pkgs.buildPythonApplication rec {
   pname = "ghstack";
   version = "0.12.0";
   pyproject = true;
@@ -12,11 +12,16 @@ python3.pkgs.buildPythonApplication {
   src = fetchFromGitHub {
     owner = "ezyang";
     repo = "ghstack";
-    rev = "fa7e7023d798aad6b115b88c5ad67ce88a4fc2a6";
-    hash = "sha256-Ywwjeupa8eE/vkrbl5SIbvQs53xaLnq9ieWRFwzmuuc=";
+    rev = version;
+    hash = "sha256-pLKwDezkwGrqYgP4WnIl5nAam6bMNO6BK+xbxhp7Aq8=";
   };
 
-  build-system = [ python3.pkgs.poetry-core ];
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'requires = ["uv_build>=0.6,<0.7"]' 'requires = ["uv_build>=0.6"]'
+  '';
+
+  build-system = [ python3.pkgs.uv-build ];
 
   dependencies = with python3.pkgs; [
     aiohttp
@@ -27,13 +32,16 @@ python3.pkgs.buildPythonApplication {
     typing-extensions
   ];
 
-  pythonImportsCheck = [ "ghstack" ];
+  pythonImportsCheck = [ "ghstack.cli" ];
 
   meta = {
     description = "Submit stacked diffs to GitHub on the command line";
     homepage = "https://github.com/ezyang/ghstack";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ munksgaard ];
+    maintainers = with lib.maintainers; [
+      munksgaard
+      shikanime
+    ];
     mainProgram = "ghstack";
   };
 }


### PR DESCRIPTION
Change-Id: Id68e4d607dbc2c9e3528b563dd1906236a6a6964


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
