### PR TITLE
x{pr,load,kb{print,evd}}: refactor & move to pkgs/by-name from xorg namespace 

### DIFF
--- a/pkgs/by-name/xk/xkbevd/package.nix
+++ b/pkgs/by-name/xk/xkbevd/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  bison,
+  pkg-config,
+  util-macros,
+  libx11,
+  libxkbfile,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xkbevd";
+  version = "1.1.6";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "app";
+    repo = "xkbevd";
+    tag = "xkbevd-${finalAttrs.version}";
+    hash = "sha256-n/detXvtRvysc5pjFc0Q27yLC2QsNUBo9AIXYkUG4PQ=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    bison
+    pkg-config
+    util-macros
+  ];
+
+  buildInputs = [
+    util-macros # unused dependency but the build fails if pkg-config can't find it
+    libx11
+    libxkbfile
+  ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=xkbevd-(.*)" ]; };
+
+  meta = {
+    description = "XKB event daemon";
+    longDescription = ''
+      The xkbevd event daemon listens for specified XKB events and executes requested commands if
+      they occur. The configuration file consists of a list of event specification/action pairs
+      and/or variable definitions.
+      This command is very raw and is therefore only partially implemented; it is a rough prototype
+      for developers, not a general purpose tool for end users.
+    '';
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xkbevd";
+    license = lib.licenses.hpnd;
+    mainProgram = "xkbevd";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xk/xkbprint/package.nix
+++ b/pkgs/by-name/xk/xkbprint/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  pkg-config,
+  util-macros,
+  libx11,
+  libxkbfile,
+  xorgproto,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xkbprint";
+  version = "1.0.7";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "app";
+    repo = "xkbprint";
+    tag = "xkbprint-${finalAttrs.version}";
+    hash = "sha256-JcVXwhEV6tTdgBNki7MuUPjjZOjVE83uBP/yc+ShycE=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    util-macros
+  ];
+
+  buildInputs = [
+    libx11
+    libxkbfile
+    xorgproto
+  ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=xkbprint-(.*)" ]; };
+
+  meta = {
+    description = "Generates a PostScript image of an XKB keyboard description.";
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xkbprint";
+    license = with lib.licenses; [
+      hpnd
+      hpndDec
+    ];
+    mainProgram = "xkbprint";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xl/xload/package.nix
+++ b/pkgs/by-name/xl/xload/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  pkg-config,
+  util-macros,
+  wrapWithXFileSearchPathHook,
+  libx11,
+  libxaw,
+  libxmu,
+  xorgproto,
+  libxt,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xload";
+  version = "1.2.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "app";
+    repo = "xload";
+    tag = "xload-${finalAttrs.version}";
+    hash = "sha256-Mm09uKP+LUW0xGrwcJth/XCUqJ1RDEspbYpL92vOdk4=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    util-macros
+    wrapWithXFileSearchPathHook
+  ];
+
+  buildInputs = [
+    libx11
+    libxaw
+    libxmu
+    xorgproto
+    libxt
+  ];
+
+  installFlags = [ "appdefaultdir=$out/share/X11/app-defaults" ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=xload-(.*)" ]; };
+
+  meta = {
+    description = "System load average display for X";
+    longDescription = ''
+      xload displays a periodically updating histogram of the system load average.
+    '';
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xload";
+    license = with lib.licenses; [
+      x11
+      mit
+    ];
+    mainProgram = "xload";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xp/xpr/package.nix
+++ b/pkgs/by-name/xp/xpr/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  pkg-config,
+  util-macros,
+  xorgproto,
+  libx11,
+  libxmu,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xpr";
+  version = "1.2.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "app";
+    repo = "xpr";
+    tag = "xpr-${finalAttrs.version}";
+    hash = "sha256-q8WcQSzlAwbdIcXWyQjjHmvuqYa4k2e7O+VhShwBDUE=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    util-macros
+  ];
+
+  buildInputs = [
+    xorgproto
+    libx11
+    libxmu
+  ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=xpr-(.*)" ]; };
+
+  meta = {
+    description = "Utility to print an X window dump from xwd";
+    longDescription = ''
+      xpr takes as input a window dump file produced by xwd and formats it for output on various
+      types of printers.
+    '';
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xpr";
+    license = with lib.licenses; [
+      mit
+      x11
+      hpnd
+    ];
+    mainProgram = "xpr";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -131,6 +131,7 @@
   xgamma,
   xgc,
   xhost,
+  xkbprint,
   xkbutils,
   xkeyboard-config,
   xkill,
@@ -213,6 +214,7 @@ self: with self; {
     xgamma
     xgc
     xhost
+    xkbprint
     xkbutils
     xkill
     xload
@@ -2403,44 +2405,6 @@ self: with self; {
       buildInputs = [
         libX11
         libxkbfile
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xkbprint = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      libxkbfile,
-      xorgproto,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xkbprint";
-      version = "1.0.7";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xkbprint-1.0.7.tar.xz";
-        sha256 = "1k2rm8lvc2klcdz2s3mymb9a2ahgwqwkgg67v3phv7ij6304jkqw";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libX11
-        libxkbfile
-        xorgproto
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -146,6 +146,7 @@
   xorgproto,
   xorg-server,
   xorg-sgml-doctools,
+  xpr,
   xprop,
   xrandr,
   xrdb,
@@ -221,6 +222,7 @@ self: with self; {
     xmodmap
     xmore
     xorgproto
+    xpr
     xprop
     xrandr
     xrdb
@@ -2485,44 +2487,6 @@ self: with self; {
         libXmu
         xorgproto
         libXt
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xpr = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      libXmu,
-      xorgproto,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xpr";
-      version = "1.2.0";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xpr-1.2.0.tar.xz";
-        sha256 = "1hyf6mc2l7lzkf21d5j4z6glg9y455hlsg8lv2lz028k6gw0554b";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libX11
-        libXmu
-        xorgproto
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -131,6 +131,7 @@
   xgamma,
   xgc,
   xhost,
+  xkbevd,
   xkbprint,
   xkbutils,
   xkeyboard-config,
@@ -214,6 +215,7 @@ self: with self; {
     xgamma
     xgc
     xhost
+    xkbevd
     xkbprint
     xkbutils
     xkill
@@ -2373,42 +2375,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xkbcomp" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xkbevd = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      libxkbfile,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xkbevd";
-      version = "1.1.6";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xkbevd-1.1.6.tar.xz";
-        sha256 = "0gh73dsf4ic683k9zn2nj9bpff6dmv3gzcb3zx186mpq9kw03d6r";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libX11
-        libxkbfile
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -134,6 +134,7 @@
   xkbutils,
   xkeyboard-config,
   xkill,
+  xload,
   xlsatoms,
   xlsclients,
   xlsfonts,
@@ -214,6 +215,7 @@ self: with self; {
     xhost
     xkbutils
     xkill
+    xload
     xlsatoms
     xlsclients
     xlsfonts
@@ -2439,54 +2441,6 @@ self: with self; {
         libX11
         libxkbfile
         xorgproto
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xload = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      libXaw,
-      libXmu,
-      xorgproto,
-      libXt,
-      gettext,
-      wrapWithXFileSearchPathHook,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xload";
-      version = "1.2.0";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xload-1.2.0.tar.xz";
-        sha256 = "104snn0rpnc91bmgj797cj6sgmkrp43n9mg20wbmr8p14kbfc3rc";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        gettext
-        wrapWithXFileSearchPathHook
-      ];
-      buildInputs = [
-        libX11
-        libXaw
-        libXmu
-        xorgproto
-        libXt
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -463,6 +463,7 @@ print OUT <<EOF;
   xgamma,
   xgc,
   xhost,
+  xkbevd,
   xkbprint,
   xkbutils,
   xkeyboard-config,
@@ -546,6 +547,7 @@ self: with self; {
     xgamma
     xgc
     xhost
+    xkbevd
     xkbprint
     xkbutils
     xkill

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -478,6 +478,7 @@ print OUT <<EOF;
   xorgproto,
   xorg-server,
   xorg-sgml-doctools,
+  xpr,
   xprop,
   xrandr,
   xrdb,
@@ -553,6 +554,7 @@ self: with self; {
     xmodmap
     xmore
     xorgproto
+    xpr
     xprop
     xrandr
     xrdb

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -466,6 +466,7 @@ print OUT <<EOF;
   xkbutils,
   xkeyboard-config,
   xkill,
+  xload,
   xlsatoms,
   xlsclients,
   xlsfonts,
@@ -546,6 +547,7 @@ self: with self; {
     xhost
     xkbutils
     xkill
+    xload
     xlsatoms
     xlsclients
     xlsfonts

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -463,6 +463,7 @@ print OUT <<EOF;
   xgamma,
   xgc,
   xhost,
+  xkbprint,
   xkbutils,
   xkeyboard-config,
   xkill,
@@ -545,6 +546,7 @@ self: with self; {
     xgamma
     xgc
     xhost
+    xkbprint
     xkbutils
     xkill
     xload

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -427,7 +427,6 @@ self: super:
   xfs = addMainProgram super.xfs { };
   xinput = addMainProgram super.xinput { };
   xkbevd = addMainProgram super.xkbevd { };
-  xkbprint = addMainProgram super.xkbprint { };
 
   xwd = addMainProgram super.xwd { };
 }

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -426,7 +426,6 @@ self: super:
   xfd = addMainProgram super.xfd { };
   xfs = addMainProgram super.xfs { };
   xinput = addMainProgram super.xinput { };
-  xkbevd = addMainProgram super.xkbevd { };
 
   xwd = addMainProgram super.xwd { };
 }

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -430,8 +430,6 @@ self: super:
   xkbprint = addMainProgram super.xkbprint { };
   xload = addMainProgram super.xload { };
 
-  xpr = addMainProgram super.xpr { };
-
   xwd = addMainProgram super.xwd { };
 }
 

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -428,7 +428,6 @@ self: super:
   xinput = addMainProgram super.xinput { };
   xkbevd = addMainProgram super.xkbevd { };
   xkbprint = addMainProgram super.xkbprint { };
-  xload = addMainProgram super.xload { };
 
   xwd = addMainProgram super.xwd { };
 }

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -5,7 +5,6 @@ mirror://xorg/individual/app/xinit-1.4.4.tar.xz
 mirror://xorg/individual/app/xinput-1.6.4.tar.xz
 mirror://xorg/individual/app/xkbcomp-1.5.0.tar.xz
 mirror://xorg/individual/app/xkbevd-1.1.6.tar.xz
-mirror://xorg/individual/app/xkbprint-1.0.7.tar.xz
 mirror://xorg/individual/app/xtrap-1.0.3.tar.bz2
 mirror://xorg/individual/app/xwd-1.0.9.tar.xz
 mirror://xorg/individual/driver/xf86-input-evdev-2.11.0.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -6,7 +6,6 @@ mirror://xorg/individual/app/xinput-1.6.4.tar.xz
 mirror://xorg/individual/app/xkbcomp-1.5.0.tar.xz
 mirror://xorg/individual/app/xkbevd-1.1.6.tar.xz
 mirror://xorg/individual/app/xkbprint-1.0.7.tar.xz
-mirror://xorg/individual/app/xload-1.2.0.tar.xz
 mirror://xorg/individual/app/xtrap-1.0.3.tar.bz2
 mirror://xorg/individual/app/xwd-1.0.9.tar.xz
 mirror://xorg/individual/driver/xf86-input-evdev-2.11.0.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -4,7 +4,6 @@ mirror://xorg/individual/app/xfs-1.2.2.tar.xz
 mirror://xorg/individual/app/xinit-1.4.4.tar.xz
 mirror://xorg/individual/app/xinput-1.6.4.tar.xz
 mirror://xorg/individual/app/xkbcomp-1.5.0.tar.xz
-mirror://xorg/individual/app/xkbevd-1.1.6.tar.xz
 mirror://xorg/individual/app/xtrap-1.0.3.tar.bz2
 mirror://xorg/individual/app/xwd-1.0.9.tar.xz
 mirror://xorg/individual/driver/xf86-input-evdev-2.11.0.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -7,7 +7,6 @@ mirror://xorg/individual/app/xkbcomp-1.5.0.tar.xz
 mirror://xorg/individual/app/xkbevd-1.1.6.tar.xz
 mirror://xorg/individual/app/xkbprint-1.0.7.tar.xz
 mirror://xorg/individual/app/xload-1.2.0.tar.xz
-mirror://xorg/individual/app/xpr-1.2.0.tar.xz
 mirror://xorg/individual/app/xtrap-1.0.3.tar.bz2
 mirror://xorg/individual/app/xwd-1.0.9.tar.xz
 mirror://xorg/individual/driver/xf86-input-evdev-2.11.0.tar.xz


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- ran checks
  - [x] nixpkgs-hammering
  - [x] nix-check-deps
  - [x] passthru.updateScript
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
