### PR TITLE
fosrl-newt: 1.5.2 -> 1.7.0, modernize

### DIFF
--- a/pkgs/by-name/fo/fosrl-newt/package.nix
+++ b/pkgs/by-name/fo/fosrl-newt/package.nix
@@ -42,6 +42,7 @@ buildGoModule rec {
       fab
       jackr
       sigmasquadron
+      water-sucks
     ];
     mainProgram = "newt";
   };

--- a/pkgs/by-name/fo/fosrl-newt/package.nix
+++ b/pkgs/by-name/fo/fosrl-newt/package.nix
@@ -3,6 +3,7 @@
   buildGoModule,
   fetchFromGitHub,
   versionCheckHook,
+  nix-update-script,
 }:
 
 buildGoModule rec {
@@ -29,6 +30,8 @@ buildGoModule rec {
   doInstallCheck = true;
 
   versionCheckProgramArg = [ "-version" ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Tunneling client for Pangolin";

--- a/pkgs/by-name/fo/fosrl-newt/package.nix
+++ b/pkgs/by-name/fo/fosrl-newt/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule rec {
   pname = "newt";
-  version = "1.5.2";
+  version = "1.7.0";
 
   src = fetchFromGitHub {
     owner = "fosrl";
     repo = "newt";
     tag = version;
-    hash = "sha256-svMAMPK8f5cwIPzr0+WdoWzHDV1jtuO1Lm2oZIVHE6k=";
+    hash = "sha256-R6X9DOu1iGS/a4d5kmKoBZI0L5k7S0w3SHHFQnQH/ho=";
   };
 
-  vendorHash = "sha256-wNdZEfPx12T0jvCEDkz04X8N6t/pNIOXWFSTHteeZYs=";
+  vendorHash = "sha256-5Xr6mwPtsqEliKeKv2rhhp6JC7u3coP4nnhIxGMqccU=";
 
   postPatch = ''
     substituteInPlace main.go \

--- a/pkgs/by-name/fo/fosrl-newt/package.nix
+++ b/pkgs/by-name/fo/fosrl-newt/package.nix
@@ -18,16 +18,12 @@ buildGoModule rec {
 
   vendorHash = "sha256-5Xr6mwPtsqEliKeKv2rhhp6JC7u3coP4nnhIxGMqccU=";
 
-  postPatch = ''
-    substituteInPlace main.go \
-      --replace-fail "version_replaceme" "${version}"
-  '';
-
   nativeInstallCheckInputs = [ versionCheckHook ];
 
   ldflags = [
     "-s"
     "-w"
+    "-X=main.newtVersion=${version}"
   ];
 
   doInstallCheck = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This upgrades the `fosrl-newt` package from 1.5.2 to 1.7.0.

Changelog: https://github.com/fosrl/newt/compare/1.5.2...1.7.0

Additionally, it does some refactors:

- Uses Go's LDFLAGS to set the version instead of string substitution
- Adds the `updateScript` parameter to facilitate auto-updates by the nixpkgs bot in the future

Since I am now an employee at Pangolin, I also decided to add myself to the maintainer list.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
