### PR TITLE
meshlab: update patch to fix darwin build

### DIFF
--- a/pkgs/by-name/me/meshlab/no-plist.patch
+++ b/pkgs/by-name/me/meshlab/no-plist.patch
@@ -1,9 +1,12 @@
---- src/meshlab/CMakeLists.txt.orig	2025-10-05 23:04:12.786192073 +0200
-+++ src/meshlab/CMakeLists.txt	2025-10-05 23:04:16.379256637 +0200
-@@ -92,9 +92,6 @@
+diff --git a/src/meshlab/CMakeLists.txt b/src/meshlab/CMakeLists.txt
+index 89d9c9316..e9209573e 100644
+--- a/src/meshlab/CMakeLists.txt
++++ b/src/meshlab/CMakeLists.txt
+@@ -91,10 +91,6 @@ if (APPLE)
+ 		MACOSX_BUNDLE_INFO_STRING "MeshLab ${MESHLAB_VERSION}"
  		MACOSX_BUNDLE_COPYRIGHT "Copyright VCG-ISTI-CNR © 2005-2021. All rights reserved."
  		)
- 	
+-	
 -	set_additional_settings_info_plist(
 -		TARGET meshlab
 -		FILE ${MESHLAB_BUILD_DISTRIB_DIR}/meshlab.app/Contents/Info.plist)

--- a/pkgs/by-name/me/meshlab/package.nix
+++ b/pkgs/by-name/me/meshlab/package.nix
@@ -102,8 +102,7 @@ stdenv.mkDerivation (finalAttrs: {
     # ref. https://github.com/cnr-isti-vclab/meshlab/pull/1617
     # merged upstream
     ./1617_cmake-use-system-dependencies-install-exports.patch
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+
     ./no-plist.patch
   ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Currently fails on darwin with:
```
applying patch /nix/store/cr374x9wf7qpfvwkjddf8kpjrmjcc2dh-no-plist.patch
can't find file to patch at input line 3
Perhaps you used the wrong -p or --strip option?
The text leading up to this was:
--------------------------
|--- src/meshlab/CMakeLists.txt.orig    2025-10-05 23:04:12.786192073 +0200
|+++ src/meshlab/CMakeLists.txt 2025-10-05 23:04:16.379256637 +0200
--------------------------
File to patch:
Skip this patch? [y]
Skipping patch.
1 out of 1 hunk ignored
```

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
