### PR TITLE
nixosTests.lomiri-*-app: Fix

### DIFF
--- a/nixos/tests/lomiri-calculator-app.nix
+++ b/nixos/tests/lomiri-calculator-app.nix
@@ -39,7 +39,7 @@
         machine.sleep(10)
         machine.send_key("alt-f10")
         machine.sleep(5)
-        machine.wait_for_text("Calculator")
+        machine.wait_for_window("Calculator")
         machine.screenshot("lomiri-calculator")
 
     with subtest("lomiri calculator works"):
@@ -63,7 +63,7 @@
         machine.sleep(10)
         machine.send_key("alt-f10")
         machine.sleep(5)
-        machine.wait_for_text("Rechner")
+        machine.wait_for_window("Rechner")
         machine.screenshot("lomiri-calculator_localised")
 
     # History of previous run should have loaded

--- a/nixos/tests/lomiri-calendar-app.nix
+++ b/nixos/tests/lomiri-calendar-app.nix
@@ -55,7 +55,7 @@
         machine.sleep(2)
 
         # Still on main page
-        machine.succeed("xdotool mousemove 500 720 click 1")
+        machine.succeed("xdotool mousemove 500 740 click 1")
         machine.sleep(2)
         machine.wait_for_text(r"(Date|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday|All day|Name|Details|More)")
         machine.screenshot("lomiri-calendar_newevent")

--- a/nixos/tests/lomiri-clock-app.nix
+++ b/nixos/tests/lomiri-clock-app.nix
@@ -38,7 +38,7 @@
         machine.sleep(10)
         machine.send_key("alt-f10")
         machine.sleep(5)
-        machine.wait_for_text(r"(clock.ubports|City|Alarms)")
+        machine.wait_for_text(r"(clock.ubports|City|Alarms|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday)")
         machine.screenshot("lomiri-clock_open")
 
     machine.succeed("pkill -f lomiri-clock-app")
@@ -48,7 +48,7 @@
         machine.sleep(10)
         machine.send_key("alt-f10")
         machine.sleep(5)
-        machine.wait_for_text(r"(Stadt|Weckzeiten)")
+        machine.wait_for_text(r"(Stadt|Weckzeiten|Montag|Dienstag|Mittwoch|Donnerstag|Freitag|Samstag|Sonntag)")
         machine.screenshot("lomiri-clock_localised")
   '';
 }

--- a/nixos/tests/lomiri-docviewer-app.nix
+++ b/nixos/tests/lomiri-docviewer-app.nix
@@ -49,7 +49,7 @@ in
         machine.sleep(10)
         machine.send_key("alt-f10")
         machine.sleep(5)
-        machine.wait_for_text("No documents")
+        machine.wait_for_text(r"(No documents|Connect your device|drag files|removable media)")
         machine.screenshot("lomiri-docviewer_open")
 
     machine.succeed("pkill -f lomiri-docviewer-app")
@@ -93,7 +93,7 @@ in
         machine.sleep(10)
         machine.send_key("alt-f10")
         machine.sleep(5)
-        machine.wait_for_text("Keine Dokumente")
+        machine.wait_for_text(r"(Keine Dokumente|Rechner verbinden|Dokumentenordner ziehen|Dokumenten einstecken)")
         machine.screenshot("lomiri-docviewer_localised")
   '';
 }

--- a/nixos/tests/lomiri-mediaplayer-app.nix
+++ b/nixos/tests/lomiri-mediaplayer-app.nix
@@ -25,7 +25,7 @@ in
               ];
             }
             ''
-              magick -size 600x600 canvas:white -pointsize 20 -fill black -annotate +100+100 '${ocrContent}' output.png
+              magick -size 600x600 canvas:black -pointsize 32 -fill white -annotate +100+100 '${ocrContent}' output.png
               ffmpeg -re -loop 1 -i output.png -c:v libvpx -b:v 200K -t 120 $out -loglevel fatal
             '';
         systemPackages = with pkgs.lomiri; [


### PR DESCRIPTION
Fixing known-borked tests so they can be relied upon again.

At least one of these fixes is needed due to #456757, so backport to stable is necessary.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
