### PR TITLE
[release-25.05] {strongswan,networkmanager_strongswan}: apply patch for CVE-2025-9615

### DIFF
--- a/pkgs/by-name/ne/networkmanager_strongswan/package.nix
+++ b/pkgs/by-name/ne/networkmanager_strongswan/package.nix
@@ -22,6 +22,13 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-jL8kf63MsCbTTvYn1M7YbpUOMXPl2h/ZY7Rpz2rAr34=";
   };
 
+  patches = [
+    (fetchurl {
+      url = "https://download.strongswan.org/security/CVE-2025-9615/NetworkManager-strongswan-1.5.0-1.6.3_nm_credential_access.patch";
+      hash = "sha256-gqpFRHeIkg9sNZ5yDjdQTSB0NqpwLzqoZPoqDoFYIZ0=";
+    })
+  ];
+
   nativeBuildInputs = [
     intltool
     pkg-config

--- a/pkgs/by-name/st/strongswan/package.nix
+++ b/pkgs/by-name/st/strongswan/package.nix
@@ -91,6 +91,10 @@ stdenv.mkDerivation rec {
       url = "https://download.strongswan.org/security/CVE-2025-62291/strongswan-4.4.0-6.0.2_eap_mschapv2_failure_request_len.patch";
       hash = "sha256-9aUGGTeSrI9Ji8MfnsVZ6KrGMOB/5RuWZ/WQhY5E4+c=";
     })
+    (fetchurl {
+      url = "https://download.strongswan.org/security/CVE-2025-9615/strongswan-5.9.12-6.0.3_nm_credential_access.patch";
+      hash = "sha256-AeVb5j0AKwApGzdfkPJFfxNdoHq3GRNZfOuontCLY64=";
+    })
   ];
 
   postPatch = lib.optionalString stdenv.hostPlatform.isLinux ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
