### PR TITLE
fftw: fix build with __structuredAttrs, enable strictDeps

### DIFF
--- a/pkgs/by-name/ff/fftw/package.nix
+++ b/pkgs/by-name/ff/fftw/package.nix
@@ -66,9 +66,15 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional (precision != "double") "--enable-${precision}"
   # https://www.fftw.org/fftw3_doc/SIMD-alignment-and-fftw_005fmalloc.html
   # FFTW will try to detect at runtime whether the CPU supports these extensions
-  ++ lib.optional (
-    stdenv.hostPlatform.isx86_64 && (precision == "single" || precision == "double")
-  ) "--enable-sse2 --enable-avx --enable-avx2 --enable-avx512 --enable-avx128-fma"
+  ++
+    lib.optionals (stdenv.hostPlatform.isx86_64 && (precision == "single" || precision == "double"))
+      [
+        "--enable-sse2"
+        "--enable-avx"
+        "--enable-avx2"
+        "--enable-avx512"
+        "--enable-avx128-fma"
+      ]
   ++ lib.optionals enableMpi [
     "--enable-mpi"
     # link libfftw3_mpi explicitly with -lmpi
@@ -91,6 +97,8 @@ stdenv.mkDerivation (finalAttrs: {
   nativeCheckInputs = [ perl ];
 
   passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+
+  __structuredAttrs = true;
 
   meta = {
     description = "Fastest Fourier Transform in the West library";

--- a/pkgs/by-name/ff/fftw/package.nix
+++ b/pkgs/by-name/ff/fftw/package.nix
@@ -92,6 +92,7 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace configure --replace-fail "-mtune=native" "-mtune=generic"
   '';
 
+  strictDeps = true;
   enableParallelBuilding = true;
 
   nativeCheckInputs = [ perl ];

--- a/pkgs/by-name/ff/fftw/package.nix
+++ b/pkgs/by-name/ff/fftw/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
       "https://fftw.org/fftw-${finalAttrs.version}.tar.gz"
       "ftp://ftp.fftw.org/pub/fftw/fftw-${finalAttrs.version}.tar.gz"
     ];
-    sha256 = "sha256-VskyVJhSzdz6/as4ILAgDHdCZ1vpIXnlnmIVs0DiZGc=";
+    hash = "sha256-VskyVJhSzdz6/as4ILAgDHdCZ1vpIXnlnmIVs0DiZGc=";
   };
 
   patches = [
@@ -89,7 +89,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # fftw builds with -mtune=native by default
   postPatch = ''
-    substituteInPlace configure --replace "-mtune=native" "-mtune=generic"
+    substituteInPlace configure --replace-fail "-mtune=native" "-mtune=generic"
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Encountered the build failure with `nixpkgs.config.structuredAttrsByDefault = true;`.

Setting `strictDeps` seems to work as well, so if we rebuild the world anyway...

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-multiplatform (cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
