### PR TITLE
python3Packages.mkdocs-swagger-ui-tag: cleanup, disable failing test

### DIFF
--- a/pkgs/development/python-modules/mkdocs-swagger-ui-tag/default.nix
+++ b/pkgs/development/python-modules/mkdocs-swagger-ui-tag/default.nix
@@ -1,21 +1,25 @@
 {
-  beautifulsoup4,
+  lib,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
   hatchling,
-  lib,
+
+  # dependencies
+  beautifulsoup4,
+
+  # tests
+  click,
   mkdocs,
   playwright,
   pytestCheckHook,
-  pythonOlder,
 }:
 
 buildPythonPackage rec {
   pname = "mkdocs-swagger-ui-tag";
   version = "0.7.2";
-  format = "pyproject";
-
-  disabled = pythonOlder "3.7";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Blueswen";
@@ -24,13 +28,17 @@ buildPythonPackage rec {
     hash = "sha256-5bQJMmPrweIAR42bjfWHUqnSy4IFoTpFoBaV+Gj/OGI=";
   };
 
-  propagatedBuildInputs = [
-    beautifulsoup4
+  build-system = [
     hatchling
-    mkdocs
+  ];
+
+  dependencies = [
+    beautifulsoup4
   ];
 
   nativeCheckInputs = [
+    click
+    mkdocs
     playwright
     pytestCheckHook
   ];

--- a/pkgs/development/python-modules/mkdocs-swagger-ui-tag/default.nix
+++ b/pkgs/development/python-modules/mkdocs-swagger-ui-tag/default.nix
@@ -52,6 +52,9 @@ buildPythonPackage rec {
     "test_template"
     "test_mkdocs_screenshot"
     "test_no_console_errors"
+
+    # ValueError: I/O operation on closed file
+    "test_error"
   ];
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Currently fails on `master`

- **python3Packages.mkdocs-swagger-ui-tag: modernize**
- **python3Packages.mkdocs-swagger-ui-tag: disable failing test**

cc @snpschaaf

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
