### PR TITLE
opentelemetry-cpp: 1.23.0 -> 1.24.0, opentelemetry-proto: 1.7.0 -> 1.8.0

### DIFF
--- a/pkgs/by-name/op/opentelemetry-cpp/0001-Disable-tests-requiring-network-access.patch
+++ b/pkgs/by-name/op/opentelemetry-cpp/0001-Disable-tests-requiring-network-access.patch
@@ -47,15 +47,6 @@ index e8299202..19dbd7b1 100644
  {
    received_requests_.clear();
    curl::HttpClientSync http_client;
-@@ -495,7 +495,7 @@ TEST_F(BasicCurlHttpTests, GetBaseUri)
-             "http://127.0.0.1:31339/");
- }
- 
--TEST_F(BasicCurlHttpTests, SendGetRequestAsync)
-+TEST_F(BasicCurlHttpTests, DISABLED_SendGetRequestAsync)
- {
-   curl::HttpClient http_client;
- 
 @@ -570,7 +570,7 @@ TEST_F(BasicCurlHttpTests, SendGetRequestAsyncTimeout)
    }
  }

--- a/pkgs/by-name/op/opentelemetry-cpp/package.nix
+++ b/pkgs/by-name/op/opentelemetry-cpp/package.nix
@@ -21,19 +21,19 @@ let
   opentelemetry-proto = fetchFromGitHub {
     owner = "open-telemetry";
     repo = "opentelemetry-proto";
-    rev = "v1.7.0";
-    hash = "sha256-3SFf/7fStrglxcpwEya7hDp8Sr3wBG9OYyBoR78IUgs=";
+    rev = "v1.8.0";
+    hash = "sha256-5rNJDMjRFIOY/3j+PkAujbippBmxtAudU9busK0q8p0=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "opentelemetry-cpp";
-  version = "1.23.0";
+  version = "1.24.0";
 
   src = fetchFromGitHub {
     owner = "open-telemetry";
     repo = "opentelemetry-cpp";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-4SmKB2368I/2WTKYCqsZAAdkJygA15zCT+I7/RF8Knk=";
+    hash = "sha256-rVR8JWNoT5mxIgzynY8VzlZ4QxhWIEFBqogi+WFDcF0=";
   };
 
   patches = [
@@ -85,6 +85,13 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
   ];
 
+  # "--replace-fail" would normally be preferred, since it is better at
+  # highlighting obsolete/uneeded substitutions, but in this case
+  # "--replace-quiet" must be used.
+  # substituteInPlace with "--replace-fail" already fails if there is no
+  # substitution in at least one of the specified files. Below is applied to
+  # multiple files where some but not all of them match the substitution
+  # strings.
   postInstall = ''
     substituteInPlace $out/lib/cmake/opentelemetry-cpp/opentelemetry-cpp*-target.cmake \
       --replace-quiet "\''${_IMPORT_PREFIX}/include" "$dev/include"


### PR DESCRIPTION
* https://github.com/open-telemetry/opentelemetry-cpp/releases/tag/v1.24.0
* Added an explanation for the use of `--replace-quiet` instead of `--replace-fail` as promised in https://github.com/NixOS/nixpkgs/pull/440194#discussion_r2346950779

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `4c86238118d001bee2169d780767e82892653ae9`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 6 packages built:</summary>
  <ul>
    <li>azure-sdk-for-cpp.core-tracing-opentelemetry</li>
    <li>azure-sdk-for-cpp.core-tracing-opentelemetry.dev</li>
    <li>opentelemetry-cpp</li>
    <li>opentelemetry-cpp.dev</li>
    <li>tango-cpp</li>
    <li>tango-database</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
