### PR TITLE
hatsune-miku-windows-linux-cursors: 1.2.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4867,6 +4867,11 @@
     name = "Alex Zero";
     keys = [ { fingerprint = "A0AA 4646 B8F6 9D45 4553  5A88 A515 50ED B450 302C"; } ];
   };
+  civilterrorist = {
+    name = "THE ZERO-WIDTH BOMBER";
+    github = "civilterrorist";
+    githubId = 206461177;
+  };
   cizniarova = {
     email = "gabriel.hosquet@epitech.eu";
     github = "Ciznia";

--- a/pkgs/by-name/ha/hatsune-miku-linux-cursors/package.nix
+++ b/pkgs/by-name/ha/hatsune-miku-linux-cursors/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "hatsune-miku-cursors";
+  version = "1.2.6";
+
+  src = fetchurl {
+    url = "https://github.com/supermariofps/hatsune-miku-windows-linux-cursors/releases/download/${finalAttrs.version}/miku-cursor-linux.tar.xz";
+    hash = "sha256-ahPuw5KJN1dbw1Q1QQ8nZBDImSRdDKmMf54cwj8fJok=";
+  };
+
+  sourceRoot = ".";
+
+  unpackPhase = ''
+    tar -xvf $src
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/icons
+    cp -r ./miku-cursor-linux $out/share/icons
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Hatsune Miku cursor theme.";
+    homepage = "https://github.com/supermariofps/hatsune-miku-windows-linux-cursors";
+    license = lib.licenses.unlicense;
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/ha/hatsune-miku-linux-cursors/package.nix
+++ b/pkgs/by-name/ha/hatsune-miku-linux-cursors/package.nix
@@ -34,5 +34,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://github.com/supermariofps/hatsune-miku-windows-linux-cursors";
     license = lib.licenses.unlicense;
     platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.civilterrorist ];
   };
 })

--- a/pkgs/by-name/ha/hatsune-miku-linux-cursors/package.nix
+++ b/pkgs/by-name/ha/hatsune-miku-linux-cursors/package.nix
@@ -1,12 +1,16 @@
-{ lib, stdenvNoCC, fetchurl, nix-update-script, }:
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  nix-update-script,
+}:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "hatsune-miku-windows-linux-cursors";
   version = "1.2.6";
 
   src = fetchurl {
-    url =
-      "https://github.com/supermariofps/hatsune-miku-windows-linux-cursors/releases/download/${finalAttrs.version}/miku-cursor-linux.tar.xz";
+    url = "https://github.com/supermariofps/hatsune-miku-windows-linux-cursors/releases/download/${finalAttrs.version}/miku-cursor-linux.tar.xz";
     hash = "sha256-ahPuw5KJN1dbw1Q1QQ8nZBDImSRdDKmMf54cwj8fJok=";
   };
 
@@ -27,8 +31,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Hatsune Miku cursor theme.";
-    homepage =
-      "https://github.com/supermariofps/hatsune-miku-windows-linux-cursors";
+    homepage = "https://github.com/supermariofps/hatsune-miku-windows-linux-cursors";
     license = lib.licenses.unlicense;
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.civilterrorist ];

--- a/pkgs/by-name/ha/hatsune-miku-linux-cursors/package.nix
+++ b/pkgs/by-name/ha/hatsune-miku-linux-cursors/package.nix
@@ -1,7 +1,7 @@
 { lib, stdenvNoCC, fetchurl, nix-update-script, }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
-  pname = "hatsune-miku-cursors";
+  pname = "hatsune-miku-windows-linux-cursors";
   version = "1.2.6";
 
   src = fetchurl {

--- a/pkgs/by-name/ha/hatsune-miku-linux-cursors/package.nix
+++ b/pkgs/by-name/ha/hatsune-miku-linux-cursors/package.nix
@@ -1,16 +1,12 @@
-{
-  lib,
-  stdenvNoCC,
-  fetchurl,
-  nix-update-script,
-}:
+{ lib, stdenvNoCC, fetchurl, nix-update-script, }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "hatsune-miku-cursors";
   version = "1.2.6";
 
   src = fetchurl {
-    url = "https://github.com/supermariofps/hatsune-miku-windows-linux-cursors/releases/download/${finalAttrs.version}/miku-cursor-linux.tar.xz";
+    url =
+      "https://github.com/supermariofps/hatsune-miku-windows-linux-cursors/releases/download/${finalAttrs.version}/miku-cursor-linux.tar.xz";
     hash = "sha256-ahPuw5KJN1dbw1Q1QQ8nZBDImSRdDKmMf54cwj8fJok=";
   };
 
@@ -31,7 +27,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Hatsune Miku cursor theme.";
-    homepage = "https://github.com/supermariofps/hatsune-miku-windows-linux-cursors";
+    homepage =
+      "https://github.com/supermariofps/hatsune-miku-windows-linux-cursors";
     license = lib.licenses.unlicense;
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.civilterrorist ];


### PR DESCRIPTION
<!--
-->
This is a package for the Hatsune Miku linux cursors theme.
https://github.com/supermariofps/hatsune-miku-windows-linux-cursors
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
