### PR TITLE
nixos/sssd: fix sssd-kcm wrong command-line options

### DIFF
--- a/nixos/modules/services/misc/sssd.nix
+++ b/nixos/modules/services/misc/sssd.nix
@@ -208,7 +208,6 @@ in
         description = "SSSD Kerberos Cache Manager";
         requires = [ "sssd-kcm.socket" ];
         serviceConfig = {
-          ExecStartPre = "-${pkgs.sssd}/bin/sssd --genconf-section=kcm";
           ExecStart = "${pkgs.sssd}/libexec/sssd/sssd_kcm";
           CapabilityBoundingSet = [
             "CAP_IPC_LOCK"

--- a/nixos/modules/services/misc/sssd.nix
+++ b/nixos/modules/services/misc/sssd.nix
@@ -209,7 +209,7 @@ in
         requires = [ "sssd-kcm.socket" ];
         serviceConfig = {
           ExecStartPre = "-${pkgs.sssd}/bin/sssd --genconf-section=kcm";
-          ExecStart = "${pkgs.sssd}/libexec/sssd/sssd_kcm --uid 0 --gid 0";
+          ExecStart = "${pkgs.sssd}/libexec/sssd/sssd_kcm";
           CapabilityBoundingSet = [
             "CAP_IPC_LOCK"
             "CAP_CHOWN"


### PR DESCRIPTION
The `--uid` and `--gid` command line options were removed from sssd-kcm in 2.10.0:
https://github.com/SSSD/sssd/commit/dd7aaaf2fb41f283b20c3a1a86990367f6141360

The `--genconf-section` option was also removed from sssd in 2.10.0:
https://github.com/SSSD/sssd/commit/0485342f73ef839c2007e7118c222e02b9804369

https://sssd.io/release-notes/sssd-2.10.0.html

Fixes #470330.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
