### PR TITLE
wamrc: 2.3.1 -> 2.4.4

### DIFF
--- a/pkgs/by-name/wa/wamrc/package.nix
+++ b/pkgs/by-name/wa/wamrc/package.nix
@@ -3,19 +3,19 @@
   stdenv,
   fetchFromGitHub,
   cmake,
-  llvmPackages,
+  llvm_20,
   nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "wamrc";
-  version = "2.3.1";
+  version = "2.4.4";
 
   src = fetchFromGitHub {
     owner = "bytecodealliance";
     repo = "wasm-micro-runtime";
     tag = "WAMR-${finalAttrs.version}";
-    hash = "sha256-Rhn26TRyjkR30+zyosfooOGjhvG+ztYtJVQlRfzWEFo=";
+    hash = "sha256-pNudBKnhdR/Ye0m2tVZB/wSfJZYK8+gdCpCp0rDp0o4=";
   };
 
   nativeBuildInputs = [
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    llvmPackages.llvm
+    llvm_20
   ];
 
   cmakeFlags =
@@ -32,10 +32,10 @@ stdenv.mkDerivation (finalAttrs: {
     ]
     ++ [
       "-DWAMR_BUILD_WITH_CUSTOM_LLVM=ON"
-      "-DLLVM_DIR=${llvmPackages.llvm.dev}/lib/cmake/llvm"
+      "-DLLVM_DIR=${llvm_20.dev}/lib/cmake/llvm"
     ];
 
-  sourceRoot = "${finalAttrs.src.name}/wamr-compiler";
+  preConfigure = "cd wamr-compiler";
 
   passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=WAMR-(.*)" ]; };
 


### PR DESCRIPTION
Diff: https://github.com/bytecodealliance/wasm-micro-runtime/compare/WAMR-2.3.1...WAMR-2.4.4
Release notes: Lots, see https://github.com/bytecodealliance/wasm-micro-runtime/releases

This build was failing due to needing access to files outside the `wamr-compiler` directory, so we `cd` into the build directory instead of using `sourceRoot`.

Additionally, this fails to link with LLVM 21, so we override the LLVM version to override it to LLVM 20. Example failing Hydra build: https://hydra.nixos.org/build/314568884

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
