### PR TITLE
xf86-input-{mouse,synaptics,vmmouse,void}: refactor, move to pkgs/by-name & rename from xorg namespace

### DIFF
--- a/pkgs/by-name/xf/xf86-input-mouse/package.nix
+++ b/pkgs/by-name/xf/xf86-input-mouse/package.nix
@@ -12,7 +12,7 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "xf86-input-mouse";
-  version = "1.9.5";
+  version = "2.0.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "driver";
     repo = "xf86-input-mouse";
     tag = "xf86-input-mouse-${finalAttrs.version}";
-    hash = "sha256-vxdzLn9sclIYmPKw7vRa4oQJYmQV98WMfIjkMRosr/w=";
+    hash = "sha256-qPP0u7k1g30vw4A1c0fuVbQ9HHovTqWy8OAQ8uMGGg0=";
   };
 
   strictDeps = true;
@@ -32,6 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
+    util-macros
     xorgproto
     xorg-server
   ];
@@ -57,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
     ];
     maintainers = [ ];
     pkgConfigModules = [ "xorg-mouse" ];
-    platforms = lib.platforms.unix;
-    broken = stdenv.hostPlatform.isDarwin; # never worked: https://hydra.nixos.org/job/nixpkgs/trunk/xorg.xf86inputmouse.x86_64-darwin
+    # platforms according to the readme
+    platforms = with lib.platforms; freebsd ++ netbsd ++ openbsd ++ illumos;
   };
 })

--- a/pkgs/by-name/xf/xf86-input-mouse/package.nix
+++ b/pkgs/by-name/xf/xf86-input-mouse/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  pkg-config,
+  util-macros,
+  xorgproto,
+  xorg-server,
+  nix-update-script,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xf86-input-mouse";
+  version = "1.9.5";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "driver";
+    repo = "xf86-input-mouse";
+    tag = "xf86-input-mouse-${finalAttrs.version}";
+    hash = "sha256-vxdzLn9sclIYmPKw7vRa4oQJYmQV98WMfIjkMRosr/w=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    util-macros
+  ];
+
+  buildInputs = [
+    xorgproto
+    xorg-server
+  ];
+
+  configureFlags = [ "--with-sdkdir=${placeholder "out"}/include/xorg" ];
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version-regex=xf86-input-mouse-(.*)" ]; };
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "Mouse input driver for non-Linux platforms for the Xorg X server";
+    longDescription = ''
+      This driver is used on non-Linux operating systems such as BSD & Solaris, as modern Linux
+      systems use the xf86-input-evdev or xf86-input-libinput drivers instead.
+    '';
+    homepage = "https://gitlab.freedesktop.org/xorg/driver/xf86-input-mouse";
+    license = with lib.licenses; [
+      mit
+      hpndSellVariant
+      x11
+    ];
+    maintainers = [ ];
+    pkgConfigModules = [ "xorg-mouse" ];
+    platforms = lib.platforms.unix;
+    broken = stdenv.hostPlatform.isDarwin; # never worked: https://hydra.nixos.org/job/nixpkgs/trunk/xorg.xf86inputmouse.x86_64-darwin
+  };
+})

--- a/pkgs/by-name/xf/xf86-input-synaptics/package.nix
+++ b/pkgs/by-name/xf/xf86-input-synaptics/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  pkg-config,
+  util-macros,
+  xorg-server,
+  xorgproto,
+  libevdev,
+  libx11,
+  libxi,
+  libxtst,
+  nix-update-script,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xf86-input-synaptics";
+  version = "1.10.0";
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "driver";
+    repo = "xf86-input-synaptics";
+    tag = "xf86-input-synaptics-${finalAttrs.version}";
+    hash = "sha256-IHkUxphSV6JOlTzIgXGl5hWb6OphJ9Lyzp/YS2phVQs=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    util-macros
+    xorg-server
+  ];
+
+  buildInputs = [
+    xorg-server
+    xorgproto
+    libevdev
+    libx11
+    libxi
+    libxtst
+  ];
+
+  configureFlags = [
+    "--with-sdkdir=${placeholder "dev"}/include/xorg"
+    "--with-xorg-conf-dir=${placeholder "out"}/share/X11/xorg.conf.d"
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version-regex=xf86-input-synaptics-(.*)" ]; };
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "Synaptics touchpad driver for the Xorg X server";
+    homepage = "https://gitlab.freedesktop.org/xorg/driver/xf86-input-synaptics";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    pkgConfigModules = [ "xorg-synaptics" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xf/xf86-input-vmmouse/package.nix
+++ b/pkgs/by-name/xf/xf86-input-vmmouse/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  pkg-config,
+  util-macros,
+  xorg-server,
+  xorgproto,
+  udev,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xf86-input-vmmouse";
+  version = "13.2.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "driver";
+    repo = "xf86-input-vmmouse";
+    tag = "xf86-input-vmmouse-${finalAttrs.version}";
+    hash = "sha256-SasWsIzq9s8i3dabRwKGZ0NSuFqnUu4WCWYTu/ZZpS8=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    util-macros
+    xorg-server # xorg-server defines autoconf macros that we need
+  ];
+
+  buildInputs = [
+    xorg-server
+    xorgproto
+    udev
+  ];
+
+  configureFlags = [
+    "--sysconfdir=${placeholder "out"}/etc"
+    "--with-xorg-conf-dir=${placeholder "out"}/share/X11/xorg.conf.d"
+    "--with-udev-rules-dir=${placeholder "out"}/lib/udev/rules.d"
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version-regex=xf86-input-vmmouse-(.*)" ]; };
+  };
+
+  meta = {
+    description = "VMware guest mouse driver for the Xorg X server";
+    homepage = "https://gitlab.freedesktop.org/xorg/driver/xf86-input-vmmouse";
+    license = with lib.licenses; [
+      hpndSellVariant
+      x11
+    ];
+    maintainers = [ ];
+    platforms = lib.intersectLists lib.platforms.linux lib.platforms.x86;
+  };
+})

--- a/pkgs/by-name/xf/xf86-input-void/package.nix
+++ b/pkgs/by-name/xf/xf86-input-void/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  pkg-config,
+  util-macros,
+  xorg-server,
+  xorgproto,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xf86-input-void";
+  version = "1.4.2";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "driver";
+    repo = "xf86-input-void";
+    tag = "xf86-input-void-${finalAttrs.version}";
+    hash = "sha256-R2c+FUBJQ9GfMcZ9NKSgT0lfOkqiCKrA+lFVu8l6e10=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    util-macros
+  ];
+
+  buildInputs = [
+    xorg-server
+    xorgproto
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version-regex=xf86-input-void-(.*)" ]; };
+  };
+
+  meta = {
+    description = "Null input driver for the Xorg X server";
+    longDescription = ''
+      This is a null input driver for the Xorg X server.
+      It doesn't connect to any physical device, and it never delivers any events.
+      It functions as both a pointer and keyboard device, and may be used as the X server's core
+      pointer and/or core keyboard.
+    '';
+    homepage = "https://gitlab.freedesktop.org/xorg/driver/xf86-input-void";
+    license = with lib.licenses; [
+      hpndSellVariant
+      mit
+    ];
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+    broken = stdenv.hostPlatform.isDarwin; # never worked: https://hydra.nixos.org/job/nixpkgs/trunk/xorg.xf86inputvoid.x86_64-darwin
+  };
+})

--- a/pkgs/by-name/xo/xorg-server/package.nix
+++ b/pkgs/by-name/xo/xorg-server/package.nix
@@ -110,6 +110,8 @@ stdenv.mkDerivation (finalAttrs: {
     dri-pkgconfig-stub
     libdrm
     libgbm
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     libtirpc
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
@@ -160,6 +162,11 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dapple-applications-dir=${placeholder "out"}/Applications"
     "-Dbundle-id-prefix=org.nixos.xquartz"
     "-Dsha1=CommonCrypto"
+  ]
+  ++ lib.optionals (!stdenv.hostPlatform.isLinux) [
+    # fixed upstream (unreleased)
+    "-Dudev=false"
+    "-Dudev_kms=false"
   ];
 
   postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -129,6 +129,7 @@
   xeyes,
   xf86-input-mouse,
   xf86-input-synaptics,
+  xf86-input-vmmouse,
   xfd,
   xfontsel,
   xfs,
@@ -336,6 +337,7 @@ self: with self; {
   xcursorthemes = xcursor-themes;
   xf86inputmouse = xf86-input-mouse;
   xf86inputsynaptics = xf86-input-synaptics;
+  xf86inputvmmouse = xf86-input-vmmouse;
   xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;
   xorgdocs = xorg-docs;
@@ -529,44 +531,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xorg-libinput" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xf86inputvmmouse = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      udev,
-      xorgserver,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xf86-input-vmmouse";
-      version = "13.2.0";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/driver/xf86-input-vmmouse-13.2.0.tar.xz";
-        sha256 = "1f1rlgp1rpsan8k4ax3pzhl1hgmfn135r31m80pjxw5q19c7gw2n";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        udev
-        xorgserver
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -127,6 +127,7 @@
   xdriinfo,
   xev,
   xeyes,
+  xf86-input-mouse,
   xfd,
   xfontsel,
   xfs,
@@ -331,8 +332,9 @@ self: with self; {
   xcbutil = libxcb-util;
   xcbutilrenderutil = libxcb-render-util;
   xcbutilwm = libxcb-wm;
-  xkeyboardconfig = xkeyboard-config;
   xcursorthemes = xcursor-themes;
+  xf86inputmouse = xf86-input-mouse;
+  xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;
   xorgdocs = xorg-docs;
   xorgserver = xorg-server;
@@ -525,42 +527,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xorg-libinput" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xf86inputmouse = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      xorgserver,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xf86-input-mouse";
-      version = "1.9.5";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/driver/xf86-input-mouse-1.9.5.tar.xz";
-        sha256 = "0s4rzp7aqpbqm4474hg4bz7i7vg3ir93ck2q12if4lj3nklqmpjg";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        xorgserver
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "xorg-mouse" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -130,6 +130,7 @@
   xf86-input-mouse,
   xf86-input-synaptics,
   xf86-input-vmmouse,
+  xf86-input-void,
   xfd,
   xfontsel,
   xfs,
@@ -338,6 +339,7 @@ self: with self; {
   xf86inputmouse = xf86-input-mouse;
   xf86inputsynaptics = xf86-input-synaptics;
   xf86inputvmmouse = xf86-input-vmmouse;
+  xf86inputvoid = xf86-input-void;
   xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;
   xorgdocs = xorg-docs;
@@ -531,42 +533,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xorg-libinput" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xf86inputvoid = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgserver,
-      xorgproto,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xf86-input-void";
-      version = "1.4.2";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/driver/xf86-input-void-1.4.2.tar.xz";
-        sha256 = "11bqy2djgb82c1g8ylpfwp3wjw4x83afi8mqyn5fvqp03kidh4d2";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgserver
-        xorgproto
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -128,6 +128,7 @@
   xev,
   xeyes,
   xf86-input-mouse,
+  xf86-input-synaptics,
   xfd,
   xfontsel,
   xfs,
@@ -334,6 +335,7 @@ self: with self; {
   xcbutilwm = libxcb-wm;
   xcursorthemes = xcursor-themes;
   xf86inputmouse = xf86-input-mouse;
+  xf86inputsynaptics = xf86-input-synaptics;
   xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;
   xorgdocs = xorg-docs;
@@ -527,50 +529,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xorg-libinput" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xf86inputsynaptics = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libevdev,
-      libX11,
-      libXi,
-      xorgserver,
-      libXtst,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xf86-input-synaptics";
-      version = "1.10.0";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/driver/xf86-input-synaptics-1.10.0.tar.xz";
-        sha256 = "1hmm3g6ab4bs4hm6kmv508fdc8kr2blzb1vsz1lhipcf0vdnmhp0";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libevdev
-        libX11
-        libXi
-        xorgserver
-        libXtst
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "xorg-synaptics" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -460,6 +460,7 @@ print OUT <<EOF;
   xev,
   xeyes,
   xf86-input-mouse,
+  xf86-input-synaptics,
   xfd,
   xfontsel,
   xfs,
@@ -666,6 +667,7 @@ self: with self; {
   xcbutilwm = libxcb-wm;
   xcursorthemes = xcursor-themes;
   xf86inputmouse = xf86-input-mouse;
+  xf86inputsynaptics = xf86-input-synaptics;
   xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;
   xorgdocs = xorg-docs;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -462,6 +462,7 @@ print OUT <<EOF;
   xf86-input-mouse,
   xf86-input-synaptics,
   xf86-input-vmmouse,
+  xf86-input-void,
   xfd,
   xfontsel,
   xfs,
@@ -670,6 +671,7 @@ self: with self; {
   xf86inputmouse = xf86-input-mouse;
   xf86inputsynaptics = xf86-input-synaptics;
   xf86inputvmmouse = xf86-input-vmmouse;
+  xf86inputvoid = xf86-input-void;
   xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;
   xorgdocs = xorg-docs;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -461,6 +461,7 @@ print OUT <<EOF;
   xeyes,
   xf86-input-mouse,
   xf86-input-synaptics,
+  xf86-input-vmmouse,
   xfd,
   xfontsel,
   xfs,
@@ -668,6 +669,7 @@ self: with self; {
   xcursorthemes = xcursor-themes;
   xf86inputmouse = xf86-input-mouse;
   xf86inputsynaptics = xf86-input-synaptics;
+  xf86inputvmmouse = xf86-input-vmmouse;
   xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;
   xorgdocs = xorg-docs;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -459,6 +459,7 @@ print OUT <<EOF;
   xdriinfo,
   xev,
   xeyes,
+  xf86-input-mouse,
   xfd,
   xfontsel,
   xfs,
@@ -663,8 +664,9 @@ self: with self; {
   xcbutil = libxcb-util;
   xcbutilrenderutil = libxcb-render-util;
   xcbutilwm = libxcb-wm;
-  xkeyboardconfig = xkeyboard-config;
   xcursorthemes = xcursor-themes;
+  xf86inputmouse = xf86-input-mouse;
+  xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;
   xorgdocs = xorg-docs;
   xorgserver = xorg-server;

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -147,21 +147,6 @@ self: super:
     ];
   });
 
-  xf86inputvmmouse = super.xf86inputvmmouse.overrideAttrs (attrs: {
-    configureFlags = [
-      "--sysconfdir=${placeholder "out"}/etc"
-      "--with-xorg-conf-dir=${placeholder "out"}/share/X11/xorg.conf.d"
-      "--with-udev-rules-dir=${placeholder "out"}/lib/udev/rules.d"
-    ];
-
-    meta = attrs.meta // {
-      platforms = [
-        "i686-linux"
-        "x86_64-linux"
-      ];
-    };
-  });
-
   xf86inputvoid = brokenOnDarwin super.xf86inputvoid; # never worked: https://hydra.nixos.org/job/nixpkgs/trunk/xorg.xf86inputvoid.x86_64-darwin
   xf86videodummy = brokenOnDarwin super.xf86videodummy; # never worked: https://hydra.nixos.org/job/nixpkgs/trunk/xorg.xf86videodummy.x86_64-darwin
 

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -122,15 +122,6 @@ self: super:
     ];
   });
 
-  xf86inputmouse = super.xf86inputmouse.overrideAttrs (attrs: {
-    configureFlags = [
-      "--with-sdkdir=${placeholder "out"}/include/xorg"
-    ];
-    meta = attrs.meta // {
-      broken = isDarwin; # never worked: https://hydra.nixos.org/job/nixpkgs/trunk/xorg.xf86inputmouse.x86_64-darwin
-    };
-  });
-
   xf86inputjoystick = super.xf86inputjoystick.overrideAttrs (attrs: {
     configureFlags = [
       "--with-sdkdir=${placeholder "out"}/include/xorg"

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -147,17 +147,6 @@ self: super:
     ];
   });
 
-  xf86inputsynaptics = super.xf86inputsynaptics.overrideAttrs (attrs: {
-    outputs = [
-      "out"
-      "dev"
-    ]; # *.pc pulls xorgserver.dev
-    configureFlags = [
-      "--with-sdkdir=${placeholder "dev"}/include/xorg"
-      "--with-xorg-conf-dir=${placeholder "out"}/share/X11/xorg.conf.d"
-    ];
-  });
-
   xf86inputvmmouse = super.xf86inputvmmouse.overrideAttrs (attrs: {
     configureFlags = [
       "--sysconfdir=${placeholder "out"}/etc"

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -147,7 +147,6 @@ self: super:
     ];
   });
 
-  xf86inputvoid = brokenOnDarwin super.xf86inputvoid; # never worked: https://hydra.nixos.org/job/nixpkgs/trunk/xorg.xf86inputvoid.x86_64-darwin
   xf86videodummy = brokenOnDarwin super.xf86videodummy; # never worked: https://hydra.nixos.org/job/nixpkgs/trunk/xorg.xf86videodummy.x86_64-darwin
 
   xf86videoark = super.xf86videoark.overrideAttrs (attrs: {

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -7,7 +7,6 @@ mirror://xorg/individual/driver/xf86-input-evdev-2.11.0.tar.xz
 mirror://xorg/individual/driver/xf86-input-joystick-1.6.4.tar.xz
 mirror://xorg/individual/driver/xf86-input-keyboard-2.1.0.tar.xz
 mirror://xorg/individual/driver/xf86-input-libinput-1.5.0.tar.xz
-mirror://xorg/individual/driver/xf86-input-mouse-1.9.5.tar.xz
 mirror://xorg/individual/driver/xf86-input-synaptics-1.10.0.tar.xz
 mirror://xorg/individual/driver/xf86-input-vmmouse-13.2.0.tar.xz
 mirror://xorg/individual/driver/xf86-input-void-1.4.2.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -7,7 +7,6 @@ mirror://xorg/individual/driver/xf86-input-evdev-2.11.0.tar.xz
 mirror://xorg/individual/driver/xf86-input-joystick-1.6.4.tar.xz
 mirror://xorg/individual/driver/xf86-input-keyboard-2.1.0.tar.xz
 mirror://xorg/individual/driver/xf86-input-libinput-1.5.0.tar.xz
-mirror://xorg/individual/driver/xf86-input-vmmouse-13.2.0.tar.xz
 mirror://xorg/individual/driver/xf86-input-void-1.4.2.tar.xz
 mirror://xorg/individual/driver/xf86-video-amdgpu-23.0.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-apm-1.3.0.tar.bz2

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -7,7 +7,6 @@ mirror://xorg/individual/driver/xf86-input-evdev-2.11.0.tar.xz
 mirror://xorg/individual/driver/xf86-input-joystick-1.6.4.tar.xz
 mirror://xorg/individual/driver/xf86-input-keyboard-2.1.0.tar.xz
 mirror://xorg/individual/driver/xf86-input-libinput-1.5.0.tar.xz
-mirror://xorg/individual/driver/xf86-input-synaptics-1.10.0.tar.xz
 mirror://xorg/individual/driver/xf86-input-vmmouse-13.2.0.tar.xz
 mirror://xorg/individual/driver/xf86-input-void-1.4.2.tar.xz
 mirror://xorg/individual/driver/xf86-video-amdgpu-23.0.0.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -7,7 +7,6 @@ mirror://xorg/individual/driver/xf86-input-evdev-2.11.0.tar.xz
 mirror://xorg/individual/driver/xf86-input-joystick-1.6.4.tar.xz
 mirror://xorg/individual/driver/xf86-input-keyboard-2.1.0.tar.xz
 mirror://xorg/individual/driver/xf86-input-libinput-1.5.0.tar.xz
-mirror://xorg/individual/driver/xf86-input-void-1.4.2.tar.xz
 mirror://xorg/individual/driver/xf86-video-amdgpu-23.0.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-apm-1.3.0.tar.bz2
 mirror://xorg/individual/driver/xf86-video-ark-0.7.6.tar.xz


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux 
    - [x] pkgs + pkgsCross.aarch64-linux (not `xf86-input-mouse`)
    - [x] pkgsCross.x86_64-freebsd (only `xf86-input-mouse`)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- ran tests:
  - [x] nixpkgs-hammering
  - [x] nix-check-deps
  - [x] ran passthru.updateScript
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
