### PR TITLE
gcc{14,15}: Pick c++tools --enable-default-pie patch

### DIFF
--- a/pkgs/development/compilers/gcc/patches/c++tools-dont-check-enable-default-pie.patch
+++ b/pkgs/development/compilers/gcc/patches/c++tools-dont-check-enable-default-pie.patch
@@ -1,0 +1,80 @@
+From 3f1f99ef82a65d66e3aaa429bf4fb746b93da0db Mon Sep 17 00:00:00 2001
+From: Kito Cheng <kito.cheng@sifive.com>
+Date: Tue, 27 May 2025 10:10:15 +0800
+Subject: [PATCH] c++tools: Don't check --enable-default-pie.
+
+`--enable-default-pie` is an option to specify whether to enable
+position-independent executables by default for `target`.
+
+However c++tools is build for `host`, so it should just follow
+`--enable-host-pie` option to determine whether to build with
+position-independent executables or not.
+
+NOTE:
+
+I checked PR 98324 and build with same configure option
+(`--enable-default-pie` and lto bootstrap) on x86-64 linux to make sure
+it won't cause same problem.
+
+c++tools/ChangeLog:
+
+	* configure.ac: Don't check `--enable-default-pie`.
+	* configure: Regen.
+---
+ c++tools/configure    | 11 -----------
+ c++tools/configure.ac |  6 ------
+ 2 files changed, 17 deletions(-)
+
+diff --git a/c++tools/configure b/c++tools/configure
+index 1353479becaf4..6df4a2f0dfaed 100755
+--- a/c++tools/configure
++++ b/c++tools/configure
+@@ -700,7 +700,6 @@ enable_option_checking
+ enable_c___tools
+ enable_maintainer_mode
+ enable_checking
+-enable_default_pie
+ enable_host_pie
+ enable_host_bind_now
+ with_gcc_major_version_only
+@@ -1335,7 +1334,6 @@ Optional Features:
+                           enable expensive run-time checks. With LIST, enable
+                           only specific categories of checks. Categories are:
+                           yes,no,all,none,release.
+-  --enable-default-pie    enable Position Independent Executable as default
+   --enable-host-pie       build host code as PIE
+   --enable-host-bind-now  link host code as BIND_NOW
+ 
+@@ -2946,15 +2944,6 @@ $as_echo "#define ENABLE_ASSERT_CHECKING 1" >>confdefs.h
+ 
+ fi
+ 
+-# Check whether --enable-default-pie was given.
+-# Check whether --enable-default-pie was given.
+-if test "${enable_default_pie+set}" = set; then :
+-  enableval=$enable_default_pie; PICFLAG=-fPIE
+-else
+-  PICFLAG=
+-fi
+-
+-
+ # Enable --enable-host-pie
+ # Check whether --enable-host-pie was given.
+ if test "${enable_host_pie+set}" = set; then :
+diff --git a/c++tools/configure.ac b/c++tools/configure.ac
+index db34ee678e033..8c4b72a8023a8 100644
+--- a/c++tools/configure.ac
++++ b/c++tools/configure.ac
+@@ -97,12 +97,6 @@ if test x$ac_assert_checking != x ; then
+ [Define if you want assertions enabled.  This is a cheap check.])
+ fi
+ 
+-# Check whether --enable-default-pie was given.
+-AC_ARG_ENABLE(default-pie,
+-[AS_HELP_STRING([--enable-default-pie],
+-		  [enable Position Independent Executable as default])],
+-[PICFLAG=-fPIE], [PICFLAG=])
+-
+ # Enable --enable-host-pie
+ AC_ARG_ENABLE(host-pie,
+ [AS_HELP_STRING([--enable-host-pie],

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -97,6 +97,9 @@ optionals noSysDirs (
 # See https://github.com/NixOS/nixpkgs/pull/354107/commits/2de1b4b14e17f42ba8b4bf43a29347c91511e008
 ++ optional (!atLeast14) ./cfi_startproc-reorder-label-09-1.diff
 ++ optional (atLeast14 && !canApplyIainsDarwinPatches) ./cfi_startproc-reorder-label-14-1.diff
+# c++tools: Don't check --enable-default-pie.
+# --enable-default-pie breaks bootstrap gcc otherwise, because libiberty.a is not found
+++ optional atLeast14 ./c++tools-dont-check-enable-default-pie.patch
 
 ## 2. Patches relevant on specific platforms ####################################
 

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -47,21 +47,10 @@ rec {
     '';
   };
 
-  bootGCC =
-    (pkgs.gcc.cc.override {
-      enableLTO = false;
-      isl = null;
-    }).overrideAttrs
-      (old: {
-        patches = old.patches or [ ] ++ [
-          (pkgs.fetchpatch {
-            # c++tools: Don't check --enable-default-pie.
-            # --enable-default-pie breaks bootstrap gcc otherwise, because libiberty.a is not found
-            url = "https://github.com/gcc-mirror/gcc/commit/3f1f99ef82a65d66e3aaa429bf4fb746b93da0db.patch";
-            hash = "sha256-wKVuwrW22gSN1woYFYxsyVk49oYmbogIN6FWbU8cVds=";
-          })
-        ];
-      });
+  bootGCC = pkgs.gcc.cc.override {
+    enableLTO = false;
+    isl = null;
+  };
 
   bootBinutils = pkgs.binutils.bintools.override {
     withAllTargets = false;


### PR DESCRIPTION
Revert of #448220 and moving it into gcc-unwrapped

This patch hasn't landed in gcc 15 for some reason?

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [X] aarch64-linux (`gcc14`, `gcc`, `stdenvBootstrapTools.aarch64-unknown-linux-gnu.test`)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
