### PR TITLE
nixos/automatic-timezoned: Fix boot delays and systemd unit ordering

### DIFF
--- a/nixos/modules/services/system/automatic-timezoned.nix
+++ b/nixos/modules/services/system/automatic-timezoned.nix
@@ -57,13 +57,16 @@ in
       automatic-timezoned = {
         description = "Automatically update system timezone based on location";
         requires = [ "automatic-timezoned-geoclue-agent.service" ];
-        after = [ "automatic-timezoned-geoclue-agent.service" ];
+        after = [
+          "automatic-timezoned-geoclue-agent.service"
+          "multi-user.target"
+        ];
         serviceConfig = {
           Type = "exec";
           User = "automatic-timezoned";
           ExecStart = "${cfg.package}/bin/automatic-timezoned";
         };
-        wantedBy = [ "default.target" ];
+        wantedBy = [ "multi-user.target" ];
       };
 
       automatic-timezoned-geoclue-agent = {
@@ -77,7 +80,6 @@ in
           Restart = "on-failure";
           PrivateTmp = true;
         };
-        wantedBy = [ "default.target" ];
       };
 
     };


### PR DESCRIPTION
Since the service sets `WantedBy=default.target`, `graphical.target` ends up waiting for it to complete. Since `geoclue.service`, which *this* service depends on, in turn depends on `network-online.target`, this ends up making full boot wait for network availability.

This is obviously unintended; The unit should have always had an `After=default.target`.

Furthermore, the systemd docs recommend depending on specifically `multi-user.target` *or* `graphical.target`, rather than `default.target`. In practice, on a default NixOS system, using `default.target` delays starting this service until a graphical session starts - this is obviously not ideal, since it makes sense to update the timezone on a non-graphical system as well, so we fix that while we're at it.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
