### PR TITLE
freetube: 0.23.12 -> 0.23.12-unstable-2025-12-13

### DIFF
--- a/pkgs/by-name/fr/freetube/package.nix
+++ b/pkgs/by-name/fr/freetube/package.nix
@@ -20,13 +20,14 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "freetube";
-  version = "0.23.12";
+  version = "0.23.12-unstable-2025-12-13";
 
   src = fetchFromGitHub {
     owner = "FreeTubeApp";
     repo = "FreeTube";
-    tag = "v${finalAttrs.version}-beta";
-    hash = "sha256-DH5uT3dPDFZnFYoiMjxpNouNDRbWDctVqvDwHpUlnkY=";
+    # tag = "v${finalAttrs.version}-beta";
+    rev = "6717114de5653b08caec20b7bf3f3217723866a4";
+    hash = "sha256-PfK4Ny8MyBJ9Xw6ozJUzu+4rX+/rLWNac3lE8dBNPE0=";
   };
 
   # Darwin requires writable Electron dist
@@ -38,7 +39,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       ''
     else
       ''
-        ln -s ${electron.dist} electron-dist
+        ln -s ${electron.dist} source/electron-dist
       '';
 
   patches = [
@@ -49,7 +50,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   yarnOfflineCache = fetchYarnDeps {
     yarnLock = "${finalAttrs.src}/yarn.lock";
-    hash = "sha256-sM9CkDnATSEUf/uuUyT4JuRmjzwa1WzIyNYEw69MPtU=";
+    hash = "sha256-at/Kq7M8qSjlDmB6R4z51VRZRvkKAGyjU6sgHho8tBQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/fr/freetube/patch-build-script.patch
+++ b/pkgs/by-name/fr/freetube/patch-build-script.patch
@@ -1,13 +1,13 @@
-diff --git a/_scripts/ebuilder.config.js b/_scripts/ebuilder.config.js
-index 5b79d961..9f5945d2 100644
---- a/_scripts/ebuilder.config.js
-+++ b/_scripts/ebuilder.config.js
-@@ -1,6 +1,8 @@
- const { name, productName } = require('../package.json')
+diff --git a/_scripts/ebuilder.config.mjs b/_scripts/ebuilder.config.mjs
+index 55e72b227..d218f5ac4 100644
+--- a/_scripts/ebuilder.config.mjs
++++ b/_scripts/ebuilder.config.mjs
+@@ -2,6 +2,8 @@ import packageDetails from '../package.json' with { type: 'json' }
  
- const config = {
+ /** @type {import('electron-builder').Configuration} */
+ export default {
 +  electronVersion: "@electron-version@",
 +  electronDist: "electron-dist",
-   appId: `io.freetubeapp.${name}`,
-   copyright: 'Copyleft © 2020-2024 freetubeapp@protonmail.com',
+   appId: `io.freetubeapp.${packageDetails.name}`,
+   copyright: 'Copyleft © 2020-2025 freetubeapp@protonmail.com',
    // asar: false,


### PR DESCRIPTION
Trying to resolve: #469495

Had to update the patch, as upstream files changed.
Could someone test darwin, please? We might need to apply the same change to the `postUnpack` phase.

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
