### PR TITLE
ocamlPackages.ppx_deriving_variant_string: init at 1.0.1

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_deriving_variant_string/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving_variant_string/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  fetchurl,
+  buildDunePackage,
+  ppxlib,
+  ounit2,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "ppx_deriving_variant_string";
+  version = "1.0.1";
+
+  src = fetchurl {
+    url = "https://github.com/ahrefs/ppx_deriving_variant_string/releases/download/${finalAttrs.version}/ppx_deriving_variant_string-${finalAttrs.version}.tbz";
+    hash = "sha256-nSU9LEwPOOQuCpNAVQgBGucHuk5wjJ3dDIj708djLwc=";
+  };
+
+  propagatedBuildInputs = [
+    ppxlib
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    ounit2
+  ];
+
+  meta = {
+    homepage = "https://github.com/ahrefs/ppx_deriving_variant_string";
+    description = "OCaml PPX deriver that generates converters between regular or polymorphic variants and strings.";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.marijanp ];
+    changelog = "https://raw.githubusercontent.com/ahrefs/ppx_deriving_variant_string/${finalAttrs.version}/CHANGES.md";
+  };
+})

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1715,6 +1715,10 @@ let
 
         ppx_deriving_rpc = callPackage ../development/ocaml-modules/ppx_deriving_rpc { };
 
+        ppx_deriving_variant_string =
+          callPackage ../development/ocaml-modules/ppx_deriving_variant_string
+            { };
+
         ppx_deriving_yaml = callPackage ../development/ocaml-modules/ppx_deriving_yaml {
           mdx = mdx.override { inherit logs; };
         };


### PR DESCRIPTION


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
