### PR TITLE
wmbusmeters: init at 3.0.0

### DIFF
--- a/pkgs/by-name/wm/wmbusmeters/package.nix
+++ b/pkgs/by-name/wm/wmbusmeters/package.nix
@@ -18,9 +18,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "wmbusmeters";
     repo = "wmbusmeters";
-
-    # need to store rev as COMMIT_HASH later
-    rev = "41dc2d47fda72e78964b9283c99a0c98492360ba";
+    tag = version;
     hash = "sha256-Y/xHw++llHw3iIImXllJg7QqU0Ngj0MLJyyqE1dBNjA=";
   };
 
@@ -41,8 +39,9 @@ stdenv.mkDerivation rec {
   ];
 
   # avoid reading the version from git to avoid fetching all tags
+  # TODO read COMMIT_HASH
   makeFlags = [
-    "COMMIT_HASH=${src.rev}"
+    "COMMIT_HASH="
     "TAG=${version}"
     "BRANCH="
     "CHANGES="
@@ -74,6 +73,8 @@ stdenv.mkDerivation rec {
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Read the wired or wireless mbus protocol to acquire utility meter readings.";

--- a/pkgs/by-name/wm/wmbusmeters/package.nix
+++ b/pkgs/by-name/wm/wmbusmeters/package.nix
@@ -4,7 +4,6 @@
   fetchgit,
   rtl-sdr,
   libxml2,
-  git,
   pkg-config,
   netcat,
   jq,
@@ -21,10 +20,16 @@ stdenv.mkDerivation rec {
   src = fetchgit {
     url = "https://github.com/wmbusmeters/wmbusmeters";
     tag = version;
-    hash = "sha256-JMDwK+4pEMpl8DGitsytLooxwz82KFO0kbduRtToAV8=";
+    hash = "sha256-e0clXik/jwUkiOhU+puhkvCVFhS2EYagly10Rzw+qTs=";
 
     # need to fetch revision from git
     leaveDotGit = true;
+    postFetch = ''
+      # avoid having the whole .git-folder
+      substituteInPlace $out/Makefile --replace-fail "COMMIT_HASH?=\$(shell \$(SUPRE) git log --pretty=format:'%H' -n 1 \$(SUPOST))" "COMMIT_HASH:=$(git -C $out log --pretty=format:'%H' -n 1)"
+
+      rm -rf $out/.git
+    '';
   };
 
   buildInputs = [
@@ -33,7 +38,6 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [
-    git
     pkg-config
     libxml2.dev
   ];

--- a/pkgs/by-name/wm/wmbusmeters/package.nix
+++ b/pkgs/by-name/wm/wmbusmeters/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rtl-sdr,
+  libxml2,
+  pkg-config,
+  netcat,
+  jq,
+  unixtools,
+  versionCheckHook,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "wmbusmeters";
+  version = "1.19.0";
+
+  src = fetchFromGitHub {
+    owner = "wmbusmeters";
+    repo = "wmbusmeters";
+
+    # need to store rev as COMMIT_HASH later
+    rev = "41dc2d47fda72e78964b9283c99a0c98492360ba";
+    hash = "sha256-Y/xHw++llHw3iIImXllJg7QqU0Ngj0MLJyyqE1dBNjA=";
+  };
+
+  buildInputs = [
+    rtl-sdr
+    libxml2
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    libxml2.dev
+  ];
+
+  checkInputs = [
+    netcat
+    jq
+    unixtools.xxd
+  ];
+
+  # avoid reading the version from git to avoid fetching all tags
+  makeFlags = [
+    "COMMIT_HASH=${src.rev}"
+    "TAG=${version}"
+    "BRANCH="
+    "CHANGES="
+  ];
+
+  postPatch = ''
+    # See https://github.com/wmbusmeters/wmbusmeters/pull/1666
+    substituteInPlace Makefile --replace-fail "/usr/include/libxml2" "${libxml2.dev}/include/libxml2"
+
+    patchShebangs scripts/generate_authors.sh
+    patchShebangs test.sh tests/*.sh
+  '';
+
+  # avoid install.sh
+  installPhase = ''
+    mkdir -p $out/bin
+    cp build/wmbusmeters $out/bin
+
+    mkdir -p $out/man/man1
+    gzip -v9 -n -c wmbusmeters.1 > $out/man/man1/wmbusmeters.1.gz
+  '';
+
+  doCheck = true;
+  checkTarget = "test";
+  preCheck = ''
+    # avoid building of xmq and skip these tests
+    substituteInPlace Makefile --replace-fail "test: build/xmq" "test:"
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "Read the wired or wireless mbus protocol to acquire utility meter readings.";
+    downloadPage = "https://github.com/wmbusmeters/wmbusmeters";
+    homepage = "https://wmbusmeters.org/";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "wmbusmeters";
+    platforms = with lib.platforms; linux ++ darwin;
+  };
+}

--- a/pkgs/by-name/wm/wmbusmeters/package.nix
+++ b/pkgs/by-name/wm/wmbusmeters/package.nix
@@ -1,25 +1,30 @@
 {
   lib,
   stdenv,
-  fetchFromGitHub,
+  fetchgit,
   rtl-sdr,
   libxml2,
+  git,
   pkg-config,
   netcat,
   jq,
   unixtools,
   versionCheckHook,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
   pname = "wmbusmeters";
   version = "1.19.0";
 
-  src = fetchFromGitHub {
-    owner = "wmbusmeters";
-    repo = "wmbusmeters";
+  # fetchFromGitHub does not support leaveDotGit
+  src = fetchgit {
+    url = "https://github.com/wmbusmeters/wmbusmeters";
     tag = version;
-    hash = "sha256-Y/xHw++llHw3iIImXllJg7QqU0Ngj0MLJyyqE1dBNjA=";
+    hash = "sha256-JMDwK+4pEMpl8DGitsytLooxwz82KFO0kbduRtToAV8=";
+
+    # need to fetch revision from git
+    leaveDotGit = true;
   };
 
   buildInputs = [
@@ -28,6 +33,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [
+    git
     pkg-config
     libxml2.dev
   ];
@@ -39,9 +45,7 @@ stdenv.mkDerivation rec {
   ];
 
   # avoid reading the version from git to avoid fetching all tags
-  # TODO read COMMIT_HASH
   makeFlags = [
-    "COMMIT_HASH="
     "TAG=${version}"
     "BRANCH="
     "CHANGES="

--- a/pkgs/by-name/wm/wmbusmeters/package.nix
+++ b/pkgs/by-name/wm/wmbusmeters/package.nix
@@ -63,6 +63,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin
     cp build/wmbusmeters $out/bin
+    cp build/wmbusmetersd $out/bin
 
     mkdir -p $out/man/man1
     gzip -v9 -n -c wmbusmeters.1 > $out/man/man1/wmbusmeters.1.gz

--- a/pkgs/by-name/wm/wmbusmeters/package.nix
+++ b/pkgs/by-name/wm/wmbusmeters/package.nix
@@ -1,0 +1,107 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rtl-sdr,
+  rtl_wmbus,
+  rtl_433,
+  libxml2,
+  pkg-config,
+  netcat,
+  jq,
+  unixtools,
+  versionCheckHook,
+  nix-update-script,
+  installShellFiles,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  pname = "wmbusmeters";
+  version = "3.0.0";
+
+  src = fetchFromGitHub {
+    owner = "wmbusmeters";
+    repo = "wmbusmeters";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-kguAEWFRzdjsqgiXC7wrAkkR8qvE2ksOOhT7VrDzqc4=";
+
+    # need to fetch revision from git
+    leaveDotGit = true;
+    postFetch = ''
+      # avoid having the whole .git-folder
+      substituteInPlace $out/Makefile --replace-fail "COMMIT_HASH?=\$(shell \$(SUPRE) git log --pretty=format:'%H' -n 1 \$(SUPOST))" "COMMIT_HASH:=$(git -C $out log --pretty=format:'%H' -n 1)"
+
+      rm -rf $out/.git
+    '';
+  };
+
+  buildInputs = [
+    rtl-sdr
+    rtl_wmbus
+    rtl_433
+    libxml2
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
+    libxml2.dev # for xml2-config
+  ];
+
+  nativeCheckInputs = [
+    netcat
+    jq
+    unixtools.xxd
+  ];
+
+  # avoid reading the version from git to avoid fetching all tags
+  makeFlags = [
+    "TAG=${finalAttrs.version}"
+    "BRANCH="
+    "CHANGES="
+  ];
+
+  postPatch = ''
+    # avoid building of xmq and skip these tests
+    substituteInPlace Makefile --replace-fail "test: build/xmq" "test:"
+
+    patchShebangs \
+      scripts/{generate_authors,generate_short_manual}.sh \
+      test.sh tests/*.sh
+  '';
+
+  # avoid install.sh
+  installPhase = ''
+    mkdir -p $out/bin
+    cp build/wmbusmeters $out/bin
+    cp build/wmbusmetersd $out/bin
+
+    # wmbusmeters will look in its own directory for these executables
+    ln -s ${rtl-sdr}/bin/rtl_sdr $out/bin
+    ln -s ${rtl_wmbus}/bin/rtl_wmbus $out/bin
+    ln -s ${rtl_433}/bin/rtl_433 $out/bin
+
+    installManPage wmbusmeters.1
+  '';
+
+  doCheck = true;
+  checkTarget = "test";
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Read the wired or wireless mbus protocol to acquire utility meter readings";
+    downloadPage = "https://github.com/wmbusmeters/wmbusmeters";
+    homepage = "https://wmbusmeters.org/";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "wmbusmeters";
+    maintainers = with lib.maintainers; [ prauscher ];
+    platforms = with lib.platforms; linux;
+  };
+})


### PR DESCRIPTION
Adds `wmbusmeters` (v3.0.0) which is used to translate wireless M-bus messages read from the air using various drivers and send them to an external programm, e.g. mosquitto-pub. Their website can be found at https://wmbusmeters.org/ and the code is hosted at https://github.com/wmbusmeters/wmbusmeters .

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
