### PR TITLE
iocaine_3: init at 3.0.1

### DIFF
--- a/pkgs/by-name/io/iocaine_3/package.nix
+++ b/pkgs/by-name/io/iocaine_3/package.nix
@@ -1,0 +1,30 @@
+{
+  stdenv,
+  lib,
+  rustPlatform,
+  fetchFromGitea,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "iocaine";
+  version = "3.0.1";
+
+  src = fetchFromGitea {
+    domain = "git.madhouse-project.org";
+    owner = "iocaine";
+    repo = "iocaine";
+    tag = "iocaine-${version}";
+    hash = "sha256-FLjoOAiKwxQ6fs/p943lb4+vM8cXHlThBCeyBdo1GRo=";
+  };
+
+  cargoHash = "sha256-UDsF8OeylCz0YfmhZ+phfQfC9HpweI51G4OHnK1dDfk=";
+
+  meta = {
+    description = "Deadliest poison known to AI";
+    homepage = "https://iocaine.madhouse-project.org/";
+    changelog = "https://git.madhouse-project.org/iocaine/iocaine/src/tag/${src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sugar700 ];
+    mainProgram = "iocaine";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Upgrading iocaine, which due to breaking changes needs to be handled in a separate attribute, essentially mostly the same thing as https://github.com/NixOS/nixpkgs/pull/467331, except with a new attribute. Old iocaine is going to be removed later on to not break configurations (planning to remove it within a month from this merging in).

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
