### PR TITLE
freecad: fix PYTHONPATH patch header attribution

### DIFF
--- a/pkgs/by-name/fr/freecad/0001-NIXOS-don-t-ignore-PYTHONPATH.patch
+++ b/pkgs/by-name/fr/freecad/0001-NIXOS-don-t-ignore-PYTHONPATH.patch
@@ -1,21 +1,20 @@
 commit c534a831c2f7186ebabe4e17f1e1df6d11ebff89
-Author: Samuel Rounce <me@samuelrounce.co.uk>
+From: Andreas Rammhold <andreas@rammhold.de>
 Date:   Thu Sep 5 22:17:21 2024 +0100
+Subject: [PATCH] NIXOS: don't ignore PYTHONPATH
 
-    [PATCH] NIXOS: don't ignore PYTHONPATH
-    
-    On NixOS or rather within nixpkgs we provide the runtime Python
-    packages via the PYTHONPATH environment variable. FreeCAD tries its
-    best to ignore Python environment variables that are being inherited
-    from the environment. For Python versions >=3.11 it also tries to
-    initialize the interpreter config without any environmental data. We
-    have to initialize the configuration *with* the information from the
-    environment for our packaging to work.
-    
-    Upstream has purposely isolated the environments AFAIK and thus
-    shouldn't accept this patch (as is). What they might accept (once
-    support for older Python versions has been dropped) is removing the
-    PYTHONPATH specific putenv calls.
+On NixOS or rather within nixpkgs we provide the runtime Python
+packages via the PYTHONPATH environment variable. FreeCAD tries its
+best to ignore Python environment variables that are being inherited
+from the environment. For Python versions >=3.11 it also tries to
+initialize the interpreter config without any environmental data. We
+have to initialize the configuration *with* the information from the
+environment for our packaging to work.
+
+Upstream has purposely isolated the environments AFAIK and thus
+shouldn't accept this patch (as is). What they might accept (once
+support for older Python versions has been dropped) is removing the
+PYTHONPATH specific putenv calls.
 ---
  src/Base/Interpreter.cpp | 1 +
  src/Main/MainGui.cpp     | 3 ---


### PR DESCRIPTION
In the course of updating this patch to apply cleanly I'd accidentally erased evidence of @andir's earlier work. Updating the patch header and formatting to amend this error.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
