### PR TITLE
adios2: fix double import cmake conflict

### DIFF
--- a/pkgs/by-name/ad/adios2/package.nix
+++ b/pkgs/by-name/ad/adios2/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
   perl,
   cmake,
   ninja,
@@ -66,12 +67,25 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     chmod +x cmake/install/post/adios2-config.pre.sh.in
     patchShebangs cmake/install/post/{generate-adios2-config,adios2-config.pre}.sh.in
+  '';
 
+  # TODO: remove these patches when updating to > v2.11.x, which will already include these commits
+  patches = [
     # use upstream GoogleTest.cmake
     # see https://github.com/ornladios/ADIOS2/issues/4659
-    substituteInPlace cmake/GoogleTest.cmake \
-      --replace-fail 'CMAKE_VERSION VERSION_LESS 4' 'TRUE'
-  '';
+    (fetchpatch2 {
+      name = "googletest-cmake-fix.patch";
+      url = "https://github.com/ornladios/ADIOS2/commit/20aab0f99d38dc4437b086edf6b44ecf4100ed76.patch?full_index=1";
+      hash = "sha256-CZD3QUATX0JI75Oip0LNwirWIwgQakWuCHs1fIjwzj0=";
+    })
+    # fix double import cmake conflict
+    # see https://github.com/ornladios/ADIOS2/issues/4760
+    (fetchpatch2 {
+      name = "cmake-target-guard-fix.patch";
+      url = "https://github.com/ornladios/ADIOS2/commit/23fd08a10b52a971150f93f99d341b83b8096e3d.patch?full_index=1";
+      hash = "sha256-+29a9JgiCv2kBz0uUT8Kn/Tf3KDD1JNPdzeb/DruTBo=";
+    })
+  ];
 
   nativeBuildInputs = [
     perl


### PR DESCRIPTION
Fixes transient build issue as documented here: https://github.com/ornladios/ADIOS2/issues/4760
Affected downstream dependencies:
- vtk-dicom (https://hydra.nixos.org/build/315369682/nixlog/1)
- ants (https://hydra.nixos.org/build/316060323/nixlog/1)

@qbisi can you review?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
