### PR TITLE
x{init,input,wd,kbcomp}: migrate to pkgs/by-name && xorg.{libXtrap,xtrap}: drop

### DIFF
--- a/pkgs/by-name/xi/xinit/package.nix
+++ b/pkgs/by-name/xi/xinit/package.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  buildPackages,
+  autoreconfHook,
+  pkg-config,
+  util-macros,
+  darwin,
+  libx11,
+  xorgproto,
+  xauth,
+  xorg-server,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xinit";
+  version = "1.4.4";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "app";
+    repo = "xinit";
+    tag = "xinit-${finalAttrs.version}";
+    hash = "sha256-1GL0xJ/l9BnhoUyD5m1Ch86hjcRdBnys366qM4Lj84U=";
+  };
+
+  strictDeps = true;
+
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    util-macros
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    darwin.bootstrap_cmds
+  ];
+
+  buildInputs = [
+    libx11
+    xorgproto
+  ];
+
+  propagatedBuildInputs = [
+    xauth
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    libx11
+    xorgproto
+  ];
+
+  configureFlags = [
+    "--with-xserver=${xorg-server.out}/bin/X"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    "--with-bundle-id-prefix=org.nixos.xquartz"
+    "--with-launchdaemons-dir=${placeholder "out"}/LaunchDaemons"
+    "--with-launchagents-dir=${placeholder "out"}/LaunchAgents"
+  ];
+
+  postFixup = ''
+    substituteInPlace $out/bin/startx \
+      --replace-fail '"''${prefix}/etc/X11/xinit/xinitrc"' '/etc/X11/xinit/xinitrc' \
+      --replace-fail '"$xinitdir/xserverrc"' '/etc/X11/xinit/xserverrc'
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version-regex=xinit-(.*)" ]; };
+  };
+
+  meta = {
+    description = "X server & client startup utilities (includes startx)";
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xinit";
+    license = with lib.licenses; [
+      mitOpenGroup
+      x11
+    ];
+    mainProgram = "xinit";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xi/xinput/package.nix
+++ b/pkgs/by-name/xi/xinput/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  pkg-config,
+  util-macros,
+  xorgproto,
+  libx11,
+  libxext,
+  libxi,
+  libxinerama,
+  libxrandr,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xinput";
+  version = "1.6.4";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "app";
+    repo = "xinput";
+    tag = "xinput-${finalAttrs.version}";
+    hash = "sha256-EsSytLzwAHMwseW4pD/c+/J1MaCWPsE7RPoMIwT96yk=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    util-macros
+  ];
+
+  buildInputs = [
+    xorgproto
+    libx11
+    libxext
+    libxi
+    libxinerama
+    libxrandr
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version-regex=xinput-(.*)" ]; };
+  };
+
+  meta = {
+    description = "Utility to configure and test XInput devices";
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xinput";
+    license = with lib.licenses; [
+      hpndSellVariant
+      mit
+    ];
+    mainProgram = "xinput";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xk/xkbcomp/package.nix
+++ b/pkgs/by-name/xk/xkbcomp/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  pkg-config,
+  util-macros,
+  bison,
+  libx11,
+  libxkbfile,
+  xorgproto,
+  xkeyboard-config,
+  nix-update-script,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xkbcomp";
+  version = "1.5.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "app";
+    repo = "xkbcomp";
+    tag = "xkbcomp-${finalAttrs.version}";
+    hash = "sha256-nkyBjIOX9Qr0K+R0JcvJ7egI0a8Zh/tyhZvG7E+VlZU=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    util-macros
+    bison
+  ];
+
+  buildInputs = [
+    util-macros # unused dependency but the build fails if pkg-config can't find it
+    libx11
+    libxkbfile
+    xorgproto
+  ];
+
+  configureFlags = [ "--with-xkb-config-root=${xkeyboard-config}/share/X11/xkb" ];
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version-regex=xkbcomp-(.*)" ]; };
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "XKB keyboard description compiler";
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xkbcomp";
+    license = with lib.licenses; [
+      hpnd
+      mitOpenGroup
+      hpndDec
+    ];
+    mainProgram = "xkbcomp";
+    maintainers = [ ];
+    pkgConfigModules = [ "xkbcomp" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xw/xwd/package.nix
+++ b/pkgs/by-name/xw/xwd/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  pkg-config,
+  util-macros,
+  libxkbfile,
+  libx11,
+  xorgproto,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xwd";
+  version = "1.0.9";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "app";
+    repo = "xwd";
+    tag = "xwd-${finalAttrs.version}";
+    hash = "sha256-cEKm0c50qwWzGSkH1sdovNfN3dW1hmnaEDwuJKwxGdo=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    util-macros
+  ];
+
+  buildInputs = [
+    libxkbfile
+    libx11
+    xorgproto
+  ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=xwd-(.*)" ]; };
+
+  meta = {
+    description = "Utility to dump an image of an X window in XWD format";
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xwd";
+    license = with lib.licenses; [
+      mitOpenGroup
+      hpndSellVariant
+    ];
+    mainProgram = "xwd";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -166,6 +166,7 @@
   xtrans,
   xvfb,
   xvinfo,
+  xwd,
   xwininfo,
   xwud,
 }:
@@ -250,6 +251,7 @@ self: with self; {
     xtrans
     xvfb
     xvinfo
+    xwd
     xwininfo
     xwud
     ;
@@ -2195,44 +2197,6 @@ self: with self; {
         libX11
         libXt
         libXTrap
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xwd = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libxkbfile,
-      libX11,
-      xorgproto,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xwd";
-      version = "1.0.9";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xwd-1.0.9.tar.xz";
-        sha256 = "0gxx3y9zlh13jgwkayxljm6i58ng8jc1xzqv2g8s7d3yjj21n4nw";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libxkbfile
-        libX11
-        xorgproto
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -136,6 +136,7 @@
   xhost,
   xinit,
   xinput,
+  xkbcomp,
   xkbevd,
   xkbprint,
   xkbutils,
@@ -226,6 +227,7 @@ self: with self; {
     xhost
     xinit
     xinput
+    xkbcomp
     xkbevd
     xkbprint
     xkbutils
@@ -2085,44 +2087,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xkbcomp = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      libxkbfile,
-      xorgproto,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xkbcomp";
-      version = "1.5.0";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xkbcomp-1.5.0.tar.xz";
-        sha256 = "0q3092w42w9wyfr5zf3ymkmzlqr24z6kz6ypkinxnxh7c0k1zhra";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libX11
-        libxkbfile
-        xorgproto
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "xkbcomp" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -134,6 +134,7 @@
   xgamma,
   xgc,
   xhost,
+  xinit,
   xkbevd,
   xkbprint,
   xkbutils,
@@ -221,6 +222,7 @@ self: with self; {
     xgamma
     xgc
     xhost
+    xinit
     xkbevd
     xkbprint
     xkbutils
@@ -2115,42 +2117,6 @@ self: with self; {
         xorgproto
         libpciaccess
         xorgserver
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xinit = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      xorgproto,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xinit";
-      version = "1.4.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xinit-1.4.4.tar.xz";
-        sha256 = "1ygymifhg500sx1ybk8x4d1zn4g4ywvlnyvqwcf9hzsc2rx7r920";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libX11
-        xorgproto
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -345,46 +345,6 @@ self: with self; {
   xorgsgmldoctools = xorg-sgml-doctools;
 
   # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libXTrap = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libX11,
-      libXext,
-      libXt,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libXTrap";
-      version = "1.0.1";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/lib/libXTrap-1.0.1.tar.bz2";
-        sha256 = "0bi5wxj6avim61yidh9fd3j4n8czxias5m8vss9vhxjnk1aksdwg";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libX11
-        libXext
-        libXt
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "xtrap" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
   xf86inputevdev = callPackage (
     {
       stdenv,
@@ -2163,44 +2123,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xkbcomp" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xtrap = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      libXt,
-      libXTrap,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xtrap";
-      version = "1.0.3";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xtrap-1.0.3.tar.bz2";
-        sha256 = "0sqm4j1zflk1s94iq4waa70hna1xcys88v9a70w0vdw66czhvj2j";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libX11
-        libXt
-        libXTrap
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -135,6 +135,7 @@
   xgc,
   xhost,
   xinit,
+  xinput,
   xkbevd,
   xkbprint,
   xkbutils,
@@ -223,6 +224,7 @@ self: with self; {
     xgc
     xhost
     xinit
+    xinput
     xkbevd
     xkbprint
     xkbutils
@@ -2117,50 +2119,6 @@ self: with self; {
         xorgproto
         libpciaccess
         xorgserver
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xinput = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libX11,
-      libXext,
-      libXi,
-      libXinerama,
-      libXrandr,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xinput";
-      version = "1.6.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xinput-1.6.4.tar.xz";
-        sha256 = "1j2pf28c54apr56v1fmvprp657n6x4sdrv8f24rx3138cl6x015d";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libX11
-        libXext
-        libXi
-        libXinerama
-        libXrandr
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -468,6 +468,7 @@ print OUT <<EOF;
   xhost,
   xinit,
   xinput,
+  xkbcomp,
   xkbevd,
   xkbprint,
   xkbutils,
@@ -558,6 +559,7 @@ self: with self; {
     xhost
     xinit
     xinput
+    xkbcomp
     xkbevd
     xkbprint
     xkbutils

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -498,6 +498,7 @@ print OUT <<EOF;
   xtrans,
   xvfb,
   xvinfo,
+  xwd,
   xwininfo,
   xwud,
 }:
@@ -582,6 +583,7 @@ self: with self; {
     xtrans
     xvfb
     xvinfo
+    xwd
     xwininfo
     xwud
     ;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -467,6 +467,7 @@ print OUT <<EOF;
   xgc,
   xhost,
   xinit,
+  xinput,
   xkbevd,
   xkbprint,
   xkbutils,
@@ -555,6 +556,7 @@ self: with self; {
     xgc
     xhost
     xinit
+    xinput
     xkbevd
     xkbprint
     xkbutils

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -466,6 +466,7 @@ print OUT <<EOF;
   xgamma,
   xgc,
   xhost,
+  xinit,
   xkbevd,
   xkbprint,
   xkbutils,
@@ -553,6 +554,7 @@ self: with self; {
     xgamma
     xgc
     xhost
+    xinit
     xkbevd
     xkbprint
     xkbutils

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -59,17 +59,6 @@
 let
   inherit (stdenv.hostPlatform) isDarwin;
 
-  addMainProgram =
-    pkg:
-    {
-      mainProgram ? pkg.pname,
-    }:
-    pkg.overrideAttrs (attrs: {
-      meta = attrs.meta // {
-        inherit mainProgram;
-      };
-    });
-
   brokenOnDarwin =
     pkg:
     pkg.overrideAttrs (attrs: {
@@ -384,8 +373,6 @@ self: super:
       })
     ];
   });
-
-  xwd = addMainProgram super.xwd { };
 }
 
 # deprecate some packages

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -385,8 +385,6 @@ self: super:
     ];
   });
 
-  xinput = addMainProgram super.xinput { };
-
   xwd = addMainProgram super.xwd { };
 }
 

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -263,13 +263,6 @@ self: super:
     };
   });
 
-  xkbcomp = super.xkbcomp.overrideAttrs (attrs: {
-    configureFlags = [ "--with-xkb-config-root=${xorg.xkeyboardconfig}/share/X11/xkb" ];
-    meta = attrs.meta // {
-      mainProgram = "xkbcomp";
-    };
-  });
-
   # xkeyboardconfig variant extensible with custom layouts.
   # See nixos/modules/services/x11/extra-layouts.nix
   xkeyboardconfig_custom =

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -378,6 +378,8 @@ self: super:
 # deprecate some packages
 // lib.optionalAttrs config.allowAliases {
   fontbitstreamspeedo = throw "Bitstream Speedo is an obsolete font format that hasn't been supported by Xorg since 2005"; # added 2025-09-24
+  libXtrap = throw "XTrap was a proposed X11 extension that hasn't been in Xorg since X11R6 in 1994, it is deprecated and archived upstream."; # added 2025-12-13
+  xtrap = throw "XTrap was a proposed X11 extension that hasn't been in Xorg since X11R6 in 1994, it is deprecated and archived upstream."; # added 2025-12-13
   xf86videoglide = throw "The Xorg Glide video driver has been archived upstream due to being obsolete"; # added 2025-12-13
   xf86videoglint = throw ''
     The Xorg GLINT/Permedia video driver has been broken since xorg 21.

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -1,4 +1,3 @@
-mirror://xorg/individual/app/xkbcomp-1.5.0.tar.xz
 mirror://xorg/individual/driver/xf86-input-evdev-2.11.0.tar.xz
 mirror://xorg/individual/driver/xf86-input-joystick-1.6.4.tar.xz
 mirror://xorg/individual/driver/xf86-input-keyboard-2.1.0.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -1,6 +1,5 @@
 mirror://xorg/individual/app/xkbcomp-1.5.0.tar.xz
 mirror://xorg/individual/app/xtrap-1.0.3.tar.bz2
-mirror://xorg/individual/app/xwd-1.0.9.tar.xz
 mirror://xorg/individual/driver/xf86-input-evdev-2.11.0.tar.xz
 mirror://xorg/individual/driver/xf86-input-joystick-1.6.4.tar.xz
 mirror://xorg/individual/driver/xf86-input-keyboard-2.1.0.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -1,4 +1,3 @@
-mirror://xorg/individual/app/xinit-1.4.4.tar.xz
 mirror://xorg/individual/app/xinput-1.6.4.tar.xz
 mirror://xorg/individual/app/xkbcomp-1.5.0.tar.xz
 mirror://xorg/individual/app/xtrap-1.0.3.tar.bz2

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -1,5 +1,4 @@
 mirror://xorg/individual/app/xkbcomp-1.5.0.tar.xz
-mirror://xorg/individual/app/xtrap-1.0.3.tar.bz2
 mirror://xorg/individual/driver/xf86-input-evdev-2.11.0.tar.xz
 mirror://xorg/individual/driver/xf86-input-joystick-1.6.4.tar.xz
 mirror://xorg/individual/driver/xf86-input-keyboard-2.1.0.tar.xz
@@ -44,4 +43,3 @@ mirror://xorg/individual/driver/xf86-video-vboxvideo-1.0.1.tar.xz
 mirror://xorg/individual/driver/xf86-video-vesa-2.6.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-vmware-13.4.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-voodoo-1.2.6.tar.xz
-mirror://xorg/individual/lib/libXTrap-1.0.1.tar.bz2

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -1,4 +1,3 @@
-mirror://xorg/individual/app/xinput-1.6.4.tar.xz
 mirror://xorg/individual/app/xkbcomp-1.5.0.tar.xz
 mirror://xorg/individual/app/xtrap-1.0.3.tar.bz2
 mirror://xorg/individual/app/xwd-1.0.9.tar.xz


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux + cross to aarch64-linux
  - [x] x86_64-linux-static (except xinit)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - [x] xinput against xwayland
  - [x] xwd against xwayland
  - [x] xkbcomp against xwayland
  - [x] xinit help output 
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- ran checks
  - [x] nixpkgs-hammering
  - [x] nix-check-deps
  - [x] ran passthru.updateScript  
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
