### PR TITLE
python3Packages.tantivy: init at 0.25.1

### DIFF
--- a/pkgs/development/python-modules/tantivy/default.nix
+++ b/pkgs/development/python-modules/tantivy/default.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  pkgs,
+  buildPythonPackage,
+  fetchFromGitHub,
+  rustPlatform,
+
+  # nativeBuildInputs
+  pkg-config,
+
+  # tests
+  mktestdocs,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "tantivy";
+  version = "0.25.1";
+  pyproject = true;
+
+  # # Python sources are not on the main GitHub repo
+  # src = fetchPypi {
+  #   inherit pname version;
+  #   hash = "sha256-aKMxRpmn0Y/PM4tSuujORql93hEoo+R+M/pNt/cfJl4=";
+  # };
+  src = fetchFromGitHub {
+    owner = "quickwit-oss";
+    repo = "tantivy-py";
+    tag = version;
+    hash = "sha256-rayr38TfBYCKDddJabhC+r/jIyqJtpKct81h1z8YPFw=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit pname version src;
+    hash = "sha256-xJdAD/E17mzTkRq5wwNxYtNtv386U1xD4mJhY0LiZFE=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.cargoSetupHook
+    rustPlatform.maturinBuildHook
+  ];
+
+  buildInputs = [
+    pkgs.zstd
+  ];
+
+  env = {
+    ZSTD_SYS_USE_PKG_CONFIG = true;
+  };
+
+  pythonImportsCheck = [ "tantivy" ];
+
+  preCheck = ''
+    rm -rf tantivy
+  '';
+
+  nativeCheckInputs = [
+    mktestdocs
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Official Python bindings for the Tantivy search engine";
+    homepage = "https://pypi.org/project/tantivy/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18388,6 +18388,8 @@ self: super: with self; {
 
   tank-utility = callPackage ../development/python-modules/tank-utility { };
 
+  tantivy = callPackage ../development/python-modules/tantivy { };
+
   tappy = callPackage ../development/python-modules/tappy { };
 
   tapsaff = callPackage ../development/python-modules/tapsaff { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add [tantivy](https://github.com/quickwit-oss/tantivy), a full-text search engine library inspired by Apache Lucene and written in Rust.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
