### PR TITLE
x{clock,fd,fs}: refactor & move to pkgs/by-name from xorg namespace

### DIFF
--- a/pkgs/by-name/xc/xclock/package.nix
+++ b/pkgs/by-name/xc/xclock/package.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  fetchpatch,
+  meson,
+  ninja,
+  pkg-config,
+  wrapWithXFileSearchPathHook,
+  libx11,
+  libxaw,
+  libxft,
+  libxkbfile,
+  libxmu,
+  libxrender,
+  libxt,
+  xorgproto,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xclock";
+  version = "1.1.1";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "app";
+    repo = "xclock";
+    tag = "xclock-${finalAttrs.version}";
+    hash = "sha256-ZgUb+iVO45Az/C+2YJ1TXxcTLk3zQjM1GGv2E69WNfo=";
+  };
+
+  patches = [
+    # meson build system patch
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/xorg/app/xclock/-/commit/28e10bd26ac7e02fe8a4fb8016bb115f8d664032.patch";
+      hash = "sha256-KdrS7VneJqwVPB+TRJoMmtR03Ju3PvvUMYfXz5tII6k=";
+    })
+  ];
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    wrapWithXFileSearchPathHook
+  ];
+
+  buildInputs = [
+    libx11
+    libxaw
+    libxft
+    libxkbfile
+    libxmu
+    libxrender
+    libxt
+    xorgproto
+  ];
+
+  mesonFlags = [
+    (lib.mesonOption "appdefaultdir" "${placeholder "out"}/share/X11/app-defaults")
+  ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=xclock-(.*)" ]; };
+
+  meta = {
+    description = "analog / digital clock for X";
+    longDescription = ''
+      xclock is the classic X Window System clock utility. It displays the time in analog or digital
+      form, continuously updated at a frequency which may be specified by the user.
+    '';
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xclock";
+    license = with lib.licenses; [
+      mitOpenGroup
+      hpnd
+      mit
+    ];
+    mainProgram = "xclock";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xf/xfd/package.nix
+++ b/pkgs/by-name/xf/xfd/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  pkg-config,
+  util-macros,
+  wrapWithXFileSearchPathHook,
+  fontconfig,
+  libxaw,
+  libxft,
+  libxkbfile,
+  libxmu,
+  libxrender,
+  libxt,
+  xorgproto,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xfd";
+  version = "1.1.4";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "app";
+    repo = "xfd";
+    tag = "xfd-${finalAttrs.version}";
+    hash = "sha256-8kkoJILNlVgDIV029mF3err6es5V001FQqUnTtD9/LQ=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    util-macros
+    wrapWithXFileSearchPathHook
+  ];
+
+  buildInputs = [
+    fontconfig
+    libxaw
+    libxft
+    libxkbfile
+    libxmu
+    libxrender
+    libxt
+    xorgproto
+  ];
+
+  installFlags = [ "appdefaultdir=$out/share/X11/app-defaults" ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=xfd-(.*)" ]; };
+
+  meta = {
+    description = "X font display utility, using either the X11 core protocol or libXft2.";
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xfd";
+    license = lib.licenses.mitOpenGroup;
+    mainProgram = "xfd";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xf/xfs/package.nix
+++ b/pkgs/by-name/xf/xfs/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  libxfont_2,
+  xorgproto,
+  xtrans,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xfs";
+  version = "1.2.2";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/xfs-${finalAttrs.version}.tar.xz";
+    hash = "sha256-twvUYzHiQbMOXgDb3C6rt/P4iAzUQkSs3hPXl20Jjsw=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libxfont_2
+    xorgproto
+    xtrans
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "X Font Server, for X11 core protocol fonts";
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xfs";
+    license = with lib.licenses; [
+      mitOpenGroup
+      hpndSellVariant
+      x11
+      hpnd
+    ];
+    mainProgram = "xfs";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+    broken = stdenv.hostPlatform.isStatic;
+  };
+})

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -116,6 +116,7 @@
   xbitmaps,
   xcalc,
   xcb-proto,
+  xclock,
   xcmsdb,
   xcompmgr,
   xconsole,
@@ -197,6 +198,7 @@ self: with self; {
     xbacklight
     xbitmaps
     xcalc
+    xclock
     xcmsdb
     xcompmgr
     xconsole
@@ -359,58 +361,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xtrap" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xclock = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      libXaw,
-      libXft,
-      libxkbfile,
-      libXmu,
-      xorgproto,
-      libXrender,
-      libXt,
-      wrapWithXFileSearchPathHook,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xclock";
-      version = "1.1.1";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xclock-1.1.1.tar.xz";
-        sha256 = "0b3l1zwz2b1cn46f8pd480b835j9anadf929vqpll107iyzylz6z";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        wrapWithXFileSearchPathHook
-      ];
-      buildInputs = [
-        libX11
-        libXaw
-        libXft
-        libxkbfile
-        libXmu
-        xorgproto
-        libXrender
-        libXt
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -127,6 +127,7 @@
   xdriinfo,
   xev,
   xeyes,
+  xfd,
   xfontsel,
   xfsinfo,
   xgamma,
@@ -208,6 +209,7 @@ self: with self; {
     xdriinfo
     xev
     xeyes
+    xfd
     xfontsel
     xfsinfo
     xgamma
@@ -2103,60 +2105,6 @@ self: with self; {
         xorgproto
         libpciaccess
         xorgserver
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xfd = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libxkbfile,
-      fontconfig,
-      libXaw,
-      libXft,
-      libXmu,
-      xorgproto,
-      libXrender,
-      libXt,
-      gettext,
-      wrapWithXFileSearchPathHook,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xfd";
-      version = "1.1.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xfd-1.1.4.tar.xz";
-        sha256 = "1zbnj0z28dx2rm2h7pjwcz7z1jnl28gz0v9xn3hs2igxcvxhyiym";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        gettext
-        wrapWithXFileSearchPathHook
-      ];
-      buildInputs = [
-        libxkbfile
-        fontconfig
-        libXaw
-        libXft
-        libXmu
-        xorgproto
-        libXrender
-        libXt
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -129,6 +129,7 @@
   xeyes,
   xfd,
   xfontsel,
+  xfs,
   xfsinfo,
   xgamma,
   xgc,
@@ -211,6 +212,7 @@ self: with self; {
     xeyes
     xfd
     xfontsel
+    xfs
     xfsinfo
     xgamma
     xgc
@@ -2105,44 +2107,6 @@ self: with self; {
         xorgproto
         libpciaccess
         xorgserver
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xfs = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libXfont2,
-      xorgproto,
-      xtrans,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xfs";
-      version = "1.2.2";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xfs-1.2.2.tar.xz";
-        sha256 = "1k4f15nrgmqkvsn48hnl1j4giwxpmcpdrnq0bq7b6hg265ix82xp";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libXfont2
-        xorgproto
-        xtrans
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -461,6 +461,7 @@ print OUT <<EOF;
   xeyes,
   xfd,
   xfontsel,
+  xfs,
   xfsinfo,
   xgamma,
   xgc,
@@ -543,6 +544,7 @@ self: with self; {
     xeyes
     xfd
     xfontsel
+    xfs
     xfsinfo
     xgamma
     xgc

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -459,6 +459,7 @@ print OUT <<EOF;
   xdriinfo,
   xev,
   xeyes,
+  xfd,
   xfontsel,
   xfsinfo,
   xgamma,
@@ -540,6 +541,7 @@ self: with self; {
     xdriinfo
     xev
     xeyes
+    xfd
     xfontsel
     xfsinfo
     xgamma

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -448,6 +448,7 @@ print OUT <<EOF;
   xbitmaps,
   xcalc,
   xcb-proto,
+  xclock,
   xcmsdb,
   xcompmgr,
   xconsole,
@@ -529,6 +530,7 @@ self: with self; {
     xbacklight
     xbitmaps
     xcalc
+    xclock
     xcmsdb
     xcompmgr
     xconsole

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -421,7 +421,6 @@ self: super:
     ];
   });
 
-  xfd = addMainProgram super.xfd { };
   xfs = addMainProgram super.xfs { };
   xinput = addMainProgram super.xinput { };
   xkbevd = addMainProgram super.xkbevd { };

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -338,8 +338,6 @@ self: super:
       postPatch = lib.concatStrings (lib.mapAttrsToList patchIn layouts);
     });
 
-  xclock = addMainProgram super.xclock { };
-
   xinit =
     (super.xinit.override {
       stdenv = if isDarwin then clangStdenv else stdenv;

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -421,7 +421,6 @@ self: super:
     ];
   });
 
-  xfs = addMainProgram super.xfs { };
   xinput = addMainProgram super.xinput { };
   xkbevd = addMainProgram super.xkbevd { };
   xkbprint = addMainProgram super.xkbprint { };

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -1,4 +1,3 @@
-mirror://xorg/individual/app/xfd-1.1.4.tar.xz
 mirror://xorg/individual/app/xfs-1.2.2.tar.xz
 mirror://xorg/individual/app/xinit-1.4.4.tar.xz
 mirror://xorg/individual/app/xinput-1.6.4.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -1,4 +1,3 @@
-mirror://xorg/individual/app/xclock-1.1.1.tar.xz
 mirror://xorg/individual/app/xfd-1.1.4.tar.xz
 mirror://xorg/individual/app/xfs-1.2.2.tar.xz
 mirror://xorg/individual/app/xinit-1.4.4.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -1,4 +1,3 @@
-mirror://xorg/individual/app/xfs-1.2.2.tar.xz
 mirror://xorg/individual/app/xinit-1.4.4.tar.xz
 mirror://xorg/individual/app/xinput-1.6.4.tar.xz
 mirror://xorg/individual/app/xkbcomp-1.5.0.tar.xz


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - xclock works
  - xfd and xfs, without any argument throw me exactly the same error on my sway system as before this pr
  - help/version output works for xfd and xfs
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- ran checks
  - [x] nixpkgs-hammering
  - [x] nix-check-deps
  - [x] passthru.updateScript
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
