### PR TITLE
python3Packages.consul: 1.6.0 -> 1.7.1

### DIFF
--- a/pkgs/development/python-modules/consul/default.nix
+++ b/pkgs/development/python-modules/consul/default.nix
@@ -5,27 +5,23 @@
   fetchpatch,
   setuptools,
   requests,
-  pythonOlder,
   pytestCheckHook,
   aiohttp,
   pytest-asyncio,
   pytest-cov-stub,
   python,
-  docker,
 }:
 
 buildPythonPackage rec {
   pname = "py-consul";
-  version = "1.6.0";
+  version = "1.7.1";
   pyproject = true;
-
-  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "criteo";
     repo = "py-consul";
     tag = "v${version}";
-    hash = "sha256-kNIFpY8rXdfGmaW2GAq7SvjK+4ahgaFnyXEqcUrXoEs=";
+    hash = "sha256-DpGSiwpxAF1kCraRFl6XPJ1eSzvR6Rdq8PkK30J/vA0=";
   };
 
   patches = [
@@ -33,6 +29,9 @@ buildPythonPackage rec {
       url = "https://salsa.debian.org/python-team/packages/python-consul/-/raw/master/debian/patches/avoir-usr-requirements.txt.patch";
       hash = "sha256-lB9Irzuc2IpbQOIP/C3JQ4iYqugf1U6CVlAEXrrFUfI=";
     })
+
+    # conftest.py always imports docker, even if related tests are disabled
+    ./disable-docker-tests.patch
   ];
 
   build-system = [
@@ -53,7 +52,6 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-asyncio
     pytest-cov-stub
-    docker
   ];
 
   # Most tests want to run a consul docker container ("hashicorp/consul:{version}" in conftest.py)
@@ -107,6 +105,12 @@ buildPythonPackage rec {
     "test_transaction"
     "test_consul_ctor"
     "test_acl_token_delete"
+    "test_acl_templated_policy_list"
+    "test_acl_templated_policy_preview"
+    "test_acl_templated_policy_read"
+    "test_acl_templated_policy_wrote"
+    "test_agent_service_tagged_addresses"
+    "test_agent_service_connect"
   ];
 
   pythonImportsCheck = [ "consul" ];

--- a/pkgs/development/python-modules/consul/disable-docker-tests.patch
+++ b/pkgs/development/python-modules/consul/disable-docker-tests.patch
@@ -1,0 +1,19 @@
+diff --git a/conftest.py b/conftest.py
+index 533d99c..c57afd8 100644
+--- a/conftest.py
++++ b/conftest.py
+@@ -7,11 +7,11 @@ import socket
+ import time
+ import uuid
+ 
+-import docker
++#import docker
+ import pytest
+ import requests
+-from docker import DockerClient
+-from docker.errors import APIError, NotFound
++#from docker import DockerClient
++#from docker.errors import APIError, NotFound
+ from requests import RequestException
+ 
+ CONSUL_VERSIONS = ["1.17.3", "1.19.2", "1.20.2"]


### PR DESCRIPTION
https://github.com/criteo/py-consul/releases/tag/v1.7.0
https://github.com/criteo/py-consul/releases/tag/v1.7.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `89d64c7bd678a33103302c81d8c3290015de35a7`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 6 packages built:</summary>
  <ul>
    <li>patroni</li>
    <li>patroni.dist</li>
    <li>python312Packages.consul</li>
    <li>python312Packages.consul.dist</li>
    <li>python313Packages.consul</li>
    <li>python313Packages.consul.dist</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
