### PR TITLE
xf86-input-{evdev,joystick,keyboard,libinput}: refactor & move to pkgs/by-name from xorg namespace

### DIFF
--- a/pkgs/by-name/xf/xf86-input-evdev/package.nix
+++ b/pkgs/by-name/xf/xf86-input-evdev/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  pkg-config,
+  util-macros,
+  xorgproto,
+  libevdev,
+  udev,
+  mtdev,
+  xorg-server,
+  nix-update-script,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xf86-input-evdev";
+  version = "2.11.0";
+
+  # to get rid of xorgserver.dev; man is tiny
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "driver";
+    repo = "xf86-input-evdev";
+    tag = "xf86-input-evdev-${finalAttrs.version}";
+    hash = "sha256-tXB50laCJcLoBbwM/hE+qEiHzmN7Q+r8uu6NPlRmpTM=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    util-macros
+  ];
+
+  buildInputs = [
+    xorgproto
+    libevdev
+    udev
+    mtdev
+    xorg-server
+  ];
+
+  configureFlags = [
+    "--with-sdkdir=${placeholder "dev"}/include/xorg"
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version-regex=xf86-input-evdev-(.*)" ]; };
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "Generic Linux input driver for the Xorg X server";
+    homepage = "https://gitlab.freedesktop.org/xorg/driver/xf86-input-evdev";
+    license = with lib.licenses; [
+      hpndSellVariant
+      mit
+    ];
+    maintainers = [ ];
+    pkgConfigModules = [ "xorg-evdev" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xf/xf86-input-joystick/package.nix
+++ b/pkgs/by-name/xf/xf86-input-joystick/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  pkg-config,
+  util-macros,
+  xorgproto,
+  xorg-server,
+  nix-update-script,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xf86-input-joystick";
+  version = "1.6.4";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "driver";
+    repo = "xf86-input-joystick";
+    tag = "xf86-input-joystick-${finalAttrs.version}";
+    hash = "sha256-JxSnhWx5V3/pdlu3mwRNrgicdfaUK5nIwBK3reqchQs=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    util-macros
+    xorg-server # xorg-server defines autoconf macros that we need
+  ];
+
+  buildInputs = [
+    util-macros # unused dependency but the build fails if pkg-config can't find it
+    xorgproto
+    xorg-server
+  ];
+
+  configureFlags = [ "--with-sdkdir=${placeholder "out"}/include/xorg" ];
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version-regex=xf86-input-joystick-(.*)" ]; };
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "Joystick input driver for the Xorg X server";
+    homepage = "https://gitlab.freedesktop.org/xorg/driver/xf86-input-joystick";
+    license = lib.licenses.hpndSellVariant;
+    maintainers = [ ];
+    pkgConfigModules = [ "xorg-joystick" ];
+    platforms = lib.platforms.unix;
+    broken = stdenv.hostPlatform.isDarwin; # never worked: https://hydra.nixos.org/job/nixpkgs/trunk/xorg.xf86inputjoystick.x86_64-darwin
+  };
+})

--- a/pkgs/by-name/xf/xf86-input-keyboard/package.nix
+++ b/pkgs/by-name/xf/xf86-input-keyboard/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  pkg-config,
+  util-macros,
+  xorgproto,
+  xorg-server,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xf86-input-keyboard";
+  version = "2.1.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "driver";
+    repo = "xf86-input-keyboard";
+    tag = "xf86-input-keyboard-${finalAttrs.version}";
+    hash = "sha256-M0D6oTAhnADI7pgWKt4ueHGbdMVDTVOXy3w07DGcCSg=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    util-macros
+  ];
+
+  buildInputs = [
+    xorgproto
+    xorg-server
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version-regex=xf86-input-keyboard-(.*)" ]; };
+  };
+
+  meta = {
+    description = "Keyboard input driver for non-Linux platforms for the Xorg X server";
+    homepage = "https://gitlab.freedesktop.org/xorg/driver/xf86-input-keyboard";
+    license = [
+      lib.licenses.x11
+      lib.licenses.hpndSellVariant
+    ]
+    # only solaris part is MIT
+    ++ lib.optional stdenv.hostPlatform.isSunOS lib.licenses.mit;
+    maintainers = [ ];
+    # platforms according to the readme:
+    # BSD, GNU Hurd, illumos & Solaris
+    platforms = with lib.platforms; freebsd ++ netbsd ++ openbsd ++ illumos;
+  };
+})

--- a/pkgs/by-name/xf/xf86-input-libinput/package.nix
+++ b/pkgs/by-name/xf/xf86-input-libinput/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  pkg-config,
+  util-macros,
+  xorgproto,
+  libinput,
+  xorg-server,
+  nix-update-script,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xf86-input-libinput";
+  version = "1.5.0";
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "driver";
+    repo = "xf86-input-libinput";
+    tag = "xf86-input-libinput-${finalAttrs.version}";
+    hash = "sha256-yZi5h3k6cwunucLhmH/wNchA0M11U3KBwrRuY/oATh8=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    util-macros
+  ];
+
+  buildInputs = [
+    xorgproto
+    libinput
+    xorg-server
+  ];
+
+  configureFlags = [
+    "--with-sdkdir=${placeholder "dev"}/include/xorg"
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version-regex=xf86-input-libinput-(.*)" ]; };
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "libinput-based input driver for the Xorg X server";
+    longDescription = ''
+      This is an X driver based on libinput. It is a thin wrapper around libinput, so while it does
+      provide all features that libinput supports it does little beyond.
+    '';
+    homepage = "https://gitlab.freedesktop.org/xorg/driver/xf86-input-libinput";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    pkgConfigModules = [ "xorg-libinput" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -128,6 +128,7 @@
   xdriinfo,
   xev,
   xeyes,
+  xf86-input-evdev,
   xf86-input-mouse,
   xf86-input-synaptics,
   xf86-input-vmmouse,
@@ -346,6 +347,7 @@ self: with self; {
   xcbutilrenderutil = libxcb-render-util;
   xcbutilwm = libxcb-wm;
   xcursorthemes = xcursor-themes;
+  xf86inputevdev = xf86-input-evdev;
   xf86inputmouse = xf86-input-mouse;
   xf86inputsynaptics = xf86-input-synaptics;
   xf86inputvmmouse = xf86-input-vmmouse;
@@ -355,48 +357,6 @@ self: with self; {
   xorgdocs = xorg-docs;
   xorgserver = xorg-server;
   xorgsgmldoctools = xorg-sgml-doctools;
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xf86inputevdev = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libevdev,
-      udev,
-      mtdev,
-      xorgserver,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xf86-input-evdev";
-      version = "2.11.0";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/driver/xf86-input-evdev-2.11.0.tar.xz";
-        sha256 = "058k0xdf4hkn8lz5gx4c08mgbzvv58haz7a32axndhscjgg2403k";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libevdev
-        udev
-        mtdev
-        xorgserver
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "xorg-evdev" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
 
   # THIS IS A GENERATED FILE.  DO NOT EDIT!
   xf86inputjoystick = callPackage (

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -130,6 +130,7 @@
   xeyes,
   xf86-input-evdev,
   xf86-input-joystick,
+  xf86-input-keyboard,
   xf86-input-mouse,
   xf86-input-synaptics,
   xf86-input-vmmouse,
@@ -350,6 +351,7 @@ self: with self; {
   xcursorthemes = xcursor-themes;
   xf86inputevdev = xf86-input-evdev;
   xf86inputjoystick = xf86-input-joystick;
+  xf86inputkeyboard = xf86-input-keyboard;
   xf86inputmouse = xf86-input-mouse;
   xf86inputsynaptics = xf86-input-synaptics;
   xf86inputvmmouse = xf86-input-vmmouse;
@@ -359,42 +361,6 @@ self: with self; {
   xorgdocs = xorg-docs;
   xorgserver = xorg-server;
   xorgsgmldoctools = xorg-sgml-doctools;
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xf86inputkeyboard = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      xorgserver,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xf86-input-keyboard";
-      version = "2.1.0";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/driver/xf86-input-keyboard-2.1.0.tar.xz";
-        sha256 = "0mvwxrnkq0lzhjr894p420zxffdn34nc2scinmp7qd1hikr51kkp";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        xorgserver
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
 
   # THIS IS A GENERATED FILE.  DO NOT EDIT!
   xf86inputlibinput = callPackage (

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -129,6 +129,7 @@
   xev,
   xeyes,
   xf86-input-evdev,
+  xf86-input-joystick,
   xf86-input-mouse,
   xf86-input-synaptics,
   xf86-input-vmmouse,
@@ -348,6 +349,7 @@ self: with self; {
   xcbutilwm = libxcb-wm;
   xcursorthemes = xcursor-themes;
   xf86inputevdev = xf86-input-evdev;
+  xf86inputjoystick = xf86-input-joystick;
   xf86inputmouse = xf86-input-mouse;
   xf86inputsynaptics = xf86-input-synaptics;
   xf86inputvmmouse = xf86-input-vmmouse;
@@ -357,42 +359,6 @@ self: with self; {
   xorgdocs = xorg-docs;
   xorgserver = xorg-server;
   xorgsgmldoctools = xorg-sgml-doctools;
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xf86inputjoystick = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      xorgserver,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xf86-input-joystick";
-      version = "1.6.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/driver/xf86-input-joystick-1.6.4.tar.xz";
-        sha256 = "1lnc6cvrg81chb2hj3jphgx7crr4ab8wn60mn8f9nsdwza2w8plh";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        xorgserver
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "xorg-joystick" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
 
   # THIS IS A GENERATED FILE.  DO NOT EDIT!
   xf86inputkeyboard = callPackage (

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -131,6 +131,7 @@
   xf86-input-evdev,
   xf86-input-joystick,
   xf86-input-keyboard,
+  xf86-input-libinput,
   xf86-input-mouse,
   xf86-input-synaptics,
   xf86-input-vmmouse,
@@ -352,6 +353,7 @@ self: with self; {
   xf86inputevdev = xf86-input-evdev;
   xf86inputjoystick = xf86-input-joystick;
   xf86inputkeyboard = xf86-input-keyboard;
+  xf86inputlibinput = xf86-input-libinput;
   xf86inputmouse = xf86-input-mouse;
   xf86inputsynaptics = xf86-input-synaptics;
   xf86inputvmmouse = xf86-input-vmmouse;
@@ -361,44 +363,6 @@ self: with self; {
   xorgdocs = xorg-docs;
   xorgserver = xorg-server;
   xorgsgmldoctools = xorg-sgml-doctools;
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xf86inputlibinput = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libinput,
-      xorgserver,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xf86-input-libinput";
-      version = "1.5.0";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/driver/xf86-input-libinput-1.5.0.tar.xz";
-        sha256 = "1rl06l0gdqmc4v08mya93m74ana76b7s3fzkmq8ylm3535gw6915";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libinput
-        xorgserver
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "xorg-libinput" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
 
   # THIS IS A GENERATED FILE.  DO NOT EDIT!
   xf86videoamdgpu = callPackage (

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -460,6 +460,7 @@ print OUT <<EOF;
   xdriinfo,
   xev,
   xeyes,
+  xf86-input-evdev,
   xf86-input-mouse,
   xf86-input-synaptics,
   xf86-input-vmmouse,
@@ -678,6 +679,7 @@ self: with self; {
   xcbutilrenderutil = libxcb-render-util;
   xcbutilwm = libxcb-wm;
   xcursorthemes = xcursor-themes;
+  xf86inputevdev = xf86-input-evdev;
   xf86inputmouse = xf86-input-mouse;
   xf86inputsynaptics = xf86-input-synaptics;
   xf86inputvmmouse = xf86-input-vmmouse;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -463,6 +463,7 @@ print OUT <<EOF;
   xf86-input-evdev,
   xf86-input-joystick,
   xf86-input-keyboard,
+  xf86-input-libinput,
   xf86-input-mouse,
   xf86-input-synaptics,
   xf86-input-vmmouse,
@@ -684,6 +685,7 @@ self: with self; {
   xf86inputevdev = xf86-input-evdev;
   xf86inputjoystick = xf86-input-joystick;
   xf86inputkeyboard = xf86-input-keyboard;
+  xf86inputlibinput = xf86-input-libinput;
   xf86inputmouse = xf86-input-mouse;
   xf86inputsynaptics = xf86-input-synaptics;
   xf86inputvmmouse = xf86-input-vmmouse;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -462,6 +462,7 @@ print OUT <<EOF;
   xeyes,
   xf86-input-evdev,
   xf86-input-joystick,
+  xf86-input-keyboard,
   xf86-input-mouse,
   xf86-input-synaptics,
   xf86-input-vmmouse,
@@ -682,6 +683,7 @@ self: with self; {
   xcursorthemes = xcursor-themes;
   xf86inputevdev = xf86-input-evdev;
   xf86inputjoystick = xf86-input-joystick;
+  xf86inputkeyboard = xf86-input-keyboard;
   xf86inputmouse = xf86-input-mouse;
   xf86inputsynaptics = xf86-input-synaptics;
   xf86inputvmmouse = xf86-input-vmmouse;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -461,6 +461,7 @@ print OUT <<EOF;
   xev,
   xeyes,
   xf86-input-evdev,
+  xf86-input-joystick,
   xf86-input-mouse,
   xf86-input-synaptics,
   xf86-input-vmmouse,
@@ -680,6 +681,7 @@ self: with self; {
   xcbutilwm = libxcb-wm;
   xcursorthemes = xcursor-themes;
   xf86inputevdev = xf86-input-evdev;
+  xf86inputjoystick = xf86-input-joystick;
   xf86inputmouse = xf86-input-mouse;
   xf86inputsynaptics = xf86-input-synaptics;
   xf86inputvmmouse = xf86-input-vmmouse;

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -71,15 +71,6 @@ self: super:
 {
   mkfontdir = xorg.mkfontscale;
 
-  xf86inputjoystick = super.xf86inputjoystick.overrideAttrs (attrs: {
-    configureFlags = [
-      "--with-sdkdir=${placeholder "out"}/include/xorg"
-    ];
-    meta = attrs.meta // {
-      broken = isDarwin; # never worked: https://hydra.nixos.org/job/nixpkgs/trunk/xorg.xf86inputjoystick.x86_64-darwin
-    };
-  });
-
   xf86inputkeyboard = super.xf86inputkeyboard.overrideAttrs (attrs: {
     meta = attrs.meta // {
       platforms = lib.platforms.freebsd ++ lib.platforms.netbsd ++ lib.platforms.openbsd;

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -71,12 +71,6 @@ self: super:
 {
   mkfontdir = xorg.mkfontscale;
 
-  xf86inputkeyboard = super.xf86inputkeyboard.overrideAttrs (attrs: {
-    meta = attrs.meta // {
-      platforms = lib.platforms.freebsd ++ lib.platforms.netbsd ++ lib.platforms.openbsd;
-    };
-  });
-
   xf86inputlibinput = super.xf86inputlibinput.overrideAttrs (attrs: {
     outputs = [
       "out"

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -71,16 +71,6 @@ self: super:
 {
   mkfontdir = xorg.mkfontscale;
 
-  xf86inputlibinput = super.xf86inputlibinput.overrideAttrs (attrs: {
-    outputs = [
-      "out"
-      "dev"
-    ];
-    configureFlags = [
-      "--with-sdkdir=${placeholder "dev"}/include/xorg"
-    ];
-  });
-
   xf86videodummy = brokenOnDarwin super.xf86videodummy; # never worked: https://hydra.nixos.org/job/nixpkgs/trunk/xorg.xf86videodummy.x86_64-darwin
 
   xf86videoark = super.xf86videoark.overrideAttrs (attrs: {

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -71,17 +71,6 @@ self: super:
 {
   mkfontdir = xorg.mkfontscale;
 
-  xf86inputevdev = super.xf86inputevdev.overrideAttrs (attrs: {
-    outputs = [
-      "out"
-      "dev"
-    ]; # to get rid of xorgserver.dev; man is tiny
-    preBuild = "sed -e '/motion_history_proc/d; /history_size/d;' -i src/*.c";
-    configureFlags = [
-      "--with-sdkdir=${placeholder "dev"}/include/xorg"
-    ];
-  });
-
   xf86inputjoystick = super.xf86inputjoystick.overrideAttrs (attrs: {
     configureFlags = [
       "--with-sdkdir=${placeholder "out"}/include/xorg"

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -1,4 +1,3 @@
-mirror://xorg/individual/driver/xf86-input-joystick-1.6.4.tar.xz
 mirror://xorg/individual/driver/xf86-input-keyboard-2.1.0.tar.xz
 mirror://xorg/individual/driver/xf86-input-libinput-1.5.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-amdgpu-23.0.0.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -1,4 +1,3 @@
-mirror://xorg/individual/driver/xf86-input-keyboard-2.1.0.tar.xz
 mirror://xorg/individual/driver/xf86-input-libinput-1.5.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-amdgpu-23.0.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-apm-1.3.0.tar.bz2

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -1,4 +1,3 @@
-mirror://xorg/individual/driver/xf86-input-evdev-2.11.0.tar.xz
 mirror://xorg/individual/driver/xf86-input-joystick-1.6.4.tar.xz
 mirror://xorg/individual/driver/xf86-input-keyboard-2.1.0.tar.xz
 mirror://xorg/individual/driver/xf86-input-libinput-1.5.0.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -1,4 +1,3 @@
-mirror://xorg/individual/driver/xf86-input-libinput-1.5.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-amdgpu-23.0.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-apm-1.3.0.tar.bz2
 mirror://xorg/individual/driver/xf86-video-ark-0.7.6.tar.xz


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux 
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
