### PR TITLE
sg-323: init at 1.0.1

### DIFF
--- a/pkgs/by-name/sg/sg-323/package.nix
+++ b/pkgs/by-name/sg/sg-323/package.nix
@@ -1,0 +1,108 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  fetchpatch,
+  cmake,
+  pkg-config,
+  libx11,
+  libxrandr,
+  libxinerama,
+  libxext,
+  libxcursor,
+  freetype,
+  fontconfig,
+  alsa-lib,
+  expat,
+  nix-update-script,
+
+  buildVST3 ? true,
+  buildLV2 ? true,
+  buildCLAP ? true,
+}:
+let
+  formats = lib.concatStringsSep " " [
+    (lib.optionalString buildVST3 "VST3")
+    (lib.optionalString buildLV2 "LV2")
+  ];
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sg-323";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "greyboxaudio";
+    repo = "SG-323";
+    tag = finalAttrs.version;
+    hash = "sha256-DvA9Y7eAG0pWLmHEZmJlo0JLU+0B4c8rlkX1bbVcnL8=";
+    fetchSubmodules = true;
+  };
+
+  patches = [
+    # Adds BUILD_CLAP option
+    (fetchpatch {
+      url = "https://github.com/greyboxaudio/SG-323/pull/26.patch";
+      hash = "sha256-k1KY6elA6sajVLgI2omW9LpMdB5RtKA4NsE/G/b/SdM=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "juce::juce_recommended_lto_flags" "# Not enforcing lto" \
+      --replace-fail "FORMATS VST3 AAX AU LV2" "FORMATS ${formats}"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    libx11
+    libxrandr
+    libxinerama
+    libxext
+    libxcursor
+    freetype
+    fontconfig
+    alsa-lib
+    expat
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_CLAP" buildCLAP)
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    cd SG323_artefacts/Release
+
+    ${lib.optionalString buildVST3 ''
+      mkdir -p $out/lib/vst3
+      cp -r VST3/SG-323.vst3 $out/lib/vst3
+    ''}
+
+    ${lib.optionalString buildLV2 ''
+      mkdir -p $out/lib/lv2
+      cp -r LV2/SG-323.lv2 $out/lib/lv2
+    ''}
+
+    ${lib.optionalString buildCLAP ''
+      mkdir -p $out/lib/clap
+      cp -r CLAP/SG-323.clap $out/lib/clap
+    ''}
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Ursa Major Stargate 323 emulation plugin";
+    homepage = "https://store.greyboxaudio.com/products/sg-323-reverb";
+    platforms = lib.platforms.linux;
+    license = [ lib.licenses.gpl3Plus ];
+    maintainers = [ lib.maintainers.mrtnvgr ];
+  };
+})


### PR DESCRIPTION


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
