### PR TITLE
perlPackages.DBDPg: fix build with gcc15

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -9846,6 +9846,16 @@ with self;
       hash = "sha256-jZANTA50nzchh1KmZh+w01V6sfzMjeo4TLWHw4LeIZs=";
     };
 
+    patches = [
+      # Fix build with gcc15
+      # https://github.com/bucardo/dbdpg/pull/148
+      (fetchpatch {
+        name = "perl-dbdpg-fix-c23-compliance.patch";
+        url = "https://github.com/bucardo/dbdpg/commit/8da04f9169d017469e3a12f08322e6bd88e8f239.patch";
+        hash = "sha256-MpVpaZoRgN1ABk6F6hFZvo9IkQJX2frHDygOTa0wics=";
+      })
+    ];
+
     buildInputs = [ pkgs.postgresql ];
     propagatedBuildInputs = [ DBI ];
 


### PR DESCRIPTION
- add patch from merged upstream PR:
https://www.github.com/bucardo/dbdpg/pull/148
https://github.com/bucardo/dbdpg/commit/8da04f9169d017469e3a12f08322e6bd88e8f239

Upstream issue:
https://www.github.com/bucardo/dbdpg/issues/135

Fixes build failure with gcc15:
```
Pg.xs: In function 'XS_DBD__Pg__db_quote':
Pg.xs:330:22: error: too many arguments to function 'type_info->quote';
expected 0, have 5
  330 |             quoted = type_info->quote(aTHX_ to_quote, len, &retlen, imp_dbh->pg_server_version >= 80100 ? 1 : 0);
      |                      ^~~~~~~~~
In file included from Pg.h:66,
                 from Pg.xs:14:
types.h:11:15: note: declared here
   11 |     char*   (*quote)();
      |               ^~~~~
```
---
Tested build with:
```bash
nix-build --expr 'with import ./. {}; (perlPackages.overrideScope (final: prev: { stdenv = gcc15Stdenv; })).DBDPg'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

---

There might be a version update (`3.19.0`) with this fix included soon, but it is not in cpan yet:
https://github.com/bucardo/dbdpg/commit/d02e38fa462360e63964f88617ac636a6e8096e2

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
