### PR TITLE
gnomeExtensions.printers: patch hardcoded binary paths

### DIFF
--- a/pkgs/desktops/gnome/extensions/extensionOverrides.nix
+++ b/pkgs/desktops/gnome/extensions/extensionOverrides.nix
@@ -2,6 +2,7 @@
   lib,
   fetchFromGitLab,
   cpio,
+  cups,
   ddcutil,
   easyeffects,
   gjs,
@@ -168,6 +169,14 @@ lib.trivial.pipe super [
       ];
     }
   ))
+
+  (patchExtension "printers@linux-man.org" (old: {
+    patches = [
+      (replaceVars ./extensionOverridesPatches/printers_at_linux-man.org.patch {
+        inherit cups;
+      })
+    ];
+  }))
 
   (patchExtension "system-monitor@gnome-shell-extensions.gcampax.github.com" (old: {
     patches = [

--- a/pkgs/desktops/gnome/extensions/extensionOverridesPatches/printers_at_linux-man.org.patch
+++ b/pkgs/desktops/gnome/extensions/extensionOverridesPatches/printers_at_linux-man.org.patch
@@ -1,0 +1,42 @@
+diff --git a/extension.js b/extension.js
+index 91b81dc..e4a2552 100755
+--- a/extension.js
++++ b/extension.js
+@@ -122,8 +122,8 @@ const PrintersManager = GObject.registerClass(class PrintersManager extends Pane
+         this.menu.addMenuItem(printers);
+ //Add Printers
+         this.printers = [];
+-        let p_list = await exec_async(['/usr/bin/lpstat', '-a']);
+-        let p_default = await exec_async(['/usr/bin/lpstat', '-d']);
++        let p_list = await exec_async(['@cups@/bin/lpstat', '-a']);
++        let p_default = await exec_async(['@cups@/bin/lpstat', '-d']);
+         if(p_default.split(': ')[1] != undefined) p_default = p_default.split(': ')[1].trim();
+         else p_default = 'no default';
+         p_list = p_list.split('\n');
+@@ -143,7 +143,7 @@ const PrintersManager = GObject.registerClass(class PrintersManager extends Pane
+             }
+         }
+ //Jobs
+-        let p_jobs = await exec_async(['/usr/bin/lpstat', '-o']);
++        let p_jobs = await exec_async(['@cups@/bin/lpstat', '-o']);
+ //Cancel all Jobs
+         if(p_jobs.length > 0) {
+             this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+@@ -154,7 +154,7 @@ const PrintersManager = GObject.registerClass(class PrintersManager extends Pane
+ //Add Jobs
+         p_jobs = p_jobs.split(/\n/);
+         this.jobsCount = p_jobs.length - 1
+-        let p_jobs2 = await exec_async(['/usr/bin/lpq', '-a']);
++        let p_jobs2 = await exec_async(['@cups@/bin/lpq', '-a']);
+         p_jobs2 = p_jobs2.replace(/\n/g, ' ').split(/\s+/);
+         let sendJobs = [];
+         for(var n = 0; n < p_jobs.length - 1; n++) {
+@@ -194,7 +194,7 @@ const PrintersManager = GObject.registerClass(class PrintersManager extends Pane
+         this.show();
+         if(this.show_icon == 0 || (this.show_icon == 1 && this.printersCount > 0) || (this.show_icon == 2 && this.jobsCount > 0)) {
+ 			this.show();
+-			let p_error = await exec_async(['/usr/bin/lpstat', '-l']);
++			let p_error = await exec_async(['@cups@/bin/lpstat', '-l']);
+ 			this.printError = p_error.indexOf('Unable') >= 0 || p_error.indexOf(' not ') >= 0 || p_error.indexOf(' failed') >= 0;
+ 			if(this.printWarning) this._icon.icon_name = warningIcon;
+ 			else if(this.show_error && this.printError) this._icon.icon_name = errorIcon;


### PR DESCRIPTION
I've been using this patch locally for some time now, thought I'd upstream.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
