### PR TITLE
wolfssl: 5.8.2 -> 5.8.4

### DIFF
--- a/pkgs/by-name/wo/wolfssl/package.nix
+++ b/pkgs/by-name/wo/wolfssl/package.nix
@@ -17,13 +17,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "wolfssl-${variant}";
-  version = "5.8.2";
+  version = "5.8.4";
 
   src = fetchFromGitHub {
     owner = "wolfSSL";
     repo = "wolfssl";
     tag = "v${finalAttrs.version}-stable";
-    hash = "sha256-rWBfpI6tdpKvQA/XdazBvU5hzyai5PtKRBpM4iplZDU=";
+    hash = "sha256-vfJKmDdM0r591t5GnuSS7NyiUYXCQOTKbWLVydB3N9s=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Fixes CVE-2025-12888, CVE-2025-11936, CVE-2025-11935, CVE-2025-11934, CVE-2025-11933, CVE-2025-11931, CVE-2025-11932 and CVE-2025-12889.

Fixes #470470
Fixes #470471

Changes:
https://github.com/wolfSSL/wolfssl/releases/tag/v5.8.4-stable


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 470478`
Commit: `b4bdc1b3773e487a577b57b4daaf91157fa47026`

---
### `x86_64-linux`
<details>
  <summary>:x: 1 package failed to build:</summary>
  <ul>
    <li>tests.devShellTools.nixos</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 1 test built:</summary>
  <ul>
    <li>nixosTests.simple</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 70 packages built:</summary>
  <ul>
    <li>OVMFFull</li>
    <li>OVMFFull.fd</li>
    <li>android-translation-layer</li>
    <li>art-standalone</li>
    <li>colima</li>
    <li>cot (python313Packages.cot)</li>
    <li>cot.dist (python313Packages.cot.dist)</li>
    <li>debos</li>
    <li>diffoscope</li>
    <li>diffoscope.dist</li>
    <li>diffoscope.man</li>
    <li>goldboot</li>
    <li>kata-runtime</li>
    <li>libguestfs (python313Packages.guestfs)</li>
    <li>libguestfs.guestfsd (python313Packages.guestfs.guestfsd)</li>
    <li>libubox-wolfssl</li>
    <li>lima</li>
    <li>mkosi-full</li>
    <li>mkosi-full.dist</li>
    <li>mkosi-full.man</li>
    <li>nemu</li>
    <li>open-watcom-bin</li>
    <li>open-watcom-bin-unwrapped</li>
    <li>out-of-tree</li>
    <li>python312Packages.cot</li>
    <li>python312Packages.cot.dist</li>
    <li>python312Packages.guestfs</li>
    <li>python312Packages.guestfs.guestfsd</li>
    <li>qemu</li>
    <li>qemu.debug</li>
    <li>qemu.doc</li>
    <li>qemu.ga</li>
    <li>qemu_full</li>
    <li>qemu_full.debug</li>
    <li>qemu_full.doc</li>
    <li>qemu_full.ga</li>
    <li>qemu_kvm</li>
    <li>qemu_kvm.debug</li>
    <li>qemu_kvm.doc</li>
    <li>qemu_kvm.ga</li>
    <li>qemu_test</li>
    <li>qemu_test.debug</li>
    <li>qemu_test.doc</li>
    <li>qemu_test.ga</li>
    <li>qemu_xen</li>
    <li>qemu_xen.debug</li>
    <li>qemu_xen.doc</li>
    <li>qemu_xen.ga</li>
    <li>qtemu</li>
    <li>quickemu</li>
    <li>quickgui</li>
    <li>quickgui.debug</li>
    <li>quickgui.pubcache</li>
    <li>rpcs3</li>
    <li>simh</li>
    <li>solo5</li>
    <li>solo5.debug</li>
    <li>tests.testers.lycheeLinkCheck.network</li>
    <li>tests.testers.nixosTest-example</li>
    <li>tests.testers.runNixOSTest-example (tests.testers.runNixOSTest-extendNixOS)</li>
    <li>tests.trivial-builders.references</li>
    <li>ustream-ssl-wolfssl</li>
    <li>vagrant</li>
    <li>vde2</li>
    <li>virt-v2v</li>
    <li>vmctl</li>
    <li>wolfssl</li>
    <li>wolfssl.dev</li>
    <li>wolfssl.doc</li>
    <li>wolfssl.lib</li>
  </ul>
</details>

---
<details>
<summary>Error logs: `x86_64-linux`</summary>
<details>
<summary>tests.devShellTools.nixos</summary>
<pre>docker # [  341.087374] dockerd[878]: time=&quot;2025-12-14T18:11:19.849431244Z&quot; level=error msg=&quot;Error saving dying container to disk: invalid output path: stat /var/lib/docker/containers/260316;
docker # [  341.091314] dockerd[878]: time=&quot;2025-12-14T18:11:19.853499079Z&quot; level=error msg=&quot;Handler for POST /v1.52/containers/create returned error: apply layer error for \&quot;\&quot;: failed;
docker # docker: Error response from daemon: apply layer error for &quot;&quot;: failed to prepare extraction snapshot &quot;extract-841560970-ISdA sha256:775f6077b7121e2879ea7c0568a68e6b07568bcd75462c03c21cb2de
docker # 
docker # Run &#x27;docker run --help&#x27; for more information
docker: output: 
!!! Test &quot;buildNixShellImage: can build derivations&quot; failed with error: &quot;command `docker run --rm -it nix-shell-build-derivation` failed (exit code 125)&quot;
!!! Traceback (most recent call last):
!!!   File &quot;&lt;string&gt;&quot;, line 58, in &lt;module&gt;
!!!     docker.succeed(
!!! 
!!! RequestedAssertionFailed: command `docker run --rm -it nix-shell-build-derivation` failed (exit code 125)
cleanup
kill machine (pid 9)
qemu-system-x86_64: terminating on signal 15 from pid 6 (/nix/store/3lll9y925zz9393sa59h653xik66srjb-python3-3.13.9/bin/python3.13)
vde_switch: EOF data port: Interrupted system call
kill vlan (pid 7)
vde_switch: EOF on stdin, cleaning up and exiting
vde_switch: Caught signal 15, cleaning up and exiting
(finished: cleanup, in 0.01 seconds)</pre>
</details>
</details>
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
