### PR TITLE
nixos/test-driver: Document utility functions used in existing tests

### DIFF
--- a/nixos/lib/test-driver/src/test_driver/machine/__init__.py
+++ b/nixos/lib/test-driver/src/test_driver/machine/__init__.py
@@ -292,12 +292,18 @@ class Machine:
         return self.booted and self.connected
 
     def log(self, msg: str) -> None:
+        """
+        Log a message to console.
+        """
         self.logger.log(msg, {"machine": self.name})
 
     def log_serial(self, msg: str) -> None:
         self.logger.log_serial(msg, self.name)
 
     def nested(self, msg: str, attrs: dict[str, str] = {}) -> _GeneratorContextManager:
+        """
+        Get nested logger, optionally with extra attributes.
+        """
         my_attrs = {"machine": self.name}
         my_attrs.update(attrs)
         return self.logger.nested(msg, my_attrs)
@@ -357,6 +363,9 @@ class Machine:
             retry(check_active, timeout)
 
     def get_unit_info(self, unit: str, user: str | None = None) -> dict[str, str]:
+        """
+        Get a dictionary of systemd unit properties, as obtained via `systemctl show`.
+        """
         status, lines = self.systemctl(f'--no-pager show "{unit}"', user)
         if status != 0:
             raise RequestedAssertionFailed(
@@ -384,6 +393,9 @@ class Machine:
         property: str,
         user: str | None = None,
     ) -> str:
+        """
+        Get the string value of a single systemd unit property
+        """
         status, lines = self.systemctl(
             f'--no-pager show "{unit}" --property="{property}"',
             user,
@@ -431,6 +443,9 @@ class Machine:
         return self.execute(f"systemctl {q}")
 
     def require_unit_state(self, unit: str, require_state: str = "active") -> None:
+        """
+        Assert that the current state of a unit has a specific value. The default state is "active".
+        """
         with self.nested(
             f"checking if unit '{unit}' has reached state '{require_state}'"
         ):
@@ -648,6 +663,10 @@ class Machine:
             return output
 
     def wait_for_shutdown(self) -> None:
+        """
+        Wait for the VM to power off. This does *not* initiate a shutdown;
+        that's usually done via `shutdown()`.
+        """
         if not self.booted:
             return
 
@@ -687,6 +706,9 @@ class Machine:
                 raise TimeoutError
 
     def get_tty_text(self, tty: str) -> str:
+        """
+        Get the output printed to a given TTY.
+        """
         status, output = self.execute(
             f"fold -w$(stty -F /dev/tty{tty} size | awk '{{print $2}}') /dev/vcs{tty}"
         )
@@ -785,15 +807,25 @@ class Machine:
             retry(port_is_closed, timeout)
 
     def start_job(self, jobname: str, user: str | None = None) -> tuple[int, str]:
+        """
+        Start systemd service.
+        """
         return self.systemctl(f"start {jobname}", user)
 
     def stop_job(self, jobname: str, user: str | None = None) -> tuple[int, str]:
+        """
+        Stop systemd service.
+        """
         return self.systemctl(f"stop {jobname}", user)
 
     def wait_for_job(self, jobname: str) -> None:
         self.wait_for_unit(jobname)
 
     def connect(self) -> None:
+        """
+        Wait for a connection to the guest root shell
+        """
+
         def shell_ready(timeout_secs: int) -> bool:
             """We sent some data from the backdoor service running on the guest
             to indicate that the backdoor shell is ready.


### PR DESCRIPTION
A docstring is necessary for a function to show up in the [Machine objects section of the NixOS manual](https://nixos.org/manual/nixos/stable/#ssec-machine-objects). Since all of these functions are currently in use in actual tests, and not just in the test framework itself, they should be documented.

For most of these I've just added a simple, generic description. Suggestions for more in-depth descriptions are welcome.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
