### PR TITLE
fetchurl: export SSL_CERT_FILE

### DIFF
--- a/pkgs/build-support/fetchurl/builder.sh
+++ b/pkgs/build-support/fetchurl/builder.sh
@@ -1,6 +1,9 @@
 source "$NIX_ATTRS_SH_FILE"
 source $mirrorsFile
 
+# Export SSL_CERT_FILE so curl can see it
+export SSL_CERT_FILE="$SSL_CERT_FILE"
+
 curlVersion=$(curl -V | head -1 | cut -d' ' -f2)
 
 # Curl flags to handle redirects, not use EPSV, handle cookies for


### PR DESCRIPTION
Since https://github.com/NixOS/nixpkgs/pull/464475 enabled structured attrs in `fetchurl`, empty-hash FODs have been failing with:

```
$ nix-build --expr '(import ./. {}).fetchurl { url = "https://example.com"; hash = ""; }'
this derivation will be built:
  /nix/store/ryngk5xndc9sdhpw1pk5g8bi7b7dix8a-example.com.drv
building '/nix/store/ryngk5xndc9sdhpw1pk5g8bi7b7dix8a-example.com.drv'...
structuredAttrs is enabled

trying https://example.com
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0   0     0   0     0     0     0  --:--:-- --:--:-- --:--:--     0
curl: (60) SSL certificate OpenSSL verify result: unable to get local issuer certificate (20)
More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the webpage mentioned above.
Warning: Problem (retrying all errors). Will retry in 1 second. 3 retries left.
  0     0   0     0   0     0     0     0  --:--:-- --:--:-- --:--:--     0
curl: (60) SSL certificate OpenSSL verify result: unable to get local issuer certificate (20)
More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the webpage mentioned above.
Warning: Problem (retrying all errors). Will retry in 2 seconds. 2 retries
Warning: left.
  0     0   0     0   0     0     0     0  --:--:-- --:--:-- --:--:--     0
curl: (60) SSL certificate OpenSSL verify result: unable to get local issuer certificate (20)
More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the webpage mentioned above.
Warning: Problem (retrying all errors). Will retry in 4 seconds. 1 retry left.
  0     0   0     0   0     0     0     0  --:--:-- --:--:-- --:--:--     0
curl: (60) SSL certificate OpenSSL verify result: unable to get local issuer certificate (20)
More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the webpage mentioned above.
error checking the existence of https://tarballs.nixos.org//sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=:
curl: (60) SSL certificate OpenSSL verify result: unable to get local issuer certificate (20)
More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the webpage mentioned above.
error: cannot download example.com from any mirror
error: Cannot build '/nix/store/ryngk5xndc9sdhpw1pk5g8bi7b7dix8a-example.com.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/6jix8ihxjjw4l9l2lpjvjr4wv9psmp7j-example.com
       Last 25 log lines:
       > Warning: Problem (retrying all errors). Will retry in 2 seconds. 2 retries
       > Warning: left.
       >   0     0   0     0   0     0     0     0  --:--:-- --:--:-- --:--:--     0
       > curl: (60) SSL certificate OpenSSL verify result: unable to get local issuer certificate (20)
       > More details here: https://curl.se/docs/sslcerts.html
       >
       > curl failed to verify the legitimacy of the server and therefore could not
       > establish a secure connection to it. To learn more about this situation and
       > how to fix it, please visit the webpage mentioned above.
       > Warning: Problem (retrying all errors). Will retry in 4 seconds. 1 retry left.
       >   0     0   0     0   0     0     0     0  --:--:-- --:--:-- --:--:--     0
       > curl: (60) SSL certificate OpenSSL verify result: unable to get local issuer certificate (20)
       > More details here: https://curl.se/docs/sslcerts.html
       >
       > curl failed to verify the legitimacy of the server and therefore could not
       > establish a secure connection to it. To learn more about this situation and
       > how to fix it, please visit the webpage mentioned above.
       > error checking the existence of https://tarballs.nixos.org//sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=:
       > curl: (60) SSL certificate OpenSSL verify result: unable to get local issuer certificate (20)
       > More details here: https://curl.se/docs/sslcerts.html
       >
       > curl failed to verify the legitimacy of the server and therefore could not
       > establish a secure connection to it. To learn more about this situation and
       > how to fix it, please visit the webpage mentioned above.
       > error: cannot download example.com from any mirror
       For full logs, run:
         nix log /nix/store/ryngk5xndc9sdhpw1pk5g8bi7b7dix8a-example.com.drv
```

---


With `__structuredAttrs`, `SSL_CERT_FILE` gets defined in `$NIX_ATTRS_SH_FILE` as:
```sh
declare SSL_CERT_FILE='/nix/store/m65dckzfgr1lr90g5v6jx0iynnz38nsk-nss-cacert-3.115/etc/ssl/certs/ca-bundle.crt'
```

I suspect previously (without `__structuredAttrs`), `derivation` would _export_ the variable instead of only _declaring_ it?

This PR manually restores the exported variable.

Building the same empty-hash FOD with this PR:

```
$ nix-build --expr '(import ./. {}).fetchurl { url = "https://example.com"; hash = ""; }'
this derivation will be built:
  /nix/store/53h6qx0bkr1vwxc2b2l535xyxhl8vvsg-example.com.drv
building '/nix/store/53h6qx0bkr1vwxc2b2l535xyxhl8vvsg-example.com.drv'...
structuredAttrs is enabled

trying https://example.com
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   513 100   513   0     0  1708     0  --:--:-- --:--:-- --:--:--  1710
error: hash mismatch in fixed-output derivation '/nix/store/53h6qx0bkr1vwxc2b2l535xyxhl8vvsg-example.com.drv':
         specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
            got:    sha256-b1Y1A182rVALT8S7eBa7cu9VlOG8rkT6B0xemI/EwP4=
```





<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
