### PR TITLE
nixosTests.lomiri-*-app: More fixing

### DIFF
--- a/nixos/tests/lomiri-calendar-app.nix
+++ b/nixos/tests/lomiri-calendar-app.nix
@@ -63,19 +63,28 @@
         # On New Event page
         machine.succeed("xdotool mousemove 500 230 click 1")
         machine.sleep(2)
-        machine.send_chars("foobar")
+        machine.send_chars("Poke")
         machine.sleep(2) # make sure they're actually in there
         machine.succeed("xdotool mousemove 1000 40 click 1")
+        machine.sleep(10) # Give the app some time to save the event
+
+        # Can't consistently OCR for "Agenda". Just restart it.
+        machine.succeed("pgrep -afx lomiri-calendar-app >&2")
+        machine.succeed("pkill -efx lomiri-calendar-app >&2")
+        machine.wait_until_fails("pgrep -afx lomiri-calendar-app >&2")
+        machine.succeed("lomiri-calendar-app >&2 &")
+        machine.sleep(10)
+        machine.send_key("alt-f10")
         machine.sleep(2)
-        machine.wait_for_text("Agenda")
-        machine.screenshot("lomiri-calendar_eventadded")
 
         # Back on main page
         # Event was created, does it have the correct name?
-        machine.wait_for_text("foobar")
+        machine.wait_for_text("Poke")
         machine.screenshot("lomiri-calendar_works")
 
-    machine.succeed("pkill -f lomiri-calendar-app")
+    machine.succeed("pgrep -afx lomiri-calendar-app >&2")
+    machine.succeed("pkill -efx lomiri-calendar-app >&2")
+    machine.wait_until_fails("pgrep -afx lomiri-calendar-app >&2")
 
     with subtest("lomiri calendar localisation works"):
         machine.succeed("env LANG=de_DE.UTF-8 lomiri-calendar-app >&2 &")

--- a/nixos/tests/lomiri-music-app.nix
+++ b/nixos/tests/lomiri-music-app.nix
@@ -145,12 +145,12 @@ in
     with subtest("lomiri music plays music"):
         machine.succeed("xdotool mousemove 30 720 click 1") # Skip intro
         machine.sleep(2)
-        machine.wait_for_text("Albums")
+        machine.wait_for_window("Albums")
         machine.succeed("xdotool mousemove 25 45 click 1") # Open categories
         machine.sleep(2)
         machine.succeed("xdotool mousemove 25 240 click 1") # Switch to Tracks category
         machine.sleep(2)
-        machine.wait_for_text("Tracks") # Written in larger text now, easier for OCR
+        machine.wait_for_window("Tracks")
         machine.screenshot("lomiri-music_listing")
 
         # Ensure pause colours isn't present already
@@ -192,7 +192,7 @@ in
         machine.sleep(10)
         machine.send_key("alt-f10")
         machine.sleep(2)
-        machine.wait_for_text("Titel")
+        machine.wait_for_window("Titel")
         machine.screenshot("lomiri-music_localised")
   '';
 }


### PR DESCRIPTION
*Grumble grumble grumble…*

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
