### PR TITLE
python3Packages.pycrdt-store: 0.1.3b1 -> 0.1.3

### DIFF
--- a/pkgs/development/python-modules/pycrdt-store/default.nix
+++ b/pkgs/development/python-modules/pycrdt-store/default.nix
@@ -18,14 +18,14 @@
 
 buildPythonPackage rec {
   pname = "pycrdt-store";
-  version = "0.1.3b1";
+  version = "0.1.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "y-crdt";
     repo = "pycrdt-store";
     tag = version;
-    hash = "sha256-UMLR30PqtPUlD6z7VTPl7ZkSSw4HkmO5bUa/lSeFFoE=";
+    hash = "sha256-KlB3BDhL/dt1IaQvWOfq1hgTKptrobgoBpus/mjZ26M=";
   };
 
   build-system = [
@@ -42,6 +42,8 @@ buildPythonPackage rec {
     pytestCheckHook
     trio
   ];
+
+  disabledTestMarks = [ "flaky" ];
 
   pythonImportsCheck = [ "pycrdt.store" ];
 


### PR DESCRIPTION
CHANGELOG: https://github.com/y-crdt/pycrdt-store/releases/tag/0.1.3
DIFF: https://github.com/y-crdt/pycrdt-store/compare/0.1.3b1...0.1.3

Supersedes #470332 by disabling flaky (timing-sensitive) tests.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
