### PR TITLE
prefetch-npm-deps: add cacheVersion for packument support

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -71,6 +71,8 @@
 
 - `fetchPnpmDeps` and `pnpmConfigHook` were added as top-level attributes, replacing the now deprecated `pnpm.fetchDeps` and `pnpm.configHook` attributes.
 
+- `buildNpmPackage` now supports `npmDepsCacheVersion`. Set to `2` to enable packument caching, which fixes builds for projects using npm workspaces.
+
 - Added `dell-bios-fan-control` package and service.
 
 - We now use the upstream wrapper script for Gradle, supporting both the `JAVA_HOME` and `GRADLE_OPTS` environment variables.

--- a/pkgs/build-support/node/build-npm-package/default.nix
+++ b/pkgs/build-support/node/build-npm-package/default.nix
@@ -89,6 +89,10 @@ lib.extendMkDerivation {
     {
       inherit npmDeps npmBuildScript;
 
+      env = (args.env or { }) // {
+        NIX_NPM_CACHE_VERSION = npmDepsCacheVersion;
+      };
+
       nativeBuildInputs =
         nativeBuildInputs
         ++ [

--- a/pkgs/build-support/node/build-npm-package/default.nix
+++ b/pkgs/build-support/node/build-npm-package/default.nix
@@ -26,6 +26,9 @@ lib.extendMkDerivation {
       # The output hash of the dependencies for this project.
       # Can be calculated in advance with prefetch-npm-deps.
       npmDepsHash ? "",
+      # Cache format version for npmDeps. Set to 2 to enable packument caching
+      # for workspace support. Changing this will invalidate npmDepsHash.
+      npmDepsCacheVersion ? 1,
       # Whether to force the usage of Git dependencies that have install scripts, but not a lockfile.
       # Use with care.
       forceGitDeps ? false,
@@ -66,6 +69,7 @@ lib.extendMkDerivation {
           ;
         name = "${name}-npm-deps";
         hash = npmDepsHash;
+        cacheVersion = npmDepsCacheVersion;
       },
       # Custom npmConfigHook
       npmConfigHook ? null,

--- a/pkgs/build-support/node/build-npm-package/default.nix
+++ b/pkgs/build-support/node/build-npm-package/default.nix
@@ -26,9 +26,9 @@ lib.extendMkDerivation {
       # The output hash of the dependencies for this project.
       # Can be calculated in advance with prefetch-npm-deps.
       npmDepsHash ? "",
-      # Cache format version for npmDeps. Set to 2 to enable packument caching
+      # Fetcher format version for npmDeps. Set to 2 to enable packument caching
       # for workspace support. Changing this will invalidate npmDepsHash.
-      npmDepsCacheVersion ? 1,
+      npmDepsFetcherVersion ? 1,
       # Whether to force the usage of Git dependencies that have install scripts, but not a lockfile.
       # Use with care.
       forceGitDeps ? false,
@@ -69,7 +69,7 @@ lib.extendMkDerivation {
           ;
         name = "${name}-npm-deps";
         hash = npmDepsHash;
-        cacheVersion = npmDepsCacheVersion;
+        fetcherVersion = npmDepsFetcherVersion;
       },
       # Custom npmConfigHook
       npmConfigHook ? null,
@@ -90,7 +90,7 @@ lib.extendMkDerivation {
       inherit npmDeps npmBuildScript;
 
       env = (args.env or { }) // {
-        NIX_NPM_CACHE_VERSION = npmDepsCacheVersion;
+        NIX_NPM_FETCHER_VERSION = npmDepsFetcherVersion;
       };
 
       nativeBuildInputs =

--- a/pkgs/build-support/node/build-npm-package/hooks/npm-config-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-config-hook.sh
@@ -127,9 +127,10 @@ npmConfigHook() {
         echo "ERROR: npm failed to install dependencies"
         echo
         echo "Here are a few things you can try, depending on the error:"
-        echo '1. Set `makeCacheWritable = true`'
+        echo '1. Set `npmDepsCacheVersion = 2` (and update `npmDepsHash`)'
+        echo '2. Set `makeCacheWritable = true`'
         echo "  Note that this won't help if npm is complaining about not being able to write to the logs directory -- look above that for the actual error."
-        echo '2. Set `npmFlags = [ "--legacy-peer-deps" ]`'
+        echo '3. Set `npmFlags = [ "--legacy-peer-deps" ]`'
         echo
 
         exit 1

--- a/pkgs/build-support/node/build-npm-package/hooks/npm-config-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-config-hook.sh
@@ -28,29 +28,27 @@ npmConfigHook() {
         exit 1
     fi
 
+    if [[ -e "$npmDeps/cache_version" ]]; then
+      local -r cacheVersion=$(cat "$npmDeps/cache_version")
+    else
+      local -r cacheVersion="1"
+    fi
+
     # Only run this in buildNpmPackage, this is just for a nicer error message; we trust that
     # people using the setup hook directly also know how FODs work. ;)
-    if [[ -n ${NIX_NPM_CACHE_VERSION+x} ]]; then
-      if [[ -e "$npmDeps/cache_version" ]]; then
-        local -r cacheVersion=$(cat "$npmDeps/cache_version")
-      else
-        local -r cacheVersion="1"
-      fi
+    if [[ -n ${NIX_NPM_CACHE_VERSION+x} ]] && [[ $NIX_NPM_CACHE_VERSION != $cacheVersion ]]; then
+      echo
+      echo "ERROR: npmDepsHash is out of date"
+      echo
+      echo "The cache version in the arguments to buildNpmPackage ($NIX_NPM_CACHE_VERSION) is not the same as the one in $npmDeps ($cacheVersion)."
+      echo
+      echo "To fix the issue:"
+      echo '1. Use `lib.fakeHash` as the npmDepsHash value'
+      echo "2. Build the derivation and wait for it to fail with a hash mismatch"
+      echo "3. Copy the 'got: sha256-' value back into the npmDepsHash field"
+      echo
 
-      if [[ $NIX_NPM_CACHE_VERSION != $cacheVersion ]]; then
-        echo
-        echo "ERROR: npmDepsHash is out of date"
-        echo
-        echo "The cache version in the arguments to buildNpmPackage ($NIX_NPM_CACHE_VERSION) is not the same as the one in $npmDeps ($cacheVersion)."
-        echo
-        echo "To fix the issue:"
-        echo '1. Use `lib.fakeHash` as the npmDepsHash value'
-        echo "2. Build the derivation and wait for it to fail with a hash mismatch"
-        echo "3. Copy the 'got: sha256-' value back into the npmDepsHash field"
-        echo
-
-        exit 1
-      fi
+      exit 1
     fi
 
     local -r cacheLockfile="$npmDeps/package-lock.json"
@@ -103,7 +101,11 @@ npmConfigHook() {
 
     local cachePath
 
-    if [ -z "${makeCacheWritable-}" ]; then
+    # When a given cache key has multiple entries (which is the case with
+    # cache version 2), npm always needs to write to the cache.
+    #
+    # TODO(winter): report upstream?
+    if [ -z "${makeCacheWritable-}" ] && (( cacheVersion == 1 )); then
         cachePath="$npmDeps"
     else
         echo "Making cache writable"

--- a/pkgs/build-support/node/build-npm-package/hooks/npm-config-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-config-hook.sh
@@ -28,19 +28,19 @@ npmConfigHook() {
         exit 1
     fi
 
-    if [[ -e "$npmDeps/cache_version" ]]; then
-      local -r cacheVersion=$(cat "$npmDeps/cache_version")
+    if [[ -e "$npmDeps/.fetcher-version" ]]; then
+      local -r fetcherVersion=$(cat "$npmDeps/.fetcher-version")
     else
-      local -r cacheVersion="1"
+      local -r fetcherVersion="1"
     fi
 
     # Only run this in buildNpmPackage, this is just for a nicer error message; we trust that
     # people using the setup hook directly also know how FODs work. ;)
-    if [[ -n ${NIX_NPM_CACHE_VERSION+x} ]] && [[ $NIX_NPM_CACHE_VERSION != $cacheVersion ]]; then
+    if [[ -n ${NIX_NPM_FETCHER_VERSION+x} ]] && [[ $NIX_NPM_FETCHER_VERSION != $fetcherVersion ]]; then
       echo
       echo "ERROR: npmDepsHash is out of date"
       echo
-      echo "The cache version in the arguments to buildNpmPackage ($NIX_NPM_CACHE_VERSION) is not the same as the one in $npmDeps ($cacheVersion)."
+      echo "The fetcher version in the arguments to buildNpmPackage ($NIX_NPM_FETCHER_VERSION) is not the same as the one in $npmDeps ($fetcherVersion)."
       echo
       echo "To fix the issue:"
       echo '1. Use `lib.fakeHash` as the npmDepsHash value'
@@ -102,10 +102,10 @@ npmConfigHook() {
     local cachePath
 
     # When a given cache key has multiple entries (which is the case with
-    # cache version 2), npm always needs to write to the cache.
+    # fetcher version 2), npm always needs to write to the cache.
     #
     # TODO(winter): report upstream?
-    if [ -z "${makeCacheWritable-}" ] && (( cacheVersion == 1 )); then
+    if [ -z "${makeCacheWritable-}" ] && (( fetcherVersion == 1 )); then
         cachePath="$npmDeps"
     else
         echo "Making cache writable"
@@ -127,7 +127,7 @@ npmConfigHook() {
         echo "ERROR: npm failed to install dependencies"
         echo
         echo "Here are a few things you can try, depending on the error:"
-        echo '1. Set `npmDepsCacheVersion = 2` (and update `npmDepsHash`)'
+        echo '1. Set `npmDepsFetcherVersion = 2` (and update `npmDepsHash`)'
         echo '2. Set `makeCacheWritable = true`'
         echo "  Note that this won't help if npm is complaining about not being able to write to the logs directory -- look above that for the actual error."
         echo '3. Set `npmFlags = [ "--legacy-peer-deps" ]`'

--- a/pkgs/build-support/node/prefetch-npm-deps/default.nix
+++ b/pkgs/build-support/node/prefetch-npm-deps/default.nix
@@ -215,10 +215,10 @@
       # A string with a JSON attrset specifying registry mirrors, for example
       #   {"registry.example.org": "my-mirror.local/registry.example.org"}
       npmRegistryOverridesString ? config.npmRegistryOverridesString,
-      # Cache format version. Bump this to invalidate all existing hashes.
+      # Fetcher format version. Bump this to invalidate all existing hashes.
       # Version 1: original format (tarballs only)
       # Version 2: includes packuments for workspace support
-      cacheVersion ? 1,
+      fetcherVersion ? 1,
       ...
     }@args:
     let
@@ -276,9 +276,9 @@
 
         NIX_NPM_REGISTRY_OVERRIDES = npmRegistryOverridesString;
 
-        # Cache version controls which features are enabled in prefetch-npm-deps
+        # Fetcher version controls which features are enabled in prefetch-npm-deps
         # Version 2+ enables packument fetching for workspace support
-        NPM_CACHE_VERSION = toString cacheVersion;
+        NPM_FETCHER_VERSION = toString fetcherVersion;
 
         SSL_CERT_FILE =
           if

--- a/pkgs/build-support/node/prefetch-npm-deps/default.nix
+++ b/pkgs/build-support/node/prefetch-npm-deps/default.nix
@@ -215,6 +215,10 @@
       # A string with a JSON attrset specifying registry mirrors, for example
       #   {"registry.example.org": "my-mirror.local/registry.example.org"}
       npmRegistryOverridesString ? config.npmRegistryOverridesString,
+      # Cache format version. Bump this to invalidate all existing hashes.
+      # Version 1: original format (tarballs only)
+      # Version 2: includes packuments for workspace support
+      cacheVersion ? 1,
       ...
     }@args:
     let
@@ -271,6 +275,10 @@
         impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [ "NIX_NPM_TOKENS" ];
 
         NIX_NPM_REGISTRY_OVERRIDES = npmRegistryOverridesString;
+
+        # Cache version controls which features are enabled in prefetch-npm-deps
+        # Version 2+ enables packument fetching for workspace support
+        NPM_CACHE_VERSION = toString cacheVersion;
 
         SSL_CERT_FILE =
           if

--- a/pkgs/build-support/node/prefetch-npm-deps/src/cacache.rs
+++ b/pkgs/build-support/node/prefetch-npm-deps/src/cacache.rs
@@ -134,7 +134,7 @@ impl Cache {
             .open(&index_path)?;
 
         // cacache format uses newline as entry separator (see cacache entry-index.js)
-        // Only add newline prefix if file already has content, to maintain backwards compatibility
+        // Only add newline prefix if file already has content, to maintain backwards compatibility with previous versions of prefetch-npm-deps, which handled this case incorrectly.
         let needs_newline = fs::metadata(&index_path)
             .map(|m| m.len() > 0)
             .unwrap_or(false);

--- a/pkgs/build-support/node/prefetch-npm-deps/src/cacache.rs
+++ b/pkgs/build-support/node/prefetch-npm-deps/src/cacache.rs
@@ -24,7 +24,14 @@ pub(super) struct Key {
 #[derive(Serialize, Deserialize)]
 pub(super) struct Metadata {
     pub(super) url: Url,
+    #[serde(rename = "reqHeaders", skip_serializing_if = "Option::is_none")]
+    pub(super) req_headers: Option<ReqHeaders>,
     pub(super) options: Options,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ReqHeaders {
+    pub accept: String,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -58,6 +65,7 @@ impl Cache {
         url: Url,
         data: &[u8],
         integrity: Option<String>,
+        req_headers: Option<ReqHeaders>,
     ) -> anyhow::Result<()> {
         let (algo, hash, integrity) = if let Some(integrity) = integrity {
             let (algo, hash) = integrity
@@ -115,13 +123,27 @@ impl Cache {
             size: data.len(),
             metadata: Metadata {
                 url,
+                req_headers,
                 options: Options { compress: true },
             },
         })?;
 
-        let mut file = File::options().append(true).create(true).open(index_path)?;
+        let mut file = File::options()
+            .append(true)
+            .create(true)
+            .open(&index_path)?;
 
-        write!(file, "{:x}\t{data}", Sha1::new().chain(&data).finalize())?;
+        // cacache format uses newline as entry separator (see cacache entry-index.js)
+        // Only add newline prefix if file already has content, to maintain backwards compatibility
+        let needs_newline = fs::metadata(&index_path)
+            .map(|m| m.len() > 0)
+            .unwrap_or(false);
+        let prefix = if needs_newline { "\n" } else { "" };
+        write!(
+            file,
+            "{prefix}{:x}\t{data}",
+            Sha1::new().chain(&data).finalize()
+        )?;
 
         Ok(())
     }

--- a/pkgs/build-support/node/prefetch-npm-deps/src/main.rs
+++ b/pkgs/build-support/node/prefetch-npm-deps/src/main.rs
@@ -386,6 +386,7 @@ fn main() -> anyhow::Result<()> {
 
     if cache_version >= 2 {
         fetch_packuments(&cache, package_names)?;
+        fs::write(out.join("cache_version"), format!("{cache_version}"))?;
     }
 
     fs::write(out.join("package-lock.json"), lock_content)?;

--- a/pkgs/build-support/node/prefetch-npm-deps/src/main.rs
+++ b/pkgs/build-support/node/prefetch-npm-deps/src/main.rs
@@ -357,15 +357,15 @@ fn main() -> anyhow::Result<()> {
         Ok::<_, anyhow::Error>(())
     })?;
 
-    // Fetch and cache packuments (package metadata) - only for cache version 2+
-    let cache_version: u32 = env::var("NPM_CACHE_VERSION")
+    // Fetch and cache packuments (package metadata) - only for fetcher version 2+
+    let fetcher_version: u32 = env::var("NPM_FETCHER_VERSION")
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(1);
 
-    if cache_version >= 2 {
+    if fetcher_version >= 2 {
         fetch_packuments(&cache, package_names)?;
-        fs::write(out.join("cache_version"), format!("{cache_version}"))?;
+        fs::write(out.join(".fetcher-version"), format!("{fetcher_version}"))?;
     }
 
     fs::write(out.join("package-lock.json"), lock_content)?;

--- a/pkgs/build-support/node/prefetch-npm-deps/src/parse/lock.rs
+++ b/pkgs/build-support/node/prefetch-npm-deps/src/parse/lock.rs
@@ -25,7 +25,12 @@ pub(super) fn packages(content: &str) -> anyhow::Result<Vec<Package>> {
             .unwrap_or_default()
             .into_iter()
             .filter(|(n, p)| !n.is_empty() && matches!(p.resolved, Some(UrlOrString::Url(_))))
-            .map(|(n, p)| Package { name: Some(n), ..p })
+            .map(|(n, p)| Package {
+                // Use the package's own name if present (for aliases like string-width-cjs -> string-width),
+                // otherwise extract from the lockfile key
+                name: Some(p.name.unwrap_or(n)),
+                ..p
+            })
             .collect(),
         _ => bail!(
             "We don't support lockfile version {}, please file an issue.",

--- a/pkgs/build-support/node/prefetch-npm-deps/src/parse/lock.rs
+++ b/pkgs/build-support/node/prefetch-npm-deps/src/parse/lock.rs
@@ -78,6 +78,7 @@ struct OldPackage {
 pub(super) struct Package {
     #[serde(default)]
     pub(super) name: Option<String>,
+    pub(super) version: Option<String>,
     pub(super) resolved: Option<UrlOrString>,
     pub(super) integrity: Option<HashCollection>,
 }
@@ -254,6 +255,7 @@ fn to_new_packages(
 
         new.push(Package {
             name: Some(name),
+            version: None, // v1 lockfiles don't include version in the same structure
             resolved: if matches!(package.version, UrlOrString::Url(_)) {
                 Some(package.version)
             } else {
@@ -315,6 +317,7 @@ mod tests {
         assert_eq!(new.len(), 1, "new packages map should contain 1 value");
         assert_eq!(new[0], Package {
             name: Some(String::from("sqlite3")),
+            version: None,
             resolved: Some(UrlOrString::Url(Url::parse("git+ssh://git@github.com/mapbox/node-sqlite3.git#593c9d498be2510d286349134537e3bf89401c4a").unwrap())),
             integrity: None
         });

--- a/pkgs/build-support/node/prefetch-npm-deps/src/parse/mod.rs
+++ b/pkgs/build-support/node/prefetch-npm-deps/src/parse/mod.rs
@@ -112,6 +112,7 @@ pub fn lockfile(
 #[derive(Debug)]
 pub struct Package {
     pub name: String,
+    pub version: Option<String>,
     pub url: Url,
     specifics: Specifics,
 }
@@ -175,6 +176,7 @@ impl Package {
 
         Ok(Package {
             name: pkg.name.unwrap(),
+            version: pkg.version,
             url: resolved,
             specifics,
         })


### PR DESCRIPTION
Add a cacheVersion parameter to fetchNpmDeps and npmDepsCacheVersion to buildNpmPackage. When set to 2, prefetch-npm-deps will also fetch and cache packuments (package metadata) in addition to tarballs.

npm can request packuments with two different Accept headers:
- corgiDoc: abbreviated metadata (default)
- fullDoc: full metadata (used for workspaces)

npm's cache policy requires headers to match, so we cache both versions.

This is opt-in via cacheVersion to avoid breaking existing hashes. Set npmDepsCacheVersion = 2 for projects using npm workspaces.

Also fix cacache index format to properly separate multiple entries with newlines, and update map_cache() to parse multi-line index files.


This change allows me to build qwen-code.

Fixes https://github.com/NixOS/nixpkgs/issues/474535

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
