### PR TITLE
{workflows/lint,ci/github-script}: lint commit messages

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -124,3 +124,25 @@ jobs:
             echo "If you're having trouble, ping @NixOS/nixpkgs-vet"
             exit "$exitCode"
           fi
+
+  commits:
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+          path: trusted
+          sparse-checkout: |
+            ci/github-script
+      - name: Check commit messages
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const checkCommitMessages = require('./trusted/ci/github-script/lint-commits.js')
+
+            checkCommitMessages({
+              github,
+              context,
+              core,
+            })

--- a/ci/github-script/lint-commits.js
+++ b/ci/github-script/lint-commits.js
@@ -1,0 +1,90 @@
+// @ts-check
+const { classify } = require('../supportedBranches.js')
+
+/**
+ * @param {{
+ *  github: InstanceType<import('@actions/github/lib/utils').GitHub>,
+ *  context: import('@actions/github/lib/context').Context
+ *  core: import('@actions/core')
+ * }} CheckCommitMessagesProps
+ */
+async function checkCommitMessages({ github, context, core }) {
+  // Do not run on merge groups: it'd be much harder, and there is no need
+  // (changes to the target branch can't change commit messages on the base branch).
+  const pull_number = context.payload.pull_request?.number
+  if (!pull_number) {
+    core.info('This is not a pull request. Skipping checks.')
+    return
+  }
+
+  const pr = (
+    await github.rest.pulls.get({
+      ...context.repo,
+      pull_number,
+    })
+  ).data
+
+  const baseBranchType = classify(
+    pr.base.ref.replace(/^refs\/heads\//, ''),
+  ).type
+  const headBranchType = classify(
+    pr.head.ref.replace(/^refs\/heads\//, ''),
+  ).type
+
+  if (
+    baseBranchType.includes('development') &&
+    headBranchType.includes('development')
+  ) {
+    // This matches, for example, PRs from staging-next to master, or vice versa.
+    // Ignore them: we should only care about PRs introducing *new* commits.
+    core.info(
+      'This PR is from one development branch to another. Skipping checks.',
+    )
+    return
+  }
+
+  const commits = await github.paginate(github.rest.pulls.listCommits, {
+    ...context.repo,
+    pull_number,
+  })
+
+  const failures = new Set()
+
+  for (const commit of commits) {
+    const message = commit.commit.message
+    const firstLine = message.split('\n')[0]
+
+    const logMsgStart = `Commit ${commit.sha}'s message's subject ("${firstLine}")`
+
+    if (!firstLine.includes(':')) {
+      core.error(
+        `${logMsgStart} was detected as not meeting our guidelines because ` +
+          'it does not contain a colon. There are likely other issues as well.',
+      )
+      failures.add(commit.sha)
+    }
+
+    if (firstLine.endsWith('.')) {
+      core.error(
+        `${logMsgStart} was detected as not meeting our guidelines because ` +
+          'it ends in a period. There may be other issues as well.',
+      )
+      failures.add(commit.sha)
+    }
+
+    if (!failures.has(commit.sha)) {
+      core.info(`${logMsgStart} passed our automated checks!`)
+    }
+  }
+
+  if (failures.size !== 0) {
+    core.error(
+      'Please review the guidelines at ' +
+        'https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#commit-conventions, ' +
+        'as well as the applicable area-specific guidelines linked there.',
+    )
+    core.setFailed('Committers: merging is discouraged.')
+  }
+}
+
+module.exports = checkCommitMessages

--- a/ci/github-script/run
+++ b/ci/github-script/run
@@ -94,4 +94,15 @@ program
     await run(getTeams, owner, repo, undefined, { ...options, outFile })
   })
 
+program
+  .command('lint-commits')
+  .description('Lint for common errors in commit messages')
+  .argument('<owner>', 'Owner of the GitHub repository to run on (Example: NixOS)')
+  .argument('<repo>', 'Name of the GitHub repository to run on (Example: nixpkgs)')
+  .argument('<pr>', 'Number of the Pull Request to run on')
+  .action(async (owner, repo, pr, options) => {
+    const checkCommitMessages = (await import('./lint-commits.js')).default
+    await run(checkCommitMessages, owner, repo, pr, options)
+  })
+
 await program.parse()


### PR DESCRIPTION
Requested in the Staging room on Matrix.

This PR adds two rules: every commit's subject must contain a colon, and must not end in a period.

Details:
* This only runs as PRs, not as part of a merge group. Running on merge groups is more difficult (as it's harder to get a list of all commits), and has no benefit I'm aware of (changes to the base branch can't change the head branch's commit messages). 
* PRs that are both from and to a development branch (as categorized by [`ci/supportedBranches.js`](https://github.com/NixOS/nixpkgs/blob/master/ci/supportedBranches.js)) are skipped. Therefore, e.g. staging-next to master PRs, and their many merge commits, are unaffected.
* Failure will result in an failure of the job. Because only commits that are added by the PR are checked, if the PR is merged anyways, there are not negative effects on other PRs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested:
  * mdaniels5757/unconnected-nixpkgs#12
  * mdaniels5757/unconnected-nixpkgs#13
  * mdaniels5757/unconnected-nixpkgs#14
  * mdaniels5757/unconnected-nixpkgs#15
  * mdaniels5757/unconnected-nixpkgs#16
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
