### PR TITLE
apacheHttpdPackages.mod_tile: 0.7.2 -> 0.8.1

### DIFF
--- a/pkgs/servers/http/apache-modules/mod_tile/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_tile/default.nix
@@ -16,18 +16,22 @@
   iniparser,
   libmemcached,
   mapnik,
+  ps,
+  jq,
+  memcached,
+  iana-etc,
   nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
   pname = "mod_tile";
-  version = "0.7.2";
+  version = "0.8.1";
 
   src = fetchFromGitHub {
     owner = "openstreetmap";
     repo = "mod_tile";
     tag = "v${version}";
-    hash = "sha256-JC275LKsCeEo5DcIX0X7kcLoijQJqfJvBvw8xi2gwpk=";
+    hash = "sha256-zDe+pFzK16K+8I0v1Z7p83PIgQlVDbjcnD4vzwdB1Oo=";
   };
 
   nativeBuildInputs = [
@@ -67,6 +71,15 @@ stdenv.mkDerivation rec {
   doCheck = true;
   # Do not run tests in parallel
   enableParallelChecking = false;
+
+  nativeCheckInputs = [
+    iana-etc
+    ps
+  ]
+  ++ lib.filter (pkg: !pkg.meta.broken) [
+    jq
+    memcached
+  ];
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
Fixes this broken build on master:

https://hydra.nixos.org/build/316060316


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
