### PR TITLE
evcxr: fix runtime breakage due to mold

### DIFF
--- a/pkgs/by-name/ev/evcxr/package.nix
+++ b/pkgs/by-name/ev/evcxr/package.nix
@@ -9,12 +9,8 @@
   libiconv,
   cargo,
   gcc,
-  mold,
   rustc,
   nix-update-script,
-
-  # On non-darwin, `mold` is the default linker, but it's broken on Darwin.
-  withMold ? with stdenv.hostPlatform; isUnix && !isDarwin,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -69,14 +65,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
       wrap = exe: ''
         wrapProgram $out/bin/${exe} \
           --prefix PATH : ${
-            lib.makeBinPath (
-              [
-                cargo
-                gcc
-                rustc
-              ]
-              ++ lib.optional withMold mold
-            )
+            lib.makeBinPath [
+              cargo
+              gcc
+              rustc
+            ]
           } \
           --set-default RUST_SRC_PATH "$RUST_SRC_PATH"
       '';


### PR DESCRIPTION
`mold` is used by upstream, but it is not required for evcxr to build or run, and in this case is responsible for breakage.

Fixes https://github.com/NixOS/nixpkgs/issues/470532


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
