### PR TITLE
grummage: init at 2.0.0

### DIFF
--- a/pkgs/by-name/gr/grummage/package.nix
+++ b/pkgs/by-name/gr/grummage/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  grype,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "grummage";
+  version = "2.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "popey";
+    repo = "grummage";
+    tag = "v${version}";
+    hash = "sha256-K5/k4wSl2Ary9McPaK+T6nHqvIULuUcB3emJ7EibQrs=";
+  };
+
+  build-system = [
+    python3Packages.hatchling
+  ];
+
+  dependencies = [
+    python3Packages.textual
+  ];
+
+  makeWrapperArgs = [ "--suffix PATH : ${lib.makeBinPath [ grype ]}" ];
+
+  # no included tests or version flag
+  doCheck = false;
+
+  meta = {
+    description = "Interactive terminal frontend to Grype";
+    homepage = "https://github.com/popey/grummage";
+    changelog = "https://github.com/popey/grummage/releases/tag/${src.tag}";
+    maintainers = with lib.maintainers; [ ethancedwards8 ];
+    license = lib.licenses.mit;
+    mainProgram = "grummage";
+  };
+}


### PR DESCRIPTION
Homepage: https://github.com/popey/grummage
Tested with: https://github.com/CortezFrazierJr/my_recipe_book/blob/main/sampleCycloneDX.json


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
