### PR TITLE
chkbit: init at 6.5.0

### DIFF
--- a/pkgs/by-name/ch/chkbit/package.nix
+++ b/pkgs/by-name/ch/chkbit/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "chkbit";
+  version = "6.5.0";
+
+  src = fetchFromGitHub {
+    owner = "laktak";
+    repo = "chkbit";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-zf5UNpTsdTRym9B2xfuRIBl4Mpv97K+4VVbVPTEWFms=";
+  };
+
+  vendorHash = "sha256-hiXn7LmO4bYti9iufonQSLM1G0BZGB8u0QRqSYBvxNc=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.appVersion=${finalAttrs.version}"
+  ];
+
+  # Tests expect binary to be in the source directory
+  preCheck = ''
+    ln -s ../go/bin/chkbit .
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+
+  meta = {
+    description = "Check your files for data corruption and run quick file deduplication";
+    homepage = "https://github.com/laktak/chkbit";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ qubitnano ];
+    mainProgram = "chkbit";
+  };
+})


### PR DESCRIPTION
chkbit alerts you to data corruption in your files, especially during transfers, backups, and after recovery. It helps detect issues like disk damage, filesystem errors, and malware interference.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
