### PR TITLE
gnome-kra-ora-thumbnailer: init at 1.4

### DIFF
--- a/pkgs/by-name/gn/gnome-kra-ora-thumbnailer/package.nix
+++ b/pkgs/by-name/gn/gnome-kra-ora-thumbnailer/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  gnome-common,
+  intltool,
+  libarchive,
+  gdk-pixbuf,
+  autoreconfHook,
+  pkg-config,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gnome-kra-ora-thumbnailer";
+  version = "1.4";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "GNOME";
+    repo = "gnome-kra-ora-thumbnailer";
+    tag = finalAttrs.version;
+    hash = "sha256-zyEX8vOn8Gdt3B8sx3oXcRUpm2h2use4CUKsWqaqbaw=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    intltool
+    autoreconfHook
+    pkg-config
+    gnome-common
+  ];
+
+  buildInputs = [
+    libarchive
+    gdk-pixbuf
+  ];
+
+  meta = {
+    description = "Thumbnailer for Krita and MyPaint images";
+    homepage = "https://gitlab.gnome.org/GNOME/gnome-kra-ora-thumbnailer/-/blob/${finalAttrs.src.tag}?ref_type=tags";
+    changelog = "https://gitlab.gnome.org/GNOME/gnome-kra-ora-thumbnailer/-/blob/${finalAttrs.src.tag}/NEWS?ref_type=tags";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ pancaek ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Closes #275046
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
