### PR TITLE
androidenv: fix 'latest' where SDK level is not an int

### DIFF
--- a/pkgs/development/mobile/androidenv/examples/shell-with-emulator.nix
+++ b/pkgs/development/mobile/androidenv/examples/shell-with-emulator.nix
@@ -78,6 +78,9 @@ let
   androidSdk = androidComposition.androidsdk;
   platformTools = androidComposition.platform-tools;
   latestSdk = pkgs.lib.foldl' pkgs.lib.max 0 androidComposition.platformVersions;
+  latestSdkVersion = pkgs.lib.foldl' (
+    s: x: if pkgs.lib.strings.compareVersions x s > 0 then x else s
+  ) "0" androidComposition.platformVersionStrings;
   jdk = pkgs.jdk;
 in
 pkgs.mkShell rec {
@@ -123,8 +126,8 @@ pkgs.mkShell rec {
 
           packages=(
             "build-tools" "cmdline-tools" \
-            "platform-tools" "platforms;android-${toString latestSdk}" \
-            "system-images;android-${toString latestSdk};google_apis;x86_64"
+            "platform-tools" "platforms;android-${toString latestSdkVersion}" \
+            "system-images;android-${toString latestSdkVersion};google_apis;x86_64"
           )
           ${pkgs.lib.optionalString emulatorSupported ''packages+=("emulator")''}
 
@@ -184,7 +187,7 @@ pkgs.mkShell rec {
             mkdir -p $ANDROID_USER_HOME
 
             avdmanager delete avd -n testAVD || true
-            echo "" | avdmanager create avd --force --name testAVD --package 'system-images;android-${toString latestSdk};google_apis;x86_64'
+            echo "" | avdmanager create avd --force --name testAVD --package 'system-images;android-${toString latestSdkVersion};google_apis;x86_64'
             result=$(avdmanager list avd)
 
             if [[ ! $result =~ "Name: testAVD" ]]; then

--- a/pkgs/development/mobile/androidenv/examples/shell-without-emulator.nix
+++ b/pkgs/development/mobile/androidenv/examples/shell-without-emulator.nix
@@ -48,6 +48,8 @@ let
     includeSystemImages = false;
     includeEmulator = false;
 
+    platformVersions = [ "latest" ];
+
     # Accepting more licenses declaratively:
     extraLicenses = [
       # Already accepted for you with the global accept_license = true or


### PR DESCRIPTION
Map 'latest' to the latest minor version of each SDK level, since Google now has minor versions of SDK levels. The SDK levels are still integers, so also map "36" to (e.g.) "36.1" by default, since the user likely wants the latest revision of "36" we have.

Fix: #468525


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
