### PR TITLE
maid: 0.10.0 -> 0.11.2

### DIFF
--- a/pkgs/by-name/ma/maid/Gemfile
+++ b/pkgs/by-name/ma/maid/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
-gem 'maid', '~> 0.10.0'
+gem 'maid', '~> 0.11.2'
 gem 'rake'

--- a/pkgs/by-name/ma/maid/Gemfile.lock
+++ b/pkgs/by-name/ma/maid/Gemfile.lock
@@ -21,7 +21,7 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
-    maid (0.10.0)
+    maid (0.11.2)
       deprecated (~> 3.0.0)
       dimensions (>= 1.0.0, < 2.0)
       escape (>= 0.0.1, < 0.1.0)
@@ -31,7 +31,7 @@ GEM
       mime-types (~> 3.0, < 4.0)
       rubyzip (~> 2.3.2)
       rufus-scheduler (~> 3.8.2)
-      thor (~> 1.2.1)
+      thor (~> 1.4.0)
       xdg (~> 2.2.3)
     mime-types (3.7.0)
       logger
@@ -45,7 +45,7 @@ GEM
     rubyzip (2.3.2)
     rufus-scheduler (3.8.2)
       fugit (~> 1.1, >= 1.1.6)
-    thor (1.2.2)
+    thor (1.4.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     xdg (2.2.5)
@@ -54,8 +54,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  maid (~> 0.10.0)
+  maid (~> 0.11.2)
   rake
 
 BUNDLED WITH
-   2.6.6
+   2.7.2

--- a/pkgs/by-name/ma/maid/gemset.nix
+++ b/pkgs/by-name/ma/maid/gemset.nix
@@ -160,10 +160,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0v1lhwgxyli10rinw6h33ikhskx9j3b20h7plrx8c69z05sfsdd9";
+      sha256 = "154rhbdplhrirxpli2jwwsmzcrk8vj51cn6zh8r7lp97vlrkybgp";
       type = "gem";
     };
-    version = "0.10.0";
+    version = "0.11.2";
   };
   mime-types = {
     dependencies = [
@@ -256,10 +256,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0k7j2wn14h1pl4smibasw0bp66kg626drxb59z7rzflch99cd4rg";
+      sha256 = "0gcarlmpfbmqnjvwfz44gdjhcmm634di7plcx2zdgwdhrhifhqw7";
       type = "gem";
     };
-    version = "1.2.2";
+    version = "1.4.0";
   };
   tzinfo = {
     dependencies = [ "concurrent-ruby" ];


### PR DESCRIPTION
https://github.com/maid/maid/releases/tag/v0.11.2

- 0.11.2 (2025-11-29)
    - Logger: Provide default logger
- 0.11.1 (2025-08-16)
    - thor: Upgrade thor to fix vulnerability
- 0.11.0 (2025-03-30)
    - Drop support for ruby < 3.2 (EOL rubies)
    - Update to Ruby 3.4

CC Maintainer @alanpearce 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
