### PR TITLE
python3Packages.sentencepiece: fix segfault on import for darwin

### DIFF
--- a/pkgs/by-name/se/sentencepiece/package.nix
+++ b/pkgs/by-name/se/sentencepiece/package.nix
@@ -48,8 +48,5 @@ stdenv.mkDerivation rec {
     license = lib.licenses.asl20;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ pashashocky ];
-    # sentencepiece 0.2.1 segfaults on darwin when instantiated
-    # See https://github.com/NixOS/nixpkgs/issues/466092
-    badPlatforms = [ lib.systems.inspect.patterns.isDarwin ];
   };
 }

--- a/pkgs/by-name/se/sentencepiece/package.nix
+++ b/pkgs/by-name/se/sentencepiece/package.nix
@@ -36,6 +36,12 @@ stdenv.mkDerivation rec {
       --replace '\$'{prefix}/'$'{CMAKE_INSTALL_INCLUDEDIR} '$'{CMAKE_INSTALL_FULL_INCLUDEDIR}
   '';
 
+  # On Darwin, non-static build segfaults on python module import.
+  # See: https://github.com/NixOS/nixpkgs/issues/466092
+  cmakeFlags = lib.optionals stdenv.hostPlatform.isDarwin [
+    "-DSPM_ENABLE_SHARED=OFF"
+  ];
+
   meta = {
     homepage = "https://github.com/google/sentencepiece";
     description = "Unsupervised text tokenizer for Neural Network-based text generation";

--- a/pkgs/development/python-modules/gguf/default.nix
+++ b/pkgs/development/python-modules/gguf/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -38,12 +37,8 @@ buildPythonPackage rec {
     numpy
     pyside6
     pyyaml
-    tqdm
-  ]
-  # Sentencepiece is optional and its inclusion crashes darwin
-  # See https://github.com/NixOS/nixpkgs/issues/466092
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
     sentencepiece
+    tqdm
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/mistral-common/default.nix
+++ b/pkgs/development/python-modules/mistral-common/default.nix
@@ -14,6 +14,7 @@
   pydantic,
   pydantic-extra-types,
   requests,
+  sentencepiece,
   tiktoken,
   typing-extensions,
 
@@ -25,7 +26,6 @@
   pycountry,
   pydantic-settings,
   pytestCheckHook,
-  sentencepiece,
   soundfile,
   soxr,
   uvicorn,
@@ -53,6 +53,7 @@ buildPythonPackage rec {
     pydantic
     pydantic-extra-types
     requests
+    sentencepiece
     tiktoken
     typing-extensions
   ];
@@ -96,8 +97,7 @@ buildPythonPackage rec {
     soundfile
     soxr
     uvicorn
-  ]
-  ++ lib.flatten (lib.attrValues optional-dependencies);
+  ];
 
   disabledTests = [
     # Require internet

--- a/pkgs/development/python-modules/mistral-common/default.nix
+++ b/pkgs/development/python-modules/mistral-common/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -62,8 +61,7 @@ buildPythonPackage rec {
     opencv = [
       opencv-python-headless
     ];
-    # Broken on Darwin. See https://github.com/NixOS/nixpkgs/issues/466092
-    sentencepiece = lib.optionals (!stdenv.hostPlatform.isDarwin) [
+    sentencepiece = [
       sentencepiece
     ];
     soundfile = [
@@ -99,7 +97,7 @@ buildPythonPackage rec {
     soxr
     uvicorn
   ]
-  ++ lib.concatAttrValues optional-dependencies;
+  ++ lib.flatten (lib.attrValues optional-dependencies);
 
   disabledTests = [
     # Require internet
@@ -112,20 +110,6 @@ buildPythonPackage rec {
 
     # AssertionError, Extra items in the right set
     "test_openai_chat_fields"
-  ];
-
-  # Requires sentencepiece which segfaults when initialized on Darwin
-  # See https://github.com/NixOS/nixpkgs/issues/466092
-  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
-    "tests/experimental/test_app.py"
-    "tests/experimental/test_tools.py"
-    "tests/test_fim_tokenizer.py"
-    "tests/test_integration_samples.py"
-    "tests/test_mistral_tokenizer.py"
-    "tests/test_tokenize_v1.py"
-    "tests/test_tokenize_v2.py"
-    "tests/test_tokenize_v3.py"
-    "tests/test_tokenizer_v7.py"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/pytorch-tokenizers/default.nix
+++ b/pkgs/development/python-modules/pytorch-tokenizers/default.nix
@@ -90,10 +90,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/meta-pytorch/tokenizers";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ GaetanLepage ];
-    badPlatforms = [
-      # sentencepiece 0.21.0 segfaults when initialized on Darwin
-      # See https://github.com/NixOS/nixpkgs/issues/466092
-      lib.systems.inspect.patterns.isDarwin
-    ];
   };
 }

--- a/pkgs/development/python-modules/sentencepiece/default.nix
+++ b/pkgs/development/python-modules/sentencepiece/default.nix
@@ -15,6 +15,8 @@ buildPythonPackage rec {
 
   sourceRoot = "${src.name}/python";
 
+  pythonImportsCheck = [ "sentencepiece" ];
+
   # sentencepiece installs 'bin' output.
   meta = removeAttrs sentencepiece.meta [ "outputsToInstall" ];
 }

--- a/pkgs/development/python-modules/speechbrain/default.nix
+++ b/pkgs/development/python-modules/speechbrain/default.nix
@@ -67,9 +67,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/speechbrain/speechbrain/releases/tag/v${version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ GaetanLepage ];
-    badPlatforms = [
-      # See https://github.com/NixOS/nixpkgs/issues/466092
-      lib.systems.inspect.patterns.isDarwin
-    ];
   };
 }

--- a/pkgs/development/python-modules/torchtune/default.nix
+++ b/pkgs/development/python-modules/torchtune/default.nix
@@ -119,10 +119,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/meta-pytorch/torchtune/releases/tag/${src.tag}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ GaetanLepage ];
-    badPlatforms = [
-      # sentencepiece 0.21.0 segfaults when initialized on Darwin
-      # See https://github.com/NixOS/nixpkgs/issues/466092
-      lib.systems.inspect.patterns.isDarwin
-    ];
   };
 }


### PR DESCRIPTION
- **sentencepiece: set SPM_ENABLE_SHARED=OFF on darwin**
- **python3Packages.sentencepiece: add import check**
- **Revert "sentencepiece: mark as broken on Darwin (can remove after 0.2.1 release)"**
- **Revert "python3Packages.torchtune: disable on Darwin due to sentencepiece bug"**
- **Revert "python3Packages.gguf: exclude optional sentencepiece on Darwin"**
- **Revert "python3Packages.mistral-common: disable sentencepiece dependency on Darwin"**
- **Revert "python3Packages.mistral-common: use sentencepiece as an optional dependency"**
- **Revert "python3Packages.pytorch-tokenizers: disable on Darwin due to broken sentencepiece"**
- **Revert "python3Packages.speechbrain: disable on Darwin due to broken sentencepiece"**

Fixes #466092

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
