### PR TITLE
vimPlugins.gruvbox-alabaster-nvim: init at 2025-12-08

### DIFF
--- a/pkgs/applications/editors/vim/plugins/generated.nix
+++ b/pkgs/applications/editors/vim/plugins/generated.nix
@@ -6036,6 +6036,19 @@ final: prev: {
     meta.hydraPlatforms = [ ];
   };
 
+  gruvbox-alabaster-nvim = buildVimPlugin {
+    pname = "gruvbox-alabaster.nvim";
+    version = "2025-12-08";
+    src = fetchFromGitHub {
+      owner = "Xoconoch";
+      repo = "gruvbox-alabaster.nvim";
+      rev = "246822279aa2c23b9374c5aee8ee71dbc06d26e6";
+      sha256 = "0l5r429al3m6l65lvq6mlvbgpga8081swpigixhbm5sw728npfhz";
+    };
+    meta.homepage = "https://github.com/Xoconoch/gruvbox-alabaster.nvim/";
+    meta.hydraPlatforms = [ ];
+  };
+
   gruvbox-baby = buildVimPlugin {
     pname = "gruvbox-baby";
     version = "2024-01-25";

--- a/pkgs/applications/editors/vim/plugins/vim-plugin-names
+++ b/pkgs/applications/editors/vim/plugins/vim-plugin-names
@@ -462,6 +462,7 @@ https://github.com/liuchengxu/graphviz.vim/,,
 https://github.com/cbochs/grapple.nvim/,HEAD,
 https://github.com/blazkowolf/gruber-darker.nvim/,,
 https://github.com/morhetz/gruvbox/,,
+https://github.com/Xoconoch/gruvbox-alabaster.nvim/,HEAD,
 https://github.com/luisiacc/gruvbox-baby/,HEAD,
 https://github.com/gruvbox-community/gruvbox/,,gruvbox-community
 https://github.com/eddyekofo94/gruvbox-flat.nvim/,,


### PR DESCRIPTION
Added the gruvbox-alabaster.nvim colorscheme. I am its main maintainer and I wanted to distribute it in my favorite distro!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
