### PR TITLE
treewide: replace ftp references to invisible-island.net with https

### DIFF
--- a/pkgs/by-name/by/byacc/package.nix
+++ b/pkgs/by-name/by/byacc/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchurl {
     urls = [
       "https://invisible-mirror.net/archives/byacc/byacc-${finalAttrs.version}.tgz"
-      "ftp://ftp.invisible-island.net/byacc/byacc-${finalAttrs.version}.tgz"
+      "https://invisible-island.net/archives/byacc/byacc-${finalAttrs.version}.tgz"
     ];
     hash = "sha256-GSwvrgSNTn9RS6RRYn+cTmEnZQmfgZwZGR+f3j5glnM=";
   };

--- a/pkgs/by-name/cp/cproto/package.nix
+++ b/pkgs/by-name/cp/cproto/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     urls = [
       "mirror://debian/pool/main/c/cproto/cproto_${version}.orig.tar.gz"
       # No version listings and apparently no versioned tarball over http(s).
-      "ftp://ftp.invisible-island.net/cproto/cproto-${version}.tgz"
+      "https://invisible-island.net/archives/cproto/cproto-${version}.tgz"
     ];
     sha256 = "sha256-C9HYvo/wpMpD+Uf5V1DTT2TtqTyeLKeRAP1gFAt8YzE=";
   };

--- a/pkgs/by-name/di/diffstat/package.nix
+++ b/pkgs/by-name/di/diffstat/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     urls = [
-      "ftp://ftp.invisible-island.net/diffstat/diffstat-${version}.tgz"
+      "https://invisible-island.net/archives/diffstat/diffstat-${version}.tgz"
       "https://invisible-mirror.net/archives/diffstat/diffstat-${version}.tgz"
     ];
     hash = "sha256-ifkpSorHT8728bmsQI9D6+340gjj7+C5m0rMFtxlgsc=";

--- a/pkgs/by-name/ly/lynx/package.nix
+++ b/pkgs/by-name/ly/lynx/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     urls = [
-      "ftp://ftp.invisible-island.net/lynx/tarballs/lynx${version}.tar.bz2"
+      "https://invisible-island.net/archives/lynx/tarballs/lynx${version}.tar.bz2"
       "https://invisible-mirror.net/archives/lynx/tarballs/lynx${version}.tar.bz2"
     ];
     hash = "sha256-c3S4mTbZkWaeEB9Ol/LJWSA24ejNqnuvwlmnerb7B84=";

--- a/pkgs/by-name/ma/mawk/package.nix
+++ b/pkgs/by-name/ma/mawk/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchurl {
     urls = [
       "https://invisible-mirror.net/archives/mawk/mawk-${finalAttrs.version}.tgz"
-      "ftp://ftp.invisible-island.net/mawk/mawk-${finalAttrs.version}.tgz"
+      "https://invisible-island.net/archives/mawk/mawk-${finalAttrs.version}.tgz"
     ];
     hash = "sha256-bh/ejuetilwVOCMWhj/WtMbSP6t4HdWrAXf/o+6arlw=";
   };

--- a/pkgs/by-name/vt/vttest/package.nix
+++ b/pkgs/by-name/vt/vttest/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   src = fetchurl {
     urls = [
       "https://invisible-mirror.net/archives/vttest/vttest-${version}.tgz"
-      "ftp://ftp.invisible-island.net/vttest/vttest-${version}.tgz"
+      "https://invisible-island.net/archives/vttest/vttest-${version}.tgz"
     ];
     sha256 = "sha256-j+47rH6H1KpKIXvSs4q5kQw7jPmmBbRQx2zMCtKmUZ0=";
   };

--- a/pkgs/by-name/xt/xterm/package.nix
+++ b/pkgs/by-name/xt/xterm/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     urls = [
-      "ftp://ftp.invisible-island.net/xterm/${pname}-${version}.tgz"
+      "https://invisible-island.net/archives/xterm/${pname}-${version}.tgz"
       "https://invisible-mirror.net/archives/xterm/${pname}-${version}.tgz"
     ];
     hash = "sha256-YzMvkhwie6WeWJ+gff2tFZnBCshZ6ibHKsHdSkG1ZaQ=";


### PR DESCRIPTION
https://invisible-island.net/
- ftp://ftp.invisible-island.net (ended May 2023) 

## Things done

I built the following without substitutes: `byacc.src cproto.src diffstat.src lynx.src mawk.src vttest.src xterm.src`

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
