### PR TITLE
xf86-video-{ark,geode,nouveau,s3virge,v4l}: refactor, move to pkgs/by-name & rename from xorg namespace 

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -1542,6 +1542,11 @@ lib.mapAttrs mkLicense (
       fullName = "X11 License";
     };
 
+    x11BsdClause = {
+      fullName = "X11 License with third BSD clause";
+      url = "https://gitlab.freedesktop.org/xorg/driver/xf86-video-geode/-/blob/d147c3f1b6907ae9db6f12853cedd450537d99d2/COPYING";
+    };
+
     x11NoPermitPersons = {
       spdxId = "X11-no-permit-persons";
       fullName = "X11 no permit persons clause";

--- a/pkgs/by-name/xf/xf86-video-ark/package.nix
+++ b/pkgs/by-name/xf/xf86-video-ark/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  pkg-config,
+  util-macros,
+  xorg-server,
+  xorgproto,
+  libpciaccess,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xf86-video-ark";
+  version = "0.7.6";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "driver";
+    repo = "xf86-video-ark";
+    tag = "xf86-video-ark-${finalAttrs.version}";
+    hash = "sha256-IE35hEZVsfxjwrNxV/xtw8bdox9pwlO/Ra8vkcK19pM=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    util-macros
+    xorg-server # for some autoconf macros
+  ];
+
+  buildInputs = [
+    xorg-server
+    xorgproto
+    libpciaccess
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version-regex=xf86-video-ark-(.*)" ]; };
+  };
+
+  meta = {
+    description = "ARK Logic video driver for the Xorg X server";
+    homepage = "https://gitlab.freedesktop.org/xorg/driver/xf86-video-ark";
+    license = lib.licenses.hpndSellVariant;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+    badPlatforms = lib.platforms.aarch64;
+  };
+})

--- a/pkgs/by-name/xf/xf86-video-geode/package.nix
+++ b/pkgs/by-name/xf/xf86-video-geode/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  pkg-config,
+  util-macros,
+  xorg-server,
+  xorgproto,
+  libpciaccess,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xf86-video-geode";
+  version = "2.18.1";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "driver";
+    repo = "xf86-video-geode";
+    tag = "xf86-video-geode-${finalAttrs.version}";
+    hash = "sha256-y9fQpMg6qKjaQvDfqYbWscFomtzmHQ1cvzMaa4anhOE=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    util-macros
+    xorg-server # for some autoconf macros
+  ];
+
+  buildInputs = [
+    xorg-server
+    xorgproto
+    libpciaccess
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version-regex=xf86-video-geode-(.*)" ]; };
+  };
+
+  meta = {
+    description = "AMD Geode GX and LX graphics driver for the Xorg X server";
+    homepage = "https://gitlab.freedesktop.org/xorg/driver/xf86-video-geode";
+    license = with lib.licenses; [
+      x11
+      x11BsdClause
+    ];
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+    badPlatforms = lib.platforms.aarch64;
+  };
+})

--- a/pkgs/by-name/xf/xf86-video-nouveau/package.nix
+++ b/pkgs/by-name/xf/xf86-video-nouveau/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  pkg-config,
+  util-macros,
+  xorg-server,
+  xorgproto,
+  libdrm,
+  libpciaccess,
+  udev,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xf86-video-nouveau";
+  version = "1.0.18";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "driver";
+    repo = "xf86-video-nouveau";
+    tag = "xf86-video-nouveau-${finalAttrs.version}";
+    hash = "sha256-gsrq32h0EKesivMoNbe1Thlc7FfubmS6zdwQmMxHsOk=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    util-macros
+    xorg-server # for some autoconf macros
+  ];
+
+  buildInputs = [
+    xorg-server
+    xorgproto
+    libdrm
+    libpciaccess
+    udev
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version-regex=xf86-video-nouveau-(.*)" ]; };
+  };
+
+  meta = {
+    description = "Xorg X server driver for NVIDIA video cards";
+    homepage = "https://gitlab.freedesktop.org/xorg/driver/xf86-video-nouveau";
+    license = with lib.licenses; [
+      mit
+      hpndSellVariant
+      # possibly unfree code according to the manpage in the repo
+      # https://gitlab.freedesktop.org/xorg/driver/xf86-video-nouveau/-/merge_requests/17
+      # unfree
+    ];
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xf/xf86-video-s3virge/package.nix
+++ b/pkgs/by-name/xf/xf86-video-s3virge/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  pkg-config,
+  util-macros,
+  xorg-server,
+  xorgproto,
+  libpciaccess,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xf86-video-s3virge";
+  version = "1.11.1";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "driver";
+    repo = "xf86-video-s3virge";
+    tag = "xf86-video-s3virge-${finalAttrs.version}";
+    hash = "sha256-UxAzsevKIMA3p6Q5cKjRPOku4cfbXiLmcJQWNEjpu7s=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    util-macros
+    xorg-server # for some autoconf macros
+  ];
+
+  buildInputs = [
+    xorg-server
+    xorgproto
+    libpciaccess
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version-regex=xf86-video-s3virge-(.*)" ]; };
+  };
+
+  meta = {
+    description = "S3 ViRGE video driver for the Xorg X server";
+    homepage = "https://gitlab.freedesktop.org/xorg/driver/xf86-video-s3virge";
+    license = with lib.licenses; [
+      x11
+      free # unknown free license TODO add to spdx
+      mit
+    ];
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+    badPlatforms = lib.platforms.aarch64;
+  };
+})

--- a/pkgs/by-name/xf/xf86-video-v4l/package.nix
+++ b/pkgs/by-name/xf/xf86-video-v4l/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  pkg-config,
+  util-macros,
+  xorg-server,
+  xorgproto,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xf86-video-v4l";
+  version = "0.3.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "driver";
+    repo = "xf86-video-v4l";
+    tag = "xf86-video-v4l-${finalAttrs.version}";
+    hash = "sha256-uCKeecAqHycYduKaDVMupGvMN84vHeF3ECyVchkXwdA=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    util-macros
+    xorg-server # for some autoconf macros
+  ];
+
+  buildInputs = [
+    xorg-server
+    xorgproto
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version-regex=xf86-video-v4l-(.*)" ]; };
+  };
+
+  meta = {
+    description = "Video 4 Linux adaptor driver for the Xorg X server";
+    homepage = "https://gitlab.freedesktop.org/xorg/driver/xf86-video-v4l";
+    license = with lib.licenses; [
+      # MIT AND X11 AND (GPL-2.0-or-later OR BSD-3-Clause)
+      mit
+      x11
+      gpl2Plus
+      bsd3
+    ];
+    maintainers = [ ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -134,6 +134,7 @@
   xf86-input-void,
   xf86-video-ark,
   xf86-video-geode,
+  xf86-video-nouveau,
   xfd,
   xfontsel,
   xfs,
@@ -346,6 +347,7 @@ self: with self; {
   xf86inputvoid = xf86-input-void;
   xf86videoark = xf86-video-ark;
   xf86videogeode = xf86-video-geode;
+  xf86videonouveau = xf86-video-nouveau;
   xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;
   xorgdocs = xorg-docs;
@@ -1073,48 +1075,6 @@ self: with self; {
       nativeBuildInputs = [ pkg-config ];
       buildInputs = [
         xorgproto
-        libpciaccess
-        xorgserver
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xf86videonouveau = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libdrm,
-      udev,
-      libpciaccess,
-      xorgserver,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xf86-video-nouveau";
-      version = "3ee7cbca8f9144a3bb5be7f71ce70558f548d268";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "https://gitlab.freedesktop.org/xorg/driver/xf86-video-nouveau/-/archive/3ee7cbca8f9144a3bb5be7f71ce70558f548d268/xf86-video-nouveau-3ee7cbca8f9144a3bb5be7f71ce70558f548d268.tar.bz2";
-        sha256 = "0rhs3z274jdzd82pcsl25xn8hmw6i4cxs2kwfnphpfhxbbkiq7wl";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libdrm
-        udev
         libpciaccess
         xorgserver
       ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -136,6 +136,7 @@
   xf86-video-geode,
   xf86-video-nouveau,
   xf86-video-s3virge,
+  xf86-video-v4l,
   xfd,
   xfontsel,
   xfs,
@@ -350,6 +351,7 @@ self: with self; {
   xf86videogeode = xf86-video-geode;
   xf86videonouveau = xf86-video-nouveau;
   xf86videos3virge = xf86-video-s3virge;
+  xf86videov4l = xf86-video-v4l;
   xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;
   xorgdocs = xorg-docs;
@@ -1626,42 +1628,6 @@ self: with self; {
       buildInputs = [
         xorgproto
         libpciaccess
-        xorgserver
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xf86videov4l = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      xorgserver,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xf86-video-v4l";
-      version = "0.3.0";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/driver/xf86-video-v4l-0.3.0.tar.bz2";
-        sha256 = "084x4p4avy72mgm2vnnvkicw3419i6pp3wxik8zqh7gmq4xv5z75";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
         xorgserver
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -135,6 +135,7 @@
   xf86-video-ark,
   xf86-video-geode,
   xf86-video-nouveau,
+  xf86-video-s3virge,
   xfd,
   xfontsel,
   xfs,
@@ -348,6 +349,7 @@ self: with self; {
   xf86videoark = xf86-video-ark;
   xf86videogeode = xf86-video-geode;
   xf86videonouveau = xf86-video-nouveau;
+  xf86videos3virge = xf86-video-s3virge;
   xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;
   xorgdocs = xorg-docs;
@@ -1281,44 +1283,6 @@ self: with self; {
       buildInputs = [
         xorgproto
         libdrm
-        libpciaccess
-        xorgserver
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xf86videos3virge = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libpciaccess,
-      xorgserver,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xf86-video-s3virge";
-      version = "1.11.1";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/driver/xf86-video-s3virge-1.11.1.tar.xz";
-        sha256 = "1qzfcq3rlpfdb6qxz8hrp9py1q11vyzl4iqxip1vpgfnfn83vl6f";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
         libpciaccess
         xorgserver
       ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -132,6 +132,7 @@
   xf86-input-synaptics,
   xf86-input-vmmouse,
   xf86-input-void,
+  xf86-video-ark,
   xfd,
   xfontsel,
   xfs,
@@ -342,6 +343,7 @@ self: with self; {
   xf86inputsynaptics = xf86-input-synaptics;
   xf86inputvmmouse = xf86-input-vmmouse;
   xf86inputvoid = xf86-input-void;
+  xf86videoark = xf86-video-ark;
   xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;
   xorgdocs = xorg-docs;
@@ -602,44 +604,6 @@ self: with self; {
       src = fetchurl {
         url = "mirror://xorg/individual/driver/xf86-video-apm-1.3.0.tar.bz2";
         sha256 = "0znwqfc8abkiha98an8hxsngnz96z6cd976bc4bsvz1km6wqk0c0";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libpciaccess
-        xorgserver
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xf86videoark = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libpciaccess,
-      xorgserver,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xf86-video-ark";
-      version = "0.7.6";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/driver/xf86-video-ark-0.7.6.tar.xz";
-        sha256 = "0p88blr3zgy47jc4aqivc6ypj4zq9pad1cl70wwz9xig29w9xk2s";
       };
       hardeningDisable = [
         "bindnow"

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -133,6 +133,7 @@
   xf86-input-vmmouse,
   xf86-input-void,
   xf86-video-ark,
+  xf86-video-geode,
   xfd,
   xfontsel,
   xfs,
@@ -344,6 +345,7 @@ self: with self; {
   xf86inputvmmouse = xf86-input-vmmouse;
   xf86inputvoid = xf86-input-void;
   xf86videoark = xf86-video-ark;
+  xf86videogeode = xf86-video-geode;
   xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;
   xorgdocs = xorg-docs;
@@ -838,44 +840,6 @@ self: with self; {
       src = fetchurl {
         url = "mirror://xorg/individual/driver/xf86-video-fbdev-0.5.1.tar.xz";
         sha256 = "11zk8whari4m99ad3w30xwcjkgya4xbcpmg8710q14phkbxw0aww";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libpciaccess
-        xorgserver
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xf86videogeode = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libpciaccess,
-      xorgserver,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xf86-video-geode";
-      version = "2.18.1";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/driver/xf86-video-geode-2.18.1.tar.xz";
-        sha256 = "0a8c6g3ndzf76rrrm3dwzmndcdy4y2qfai4324sdkmi8k9szicjr";
       };
       hardeningDisable = [
         "bindnow"

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -465,6 +465,7 @@ print OUT <<EOF;
   xf86-input-vmmouse,
   xf86-input-void,
   xf86-video-ark,
+  xf86-video-geode,
   xfd,
   xfontsel,
   xfs,
@@ -676,6 +677,7 @@ self: with self; {
   xf86inputvmmouse = xf86-input-vmmouse;
   xf86inputvoid = xf86-input-void;
   xf86videoark = xf86-video-ark;
+  xf86videogeode = xf86-video-geode;
   xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;
   xorgdocs = xorg-docs;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -468,6 +468,7 @@ print OUT <<EOF;
   xf86-video-geode,
   xf86-video-nouveau,
   xf86-video-s3virge,
+  xf86-video-v4l,
   xfd,
   xfontsel,
   xfs,
@@ -682,6 +683,7 @@ self: with self; {
   xf86videogeode = xf86-video-geode;
   xf86videonouveau = xf86-video-nouveau;
   xf86videos3virge = xf86-video-s3virge;
+  xf86videov4l = xf86-video-v4l;
   xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;
   xorgdocs = xorg-docs;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -466,6 +466,7 @@ print OUT <<EOF;
   xf86-input-void,
   xf86-video-ark,
   xf86-video-geode,
+  xf86-video-nouveau,
   xfd,
   xfontsel,
   xfs,
@@ -678,6 +679,7 @@ self: with self; {
   xf86inputvoid = xf86-input-void;
   xf86videoark = xf86-video-ark;
   xf86videogeode = xf86-video-geode;
+  xf86videonouveau = xf86-video-nouveau;
   xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;
   xorgdocs = xorg-docs;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -464,6 +464,7 @@ print OUT <<EOF;
   xf86-input-synaptics,
   xf86-input-vmmouse,
   xf86-input-void,
+  xf86-video-ark,
   xfd,
   xfontsel,
   xfs,
@@ -674,6 +675,7 @@ self: with self; {
   xf86inputsynaptics = xf86-input-synaptics;
   xf86inputvmmouse = xf86-input-vmmouse;
   xf86inputvoid = xf86-input-void;
+  xf86videoark = xf86-video-ark;
   xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;
   xorgdocs = xorg-docs;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -467,6 +467,7 @@ print OUT <<EOF;
   xf86-video-ark,
   xf86-video-geode,
   xf86-video-nouveau,
+  xf86-video-s3virge,
   xfd,
   xfontsel,
   xfs,
@@ -680,6 +681,7 @@ self: with self; {
   xf86videoark = xf86-video-ark;
   xf86videogeode = xf86-video-geode;
   xf86videonouveau = xf86-video-nouveau;
+  xf86videos3virge = xf86-video-s3virge;
   xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;
   xorgdocs = xorg-docs;

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -146,16 +146,6 @@ self: super:
     configureFlags = [ "--with-xorg-conf-dir=$(out)/share/X11/xorg.conf.d" ];
   });
 
-  xf86videonouveau = super.xf86videonouveau.overrideAttrs (attrs: {
-    nativeBuildInputs = attrs.nativeBuildInputs ++ [
-      autoreconfHook
-      buildPackages.xorg.utilmacros # For xorg-utils.m4 macros
-      buildPackages.xorg.xorgserver # For xorg-server.m4 macros
-    ];
-    # fixes `implicit declaration of function 'wfbScreenInit'; did you mean 'fbScreenInit'?
-    NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
-  });
-
   xf86videosuncg6 = super.xf86videosuncg6.overrideAttrs (attrs: {
     meta = attrs.meta // {
       broken = isDarwin;

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -126,12 +126,6 @@ self: super:
     };
   });
 
-  xf86videov4l = super.xf86videov4l.overrideAttrs (attrs: {
-    meta = attrs.meta // {
-      platforms = lib.platforms.linux;
-    };
-  });
-
   xf86videoomap = super.xf86videoomap.overrideAttrs (attrs: {
     env.NIX_CFLAGS_COMPILE = toString [ "-Wno-error=format-overflow" ];
   });

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -126,12 +126,6 @@ self: super:
     };
   });
 
-  xf86videos3virge = super.xf86videos3virge.overrideAttrs (attrs: {
-    meta = attrs.meta // {
-      badPlatforms = lib.platforms.aarch64;
-    };
-  });
-
   xf86videov4l = super.xf86videov4l.overrideAttrs (attrs: {
     meta = attrs.meta // {
       platforms = lib.platforms.linux;

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -120,12 +120,6 @@ self: super:
 
   xf86videodummy = brokenOnDarwin super.xf86videodummy; # never worked: https://hydra.nixos.org/job/nixpkgs/trunk/xorg.xf86videodummy.x86_64-darwin
 
-  xf86videogeode = super.xf86videogeode.overrideAttrs (attrs: {
-    meta = attrs.meta // {
-      badPlatforms = lib.platforms.aarch64;
-    };
-  });
-
   xf86videoi128 = super.xf86videoi128.overrideAttrs (attrs: {
     meta = attrs.meta // {
       badPlatforms = lib.platforms.aarch64;

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -120,12 +120,6 @@ self: super:
 
   xf86videodummy = brokenOnDarwin super.xf86videodummy; # never worked: https://hydra.nixos.org/job/nixpkgs/trunk/xorg.xf86videodummy.x86_64-darwin
 
-  xf86videoark = super.xf86videoark.overrideAttrs (attrs: {
-    meta = attrs.meta // {
-      badPlatforms = lib.platforms.aarch64;
-    };
-  });
-
   xf86videogeode = super.xf86videogeode.overrideAttrs (attrs: {
     meta = attrs.meta // {
       badPlatforms = lib.platforms.aarch64;

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -20,7 +20,6 @@ mirror://xorg/individual/driver/xf86-video-i740-1.4.0.tar.bz2
 mirror://xorg/individual/driver/xf86-video-intel-2.99.917.tar.bz2
 mirror://xorg/individual/driver/xf86-video-mga-2.1.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-neomagic-1.3.1.tar.xz
-https://gitlab.freedesktop.org/xorg/driver/xf86-video-nouveau/-/archive/3ee7cbca8f9144a3bb5be7f71ce70558f548d268/xf86-video-nouveau-3ee7cbca8f9144a3bb5be7f71ce70558f548d268.tar.bz2
 mirror://xorg/individual/driver/xf86-video-nv-2.1.23.tar.xz
 mirror://xorg/individual/driver/xf86-video-omap-0.4.5.tar.bz2
 mirror://xorg/individual/driver/xf86-video-openchrome-0.6.0.tar.bz2

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -34,7 +34,6 @@ mirror://xorg/individual/driver/xf86-video-sunffb-1.2.3.tar.xz
 mirror://xorg/individual/driver/xf86-video-sunleo-1.2.3.tar.xz
 mirror://xorg/individual/driver/xf86-video-tdfx-1.5.0.tar.bz2
 mirror://xorg/individual/driver/xf86-video-trident-1.4.0.tar.xz
-mirror://xorg/individual/driver/xf86-video-v4l-0.3.0.tar.bz2
 mirror://xorg/individual/driver/xf86-video-vboxvideo-1.0.1.tar.xz
 mirror://xorg/individual/driver/xf86-video-vesa-2.6.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-vmware-13.4.0.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -9,7 +9,6 @@ mirror://xorg/individual/driver/xf86-input-keyboard-2.1.0.tar.xz
 mirror://xorg/individual/driver/xf86-input-libinput-1.5.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-amdgpu-23.0.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-apm-1.3.0.tar.bz2
-mirror://xorg/individual/driver/xf86-video-ark-0.7.6.tar.xz
 mirror://xorg/individual/driver/xf86-video-ast-1.2.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-ati-22.0.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-chips-1.5.0.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -15,7 +15,6 @@ mirror://xorg/individual/driver/xf86-video-chips-1.5.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-cirrus-1.6.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-dummy-0.4.1.tar.xz
 mirror://xorg/individual/driver/xf86-video-fbdev-0.5.1.tar.xz
-mirror://xorg/individual/driver/xf86-video-geode-2.18.1.tar.xz
 mirror://xorg/individual/driver/xf86-video-i128-1.4.1.tar.xz
 mirror://xorg/individual/driver/xf86-video-i740-1.4.0.tar.bz2
 mirror://xorg/individual/driver/xf86-video-intel-2.99.917.tar.bz2

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -25,7 +25,6 @@ mirror://xorg/individual/driver/xf86-video-omap-0.4.5.tar.bz2
 mirror://xorg/individual/driver/xf86-video-openchrome-0.6.0.tar.bz2
 mirror://xorg/individual/driver/xf86-video-qxl-0.1.6.tar.xz
 mirror://xorg/individual/driver/xf86-video-r128-6.13.0.tar.xz
-mirror://xorg/individual/driver/xf86-video-s3virge-1.11.1.tar.xz
 mirror://xorg/individual/driver/xf86-video-savage-2.4.1.tar.xz
 mirror://xorg/individual/driver/xf86-video-siliconmotion-1.7.10.tar.xz
 mirror://xorg/individual/driver/xf86-video-sis-0.12.0.tar.gz


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux also cross to aarch64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- ran checks
  - [x] nixpkgs-hammering
  - [x] nix-check-deps
  - [x] ran passthru.updateScript 
    - xf86-video-geode actually has an update but lets let r-ryantm do this
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
