### PR TITLE
libHX: 3.22 -> 5.2; pam_mount: 2.20 -> 2.22; hxtools: 20250309 -> 20251011

### DIFF
--- a/pkgs/by-name/hx/hxtools/package.nix
+++ b/pkgs/by-name/hx/hxtools/package.nix
@@ -1,29 +1,31 @@
 {
   lib,
+  stdenv,
+  fetchFromGitea,
+  pkg-config,
+  autoreconfHook,
   bash,
-  fetchurl,
-  libHX,
-  makeWrapper,
   perl,
   perlPackages,
-  stdenv,
-  pkg-config,
-  zstd,
+  libHX,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hxtools";
-  version = "20250309";
+  version = "20251011";
 
-  src = fetchurl {
-    url = "https://inai.de/files/hxtools/hxtools-${finalAttrs.version}.tar.zst";
-    hash = "sha256-2ItcEiMe0GzgJ3MxZ28wjmXGSbZtc7BHpkpKIAodAwA=";
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    tag = "rel-${finalAttrs.version}";
+    owner = "jengelh";
+    repo = "hxtools";
+    hash = "sha256-qwo8QfC1ZEvMTU7g2ZnIX3WQM+xjSPb6Y/inPI20x/g=";
   };
 
   nativeBuildInputs = [
-    makeWrapper
+    autoreconfHook
     pkg-config
-    zstd
   ];
 
   buildInputs = [
@@ -31,14 +33,12 @@ stdenv.mkDerivation (finalAttrs: {
     perl
     bash
     libHX
-  ];
-
-  postInstall = ''
-    wrapProgram $out/bin/man2html \
-      --prefix PERL5LIB : "${with perlPackages; makePerlPath [ TextCSV_XS ]}"
-  '';
+  ]
+  ++ (with perlPackages; [ TextCSV_XS ]);
 
   strictDeps = true;
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://inai.de/projects/hxtools/";
@@ -50,7 +50,10 @@ stdenv.mkDerivation (finalAttrs: {
       lgpl21Plus
       gpl2Plus
     ];
-    maintainers = with lib.maintainers; [ meator ];
+    maintainers = with lib.maintainers; [
+      meator
+      chillcicada
+    ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/li/libHX/package.nix
+++ b/pkgs/by-name/li/libHX/package.nix
@@ -1,46 +1,41 @@
 {
   lib,
   stdenv,
-  fetchurl,
-  autoconf,
-  automake,
-  libtool,
+  fetchFromGitea,
+  autoreconfHook,
+  nix-update-script,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libHX";
-  version = "3.22";
+  version = "5.2";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/libhx/libHX/${version}/${pname}-${version}.tar.xz";
-    sha256 = "18w39j528lyg2026dr11f2xxxphy91cg870nx182wbd8cjlqf86c";
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    tag = "v${finalAttrs.version}";
+    owner = "jengelh";
+    repo = "libhx";
+    hash = "sha256-z1/D5dkcDc2VIoGCvunUYsLGq3AV6jZ01Edf1vuUx9o=";
   };
 
-  patches = [ ];
+  nativeBuildInputs = [ autoreconfHook ];
 
-  nativeBuildInputs = [
-    autoconf
-    automake
-    libtool
-  ];
-
-  preConfigure = ''
-    sh autogen.sh
-  '';
+  passthru.updateScript = nix-update-script { };
 
   meta = {
-    homepage = "https://libhx.sourceforge.net/";
+    homepage = "https://inai.de/projects/libhx/";
     longDescription = ''
       libHX is a C library (with some C++ bindings available) that provides data structures
       and functions commonly needed, such as maps, deques, linked lists, string formatting
       and autoresizing, option and config file parsing, type checking casts and more.
     '';
-    maintainers = [ ];
+    changelog = "https://codeberg.org/jengelh/libhx/src/branch/master/doc/changelog.rst";
+    maintainers = with lib.maintainers; [ chillcicada ];
     platforms = lib.platforms.linux;
     license = with lib.licenses; [
       gpl3
       lgpl21Plus
-      wtfpl
+      mit
     ];
   };
-}
+})

--- a/pkgs/by-name/pa/pam_mount/resolve_build_failure_with_gcc-13.patch
+++ b/pkgs/by-name/pa/pam_mount/resolve_build_failure_with_gcc-13.patch
@@ -1,0 +1,24 @@
+From 64dfcc87ccb6f7b0243b206524f7ea9aa9c59bc8 Mon Sep 17 00:00:00 2001
+From: Jan Engelhardt <jengelh@inai.de>
+Date: Thu, 30 Oct 2025 12:22:01 +0100
+Subject: [PATCH] build: resolve build failure with gcc-13
+
+nullptr is a C23-ism.
+---
+ src/pam_mount.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/pam_mount.h b/src/pam_mount.h
+index 61395f7..f547d8c 100644
+--- a/src/pam_mount.h
++++ b/src/pam_mount.h
+@@ -14,6 +14,9 @@
+ #else
+ #	define EXPORT_SYMBOL
+ #endif
++#if defined(__STDC_VERSION__) && __STDC_VERSION__ < 202300L
++#	define nullptr NULL
++#endif
+ 
+ #define sizeof_z(x) (sizeof(x) - 1)
+ 


### PR DESCRIPTION
replace sources with codeberg, update build process, add nix-update-script and add me as maintainers

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
