### PR TITLE
easyeffects: 8.0.6 -> 8.0.8

### DIFF
--- a/pkgs/by-name/ea/easyeffects/package.nix
+++ b/pkgs/by-name/ea/easyeffects/package.nix
@@ -14,8 +14,7 @@
   ladspaH,
   libbs2b,
   libebur128,
-  libportal-qt6,
-  libsamplerate,
+  libmysofa,
   libsigcxx30,
   libsndfile,
   lilv,
@@ -43,11 +42,9 @@ let
   inherit (qt6)
     qtbase
     qtgraphs
-    qtwebengine
     wrapQtAppsHook
     ;
   inherit (kdePackages)
-    appstream-qt
     breeze
     breeze-icons
     extra-cmake-modules
@@ -62,13 +59,13 @@ in
 
 stdenv.mkDerivation rec {
   pname = "easyeffects";
-  version = "8.0.6";
+  version = "8.0.8";
 
   src = fetchFromGitHub {
     owner = "wwmm";
     repo = "easyeffects";
     tag = "v${version}";
-    hash = "sha256-5UPwCdpFU1SiD9nlQd99lAK7QdC9jcizj5X3BhBYJ4U=";
+    hash = "sha256-Pw9rMYHrRBSttdtElWDH1YOF0tNWgb2zBzJBI9jJe4Q=";
   };
 
   patches = [ ./qmlmodule-fix.patch ];
@@ -86,7 +83,6 @@ stdenv.mkDerivation rec {
   dontWrapGApps = true;
 
   buildInputs = [
-    appstream-qt
     breeze
     breeze-icons
     deepfilternet
@@ -103,8 +99,7 @@ stdenv.mkDerivation rec {
     qqc2-desktop-style
     libbs2b
     libebur128
-    libportal-qt6
-    libsamplerate
+    libmysofa
     libsigcxx30
     libsndfile
     lilv
@@ -113,7 +108,6 @@ stdenv.mkDerivation rec {
     pipewire
     qtbase
     qtgraphs
-    qtwebengine
     rnnoise
     rubberband
     soundtouch
@@ -154,7 +148,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Audio effects for PipeWire applications";
     homepage = "https://github.com/wwmm/easyeffects";
-    changelog = "https://github.com/wwmm/easyeffects/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/wwmm/easyeffects/blob/v${version}/src/contents/docs/community/CHANGELOG.md";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       getchoo


### PR DESCRIPTION
https://github.com/wwmm/easyeffects/blob/v8.0.8/src/contents/docs/community/CHANGELOG.md
https://github.com/wwmm/easyeffects/compare/v8.0.6...v8.0.8
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
