### PR TITLE
fetchurl: fix handling of fallback URLs

### DIFF
--- a/pkgs/build-support/fetchurl/builder.sh
+++ b/pkgs/build-support/fetchurl/builder.sh
@@ -109,7 +109,7 @@ tryHashedMirrors() {
 set -o noglob
 
 urls2=
-for url in $urls; do
+for url in "${urls[@]}"; do
     if test "${url:0:9}" != "mirror://"; then
         urls2="$urls2 $url"
     else


### PR DESCRIPTION
Without the change fallback to `urls = []` does not work as `$urls` evaluates on ony first entry. Use
`${urls[@]}` instead.

Example derivation that is fixed in `master` is
`xterm.src`:

Before:

    $ nix build --no-link -f. xterm.src --rebuild -L
    xterm> structuredAttrs is enabled
    ...
    xterm> trying ftp://ftp.invisible-island.net/xterm/xterm-403.tgz
    ...
    xterm> curl: (67) Access denied: 550
    xterm> error: cannot download xterm-403.tgz from any mirror

After:

    $ nix build --no-link -f. xterm.src --rebuild -L
    xterm> structuredAttrs is enabled
    ...
    xterm> trying ftp://ftp.invisible-island.net/xterm/xterm-403.tgz
    ...
    xterm> curl: (67) Access denied: 550
    ...
    xterm> trying https://invisible-mirror.net/archives/xterm/xterm-403.tgz
    xterm>   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
    xterm>                                  Dload  Upload   Total   Spent    Left  Speed
    xterm> 100  1577k 100  1577k   0     0 703670     0   0:00:02  0:00:02 --:--:-- 703866


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
