### PR TITLE
Cinnamon updates 2025-12-14

### DIFF
--- a/pkgs/applications/backup/timeshift/unwrapped.nix
+++ b/pkgs/applications/backup/timeshift/unwrapped.nix
@@ -18,7 +18,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "timeshift";
-  version = "25.12.0";
+  version = "25.12.1";
   outputs = [
     "out"
     "man"
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "linuxmint";
     repo = "timeshift";
     tag = finalAttrs.version;
-    hash = "sha256-JAp1kZ8DBjhB6Xk4ZeL2ozJoTPPcu5gn7Fh+vbm+Zjg=";
+    hash = "sha256-m+eSF+cALWSaNt/0V0XTrDZiocddsLqK1YDU7yBdXjw=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/ci/cinnamon-translations/package.nix
+++ b/pkgs/by-name/ci/cinnamon-translations/package.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-translations";
-  version = "6.6.0";
+  version = "6.6.1";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "cinnamon-translations";
     tag = version;
-    hash = "sha256-+aqMXice5INNkqLmPc4hawlrc2jRnsGimDPZf28dUSE=";
+    hash = "sha256-6y1zHKO/qpkAL5fs6QUjNJki16X+bxW/175Sz1PUPQw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/fo/folder-color-switcher/package.nix
+++ b/pkgs/by-name/fo/folder-color-switcher/package.nix
@@ -8,14 +8,14 @@
 
 stdenvNoCC.mkDerivation {
   pname = "folder-color-switcher";
-  version = "1.6.9";
+  version = "1.7.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "folder-color-switcher";
     # They don't really do tags, this is just a named commit.
-    rev = "fefe156e336d2a0bbfe1ca61cf4e6873c74ae405";
-    hash = "sha256-KL3ipzZiHEj+jwAmbIOCeSBOwm3bMpJf4PVhGS+Xx24=";
+    rev = "c528788f05697d1e176df4f869d64bcebbab1528";
+    hash = "sha256-RSIiNjoU2Qk+0ACirUeo+VSfpjQ8NNJqmKKASD7RZXs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-online-accounts-gtk/package.nix
+++ b/pkgs/by-name/gn/gnome-online-accounts-gtk/package.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-online-accounts-gtk";
-  version = "3.50.8";
+  version = "3.50.9";
 
   src = fetchFromGitHub {
     owner = "xapp-project";
     repo = "gnome-online-accounts-gtk";
     rev = finalAttrs.version;
-    hash = "sha256-DcW88Zx8uoxOL+2mV7uBIsnmQEuy02tbAO1ljf0ZigQ=";
+    hash = "sha256-X7/TfY4Amei/CYO+FaXoSb48Y3/mQwduw40rTl6pN50=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/hy/hypnotix/package.nix
+++ b/pkgs/by-name/hy/hypnotix/package.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "hypnotix";
-  version = "5.4";
+  version = "5.5";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "hypnotix";
     tag = version;
-    hash = "sha256-aLcuRg6I1PaHBKyHMEV+TYOM82wb1hPVzMuF0SZixs8=";
+    hash = "sha256-/bFqPar/Ey48e+KG1EN0IuTF4HX+2jeMcFkqcEcOKMs=";
   };
 
   patches = [

--- a/pkgs/by-name/li/lightdm-slick-greeter/package.nix
+++ b/pkgs/by-name/li/lightdm-slick-greeter/package.nix
@@ -23,13 +23,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lightdm-slick-greeter";
-  version = "2.2.4";
+  version = "2.2.5";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "slick-greeter";
     rev = version;
-    hash = "sha256-Kq5FcippvMyxxA56uH41UdOCrP2wSuw0Tyv1OFxKD5Q=";
+    hash = "sha256-soXhVpzO4bJfZ5EV6uEDJOhwV9HJDfxUIuHi9AxaE0A=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/pi/pix/package.nix
+++ b/pkgs/by-name/pi/pix/package.nix
@@ -35,13 +35,13 @@
 
 stdenv.mkDerivation rec {
   pname = "pix";
-  version = "3.4.8";
+  version = "3.4.9";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "pix";
     rev = version;
-    hash = "sha256-zK02qhTGuYgZWHkJ6c3EVinUcojNEWwecvPjblECLkw=";
+    hash = "sha256-cuNggVsNNqACWttPy1Tt8MfPFQKiuYhaMnh8TTHCi74=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/wa/warpinator/package.nix
+++ b/pkgs/by-name/wa/warpinator/package.nix
@@ -42,13 +42,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "warpinator";
-  version = "2.0.1";
+  version = "2.0.2";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "warpinator";
     rev = version;
-    hash = "sha256-HfOxEVzMmZ7lqT6M3sT5FxynqKFQHHmzvHA4Wu4NPr8=";
+    hash = "sha256-bVK60fSIWp02qrKCJ68awyPcZhMTW5bjRPI7YHmmScc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xa/xapp/package.nix
+++ b/pkgs/by-name/xa/xapp/package.nix
@@ -24,7 +24,7 @@
 
 stdenv.mkDerivation rec {
   pname = "xapp";
-  version = "3.2.0";
+  version = "3.2.1";
 
   outputs = [
     "out"
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     owner = "linuxmint";
     repo = "xapp";
     rev = version;
-    hash = "sha256-jO1FyJfAg/kZExAS6gT0u15ans8cDsXfBE5V+w2fQXU=";
+    hash = "sha256-Uc3vMcWVzT0N9FCDxxI2e4yk1fg6FJiC7XXpY80mV0c=";
   };
 
   # Recommended by upstream, which enables the build of xapp-debug.

--- a/pkgs/by-name/xe/xed-editor/package.nix
+++ b/pkgs/by-name/xe/xed-editor/package.nix
@@ -23,13 +23,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xed-editor";
-  version = "3.8.6";
+  version = "3.8.7";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "xed";
     rev = version;
-    hash = "sha256-CeKgJg9pyQdnpatdlgqviLnzNv9JCVDm+bFv56trrT8=";
+    hash = "sha256-Vl2yf4PlREvyAY/lRP+nB47GEuuyYeLnBARKhDEfG4M=";
   };
 
   patches = [

--- a/pkgs/by-name/xr/xreader/package.nix
+++ b/pkgs/by-name/xr/xreader/package.nix
@@ -37,13 +37,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xreader";
-  version = "4.6.0";
+  version = "4.6.1";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "xreader";
     rev = version;
-    hash = "sha256-cp/pZ42AS98AD78BVMeY3SHQHkYA2h4o0kddr/H+kUA=";
+    hash = "sha256-+T89KxGTGycN1pnXBxJY15ViRvwJbM2adZVUTTSG3VQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xv/xviewer/package.nix
+++ b/pkgs/by-name/xv/xviewer/package.nix
@@ -29,13 +29,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xviewer";
-  version = "3.4.14";
+  version = "3.4.15";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "xviewer";
     rev = version;
-    hash = "sha256-2UWe9c9JkNhJyukDp+NTG/bvbMuwSyLBkk2wWvPbxRk=";
+    hash = "sha256-fAB7nbkGx6aNKwRA01013hAiGJ8pEovI0WClOqT0D10=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Only contains translation updates.

<!--

gnome-online-accounts-gtk: 3.50.8 -> 3.50.9
xed-editor: 3.8.6 -> 3.8.7
timeshift: 25.12.0 -> 25.12.1
lightdm-slick-greeter: 2.2.4 -> 2.2.5
hypnotix: 5.4 -> 5.5
xviewer: 3.4.14 -> 3.4.15
xreader: 4.6.0 -> 4.6.1
xapp: 3.2.0 -> 3.2.1
warpinator: 2.0.1 -> 2.0.2
pix: 3.4.8 -> 3.4.9
folder-color-switcher: 1.6.9 -> 1.7.0
cinnamon-translations: 6.6.0 -> 6.6.1

-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

