### PR TITLE
rtl_wmbus: init at 1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22936,6 +22936,12 @@
     name = "Pradyuman Vig";
     keys = [ { fingerprint = "240B 57DE 4271 2480 7CE3  EAC8 4F74 D536 1C4C A31E"; } ];
   };
+  prauscher = {
+    email = "prauscher@prauscher.de";
+    github = "prauscher";
+    githubId = 175521;
+    name = "Patrick Rauscher";
+  };
   preisschild = {
     email = "florian@florianstroeger.com";
     github = "Preisschild";

--- a/pkgs/by-name/rt/rtl_wmbus/package.nix
+++ b/pkgs/by-name/rt/rtl_wmbus/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  pname = "rtl-wmbus";
+  version = "1.1.0";
+  src = fetchFromGitHub {
+    owner = "xaelsouth";
+    repo = "rtl-wmbus";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-T8cYRkj7w4nAtcPvDkpPTwbDPXUr1qYZtyDtTjHWDMA=";
+
+    # need to fetch revision from git
+    leaveDotGit = true;
+    postFetch = ''
+      # avoid having the whole .git-folder
+      substituteInPlace $out/Makefile --replace-fail "COMMIT_HASH?=\$(shell git log --pretty=format:'%H' -n 1)" "COMMIT_HASH:=$(git -C $out log --pretty=format:'%H' -n 1)"
+
+      rm -rf $out/.git
+    '';
+  };
+
+  # avoid reading the version from git to avoid fetching all tags
+  makeFlags = [
+    "TAG=${finalAttrs.version}"
+    "BRANCH="
+    "CHANGES="
+  ];
+
+  # make install would use /usr/bin
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp build/rtl_wmbus $out/bin
+
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = false;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Software defined receiver for Wireless-M-Bus with RTL-SDR";
+    homepage = "https://github.com/xaelsouth/rtl-wmbus";
+    license = lib.licenses.bsd2;
+    mainProgram = "rtl_wmbus";
+    maintainers = with lib.maintainers; [
+      prauscher
+    ];
+  };
+})


### PR DESCRIPTION
add rtl_wmbus: https://github.com/xaelsouth/rtl-wmbus
Do not be confused by the version number, this is actually the only tag in this repository. rtl_wmbus is a dependency for wmbusmeters to be introduced in #470414 

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
