### PR TITLE
pantheon.elementary-screenshot: Do not use portals

### DIFF
--- a/pkgs/desktops/pantheon/apps/elementary-screenshot/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-screenshot/default.nix
@@ -6,24 +6,27 @@
   ninja,
   pkg-config,
   vala,
-  wrapGAppsHook4,
+  wrapGAppsHook3,
   gdk-pixbuf,
   glib,
-  granite7,
-  gtk4,
-  libportal,
+  granite,
+  gtk3,
+  libhandy,
   nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
   pname = "elementary-screenshot";
-  version = "8.0.3";
+  # nixpkgs-update: no auto update
+  # We disabled x-d-p-pantheon due to https://github.com/elementary/portals/issues/157
+  # so hold back this before the issue is fixed since later versions enforce using portals.
+  version = "8.0.0";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = "screenshot";
     rev = version;
-    hash = "sha256-nEJCyQs77zcUb9mc2dUBbZP3zWdPFHTOORROe3u6sSA=";
+    hash = "sha256-z7FP+OZYF/9YLXYCQF/ElihKjKHVfeHc38RHdPb2aIE=";
   };
 
   nativeBuildInputs = [
@@ -31,15 +34,15 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     vala
-    wrapGAppsHook4
+    wrapGAppsHook3
   ];
 
   buildInputs = [
     gdk-pixbuf
     glib
-    granite7
-    gtk4
-    libportal
+    granite
+    gtk3
+    libhandy
   ];
 
   passthru = {


### PR DESCRIPTION

Upstream does not respond to the [x-d-p-pantheon issue](https://github.com/elementary/portals/issues?q=is%3Aissue%20state%3Aopen%20Timeout%20was%20reached)...

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

