### PR TITLE
fira: correct references from 'bboxtype' to 'carrois'

### DIFF
--- a/pkgs/by-name/fi/fira-go/package.nix
+++ b/pkgs/by-name/fi/fira-go/package.nix
@@ -4,27 +4,27 @@
   fetchzip,
 }:
 
-stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation rec {
   pname = "fira-go";
   version = "1.001";
 
   src = fetchzip {
-    url = "https://github.com/bBoxType/FiraGo/archive/9882ba0851f88ab904dc237f250db1d45641f45d.zip";
-    hash = "sha256-WwgPg7OLrXBjR6oHG5061RO3HeNkj2Izs6ktwIxVw9o=";
+    url = "https://carrois.com/downloads/FiraGO/Download_Folder_FiraGO_${
+      lib.replaceStrings [ "." ] [ "" ] version
+    }.zip";
+    hash = "sha256-+lw4dh7G/Xv3pzGXdMUl9xNc2Nk7wUOAh+lq3K1LrXs=";
   };
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/share/fonts/opentype
-    mv Fonts/FiraGO_OTF_1001/{Roman,Italic}/*.otf \
-      $out/share/fonts/opentype
+    install --mode=644 -Dt $out/share/fonts/opentype Download_Folder_FiraGO*/Fonts/FiraGO_OTF*/*/*.otf
 
     runHook postInstall
   '';
 
   meta = {
-    homepage = "https://bboxtype.com/typefaces/FiraGO";
+    homepage = "https://carrois.com/fira/";
     description = ''
       Font with the same glyph set as Fira Sans 4.3 and additionally
       supports Arabic, Devenagari, Georgian, Hebrew and Thai

--- a/pkgs/by-name/fi/fira-mono/package.nix
+++ b/pkgs/by-name/fi/fira-mono/package.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation rec {
   version = "3.2";
 
   src = fetchzip {
-    url = "https://bboxtype.com/downloads/Fira/Fira_Mono_${
+    url = "https://carrois.com/downloads/Fira/Fira_Mono_${
       lib.replaceStrings [ "." ] [ "_" ] version
     }.zip";
     hash = "sha256-Ukc+K2sdSz+vUQFD8mmwJHZQ3N68oM4fk6YzGLwzAfQ=";
@@ -24,7 +24,7 @@ stdenvNoCC.mkDerivation rec {
   '';
 
   meta = {
-    homepage = "https://bboxtype.com/fira/";
+    homepage = "https://carrois.com/fira/";
     description = "Monospace font for Firefox OS";
     longDescription = ''
       Fira Mono is a monospace font designed by Erik Spiekermann,

--- a/pkgs/by-name/fi/fira-sans/package.nix
+++ b/pkgs/by-name/fi/fira-sans/package.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation rec {
   version = "4.301";
 
   src = fetchzip {
-    url = "https://bboxtype.com/downloads/Fira/Download_Folder_FiraSans_${
+    url = "https://carrois.com/downloads/Fira/Download_Folder_FiraSans_${
       lib.replaceStrings [ "." ] [ "" ] version
     }.zip";
     hash = "sha256-WBt3oqPK7ACqMhilYkyFx9Ek2ugwdCDFZN+8HLRnGRs";
@@ -19,13 +19,13 @@ stdenvNoCC.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    install --mode=-x -Dt $out/share/fonts/opentype Download_Folder_FiraSans*/Fonts/Fira_Sans_OTF*/*/*/*.otf
+    install --mode=644 -Dt $out/share/fonts/opentype Download_Folder_FiraSans*/Fonts/Fira_Sans_OTF*/*/*/*.otf
 
     runHook postInstall
   '';
 
   meta = {
-    homepage = "https://bboxtype.com/fira/";
+    homepage = "https://carrois.com/fira/";
     description = "Sans-serif font for Firefox OS";
     longDescription = ''
       Fira Sans is a sans-serif font designed by Erik Spiekermann,

--- a/pkgs/by-name/fi/fira/package.nix
+++ b/pkgs/by-name/fi/fira/package.nix
@@ -17,7 +17,7 @@ symlinkJoin rec {
 
   meta = {
     description = "Font family including Fira Sans and Fira Mono";
-    homepage = "https://bboxtype.com/fira/";
+    homepage = "https://carrois.com/fira/";
     license = lib.licenses.ofl;
     platforms = lib.platforms.all;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

It seems BBoxType has rebranded as Carrois and thus all of the urls around Fira need to be updated. Lucky for me it was a simple find and replace. You can head to https://bboxtype.com/ and get redirected to see for oneself.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
