### PR TITLE
w3m: inline patch due to errors fetching from AUR

### DIFF
--- a/pkgs/by-name/w3/w3m/https.patch
+++ b/pkgs/by-name/w3/w3m/https.patch
@@ -1,0 +1,19 @@
+Fedora patch; see https://bugzilla.redhat.com/show_bug.cgi?id=707994
+
+--- old/url.c	2011-01-04 14:52:24.000000000 +0530
++++ new/url.c	2011-09-02 18:25:43.305652690 +0530
+@@ -82,11 +82,11 @@
+     {"ftp", SCM_FTP},
+     {"local", SCM_LOCAL},
+     {"file", SCM_LOCAL},
+-    /*  {"exec", SCM_EXEC}, */
++    {"exec", SCM_EXEC}, 
+     {"nntp", SCM_NNTP},
+-    /*  {"nntp", SCM_NNTP_GROUP}, */
++    {"nntp", SCM_NNTP_GROUP}, 
+     {"news", SCM_NEWS},
+-    /*  {"news", SCM_NEWS_GROUP}, */
++    {"news", SCM_NEWS_GROUP}, 
+     {"data", SCM_DATA},
+ #ifndef USE_W3MMAILER
+     {"mailto", SCM_MAILTO},

--- a/pkgs/by-name/w3/w3m/package.nix
+++ b/pkgs/by-name/w3/w3m/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromSourcehut,
-  fetchpatch,
   ncurses,
   boehmgc,
   gettext,
@@ -66,11 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./RAND_egd.libressl.patch
-    (fetchpatch {
-      name = "https.patch";
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/https.patch?h=w3m-mouse&id=5b5f0fbb59f674575e87dd368fed834641c35f03";
-      sha256 = "08skvaha1hjyapsh8zw5dgfy433mw2hk7qy9yy9avn8rjqj7kjxk";
-    })
+    ./https.patch
   ];
 
   postPatch = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Similarly to https://github.com/NixOS/nixpkgs/pull/470480 this inlines a patch from the AUR in w3m to fix local building.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
