### PR TITLE
xorgproto: inline patch due to errors fetching from AUR

### DIFF
--- a/pkgs/by-name/xo/xorgproto/meson.patch
+++ b/pkgs/by-name/xo/xorgproto/meson.patch
@@ -1,0 +1,14 @@
+--- xorgproto-2018.4.orig/include/X11/meson.build	2018-02-28 16:45:07.000000000 +0000
++++ xorgproto-2018.4/include/X11/meson.build	2019-01-26 02:34:52.763165148 +0000
+@@ -10,8 +10,10 @@
+     endif
+ endforeach
+ 
+ # generated headers. try not to make more of these, please.
+-if cc.has_member('fd_set', 'fds_bits', prefix: fd_set_headers)
++if cc.get_define('_WIN32') == '1' and cc.get_define('CYGWIN') != '1'
++    fds_bits = 'dummy'
++elif cc.has_member('fd_set', 'fds_bits', prefix: fd_set_headers)
+     fds_bits = 'fds_bits'
+ elif cc.has_member('fd_set', '__fds_bits', prefix: fd_set_headers)
+     fds_bits = '__fds_bits'

--- a/pkgs/by-name/xo/xorgproto/package.nix
+++ b/pkgs/by-name/xo/xorgproto/package.nix
@@ -21,10 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     # small fix for mingw
-    (fetchpatch {
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/meson.patch?h=mingw-w64-xorgproto&id=7b817efc3144a50e6766817c4ca7242f8ce49307";
-      sha256 = "sha256-Izzz9In53W7CC++k1bLr78iSrmxpFm1cH8qcSpptoUQ=";
-    })
+    ./meson.patch
   ];
 
   strictDeps = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Similarly to https://github.com/NixOS/nixpkgs/pull/470480 this inlines a patch from the AUR in xorgproto to fix local building.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
