### PR TITLE
kdePackages.powerdevil: fix build nondeterminism

### DIFF
--- a/pkgs/kde/plasma/powerdevil/default.nix
+++ b/pkgs/kde/plasma/powerdevil/default.nix
@@ -7,6 +7,10 @@
 mkKdeDerivation {
   pname = "powerdevil";
 
+  patches = [
+    # https://invent.kde.org/plasma/powerdevil/-/merge_requests/595
+    ./rb-brightness.patch
+  ];
   extraNativeBuildInputs = [ pkg-config ];
   extraBuildInputs = [
     ddcutil

--- a/pkgs/kde/plasma/powerdevil/rb-brightness.patch
+++ b/pkgs/kde/plasma/powerdevil/rb-brightness.patch
@@ -1,0 +1,24 @@
+commit a34d894278d2c7938427d3c4d0fc07d96c26e55f
+Author: Arnout Engelen <arnout@bzzt.net>
+Date:   Sun Dec 14 11:33:08 2025 +0100
+
+    reproducible builds: make build deterministic by adding explicit deps
+    
+    Similar to https://qt-project.atlassian.net/browse/QTBUG-137440
+    
+    To fix https://bugs.kde.org/show_bug.cgi?id=512867
+    
+    I'll admit I don't quite know what I'm doing here, I'm mostly guessing and mimicking, but it does seem to remove the nondeterminism :)
+    
+    Inspired in part by https://invent.kde.org/plasma/plasma-workspace/-/merge_requests/6075/diffs
+
+diff --git a/applets/brightness/CMakeLists.txt b/applets/brightness/CMakeLists.txt
+index 3d1fce43..99331f85 100644
+--- a/applets/brightness/CMakeLists.txt
++++ b/applets/brightness/CMakeLists.txt
+@@ -16,3 +16,5 @@ plasma_add_applet(org.kde.plasma.brightness
+         PopupDialog.qml
+     GENERATE_APPLET_CLASS
+ )
++
++add_dependencies(org.kde.plasma.brightness brightnesscontrolplugin)


### PR DESCRIPTION
Cherry-pick
https://invent.kde.org/plasma/powerdevil/-/merge_requests/595 for wider testing

Fixes #467100


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
