### PR TITLE
kdePackages.kirigami.unwrapped: fix build nondeterminism

### DIFF
--- a/pkgs/kde/frameworks/kirigami/default.nix
+++ b/pkgs/kde/frameworks/kirigami/default.nix
@@ -17,6 +17,10 @@ let
   unwrapped = mkKdeDerivation {
     pname = "kirigami";
 
+    patches = [
+      ./rb-templates.patch
+    ];
+
     extraNativeBuildInputs = [
       qtsvg
       qttools

--- a/pkgs/kde/frameworks/kirigami/rb-templates.patch
+++ b/pkgs/kde/frameworks/kirigami/rb-templates.patch
@@ -1,0 +1,52 @@
+commit a1801928b5eea0bf224c81a638f658bf3a9d9a6c
+Author: Arnout Engelen <arnout@bzzt.net>
+Date:   Wed Nov 26 11:24:02 2025 +0100
+
+    Make qml generation deterministic by adding explicit dependencies
+    
+    Similar to https://qt-project.atlassian.net/browse/QTBUG-137440
+    
+    To fix https://bugs.kde.org/show_bug.cgi?id=513292
+
+diff --git a/src/dialogs/CMakeLists.txt b/src/dialogs/CMakeLists.txt
+index 9bf3cde9..c199c6f5 100644
+--- a/src/dialogs/CMakeLists.txt
++++ b/src/dialogs/CMakeLists.txt
+@@ -5,6 +5,7 @@ ecm_add_qml_module(KirigamiDialogs URI "org.kde.kirigami.dialogs"
+     GENERATE_PLUGIN_SOURCE
+     INSTALLED_PLUGIN_TARGET KF6KirigamiDialogsplugin
+     DEPENDENCIES QtQuick org.kde.kirigami.platform
++    LIBRARIES KirigamiPrimitives
+ )
+ 
+ 
+@@ -26,7 +27,7 @@ set_target_properties(KirigamiDialogs PROPERTIES
+ 
+ target_include_directories(KirigamiDialogs PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
+ 
+-target_link_libraries(KirigamiDialogs PRIVATE Qt6::Quick KirigamiPlatform)
++target_link_libraries(KirigamiDialogs PRIVATE Qt6::Quick KirigamiPlatform KirigamiPrimitives)
+ 
+ ecm_finalize_qml_module(KirigamiDialogs EXPORT KirigamiTargets)
+ 
+diff --git a/src/templates/CMakeLists.txt b/src/templates/CMakeLists.txt
+index b0027ea2..6813a6d0 100644
+--- a/src/templates/CMakeLists.txt
++++ b/src/templates/CMakeLists.txt
+@@ -4,6 +4,8 @@ ecm_add_qml_module(KirigamiTemplates URI "org.kde.kirigami.templates"
+     VERSION 2.0
+     GENERATE_PLUGIN_SOURCE
+     INSTALLED_PLUGIN_TARGET KF6KirigamiTemplates
++    DEPENDENCIES
++    LIBRARIES KirigamiPrimitives KirigamiLayouts
+ )
+ 
+ set_source_files_properties(AppHeaderSizeGroup.qml PROPERTIES
+@@ -37,6 +39,7 @@ set_target_properties(KirigamiTemplates PROPERTIES
+ 
+ target_include_directories(KirigamiTemplates PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
+ 
++target_link_libraries(KirigamiTemplates PRIVATE KirigamiPrimitives KirigamiLayouts)
+ 
+ ecm_finalize_qml_module(KirigamiTemplates EXPORT KirigamiTargets)
+ 


### PR DESCRIPTION
Cherry-pick
https://invent.kde.org/plasma/libplasma/-/merge_requests/1991 for wider testing

Fixes #450720


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
