### PR TITLE
darwin.libcxx: 19.1.2+apple-sdk-15.5 -> 20.1.0+apple-sdk-26.0

### DIFF
--- a/pkgs/os-specific/darwin/libcxx/default.nix
+++ b/pkgs/os-specific/darwin/libcxx/default.nix
@@ -1,7 +1,7 @@
 {
   # Use the text-based stubs and headers from the latest SDK (currently 15.x). This is safe because
   # using features that are not available on an older deployment target is a hard error.
-  apple-sdk_15,
+  apple-sdk_26,
   stdenvNoCC,
 }:
 
@@ -9,8 +9,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "libcxx";
   # Keep this in sync with the corresponding LLVM libc++ version
   # defined as `_LIBCPP_VERSION` in `usr/include/c++/v1/__config`.
-  version = "19.1.2+apple-sdk-${apple-sdk_15.version}";
-  inherit (apple-sdk_15) src;
+  version = "20.1.0+apple-sdk-${apple-sdk_26.version}";
+  inherit (apple-sdk_26) src;
 
   dontConfigure = true;
   dontBuild = true;


### PR DESCRIPTION
This updates Darwin to use libc++ from the 26.0 SDK instead of from the 15.5 SDK.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
