### PR TITLE
asleap: 0-unstable-2020-11-28 -> 0-unstable-2021-06-20

### DIFF
--- a/pkgs/by-name/as/asleap/package.nix
+++ b/pkgs/by-name/as/asleap/package.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation {
   pname = "asleap";
-  version = "0-unstable-2020-11-28";
+  version = "0-unstable-2021-06-20";
 
   src = fetchFromGitHub {
-    owner = "joswr1ght";
+    owner = "zackw";
     repo = "asleap";
-    rev = "254acabba34cb44608c9d2dcf7a147553d3d5ba3";
-    hash = "sha256-MQjPup3EX7DCXY/zyroTj/+U2GIq12+VQQJD0gru7C8=";
+    rev = "eb3bd42098cba42b65f499c9d8c73d890861b94f";
+    hash = "sha256-S6jS0cg9tHSfmP6VHyISkXJxczhPx3HDdxT46c+YmE8=";
   };
 
   buildInputs = [
@@ -34,7 +34,9 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch=zack/no-external-crypto" ];
+  };
 
   meta = {
     homepage = "https://github.com/zackw/asleap";


### PR DESCRIPTION
This package is broken since https://github.com/NixOS/nixpkgs/pull/464743 has been merged.
The commit mentioned in the previous PR was never lost, it just was in a different branch.
I have set the correct branch in nix-update-script.

Hydra Log of broken package: https://hydra.nixos.org/build/315521014/log

Fixes https://github.com/NixOS/nixpkgs/issues/468666


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
