### PR TITLE
nixos/anubis: switch default runtime directory to the new one

### DIFF
--- a/nixos/modules/services/networking/anubis.nix
+++ b/nixos/modules/services/networking/anubis.nix
@@ -204,7 +204,7 @@ let
     options = {
       # see other options above
       BIND = lib.mkOption {
-        default = "/run/anubis/${instanceName name}.sock";
+        default = "${runtimeDirectoryPrefix name}anubis.sock";
         description = ''
           The address that Anubis listens to. See Go's [`net.Listen`](https://pkg.go.dev/net#Listen) for syntax.
           Use the prefix "${runtimeDirectoryPrefix "<name>"}". The prefix "/run/anubis" is deprecated.
@@ -215,7 +215,7 @@ let
         type = types.str;
       };
       METRICS_BIND = lib.mkOption {
-        default = "/run/anubis/${instanceName name}-metrics.sock";
+        default = "${runtimeDirectoryPrefix name}anubis-metrics.sock";
         description = ''
           The address Anubis' metrics server listens to. See Go's [`net.Listen`](https://pkg.go.dev/net#Listen) for
           syntax.


### PR DESCRIPTION
RFC. This PR switches the default values for BIND and METRICS_BIND to the new runtime directory (`/run/anubis/anubis-<name>`).

### Motivation 
As of right now (both 25.11 and unstable), a "minimal" anubis configuration either results in a deprecation warning, or worse, not evaluating at all due to the `useLegacyRuntimeDirectory` assertion. For example, the following doesn't evaluate, due to the module wanting the new runtime directories:
```nix
services.anubis.instances = {
  "forgejo".settings.TARGET = "http://etna:3000";
  "nitter".settings = {
    TARGET = "http://localhost:1234";
    DIFFICULTY = 6;
  };
};
```

BIND _and_ METRICS_BIND therefore have to be both defined manually, which in my opinion adds a lot of unnecessary friction to the module. However, this is a breaking change. In an attempt to keep some sort of backwards compatibility, I tried both making the default value dependent on `useLegacyRuntimeDirectory` which causes an infinite recursion, or to make it dependent on `stateVersion` which doesn't really fix the issue for the existing module users.

I don't even really know if this change is really interesting in the scope of the module, therefore I'm leaving this PR as a draft until a consensus is found.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
