### PR TITLE
imake: fix for structuredAttrs

### DIFF
--- a/pkgs/by-name/im/imake/package.nix
+++ b/pkgs/by-name/im/imake/package.nix
@@ -64,6 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
     CFLAGS = "-DIMAKE_COMPILETIME_CPP='\"${
       if stdenv.hostPlatform.isDarwin then "${tradcpp}/bin/cpp" else "gcc"
     }\"'";
+    inherit tradcpp;
   };
 
   preInstall = ''
@@ -71,7 +72,7 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s ${xorg-cf-files}/lib/X11/config/* $out/lib/X11/config
   '';
 
-  inherit tradcpp xorg-cf-files;
+  inherit xorg-cf-files;
   setupHook = ./setup-hook.sh;
 
   passthru = {

--- a/pkgs/by-name/im/imake/package.nix
+++ b/pkgs/by-name/im/imake/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   fetchpatch,
+  replaceVars,
   tradcpp,
   xorg-cf-files,
   pkg-config,
@@ -60,19 +61,18 @@ stdenv.mkDerivation (finalAttrs: {
     "ac_cv_path_RAWCPP=${stdenv.cc.targetPrefix}cpp"
   ];
 
-  env = {
-    CFLAGS = "-DIMAKE_COMPILETIME_CPP='\"${
-      if stdenv.hostPlatform.isDarwin then "${tradcpp}/bin/cpp" else "gcc"
-    }\"'";
-    inherit tradcpp;
-  };
+  env.CFLAGS = "-DIMAKE_COMPILETIME_CPP='\"${
+    if stdenv.hostPlatform.isDarwin then "${tradcpp}/bin/cpp" else "gcc"
+  }\"'";
 
   preInstall = ''
     mkdir -p $out/lib/X11/config
     ln -s ${xorg-cf-files}/lib/X11/config/* $out/lib/X11/config
   '';
 
-  setupHook = ./setup-hook.sh;
+  setupHook = replaceVars ./setup-hook.sh {
+    inherit tradcpp;
+  };
 
   passthru = {
     updateScript = writeScript "update-${finalAttrs.pname}" ''

--- a/pkgs/by-name/im/imake/package.nix
+++ b/pkgs/by-name/im/imake/package.nix
@@ -72,7 +72,6 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s ${xorg-cf-files}/lib/X11/config/* $out/lib/X11/config
   '';
 
-  inherit xorg-cf-files;
   setupHook = ./setup-hook.sh;
 
   passthru = {


### PR DESCRIPTION
tradcpp must be in env for substitution in setupHook


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
