### PR TITLE
haskell-language-server: Disable broken hlint plugin on ghc 9.10

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
@@ -90,4 +90,8 @@ in
   #
   call-stack = dontCheck super.call-stack; # https://github.com/sol/call-stack/issues/19
   monad-dijkstra = dontCheck super.monad-dijkstra; # needs hlint 3.10
+
+  # Workaround https://github.com/haskell/haskell-language-server/issues/4674
+  haskell-language-server = haskellLib.disableCabalFlag "hlint" super.haskell-language-server;
+
 }


### PR DESCRIPTION
Workaround for https://github.com/haskell/haskell-language-server/issues/4674

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.