### PR TITLE
cvs: fix build with gcc15

### DIFF
--- a/pkgs/by-name/cv/cvs/package.nix
+++ b/pkgs/by-name/cv/cvs/package.nix
@@ -46,6 +46,10 @@ stdenv.mkDerivation {
     texinfo
   ];
 
+  # Fix build with gcc15
+  # https://savannah.nongnu.org/bugs/index.php?66726
+  env.NIX_CFLAGS_COMPILE = "-std=gnu17";
+
   configureFlags = [
     "--with-editor=${nano}/bin/nano"
 


### PR DESCRIPTION
- add "-std=gnu17" to `env.NIX_CFLAGS_COMPILE`

Upstream had no updates since 2019

Fedora used 13k LOC patch instead and submitted it upstream:
https://src.fedoraproject.org/rpms/cvs/c/43fad212ad729bdeabfe93b1f12007a75fc2862d
https://savannah.nongnu.org/bugs/index.php?66726

Fixes build failure with gcc15:
```
sighandle.c: In function 'SIG_handle':
sighandle.c:207:18: error: too many arguments to function
'this->handler'; expected 0, have 1
  207 |                 (*this->handler)(sig);
      |                 ~^~~~~~~~~~~~~~~ ~~~
sighandle.c:59:35: note: declared here
   59 |         RETSIGTYPE              (*handler)();
      |                                   ^~~~~~~
```

---

Tested build with:
```bash
nix-build --expr 'with import ./. {}; cvs.override { stdenv = gcc15Stdenv; }'
```
Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
