### PR TITLE
nixos/oauth2-proxy: require secrets be put in files

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -82,6 +82,8 @@ of pulling the upstream container image from Docker Hub. If you want the old beh
   - `systemd.services.stalwart` owned by `stalwart:stalwart`. The `user` and `group` are configurable via `services.stalwart.user` and `services.stalwart.group`, respectively. By default, if `stateVersion` is older than `26.05`, will fallback to legacy value of `stalwart-mail` for both `user` and `group`.
   - Default value for `services.stalwart.dataDir` has changed to `/var/lib/stalwart`. If `stateVersion` is older than `26.05`, will fallback to legacy value of `/var/lib/stalwart-mail`.
 
+- `services.oauth2-proxy.clientSecret` and `services.oauth2-proxy.cookie.secret` have been replaced with `services.oauth2-proxy.clientSecretFile` and `services.oauth2-proxy.cookie.secretFile` respectively. This was done to ensure secrets don't get made world-readable.
+
 - Ethercalc and its associated module have been removed, as the package is unmaintained and cannot be installed from source with npm now.
 
 - `services.cgit` before always had the git-http-backend and its "export all" setting enabled, which sidestepped any access control configured in cgit's settings. Now you have to make a decision and either enable or disable `services.cgit.gitHttpBackend.checkExportOkFiles` (or disable the git-http-backend).

--- a/nixos/modules/services/security/oauth2-proxy.nix
+++ b/nixos/modules/services/security/oauth2-proxy.nix
@@ -187,7 +187,7 @@ in
       type = lib.types.nullOr lib.types.path;
       default = null;
       description = ''
-        Alternative to `clientSecret`: path to a file containing the OAuth Client Secret.
+        Alternative to `clientSecret` and `keyFile`: path to a file containing the OAuth Client Secret.
       '';
       example = "/run/keys/oauth2-client-secret";
     };
@@ -445,7 +445,7 @@ in
         type = lib.types.nullOr lib.types.path;
         default = null;
         description = ''
-          Alternative to `secret`: path to a file containing the cookie secret.
+          Alternative to `secret` and `keyFile`: path to a file containing the cookie secret.
         '';
         example = "/run/keys/oauth2-cookie-secret";
       };

--- a/nixos/modules/services/security/oauth2-proxy.nix
+++ b/nixos/modules/services/security/oauth2-proxy.nix
@@ -616,14 +616,6 @@ in
         assertion = cfg.clientID != null || cfg.keyFile != null;
         message = "Either services.oauth2-proxy.clientID or services.oauth2-proxy.keyFile must be specified.";
       }
-      {
-        assertion = cfg.clientSecretFile != null || cfg.keyFile != null;
-        message = "Either services.oauth2-proxy.clientSecretFile or services.oauth2-proxy.keyFile must be specified.";
-      }
-      {
-        assertion = cfg.cookie.secretFile != null || cfg.keyFile != null;
-        message = "Either services.oauth2-proxy.cookie.secretFile or services.oauth2-proxy.keyFile must be specified.";
-      }
     ];
 
     users.users.oauth2-proxy = {


### PR DESCRIPTION
Removes support for specifying the `clientSecret` and `cookie.secret` in Nix. Adds support for specifying files that will be `LoadCredential`ed instead.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
