### PR TITLE
speechd: refactor and small improvements

### DIFF
--- a/pkgs/by-name/sp/speechd/package.nix
+++ b/pkgs/by-name/sp/speechd/package.nix
@@ -155,13 +155,16 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description =
-      "Common interface to speech synthesis" + lib.optionalString libsOnly " - client libraries only";
+      "Common high-level interface to speech synthesis"
+      + lib.optionalString libsOnly " - client libraries only";
     homepage = "https://devel.freebsoft.org/speechd";
+    changelog = "https://github.com/brailcom/speechd/blob/${finalAttrs.version}/NEWS";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
       berce
       jtojnar
     ];
+    sourceProvenance = [ lib.sourceTypes.fromSource ];
     # TODO: remove checks for `withPico` once PR #375450 is merged
     platforms = if withAlsa || withPico then lib.platforms.linux else lib.platforms.unix;
     mainProgram = "speech-dispatcher";

--- a/pkgs/by-name/sp/speechd/package.nix
+++ b/pkgs/by-name/sp/speechd/package.nix
@@ -36,9 +36,6 @@
   libsOnly ? false,
 }:
 
-let
-  inherit (python3Packages) python pyxdg wrapPython;
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "speech-dispatcher";
   version = "0.12.1";
@@ -74,7 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
     libtool
     itstool
     texinfo
-    wrapPython
+    python3Packages.wrapPython
   ];
 
   buildInputs = [
@@ -83,7 +80,7 @@ stdenv.mkDerivation (finalAttrs: {
     libsndfile
     libao
     libpulseaudio
-    python
+    python3Packages.python
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     systemdMinimal # libsystemd
@@ -104,7 +101,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   pythonPath = [
-    pyxdg
+    python3Packages.pyxdg
   ];
 
   configureFlags = [

--- a/pkgs/by-name/sp/speechd/package.nix
+++ b/pkgs/by-name/sp/speechd/package.nix
@@ -134,7 +134,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postPatch = lib.optionalString withPico ''
-    substituteInPlace src/modules/pico.c --replace "/usr/share/pico/lang" "${svox}/share/pico/lang"
+    substituteInPlace src/modules/pico.c --replace-fail "/usr/share/pico/lang" "${svox}/share/pico/lang"
   '';
 
   installFlags = [

--- a/pkgs/by-name/sp/speechd/package.nix
+++ b/pkgs/by-name/sp/speechd/package.nix
@@ -16,23 +16,34 @@
   glib,
   dotconf,
   libsndfile,
-  runtimeShell,
+
   withLibao ? true,
   libao,
+
+  withPipewire ? true,
+  pipewire,
+
   withPulse ? false,
   libpulseaudio,
+
   withAlsa ? false,
   alsa-lib,
+
   withOss ? false,
+
   withFlite ? true,
   flite,
+
   withEspeak ? true,
   espeak,
   sonic,
   pcaudiolib,
   mbrola,
+
   withPico ? true,
   svox,
+  runtimeShell,
+
   libsOnly ? false,
 }:
 
@@ -85,6 +96,9 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     systemdMinimal # libsystemd
   ]
+  ++ lib.optionals withPipewire [
+    pipewire
+  ]
   ++ lib.optionals withAlsa [
     alsa-lib
   ]
@@ -111,9 +125,10 @@ stdenv.mkDerivation (finalAttrs: {
     [
       "--sysconfdir=/etc"
       # Audio method falls back from left to right.
-      "--with-default-audio-method=\"libao,pulse,alsa,oss\""
+      "--with-default-audio-method=\"libao,pulse,pipewire,alsa,oss\""
       "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
       "--with-systemduserunitdir=${placeholder "out"}/lib/systemd/user"
+      (withFeature withPipewire "pipewire")
       (withFeature withPulse "pulse")
       (withFeature withLibao "libao")
       (withFeature withAlsa "alsa")

--- a/pkgs/by-name/sp/speechd/package.nix
+++ b/pkgs/by-name/sp/speechd/package.nix
@@ -104,31 +104,23 @@ stdenv.mkDerivation (finalAttrs: {
     python3Packages.pyxdg
   ];
 
-  configureFlags = [
-    "--sysconfdir=/etc"
-    # Audio method falls back from left to right.
-    "--with-default-audio-method=\"libao,pulse,alsa,oss\""
-    "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
-    "--with-systemduserunitdir=${placeholder "out"}/lib/systemd/user"
-  ]
-  ++ lib.optionals withPulse [
-    "--with-pulse"
-  ]
-  ++ lib.optionals withAlsa [
-    "--with-alsa"
-  ]
-  ++ lib.optionals withLibao [
-    "--with-libao"
-  ]
-  ++ lib.optionals withOss [
-    "--with-oss"
-  ]
-  ++ lib.optionals withEspeak [
-    "--with-espeak-ng"
-  ]
-  ++ lib.optionals withPico [
-    "--with-pico"
-  ];
+  configureFlags =
+    let
+      inherit (lib) withFeature;
+    in
+    [
+      "--sysconfdir=/etc"
+      # Audio method falls back from left to right.
+      "--with-default-audio-method=\"libao,pulse,alsa,oss\""
+      "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
+      "--with-systemduserunitdir=${placeholder "out"}/lib/systemd/user"
+      (withFeature withPulse "pulse")
+      (withFeature withLibao "libao")
+      (withFeature withAlsa "alsa")
+      (withFeature withOss "oss")
+      (withFeature withEspeak "espeak-ng")
+      (withFeature withPico "pico")
+    ];
 
   postPatch = lib.optionalString withPico ''
     substituteInPlace src/modules/pico.c --replace-fail "/usr/share/pico/lang" "${svox}/share/pico/lang"

--- a/pkgs/by-name/sp/speechd/package.nix
+++ b/pkgs/by-name/sp/speechd/package.nix
@@ -119,6 +119,7 @@ stdenv.mkDerivation (finalAttrs: {
       (withFeature withAlsa "alsa")
       (withFeature withOss "oss")
       (withFeature withEspeak "espeak-ng")
+      (withFeature withFlite "flite")
       (withFeature withPico "pico")
     ];
 

--- a/pkgs/by-name/sp/speechd/package.nix
+++ b/pkgs/by-name/sp/speechd/package.nix
@@ -133,7 +133,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postPatch = lib.optionalString withPico ''
-    substituteInPlace src/modules/pico.c --replace "/usr/share/pico/lang" "${picotts}/share/pico/lang"
+    substituteInPlace src/modules/pico.c --replace-fail "/usr/share/pico/lang" "${picotts}/share/pico/lang"
   '';
 
   installFlags = [

--- a/pkgs/by-name/sp/speechd/package.nix
+++ b/pkgs/by-name/sp/speechd/package.nix
@@ -118,6 +118,7 @@ stdenv.mkDerivation (finalAttrs: {
       (withFeature withAlsa "alsa")
       (withFeature withOss "oss")
       (withFeature withEspeak "espeak-ng")
+      (withFeature withFlite "flite")
       (withFeature withPico "pico")
     ];
 

--- a/pkgs/by-name/sp/speechd/package.nix
+++ b/pkgs/by-name/sp/speechd/package.nix
@@ -103,31 +103,23 @@ stdenv.mkDerivation (finalAttrs: {
     python3Packages.pyxdg
   ];
 
-  configureFlags = [
-    "--sysconfdir=/etc"
-    # Audio method falls back from left to right.
-    "--with-default-audio-method=\"libao,pulse,alsa,oss\""
-    "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
-    "--with-systemduserunitdir=${placeholder "out"}/lib/systemd/user"
-  ]
-  ++ lib.optionals withPulse [
-    "--with-pulse"
-  ]
-  ++ lib.optionals withAlsa [
-    "--with-alsa"
-  ]
-  ++ lib.optionals withLibao [
-    "--with-libao"
-  ]
-  ++ lib.optionals withOss [
-    "--with-oss"
-  ]
-  ++ lib.optionals withEspeak [
-    "--with-espeak-ng"
-  ]
-  ++ lib.optionals withPico [
-    "--with-pico"
-  ];
+  configureFlags =
+    let
+      inherit (lib) withFeature;
+    in
+    [
+      "--sysconfdir=/etc"
+      # Audio method falls back from left to right.
+      "--with-default-audio-method=\"libao,pulse,alsa,oss\""
+      "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
+      "--with-systemduserunitdir=${placeholder "out"}/lib/systemd/user"
+      (withFeature withPulse "pulse")
+      (withFeature withLibao "libao")
+      (withFeature withAlsa "alsa")
+      (withFeature withOss "oss")
+      (withFeature withEspeak "espeak-ng")
+      (withFeature withPico "pico")
+    ];
 
   postPatch = lib.optionalString withPico ''
     substituteInPlace src/modules/pico.c --replace-fail "/usr/share/pico/lang" "${picotts}/share/pico/lang"

--- a/pkgs/by-name/sp/speechd/package.nix
+++ b/pkgs/by-name/sp/speechd/package.nix
@@ -154,8 +154,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description =
-      "Common interface to speech synthesis" + lib.optionalString libsOnly " - client libraries only";
+      "Common high-level interface to speech synthesis"
+      + lib.optionalString libsOnly " - client libraries only";
     homepage = "https://devel.freebsoft.org/speechd";
+    changelog = "https://github.com/brailcom/speechd/blob/${finalAttrs.version}/NEWS";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ jtojnar ];
     # TODO: remove checks for `withPico` once PR #375450 is merged

--- a/pkgs/by-name/sp/speechd/package.nix
+++ b/pkgs/by-name/sp/speechd/package.nix
@@ -35,9 +35,6 @@
   libsOnly ? false,
 }:
 
-let
-  inherit (python3Packages) python pyxdg wrapPython;
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "speech-dispatcher";
   version = "0.12.1";
@@ -73,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
     libtool
     itstool
     texinfo
-    wrapPython
+    python3Packages.wrapPython
   ];
 
   buildInputs = [
@@ -82,7 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
     libsndfile
     libao
     libpulseaudio
-    python
+    python3Packages.python
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     systemdMinimal # libsystemd
@@ -103,7 +100,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   pythonPath = [
-    pyxdg
+    python3Packages.pyxdg
   ];
 
   configureFlags = [

--- a/pkgs/by-name/sp/speechd/package.nix
+++ b/pkgs/by-name/sp/speechd/package.nix
@@ -16,22 +16,33 @@
   glib,
   dotconf,
   libsndfile,
+
   withLibao ? true,
   libao,
+
+  withPipewire ? true,
+  pipewire,
+
   withPulse ? false,
   libpulseaudio,
+
   withAlsa ? false,
   alsa-lib,
+
   withOss ? false,
+
   withFlite ? true,
   flite,
+
   withEspeak ? true,
   espeak,
   sonic,
   pcaudiolib,
   mbrola,
+
   withPico ? true,
   picotts,
+
   libsOnly ? false,
 }:
 
@@ -84,6 +95,9 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     systemdMinimal # libsystemd
   ]
+  ++ lib.optionals withPipewire [
+    pipewire
+  ]
   ++ lib.optionals withAlsa [
     alsa-lib
   ]
@@ -110,11 +124,12 @@ stdenv.mkDerivation (finalAttrs: {
     [
       "--sysconfdir=/etc"
       # Audio method falls back from left to right.
-      "--with-default-audio-method=\"libao,pulse,alsa,oss\""
+      "--with-default-audio-method=\"libao,pulse,pipewire,alsa,oss\""
       "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
       "--with-systemduserunitdir=${placeholder "out"}/lib/systemd/user"
       (withFeature withPulse "pulse")
       (withFeature withLibao "libao")
+      (withFeature withPipewire "pipewire")
       (withFeature withAlsa "alsa")
       (withFeature withOss "oss")
       (withFeature withEspeak "espeak-ng")

--- a/pkgs/by-name/sp/speechd/package.nix
+++ b/pkgs/by-name/sp/speechd/package.nix
@@ -47,6 +47,19 @@
   libsOnly ? false,
 }:
 
+let
+  withSupports =
+    lib.optional withPulse "pulse"
+    ++ lib.optional withLibao "libao"
+    ++ lib.optional withPipewire "pipewire"
+    ++ lib.optional withAlsa "alsa"
+    ++ lib.optional withOss "oss"
+    ++ lib.optional withEspeak "espeak-ng"
+    ++ lib.optional withFlite "flite"
+    ++ lib.optional withPico "pico";
+  hasOptionalSupports = withSupports != [ ];
+  withOptionalSupports = lib.optionalString hasOptionalSupports " with ${lib.strings.concatStringsSep " and " withSupports} supports";
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "speech-dispatcher";
   version = "0.12.1";
@@ -178,6 +191,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description =
       "Common high-level interface to speech synthesis"
+      + withOptionalSupports
       + lib.optionalString libsOnly " - client libraries only";
     homepage = "https://devel.freebsoft.org/speechd";
     changelog = "https://github.com/brailcom/speechd/blob/${finalAttrs.version}/NEWS";

--- a/pkgs/by-name/sp/speechd/package.nix
+++ b/pkgs/by-name/sp/speechd/package.nix
@@ -51,6 +51,8 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "speech-dispatcher";
   version = "0.12.1";
 
+  __structuredAttrs = true;
+  strictDeps = true;
   src = fetchurl {
     url = "https://github.com/brailcom/speechd/releases/download/${finalAttrs.version}/speech-dispatcher-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-sUpSONKH0tzOTdQrvWbKZfoijn5oNwgmf3s0A297pLQ=";

--- a/pkgs/by-name/sp/speechd/package.nix
+++ b/pkgs/by-name/sp/speechd/package.nix
@@ -127,7 +127,15 @@ stdenv.mkDerivation (finalAttrs: {
     [
       "--sysconfdir=/etc"
       # Audio method falls back from left to right.
-      "--with-default-audio-method=\"libao,pulse,pipewire,alsa,oss\""
+      ''--with-default-audio-method="${
+        lib.concatStringsSep "," (
+          lib.optional withLibao "libao"
+          ++ lib.optional withPulse "pulse"
+          ++ lib.optional withAlsa "alsa"
+          ++ lib.optional withPipewire "pipewire"
+          ++ lib.optional withOss "oss"
+        )
+      }"''
       "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
       "--with-systemduserunitdir=${placeholder "out"}/lib/systemd/user"
       (withFeature withPulse "pulse")

--- a/pkgs/by-name/sp/speechd/package.nix
+++ b/pkgs/by-name/sp/speechd/package.nix
@@ -5,6 +5,7 @@
   pkg-config,
   fetchurl,
   fetchpatch,
+  testers,
   python3Packages,
   gettext,
   itstool,
@@ -156,6 +157,13 @@ stdenv.mkDerivation (finalAttrs: {
       '';
 
   enableParallelBuilding = true;
+  passthru = {
+    tests = lib.optionalAttrs (!libsOnly) {
+      version = testers.testVersion {
+        package = finalAttrs.finalPackage;
+      };
+    };
+  };
 
   meta = {
     description =


### PR DESCRIPTION
I used to use [Pied](https://search.nixos.org/packages?channel=25.11&show=pied) to have a voice generated by piper

I have [upgraded NixOS from 25.05 to 25.11](https://gitlab.com/pinage404/dotfiles/-/commit/b481b7496e5f724b57f166b0534c690ad5f81b52?page=2#58cb4f58166586c1ed7f076c568d41682df3661c_14_14)

Since speech-dispatcher seems to not work

I was trying to use a more recent version of speech-dispatcher which include piper https://github.com/brailcom/speechd/pull/996

https://github.com/NixOS/nixpkgs/compare/master...pinage404:nixpkgs:speechd-upgrade i let this branch here, in a hope that could give a little help when upgrading after the future release 

With piper, the linker fails, i don't understand why, i tried to add many things in a hope to fix it

While doing all of this thing, i refactored and did some small improvement that can be merge upstream

I tried to have [explicit commits](https://github.com/NixOS/nixpkgs/pull/470797/commits)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
