### PR TITLE
argo-workflows: 3.6.10 -> 3.7.6

### DIFF
--- a/pkgs/by-name/ar/argo-workflows/package.nix
+++ b/pkgs/by-name/ar/argo-workflows/package.nix
@@ -9,18 +9,24 @@
 
 buildGoModule rec {
   pname = "argo-workflows";
-  version = "3.6.10";
+  version = "3.7.6";
 
   src = fetchFromGitHub {
     owner = "argoproj";
     repo = "argo";
     tag = "v${version}";
-    hash = "sha256-TM/eK8biMxKV4SFJ1Lys+NPPeaHVjbBo83k2RH1Xi40=";
+    hash = "sha256-CeSXWtbwXnxATeLpiKdnxxWJhbMYkpAwjOAWq3ct+LQ=";
   };
 
-  vendorHash = "sha256-Y/2+ykzcJdA5uwP1v9Z1wZtF3hBV2x7XZc7+FhPJP64=";
+  vendorHash = "sha256-ePEAtQ3VnuhEoWgTSC3dMzu7/+fAAgDtnPRPvU2tAF0=";
 
   doCheck = false;
+
+  preBuild = ''
+    # Create placeholder file for UI's go:embed directive
+    mkdir -p ui/dist/app
+    touch ui/dist/app/index.html
+  '';
 
   subPackages = [
     "cmd/argo"


### PR DESCRIPTION
https://github.com/argoproj/argo-workflows/blob/main/CHANGELOG.md#v376-2025-12-09

A small change to how the UI is included in the binary meant adding a fake index.html which was handled. The CLI binary can also run as `argo-server` when it has the UI bundled in, but for most CLIs we just bake in a blank UI.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
