### PR TITLE
Revert "fetchurl, fetchgitlab: fix curlOpts extension"

### DIFF
--- a/pkgs/build-support/fetchgitlab/default.nix
+++ b/pkgs/build-support/fetchgitlab/default.nix
@@ -94,7 +94,7 @@ lib.makeOverridable (
               cat > private-token <<EOF
               PRIVATE-TOKEN: ''$${varBase}PASSWORD
               EOF
-              curlOpts+=(--header @./private-token)
+              curlOpts="$curlOpts --header @./private-token"
             ''
         );
         netrcImpureEnvVars = [

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -339,7 +339,7 @@ lib.extendMkDerivation {
         else
           ''
             ${netrcPhase}
-            curlOpts+=(--netrc-file "$PWD/netrc")
+            curlOpts="$curlOpts --netrc-file $PWD/netrc"
           '';
 
       inherit meta;


### PR DESCRIPTION
Reverts NixOS/nixpkgs#470550

PR #470550 is based on the assumption that `curlOpts` is passed as a Bash array since PR #464475 sets `__structuredAttrs = true` for all `fetchurl`-constructed FODs. However, `curlOpts` is only passed as a Bash array if it is specified as a list, and passing `curlOpts` has already been warned against before PR #464475.