### PR TITLE
lib/types: add types json from pkgs.formats

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -254,6 +254,19 @@ checkConfigError 'A definition for option .* is not of type .fileset.. Definitio
 checkConfigError 'A definition for option .* is not of type .fileset.. Definition values:\n.*' config.filesetCardinal.err3 ./fileset.nix
 checkConfigError 'A definition for option .* is not of type .fileset.. Definition values:\n.*' config.filesetCardinal.err4 ./fileset.nix
 
+# types.serializableValueWith
+checkConfigOutput '^null$' config.nullableValue.null ./types.nix
+checkConfigOutput '^true$' config.nullableValue.bool ./types.nix
+checkConfigOutput '^1$' config.nullableValue.int ./types.nix
+checkConfigOutput '^1.1$' config.nullableValue.float ./types.nix
+checkConfigOutput '^"foo"$' config.nullableValue.str ./types.nix
+checkConfigOutput '^".*/store.*"$' config.nullableValue.path ./types.nix
+STRICT_EVAL=1 checkConfigOutput '^\{"foo":1\}$' config.nullableValue.attrs ./types.nix
+STRICT_EVAL=1 checkConfigOutput '^\[\{"bar":\[1\]\}\]$' config.nullableValue.list ./types.nix
+
+checkConfigError 'A definition for option .* is not of type .VAL value.. .*' config.nullableValue.lambda ./types.nix
+checkConfigError 'A definition for option .* is not of type .VAL value.. .*' config.structuredValue.null ./types.nix
+
 # Check boolean option.
 checkConfigOutput '^false$' config.enable ./declare-enable.nix
 checkConfigError 'The option .* does not exist. Definition values:\n\s*- In .*: true' config.enable ./define-enable.nix

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -58,12 +58,19 @@ logFailure() {
 evalConfig() {
     local attr=$1
     shift
-    local script="import ./default.nix { modules = [ $* ];}"
+
+    local nix_args=()
+
     if [ "${ABORT_ON_WARN-0}" = "1" ]; then
-      local-nix-instantiate --option abort-on-warn true -E "$script" -A "$attr"
-    else
-      local-nix-instantiate -E "$script" -A "$attr"
+        nix_args+=(--option abort-on-warn true)
     fi
+
+    if [ "${STRICT_EVAL-0}" = "1" ]; then
+        nix_args+=(--strict)
+    fi
+
+    local script="import ./default.nix { modules = [ $* ];}"
+    local-nix-instantiate "${nix_args[@]}" -E "$script" -A "$attr"
 }
 
 reportFailure() {

--- a/lib/tests/modules/types.nix
+++ b/lib/tests/modules/types.nix
@@ -16,6 +16,19 @@ in
   options = {
     pathInStore = mkOption { type = types.lazyAttrsOf types.pathInStore; };
     externalPath = mkOption { type = types.lazyAttrsOf types.externalPath; };
+    # serializableValueWith
+    nullableValue = mkOption {
+      type = types.attrsOf (types.serializableValueWith { typeName = "VAL"; });
+    };
+    structuredValue = mkOption {
+      type = types.attrsOf (
+        types.serializableValueWith {
+          typeName = "VAL";
+          nullable = false;
+        }
+      );
+    };
+
     assertions = mkOption { };
   };
   config = {
@@ -34,6 +47,22 @@ in
     externalPath.bad5 = "./foo/bar";
     externalPath.ok1 = "/foo/bar";
     externalPath.ok2 = "/";
+
+    # serializableValueWith { nullable = true; }
+    nullableValue.null = null; # null
+    nullableValue.bool = true; # bool
+    nullableValue.int = 1; # int
+    nullableValue.float = 1.1; # float
+    nullableValue.str = "foo"; # str
+    nullableValue.path = ./.; # path
+    nullableValue.attrs = {
+      foo = 1;
+    };
+    nullableValue.list = [ { bar = [ 1 ]; } ]; # list
+    nullableValue.lambda = x: x; # Error
+
+    # serializableValueWith { nullable = false; }
+    structuredValue.null = null; # Error
 
     assertions =
       with lib.types;
@@ -486,6 +515,9 @@ in
       assert (unique { message = "custom"; } (listOf str)).description == "list of string";
       assert (unique { message = "test"; } (either int str)).description == "signed integer or string";
       assert (unique { message = "test"; } (listOf str)).description == "list of string";
+      # json & toml
+      assert json.description == "JSON value";
+      assert toml.description == "TOML value";
       # done
       "ok";
   };

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1437,6 +1437,45 @@ rec {
       };
     };
 
+  /**
+    Creates a value type suitable for serialization formats.
+
+    Parameters:
+    - typeName: String describing the format (e.g. "JSON", "YAML", "XML")
+    - nullable: Whether the structured value type allows `null` values.
+
+    Returns a type suitable for structured data formats that supports:
+    - Basic types: boolean, integer, float, string, path
+    - Complex types: attribute sets and lists
+  */
+  serializableValueWith =
+    {
+      typeName,
+      nullable ? true,
+    }:
+    let
+      baseType = oneOf [
+        bool
+        int
+        float
+        str
+        path
+        (attrsOf valueType)
+        (listOf valueType)
+      ];
+      valueType = (if nullable then nullOr baseType else baseType) // {
+        description = "${typeName} value";
+      };
+    in
+    valueType;
+
+  json = serializableValueWith { typeName = "JSON"; };
+
+  toml = serializableValueWith {
+    typeName = "TOML";
+    nullable = false;
+  };
+
   # Either value of type `t1` or `t2`.
   either =
     t1: t2:

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -497,6 +497,20 @@ Composed types are types that take a type as parameter. `listOf
     value of type *`to`*. Can be used to preserve backwards compatibility
     of an option if its type was changed.
 
+`types.json`
+
+:   A type representing JSON-compatible values. This includes `null`, booleans,
+    integers, floats, strings, paths, attribute sets, and lists.
+    Attribute sets and lists can be arbitrarily nested and contain any JSON-compatible
+    values.
+
+`types.toml`
+
+:   A type representing TOML-compatible values. This includes booleans,
+    integers, floats, strings, paths, attribute sets, and lists.
+    Attribute sets and lists can be arbitrarily nested and contain any TOML-compatible
+    values.
+
 ## Submodule {#section-option-types-submodule}
 
 `submodule` is a very powerful type that defines a set of sub-options


### PR DESCRIPTION
Motivation:

Issue: https://github.com/NixOS/nixpkgs/issues/468919

Description of the change: 

Move `mkStructuredType` from pkgs-lib to lib.types

Add `lib.types`

- `json` defined as `mkStructuredType { typeName = "JSON"; nullable = true; }`
- `toml` defined as `mkStructuredType { typeName = "TOML"; nullable = false; }`

- [x] add unit tests for the types

Todo:

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
