### PR TITLE
mir: 2.23.0 -> 2.25.2

### DIFF
--- a/pkgs/by-name/mi/miracle-wm/package.nix
+++ b/pkgs/by-name/mi/miracle-wm/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  fetchpatch,
   gitUpdater,
   nixosTests,
   boost,
@@ -40,10 +41,26 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-RzqF3UDC4MY85ex9TOD2L0Zd7T6mgiZ+ImJuJG+xtjo=";
   };
 
+  patches = [
+    # Fix compat with newer Mir
+    # Remove when version > 0.8.2
+    (fetchpatch {
+      url = "https://github.com/miracle-wm-org/miracle-wm/commit/3f3389bf49ad780d258d34109f87e73ef7c02344.patch";
+      hash = "sha256-dxrYfn/MhpCkgsmunMAl5TrPxY8FO0dqQf4LYcuiFGk=";
+    })
+  ];
+
   postPatch = ''
     substituteInPlace CMakeLists.txt \
       --replace-fail 'DESTINATION /usr/lib' 'DESTINATION ''${CMAKE_INSTALL_LIBDIR}' \
-      --replace-fail '-march=native' '# -march=native' \
+      --replace-fail '-march=native' '# -march=native'
+  ''
+  # Fix compat with newer Mir
+  # https://github.com/miracle-wm-org/miracle-wm/commit/aaae6e64261d8a00c2a1df47e2eab99400382d69
+  # Remove when version > 0.8.2
+  + ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'pkg_check_modules(MIRRENDERER REQUIRED mirrenderer' 'pkg_check_modules(MIRRENDERER mirrenderer'
   ''
   + lib.optionalString (!finalAttrs.finalPackage.doCheck) ''
     substituteInPlace CMakeLists.txt \

--- a/pkgs/servers/mir/common.nix
+++ b/pkgs/servers/mir/common.nix
@@ -1,10 +1,13 @@
 {
   stdenv,
+  rustPlatform,
   lib,
   fetchFromGitHub,
   nixosTests,
   testers,
+  cargo,
   cmake,
+  ctestCheckHook,
   pkg-config,
   python3,
   boost,
@@ -46,216 +49,241 @@
   version,
   pinned ? false,
   hash,
+  cargoHash ? null,
   patches ? [ ],
 }:
 
-stdenv.mkDerivation (finalAttrs: {
-  pname = "mir";
-  inherit version;
+stdenv.mkDerivation (
+  finalAttrs:
+  {
+    pname = "mir";
+    inherit version;
 
-  src = fetchFromGitHub {
-    owner = "canonical";
-    repo = "mir";
-    rev = "v${finalAttrs.version}";
-    inherit hash;
-  };
+    src = fetchFromGitHub {
+      owner = "canonical";
+      repo = "mir";
+      rev = "v${finalAttrs.version}";
+      inherit hash;
+    };
 
-  inherit patches;
+    inherit patches;
 
-  postPatch = ''
-    # Fix scripts that get run in tests
-    patchShebangs tools/detect_fd_leaks.bash tests/acceptance-tests/wayland-generator/test_wayland_generator.sh.in
+    postPatch = ''
+      # Fix scripts that get run in tests
+      patchShebangs tools/detect_fd_leaks.bash tests/acceptance-tests/wayland-generator/test_wayland_generator.sh.in
 
-    # Fix LD_PRELOADing in tests
-    substituteInPlace \
-      cmake/MirCommon.cmake \
-      tests/umock-acceptance-tests/CMakeLists.txt \
-      tests/unit-tests/platforms/gbm-kms/kms/CMakeLists.txt \
-      tests/unit-tests/CMakeLists.txt \
-      --replace-warn 'LD_PRELOAD=liblttng-ust-fork.so' 'LD_PRELOAD=${lib.getLib lttng-ust}/lib/liblttng-ust-fork.so' \
-      --replace-warn 'LD_PRELOAD=libumockdev-preload.so.0' 'LD_PRELOAD=${lib.getLib umockdev}/lib/libumockdev-preload.so.0'
+      # Fix LD_PRELOADing in tests
+      substituteInPlace \
+        cmake/MirCommon.cmake \
+        tests/umock-acceptance-tests/CMakeLists.txt \
+        tests/unit-tests/platforms/gbm-kms/kms/CMakeLists.txt \
+        tests/unit-tests/CMakeLists.txt \
+        --replace-warn 'LD_PRELOAD=liblttng-ust-fork.so' 'LD_PRELOAD=${lib.getLib lttng-ust}/lib/liblttng-ust-fork.so' \
+        --replace-warn 'LD_PRELOAD=libumockdev-preload.so.0' 'LD_PRELOAD=${lib.getLib umockdev}/lib/libumockdev-preload.so.0'
 
-    # Fix Xwayland default
-    substituteInPlace src/miral/x11_support.cpp \
-      --replace-fail '/usr/bin/Xwayland' '${lib.getExe xwayland}'
-  ''
-  + lib.optionalString (lib.strings.versionOlder version "2.18.0") ''
+      # Fix Xwayland default
+      substituteInPlace src/miral/x11_support.cpp \
+        --replace-fail '/usr/bin/Xwayland' '${lib.getExe xwayland}'
+    ''
+    + lib.optionalString (lib.strings.versionOlder version "2.18.0") ''
 
-    # Fix paths for generating drm-formats
-    substituteInPlace src/platform/graphics/CMakeLists.txt \
-      --replace-fail "/usr/include/drm/drm_fourcc.h" "${lib.getDev libdrm}/include/libdrm/drm_fourcc.h" \
-      --replace-fail "/usr/include/libdrm/drm_fourcc.h" "${lib.getDev libdrm}/include/libdrm/drm_fourcc.h"
-  '';
+      # Fix paths for generating drm-formats
+      substituteInPlace src/platform/graphics/CMakeLists.txt \
+        --replace-fail "/usr/include/drm/drm_fourcc.h" "${lib.getDev libdrm}/include/libdrm/drm_fourcc.h" \
+        --replace-fail "/usr/include/libdrm/drm_fourcc.h" "${lib.getDev libdrm}/include/libdrm/drm_fourcc.h"
+    '';
 
-  strictDeps = true;
+    strictDeps = true;
 
-  nativeBuildInputs = [
-    cmake
-    glib # gdbus-codegen
-    lttng-ust # lttng-gen-tp
-    pkg-config
-    (python3.withPackages (
-      ps:
-      with ps;
-      [ pillow ]
-      ++ lib.optionals finalAttrs.finalPackage.doCheck [
-        pygobject3
-        python-dbusmock
-      ]
-    ))
-    validatePkgConfig
-    wayland-scanner
-  ];
-
-  buildInputs = [
-    boost
-    egl-wayland
-    freetype
-    glib
-    glm
-    libdrm
-    libepoxy
-    libevdev
-    libglvnd
-    libinput
-    libuuid
-    libxcb
-    libxkbcommon
-    libxmlxx
-    yaml-cpp
-    lttng-ust
-    libgbm
-    nettle
-    udev
-    wayland
-    xorg.libX11
-    xorg.libXcursor
-    xorg.xorgproto
-    xwayland
-  ]
-  ++ lib.optionals (lib.strings.versionAtLeast version "2.18.0") [
-    libapparmor
-  ]
-  ++ lib.optionals (lib.strings.versionAtLeast version "2.21.0") [
-    pixman
-  ]
-  ++ lib.optionals (lib.strings.versionAtLeast version "2.22.0") [
-    libdisplay-info
-  ];
-
-  nativeCheckInputs = [
-    dbus
-    gobject-introspection
-  ]
-  ++ lib.optionals (lib.strings.versionAtLeast version "2.22.0") [
-    mesa.llvmpipeHook
-  ]
-  ++ lib.optionals (lib.strings.versionAtLeast version "2.23.0") [
-    xwayland
-  ];
-
-  checkInputs = [
-    gtest
-    umockdev
-    wlcs
-  ];
-
-  cmakeFlags = [
-    (lib.cmakeBool "BUILD_DOXYGEN" false)
-    (lib.cmakeFeature "MIR_PLATFORM" (
-      lib.strings.concatStringsSep ";" [
-        "atomic-kms"
-        "gbm-kms"
-        "eglstream-kms"
-        "x11"
-        "wayland"
-      ]
-    ))
-    (lib.cmakeBool "MIR_ENABLE_TESTS" finalAttrs.finalPackage.doCheck)
-    # BadBufferTest.test_truncated_shm_file *doesn't* throw an error as the test expected, mark as such
-    # https://github.com/canonical/mir/pull/1947#issuecomment-811810872
-    (lib.cmakeBool "MIR_SIGBUS_HANDLER_ENVIRONMENT_BROKEN" true)
-    (lib.cmakeFeature "MIR_EXCLUDE_TESTS" (
-      lib.strings.concatStringsSep ";" (
-        lib.optionals (lib.strings.versionOlder version "2.22.0") [
-          # https://github.com/canonical/mir/issues/3716#issuecomment-2580698552
-          "UdevWrapperTest.UdevMonitorDoesNotTriggerBeforeEnabling"
+    nativeBuildInputs = [
+      cmake
+      glib # gdbus-codegen
+      lttng-ust # lttng-gen-tp
+      pkg-config
+      (python3.withPackages (
+        ps:
+        with ps;
+        [ pillow ]
+        ++ lib.optionals finalAttrs.finalPackage.doCheck [
+          pygobject3
+          python-dbusmock
         ]
-      )
-    ))
-    # These get built but don't get executed by default, yet they get installed when tests are enabled
-    (lib.cmakeBool "MIR_BUILD_PERFORMANCE_TESTS" false)
-    (lib.cmakeBool "MIR_BUILD_PLATFORM_TEST_HARNESS" false)
-    # https://github.com/canonical/mir/issues/2987
-    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=106799
-    (lib.cmakeBool "MIR_USE_PRECOMPILED_HEADERS" false)
-    (lib.cmakeFeature "MIR_COMPILER_QUIRKS" (
-      lib.strings.concatStringsSep ";" (
-        lib.optionals (lib.strings.versionOlder version "2.22.0") [
-          # https://github.com/canonical/mir/issues/3017 actually affects x86_64 as well
-          "test_touchspot_controller.cpp:array-bounds"
-        ]
-      )
-    ))
-  ];
-
-  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
-
-  preCheck = ''
-    export HOME=$TMP # shader cache
-    export XDG_RUNTIME_DIR=$TMP
-  '';
-
-  outputs = [
-    "out"
-    "dev"
-  ];
-
-  passthru = {
-    tests = {
-      pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-    }
-    // lib.optionalAttrs (!pinned) { inherit (nixosTests) miriway miracle-wm; };
-    providedSessions = lib.optionals (lib.strings.versionOlder version "2.16.0") [
-      # More of an example than a fully functioning shell, some notes for the adventurous:
-      # - ~/.config/miral-shell.config is one possible user config location,
-      #   accepted options=value are according to `mir-shell --help`
-      # - default icon theme setting is DMZ-White, needs vanilla-dmz installed & on XCURSOR_PATH
-      #   or setting to be changed to an available theme
-      # - terminal emulator setting may need to be changed if miral-terminal script
-      #   does not know about preferred terminal
-      "mir-shell"
-    ];
-  }
-  // lib.optionalAttrs (!pinned) { updateScript = ./update.sh; };
-
-  meta = {
-    description = "Display server and Wayland compositor developed by Canonical";
-    homepage = "https://mir-server.io";
-    changelog = "https://github.com/canonical/mir/releases/tag/v${finalAttrs.version}";
-    license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [
-      OPNA2608
-    ];
-    # Onle LE has valid graphics buffer formats
-    # https://github.com/canonical/mir/blob/ba8e83f75084379dec8e23131fdf04fa4a4567ac/src/platforms/common/server/shm_buffer.cpp#L61-L65
-    platforms = lib.lists.intersectLists lib.platforms.linux lib.platforms.littleEndian;
-    pkgConfigModules = [
-      "miral"
-      "mircommon"
-      "mircore"
-      "miroil"
-      "mirplatform"
-      "mir-renderer-gl-dev"
-      "mirrenderer"
-      "mirserver"
-      "mirtest"
-      "mirwayland"
+      ))
+      validatePkgConfig
+      wayland-scanner
     ]
-    ++ lib.optionals (lib.strings.versionOlder version "2.17.0") [ "mircookie" ]
-    ++ lib.optionals (lib.strings.versionAtLeast version "2.17.0") [
-      "mircommon-internal"
-      "mirserver-internal"
+    ++ lib.optionals (lib.strings.versionAtLeast version "2.22.0") [
+      rustPlatform.cargoSetupHook
+      cargo
     ];
-  };
-})
+
+    buildInputs = [
+      boost
+      egl-wayland
+      freetype
+      glib
+      glm
+      libdrm
+      libepoxy
+      libevdev
+      libglvnd
+      libinput
+      libuuid
+      libxcb
+      libxkbcommon
+      libxmlxx
+      yaml-cpp
+      lttng-ust
+      libgbm
+      nettle
+      udev
+      wayland
+      xorg.libX11
+      xorg.libXcursor
+      xorg.xorgproto
+      xwayland
+    ]
+    ++ lib.optionals (lib.strings.versionAtLeast version "2.18.0") [
+      libapparmor
+    ]
+    ++ lib.optionals (lib.strings.versionAtLeast version "2.21.0") [
+      pixman
+    ]
+    ++ lib.optionals (lib.strings.versionAtLeast version "2.22.0") [
+      libdisplay-info
+    ];
+
+    nativeCheckInputs = [
+      ctestCheckHook
+      dbus
+      gobject-introspection
+    ]
+    ++ lib.optionals (lib.strings.versionAtLeast version "2.22.0") [
+      mesa.llvmpipeHook
+    ]
+    ++ lib.optionals (lib.strings.versionAtLeast version "2.23.0") [
+      xwayland
+    ];
+
+    checkInputs = [
+      gtest
+      umockdev
+      wlcs
+    ];
+
+    cmakeFlags = [
+      (lib.cmakeBool "BUILD_DOXYGEN" false)
+      (lib.cmakeFeature "MIR_PLATFORM" (
+        lib.strings.concatStringsSep ";" [
+          "atomic-kms"
+          "gbm-kms"
+          "eglstream-kms"
+          "x11"
+          "wayland"
+        ]
+      ))
+      (lib.cmakeBool "MIR_ENABLE_TESTS" finalAttrs.finalPackage.doCheck)
+      # BadBufferTest.test_truncated_shm_file *doesn't* throw an error as the test expected, mark as such
+      # https://github.com/canonical/mir/pull/1947#issuecomment-811810872
+      (lib.cmakeBool "MIR_SIGBUS_HANDLER_ENVIRONMENT_BROKEN" true)
+      (lib.cmakeFeature "MIR_EXCLUDE_TESTS" (
+        lib.strings.concatStringsSep ";" (
+          lib.optionals (lib.strings.versionOlder version "2.22.0") [
+            # https://github.com/canonical/mir/issues/3716#issuecomment-2580698552
+            "UdevWrapperTest.UdevMonitorDoesNotTriggerBeforeEnabling"
+          ]
+        )
+      ))
+      # These get built but don't get executed by default, yet they get installed when tests are enabled
+      (lib.cmakeBool "MIR_BUILD_PERFORMANCE_TESTS" false)
+      (lib.cmakeBool "MIR_BUILD_PLATFORM_TEST_HARNESS" false)
+      (lib.cmakeBool "MIR_USE_APPARMOR" true)
+      (lib.cmakeBool "MIR_ENABLE_RUST" true)
+      # https://github.com/canonical/mir/issues/2987
+      # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=106799
+      (lib.cmakeBool "MIR_USE_PRECOMPILED_HEADERS" false)
+      (lib.cmakeFeature "MIR_COMPILER_QUIRKS" (
+        lib.strings.concatStringsSep ";" (
+          lib.optionals (lib.strings.versionOlder version "2.22.0") [
+            # https://github.com/canonical/mir/issues/3017 actually affects x86_64 as well
+            "test_touchspot_controller.cpp:array-bounds"
+          ]
+        )
+      ))
+    ];
+
+    doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+    disabledTests = lib.optionals (lib.strings.versionAtLeast version "2.25.0") [
+      # We don't care about the documentation, so we also don't care if there are any changes in it
+      "verify-options-reference-unchanged"
+    ];
+
+    preCheck = ''
+      export HOME=$TMP # shader cache
+      export XDG_RUNTIME_DIR=$TMP
+    '';
+
+    outputs = [
+      "out"
+      "dev"
+    ];
+
+    passthru = {
+      tests = {
+        pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+      }
+      // lib.optionalAttrs (!pinned) { inherit (nixosTests) miriway miracle-wm; };
+      providedSessions = lib.optionals (lib.strings.versionOlder version "2.16.0") [
+        # More of an example than a fully functioning shell, some notes for the adventurous:
+        # - ~/.config/miral-shell.config is one possible user config location,
+        #   accepted options=value are according to `mir-shell --help`
+        # - default icon theme setting is DMZ-White, needs vanilla-dmz installed & on XCURSOR_PATH
+        #   or setting to be changed to an available theme
+        # - terminal emulator setting may need to be changed if miral-terminal script
+        #   does not know about preferred terminal
+        "mir-shell"
+      ];
+    }
+    // lib.optionalAttrs (!pinned) { updateScript = ./update.sh; };
+
+    meta = {
+      description = "Display server and Wayland compositor developed by Canonical";
+      homepage = "https://mir-server.io";
+      changelog = "https://github.com/canonical/mir/releases/tag/v${finalAttrs.version}";
+      license = lib.licenses.gpl2Plus;
+      maintainers = with lib.maintainers; [
+        OPNA2608
+      ];
+      # Onle LE has valid graphics buffer formats
+      # https://github.com/canonical/mir/blob/ba8e83f75084379dec8e23131fdf04fa4a4567ac/src/platforms/common/server/shm_buffer.cpp#L61-L65
+      platforms = lib.lists.intersectLists lib.platforms.linux lib.platforms.littleEndian;
+      pkgConfigModules = [
+        "miral"
+        "mircommon"
+        "mircore"
+        "miroil"
+        "mirplatform"
+        "mirserver"
+        "mirtest"
+        "mirwayland"
+      ]
+      ++ lib.optionals (lib.strings.versionOlder version "2.17.0") [ "mircookie" ]
+      ++ lib.optionals (lib.strings.versionAtLeast version "2.17.0") [
+        "mircommon-internal"
+        "mirserver-internal"
+      ]
+      ++ lib.optionals (lib.strings.versionOlder version "2.25.0") [
+        "mir-renderer-gl-dev"
+        "mirrenderer"
+      ];
+    };
+  }
+  // lib.optionalAttrs (lib.strings.versionAtLeast version "2.22.0") {
+    cargoDeps = rustPlatform.fetchCargoVendor {
+      src = finalAttrs.src;
+      sourceRoot = finalAttrs.src.name;
+      hash = cargoHash;
+    };
+  }
+)

--- a/pkgs/servers/mir/default.nix
+++ b/pkgs/servers/mir/default.nix
@@ -5,8 +5,8 @@ let
 in
 {
   mir = common {
-    version = "2.25.1";
-    hash = "sha256-i2kvOCP6uomRmg0GlGk2AJCTehW+uN91zZ3NQh1A/rw=";
+    version = "2.25.2";
+    hash = "sha256-+nahWuAcGWgxBM6/a2HWwDw5DkQpUt5i/CEGzTLwNQw=";
     cargoHash = "sha256-fVD+RGU/2UGVihIktKg2+eDWmlWomDOAcrY6k2XwF1c=";
   };
 

--- a/pkgs/servers/mir/default.nix
+++ b/pkgs/servers/mir/default.nix
@@ -5,8 +5,9 @@ let
 in
 {
   mir = common {
-    version = "2.23.0";
-    hash = "sha256-Sib2dxNDxyJCJwxuP8TVphdZvnkrn+8/t7cnEjfXIsw=";
+    version = "2.25.1";
+    hash = "sha256-i2kvOCP6uomRmg0GlGk2AJCTehW+uN91zZ3NQh1A/rw=";
+    cargoHash = "sha256-fVD+RGU/2UGVihIktKg2+eDWmlWomDOAcrY6k2XwF1c=";
   };
 
   mir_2_15 = common {

--- a/pkgs/servers/mir/update.sh
+++ b/pkgs/servers/mir/update.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl gnused jq common-updater-scripts
-
-set -eou pipefail
-
-version="$(curl --silent "https://api.github.com/repos/canonical/mir/tags" | jq '.[0].name' --raw-output)"
-
-update-source-version mir "${version:1}" --file=./pkgs/servers/mir/default.nix


### PR DESCRIPTION
Adds support for building the Rust platform module. `mir.passthru.updateScript` will need some changes to support that. Don't know if I have the spoons for that rn…

https://github.com/canonical/mir/releases/tag/v2.25.0
https://github.com/canonical/mir/releases/tag/v2.25.1
https://github.com/canonical/mir/releases/tag/v2.25.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
