### PR TITLE
mdbook-cmdrun,mealie: use nodejs, not nodePackages.nodejs

### DIFF
--- a/pkgs/by-name/md/mdbook-cmdrun/package.nix
+++ b/pkgs/by-name/md/mdbook-cmdrun/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   mdbook,
-  nodePackages,
+  nodejs,
   python3,
   util-linux,
   rustPlatform,
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage {
 
   nativeCheckInputs = [
     mdbook # used by tests/book.rs
-    nodePackages.nodejs # used by tests/regression/inline_call/input.md
+    nodejs # used by tests/regression/inline_call/input.md
     python3 # used by tests/regression/py_*
     util-linux # used by tests/regression/shell/input.md
   ];

--- a/pkgs/by-name/me/mealie/mealie-frontend.nix
+++ b/pkgs/by-name/me/mealie/mealie-frontend.nix
@@ -4,15 +4,12 @@ src: version:
   fetchFromGitHub,
   fetchYarnDeps,
   dart-sass,
-  nodePackages_latest,
+  nodejs,
   fixup-yarn-lock,
   stdenv,
   yarn,
   writableTmpDirAsHomeHook,
 }:
-let
-  nodejs = nodePackages_latest.nodejs;
-in
 stdenv.mkDerivation {
   name = "mealie-frontend";
   inherit version;


### PR DESCRIPTION
No reason for them to be doing this.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
