### PR TITLE
libkrun-efi: 1.15.1 -> 1.16.0

### DIFF
--- a/pkgs/by-name/li/libkrun-efi/package.nix
+++ b/pkgs/by-name/li/libkrun-efi/package.nix
@@ -8,18 +8,27 @@
   libkrun-efi,
   moltenvk,
   pkg-config,
+  buildPackages,
   rustc,
   rustPlatform,
   rutabaga_gfx,
   nix-update-script,
   stdenv,
-  buildPackages,
   meson,
   ninja,
   vulkan-headers,
   withGpu ? true,
 }:
 let
+  version = "1.16.0";
+
+  src = fetchFromGitHub {
+    owner = "containers";
+    repo = "libkrun";
+    tag = "v${version}";
+    hash = "sha256-ZMR6+psxA8IOidilcZxoiwiL4Npo6kBmGDt/96oTjdE=";
+  };
+
   virglrenderer = stdenv.mkDerivation (finalAttrs: {
     pname = "virglrenderer";
     version = "0.10.4d-krunkit";
@@ -59,17 +68,30 @@ let
       maintainers = [ lib.maintainers.quinneden ];
     };
   });
+
+  initBinary = buildPackages.pkgsCross.aarch64-multiplatform.pkgsStatic.stdenv.mkDerivation {
+    pname = "libkrun-init";
+    inherit version src;
+
+    dontConfigure = true;
+
+    buildPhase = ''
+      runHook preBuild
+      cd init
+      $CC -O2 -static -Wall -o init init.c
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      install -D init $out/init
+      runHook postInstall
+    '';
+  };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "libkrun-efi";
-  version = "1.15.1";
-
-  src = fetchFromGitHub {
-    owner = "containers";
-    repo = "libkrun";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-VhlFyYJ/TH12I3dUq0JTus60rQEJq5H4Pm1puCnJV5A=";
-  };
+  inherit version src;
 
   outputs = [
     "out"
@@ -77,8 +99,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
-    hash = "sha256-dK3V7HCCvTqmQhB5Op2zmBPa9FO3h9gednU9tpQk+1U=";
+    inherit src;
+    hash = "sha256-WZDLz560Un+2P+I6y9V3RB4jiHW0NLN0X8y2TAvwFp8=";
   };
 
   nativeBuildInputs = [
@@ -101,6 +123,10 @@ stdenv.mkDerivation (finalAttrs: {
     "EFI=1"
   ]
   ++ lib.optional withGpu "GPU=1";
+
+  preBuild = ''
+    cp ${initBinary}/init init/init
+  '';
 
   passthru = {
     tests.withoutGpu = libkrun-efi.override { withGpu = false; };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

libkrun-efi: 1.15.1 -> 1.16.0

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
