### PR TITLE
python3Packages.keyutils: use debian source as github source has disappeared

### DIFF
--- a/pkgs/development/python-modules/keyutils/default.nix
+++ b/pkgs/development/python-modules/keyutils/default.nix
@@ -2,22 +2,20 @@
   lib,
   buildPythonPackage,
   cython,
-  fetchFromGitHub,
+  fetchzip,
   keyutils,
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "keyutils";
   version = "0.6";
   format = "setuptools";
 
   # github version comes bundled with tests
-  src = fetchFromGitHub {
-    owner = "sassoftware";
-    repo = "python-keyutils";
-    rev = version;
-    sha256 = "0pfqfr5xqgsqkxzrmj8xl2glyl4nbq0irs0k6ik7iy3gd3mxf5g1";
+  src = fetchzip {
+    url = "http://deb.debian.org/debian/pool/main/p/python-keyutils/python-keyutils_0.6.orig.tar.gz";
+    hash = "sha256-/oL510Qi6ryugCuqx8/jPQGYlhGKDlMY54+2a9NTM88=";
   };
 
   postPatch = ''
@@ -34,7 +32,7 @@ buildPythonPackage rec {
 
   buildInputs = [ keyutils ];
   nativeBuildInputs = [ cython ];
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [ ];
 
   meta = {
     description = "Set of python bindings for keyutils";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This changes python-keyutils to rely on the debian sources for python-keyutils. It seems the github repo https://github.com/sassoftware/python-keyutils has disappeared? I wasn't sure what to do when I encountered this, but this was the best solution that I found. Input on alternative sources is welcome.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
