### PR TITLE
python3Packages.sqlalchemy-utils: revert to existing version

### DIFF
--- a/pkgs/development/python-modules/sqlalchemy-utils/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy-utils/default.nix
@@ -31,7 +31,7 @@
 
 buildPythonPackage rec {
   pname = "sqlalchemy-utils";
-  version = "0.42.2";
+  version = "0.42.1";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     owner = "kvesteri";
     repo = "sqlalchemy-utils";
     tag = version;
-    hash = "sha256-jC8onlCiuzpMlJ3EzpzCnQ128xpkLzrZEuGWQv7pvVE=";
+    hash = "sha256-lqtuIOeRqjaDohejZOQv6uXQ6JG/WpdcfrSBK8q4wVs=";
   };
 
   patches = [ ./skip-database-tests.patch ];

--- a/pkgs/development/python-modules/sqlalchemy-utils/skip-database-tests.patch
+++ b/pkgs/development/python-modules/sqlalchemy-utils/skip-database-tests.patch
@@ -1,16 +1,13 @@
-diff --git a/conftest.py b/conftest.py
-index 4426e02..1f84096 100644
---- a/conftest.py
-+++ b/conftest.py
-@@ -73,17 +73,12 @@ def mysql_db_user():
- @pytest.fixture
- def postgresql_dsn(postgresql_db_user, postgresql_db_password, postgresql_db_host,
-                    db_name):
+diff --git a/tests/conftest.py b/tests/conftest.py
+index c63468c..4c1c061 100644
+--- a/tests/conftest.py
++++ b/tests/conftest.py
+@@ -64,29 +64,27 @@ def mysql_db_user():
+ def postgresql_dsn(
+     postgresql_db_user, postgresql_db_password, postgresql_db_host, db_name
+ ):
 -    return 'postgresql://{}:{}@{}/{}'.format(
--        postgresql_db_user,
--        postgresql_db_password,
--        postgresql_db_host,
--        db_name
+-        postgresql_db_user, postgresql_db_password, postgresql_db_host, db_name
 -    )
 +    pytest.skip()
  
@@ -22,12 +19,33 @@ index 4426e02..1f84096 100644
  
  
  @pytest.fixture
-@@ -121,8 +116,7 @@ def mssql_db_driver():
+ def sqlite_memory_dsn():
+-    return 'sqlite:///:memory:'
++    pytest.skip()
+ 
+ 
+ @pytest.fixture
+ def sqlite_none_database_dsn():
+-    return 'sqlite://'
++    pytest.skip()
+ 
+ 
+ @pytest.fixture
+ def sqlite_file_dsn(db_name):
+-    return f'sqlite:///{db_name}.db'
++    pytest.skip()
+ 
+ 
+ @pytest.fixture
+@@ -109,11 +107,7 @@ def mssql_db_driver():
  
  @pytest.fixture
  def mssql_dsn(mssql_db_user, mssql_db_password, mssql_db_driver, db_name):
--    return 'mssql+pyodbc://{}:{}@localhost/{}?driver={}'\
--        .format(mssql_db_user, mssql_db_password, db_name, mssql_db_driver)
+-    return (
+-        'mssql+pyodbc://{}:{}@localhost/{}?driver={}&TrustServerCertificate=yes'.format(
+-            mssql_db_user, mssql_db_password, db_name, mssql_db_driver
+-        )
+-    )
 +    pytest.skip()
  
  


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This reverts sqlalchemy to version 42.1, 42.2 does not exist in the upstream repo. It also fixes the tests to correspond to where the conftests file is in the upstream repo and removes the tests for the additional database sources as well.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
