### PR TITLE
mariokart64recomp: 0.9.1-unstable-2025-10-02 -> 0.9.1-unstable-2025-10-15, fix fetching src

### DIFF
--- a/pkgs/by-name/ma/mariokart64recomp/package.nix
+++ b/pkgs/by-name/ma/mariokart64recomp/package.nix
@@ -14,11 +14,9 @@
   SDL2,
   gtk3,
   vulkan-loader,
-  graphicsmagick,
   makeDesktopItem,
   n64recomp,
   directx-shader-compiler,
-  sdl_gamecontrollerdb,
   forceX11 ? false,
 }:
 
@@ -44,21 +42,20 @@ in
 
 llvmPackages_19.stdenv.mkDerivation (finalAttrs: {
   pname = "mariokart64recomp";
-  version = "0.9.1-unstable-2025-10-02";
+  version = "0.9.1-unstable-2025-10-15";
 
-  src =
-    (fetchFromGitHub {
-      owner = "sonicdcer";
-      repo = "MarioKart64Recomp";
-      rev = "6f5791b3f4eae60bd341502b7af71372a9d531a9";
-      hash = "sha256-qVAXFUJYR4Q7WfbuY0h7ZhvIsgkfpD5W0eo5mUv4TEg=";
-      fetchSubmodules = true;
-    }).overrideAttrs
-      (_: {
-        GIT_CONFIG_COUNT = 1;
-        GIT_CONFIG_KEY_0 = "url.https://github.com/.insteadOf";
-        GIT_CONFIG_VALUE_0 = "git@github.com:";
-      });
+  src = fetchFromGitHub {
+    owner = "sonicdcer";
+    repo = "MarioKart64Recomp";
+    rev = "f019c3906d47cddbc8bcbea744948b9f4825f54d";
+    hash = "sha256-lMN7FY9EvFbHEc3bLiTWP9LS15syo7dANxeFOpS4YaA=";
+    preFetch = ''
+      export GIT_CONFIG_COUNT=1
+      export GIT_CONFIG_KEY_0=url.https://github.com/.insteadOf
+      export GIT_CONFIG_VALUE_0=git@github.com:
+    '';
+    fetchSubmodules = true;
+  };
 
   strictDeps = true;
 


### PR DESCRIPTION
Fixes: https://github.com/NixOS/nixpkgs/issues/473021

Diff: https://github.com/sonicdcer/MarioKart64Recomp/compare/6f5791b3f4eae60bd341502b7af71372a9d531a9..f019c3906d47cddbc8bcbea744948b9f4825f54d

Also rework the git -> https override since it fails with recent fetchgit changes


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
