### PR TITLE
pkgs.timegap: init

### DIFF
--- a/pkgs/by-name/ti/timegap/package.nix
+++ b/pkgs/by-name/ti/timegap/package.nix
@@ -1,0 +1,24 @@
+{ lib, stdenv, fetchurl, meson, ninja }:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "timegap";
+  version = "8a822d4c21";
+
+  src = fetchurl {
+    url =
+      "https://codeberg.org/sphi/timegap/archive/${finalAttrs.version}.tar.gz";
+    hash = "sha256-aDLuxDWx5MIRJ7qIaJ5y4MYpToniy3xIvlISJtmBxUM=";
+  };
+
+  nativeBuildInputs = [ meson ninja ];
+
+  meta = {
+    description = ''
+      A tool to add timestamps to output lines of an arbitrary program and/or
+      display the duration of gaps between output lines.'';
+    license = lib.licenses.mit;
+    homepage = "https://codeberg.org/sphi/timegap";
+    mainProgram = "tg";
+    maintainers = with lib.maintainers; [ glittershark ];
+  };
+})


### PR DESCRIPTION
Add pkgs.timegap, a simple program for displaying the time delay between lines of output in a command

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
