### PR TITLE
cavasik: init at 3.2.0

### DIFF
--- a/pkgs/by-name/ca/cavasik/package.nix
+++ b/pkgs/by-name/ca/cavasik/package.nix
@@ -1,0 +1,83 @@
+{
+  cava,
+  desktop-file-utils,
+  fetchFromGitHub,
+  gobject-introspection,
+  gst_all_1,
+  gtk4,
+  lib,
+  libadwaita,
+  meson,
+  ninja,
+  nix-update-script,
+  pkg-config,
+  python3Packages,
+  wrapGAppsHook4,
+}:
+
+let
+  pname = "cavasik";
+  version = "3.2.0";
+in
+python3Packages.buildPythonApplication {
+  inherit pname version;
+
+  pyproject = false; # Built with meson
+
+  src = fetchFromGitHub {
+    owner = "TheWisker";
+    repo = "Cavasik";
+    tag = "v${version}";
+    hash = "sha256-O8rFtqzmDktXKF3219RAo1yxqjfPm1qkHhAyoT7N8AU=";
+  };
+
+  postPatch = ''
+    substituteInPlace src/cava.py \
+      --replace-fail '"cava"' '"${lib.getExe cava}"'
+  '';
+
+  nativeBuildInputs = [
+    desktop-file-utils
+    gobject-introspection
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    gst_all_1.gstreamer
+    gtk4
+    libadwaita
+  ];
+
+  dependencies = with python3Packages; [
+    pycairo
+    pydbus
+    pygobject3
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    meson test --print-errorlog
+
+    runHook postCheck
+  '';
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=(''${gappsWrapperArgs[@]})
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Audio visualizer based on CAVA with extended capabilities";
+    mainProgram = "cavasik";
+    homepage = "https://github.com/TheWisker/Cavasik";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ starryreverie ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This PR adds `cavasik`, an audio visualizer based on CAVA with extended capabilities.

Home page: <https://github.com/TheWisker/Cavasik>.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
