### PR TITLE
pywal16: fix missing dependency; allow build with backends

### DIFF
--- a/pkgs/by-name/py/pywal16/package.nix
+++ b/pkgs/by-name/py/pywal16/package.nix
@@ -2,9 +2,17 @@
   lib,
   python3,
   fetchFromGitHub,
-  imagemagick,
   installShellFiles,
   nix-update-script,
+
+  imagemagick,
+  colorz,
+
+  withColorthief ? false,
+  withColorz ? false,
+  withFastColorthief ? false,
+  withHaishoku ? false,
+  withModernColorthief ? false,
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -23,12 +31,21 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
+  dependencies =
+    lib.optionals withColorthief optional-dependencies.colorthief
+    ++ lib.optionals withColorz optional-dependencies.colorz
+    ++ lib.optionals withFastColorthief optional-dependencies.fast-colorthief
+    ++ lib.optionals withHaishoku optional-dependencies.haishoku
+    ++ lib.optionals withModernColorthief optional-dependencies.modern_colorthief;
+
   nativeCheckInputs = [
     python3.pkgs.pytestCheckHook
     imagemagick
   ];
 
-  makeWrapperArgs = [ "--prefix PATH : ${lib.makeBinPath [ imagemagick ]}" ];
+  makeWrapperArgs = [
+    "--prefix PATH : ${lib.makeBinPath ([ imagemagick ] ++ lib.optional withColorz colorz)}"
+  ];
 
   postInstall = ''
     installManPage data/man/man1/wal.1
@@ -45,11 +62,13 @@ python3.pkgs.buildPythonApplication rec {
     colorz = [ colorz ];
     fast-colorthief = [ fast-colorthief ];
     haishoku = [ haishoku ];
+    modern_colorthief = [ modern-colorthief ];
     all = [
       colorthief
       colorz
-      ast-colorthief
+      fast-colorthief
       haishoku
+      modern-colorthief
     ];
   };
 

--- a/pkgs/by-name/py/pywal16/package.nix
+++ b/pkgs/by-name/py/pywal16/package.nix
@@ -28,6 +28,8 @@ python3.pkgs.buildPythonApplication rec {
     imagemagick
   ];
 
+  makeWrapperArgs = [ "--prefix PATH : ${lib.makeBinPath [ imagemagick ]}" ];
+
   postInstall = ''
     installManPage data/man/man1/wal.1
   '';

--- a/pkgs/development/python-modules/fast-colorthief/default.nix
+++ b/pkgs/development/python-modules/fast-colorthief/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  cmake,
+  nix-update-script,
+
+  numpy,
+  pillow,
+}:
+
+buildPythonPackage rec {
+  pname = "fast-colorthief";
+  version = "0.0.5";
+  pyproject = true;
+
+  # No tags on github
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-yUO1vnOt2NPyldPjFMn0jbhVX8zHcKsJ2IFVugYBZa4=";
+  };
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt --replace-fail \
+      "cmake_minimum_required(VERSION 2.8.12)" \
+      "cmake_minimum_required(VERSION 3.10)"
+    substituteInPlace pybind11/CMakeLists.txt --replace-fail \
+      "cmake_minimum_required(VERSION 3.4)" \
+      "cmake_minimum_required(VERSION 3.10)"
+  '';
+
+  build-system = [
+    setuptools
+    cmake
+  ];
+
+  dependencies = [
+    pillow
+    numpy
+  ];
+
+  # return to project root to locate pyproject.toml for build
+  preBuild = "cd ..";
+
+  pythonImportsCheck = [ "fast_colorthief" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Selection of most dominant colors in image using Modified Median Cut Quantization";
+    homepage = "https://github.com/bedapisl/fast-colorthief";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ moraxyc ];
+  };
+}

--- a/pkgs/development/python-modules/haishoku/default.nix
+++ b/pkgs/development/python-modules/haishoku/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  nix-update-script,
+
+  pillow,
+}:
+
+buildPythonPackage rec {
+  pname = "haishoku";
+  version = "1.1.8";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "LanceGin";
+    repo = "haishoku";
+    tag = "v${version}";
+    hash = "sha256-LSoZopCaM5vbknGS9gG13OZIgghgqJvPtktUkBCH04Q=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ pillow ];
+
+  # no test
+  doCheck = false;
+
+  pythonImportsCheck = [ "haishoku" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Development tool for grabbing the dominant color or representative color palette from an image";
+    homepage = "https://github.com/LanceGin/haishoku";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ moraxyc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5200,6 +5200,8 @@ self: super: with self; {
 
   fast-array-utils = callPackage ../development/python-modules/fast-array-utils { };
 
+  fast-colorthief = callPackage ../development/python-modules/fast-colorthief { };
+
   fast-histogram = callPackage ../development/python-modules/fast-histogram { };
 
   fast-query-parsers = callPackage ../development/python-modules/fast-query-parsers { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6670,6 +6670,8 @@ self: super: with self; {
 
   hacking = callPackage ../development/python-modules/hacking { };
 
+  haishoku = callPackage ../development/python-modules/haishoku { };
+
   hakuin = callPackage ../development/python-modules/hakuin { };
 
   halide =


### PR DESCRIPTION
Continuous of #467773

- Tested these backends: 
  - [x] colorthief
  - [x] colorz
  - [x] fast_colorthief
  - [x] haishoku
  - [x] modern_colorthief
  - [x] wal

- **pywal16: fix missing imagemagick dependency**
- **python3Packages.fast-colorthief: init at 0.0.5**
- **python3Packages.haishoku: init at 1.1.8**
- **pywal16: allow build with backends**

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
