### PR TITLE
ci/OWNERS: remove fricklerhandwerk from docs

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -115,9 +115,9 @@ nixos/modules/installer/tools/nix-fallback-paths.nix  @NixOS/nix-team @raitobeza
 /nixos/modules/system/activation/bootspec.cue         @grahamc @cole-h @raitobezarius
 
 # NixOS Render Docs
-/pkgs/by-name/ni/nixos-render-docs @fricklerhandwerk @GetPsyched @hsjobeki
-/doc/redirects.json                @fricklerhandwerk @GetPsyched @hsjobeki
-/nixos/doc/manual/redirects.json   @fricklerhandwerk @GetPsyched @hsjobeki
+/pkgs/by-name/ni/nixos-render-docs @GetPsyched @hsjobeki
+/doc/redirects.json                @GetPsyched @hsjobeki
+/nixos/doc/manual/redirects.json   @GetPsyched @hsjobeki
 
 # NixOS integration test driver
 /nixos/lib/test-driver  @tfc

--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -116,8 +116,8 @@ nixos/modules/installer/tools/nix-fallback-paths.nix  @NixOS/nix-team @raitobeza
 
 # NixOS Render Docs
 /pkgs/by-name/ni/nixos-render-docs @GetPsyched @hsjobeki
-/doc/redirects.json                @GetPsyched @hsjobeki
-/nixos/doc/manual/redirects.json   @GetPsyched @hsjobeki
+/doc/redirects.json                @GetPsyched
+/nixos/doc/manual/redirects.json   @GetPsyched
 
 # NixOS integration test driver
 /nixos/lib/test-driver  @tfc


### PR DESCRIPTION
I'm getting quite a few notifications that are hard to keep up with. It's a good tool to keep track of what's being added to NixOS, and helps to spot the occasional lack of care with the redirects mechanism. I'd be glad if someone keeps an eye on it.

Closes #470968

cc @GetPsyched @hsjobeki @philiptaron