### PR TITLE
python3Packages.xclim: init at 0.59.1

### DIFF
--- a/pkgs/development/python-modules/xclim/default.nix
+++ b/pkgs/development/python-modules/xclim/default.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  flit,
+  setuptools,
+
+  # dependencies
+  boltons,
+  bottleneck,
+  cf-xarray,
+  cftime,
+  click,
+  dask,
+  filelock,
+  jsonpickle,
+  numba,
+  packaging,
+  pandas,
+  pint,
+  platformdirs,
+  pooch,
+  pyarrow,
+  pyyaml,
+  scikit-learn,
+  scipy,
+  statsmodels,
+  xarray,
+  yamale,
+
+  # test
+  versionCheckHook,
+}:
+buildPythonPackage rec {
+  pname = "xclim";
+  version = "0.59.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Ouranosinc";
+    repo = "xclim";
+    tag = "v${version}";
+    hash = "sha256-n9HJoIHLyLWxrgCuDZDQ9dcW7frgEA/LoYqnTEBLqD8=";
+  };
+
+  build-system = [
+    flit
+    setuptools
+  ];
+
+  dependencies = [
+    boltons
+    bottleneck
+    cf-xarray
+    cftime
+    click
+    dask
+    filelock
+    jsonpickle
+    numba
+    packaging
+    pandas
+    pint
+    platformdirs
+    pooch
+    pyarrow
+    pyyaml
+    scikit-learn
+    scipy
+    statsmodels
+    xarray
+    yamale
+  ];
+
+  # No python test hooks has been added as all tests seems to be relying on network data
+  # https://github.com/Ouranosinc/xclim/blob/e8ce9bf37083832517afb3375acc853191782d8f/tests/conftest.py#L314
+  nativeCheckInputs = [
+    versionCheckHook
+  ];
+
+  versionCheckProgramArg = "--version";
+
+  pythonImportsCheck = [
+    "xclim"
+    "xclim.ensembles"
+    "xclim.indices"
+  ];
+
+  meta = {
+    description = "Operational Python library supporting climate services, based on xarray";
+    homepage = "https://github.com/Ouranosinc/xclim";
+    changelog = "https://github.com/Ouranosinc/xclim/releases/tag/${src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ daspk04 ];
+    mainProgram = "xclim";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20653,6 +20653,8 @@ self: super: with self; {
 
   xcffib = callPackage ../development/python-modules/xcffib { };
 
+  xclim = callPackage ../development/python-modules/xclim { };
+
   xdg = callPackage ../development/python-modules/xdg { };
 
   xdg-base-dirs = callPackage ../development/python-modules/xdg-base-dirs { };


### PR DESCRIPTION
## Things done

**xclim** is an operational Python library for climate services, providing numerous climate-related indicator tools with an extensible framework for constructing custom climate indicators, statistical downscaling and bias adjustment of climate model simulations, as well as climate model ensemble analysis tools.

Homepage: https://github.com/Ouranosinc/xclim

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
