### PR TITLE
timidity: fix build with gcc15

### DIFF
--- a/pkgs/by-name/ti/timidity/package.nix
+++ b/pkgs/by-name/ti/timidity/package.nix
@@ -99,6 +99,9 @@ stdenv.mkDerivation rec {
     sed -i 's/^\(calcnewt\$(EXEEXT):\).*/\1/g' timidity/Makefile
   '';
 
+  # Fix build with gcc15
+  env.NIX_CFLAGS_COMPILE = "-std=gnu17";
+
   # the instruments could be compressed (?)
   postInstall = ''
     mkdir -p $out/share/timidity/;


### PR DESCRIPTION
- add "-std=gnu17" to `env.NIX_CFLAGS_COMPILE`

Upstream had no version updates since 2018
Other distros also opted for "-std=gnu11" or "-std=gnu17":
https://src.fedoraproject.org/rpms/timidity++/c/ce4c5633a1d10d9065a0da748e27308a7c5c4bc7
https://github.com/gentoo/gentoo/commit/80744c4db244cadc7a5bf9da9d975404222431d6

Fixes build failure with gcc15:
```
nkflib.c:389:5: error: conflicting types for 'line_fold'; have 'int(void)'
  389 | int line_fold();
      |     ^~~~~~~~~
nkflib.c:319:17: note: previous declaration of 'line_fold' with
type 'int(int,  int)'
  319 | static  int     line_fold(int c2,int c1);
      |                 ^~~~~~~~~
nkflib.c: In function 'e_oconv':
nkflib.c:1594:16: error: too many arguments to function 'line_fold';
expected 0, have 2
 1594 |         switch(line_fold(c2,c1)) {
      |                ^~~~~~~~~ ~~
nkflib.c:389:5: note: declared here
  389 | int line_fold();
      |     ^~~~~~~~~
nkflib.c: In function 's_oconv':
nkflib.c:1646:16: error: too many arguments to function 'line_fold';
expected 0, have 2
 1646 |         switch(line_fold(c2,c1)) {
      |                ^~~~~~~~~ ~~
nkflib.c:389:5: note: declared here
  389 | int line_fold();
      |     ^~~~~~~~~
nkflib.c: In function 'j_oconv':
nkflib.c:1694:16: error: too many arguments to function 'line_fold';
expected 0, have 2
 1694 |         switch(line_fold(c2,c1)) {
      |                ^~~~~~~~~ ~~
nkflib.c:389:5: note: declared here
  389 | int line_fold();
      |     ^~~~~~~~~
nkflib.c: At top level:
nkflib.c:1829:1: error: conflicting types for 'line_fold';
have 'int(int,  int)'
 1829 | line_fold(int c2, int c1)
      | ^~~~~~~~~
nkflib.c:389:5: note: previous declaration of 'line_fold' with
type 'int(void)'
  389 | int line_fold();
      |     ^~~~~~~~~
```

---

Tested build with:
```bash
nix-build --expr 'with import ./. {}; timidity.override { stdenv = gcc15Stdenv; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

Fixes #470962

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
