### PR TITLE
python313Packages.py-improv-ble-client: 1.0.4 -> 2.0.1

### DIFF
--- a/pkgs/development/python-modules/py-improv-ble-client/default.nix
+++ b/pkgs/development/python-modules/py-improv-ble-client/default.nix
@@ -4,28 +4,25 @@
   bleak,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonOlder,
   setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "py-improv-ble-client";
-  version = "1.0.4";
+  version = "2.0.1";
   pyproject = true;
-
-  disabled = pythonOlder "3.11";
 
   src = fetchFromGitHub {
     owner = "home-assistant-libs";
     repo = "py-improv-ble-client";
     tag = version;
-    hash = "sha256-leYSDB5/jFqlvX78OYzlFkkVxIkJ7iOUoLHBuVj7tAo=";
+    hash = "sha256-PkAZhKgj+xQtOOCccBXbR2QkwlkYavJe1pfU9nMhuVs=";
   };
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail "setuptools~=65.6" "setuptools" \
-      --replace-fail "wheel~=0.37.1" "wheel"
+      --replace-fail "setuptools>=65.6,<81.0" "setuptools" \
+      --replace-fail "wheel>=0.37.1,<0.46.0" "wheel"
   '';
 
   build-system = [ setuptools ];
@@ -43,7 +40,7 @@ buildPythonPackage rec {
   meta = {
     description = "Module to provision devices which implement Improv via BLE";
     homepage = "https://github.com/home-assistant-libs/py-improv-ble-client";
-    changelog = "https://github.com/home-assistant-libs/py-improv-ble-client/releases/tag/${version}";
+    changelog = "https://github.com/home-assistant-libs/py-improv-ble-client/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };


### PR DESCRIPTION
Changelog: https://github.com/home-assistant-libs/py-improv-ble-client/releases/tag/2.0.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
