### PR TITLE
kdePackages.libplasma: fix build nondeterminism

### DIFF
--- a/pkgs/kde/plasma/libplasma/default.nix
+++ b/pkgs/kde/plasma/libplasma/default.nix
@@ -8,6 +8,11 @@
 mkKdeDerivation {
   pname = "libplasma";
 
+  patches = [
+    # https://invent.kde.org/plasma/libplasma/-/merge_requests/1406
+    ./rb-extracomponents.patch
+  ];
+
   extraNativeBuildInputs = [ pkg-config ];
 
   extraBuildInputs = [

--- a/pkgs/kde/plasma/libplasma/rb-extracomponents.patch
+++ b/pkgs/kde/plasma/libplasma/rb-extracomponents.patch
@@ -1,0 +1,27 @@
+commit fd5e1a04b024a9b955d6942e52295582144fbea7
+Author: Arnout Engelen <arnout@bzzt.net>
+Date:   Sun Dec 14 10:43:57 2025 +0100
+
+    reproducible builds: make qml dependency explicit
+    
+    Similar to https://qt-project.atlassian.net/browse/QTBUG-137440
+    
+    To fix https://bugs.kde.org/show_bug.cgi?id=512868
+    
+    I'll admit I don't quite know what I'm doing here, I'm mostly guessing and mimicking, but it does seem to remove the nondeterminism :)
+
+diff --git a/src/declarativeimports/plasmaextracomponents/CMakeLists.txt b/src/declarativeimports/plasmaextracomponents/CMakeLists.txt
+index 1a7827819..989318c80 100644
+--- a/src/declarativeimports/plasmaextracomponents/CMakeLists.txt
++++ b/src/declarativeimports/plasmaextracomponents/CMakeLists.txt
+@@ -44,6 +44,10 @@ target_link_libraries(plasmaextracomponentsplugin PRIVATE
+         KF6::WidgetsAddons
+         Plasma::Plasma)
+ 
++add_dependencies(plasmaextracomponentsplugin
++    org_kde_plasmacomponents3
++)
++
+ ecm_finalize_qml_module(plasmaextracomponentsplugin DESTINATION ${KDE_INSTALL_QMLDIR})
+ 
+ ecm_generate_qdoc(plasmaextracomponentsplugin plasmaextras.qdocconf)


### PR DESCRIPTION
Cherry-pick
https://invent.kde.org/plasma/libplasma/-/merge_requests/1406 for wider testing

Fixes #458839


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
