### PR TITLE
betterdiscord-installer: 1.0.0-beta -> 1.3.0; adopted

### DIFF
--- a/pkgs/by-name/be/betterdiscord-installer/package.nix
+++ b/pkgs/by-name/be/betterdiscord-installer/package.nix
@@ -28,7 +28,7 @@ appimageTools.wrapType2 {
     description = "Installer for BetterDiscord";
     homepage = "https://betterdiscord.app";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ chillcicada ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "betterdiscord-installer";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];

--- a/pkgs/by-name/be/betterdiscord-installer/package.nix
+++ b/pkgs/by-name/be/betterdiscord-installer/package.nix
@@ -5,11 +5,11 @@
 }:
 let
   pname = "betterdiscord-installer";
-  version = "1.0.0-beta";
+  version = "1.3.0";
 
   src = fetchurl {
     url = "https://github.com/BetterDiscord/Installer/releases/download/v${version}/Betterdiscord-Linux.AppImage";
-    sha256 = "103acb11qmvjmf6g9lgsfm5jyahfwfdqw0x9w6lmv1hzwbs26dsr";
+    hash = "sha256-In5J6TWoJsFODDwMXd1lMg3341IZJD2OJebVtgISxP0=";
   };
 
   appimageContents = appimageTools.extract { inherit pname version src; };
@@ -18,9 +18,9 @@ appimageTools.wrapType2 {
   inherit pname version src;
 
   extraInstallCommands = ''
-    install -m 444 -D ${appimageContents}/betterdiscord.desktop -t $out/share/applications
-    substituteInPlace $out/share/applications/betterdiscord.desktop \
-      --replace 'Exec=AppRun' 'Exec=${pname}'
+    install -m 444 -D ${appimageContents}/betterdiscord-installer.desktop -t $out/share/applications
+    substituteInPlace $out/share/applications/betterdiscord-installer.desktop \
+      --replace-fail 'Exec=AppRun' 'Exec=betterdiscord-installer'
     cp -r ${appimageContents}/usr/share/icons $out/share
   '';
 
@@ -31,5 +31,6 @@ appimageTools.wrapType2 {
     maintainers = [ ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "betterdiscord-installer";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
 }

--- a/pkgs/by-name/be/betterdiscord-installer/package.nix
+++ b/pkgs/by-name/be/betterdiscord-installer/package.nix
@@ -2,6 +2,7 @@
   appimageTools,
   lib,
   fetchurl,
+  nix-update-script,
 }:
 let
   pname = "betterdiscord-installer";
@@ -23,6 +24,8 @@ appimageTools.wrapType2 {
       --replace-fail 'Exec=AppRun' 'Exec=betterdiscord-installer'
     cp -r ${appimageContents}/usr/share/icons $out/share
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Installer for BetterDiscord";


### PR DESCRIPTION
update betterdiscord-installer to 1.3.0, and adopt it. note that the upstream has no update for over two years, but it seems to be undergoing refactoring so i add the nix-update-script

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
