### PR TITLE
obs-studio-plugins.obs-image-reaction: init at 1.3

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/default.nix
@@ -48,6 +48,8 @@
 
   obs-hyperion = qt6Packages.callPackage ./obs-hyperion/default.nix { };
 
+  obs-image-reaction = callPackage ./obs-image-reaction/default.nix { };
+
   obs-livesplit-one = callPackage ./obs-livesplit-one { };
 
   obs-markdown = callPackage ./obs-markdown.nix { };

--- a/pkgs/applications/video/obs-studio/plugins/obs-image-reaction/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-image-reaction/default.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenv,
+  cmake,
+  obs-studio,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "obs-image-reaction";
+  version = "1.3";
+
+  src = fetchFromGitHub {
+    owner = "scaledteam";
+    repo = "obs-image-reaction";
+    tag = finalAttrs.version;
+    sha256 = "sha256-mC1B8tveHx35pfbAcOlosB8YKaBVg87MjXbr79sf7+k=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ obs-studio ];
+
+  meta = {
+    description = "OBS Studio plugin for adding an image that reacts to a sound source";
+    homepage = "https://github.com/scaledteam/obs-image-reaction";
+    license = with lib.licenses; [
+      gpl2
+    ];
+    maintainers = [ lib.maintainers.codebam ];
+    inherit (obs-studio.meta) platforms;
+  };
+})


### PR DESCRIPTION
This is an OBS plugin that can be used to show an animated image based on the loudness of your audio source.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
