### PR TITLE
[Reapply] Minor `check-meta.nix` optimisations and cleanups

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -302,8 +302,9 @@ let
     '';
 
   handleEvalIssue =
-    { meta, attrs }:
     {
+      meta,
+      attrs,
       reason,
       errormsg ? "",
       remediation,
@@ -324,8 +325,9 @@ let
     handler msg;
 
   handleEvalWarning =
-    { meta, attrs }:
     {
+      meta,
+      attrs,
       reason,
       errormsg ? "",
       remediation,
@@ -751,9 +753,15 @@ let
           if valid == "yes" then
             true
           else if valid == "no" then
-            (handleEvalIssue { inherit meta attrs; } { inherit (validity) reason errormsg remediation; })
+            (handleEvalIssue {
+              inherit meta attrs;
+              inherit (validity) reason errormsg remediation;
+            })
           else if valid == "warn" then
-            (handleEvalWarning { inherit meta attrs; } { inherit (validity) reason errormsg remediation; })
+            (handleEvalWarning {
+              inherit meta attrs;
+              inherit (validity) reason errormsg remediation;
+            })
           else
             throw "Unknown validity: '${valid}'"
         );

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -100,7 +100,7 @@ let
   isUnfree =
     licenses:
     if isAttrs licenses then
-      !licenses.free or true
+      !(licenses.free or true)
     # TODO: Returning false in the case of a string is a bug that should be fixed.
     # In a previous implementation of this function the function body
     # was `licenses: lib.lists.any (l: !l.free or true) licenses;`
@@ -108,7 +108,7 @@ let
     else if isString licenses then
       false
     else
-      any (l: !l.free or true) licenses;
+      any (l: !(l.free or true)) licenses;
 
   hasUnfreeLicense = attrs: hasLicense attrs && isUnfree attrs.meta.license;
 
@@ -173,7 +173,7 @@ let
   isNonSource = sourceTypes: any (t: !t.isSource) sourceTypes;
 
   hasNonSourceProvenance =
-    attrs: (attrs ? meta.sourceProvenance) && isNonSource attrs.meta.sourceProvenance;
+    attrs: attrs ? meta.sourceProvenance && isNonSource attrs.meta.sourceProvenance;
 
   # Allow granular checks to allow only some non-source-built packages
   # Example:
@@ -753,15 +753,15 @@ let
           if valid == "yes" then
             true
           else if valid == "no" then
-            (handleEvalIssue {
+            handleEvalIssue {
               inherit meta attrs;
               inherit (validity) reason errormsg remediation;
-            })
+            }
           else if valid == "warn" then
-            (handleEvalWarning {
+            handleEvalWarning {
               inherit meta attrs;
               inherit (validity) reason errormsg remediation;
-            })
+            }
           else
             throw "Unknown validity: '${valid}'"
         );

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -305,50 +305,6 @@ let
       ${concatStrings (map (output: "  - ${output}\n") missingOutputs)}
     '';
 
-  handleEvalIssue =
-    {
-      meta,
-      attrs,
-      reason,
-      errormsg ? "",
-      remediation,
-    }:
-    let
-      msg =
-        if inHydra then
-          "Failed to evaluate ${getNameWithVersion attrs}: «${reason}»: ${errormsg}"
-        else
-          ''
-            Package ‘${getNameWithVersion attrs}’ in ${pos_str meta} ${errormsg}, refusing to evaluate.
-
-          ''
-          + remediation;
-
-      handler = if config ? handleEvalIssue then config.handleEvalIssue reason else throw;
-    in
-    handler msg;
-
-  handleEvalWarning =
-    {
-      meta,
-      attrs,
-      reason,
-      errormsg ? "",
-      remediation,
-    }:
-    if elem reason showWarnings then
-      let
-        msg =
-          if inHydra then
-            "Warning while evaluating ${getNameWithVersion attrs}: «${reason}»: ${errormsg}"
-          else
-            "Package ${getNameWithVersion attrs} in ${pos_str meta} ${errormsg}, continuing anyway."
-            + (optionalString (remediation != "") "\n${remediation}");
-      in
-      trace msg true
-    else
-      true;
-
   metaTypes =
     let
       types = import ./meta-types.nix { inherit lib; };
@@ -444,11 +400,10 @@ let
       identifiers = attrs;
     };
 
+  # Map attrs directly to the verify function for performance
+  metaTypes' = mapAttrs (_: t: t.verify) metaTypes;
+
   checkMetaAttr =
-    let
-      # Map attrs directly to the verify function for performance
-      metaTypes' = mapAttrs (_: t: t.verify) metaTypes;
-    in
     k: v:
     if metaTypes ? ${k} then
       if metaTypes'.${k} v then
@@ -465,11 +420,14 @@ let
           concatMapStringsSep ", " (x: "'${x}'") (attrNames metaTypes)
         }]"
       ];
-  checkMeta =
+
+  checkMeta = meta: concatMap (attr: checkMetaAttr attr meta.${attr}) (attrNames meta);
+
+  metaInvalid =
     if config.checkMeta then
-      meta: concatMap (attr: checkMetaAttr attr meta.${attr}) (attrNames meta)
+      meta: !all (attr: metaTypes ? ${attr} && metaTypes'.${attr} meta.${attr}) (attrNames meta)
     else
-      meta: [ ];
+      meta: false;
 
   checkOutputsToInstall =
     if config.checkMeta then
@@ -490,30 +448,21 @@ let
   # !!! reason strings are hardcoded into OfBorg, make sure to keep them in sync
   # Along with a boolean flag for each reason
   checkValidity =
-    let
-      validYes = {
-        valid = "yes";
-        handled = true;
-      };
-    in
     attrs:
     # Check meta attribute types first, to make sure it is always called even when there are other issues
     # Note that this is not a full type check and functions below still need to by careful about their inputs!
-    let
-      res = checkMeta (attrs.meta or { });
-    in
-    if res != [ ] then
+    if metaInvalid (attrs.meta or { }) then
       {
-        valid = "no";
         reason = "unknown-meta";
-        errormsg = "has an invalid meta attrset:${concatMapStrings (x: "\n  - " + x) res}\n";
+        errormsg = "has an invalid meta attrset:${
+          concatMapStrings (x: "\n  - " + x) (checkMeta attrs.meta)
+        }\n";
         remediation = "";
       }
 
     # --- Put checks that cannot be ignored here ---
     else if checkOutputsToInstall attrs then
       {
-        valid = "no";
         reason = "broken-outputs";
         errormsg = "has invalid meta.outputsToInstall";
         remediation = remediateOutputsToInstall attrs;
@@ -522,28 +471,24 @@ let
     # --- Put checks that can be ignored here ---
     else if hasDeniedUnfreeLicense attrs && !(hasAllowlistedLicense attrs) then
       {
-        valid = "no";
         reason = "unfree";
         errormsg = "has an unfree license (‘${showLicense attrs.meta.license}’)";
         remediation = remediate_allowlist "Unfree" (remediate_predicate "allowUnfreePredicate") attrs;
       }
     else if hasBlocklistedLicense attrs then
       {
-        valid = "no";
         reason = "blocklisted";
         errormsg = "has a blocklisted license (‘${showLicense attrs.meta.license}’)";
         remediation = "";
       }
     else if hasDeniedNonSourceProvenance attrs then
       {
-        valid = "no";
         reason = "non-source";
         errormsg = "contains elements not built from source (‘${showSourceType attrs.meta.sourceProvenance}’)";
         remediation = remediate_allowlist "NonSource" (remediate_predicate "allowNonSourcePredicate") attrs;
       }
     else if hasDeniedBroken attrs then
       {
-        valid = "no";
         reason = "broken";
         errormsg = "is marked as broken";
         remediation = remediate_allowlist "Broken" (x: "") attrs;
@@ -556,7 +501,6 @@ let
         };
       in
       {
-        valid = "no";
         reason = "unsupported";
         errormsg = ''
           is not available on the requested hostPlatform:
@@ -568,24 +512,24 @@ let
       }
     else if hasDisallowedInsecure attrs then
       {
-        valid = "no";
         reason = "insecure";
         errormsg = "is marked as insecure";
         remediation = remediate_insecure attrs;
       }
+    else
+      null;
 
-    # --- warnings ---
-    # Please also update the type in /pkgs/top-level/config.nix alongside this.
-    else if hasNoMaintainers attrs then
+  # Please also update the type in /pkgs/top-level/config.nix alongside this.
+  checkWarnings =
+    attrs:
+    if hasNoMaintainers attrs then
       {
-        valid = "warn";
         reason = "maintainerless";
         errormsg = "has no maintainers or teams";
         remediation = "";
       }
-    # -----
     else
-      validYes;
+      null;
 
   # Helper functions and declarations to handle identifiers, extracted to reduce allocations
   hasAllCPEParts =
@@ -743,35 +687,54 @@ let
         && ((config.checkMetaRecursively or false) -> all (d: d.meta.available or true) references);
     };
 
+  validYes = {
+    valid = "yes";
+    handled = true;
+  };
+
   assertValidity =
     { meta, attrs }:
     let
-      validity = checkValidity attrs;
-      inherit (validity) valid;
+      invalid = checkValidity attrs;
+      warning = checkWarnings attrs;
     in
-    if validity ? handled then
-      validity
+    if isNull invalid then
+      if isNull warning then
+        validYes
+      else
+        let
+          msg =
+            if inHydra then
+              "Warning while evaluating ${getNameWithVersion attrs}: «${warning.reason}»: ${warning.errormsg}"
+            else
+              "Package ${getNameWithVersion attrs} in ${pos_str meta} ${warning.errormsg}, continuing anyway."
+              + (optionalString (warning.remediation != "") "\n${warning.remediation}");
+
+          handled = if elem warning.reason showWarnings then trace msg true else true;
+        in
+        warning
+        // {
+          valid = "warn";
+          handled = handled;
+        }
     else
-      validity
-      // {
-        # Throw an error if trying to evaluate a non-valid derivation
-        # or, alternatively, just output a warning message.
-        handled = (
-          if valid == "yes" then
-            true
-          else if valid == "no" then
-            handleEvalIssue {
-              inherit meta attrs;
-              inherit (validity) reason errormsg remediation;
-            }
-          else if valid == "warn" then
-            handleEvalWarning {
-              inherit meta attrs;
-              inherit (validity) reason errormsg remediation;
-            }
+      let
+        msg =
+          if inHydra then
+            "Failed to evaluate ${getNameWithVersion attrs}: «${invalid.reason}»: ${invalid.errormsg}"
           else
-            throw "Unknown validity: '${valid}'"
-        );
+            ''
+              Package ‘${getNameWithVersion attrs}’ in ${pos_str meta} ${invalid.errormsg}, refusing to evaluate.
+
+            ''
+            + invalid.remediation;
+
+        handled = if config ? handleEvalIssue then config.handleEvalIssue invalid.reason msg else throw msg;
+      in
+      invalid
+      // {
+        valid = "no";
+        handled = handled;
       };
 
 in

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -234,7 +234,7 @@ let
          then pass `--impure` in order to allow use of environment variables.
     ";
 
-  remediate_allowlist = allow_attr: rebuild_amendment: attrs: ''
+  remediate_allowlist = allow_attr: rebuild_amendment: ''
     a) To temporarily allow ${remediation_phrase allow_attr}, you can use an environment variable
        for a single invocation of the nix tools.
 
@@ -243,7 +243,7 @@ let
     b) For `nixos-rebuild` you can set
       { nixpkgs.config.allow${allow_attr} = true; }
     in configuration.nix to override this.
-    ${rebuild_amendment attrs}
+    ${rebuild_amendment}
     c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
       { allow${allow_attr} = true; }
     to ~/.config/nixpkgs/config.nix.
@@ -473,7 +473,7 @@ let
       {
         reason = "unfree";
         errormsg = "has an unfree license (‘${showLicense attrs.meta.license}’)";
-        remediation = remediate_allowlist "Unfree" (remediate_predicate "allowUnfreePredicate") attrs;
+        remediation = remediate_allowlist "Unfree" (remediate_predicate "allowUnfreePredicate" attrs);
       }
     else if hasBlocklistedLicense attrs then
       {
@@ -485,13 +485,13 @@ let
       {
         reason = "non-source";
         errormsg = "contains elements not built from source (‘${showSourceType attrs.meta.sourceProvenance}’)";
-        remediation = remediate_allowlist "NonSource" (remediate_predicate "allowNonSourcePredicate") attrs;
+        remediation = remediate_allowlist "NonSource" (remediate_predicate "allowNonSourcePredicate" attrs);
       }
     else if hasDeniedBroken attrs then
       {
         reason = "broken";
         errormsg = "is marked as broken";
-        remediation = remediate_allowlist "Broken" (x: "") attrs;
+        remediation = remediate_allowlist "Broken" "";
       }
     else if hasUnsupportedPlatform attrs && !allowUnsupportedSystem then
       let
@@ -508,7 +508,7 @@ let
             package.meta.platforms = ${toPretty' (attrs.meta.platforms or [ ])}
             package.meta.badPlatforms = ${toPretty' (attrs.meta.badPlatforms or [ ])}
         '';
-        remediation = remediate_allowlist "UnsupportedSystem" (x: "") attrs;
+        remediation = remediate_allowlist "UnsupportedSystem" "";
       }
     else if hasDisallowedInsecure attrs then
       {

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -197,17 +197,6 @@ let
 
   pos_str = meta: meta.position or "«unknown-file»";
 
-  remediation = {
-    unfree = remediate_allowlist "Unfree" (remediate_predicate "allowUnfreePredicate");
-    non-source = remediate_allowlist "NonSource" (remediate_predicate "allowNonSourcePredicate");
-    broken = remediate_allowlist "Broken" (x: "");
-    unsupported = remediate_allowlist "UnsupportedSystem" (x: "");
-    blocklisted = x: "";
-    insecure = remediate_insecure;
-    broken-outputs = remediateOutputsToInstall;
-    unknown-meta = x: "";
-    maintainerless = x: "";
-  };
   remediation_env_var =
     allow_attr:
     {
@@ -317,6 +306,7 @@ let
     {
       reason,
       errormsg ? "",
+      remediation,
     }:
     let
       msg =
@@ -327,7 +317,7 @@ let
             Package ‘${getNameWithVersion attrs}’ in ${pos_str meta} ${errormsg}, refusing to evaluate.
 
           ''
-          + (builtins.getAttr reason remediation) attrs;
+          + remediation;
 
       handler = if config ? handleEvalIssue then config.handleEvalIssue reason else throw;
     in
@@ -338,15 +328,15 @@ let
     {
       reason,
       errormsg ? "",
+      remediation,
     }:
     let
-      remediationMsg = (builtins.getAttr reason remediation) attrs;
       msg =
         if inHydra then
           "Warning while evaluating ${getNameWithVersion attrs}: «${reason}»: ${errormsg}"
         else
           "Package ${getNameWithVersion attrs} in ${pos_str meta} ${errormsg}, continuing anyway."
-          + (optionalString (remediationMsg != "") "\n${remediationMsg}");
+          + (optionalString (remediation != "") "\n${remediation}");
       isEnabled = findFirst (x: x == reason) null showWarnings;
     in
     if isEnabled != null then builtins.trace msg true else true;
@@ -484,7 +474,7 @@ let
   # e.g brokenness or license.
   #
   # Return { valid: "yes", "warn" or "no" } and additionally
-  # { reason: String; errormsg: String } if it is not valid, where
+  # { reason: String; errormsg: String, remediation: String } if it is not valid, where
   # reason is one of "unfree", "blocklisted", "broken", "insecure", ...
   # !!! reason strings are hardcoded into OfBorg, make sure to keep them in sync
   # Along with a boolean flag for each reason
@@ -506,6 +496,7 @@ let
         valid = "no";
         reason = "unknown-meta";
         errormsg = "has an invalid meta attrset:${concatMapStrings (x: "\n  - " + x) res}\n";
+        remediation = "";
       }
 
     # --- Put checks that cannot be ignored here ---
@@ -514,6 +505,7 @@ let
         valid = "no";
         reason = "broken-outputs";
         errormsg = "has invalid meta.outputsToInstall";
+        remediation = remediateOutputsToInstall attrs;
       }
 
     # --- Put checks that can be ignored here ---
@@ -522,24 +514,28 @@ let
         valid = "no";
         reason = "unfree";
         errormsg = "has an unfree license (‘${showLicense attrs.meta.license}’)";
+        remediation = remediate_allowlist "Unfree" (remediate_predicate "allowUnfreePredicate") attrs;
       }
     else if hasBlocklistedLicense attrs then
       {
         valid = "no";
         reason = "blocklisted";
         errormsg = "has a blocklisted license (‘${showLicense attrs.meta.license}’)";
+        remediation = "";
       }
     else if hasDeniedNonSourceProvenance attrs then
       {
         valid = "no";
         reason = "non-source";
         errormsg = "contains elements not built from source (‘${showSourceType attrs.meta.sourceProvenance}’)";
+        remediation = remediate_allowlist "NonSource" (remediate_predicate "allowNonSourcePredicate") attrs;
       }
     else if hasDeniedBroken attrs then
       {
         valid = "no";
         reason = "broken";
         errormsg = "is marked as broken";
+        remediation = remediate_allowlist "Broken" (x: "") attrs;
       }
     else if !allowUnsupportedSystem && hasUnsupportedPlatform attrs then
       let
@@ -557,12 +553,14 @@ let
             package.meta.platforms = ${toPretty' (attrs.meta.platforms or [ ])}
             package.meta.badPlatforms = ${toPretty' (attrs.meta.badPlatforms or [ ])}
         '';
+        remediation = remediate_allowlist "UnsupportedSystem" (x: "") attrs;
       }
     else if !(hasAllowedInsecure attrs) then
       {
         valid = "no";
         reason = "insecure";
         errormsg = "is marked as insecure";
+        remediation = remediate_insecure attrs;
       }
 
     # --- warnings ---
@@ -572,6 +570,7 @@ let
         valid = "warn";
         reason = "maintainerless";
         errormsg = "has no maintainers or teams";
+        remediation = "";
       }
     # -----
     else
@@ -752,9 +751,9 @@ let
           if valid == "yes" then
             true
           else if valid == "no" then
-            (handleEvalIssue { inherit meta attrs; } { inherit (validity) reason errormsg; })
+            (handleEvalIssue { inherit meta attrs; } { inherit (validity) reason errormsg remediation; })
           else if valid == "warn" then
-            (handleEvalWarning { inherit meta attrs; } { inherit (validity) reason errormsg; })
+            (handleEvalWarning { inherit meta attrs; } { inherit (validity) reason errormsg remediation; })
           else
             throw "Unknown validity: '${valid}'"
         );

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -79,23 +79,24 @@ let
     else
       throw "allowlistedLicenses and blocklistedLicenses are not mutually exclusive.";
 
-  hasLicense = attrs: attrs ? meta.license;
-
   hasListedLicense =
     assert areLicenseListsValid;
-    list: attrs:
-    length list > 0
-    && hasLicense attrs
-    && (
-      if isList attrs.meta.license then
-        any (l: elem l list) attrs.meta.license
-      else
-        elem attrs.meta.license list
-    );
+    list:
+    if list == [ ] then
+      attrs: false
+    else
+      attrs:
+      attrs ? meta.license
+      && (
+        if isList attrs.meta.license then
+          any (l: elem l list) attrs.meta.license
+        else
+          elem attrs.meta.license list
+      );
 
-  hasAllowlistedLicense = attrs: hasListedLicense allowlist attrs;
+  hasAllowlistedLicense = hasListedLicense allowlist;
 
-  hasBlocklistedLicense = attrs: hasListedLicense blocklist attrs;
+  hasBlocklistedLicense = hasListedLicense blocklist;
 
   allowBroken = config.allowBroken || getEnv "NIXPKGS_ALLOW_BROKEN" == "1";
 
@@ -115,7 +116,7 @@ let
     else
       any (l: !(l.free or true)) licenses;
 
-  hasUnfreeLicense = attrs: hasLicense attrs && isUnfree attrs.meta.license;
+  hasUnfreeLicense = attrs: attrs ? meta.license && isUnfree attrs.meta.license;
 
   hasNoMaintainers =
     # To get usable output, we want to avoid flagging "internal" derivations.
@@ -169,14 +170,10 @@ let
     x: elem (getNameWithVersion x) (config.permittedInsecurePackages or [ ]);
   allowInsecurePredicate = config.allowInsecurePredicate or allowInsecureDefaultPredicate;
 
-  hasAllowedInsecure =
-    attrs:
-    !(isMarkedInsecure attrs) || allowInsecurePredicate attrs || getEnv "NIXPKGS_ALLOW_INSECURE" == "1";
+  allowInsecure = getEnv "NIXPKGS_ALLOW_INSECURE" == "1";
 
-  isNonSource = sourceTypes: any (t: !t.isSource) sourceTypes;
-
-  hasNonSourceProvenance =
-    attrs: attrs ? meta.sourceProvenance && isNonSource attrs.meta.sourceProvenance;
+  hasDisallowedInsecure =
+    attrs: isMarkedInsecure attrs && !allowInsecure && !allowInsecurePredicate attrs;
 
   # Allow granular checks to allow only some non-source-built packages
   # Example:
@@ -191,7 +188,11 @@ let
   # package has non-source provenance and is not explicitly allowed by the
   # `allowNonSourcePredicate` function.
   hasDeniedNonSourceProvenance =
-    attrs: hasNonSourceProvenance attrs && !allowNonSource && !allowNonSourcePredicate attrs;
+    attrs:
+    attrs ? meta.sourceProvenance
+    && any (t: !t.isSource) attrs.meta.sourceProvenance
+    && !allowNonSource
+    && !allowNonSourcePredicate attrs;
 
   showLicenseOrSourceType =
     value: toString (map (v: v.shortName or v.fullName or "unknown") (toList value));
@@ -471,13 +472,14 @@ let
       meta: [ ];
 
   checkOutputsToInstall =
-    attrs:
-    let
-      expectedOutputs = attrs.meta.outputsToInstall or [ ];
-      actualOutputs = attrs.outputs or [ "out" ];
-      missingOutputs = filter (output: !elem output actualOutputs) expectedOutputs;
-    in
-    if config.checkMeta then length missingOutputs > 0 else false;
+    if config.checkMeta then
+      attrs:
+      let
+        actualOutputs = attrs.outputs or [ "out" ];
+      in
+      any (output: !elem output actualOutputs) (attrs.meta.outputsToInstall or [ ])
+    else
+      attrs: false;
 
   # Check if a derivation is valid, that is whether it passes checks for
   # e.g brokenness or license.
@@ -546,7 +548,7 @@ let
         errormsg = "is marked as broken";
         remediation = remediate_allowlist "Broken" (x: "") attrs;
       }
-    else if !allowUnsupportedSystem && hasUnsupportedPlatform attrs then
+    else if hasUnsupportedPlatform attrs && !allowUnsupportedSystem then
       let
         toPretty' = toPretty {
           allowPrettyValues = true;
@@ -564,7 +566,7 @@ let
         '';
         remediation = remediate_allowlist "UnsupportedSystem" (x: "") attrs;
       }
-    else if !(hasAllowedInsecure attrs) then
+    else if hasDisallowedInsecure attrs then
       {
         valid = "no";
         reason = "insecure";


### PR DESCRIPTION
Reapplies https://github.com/NixOS/nixpkgs/pull/466947 with a fix and another minor change after the reversal in https://github.com/NixOS/nixpkgs/pull/470757 due to the [Hydra error](https://hydra.nixos.org/build/316232706/nixlog/1).

## Things done

- [x] Tested what previously failed and more

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
