### PR TITLE
foundry: 1.4.4 -> 1.5.0

### DIFF
--- a/pkgs/by-name/fo/foundry/package.nix
+++ b/pkgs/by-name/fo/foundry/package.nix
@@ -13,16 +13,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "foundry";
-  version = "1.4.4";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "foundry-rs";
     repo = "foundry";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-u+JCurH1gx4onC5Poxxd9+gVrUyyebcd6xnXY4Le6Rs=";
+    hash = "sha256-mbOv5XZH+AYZQjSUI+ksuAdLxZyRdF0LXK/8Q1DIgrU=";
   };
 
-  cargoHash = "sha256-JLuCZckiNv0t+kPuDk6TWmPIXKOvqf3HR/oFrQ5fKKQ=";
+  cargoHash = "sha256-vws7LcBRtoha+Sa4TLDNxMKA8caKkWFOauCLZs6we4Y=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/fo/foundry/svm-lists/linux-amd64.json
+++ b/pkgs/by-name/fo/foundry/svm-lists/linux-amd64.json
@@ -945,9 +945,21 @@
       "urls": [
         "dweb:/ipfs/QmPsmKxpd5berCgcTBXXPBC4PLHrb56tr3f6ZMxPGEf6vn"
       ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.8.31+commit.fd3a2265",
+      "version": "0.8.31",
+      "build": "commit.fd3a2265",
+      "longVersion": "0.8.31+commit.fd3a2265",
+      "keccak256": "0xc6f3968537d87ec3432a06c25840491a3fac9d538c3e7c30900f47722f978f31",
+      "sha256": "0xaac9cd0116e9ae0cd3d8f64a8641381845dc9f12e2a52653de36fb619323e557",
+      "urls": [
+        "dweb:/ipfs/QmcpFFGAaoKkwiqng4czei7sa5Mvd9Hv4vRwUpRNNTCb9r"
+      ]
     }
   ],
   "releases": {
+    "0.8.31": "solc-linux-amd64-v0.8.31+commit.fd3a2265",
     "0.8.30": "solc-linux-amd64-v0.8.30+commit.73712a01",
     "0.8.29": "solc-linux-amd64-v0.8.29+commit.ab55807c",
     "0.8.28": "solc-linux-amd64-v0.8.28+commit.7893614a",
@@ -1035,5 +1047,5 @@
     "0.4.11": "solc-linux-amd64-v0.4.11+commit.68ef5810",
     "0.4.10": "solc-linux-amd64-v0.4.10+commit.9e8cc01b"
   },
-  "latestRelease": "0.8.30"
+  "latestRelease": "0.8.31"
 }

--- a/pkgs/by-name/fo/foundry/svm-lists/macosx-amd64.json
+++ b/pkgs/by-name/fo/foundry/svm-lists/macosx-amd64.json
@@ -1066,9 +1066,21 @@
       "urls": [
         "dweb:/ipfs/QmbrZ9EQQakmwZ2MKzdT6Xp6RQfwbbc6bhrP7ZSeMGE6fx"
       ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.8.31+commit.fd3a2265",
+      "version": "0.8.31",
+      "build": "commit.fd3a2265",
+      "longVersion": "0.8.31+commit.fd3a2265",
+      "keccak256": "0xe24d2e6c51018020bd86cd51369e4087f3f59288577dd038326ebf84becf26c2",
+      "sha256": "0xf5a243d6b2dd8fba307e36c5fefa2d8eb3ae74ba81036d1c17c971b5d346ade9",
+      "urls": [
+        "dweb:/ipfs/QmXnqLGQF6Dgpkegp59Z8DcSq7UeT9jY7ENAWUzYjPaq8H"
+      ]
     }
   ],
   "releases": {
+    "0.8.31": "solc-macosx-amd64-v0.8.31+commit.fd3a2265",
     "0.8.30": "solc-macosx-amd64-v0.8.30+commit.73712a01",
     "0.8.29": "solc-macosx-amd64-v0.8.29+commit.ab55807c",
     "0.8.28": "solc-macosx-amd64-v0.8.28+commit.7893614a",
@@ -1167,5 +1179,5 @@
     "0.4.0": "solc-macosx-amd64-v0.4.0+commit.acd334c9",
     "0.3.6": "solc-macosx-amd64-v0.3.6+commit.988fe5e5"
   },
-  "latestRelease": "0.8.30"
+  "latestRelease": "0.8.31"
 }

--- a/pkgs/by-name/fo/foundry/update-svm-lists.sh
+++ b/pkgs/by-name/fo/foundry/update-svm-lists.sh
@@ -40,8 +40,8 @@ for url in "${urls[@]}"; do
     # Extract filename from URL
     filename=$(extract_filename "$url")
 
-    # Download the file and fix line endings
+    # Download the file, filter out prereleases, and fix line endings
     echo "Fetching $url to $dir/$filename"
-    curl -sL "$url" -o "${dir}/${filename}"
+    curl -sL "$url" | jq 'del(.builds[] | select(has("prerelease")))' > "${dir}/${filename}"
     ensure_unix_format "${dir}/${filename}"
 done


### PR DESCRIPTION
New version of Foundry: https://github.com/foundry-rs/foundry/releases/tag/v1.5.0

I had to update the `update-svm-lists.sh` script because the latest Solidity version (0.8.31) has a prerelease in the JSON file. This broke compilation of `svm-rs-builds` due to a duplicate constant definition in the generated code.

To keep it simple, I added a jq filter, hopefully that's an acceptable dependency to add to this helper script (which is only run locally).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
