### PR TITLE
python3Packages.fastcan: init at 0.5.0

### DIFF
--- a/pkgs/development/python-modules/fastcan/default.nix
+++ b/pkgs/development/python-modules/fastcan/default.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  cython,
+  meson-python,
+  numpy,
+  setuptools,
+
+  # nativeBuildInputs
+  pkg-config,
+
+  # dependencies
+  scikit-learn,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "fastcan";
+  version = "0.5.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "scikit-learn-contrib";
+    repo = "fastcan";
+    tag = "v${version}";
+    hash = "sha256-1ncdzBMJYEwTkpLXS64g+SaEbsiYslX7zN4xbGjUsAA=";
+  };
+
+  build-system = [
+    cython
+    meson-python
+    numpy
+    setuptools
+  ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  dependencies = [ scikit-learn ];
+
+  # Prevent pytest from importing the required python modules from the source instead of $out
+  preCheck = ''
+    rm -f fastcan/__init__.py
+    echo "" > fastcan/narx/__init__.py
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "fastcan" ];
+
+  meta = {
+    description = "Library for fast canonical-correlation-based search algorithm";
+    homepage = "https://github.com/scikit-learn-contrib/fastcan";
+    changelog = "https://github.com/scikit-learn-contrib/fastcan/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ daspk04 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5208,6 +5208,8 @@ self: super: with self; {
 
   fastcache = callPackage ../development/python-modules/fastcache { };
 
+  fastcan = callPackage ../development/python-modules/fastcan { };
+
   fastcore = callPackage ../development/python-modules/fastcore { };
 
   fastcrc = callPackage ../development/python-modules/fastcrc { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

A fast canonical-correlation-based search algorithm for feature selection, system identification, data pruning, etc.
Homepage: https://github.com/scikit-learn-contrib/fastcan/

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
