### PR TITLE
[Backport release-25.11] jetbrains: pycharm/idea unified builds; deprecate writerside & aqua

### DIFF
--- a/pkgs/applications/editors/jetbrains/bin/ides.json
+++ b/pkgs/applications/editors/jetbrains/bin/ides.json
@@ -73,7 +73,7 @@
     "meta": {
       "isOpenSource": true,
       "description": "Free Java, Kotlin, Groovy and Scala IDE from jetbrains",
-      "maintainers": [ "edwtjo", "gytis-ivaskevicius", "steinybot", "tymscar" ],
+      "maintainers": [ "gytis-ivaskevicius", "tymscar" ],
       "longDescription": "IDE for Java SE, Groovy & Scala development Powerful environment for building Google Android apps Integration with JUnit, TestNG, popular SCMs, Ant & Maven. Also known as IntelliJ.",
       "homepage": "https://www.jetbrains.com/idea/"
     }
@@ -85,7 +85,7 @@
     "meta": {
       "isOpenSource": false,
       "description": "Paid-for Java, Kotlin, Groovy and Scala IDE from jetbrains",
-      "maintainers": [ "edwtjo", "gytis-ivaskevicius", "steinybot", "tymscar" ],
+      "maintainers": [ "gytis-ivaskevicius", "tymscar" ],
       "longDescription": "IDE for Java SE, Groovy & Scala development Powerful environment for building Google Android apps Integration with JUnit, TestNG, popular SCMs, Ant & Maven. Also known as IntelliJ.",
       "homepage": "https://www.jetbrains.com/idea/"
     }

--- a/pkgs/applications/editors/jetbrains/bin/versions.json
+++ b/pkgs/applications/editors/jetbrains/bin/versions.json
@@ -56,7 +56,7 @@
       "url": "https://download.jetbrains.com/idea/ideaIC-2025.2.5.tar.gz",
       "build_number": "252.28238.7"
     },
-    "idea-ultimate": {
+    "idea": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}.tar.gz",
       "version": "2025.2.5",
@@ -89,12 +89,12 @@
       "url": "https://download.jetbrains.com/python/pycharm-community-2025.2.5.tar.gz",
       "build_number": "252.28238.29"
     },
-    "pycharm-professional": {
+    "pycharm": {
       "update-channel": "PyCharm RELEASE",
-      "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}.tar.gz",
+      "url-template": "https://download.jetbrains.com/python/pycharm-{version}.tar.gz",
       "version": "2025.2.5",
       "sha256": "b1e47419e5844c38e7a7a9be9e5260c75cea6aa8423f2584dc1727f792d5feb4",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.2.5.tar.gz",
+      "url": "https://download.jetbrains.com/python/pycharm-2025.2.5.tar.gz",
       "build_number": "252.28238.29"
     },
     "rider": {
@@ -195,7 +195,7 @@
       "url": "https://download.jetbrains.com/idea/ideaIC-2025.2.5-aarch64.tar.gz",
       "build_number": "252.28238.7"
     },
-    "idea-ultimate": {
+    "idea": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}-aarch64.tar.gz",
       "version": "2025.2.5",
@@ -228,12 +228,12 @@
       "url": "https://download.jetbrains.com/python/pycharm-community-2025.2.5-aarch64.tar.gz",
       "build_number": "252.28238.29"
     },
-    "pycharm-professional": {
+    "pycharm": {
       "update-channel": "PyCharm RELEASE",
-      "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}-aarch64.tar.gz",
+      "url-template": "https://download.jetbrains.com/python/pycharm-{version}-aarch64.tar.gz",
       "version": "2025.2.5",
       "sha256": "7037672c6913f643ec4979ca5f16791588e001ffd39f830d874587f79e358be2",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.2.5-aarch64.tar.gz",
+      "url": "https://download.jetbrains.com/python/pycharm-2025.2.5-aarch64.tar.gz",
       "build_number": "252.28238.29"
     },
     "rider": {
@@ -334,7 +334,7 @@
       "url": "https://download.jetbrains.com/idea/ideaIC-2025.2.5.dmg",
       "build_number": "252.28238.7"
     },
-    "idea-ultimate": {
+    "idea": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}.dmg",
       "version": "2025.2.5",
@@ -367,12 +367,12 @@
       "url": "https://download.jetbrains.com/python/pycharm-community-2025.2.5.dmg",
       "build_number": "252.28238.29"
     },
-    "pycharm-professional": {
+    "pycharm": {
       "update-channel": "PyCharm RELEASE",
-      "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}.dmg",
+      "url-template": "https://download.jetbrains.com/python/pycharm-{version}.dmg",
       "version": "2025.2.5",
       "sha256": "00eccdeb39bd8eeaed1b98ad99f542fbc3851389f9e7d19355d05dfd979eb669",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.2.5.dmg",
+      "url": "https://download.jetbrains.com/python/pycharm-2025.2.5.dmg",
       "build_number": "252.28238.29"
     },
     "rider": {
@@ -473,7 +473,7 @@
       "url": "https://download.jetbrains.com/idea/ideaIC-2025.2.5-aarch64.dmg",
       "build_number": "252.28238.7"
     },
-    "idea-ultimate": {
+    "idea": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}-aarch64.dmg",
       "version": "2025.2.5",
@@ -506,12 +506,12 @@
       "url": "https://download.jetbrains.com/python/pycharm-community-2025.2.5-aarch64.dmg",
       "build_number": "252.28238.29"
     },
-    "pycharm-professional": {
+    "pycharm": {
       "update-channel": "PyCharm RELEASE",
-      "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}-aarch64.dmg",
+      "url-template": "https://download.jetbrains.com/python/pycharm-{version}-aarch64.dmg",
       "version": "2025.2.5",
       "sha256": "71da1283259bc59897e5bb43c6c3771a72d026419ed4d79192889ea3885ac0de",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.2.5-aarch64.dmg",
+      "url": "https://download.jetbrains.com/python/pycharm-2025.2.5-aarch64.dmg",
       "build_number": "252.28238.29"
     },
     "rider": {

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -1,11 +1,12 @@
 let
   # `ides.json` is handwritten and contains information that doesn't change across updates, like maintainers and other metadata
   # `versions.json` contains everything generated/needed by the update script version numbers, build numbers and tarball hashes
-  ideInfo = builtins.fromJSON (builtins.readFile ./bin/ides.json);
+  ideInfo = builtins.fromJSON (builtins.readFile ./ides.json);
   versions = builtins.fromJSON (builtins.readFile ./bin/versions.json);
 in
 
 {
+  config,
   lib,
   stdenv,
   callPackage,
@@ -116,16 +117,8 @@ let
       passthru.tests = extraTests // {
         plugins = callPackage ./plugins/tests.nix { ideName = pname; };
       };
-      libdbm =
-        if ideInfo."${pname}".meta.isOpenSource then
-          communitySources."${pname}".libdbm
-        else
-          communitySources.idea-community.libdbm;
-      fsnotifier =
-        if ideInfo."${pname}".meta.isOpenSource then
-          communitySources."${pname}".fsnotifier
-        else
-          communitySources.idea-community.fsnotifier;
+      libdbm = communitySources."${pname}".libdbm or communitySources.idea-oss.libdbm;
+      fsnotifier = communitySources."${pname}".fsnotifier or communitySources.idea-oss.fsnotifier;
     };
 
   communitySources = callPackage ./source { };
@@ -181,16 +174,30 @@ let
       --replace-needed libcrypt.so.1 libcrypt.so \
       ${lib.optionalString stdenv.hostPlatform.isAarch "--replace-needed libxml2.so.2 libxml2.so"}
   '';
-in
-rec {
-  # Sorted alphabetically
 
-  aqua = mkJetBrainsProduct {
-    pname = "aqua";
+  # TODO: These can be moved down again when we don't need the aliases anymore:
+  _idea = buildIdea {
+    pname = "idea";
     extraBuildInputs = [
       lldb
+      musl
     ];
   };
+  _idea-oss = buildIdea {
+    pname = "idea-oss";
+    fromSource = true;
+  };
+  _pycharm = buildPycharm {
+    pname = "pycharm";
+    extraBuildInputs = [ musl ];
+  };
+  _pycharm-oss = buildPycharm {
+    pname = "pycharm-oss";
+    fromSource = true;
+  };
+in
+{
+  # Sorted alphabetically. Deprecated products and aliases are at the very end.
 
   clion =
     (mkJetBrainsProduct {
@@ -270,28 +277,9 @@ rec {
           '';
       });
 
-  idea-community-bin = buildIdea {
-    pname = "idea-community";
-  };
+  idea = _idea;
 
-  idea-community-src = buildIdea {
-    pname = "idea-community";
-    fromSource = true;
-  };
-
-  idea-community =
-    if stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isAarch64 then
-      idea-community-bin
-    else
-      idea-community-src;
-
-  idea-ultimate = buildIdea {
-    pname = "idea-ultimate";
-    extraBuildInputs = [
-      lldb
-      musl
-    ];
-  };
+  idea-oss = _idea-oss;
 
   mps = mkJetBrainsProduct { pname = "mps"; };
 
@@ -302,20 +290,9 @@ rec {
     ];
   };
 
-  pycharm-community-bin = buildPycharm { pname = "pycharm-community"; };
+  pycharm = _pycharm;
 
-  pycharm-community-src = buildPycharm {
-    pname = "pycharm-community";
-    fromSource = true;
-  };
-
-  pycharm-community =
-    if stdenv.hostPlatform.isDarwin then pycharm-community-bin else pycharm-community-src;
-
-  pycharm-professional = buildPycharm {
-    pname = "pycharm-professional";
-    extraBuildInputs = [ musl ];
-  };
+  pycharm-oss = _pycharm-oss;
 
   rider =
     (mkJetBrainsProduct {
@@ -390,13 +367,70 @@ rec {
     ];
   };
 
-  writerside = mkJetBrainsProduct {
-    pname = "writerside";
-    extraBuildInputs = [
-      musl
-    ];
-  };
+  # Plugins
 
   plugins = callPackage ./plugins { };
 
+}
+
+// lib.optionalAttrs config.allowAliases rec {
+
+  # Deprecated products and aliases.
+
+  aqua =
+    lib.warnOnInstantiate
+      "jetbrains.aqua: Aqua has been discontinued by Jetbrains and is not receiving updates. It will be removed in NixOS 26.05."
+      (mkJetBrainsProduct {
+        pname = "aqua";
+        extraBuildInputs = [
+          lldb
+        ];
+      });
+
+  idea-community =
+    lib.warnOnInstantiate
+      "jetbrains.idea-community: IntelliJ IDEA Community has been discontinued by Jetbrains. This deprecated alias uses the, no longer updated, binary build on Darwin & Linux aarch64. On other platforms it uses IDEA Open Source, built from source. Either switch to 'jetbrains.idea-oss' or 'jetbrains.idea'. See: https://blog.jetbrains.com/idea/2025/07/intellij-idea-unified-distribution-plan/"
+      (
+        if stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isAarch64 then
+          idea-community-bin
+        else
+          _idea-oss
+      );
+
+  idea-community-bin =
+    lib.warnOnInstantiate
+      "jetbrains.idea-community-bin: IntelliJ IDEA Community has been discontinued by Jetbrains. This binary build is no longer updated. Switch to 'jetbrains.idea-oss' for open source builds (from source) or 'jetbrains.idea' for commercial builds (binary, unfree). See: https://blog.jetbrains.com/idea/2025/07/intellij-idea-unified-distribution-plan/"
+      (buildIdea {
+        pname = "idea-community";
+      });
+
+  idea-ultimate = lib.warnOnInstantiate "'jetbrains.idea-ultimate' has been renamed to/replaced by 'jetbrains.idea'" _idea;
+
+  idea-community-src = lib.warnOnInstantiate "jetbrains.idea-community-src: IntelliJ IDEA Community has been discontinued by Jetbrains. This is now an alias for 'jetbrains.idea-oss', the Open Source build of IntelliJ. See: https://blog.jetbrains.com/idea/2025/07/intellij-idea-unified-distribution-plan/" _idea-oss;
+
+  pycharm-community =
+    lib.warnOnInstantiate
+      "pycharm-comminity: PyCharm Community has been discontinued by Jetbrains. This deprecated alias uses the, no longer updated, binary build on Darwin. On Linux it uses PyCharm Open Source, built from source. Either switch to 'jetbrains.pycharm-oss' or 'jetbrains.pycharm'. See: https://blog.jetbrains.com/pycharm/2025/04/pycharm-2025"
+      (if stdenv.hostPlatform.isDarwin then pycharm-community-bin else _pycharm-oss);
+
+  pycharm-community-bin =
+    lib.warnOnInstantiate
+      "pycharm-comminity-bin: PyCharm Community has been discontinued by Jetbrains. This binary build is no longer updated. Switch to 'jetbrains.pycharm-oss' for open source builds (from source) or 'jetbrains.pycharm' for commercial builds (binary, unfree). See: https://blog.jetbrains.com/pycharm/2025/04/pycharm-2025"
+      (buildPycharm {
+        pname = "pycharm-community";
+      });
+
+  pycharm-community-src = lib.warnOnInstantiate "jetbrains.idea-community-src: PyCharm Community has been discontinued by Jetbrains. This is now an alias for 'jetbrains.pycharm-oss', the Open Source build of PyCharm. See: https://blog.jetbrains.com/pycharm/2025/04/pycharm-2025" _pycharm-oss;
+
+  pycharm-professional = lib.warnOnInstantiate "'jetbrains.pycharm-professional' has been renamed to/replaced by 'jetbrains.pycharm'" _pycharm;
+
+  writerside =
+    lib.warnOnInstantiate
+      "jetbrains.writerside: Writerside has been discontinued by Jetbrains and is not receiving updates. It will be removed in NixOS 26.05."
+      (mkJetBrainsProduct {
+        pname = "writerside";
+        extraBuildInputs = [
+          musl
+        ];
+      });
 }

--- a/pkgs/applications/editors/jetbrains/ides.json
+++ b/pkgs/applications/editors/jetbrains/ides.json
@@ -66,25 +66,37 @@
       "homepage": "https://www.jetbrains.com/go/"
     }
   },
+  "idea": {
+    "product": "IntelliJ IDEA",
+    "productShort": "IDEA",
+    "wmClass": "jetbrains-idea",
+    "meta": {
+      "isOpenSource": false,
+      "description": "Java, Kotlin, Groovy and Scala IDE from Jetbrains",
+      "maintainers": [ "gytis-ivaskevicius", "tymscar" ],
+      "longDescription": "IDE for Java SE, Groovy & Scala development Powerful environment for building Google Android apps Integration with JUnit, TestNG, popular SCMs, Ant & Maven. Also known as IntelliJ.",
+      "homepage": "https://www.jetbrains.com/idea/"
+    }
+  },
   "idea-community": {
     "product": "IntelliJ IDEA CE",
     "productShort": "IDEA",
     "wmClass": "jetbrains-idea-ce",
     "meta": {
       "isOpenSource": true,
-      "description": "Free Java, Kotlin, Groovy and Scala IDE from jetbrains",
+      "description": "Free Java, Kotlin, Groovy and Scala IDE from Jetbrains",
       "maintainers": [ "gytis-ivaskevicius", "tymscar" ],
       "longDescription": "IDE for Java SE, Groovy & Scala development Powerful environment for building Google Android apps Integration with JUnit, TestNG, popular SCMs, Ant & Maven. Also known as IntelliJ.",
       "homepage": "https://www.jetbrains.com/idea/"
     }
   },
-  "idea-ultimate": {
-    "product": "IntelliJ IDEA",
+  "idea-oss": {
+    "product": "IntelliJ IDEA Open Source",
     "productShort": "IDEA",
-    "wmClass": "jetbrains-idea",
+    "wmClass": "jetbrains-idea-ce",
     "meta": {
-      "isOpenSource": false,
-      "description": "Paid-for Java, Kotlin, Groovy and Scala IDE from jetbrains",
+      "isOpenSource": true,
+      "description": "Free Java, Kotlin, Groovy and Scala IDE from Jetbrains",
       "maintainers": [ "gytis-ivaskevicius", "tymscar" ],
       "longDescription": "IDE for Java SE, Groovy & Scala development Powerful environment for building Google Android apps Integration with JUnit, TestNG, popular SCMs, Ant & Maven. Also known as IntelliJ.",
       "homepage": "https://www.jetbrains.com/idea/"
@@ -112,6 +124,18 @@
       "homepage": "https://www.jetbrains.com/phpstorm/"
     }
   },
+  "pycharm": {
+    "product": "PyCharm",
+    "productShort": "PyCharm",
+    "wmClass": "jetbrains-pycharm",
+    "meta": {
+      "isOpenSource": false,
+      "description": "Python IDE from JetBrains",
+      "maintainers": [ "genericnerdyusername", "tymscar" ],
+      "longDescription": "Python IDE with complete set of tools for productive development with Python programming language. In addition, the IDE provides high-class capabilities for professional Web development with Django framework and Google App Engine. It has powerful coding assistance, navigation, a lot of refactoring features, tight integration with various Version Control Systems, Unit testing, powerful all-singing all-dancing Debugger and entire customization. PyCharm is developer driven IDE. It was developed with the aim of providing you almost everything you need for your comfortable and productive development!",
+      "homepage": "https://www.jetbrains.com/pycharm/"
+    }
+  },
   "pycharm-community": {
     "product": "PyCharm CE",
     "productShort": "PyCharm",
@@ -124,13 +148,13 @@
       "homepage": "https://www.jetbrains.com/pycharm/"
     }
   },
-  "pycharm-professional": {
-    "product": "PyCharm",
+  "pycharm-oss": {
+    "product": "PyCharm Open Source",
     "productShort": "PyCharm",
-    "wmClass": "jetbrains-pycharm",
+    "wmClass": "jetbrains-pycharm-ce",
     "meta": {
-      "isOpenSource": false,
-      "description": "Paid-for Python IDE from JetBrains",
+      "isOpenSource": true,
+      "description": "Free Python IDE from JetBrains",
       "maintainers": [ "genericnerdyusername", "tymscar" ],
       "longDescription": "Python IDE with complete set of tools for productive development with Python programming language. In addition, the IDE provides high-class capabilities for professional Web development with Django framework and Google App Engine. It has powerful coding assistance, navigation, a lot of refactoring features, tight integration with various Version Control Systems, Unit testing, powerful all-singing all-dancing Debugger and entire customization. PyCharm is developer driven IDE. It was developed with the aim of providing you almost everything you need for your comfortable and productive development!",
       "homepage": "https://www.jetbrains.com/pycharm/"

--- a/pkgs/applications/editors/jetbrains/plugins/default.nix
+++ b/pkgs/applications/editors/jetbrains/plugins/default.nix
@@ -45,7 +45,14 @@ let
 
   selectFile =
     id: ide: build:
-    if !builtins.elem ide pluginsJson.plugins."${id}".compatible then
+    let
+      # Allow all PyCharm/IDEA plugins for PyCharm/IDEA Community
+      # - TODO: Remove this special case once PyCharm/IDEA Community is removed
+      communityCheck =
+        (id != "pycharm-community" || builtins.elem ide pluginsJson.plugins.pycharm.compatible)
+        || (id != "idea-community" || builtins.elem ide pluginsJson.plugins.idea.compatible);
+    in
+    if !communityCheck && !builtins.elem ide pluginsJson.plugins."${id}".compatible then
       throw "Plugin with id ${id} does not support IDE ${ide}"
     else if !pluginsJson.plugins."${id}".builds ? "${build}" then
       throw "Jetbrains IDEs with build ${build} are not in nixpkgs. Try update_plugins.py with --with-build?"

--- a/pkgs/applications/editors/jetbrains/plugins/tests.nix
+++ b/pkgs/applications/editors/jetbrains/plugins/tests.nix
@@ -25,12 +25,14 @@ let
         goland
         idea-community-src
         idea-community-bin
-        idea-ultimate
+        idea-oss
+        idea
         mps
         phpstorm
         pycharm-community-src
         pycharm-community-bin
-        pycharm-professional
+        pycharm-oss
+        pycharm
         rider
         ruby-mine
         rust-rover
@@ -62,11 +64,17 @@ in
         map (plugin: plugin.name) (
           builtins.filter (
             plugin:
+            let
+              # Allow all PyCharm/IDEA plugins for PyCharm/IDEA Community - TODO: Remove this special case once PyCharm/IDEA Community is removed
+              communityCheck =
+                (ide.pname == "pycharm-community" && builtins.elem "pycharm" plugin.compatible)
+                || (ide.pname == "idea-community" && builtins.elem "idea" plugin.compatible);
+            in
             (
               # Plugin has to not be broken
               (!builtins.elem plugin.name broken-plugins)
               # IDE has to be compatible
-              && (builtins.elem ide.pname plugin.compatible)
+              && (communityCheck || builtins.elem ide.pname plugin.compatible)
               # Assert: The build number needs to be included (if marked compatible)
               && (assertMsg (builtins.elem ide.buildNumber (builtins.attrNames plugin.builds)) "For plugin ${plugin.name} no entry for IDE build ${ide.buildNumber} is defined, even though ${ide.pname} is on that build.")
               # The plugin has to exist for the build

--- a/pkgs/applications/editors/jetbrains/plugins/update_plugins.py
+++ b/pkgs/applications/editors/jetbrains/plugins/update_plugins.py
@@ -22,19 +22,19 @@ TOKENS = {
 SNAPSHOT_VALUE = 99999
 PLUGINS_FILE = Path(__file__).parent.joinpath("plugins.json").resolve()
 IDES_BIN_FILE = Path(__file__).parent.joinpath("../bin/versions.json").resolve()
-IDES_SOURCE_FILE = Path(__file__).parent.joinpath("../source/ides.json").resolve()
+IDES_SOURCE_FILE = Path(__file__).parent.joinpath("../source/sources.json").resolve()
 # The plugin compatibility system uses a different naming scheme to the ide update system.
 # These dicts convert between them
 FRIENDLY_TO_PLUGIN = {
     "clion": "CLION",
     "datagrip": "DBE",
     "goland": "GOLAND",
-    "idea-community": "IDEA_COMMUNITY",
-    "idea-ultimate": "IDEA",
+    "idea-oss": "IDEA",  # This was "IDEA_COMMUNITY" before, but this product doesn't exist anymore.
+    "idea": "IDEA",
     "mps": "MPS",
     "phpstorm": "PHPSTORM",
-    "pycharm-community": "PYCHARM_COMMUNITY",
-    "pycharm-professional": "PYCHARM",
+    "pycharm-oss": "PYCHARM",  # This was "PYCHARM_COMMUNITY" before, but this product doesn't exist anymore.
+    "pycharm": "PYCHARM",
     "rider": "RIDER",
     "ruby-mine": "RUBYMINE",
     "rust-rover": "RUST",
@@ -172,7 +172,17 @@ def make_plugin_files(plugin_infos: dict, ide_versions: dict, quiet: bool, extra
             "builds": {},
             "name": names[pid]
         }
-        relevant_builds = [builds for ide, builds in ide_versions.items() if ide in plugin_versions["compatible"]] + [extra_builds]
+        relevant_builds = [
+            builds for ide, builds
+            in ide_versions.items()
+            if (
+                ide in plugin_versions["compatible"]
+                # TODO: Remove this once we removed pycharm-community
+                or (ide == "pycharm-community" and "pycharm" in plugin_versions["compatible"])
+                # TODO: Remove this once we removed idea-community
+                or (ide == "idea-community" and "idea" in plugin_versions["compatible"])
+            )
+        ] + [extra_builds]
         relevant_builds = sorted(list(set(flatten(relevant_builds))))  # Flatten, remove duplicates and sort
         for build in relevant_builds:
             plugin_versions["builds"][build] = get_newest_compatible(pid, build, plugin_infos[pid], quiet)

--- a/pkgs/applications/editors/jetbrains/readme.md
+++ b/pkgs/applications/editors/jetbrains/readme.md
@@ -24,10 +24,10 @@ The jdk is in `pkgs/development/compilers/jetbrains-jdk`.
 ## How to update stuff:
  - Run ./bin/update_bin.py, this will update binary IDEs and plugins, and automatically commit them
  - Source builds need a bit more effort, as they **aren't automated at the moment**:
-   - Run ./source/update.py ./source/ides.json ./bin/versions.json. This will update the source version to the version of their corresponding binary packages.
+   - Run ./source/update.py ./source/sources.json ./bin/versions.json. This will update the source version to the version of their corresponding binary packages.
    - Run these commands respectively:
-     - `nix build .#jetbrains.idea-community-src.src.src && ./source/build_maven.py source/idea_maven_artefacts.json result/` for IDEA
-     - `nix build .#jetbrains.pycharm-community-src.src.src && ./source/build_maven.py source/pycharm_maven_artefacts.json result/` for PyCharm
+     - `nix build .#jetbrains.idea-oss.src.src && ./source/build_maven.py source/idea_maven_artefacts.json result/` for IDEA
+     - `nix build .#jetbrains.pycharm-oss.src.src && ./source/build_maven.py source/pycharm_maven_artefacts.json result/` for PyCharm
    - Update `brokenPlugins` timestamp and hash (from https://web.archive.org/web/*/https://plugins.jetbrains.com/files/brokenPlugins.json)
    - Do a test build
      - Notice that sometimes a newer Kotlin version is required to build from source, if build fails, first check the recommended Kotlin version in `.idea/kotlinc.xml` in the IDEA source root
@@ -40,7 +40,7 @@ The jdk is in `pkgs/development/compilers/jetbrains-jdk`.
 ## How to add an IDE:
  - Make dummy entries in `bin/versions.json` (make sure to set the version to something older than the real one)
  - Run `bin/update_bin.py`
- - Add an entry in `bin/ides.json`
+ - Add an entry in `ides.json`
  - Add an entry in `default.nix`
 
 ### TODO:

--- a/pkgs/applications/editors/jetbrains/source/build.nix
+++ b/pkgs/applications/editors/jetbrains/source/build.nix
@@ -244,7 +244,7 @@ let
 
 in
 stdenvNoCC.mkDerivation rec {
-  pname = "${buildType}-community";
+  pname = "${buildType}-oss";
   inherit version buildNumber;
   name = "${pname}-${version}.tar.gz";
   inherit src;

--- a/pkgs/applications/editors/jetbrains/source/default.nix
+++ b/pkgs/applications/editors/jetbrains/source/default.nix
@@ -1,5 +1,5 @@
 let
-  ides = builtins.fromJSON (builtins.readFile ./ides.json);
+  ides = builtins.fromJSON (builtins.readFile ./sources.json);
 in
 {
   callPackage,

--- a/pkgs/applications/editors/jetbrains/source/sources.json
+++ b/pkgs/applications/editors/jetbrains/source/sources.json
@@ -1,5 +1,5 @@
 {
-  "idea-community": {
+  "idea-oss": {
     "version": "2025.1.1.1",
     "buildNumber": "251.25410.129",
     "buildType": "idea",
@@ -24,7 +24,7 @@
       "hash": "sha256-Bu5eCHxls6EoIgzadiEY31plAcxZ6DA2a10CXAtPqV4="
     }
   },
-  "pycharm-community": {
+  "pycharm-oss": {
     "version": "2025.1.1.1",
     "buildNumber": "251.25410.159",
     "buildType": "pycharm",

--- a/pkgs/applications/editors/jetbrains/source/update.py
+++ b/pkgs/applications/editors/jetbrains/source/update.py
@@ -93,38 +93,38 @@ def get_args() -> (str, str):
 def main():
     versions_path, out = get_args()
     versions = loads(open(versions_path).read())
-    idea_data = versions['x86_64-linux']['idea-community']
-    pycharm_data = versions['x86_64-linux']['pycharm-community']
+    idea_data = versions['x86_64-linux']['idea-oss']
+    pycharm_data = versions['x86_64-linux']['pycharm-oss']
 
-    result = { 'idea-community': {}, 'pycharm-community': {} }
-    result['idea-community']['version'] = idea_data['version']
-    result['idea-community']['buildNumber'] = idea_data['build_number']
-    result['idea-community']['buildType'] = 'idea'
-    result['pycharm-community']['version'] = pycharm_data['version']
-    result['pycharm-community']['buildNumber'] = pycharm_data['build_number']
-    result['pycharm-community']['buildType'] = 'pycharm'
+    result = { 'idea-oss': {}, 'pycharm-oss': {} }
+    result['idea-oss']['version'] = idea_data['version']
+    result['idea-oss']['buildNumber'] = idea_data['build_number']
+    result['idea-oss']['buildType'] = 'idea'
+    result['pycharm-oss']['version'] = pycharm_data['version']
+    result['pycharm-oss']['buildNumber'] = pycharm_data['build_number']
+    result['pycharm-oss']['buildType'] = 'pycharm'
     print('Fetching IDEA info...')
-    result['idea-community']['ideaHash'], ideaOutPath = prefetch_intellij_community('idea', result['idea-community']['buildNumber'])
-    result['idea-community']['androidHash'] = prefetch_android('idea', result['idea-community']['buildNumber'])
-    result['idea-community']['jpsHash'] = ''
-    result['idea-community']['restarterHash'] = ''
-    result['idea-community']['mvnDeps'] = 'idea_maven_artefacts.json'
-    result['idea-community']['repositories'] = jar_repositories(ideaOutPath)
-    result['idea-community']['kotlin-jps-plugin'] = {}
-    result['idea-community']['kotlin-jps-plugin']['version'], result['idea-community']['kotlin-jps-plugin']['hash'] = kotlin_jps_plugin_info(ideaOutPath)
+    result['idea-oss']['ideaHash'], ideaOutPath = prefetch_intellij_community('idea', result['idea-oss']['buildNumber'])
+    result['idea-oss']['androidHash'] = prefetch_android('idea', result['idea-oss']['buildNumber'])
+    result['idea-oss']['jpsHash'] = ''
+    result['idea-oss']['restarterHash'] = ''
+    result['idea-oss']['mvnDeps'] = 'idea_maven_artefacts.json'
+    result['idea-oss']['repositories'] = jar_repositories(ideaOutPath)
+    result['idea-oss']['kotlin-jps-plugin'] = {}
+    result['idea-oss']['kotlin-jps-plugin']['version'], result['idea-oss']['kotlin-jps-plugin']['hash'] = kotlin_jps_plugin_info(ideaOutPath)
     kotlinc_version = requested_kotlinc_version(ideaOutPath)
-    print(f"* Prefetched IDEA Community requested Kotlin compiler {kotlinc_version}")
+    print(f"* Prefetched IDEA Open Source requested Kotlin compiler {kotlinc_version}")
     print('Fetching PyCharm info...')
-    result['pycharm-community']['ideaHash'], pycharmOutPath = prefetch_intellij_community('pycharm', result['pycharm-community']['buildNumber'])
-    result['pycharm-community']['androidHash'] = prefetch_android('pycharm', result['pycharm-community']['buildNumber'])
-    result['pycharm-community']['jpsHash'] = ''
-    result['pycharm-community']['restarterHash'] = ''
-    result['pycharm-community']['mvnDeps'] = 'pycharm_maven_artefacts.json'
-    result['pycharm-community']['repositories'] = jar_repositories(pycharmOutPath)
-    result['pycharm-community']['kotlin-jps-plugin'] = {}
-    result['pycharm-community']['kotlin-jps-plugin']['version'], result['pycharm-community']['kotlin-jps-plugin']['hash'] = kotlin_jps_plugin_info(pycharmOutPath)
+    result['pycharm-oss']['ideaHash'], pycharmOutPath = prefetch_intellij_community('pycharm', result['pycharm-oss']['buildNumber'])
+    result['pycharm-oss']['androidHash'] = prefetch_android('pycharm', result['pycharm-oss']['buildNumber'])
+    result['pycharm-oss']['jpsHash'] = ''
+    result['pycharm-oss']['restarterHash'] = ''
+    result['pycharm-oss']['mvnDeps'] = 'pycharm_maven_artefacts.json'
+    result['pycharm-oss']['repositories'] = jar_repositories(pycharmOutPath)
+    result['pycharm-oss']['kotlin-jps-plugin'] = {}
+    result['pycharm-oss']['kotlin-jps-plugin']['version'], result['pycharm-oss']['kotlin-jps-plugin']['hash'] = kotlin_jps_plugin_info(pycharmOutPath)
     kotlinc_version = requested_kotlinc_version(pycharmOutPath)
-    print(f"* Prefetched PyCharm Community requested Kotlin compiler {kotlinc_version}")
+    print(f"* Prefetched PyCharm Open Source requested Kotlin compiler {kotlinc_version}")
 
     if out == "stdout":
         dump(result, stdout, indent=2)


### PR DESCRIPTION
Backport for #466331

The automatic backport just failed due to some changes in the maintainer lists not being backported; I backported the maintainer lists from 25.11 in a seperate commit.
