### PR TITLE
chronograph: init at 5.3.1

### DIFF
--- a/pkgs/by-name/ch/chronograph/package.nix
+++ b/pkgs/by-name/ch/chronograph/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  blueprint-compiler,
+  desktop-file-utils,
+  wrapGAppsHook4,
+  libadwaita,
+  gst_all_1,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "chronograph";
+  version = "5.3.1";
+  pyproject = false; # Built with meson
+
+  src = fetchFromGitHub {
+    owner = "Dzheremi2";
+    repo = "Chronograph";
+    tag = "v${version}";
+    hash = "sha256-xSvlvDXKJaL4sKQE+h9XkffFm3/1rHROlGxZgerBlNg=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    blueprint-compiler
+    desktop-file-utils
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    libadwaita
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-ugly
+  ];
+
+  dependencies = with python3Packages; [
+    pygobject3
+    pyyaml
+    mutagen
+    pillow
+    magic
+    httpx
+    requests
+  ];
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=(''${gappsWrapperArgs[@]})
+  '';
+
+  meta = {
+    description = "Sync lyrics of your loved songs";
+    homepage = "https://github.com/Dzheremi2/Chronograph";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "chronograph";
+    maintainers = with lib.maintainers; [ aleksana ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
