### PR TITLE
openjdk{8,11}: fix build with gcc15

### DIFF
--- a/pkgs/development/compilers/openjdk/generic.nix
+++ b/pkgs/development/compilers/openjdk/generic.nix
@@ -412,10 +412,16 @@ stdenv.mkDerivation (finalAttrs: {
       if atLeast17 then
         "-Wno-error"
       else if atLeast11 then
-        # Workaround for
-        # `cc1plus: error: '-Wformat-security' ignored without '-Wformat' [-Werror=format-security]`
-        # when building jtreg
-        "-Wformat"
+        lib.concatStringsSep " " (
+          # Workaround for
+          # `cc1plus: error: '-Wformat-security' ignored without '-Wformat' [-Werror=format-security]`
+          # when building jtreg
+          [ "-Wformat" ]
+          ++ lib.optionals (stdenv.cc.isGNU && featureVersion == "11") [
+            # Fix build with gcc15
+            "-std=gnu17"
+          ]
+        )
       else
         lib.concatStringsSep " " (
           [
@@ -435,6 +441,10 @@ stdenv.mkDerivation (finalAttrs: {
             # error by default in GCC 14
             "-Wno-error=int-conversion"
             "-Wno-error=incompatible-pointer-types"
+          ]
+          ++ lib.optionals (stdenv.cc.isGNU && featureVersion == "8") [
+            # Fix build with gcc15
+            "-std=gnu17"
           ]
         );
 


### PR DESCRIPTION
- add "-std=gnu17" to `env.NIX_CFLAGS_COMPILE` for `openjdk8` and `openjdk11`

Similar to what archlinux and gentoo did:
https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=65ea75ab7b558c1a7471eaf9ab542cee66631ea5
https://gitlab.archlinux.org/archlinux/packaging/packages/java8-openjdk/-/commit/e2b65f230bb5f15b75377306f41635ba44f84f61
https://gitlab.archlinux.org/archlinux/packaging/packages/java11-openjdk/-/commit/87ced23f8bd6b7e911f8b668545aa8c9950087e9

Fixes build failure of `openjdk8` with gcc15:
```
In file included from /build/source/hotspot/agent/src/os/linux/libproc_impl.h:30,
                 from /build/source/hotspot/agent/src/os/linux/salibelf.h:30,
                 from /build/source/hotspot/agent/src/os/linux/salibelf.c:25:
/build/source/hotspot/agent/src/os/linux/libproc.h:86:13: error: 'bool'
cannot be defined via 'typedef'
   86 | typedef int bool;
      |             ^~~~
/build/source/hotspot/agent/src/os/linux/libproc.h:86:13: note: 'bool'
is a keyword with '-std=c23' onwards
```

Fixes build failure of `openjdk11` with gcc15:
```
/build/source/src/java.base/unix/native/libnet/DefaultProxySelector.c:
In function 'getProxyByGProxyResolver':
/build/source/src/java.base/unix/native/libnet/DefaultProxySelector.c:389:16:
error: too many arguments to function 'g_proxy_resolver_lookup'; expected 0, have 4
  389 |     proxies = (*g_proxy_resolver_lookup)(resolver, uri, NULL, &error);
      |               ~^~~~~~~~~~~~~~~~~~~~~~~~~ ~~~~~~~~
/build/source/src/java.base/unix/native/libnet/DefaultProxySelector.c:408:34:
error: too many arguments to function 'g_network_address_parse_uri'; expected 0, have 3
  408 |                                 (*g_network_address_parse_uri)(proxies[i], 0,
      |                                 ~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~
```

---

Tested build with:
```bash
nix-build --expr 'with import ./. {}; openjdk8.override { stdenv = gcc15Stdenv; buildPackages = buildPackages // { stdenv = buildPackages.gcc15Stdenv; }; }'
nix-build --expr 'with import ./. {}; openjdk11.override { stdenv = gcc15Stdenv; buildPackages = buildPackages // { stdenv = buildPackages.gcc15Stdenv; }; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

---

There is probably a way to insert `-std=gnu17` in a different way, so there is no spam of warnings in log:
```text
cc1plus: warning: command-line option '-std=gnu17' is valid for C/ObjC but not for C++
```
but I could not find it.
Maybe something with `LANGSTD_CFLAGS` set or patched somehow.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
