### PR TITLE
cogl: fix build with gcc15

### DIFF
--- a/pkgs/by-name/co/cogl/package.nix
+++ b/pkgs/by-name/co/cogl/package.nix
@@ -111,9 +111,16 @@ stdenv.mkDerivation rec {
         "-I${harfbuzz.dev}/include/harfbuzz"
       ]
     );
-  }
-  // lib.optionalAttrs stdenv.cc.isClang {
-    NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
+    NIX_CFLAGS_COMPILE = toString (
+      [ ]
+      ++ lib.optional stdenv.cc.isGNU [
+        # Fix build with gcc15
+        "-std=gnu17"
+      ]
+      ++ lib.optional stdenv.cc.isClang [
+        "-Wno-error=implicit-function-declaration"
+      ]
+    );
   };
 
   #doCheck = true; # all tests fail (no idea why)


### PR DESCRIPTION
- add "-std=gnu17" to `env.NIX_CFLAGS_COMPILE`

Upstream repo is archived:
https://gitlab.gnome.org/Archive/cogl

Other distros also used "-std=gnu17":
https://gitlab.alpinelinux.org/alpine/aports/-/commit/d9e057053f20fcc7d46c7f8c6222100a88e017e8
https://github.com/gentoo/gentoo/commit/379ca097b966b40890b5a4572502b8f9352a374d
https://src.fedoraproject.org/rpms/cogl/c/442af4e8c3e17e8d5b051a4e1600f23f366f5554

Fixes build failure with gcc15:
```
cogl-path.c:1361:20: error: passing argument 3 of 'gluTessCallback'
from incompatible pointer type
[8;;https://gcc.gnu.org/onlinedocs/gcc-15.2.0/gcc/Warning-Options.html#index-Wincompatible-pointer-types-Wincompatible-pointer-types8;;]
 1361 |                    _cogl_path_tesselator_begin);
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                    |
      |                    void (*)(GLenum,  CoglPathTesselator *) {aka void (*)(unsigned int,  struct _CoglPathTesselator *)}
In file included from cogl-path.c:49:
tesselator/tesselator.h:57:70: note: expected 'void (*)(void)' but
argument is of type 'void (*)(GLenum,  CoglPathTesselator *)'
{aka 'void (*)(unsigned int,  struct _CoglPathTesselator *)'}
   57 | void gluTessCallback (GLUtesselator* tess, GLenum which, _GLUfuncptr CallBackFunc);
      |                                                          ~~~~~~~~~~~~^~~~~~~~~~~~
cogl-path.c:1094:1: note: '_cogl_path_tesselator_begin' declared here
 1094 | _cogl_path_tesselator_begin (GLenum type,
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~

```

---

Tested build with:
```bash
nix-build --expr 'with import ./. {}; cogl.override { stdenv = gcc15Stdenv; }'
```
Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
