### PR TITLE
python3Packages.arviz: 0.22.0 -> 0.23.0

### DIFF
--- a/pkgs/development/python-modules/arviz/default.nix
+++ b/pkgs/development/python-modules/arviz/default.nix
@@ -4,6 +4,9 @@
   buildPythonPackage,
   fetchFromGitHub,
 
+  # nativeBuildInputs
+  writableTmpDirAsHomeHook,
+
   # build-system
   packaging,
   setuptools,
@@ -33,21 +36,27 @@
   #, pystan (not packaged)
   pytestCheckHook,
   torchvision,
-  writableTmpDirAsHomeHook,
   zarr,
 }:
 
 buildPythonPackage rec {
   pname = "arviz";
-  version = "0.22.0";
+  version = "0.23.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "arviz-devs";
     repo = "arviz";
     tag = "v${version}";
-    hash = "sha256-ZzZZKEtpVy44119H+upU36VLriZjjwPz3gqgKrL+gRI=";
+    hash = "sha256-/Xz4hTKB1lh9cxHkVXAZY8NsZoqdadukI/V1/LRZu24=";
   };
+
+  nativeBuildInputs = [
+    # Arviz wants to write a stamp file to the homedir at import time.
+    # Without $HOME being writable, `pythonImportsCheck` fails.
+    # https://github.com/arviz-devs/arviz/commit/4db612908f588d89bb5bfb6b83a08ada3d54fd02
+    writableTmpDirAsHomeHook
+  ];
 
   build-system = [
     packaging
@@ -80,7 +89,6 @@ buildPythonPackage rec {
     # pystan (not packaged)
     pytestCheckHook
     torchvision
-    writableTmpDirAsHomeHook
     zarr
   ];
 

--- a/pkgs/development/python-modules/corner/default.nix
+++ b/pkgs/development/python-modules/corner/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  writableTmpDirAsHomeHook,
 
   # build-system
   hatch-vcs,
@@ -36,6 +37,13 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-gK2yylteI3VLVJ0p7NB7bR7cirCo2BvFKnYIH3kfyh4=";
   };
+
+  nativeBuildInputs = [
+    # During `pythonImportsCheck`, `corner` imports `arviz` which wants to write a stamp file to the
+    # homedir. It then needs to be writable.
+    # https://github.com/arviz-devs/arviz/commit/4db612908f588d89bb5bfb6b83a08ada3d54fd02
+    writableTmpDirAsHomeHook
+  ];
 
   build-system = [
     hatch-vcs


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/arviz-devs/arviz/compare/v0.22.0...v0.23.0
Changelog: https://github.com/arviz-devs/arviz/blob/v0.23.0/CHANGELOG.md

cc @OmnipotentEntity

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc