### PR TITLE
meshtastic-web: build from source

### DIFF
--- a/pkgs/by-name/me/meshtastic-web/package.nix
+++ b/pkgs/by-name/me/meshtastic-web/package.nix
@@ -1,23 +1,63 @@
 {
-  stdenv,
   lib,
-  fetchurl,
+  stdenv,
+  fetchFromGitHub,
+  pnpm_9,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  nodejs,
 }:
+
 stdenv.mkDerivation (finalAttrs: {
   pname = "meshtastic-web";
   version = "2.6.7";
 
-  src = fetchurl {
-    url = "https://github.com/meshtastic/web/releases/download/v${finalAttrs.version}/build.tar";
-    hash = "sha256-o09DYKBIZUOmmN4g3lM1V0kudjq0Wfwn/OqV0ElRRO0=";
+  src = fetchFromGitHub {
+    owner = "meshtastic";
+    repo = "web";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-71/Wr/b42fknVCdeO99AI4ZpJk8Smkse/TFisKLzBCQ=";
+    fetchSubmodules = true;
+    leaveDotGit = true;
+    postFetch = ''
+      cd "$out"
+      git rev-parse --short HEAD > $out/COMMIT
+      find "$out" -name .git -print0 | xargs -0 rm -rf
+    '';
   };
 
-  sourceRoot = ".";
+  pnpmWorkspaces = [ "*" ];
+  pnpmRoot = "packages/web";
+  pnpmDeps = fetchPnpmDeps {
+    pnpm = pnpm_9;
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      pnpmWorkspaces
+      ;
+    fetcherVersion = 2;
+    hash = "sha256-p8AdAYqaHoKaWirNy9uPLs/kRDVNDcXBJQ1y29MVAA0=";
+  };
+
+  nativeBuildInputs = [
+    pnpm_9
+    pnpmConfigHook
+    nodejs
+  ];
+
+  preConfigure = ''
+    substituteInPlace packages/web/vite.config.ts \
+      --replace-fail "hash = \"DEV\"" "hash = \"$(cat COMMIT)\"" \
+      --replace-fail "version = \"v0.0.0\"" "version = \"${finalAttrs.version}\""
+  '';
 
   buildPhase = ''
     runHook preBuild
 
-    gzip -dr .
+    pushd packages/web
+    pnpm install
+    pnpm run build
 
     runHook postBuild
   '';
@@ -26,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
 
     mkdir -p $out
-    cp -ar . $out/
+    cp -ar dist/. $out/
 
     runHook postInstall
   '';


### PR DESCRIPTION
Test this with:

```shell
nix-shell -p caddy --run 'caddy file-server --listen 127.0.0.1:8888 --root $(nix-build -A meshtastic-web --no-out-link)'
```

The website will be available at http://127.0.0.1:8888

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
