### PR TITLE
ci/github-script/bot: skip mergeability checks temporarily

### DIFF
--- a/ci/github-script/bot.js
+++ b/ci/github-script/bot.js
@@ -145,10 +145,22 @@ module.exports = async ({ github, context, core, dry }) => {
 
     // This API request is important for the merge-conflict label, because it triggers the
     // creation of a new test merge commit. This is needed to actually determine the state of a PR.
+    //
+    // NOTE (2025-12-15): Temporarily skipping mergeability checks here
+    // on GitHub’s request to measure the impact of the resulting ref
+    // writes on their internal metrics; merge conflicts resulting from
+    // changes to target branches will not have labels applied for the
+    // duration. The label should still be updated on pushes.
+    //
+    // TODO: Restore mergeability checks in some form after a few days
+    // or when we hear back from GitHub.
     const pull_request = (
       await github.rest.pulls.get({
         ...context.repo,
         pull_number,
+        // Undocumented parameter (as of 2025-12-15), added by GitHub
+        // for us; stability unclear.
+        skip_mergeability_checks: true,
       })
     ).data
 


### PR DESCRIPTION
This is an experiment and can be reverted a few days from now; if the results are positive on GitHub’s end, then we may want to make the merge conflict checks run less frequently than the rest of the labelling tasks.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] Manually with `ci/github-script/run`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
