### PR TITLE
gale: fix build by patching tauri version to match

### DIFF
--- a/pkgs/by-name/ga/gale/fix-frontend-backend-tauri-version-mismatch.patch
+++ b/pkgs/by-name/ga/gale/fix-frontend-backend-tauri-version-mismatch.patch
@@ -1,0 +1,88 @@
+diff --git a/package.json b/package.json
+index baa5356..d2c5dcf 100644
+--- a/package.json
++++ b/package.json
+@@ -32,7 +32,7 @@
+ 	},
+ 	"type": "module",
+ 	"dependencies": {
+-		"@tauri-apps/api": "^2.6.0",
++		"@tauri-apps/api": "2.7.0",
+ 		"@tauri-apps/plugin-clipboard-manager": "^2.3.0",
+ 		"@tauri-apps/plugin-deep-link": "^2.4.0",
+ 		"@tauri-apps/plugin-dialog": "^2.3.0",
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index 562bafc..50dac76 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -9,8 +9,8 @@ importers:
+   .:
+     dependencies:
+       '@tauri-apps/api':
+-        specifier: ^2.6.0
+-        version: 2.6.0
++        specifier: 2.7.0
++        version: 2.7.0
+       '@tauri-apps/plugin-clipboard-manager':
+         specifier: ^2.3.0
+         version: 2.3.0
+@@ -517,8 +517,8 @@ packages:
+     peerDependencies:
+       vite: ^5.2.0 || ^6 || ^7
+ 
+-  '@tauri-apps/api@2.6.0':
+-    resolution: {integrity: sha512-hRNcdercfgpzgFrMXWwNDBN0B7vNzOzRepy6ZAmhxi5mDLVPNrTpo9MGg2tN/F7JRugj4d2aF7E1rtPXAHaetg==}
++  '@tauri-apps/api@2.7.0':
++    resolution: {integrity: sha512-v7fVE8jqBl8xJFOcBafDzXFc8FnicoH3j8o8DNNs0tHuEBmXUDqrCOAzMRX0UkfpwqZLqvrvK0GNQ45DfnoVDg==}
+ 
+   '@tauri-apps/plugin-clipboard-manager@2.3.0':
+     resolution: {integrity: sha512-81NOBA2P+OTY8RLkBwyl9ZR/0CeggLub4F6zxcxUIfFOAqtky7J61+K/MkH2SC1FMxNBxrX0swDuKvkjkHadlA==}
+@@ -1548,39 +1548,39 @@ snapshots:
+       tailwindcss: 4.1.11
+       vite: 5.4.19(lightningcss@1.30.1)
+ 
+-  '@tauri-apps/api@2.6.0': {}
++  '@tauri-apps/api@2.7.0': {}
+ 
+   '@tauri-apps/plugin-clipboard-manager@2.3.0':
+     dependencies:
+-      '@tauri-apps/api': 2.6.0
++      '@tauri-apps/api': 2.7.0
+ 
+   '@tauri-apps/plugin-deep-link@2.4.0':
+     dependencies:
+-      '@tauri-apps/api': 2.6.0
++      '@tauri-apps/api': 2.7.0
+ 
+   '@tauri-apps/plugin-dialog@2.3.0':
+     dependencies:
+-      '@tauri-apps/api': 2.6.0
++      '@tauri-apps/api': 2.7.0
+ 
+   '@tauri-apps/plugin-http@2.5.0':
+     dependencies:
+-      '@tauri-apps/api': 2.6.0
++      '@tauri-apps/api': 2.7.0
+ 
+   '@tauri-apps/plugin-os@2.3.0':
+     dependencies:
+-      '@tauri-apps/api': 2.6.0
++      '@tauri-apps/api': 2.7.0
+ 
+   '@tauri-apps/plugin-process@2.3.0':
+     dependencies:
+-      '@tauri-apps/api': 2.6.0
++      '@tauri-apps/api': 2.7.0
+ 
+   '@tauri-apps/plugin-shell@2.3.0':
+     dependencies:
+-      '@tauri-apps/api': 2.6.0
++      '@tauri-apps/api': 2.7.0
+ 
+   '@tauri-apps/plugin-updater@2.9.0':
+     dependencies:
+-      '@tauri-apps/api': 2.6.0
++      '@tauri-apps/api': 2.7.0
+ 
+   '@types/cookie@0.6.0': {}
+ 

--- a/pkgs/by-name/ga/gale/package.nix
+++ b/pkgs/by-name/ga/gale/package.nix
@@ -29,15 +29,22 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-SnPYuMYdoY69CWMztuDxw0ohRDU2uECNhBs46hLg+eA=";
   };
 
+  patches = [ ./fix-frontend-backend-tauri-version-mismatch.patch ];
+
+  pnpmDeps = pnpm_10.fetchDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      patches
+      ;
+    fetcherVersion = 1;
+    hash = "sha256-ILhAhpY9a50a0KKWs5Y+G3jDyWuySHw8QcOJlYePzmc=";
+  };
+
   postPatch = ''
     jq '.bundle.createUpdaterArtifacts = false' src-tauri/tauri.conf.json | sponge src-tauri/tauri.conf.json
   '';
-
-  pnpmDeps = pnpm_10.fetchDeps {
-    inherit (finalAttrs) pname version src;
-    fetcherVersion = 1;
-    hash = "sha256-DYhPe59qfsSjyMIN31RL0mrHfmE6/I1SF+XutettkO8=";
-  };
 
   cargoRoot = "src-tauri";
   buildAndTestSubdir = finalAttrs.cargoRoot;


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/468830

Updating the package might also have been a solution, but I wanted to get this merged earlier so that the version bump can be reviewed separately from the build failure.
And also so that if anyone else stumbles aross this kind of issue, they have something to go off of.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
