### PR TITLE
nixos/hardware: always add renesas kernel module to initrd

### DIFF
--- a/nixos/modules/hardware/all-hardware.nix
+++ b/nixos/modules/hardware/all-hardware.nix
@@ -81,6 +81,7 @@ in
       # USB support, especially for booting from USB CD-ROM
       # drives.
       "uas"
+      "xhci-pci-renesas"
 
       # SD cards.
       "sdhci_pci"
@@ -155,9 +156,6 @@ in
       "axp20x-battery"
       "pinctrl-axp209"
       "mp8859"
-
-      # USB drivers
-      "xhci-pci-renesas"
 
       # Reset controllers
       "reset-raspberrypi" # Triggers USB chip firmware load.


### PR DESCRIPTION
Renesas controllers are used on Dell x86 servers to mount virtual media through iDRAC.

The official NixOS iso installer fails when mounted through iDRAC as virtual media:

<img width="1393" height="893" alt="Screenshot from 2025-12-15 19-09-31" src="https://github.com/user-attachments/assets/1fd68f87-1c0b-4ea3-9faf-cdd43b3741dd" />
 
The change adds the relevant kernel module to the initrd, not only on aarch64 as before.



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
