### PR TITLE
vex-tui: init at 2.0.1

### DIFF
--- a/pkgs/by-name/ve/vex-tui/package.nix
+++ b/pkgs/by-name/ve/vex-tui/package.nix
@@ -1,0 +1,36 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+}:
+buildGoModule (finalAttrs: {
+  pname = "vex-tui";
+  version = "2.0.1";
+
+  src = fetchFromGitHub {
+    owner = "CodeOne45";
+    repo = "vex-tui";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-NHGqfdto2geJD9FUFMC/MEpGocNrRN8gtJ0J/6kSJkc=";
+  };
+
+  vendorHash = "sha256-PvaV0tJjIVppB36Cxg4aAKX0MBjgFC5S4GTs1zHxCCU=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  postInstall = ''
+    mv $out/bin/{vex-tui,vex}
+  '';
+
+  meta = {
+    description = "Beautiful, fast, and feature-rich terminal-based Excel and CSV viewer built with Go";
+    homepage = "https://github.com/CodeOne45/vex-tui";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ Inarizxc ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
https://github.com/CodeOne45/vex-tui

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
