### PR TITLE
nix-scheduler-hook: init at 0.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15187,6 +15187,12 @@
     githubId = 591860;
     name = "Lionello Lunesu";
   };
+  lisanna-dettwyler = {
+    email = "lisanna.dettwyler@gmail.com";
+    github = "lisanna-dettwyler";
+    githubId = 72424138;
+    name = "Lisanna Dettwyler";
+  };
   litchipi = {
     email = "litchi.pi@proton.me";
     github = "litchipi";

--- a/pkgs/by-name/ni/nix-scheduler-hook/package.nix
+++ b/pkgs/by-name/ni/nix-scheduler-hook/package.nix
@@ -1,0 +1,83 @@
+{
+  fetchFromGitHub,
+  stdenv,
+  lib,
+  nix,
+  meson,
+  cmake,
+  ninja,
+  boost,
+  pkg-config,
+  nlohmann_json,
+  curl,
+  openpbs,
+  symlinkJoin,
+  slurm,
+}:
+let
+  restclient-cpp = fetchFromGitHub {
+    owner = "mrtazz";
+    repo = "restclient-cpp";
+    rev = "3356f816b161279cfbe318c45cb07c07fb8de6df";
+    hash = "sha256-9//KssNRD7OJFNFdXgzsu7rKP/Nlb4wtmBjfhOt2Vgw=";
+  };
+  slurmJoined = symlinkJoin {
+    name = "slurm";
+    paths = [
+      slurm
+      slurm.dev
+    ];
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "nix-scheduler-hook";
+  version = "0.6.1";
+
+  src = fetchFromGitHub {
+    owner = "lisanna-dettwyler";
+    repo = "nix-scheduler-hook";
+    tag = "v${version}";
+    hash = "sha256-pB42rjqkASgdYQJD9nPqFSM0JAUIko1FN4d0J52BUsc=";
+  };
+
+  sourceRoot = "source/src";
+
+  nativeBuildInputs = [
+    meson
+    cmake
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    boost
+    curl
+    nix.libs.nix-util
+    nix.libs.nix-store
+    nix.libs.nix-main
+    nlohmann_json
+    openpbs
+    slurmJoined
+  ];
+
+  postUnpack = ''
+    mkdir $sourceRoot/subprojects
+    cp -r ${restclient-cpp} $sourceRoot/subprojects/restclient-cpp
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv nsh $out/bin
+    mkdir -p $out/lib
+    mv subprojects/restclient-cpp/librestclient_cpp.so $out/lib
+  '';
+
+  meta = {
+    description = "Nix build hook that forwards builds to job schedulers";
+    homepage = "https://github.com/lisanna-dettwyler/nix-scheduler-hook";
+    license = lib.licenses.lgpl21;
+    mainProgram = "nsh";
+    maintainers = with lib.maintainers; [ lisanna-dettwyler ];
+    inherit (nix.meta) platforms;
+  };
+}

--- a/pkgs/by-name/op/openpbs/2709.patch
+++ b/pkgs/by-name/op/openpbs/2709.patch
@@ -1,0 +1,190 @@
+From 236aa3fa2f5ee68a8be21a5cc3a729fb90539f1e Mon Sep 17 00:00:00 2001
+From: Eisuke Kawashima <e-kwsm@users.noreply.github.com>
+Date: Sun, 25 May 2025 20:38:53 +0900
+Subject: [PATCH] fix: fix -Wincompatible-pointer-types
+
+fix #2679
+---
+ src/include/pbs_nodes.h       | 4 ++--
+ src/include/svrfunc.h         | 2 +-
+ src/include/work_task.h       | 2 +-
+ src/lib/Libattr/attr_fn_acl.c | 2 +-
+ src/lib/Libnet/net_server.c   | 2 +-
+ src/server/hook_func.c        | 2 +-
+ src/server/issue_request.c    | 6 +++---
+ src/server/node_manager.c     | 2 +-
+ src/server/req_jobobit.c      | 2 +-
+ src/server/req_manager.c      | 2 +-
+ src/server/svr_movejob.c      | 2 +-
+ 11 files changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/src/include/pbs_nodes.h b/src/include/pbs_nodes.h
+index bc206fdb77..5dbf1a3268 100644
+--- a/src/include/pbs_nodes.h
++++ b/src/include/pbs_nodes.h
+@@ -391,7 +391,7 @@ extern void set_vnode_state(struct pbsnode *, unsigned long, enum vnode_state_op
+ extern struct resvinfo *find_vnode_in_resvs(struct pbsnode *, enum vnode_degraded_op);
+ extern void free_rinf_list(struct resvinfo *);
+ extern void degrade_offlined_nodes_reservations(void);
+-extern void degrade_downed_nodes_reservations(void);
++extern void degrade_downed_nodes_reservations(struct work_task *);
+ 
+ extern int mod_node_ncpus(struct pbsnode *pnode, long ncpus, int actmode);
+ extern int initialize_pbsnode(struct pbsnode *, char *, int);
+@@ -461,7 +461,7 @@ struct pbsnode *node_recov_db(char *nd_name, struct pbsnode *pnode);
+ extern int add_mom_to_pool(mominfo_t *);
+ extern void reset_pool_inventory_mom(mominfo_t *);
+ extern vnpool_mom_t *find_vnode_pool(mominfo_t *pmom);
+-extern void mcast_msg();
++extern void mcast_msg(struct work_task *);
+ int get_job_share_type(struct job *pjob);
+ #endif
+ 
+diff --git a/src/include/svrfunc.h b/src/include/svrfunc.h
+index cc555fa88d..34f9958035 100644
+--- a/src/include/svrfunc.h
++++ b/src/include/svrfunc.h
+@@ -311,7 +311,7 @@ extern int svr_connect(pbs_net_t, unsigned int, void (*)(int), enum conn_type, i
+ #ifdef _WORK_TASK_H
+ extern void release_req(struct work_task *);
+ #ifdef _BATCH_REQUEST_H
+-extern int issue_Drequest(int, struct batch_request *, void (*)(), struct work_task **, int);
++extern int issue_Drequest(int, struct batch_request *, void (*)(struct work_task *), struct work_task **, int);
+ #endif /* _BATCH_REQUEST_H */
+ #endif /* _WORK_TASK_H */
+ 
+diff --git a/src/include/work_task.h b/src/include/work_task.h
+index 3cceb659b0..4d81795a41 100644
+--- a/src/include/work_task.h
++++ b/src/include/work_task.h
+@@ -90,7 +90,7 @@ struct work_task {
+ 	int wt_aux2;			     /* optional info 2: e.g. *real* child pid (windows), tpp msgid etc */
+ };
+ 
+-extern struct work_task *set_task(enum work_type, long event, void (*func)(), void *param);
++extern struct work_task *set_task(enum work_type, long event, void (*func)(struct work_task *), void *param);
+ extern int convert_work_task(struct work_task *ptask, enum work_type);
+ extern void clear_task(struct work_task *ptask);
+ extern void dispatch_task(struct work_task *);
+diff --git a/src/lib/Libattr/attr_fn_acl.c b/src/lib/Libattr/attr_fn_acl.c
+index 0ef2d5328e..b0373eafeb 100644
+--- a/src/lib/Libattr/attr_fn_acl.c
++++ b/src/lib/Libattr/attr_fn_acl.c
+@@ -97,7 +97,7 @@ static int user_order(char *old, char *new);
+ static int group_order(char *old, char *new);
+ static int
+ set_allacl(attribute *, attribute *, enum batch_op,
+-	   int (*order_func)());
++	   int (*order_func)(char *, char *));
+ 
+ /* for all decode_*acl() - use decode_arst() */
+ /* for all encode_*acl() - use encode_arst() */
+diff --git a/src/lib/Libnet/net_server.c b/src/lib/Libnet/net_server.c
+index 045acd303d..b9f6470dbd 100644
+--- a/src/lib/Libnet/net_server.c
++++ b/src/lib/Libnet/net_server.c
+@@ -104,7 +104,7 @@ static char logbuf[256];
+ /* Private function within this file */
+ static int conn_find_usable_index(int);
+ static int conn_find_actual_index(int);
+-static void accept_conn();
++static void accept_conn(int);
+ static void cleanup_conn(int);
+ 
+ /**
+diff --git a/src/server/hook_func.c b/src/server/hook_func.c
+index b9534dfb9a..e0d0e52745 100644
+--- a/src/server/hook_func.c
++++ b/src/server/hook_func.c
+@@ -229,7 +229,7 @@ extern pbs_list_head svr_execjob_preresume_hooks;
+ extern time_t time_now;
+ extern struct python_interpreter_data svr_interp_data;
+ extern pbs_list_head task_list_event;
+-extern struct work_task *add_mom_deferred_list(int stream, mominfo_t *minfo, void (*func)(), char *msgid, void *parm1, void *parm2);
++extern struct work_task *add_mom_deferred_list(int stream, mominfo_t *minfo, void (*func)(struct work_task *), char *msgid, void *parm1, void *parm2);
+ 
+ extern char *path_rescdef;
+ extern char *path_hooks_rescdef;
+diff --git a/src/server/issue_request.c b/src/server/issue_request.c
+index 6bef14553b..6cf28dab76 100644
+--- a/src/server/issue_request.c
++++ b/src/server/issue_request.c
+@@ -201,7 +201,7 @@ reissue_to_svr(struct work_task *pwt)
+ 		/* either timed-out or got hard error, tell post-function  */
+ 		pwt->wt_aux = -1;   /* seen as error by post function  */
+ 		pwt->wt_event = -1; /* seen as connection by post func */
+-		((void (*)()) pwt->wt_parm2)(pwt);
++		((void (*)(struct work_task *)) pwt->wt_parm2)(pwt);
+ 	}
+ 	return;
+ }
+@@ -326,7 +326,7 @@ release_req(struct work_task *pwt)
+  *
+  */
+ struct work_task *
+-add_mom_deferred_list(int stream, mominfo_t *minfo, void (*func)(), char *msgid, void *parm1, void *parm2)
++add_mom_deferred_list(int stream, mominfo_t *minfo, void (*func)(struct work_task *), char *msgid, void *parm1, void *parm2)
+ {
+ 	struct work_task *ptask = NULL;
+ 
+@@ -394,7 +394,7 @@ add_mom_deferred_list(int stream, mominfo_t *minfo, void (*func)(), char *msgid,
+  *
+  */
+ int
+-issue_Drequest(int conn, struct batch_request *request, void (*func)(), struct work_task **ppwt, int prot)
++issue_Drequest(int conn, struct batch_request *request, void (*func)(struct work_task *), struct work_task **ppwt, int prot)
+ {
+ 	struct attropl *patrl;
+ 	struct work_task *ptask;
+diff --git a/src/server/node_manager.c b/src/server/node_manager.c
+index a6fbf5805e..62661a2361 100644
+--- a/src/server/node_manager.c
++++ b/src/server/node_manager.c
+@@ -7923,7 +7923,7 @@ degrade_offlined_nodes_reservations(void)
+  * @par MT-safe: No
+  */
+ void
+-degrade_downed_nodes_reservations(void)
++degrade_downed_nodes_reservations(struct work_task *)
+ {
+ 	int i;
+ 	struct pbsnode *pn;
+diff --git a/src/server/req_jobobit.c b/src/server/req_jobobit.c
+index 37581cead4..034c3c0680 100644
+--- a/src/server/req_jobobit.c
++++ b/src/server/req_jobobit.c
+@@ -1337,7 +1337,7 @@ job_obit(ruu *pruu, int stream)
+ 	job *pjob;
+ 	svrattrl *patlist;
+ 	struct work_task *ptask;
+-	void (*eojproc)();
++	void (*eojproc)(struct work_task *);
+ 	char *mailmsg = NULL;
+ 	char *msg = NULL;
+ 
+diff --git a/src/server/req_manager.c b/src/server/req_manager.c
+index 14a50de62e..ac617d7be8 100644
+--- a/src/server/req_manager.c
++++ b/src/server/req_manager.c
+@@ -3612,7 +3612,7 @@ check_resource_set_on_jobs_or_resvs(struct batch_request *preq, resource_def *pr
+  * 		helper function to send/update resourcedef file.
+  */
+ static void
+-timed_send_rescdef()
++timed_send_rescdef(struct work_task *)
+ {
+ 	send_rescdef(1); /* forcing with 1 to avoid failures due to intermittent file stamp race issues */
+ 	rescdef_wt_g = NULL;
+diff --git a/src/server/svr_movejob.c b/src/server/svr_movejob.c
+index c438d5d739..8947dc8c85 100644
+--- a/src/server/svr_movejob.c
++++ b/src/server/svr_movejob.c
+@@ -122,7 +122,7 @@ extern time_t time_now;
+ extern int svr_create_tmp_jobscript(job *pj, char *script_name);
+ extern int scheduler_jobs_stat;
+ extern char *path_hooks_workdir;
+-extern struct work_task *add_mom_deferred_list(int stream, mominfo_t *minfo, void (*func)(), char *msgid, void *parm1, void *parm2);
++extern struct work_task *add_mom_deferred_list(int stream, mominfo_t *minfo, void (*func)(struct work_task *), char *msgid, void *parm1, void *parm2);
+ 
+ /**
+  * @brief

--- a/pkgs/by-name/op/openpbs/2711.patch
+++ b/pkgs/by-name/op/openpbs/2711.patch
@@ -1,0 +1,58 @@
+diff --git a/src/cmds/qstat.c b/src/cmds/qstat.c
+index 440e37cb..cb7fe62c 100644
+--- a/src/cmds/qstat.c
++++ b/src/cmds/qstat.c
+@@ -76,7 +76,6 @@ extern char *tcl_atrsep;
+ /* default server */
+ char *def_server;
+ 
+-static void states();
+ static char *cvtResvstate(char *);
+ static int cmp_est_time(struct batch_status *a, struct batch_status *b);
+ char *cnvt_est_start_time(char *start_time, int shortform);
+diff --git a/src/cmds/qsub.c b/src/cmds/qsub.c
+index f02bb5ef..54871a08 100644
+--- a/src/cmds/qsub.c
++++ b/src/cmds/qsub.c
+@@ -89,6 +89,7 @@
+ #include <assert.h>
+ #include <sys/un.h>
+ #include <syslog.h>
++#include <unistd.h>
+ #include "pbs_ifl.h"
+ #include "cmds.h"
+ #include "libpbs.h"
+@@ -1944,7 +1945,6 @@ job_env_basic(void)
+ 	struct utsname uns;
+ #endif
+ 	int len = 0;
+-	char *getcwd();
+ 
+ 	/* Calculate how big to make the variable string. */
+ 	len = 0;
+diff --git a/src/include/qmgr.h b/src/include/qmgr.h
+index eb021c53..17ae6522 100644
+--- a/src/include/qmgr.h
++++ b/src/include/qmgr.h
+@@ -143,7 +143,7 @@ struct objname {
+ /* prototypes */
+ struct objname *commalist2objname(char *, int);
+ struct server *find_server(char *);
+-struct server *make_connection();
++struct server *make_connection(char *);
+ struct server *new_server();
+ struct objname *new_objname();
+ struct objname *strings2objname(char **, int, int);
+diff --git a/src/tools/pbs_tclWrap.c b/src/tools/pbs_tclWrap.c
+index 558528ad..1a9dd1d4 100644
+--- a/src/tools/pbs_tclWrap.c
++++ b/src/tools/pbs_tclWrap.c
+@@ -273,7 +273,7 @@ int
+ GetREQ(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+ {
+ 	int fd;
+-	char *ret, *getreq();
++	char *ret;
+ 	char *cmd;
+ 
+ 	cmd = Tcl_GetStringFromObj(objv[0], NULL);

--- a/pkgs/by-name/op/openpbs/package.nix
+++ b/pkgs/by-name/op/openpbs/package.nix
@@ -1,0 +1,116 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  lib,
+  autoconf,
+  automake,
+  libtool,
+  gnum4,
+  symlinkJoin,
+  tcl-8_5,
+  tk-8_5,
+  swig,
+  pkg-config,
+  cjson,
+  openssl,
+  zlib,
+  libxt,
+  libx11,
+  libpq,
+  python3,
+  expat,
+  libedit,
+  hwloc,
+  libical,
+  krb5,
+  munge,
+  findutils,
+  gawk,
+}:
+let
+  tclWithTk = symlinkJoin {
+    name = "tcl-with-tk";
+    paths = [
+      tcl-8_5
+      tk-8_5
+      tk-8_5.dev
+    ];
+  };
+in
+stdenv.mkDerivation {
+  pname = "openpbs";
+  version = "23.06.06-unstable-2026-01-29";
+
+  src = fetchFromGitHub {
+    owner = "openpbs";
+    repo = "openpbs";
+    rev = "cfd431b703e8cbe3bc99db6fbbcdd970625ef032";
+    hash = "sha256-NZoSZmcl9a/6YWHO7qRNknB6ii0JBLo5bOpHDRKeuwI=";
+  };
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    libtool
+    gnum4
+    tclWithTk
+    swig
+    pkg-config
+    cjson
+  ];
+  buildInputs = [
+    openssl
+    zlib
+    libxt
+    libx11
+    libpq
+    python3
+    expat
+    libedit
+    hwloc
+    libical
+    krb5
+    munge
+  ];
+
+  enableParallelBuilding = true;
+
+  patches = [
+    ./2709.patch
+    ./2711.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace src/cmds/scripts/Makefile.am --replace-fail "/etc/profile.d" "$out/etc/profile.d"
+    substituteInPlace m4/pbs_systemd_unitdir.m4 --replace-fail "/usr/lib/systemd/system" "$out/lib/systemd/system"
+  '';
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
+
+  configureFlags = [
+    "--with-tcl=${tclWithTk}"
+    "--with-swig=${swig}"
+    "--sysconfdir=$out/etc"
+  ];
+
+  postInstall = ''
+    cp src/scheduler/pbs_{dedicated,holidays,resource_group,sched_config} $out/etc/
+  '';
+
+  postFixup = ''
+    substituteInPlace $out/libexec/pbs_habitat --replace-fail /bin/ls ls
+    find $out/bin/ $out/sbin/ $out/libexec/ $out/lib/ -type f -exec file "{}" + |
+      awk -F: '/ELF/ {print $1}' |
+      xargs patchelf --add-needed libmunge.so --add-rpath ${munge}/lib
+  '';
+
+  meta = {
+    description = "HPC workload manager and job scheduler for desktops, clusters, and clouds";
+    homepage = "https://www.openpbs.org/";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ lisanna-dettwyler ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
Adds nix-scheduler-hook, a build hook for sending builds to job schedulers. Introduction post: https://discourse.nixos.org/t/introducing-nix-scheduler-hook-a-build-hook-for-sending-builds-to-job-schedulers/73038/8

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
