### PR TITLE
textadept: 12.8 -> 12.9

### DIFF
--- a/pkgs/by-name/te/textadept/deps.nix
+++ b/pkgs/by-name/te/textadept/deps.nix
@@ -10,9 +10,9 @@
     sha256 = "sha256-G/CEzNVkwJl8CIFmSjtVEOX1bDqnnnO9hJR3VjLQf3k=";
   };
   # scintillua
-  "scintillua_6.5.zip" = {
-    url = "https://github.com/orbitalquark/scintillua/archive/scintillua_6.5.zip";
-    sha256 = "sha256-mXE4wcEenEf7vgUNyPBPzwu5vSiupbDub656+jlLP68=";
+  "scintillua_6.6.zip" = {
+    url = "https://github.com/orbitalquark/scintillua/archive/scintillua_6.6.zip";
+    sha256 = "sha256-rFza9/ISeet3GsEi9mCM6mUl9mptBfOKWbxMyYKQvGA=";
   };
   # lua
   "lua-5.4.8.tar.gz" = {
@@ -50,8 +50,8 @@
     sha256 = "sha256-IbFow4rbIvS0g5HYGT28OSfx8uZ4wgWNaUSim2Ssxsk=";
   };
   # singleapp
-  "v3.4.0.zip" = {
-    url = "https://github.com/itay-grudev/SingleApplication/archive/refs/tags/v3.4.0.zip";
-    sha256 = "sha256-FwyzM+R9ALpGH9u2RXab4Sqi4Q+p3Qs+8EdfhjPGcXY=";
+  "v3.5.3.zip" = {
+    url = "https://github.com/itay-grudev/SingleApplication/archive/refs/tags/v3.5.3.zip";
+    sha256 = "sha256-7Ipook2pdDl2aDcKWp0f4oG/y9c5DtGxRkKSFjTxiB8=";
   };
 }

--- a/pkgs/by-name/te/textadept/package.nix
+++ b/pkgs/by-name/te/textadept/package.nix
@@ -10,14 +10,14 @@
   ncurses,
 }:
 stdenv.mkDerivation (finalAttrs: {
-  version = "12.8";
+  version = "12.9";
   pname = "textadept";
 
   src = fetchFromGitHub {
     owner = "orbitalquark";
     repo = "textadept";
     tag = "textadept_${finalAttrs.version}";
-    hash = "sha256-ba5YSZaWGGEFFAbHNNXv2/a4dWrG/o5mTySCmlPauWs=";
+    hash = "sha256-vpBmDcnaHdpYZIfcy482G4NGor+64Dh1tzryb8JJ+c8=";
   };
 
   nativeBuildInputs = [ cmake ] ++ lib.optionals withQt [ libsForQt5.wrapQtAppsHook ];


### PR DESCRIPTION
Diff: https://github.com/orbitalquark/textadept/compare/textadept_12.8...textadept_12.9
Resolves #470768

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
