### PR TITLE
nixos/test-driver: warn when command exits but stdout stays open

### DIFF
--- a/nixos/tests/nixos-test-driver/succeed-stdout-warning.nix
+++ b/nixos/tests/nixos-test-driver/succeed-stdout-warning.nix
@@ -1,0 +1,45 @@
+# Run with:
+#   cd nixpkgs
+#   nix-build -A nixosTests.nixos-test-driver.succeed-stdout-warning
+{
+  name = "Test that succeed() warns when stdout stays open after command exits";
+
+  nodes = {
+    machine = (
+      { pkgs, ... }:
+      {
+      }
+    );
+  };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("multi-user.target")
+
+    with subtest("Fast command should NOT produce warning"):
+        machine.succeed("echo 'MARKER: before fast command' >&2")
+        output = machine.succeed("echo HELLO")
+        assert output == "HELLO\n", f"Expected 'HELLO\\n', got {output!r}"
+        machine.succeed("echo 'MARKER: after fast command' >&2")
+
+    with subtest("Background process keeps stdout open - should produce warning"):
+        machine.succeed("echo 'MARKER: before slow command' >&2")
+        output = machine.succeed("(echo ONE; sleep 15; echo TWO) &")
+        assert output == "ONE\nTWO\n", f"Expected 'ONE\\nTWO\\n', got {output!r}"
+        machine.succeed("echo 'MARKER: after slow command' >&2")
+
+    with subtest("Exit status should be preserved (non-zero)"):
+        try:
+            machine.succeed("exit 42")
+            assert False, "Expected command to fail with exit code 42"
+        except Exception as e:
+            # Verify the exception message contains the correct exit code
+            assert "exit code 42" in str(e), f"Expected 'exit code 42' in exception, got: {e}"
+
+    with subtest("User Command stderr should go to console"):
+        machine.succeed("echo 'STDERR_TEST_MARKER: user command stderr output' >&2")
+
+    # Fail the test so testBuildFailure can access the log
+    raise Exception("Test script done and successful so far. Intentionally failing so that testBuildFailure can perform remaining log checks")
+  '';
+}


### PR DESCRIPTION
## Motivation

I believe this issue has cost the community many hours of unnecessary troubleshooting, frustration, and I assume it has restricted the adoption of the test framework. That needs to end.

- [EDIT] Closes #144875


## Commit message

The test driver's succeed() method waits for stdout to be fully consumed before returning. When a command spawns background processes that inherit stdout, succeed() will wait silently for those processes to complete or close stdout. This wait can be arbitrarily long and users have no visibility into what's causing the delay.

Unfortunately just changing the behavior of these widely used methods is not an option.

This change detects when a command has exited but stdout remains open for more than 10 seconds, and emits a warning to help users diagnose the issue. This warning briefly explains the problem and suggests redirecting background process output to avoid the implicit wait.

The implementation uses bash coproc to independently track:
- The command process exit status (preserved for return)
- The stdout closure (via base64 process termination)
- A 10-second timeout using wait -n to race these events

When stdout closes quickly: no warning
When stdout stays open >10s: warning emitted, continues waiting


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
