### PR TITLE
ron-lsp: init at 0.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6606,6 +6606,12 @@
     github = "dietmarw";
     githubId = 9332;
   };
+  Dietr1ch = {
+    name = "Dietrich Daroch";
+    github = "Dietr1ch";
+    githubId = 2096594;
+    email = "Dietrich@Daroch.me";
+  };
   different-name = {
     name = "different-name";
     email = "hello@different-name.dev";

--- a/pkgs/by-name/ro/ron-lsp/package.nix
+++ b/pkgs/by-name/ro/ron-lsp/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ron-lsp";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "jasonjmcghee";
+    repo = "ron-lsp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-c+cJrXINuoK+NR1rMSrOeZqZzrEcg/brSTKSTu5mNr4=";
+  };
+
+  cargoHash = "sha256-eEoxgnfc9s59b0SNozEIj/1wHv+OWDmd4bniBbGsgSQ=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "RON, Rusty Object Notation, Language Server";
+    longDescription = ''
+      An LSP and CLI for RON files that provides autocomplete,
+      diagnostics, go to definition, code actions, and hover support
+      based on Rust type annotations
+    '';
+    homepage = "https://github.com/jasonjmcghee/ron-lsp";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [
+      Dietr1ch
+    ];
+    mainProgram = "ron-lsp";
+  };
+})


### PR DESCRIPTION
## Things done

(Recreating https://github.com/NixOS/nixpkgs/pull/471068 after closing it by mistake.)

Packaged [`ron-lsp`](https://github.com/jasonjmcghee/ron-lsp/) and added myself as the maintainer and into the maintainers list.

@aciceri had reviewed it initially.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
