### PR TITLE
typstPackages: Fix package set structure

### DIFF
--- a/pkgs/by-name/ty/typst/typst-packages.nix
+++ b/pkgs/by-name/ty/typst/typst-packages.nix
@@ -34,16 +34,13 @@ lib.makeScope newScope (
       # 1. Create a list of versioned packages
       # Only recurse 2 levels deep because the leaf attrs are the pkgspec attrs
       (lib.mapAttrsToListRecursiveCond (path: _: (lib.length path) < 2) (
-        path: packageSpec:
+        path:
         let
           # Path is always [ path version ]
           pname = lib.head path;
           version = lib.last path;
         in
-        {
-          name = toPackageName pname version;
-          value = makeVersionedPackage pname version packageSpec;
-        }
+        makeVersionedPackage pname version
       ))
       # 2. Transform the list into a flat attrset
       lib.listToAttrs

--- a/pkgs/by-name/ty/typst/typst-packages.nix
+++ b/pkgs/by-name/ty/typst/typst-packages.nix
@@ -17,13 +17,13 @@ lib.makeScope newScope (
       name = toPackageName pname version;
 
       value = buildUniversePackage {
+        homepage = packageSpec.homepage or null;
         inherit pname version;
         inherit (packageSpec)
           hash
           description
           license
           typstDeps
-          homepage
           ;
       };
     };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I was looking at some things and noticed that the derivations without dependencies were weird. Turns out I accidentally made it so that the `{ name = ...; value = ...; }` nested. But the strange part is that eval doesn't fail, you can build the `{ name = ...; value = ...; }` attrsets just fine. It's just that when the stdenv builder tries to splice it, it doesn't find the parts it expects.

@SuperSandro2000 oops, this is needed for #464325 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
