### PR TITLE
release.nix: move the haskell specific logic into haskell

### DIFF
--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -168,6 +168,22 @@ in
   # Default overrides that are applied to all package sets.
   packageOverrides = self: super: { };
 
+  # Selected packages (HLS) for multiple Haskell compilers
+  # to rebuild the cache after a staging merge
+  releasePackages = pkgs.lib.recurseIntoAttrs (
+    pkgs.lib.genAttrs'
+      [
+        "ghc96"
+        "ghc98"
+        "ghc910"
+        "ghc912"
+      ]
+      (name: {
+        name = "haskell-language-server-${name}";
+        value = pkgs.haskell.packages.${name}.haskell-language-server;
+      })
+  );
+
   # Always get compilers from `buildPackages`
   packages =
     let

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -354,24 +354,6 @@ let
         if attrNamesOnly then id else release-lib.getPlatforms
       );
       packageJobs = packagePlatforms pkgs // {
-        # Build selected packages (HLS) for multiple Haskell compilers to rebuild
-        # the cache after a staging merge
-        haskell = packagePlatforms pkgs.haskell // {
-          packages =
-            genAttrs
-              [
-                "ghc96"
-                "ghc98"
-                "ghc910"
-                "ghc912"
-              ]
-              (compilerName: {
-                inherit (packagePlatforms pkgs.haskell.packages.${compilerName})
-                  haskell-language-server
-                  ;
-              });
-        };
-
         pkgsLLVM.stdenv = [
           "x86_64-linux"
           "aarch64-linux"


### PR DESCRIPTION
Moving some more stuff out of `release.nix`
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
