### PR TITLE
ocamlPackages.extunix: fix

### DIFF
--- a/pkgs/development/ocaml-modules/extunix/default.nix
+++ b/pkgs/development/ocaml-modules/extunix/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildDunePackage,
-  fetchFromGitHub,
+  fetchurl,
   dune-configurator,
   ppxlib,
 }:
@@ -10,11 +10,11 @@ buildDunePackage (finalAttrs: {
   pname = "extunix";
   version = "0.4.4";
 
-  src = fetchFromGitHub {
-    owner = "ygrek";
-    repo = "extunix";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-7wJDGv19etkDHRwwQ+WONtJswxNMjr2Q2Vhis4WgFek=";
+  minimalOCamlVersion = "5.3.0";
+
+  src = fetchurl {
+    url = "https://github.com/ygrek/extunix/releases/download/v${finalAttrs.version}/extunix-${finalAttrs.version}.tbz";
+    hash = "sha256-kzTIkjFiI+aK73lcpystQp1O7Apkf0GLA142oFPRSX0=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Fix src url (now the package knows about its version).

Set minimalOCamlVersion (this library needs ppxlib ≥ 0.36).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
