### PR TITLE
beets: make it easier to override builtin plugins

### DIFF
--- a/pkgs/development/python-modules/beets/default.nix
+++ b/pkgs/development/python-modules/beets/default.nix
@@ -270,7 +270,7 @@ buildPythonPackage {
 
   passthru = {
     plugins = {
-      builtins = {
+      builtins = lib.recursiveUpdate {
         absubmit = {
           deprecated = true;
           testPaths = [ ];
@@ -441,7 +441,7 @@ buildPythonPackage {
         _utils = {
           testPaths = [ ];
         };
-      };
+      } (lib.filterAttrs (_: p: p.builtin or false) pluginOverrides);
       base = lib.mapAttrs (_: a: { builtin = true; } // a) beets.passthru.plugins.builtins;
       overrides = lib.mapAttrs (
         plugName:
@@ -485,6 +485,25 @@ buildPythonPackage {
 
             ${beets}/bin/beet -c $out/config.yaml > /dev/null
           '';
+
+      beets-with-new-builtin-plugin =
+        let
+          beets-with-new-builtin-plugin =
+            (beets.override {
+              beets = beets-with-new-builtin-plugin;
+
+              pluginOverrides = {
+                my_special_plugin.builtin = true;
+              };
+            }).overridePythonAttrs
+              (prev: {
+                postPatch = (prev.postPatch or "") + ''
+                  mkdir -p beetsplug/my_special_plugin
+                  touch beetsplug/my_special_plugin/__init__.py
+                '';
+              });
+        in
+        beets-with-new-builtin-plugin;
     };
   };
 


### PR DESCRIPTION
Previously, it was possible to override builtin plugins. Now it's not. After this commit, it is again :)

You may have a patch (e.g. a not-yet-merged or not-yet-released PR) that adds a new builtin plugin.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
