### PR TITLE
skyscraper: 3.17.5 -> 3.18.0

### DIFF
--- a/pkgs/by-name/sk/skyscraper/package.nix
+++ b/pkgs/by-name/sk/skyscraper/package.nix
@@ -2,9 +2,11 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  qt5,
+  qt6,
+  mdbtools,
   p7zip,
   python3,
+  sqlite,
   installShellFiles,
 
   # Whether to compile with XDG support
@@ -14,24 +16,29 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "skyscraper";
-  version = "3.17.5";
+  version = "3.18.0";
 
   src = fetchFromGitHub {
     owner = "Gemba";
     repo = "skyscraper";
     rev = "refs/tags/${finalAttrs.version}";
-    hash = "sha256-JbU3enkzVUNOwJ4NuqIxAscvFShSCssj95W5nmSaO6c=";
+    hash = "sha256-z6Y5JUKvwxYgE7sdXvRNOsbUTON5i/DX1q9y4wRXixE=";
   };
 
   strictDeps = true;
 
   nativeBuildInputs = [
-    qt5.wrapQtAppsHook
-    qt5.qmake
+    qt6.wrapQtAppsHook
+    qt6.qmake
     installShellFiles
   ];
 
-  buildInputs = [ python3 ];
+  buildInputs = [
+    qt6.qtbase
+    mdbtools
+    sqlite
+    python3
+  ];
 
   postPatch = lib.optionalString enableXdg ''
     substituteInPlace skyscraper.pro --replace-fail "#DEFINES+=XDG" "DEFINES+=XDG"
@@ -45,6 +52,13 @@ stdenv.mkDerivation (finalAttrs: {
   preFixup = ''
     qtWrapperArgs+=(--prefix PATH : ${lib.makeBinPath [ p7zip ]})
     chmod +x $out/bin/*.py
+    sed -i '2i\\export PATH="${
+      lib.makeBinPath [
+        mdbtools
+        sqlite
+      ]
+    }:$PATH"' \
+      $out/bin/mdb2sqlite.sh
   '';
 
   env.PREFIX = placeholder "out";


### PR DESCRIPTION
1. Updated to v3.18.0 ([release notes](https://github.com/Gemba/skyscraper/releases/tag/3.18.0))
2. Updated to build with Qt6, since that's now recommended by upstream.
3. Fixed packaging of `mdb2sqlite.sh` to include required runtime dependencies on `$PATH`.

Maintainer: @ASHGOLDOFFICIAL

Unfortunately, this doesn't solve #468852 as I had hoped it would, but it's worth having either way.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
