### PR TITLE
fetchurl: move netrcPhase invokation into build.sh and stringify `curlOpts` early

### DIFF
--- a/pkgs/build-support/fetchurl/builder.sh
+++ b/pkgs/build-support/fetchurl/builder.sh
@@ -41,10 +41,9 @@ if [[ -n "${netrcPhase-}" ]]; then
     curl+=(--netrc-file "$PWD/netrc")
 fi
 
-curl+=("${curlOptsList[@]}")
-
 curl+=(
-    ${curlOpts[*]}
+    "${curlOptsList[@]}"
+    $curlOpts
     $NIX_CURL_FLAGS
 )
 

--- a/pkgs/build-support/fetchurl/builder.sh
+++ b/pkgs/build-support/fetchurl/builder.sh
@@ -1,6 +1,16 @@
 source "$NIX_ATTRS_SH_FILE"
 source $mirrorsFile
 
+# Normalize `curlOpts` as a string.
+# If defined as a list (deprecated), it would be a bash array.
+if [[ "$(declare -p curlOpts 2&>/dev/null || true)" =~ ^"declare -a" ]]; then
+    unset _temp
+    _temp="${curlOpts[*]}"
+    unset curlOpts
+    curlOpts=$_temp
+    unset _temp
+fi
+
 curlVersion=$(curl -V | head -1 | cut -d' ' -f2)
 
 # Curl flags to handle redirects, not use EPSV, handle cookies for

--- a/pkgs/build-support/fetchurl/builder.sh
+++ b/pkgs/build-support/fetchurl/builder.sh
@@ -23,6 +23,14 @@ if ! [ -f "$SSL_CERT_FILE" ]; then
     curl+=(--insecure)
 fi
 
+# NOTE:
+# `netrcPhase` should not attempt to access builder.sh implementation details (e.g., the `${curl[@]}` array),
+# The implementation detail could change in any Nixpkgs revision, including backports.
+if [[ -n "${netrcPhase-}" ]]; then
+    runPhase netrcPhase
+    curl+=(--netrc-file "$PWD/netrc")
+fi
+
 curl+=("${curlOptsList[@]}")
 
 curl+=(
@@ -32,7 +40,6 @@ curl+=(
 
 downloadedFile="$out"
 if [ -n "$downloadToTemp" ]; then downloadedFile="$TMPDIR/file"; fi
-
 
 tryDownload() {
     local url="$1"

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -333,15 +333,6 @@ lib.extendMkDerivation {
 
       inherit preferLocalBuild;
 
-      postHook =
-        if netrcPhase == null then
-          null
-        else
-          ''
-            ${netrcPhase}
-            curlOpts="$curlOpts --netrc-file $PWD/netrc"
-          '';
-
       inherit meta;
       passthru = {
         inherit url resolvedUrl;

--- a/pkgs/build-support/fetchurl/tests.nix
+++ b/pkgs/build-support/fetchurl/tests.nix
@@ -1,11 +1,85 @@
 {
+  lib,
   testers,
   fetchurl,
+  writeShellScriptBin,
   jq,
   moreutils,
+  emptyFile,
   ...
 }:
+let
+  testFlagAppending =
+    args:
+    testers.invalidateFetcherByDrvHash
+      (fetchurl.override (previousArgs: {
+        curl = (
+          writeShellScriptBin "curl" ''
+            set -eu -o pipefail
+            hasFoo=
+            hasBar=
+            echo "curl-mock-expecting-flags: get flags: $*" >&2
+            for arg; do
+              case "$arg" in
+              -V|--version)
+                ${lib.getExe previousArgs.curl} "$arg"
+                exit "$?"
+                ;;
+              --foo)
+                echo "curl-mock-expecting-flags: \`--foo' found in the argument list passed to \`curl'." >&2
+                hasFoo=1
+                ;;
+              --bar)
+                echo "curl-mock-expecting-flags: \`--bar' found in the argument list passed to \`curl'." >&2
+                hasBar=1
+                ;;
+              esac
+            done
+            if [[ -z "$hasFoo" ]]; then
+              echo "ERROR: curl-mock-expecting-flags: \`--foo' missing in the argument list passed to \`curl'." >&2
+            fi
+            if [[ -z "$hasBar" ]]; then
+              echo "ERROR: curl-mock-expecting-flags: \`--bar' missing in the argument list passed to \`curl'." >&2
+            fi
+            if [[ -n "$hasFoo" ]] && [[ -n "$hasBar" ]]; then
+              touch $out
+            else
+              exit 1
+            fi
+          ''
+        );
+      }))
+      (
+        {
+          url = "https://www.example.com/source";
+          hash = emptyFile.outputHash;
+          recursiveHash = true; # aligned with emptyFile
+        }
+        // args
+      );
+in
 {
+  flag-appending-curlOpts = testFlagAppending {
+    name = "test-fetchurl-flag-appending-curlOpts";
+    curlOpts = "--foo --bar";
+  };
+
+  flag-appending-curlOptsList = testFlagAppending {
+    name = "test-fetchurl-flag-appending-curlOptsList";
+    curlOptsList = [
+      "--foo"
+      "--bar"
+    ];
+  };
+
+  flag-appending-netrcPhase-curlOpts = testFlagAppending {
+    name = "test-fetchurl-flag-appending-netrcPhase-curlOpts";
+    netrcPhase = ''
+      touch netrc
+      curlOpts="$curlOpts --foo --bar"
+    '';
+  };
+
   # Tests that we can send custom headers with spaces in them
   header =
     let

--- a/pkgs/build-support/fetchurl/tests.nix
+++ b/pkgs/build-support/fetchurl/tests.nix
@@ -80,6 +80,14 @@ in
     '';
   };
 
+  flag-appending-netrcPhase-curlOptsList = testFlagAppending {
+    name = "test-fetchurl-flag-appending-netrcPhase-curlOptsList";
+    netrcPhase = ''
+      touch netrc
+      curlOptsList+=("--foo" "--bar")
+    '';
+  };
+
   # Tests that we can send custom headers with spaces in them
   header =
     let


### PR DESCRIPTION
This PR cleans up the leftover of PR #464475 regarding `curlOpts` and `netrcPhase`.

- Don't rely on the `postPhase` in `$stdenv/setup.sh` provided by `stdenv/generic/make-derivation.nix`'s realBuilder hack.
- If `curlOpts` is passed as a Bash array from a Nix Language list (which we warned against at eval time), set it as a plain Bash variable after sourcing `$NIX_ATTRS_SH_FILE`, so that we don't have to handle such edge cases.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
