### PR TITLE
ieda: fix build with gcc15

### DIFF
--- a/pkgs/by-name/ie/ieda/fix-gcc15-build.patch
+++ b/pkgs/by-name/ie/ieda/fix-gcc15-build.patch
@@ -1,0 +1,20 @@
+diff --git a/src/third_party/salt/base/rsa.h b/src/third_party/salt/base/rsa.h
+index 172829fa7..41dd6222b 100644
+--- a/src/third_party/salt/base/rsa.h
++++ b/src/third_party/salt/base/rsa.h
+@@ -37,7 +37,7 @@ class InnerNode
+ class CompInnerNode
+ {
+  public:
+-  bool operator()(const InnerNode* a, const InnerNode* b)
++  bool operator()(const InnerNode* a, const InnerNode* b) const
+   {
+     return a->dist > b->dist ||  // prefer fathest one
+            (a->dist == b->dist
+@@ -88,4 +88,4 @@ class RsaBuilder : public RSABase
+   void PrintOuterNodes();
+ };
+ 
+-}  // namespace salt
+\ No newline at end of file
++}  // namespace salt

--- a/pkgs/by-name/ie/ieda/package.nix
+++ b/pkgs/by-name/ie/ieda/package.nix
@@ -51,6 +51,7 @@ let
       # Fix CMake version requirement to support newer CMake versions,
       # Should be removed once upstream fixed it.
       ./fix-cmake-require.patch
+      ./fix-gcc15-build.patch
     ];
 
     dontBuild = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

No idea why that `const` is required, but without the `const` it failed with the following error:
```
/nix/store/mppmymzvk6d7q6m47r8049xr8alrhhjb-gcc-15.2.0/include/c++/15.2.0/bits/stl_tree.h:2620:35: error: no match for call to '(const salt::CompInnerNode) (salt::InnerNode* const&, salt::InnerNode* const&)'
 2620 |         if (_M_impl._M_key_compare(__k, _S_key(__x)))
      |             ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
/build/iEDA-src-2025-11-08/src/third_party/salt/base/rsa.h:37:7: note: there is 1 candidate
   37 | class CompInnerNode
      |       ^~~~~~~~~~~~~
/build/iEDA-src-2025-11-08/src/third_party/salt/base/rsa.h:40:8: note: candidate 1: 'bool salt::CompInnerNode::operator()(const salt::InnerNode*, const salt::InnerNode*)' (near match)
   40 |   bool operator()(const InnerNode* a, const InnerNode* b)
      |        ^~~~~~~~
/build/iEDA-src-2025-11-08/src/third_party/salt/base/rsa.h:40:8: note: passing 'const salt::CompInnerNode*' as 'this' argument discards qualifiers
```
See https://hydra.nixos.org/build/315332588

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
