### PR TITLE
ocamlPackages.conduit-async: Add back async_ssl dependency

### DIFF
--- a/pkgs/development/ocaml-modules/conduit/async.nix
+++ b/pkgs/development/ocaml-modules/conduit/async.nix
@@ -1,6 +1,7 @@
 {
   buildDunePackage,
   async,
+  async_ssl ? null,
   ppx_sexp_conv,
   ppx_here,
   uri,
@@ -25,6 +26,7 @@ buildDunePackage {
 
   propagatedBuildInputs = [
     async
+    async_ssl
     conduit
     uri
     ipaddr


### PR DESCRIPTION
This dependency is required for Cohttp_async to be able to establish HTTPS connections.  It was removed in #347977 but I suspect that might have been accidental.  Since this missing dependency only causes a runtime error (the module is replaced with a dummy implementation at compile time if it is missing), I'm also slightly suspicious of whether b2345680968b7e53d24a258d021530c2562a9088 actually fixed cohttp_async_websocket or whether it merely fixed a build error.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
