### PR TITLE
bincrypter: init at v1.3

### DIFF
--- a/pkgs/by-name/bi/bincrypter/package.nix
+++ b/pkgs/by-name/bi/bincrypter/package.nix
@@ -1,8 +1,8 @@
-{
-  pkgs,
-  lib,
-  fetchFromGitHub,
-  stdenv,
+{ pkgs
+, lib
+, fetchFromGitHub
+, stdenv
+,
 }:
 
 stdenv.mkDerivation {

--- a/pkgs/by-name/bi/bincrypter/package.nix
+++ b/pkgs/by-name/bi/bincrypter/package.nix
@@ -1,0 +1,47 @@
+{
+  pkgs,
+  lib,
+  fetchFromGitHub,
+  stdenv,
+}:
+
+stdenv.mkDerivation {
+  pname = "bincrypter";
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    owner = "hackerschoice";
+    repo = "bincrypter";
+    rev = "master";
+    sha256 = "sha256-5xymjIHgYm0d3vpdNVpagq0tnUV2HlLV2DdcCXSso+Y=";
+  };
+
+  buildInputs = with pkgs; [
+    perl
+    openssl
+  ];
+
+  nativeBuildInputs = with pkgs; [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+
+    cp bincrypter.sh $out/bin/bincrypter
+
+    wrapProgram $out/bin/bincrypter \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          pkgs.perl
+          pkgs.openssl
+        ]
+      }
+  '';
+  meta = {
+    description = "Pack/Encrypt/Obfuscate ELF + SHELL scripts";
+    homepage = "https://github.com/hackerschoice/bincrypter";
+    license = lib.licenses.gpl2Plus;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ sinjin2300 ];
+    mainProgram = "bincrypter";
+  };
+}

--- a/pkgs/by-name/bi/bincrypter/package.nix
+++ b/pkgs/by-name/bi/bincrypter/package.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation {
   pname = "bincrypter";
-  version = "1.1";
+  version = "1.3";
 
   src = fetchFromGitHub {
     owner = "hackerschoice";

--- a/pkgs/by-name/bi/bincrypter/package.nix
+++ b/pkgs/by-name/bi/bincrypter/package.nix
@@ -1,8 +1,8 @@
-{ pkgs
-, lib
-, fetchFromGitHub
-, stdenv
-,
+{
+  pkgs,
+  lib,
+  fetchFromGitHub,
+  stdenv,
 }:
 
 stdenv.mkDerivation {

--- a/pkgs/by-name/bi/bincrypter/package.nix
+++ b/pkgs/by-name/bi/bincrypter/package.nix
@@ -1,41 +1,50 @@
 {
-  pkgs,
   lib,
   fetchFromGitHub,
   stdenv,
+  perl,
+  openssl,
+  makeWrapper,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "bincrypter";
   version = "1.3";
 
   src = fetchFromGitHub {
     owner = "hackerschoice";
     repo = "bincrypter";
-    rev = "master";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-5xymjIHgYm0d3vpdNVpagq0tnUV2HlLV2DdcCXSso+Y=";
   };
 
-  buildInputs = with pkgs; [
+  buildInputs = [
     perl
     openssl
   ];
 
-  nativeBuildInputs = with pkgs; [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/bin
 
     cp bincrypter.sh $out/bin/bincrypter
 
+    runHook postInstall
+  '';
+
+  postInstall = ''
     wrapProgram $out/bin/bincrypter \
       --prefix PATH : ${
         lib.makeBinPath [
-          pkgs.perl
-          pkgs.openssl
+          perl
+          openssl
         ]
       }
   '';
+
   meta = {
     description = "Pack/Encrypt/Obfuscate ELF + SHELL scripts";
     homepage = "https://github.com/hackerschoice/bincrypter";
@@ -44,4 +53,4 @@ stdenv.mkDerivation {
     maintainers = with lib.maintainers; [ sinjin2300 ];
     mainProgram = "bincrypter";
   };
-}
+})


### PR DESCRIPTION
bincrypter init at v1.3
bincrypter is a tool made to obfuscate ELFs and scripts.
[https://github.com/hackerschoice/bincrypter](https://github.com/hackerschoice/bincrypter)

## Things done


- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.

- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
