### PR TITLE
llpp: fix build with mupdf 1.26

### DIFF
--- a/pkgs/by-name/ll/llpp/mupdf-1.26.patch
+++ b/pkgs/by-name/ll/llpp/mupdf-1.26.patch
@@ -1,0 +1,25 @@
+From 3795c48b607f4fe98062e5a4a19310899398be42 Mon Sep 17 00:00:00 2001
+From: Florian Stecker <oss@florianstecker.net>
+Date: Thu, 12 Jun 2025 23:47:31 -0400
+Subject: [PATCH] Compatibility with libmupdf 1.26
+
+---
+ link.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/link.c b/link.c
+index ff635b2..9134726 100644
+--- a/link.c
++++ b/link.c
+@@ -2560,8 +2560,8 @@ ML (getfileannot (value ptr_v, value n_v))
+     pdf_obj *fs = pdf_dict_get (state.ctx,
+                                 pdf_annot_obj (state.ctx, slink->u.annot),
+                                 PDF_NAME (FS));
+-    pdf_embedded_file_params file_params;
+-    pdf_get_embedded_file_params (state.ctx, fs, &file_params);
+-    ret_v = caml_copy_string (file_params.filename);
++    pdf_filespec_params params;
++    pdf_get_filespec_params (state.ctx, fs, &params);
++    ret_v = caml_copy_string (params.filename);
+ 
+     unlock (__func__);

--- a/pkgs/by-name/ll/llpp/package.nix
+++ b/pkgs/by-name/ll/llpp/package.nix
@@ -35,6 +35,11 @@ stdenv.mkDerivation rec {
     hash = "sha256-B/jKvBtBwMOErUVmGFGXXIT8FzMl1DFidfDCHIH41TU=";
   };
 
+  patches = [
+    # Compatibility with mupdf 1.26
+    ./mupdf-1.26.patch
+  ];
+
   postPatch = ''
     sed -i "2d;s/ver=.*/ver=${version}/" build.bash
   '';


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
