### PR TITLE
nixosTests.jenkins: Allow tests to be independent from Jenkins home dir

### DIFF
--- a/nixos/tests/jenkins.nix
+++ b/nixos/tests/jenkins.nix
@@ -93,6 +93,7 @@
       configWithoutJobs = "${nodes.master.system.build.toplevel}/specialisation/noJenkinsJobs";
       jenkinsPort = nodes.master.services.jenkins.port;
       jenkinsUrl = "http://localhost:${toString jenkinsPort}";
+      jenkinsHome = nodes.master.services.jenkins.home;
     in
     ''
       start_all()
@@ -112,12 +113,12 @@
 
       with subtest("jobs are declarative"):
           # Check that jobs are created on disk.
-          master.wait_until_succeeds("test -f /var/lib/jenkins/jobs/job-1/config.xml")
-          master.wait_until_succeeds("test -f /var/lib/jenkins/jobs/folder-1/config.xml")
-          master.wait_until_succeeds("test -f /var/lib/jenkins/jobs/folder-1/jobs/job-2/config.xml")
+          master.wait_until_succeeds("test -f ${jenkinsHome}/jobs/job-1/config.xml")
+          master.wait_until_succeeds("test -f ${jenkinsHome}/jobs/folder-1/config.xml")
+          master.wait_until_succeeds("test -f ${jenkinsHome}/jobs/folder-1/jobs/job-2/config.xml")
 
           # Verify that jenkins also sees the jobs.
-          out = master.succeed("${pkgs.jenkins}/bin/jenkins-cli -s ${jenkinsUrl} -auth admin:$(cat /var/lib/jenkins/secrets/initialAdminPassword) list-jobs")
+          out = master.succeed("${pkgs.jenkins}/bin/jenkins-cli -s ${jenkinsUrl} -auth admin:$(cat ${jenkinsHome}/secrets/initialAdminPassword) list-jobs")
           jobs = [x.strip() for x in out.splitlines()]
           # Seeing jobs inside folders requires the Folders plugin
           # (https://plugins.jenkins.io/cloudbees-folder/), which we don't have
@@ -129,12 +130,12 @@
           )
 
           # Check that jobs are removed from disk.
-          master.wait_until_fails("test -f /var/lib/jenkins/jobs/job-1/config.xml")
-          master.wait_until_fails("test -f /var/lib/jenkins/jobs/folder-1/config.xml")
-          master.wait_until_fails("test -f /var/lib/jenkins/jobs/folder-1/jobs/job-2/config.xml")
+          master.wait_until_fails("test -f ${jenkinsHome}/jobs/job-1/config.xml")
+          master.wait_until_fails("test -f ${jenkinsHome}/jobs/folder-1/config.xml")
+          master.wait_until_fails("test -f ${jenkinsHome}/jobs/folder-1/jobs/job-2/config.xml")
 
           # Verify that jenkins also sees the jobs as removed.
-          out = master.succeed("${pkgs.jenkins}/bin/jenkins-cli -s ${jenkinsUrl} -auth admin:$(cat /var/lib/jenkins/secrets/initialAdminPassword) list-jobs")
+          out = master.succeed("${pkgs.jenkins}/bin/jenkins-cli -s ${jenkinsUrl} -auth admin:$(cat ${jenkinsHome}/secrets/initialAdminPassword) list-jobs")
           jobs = [x.strip() for x in out.splitlines()]
           assert jobs == [], f"jobs != []: {jobs}"
     '';


### PR DESCRIPTION
Instead of hard-coding the default directory, use the value from `services.jenkins.home`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
